### PR TITLE
Add baseline scan command with language and marker detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+ignore = "0.4"

--- a/Learning.md
+++ b/Learning.md
@@ -57,3 +57,17 @@ Architecture notes:
 - scan_directory traverses the filesystem
 - count_file_lines reads one file and returns line count
 - ScanSummary is becoming an accumulator for scan metrics
+
+## Slice 5 — Count lines only for supported text files
+
+Today I learned:
+- how to read a file extension from Path
+- how Option appears when file metadata may be missing
+- how to use an allowlist for supported extensions
+- how to avoid reading binary files as text
+- why files_count and text_files_count are different
+
+Architecture notes:
+- file type detection is a policy decision
+- count_file_lines only runs after file type validation
+- scanner now separates traversal from basic filtering rules

--- a/Learning.md
+++ b/Learning.md
@@ -1,0 +1,59 @@
+# RepoPilot Learning Notes
+
+## Slice 1 — Scan path and count files
+
+Today I learned:
+- how to create a Rust CLI project
+- how to use clap for subcommands
+- what PathBuf is
+- how to separate CLI parsing from scanner logic
+- how Result is used for filesystem errors
+
+Architecture notes:
+- main.rs handles CLI input/output
+- scan/scanner.rs handles filesystem scanning
+- scan/types.rs contains the result type
+
+## Slice 2 — Recursive scanning
+
+Today I learned:
+- what recursion is
+- how a function can call itself
+- how to use &mut to update a shared summary
+- what Default means for a struct
+- what io::Result<()> means
+- why scan_path is public and scan_directory is private
+
+Architecture notes:
+- scan_path is the public API of the scanner
+- scan_directory is an internal recursive helper
+- main.rs does not know how scanning works internally
+
+## Slice 3 — Ignore common directories
+
+Today I learned:
+- how to define a const list in Rust
+- how to read a directory name from Path
+- what Option means in practice
+- how let-else works
+- how continue works in a loop
+- how to separate traversal logic from ignore policy
+
+Architecture notes:
+- ignored directory detection lives in a helper function
+- scan_directory stays focused on traversal
+- ignore rules are currently hardcoded defaults
+
+## Slice 4 — Count total lines
+
+Today I learned:
+- how to read a file with fs::read_to_string
+- why reading files can return io::Result
+- how to count lines with content.lines().count()
+- how to use a helper function for one responsibility
+- why scan_directory should not contain all file-processing logic
+
+Architecture notes:
+- scan_directory traverses the filesystem
+- count_file_lines reads one file and returns line count
+- ScanSummary is becoming an accumulator for scan metrics

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,4 +40,5 @@ fn print_summary(summary: &ScanSummary) {
     println!("Files analyzed: {}", summary.files_count);
     println!("Directories analyzed: {}", summary.directories_count);
     println!("Total lines of code: {}", summary.total_lines);
+    println!("Text files analyzed: {}", summary.text_files_count);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(name = "repopilot")]
-#[command(about = "A CLI tool for analyzing codebases", long_about = None)]
+#[command(about = "Local-first codebase audit CLI", long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -15,7 +15,11 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    Scan { path: PathBuf },
+    /// Scan a project, folder, or file
+    Scan {
+        /// Path to project, folder, or file
+        path: PathBuf,
+    },
 }
 
 fn main() {
@@ -24,8 +28,6 @@ fn main() {
     match cli.command {
         Commands::Scan { path } => match scan_path(&path) {
             Ok(summary) => {
-                println!("RepoPilot Scan");
-                println!("Path: {}", path.display());
                 print_summary(&summary);
             }
             Err(error) => {
@@ -37,8 +39,37 @@ fn main() {
 }
 
 fn print_summary(summary: &ScanSummary) {
+    println!("RepoPilot Scan");
+    println!("Path: {}", summary.root_path.display());
+    println!();
+
     println!("Files analyzed: {}", summary.files_count);
     println!("Directories analyzed: {}", summary.directories_count);
-    println!("Total lines of code: {}", summary.total_lines);
-    println!("Text files analyzed: {}", summary.text_files_count);
+    println!("Lines of code: {}", summary.lines_of_code);
+    println!();
+
+    println!("Languages:");
+    if summary.languages.is_empty() {
+        println!("  No languages detected");
+    } else {
+        for language in &summary.languages {
+            println!("  {}: {} files", language.name, language.files_count);
+        }
+    }
+
+    println!();
+    println!("Code markers:");
+    if summary.markers.is_empty() {
+        println!("  No TODO/FIXME/HACK markers found");
+    } else {
+        for marker in &summary.markers {
+            println!(
+                "  [{}] {}:{} — {}",
+                marker.kind,
+                marker.path.display(),
+                marker.line_number,
+                marker.text.trim()
+            );
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,4 +39,5 @@ fn main() {
 fn print_summary(summary: &ScanSummary) {
     println!("Files analyzed: {}", summary.files_count);
     println!("Directories analyzed: {}", summary.directories_count);
+    println!("Total lines of code: {}", summary.total_lines);
 }

--- a/src/scan/language.rs
+++ b/src/scan/language.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+pub fn detect_language(path: &Path) -> Option<&'static str> {
+    let extension = path.extension()?.to_str()?;
+
+    match extension {
+        "rs" => Some("Rust"),
+        "js" => Some("JavaScript"),
+        "jsx" => Some("JavaScript React"),
+        "ts" => Some("TypeScript"),
+        "tsx" => Some("TypeScript React"),
+        "py" => Some("Python"),
+        "go" => Some("Go"),
+        "java" => Some("Java"),
+        "kt" => Some("Kotlin"),
+        "swift" => Some("Swift"),
+        "cs" => Some("C#"),
+        "cpp" | "cc" | "cxx" => Some("C++"),
+        "c" => Some("C"),
+        "h" | "hpp" => Some("C/C++ Header"),
+        "html" => Some("HTML"),
+        "css" => Some("CSS"),
+        "scss" => Some("SCSS"),
+        "json" => Some("JSON"),
+        "toml" => Some("TOML"),
+        "yaml" | "yml" => Some("YAML"),
+        "md" => Some("Markdown"),
+        _ => None,
+    }
+}

--- a/src/scan/markers.rs
+++ b/src/scan/markers.rs
@@ -1,0 +1,31 @@
+use crate::scan::types::{CodeMarker, MarkerKind};
+use std::path::Path;
+
+pub fn detect_markers(path: &Path, content: &str) -> Vec<CodeMarker> {
+    let mut markers = Vec::new();
+
+    for (index, line) in content.lines().enumerate() {
+        if line.contains("TODO") {
+            markers.push(build_marker(path, index, line, MarkerKind::Todo));
+        }
+
+        if line.contains("FIXME") {
+            markers.push(build_marker(path, index, line, MarkerKind::Fixme));
+        }
+
+        if line.contains("HACK") {
+            markers.push(build_marker(path, index, line, MarkerKind::Hack));
+        }
+    }
+
+    markers
+}
+
+fn build_marker(path: &Path, index: usize, line: &str, kind: MarkerKind) -> CodeMarker {
+    CodeMarker {
+        kind,
+        path: path.to_path_buf(),
+        line_number: index + 1,
+        text: line.to_string(),
+    }
+}

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -1,2 +1,4 @@
+pub mod language;
+pub mod markers;
 pub mod scanner;
 pub mod types;

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -21,6 +21,8 @@ fn scan_directory(path: &Path, summary: &mut ScanSummary) -> io::Result<()> {
 
         if metadata.is_file() {
             summary.files_count += 1;
+            let count_file_lines = count_file_lines(&entry.path())?;
+            summary.total_lines += count_file_lines;
         }
 
         if metadata.is_dir() {
@@ -44,4 +46,9 @@ fn is_ignored_directory(path: &Path) -> bool {
     };
 
     IGNORED_DIRECTORIES.contains(&directory_name)
+}
+
+fn count_file_lines(path: &Path) -> io::Result<usize> {
+    let content = fs::read_to_string(path)?;
+    Ok(content.lines().count())
 }

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -5,6 +5,10 @@ use std::path::Path;
 use super::types::ScanSummary;
 
 const IGNORED_DIRECTORIES: &[&str] = &[".git", "target", "node_modules", "dist", "build", ".next"];
+const SUPPORTED_TEXT_EXTENSIONS: &[&str] = &[
+    "rs", "ts", "tsx", "js", "jsx", "py", "md", "toml", "json", "yaml", "yml", "html", "css",
+    "scss",
+];
 
 pub fn scan_path(path: &Path) -> io::Result<ScanSummary> {
     let mut summary = ScanSummary::default();
@@ -21,8 +25,12 @@ fn scan_directory(path: &Path, summary: &mut ScanSummary) -> io::Result<()> {
 
         if metadata.is_file() {
             summary.files_count += 1;
-            let count_file_lines = count_file_lines(&entry.path())?;
-            summary.total_lines += count_file_lines;
+
+            if is_supported_text_file(&entry.path()) {
+                let count_file_lines = count_file_lines(&entry.path())?;
+                summary.total_lines += count_file_lines;
+                summary.text_files_count += 1;
+            }
         }
 
         if metadata.is_dir() {
@@ -51,4 +59,12 @@ fn is_ignored_directory(path: &Path) -> bool {
 fn count_file_lines(path: &Path) -> io::Result<usize> {
     let content = fs::read_to_string(path)?;
     Ok(content.lines().count())
+}
+
+fn is_supported_text_file(path: &Path) -> bool {
+    let Some(extension) = path.extension().and_then(|ext| ext.to_str()) else {
+        return false;
+    };
+
+    SUPPORTED_TEXT_EXTENSIONS.contains(&extension)
 }

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -1,70 +1,100 @@
+use crate::scan::language::detect_language;
+use crate::scan::markers::detect_markers;
+use crate::scan::types::{LanguageSummary, ScanSummary};
+
+use ignore::WalkBuilder;
+use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::Path;
 
-use super::types::ScanSummary;
-
-const IGNORED_DIRECTORIES: &[&str] = &[".git", "target", "node_modules", "dist", "build", ".next"];
-const SUPPORTED_TEXT_EXTENSIONS: &[&str] = &[
-    "rs", "ts", "tsx", "js", "jsx", "py", "md", "toml", "json", "yaml", "yml", "html", "css",
-    "scss",
-];
-
 pub fn scan_path(path: &Path) -> io::Result<ScanSummary> {
-    let mut summary = ScanSummary::default();
+    let mut summary = ScanSummary {
+        root_path: path.to_path_buf(),
+        ..ScanSummary::default()
+    };
 
-    scan_directory(path, &mut summary)?;
+    let mut languages: HashMap<String, usize> = HashMap::new();
+
+    if path.is_file() {
+        scan_file(path, &mut summary, &mut languages)?;
+    } else {
+        scan_directory(path, &mut summary, &mut languages)?;
+    }
+
+    summary.languages = build_language_summary(languages);
 
     Ok(summary)
 }
 
-fn scan_directory(path: &Path, summary: &mut ScanSummary) -> io::Result<()> {
-    for entry in fs::read_dir(path)? {
-        let entry = entry?;
-        let metadata = entry.metadata()?;
+fn scan_directory(
+    path: &Path,
+    summary: &mut ScanSummary,
+    languages: &mut HashMap<String, usize>,
+) -> io::Result<()> {
+    let walker = WalkBuilder::new(path)
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .build();
 
-        if metadata.is_file() {
-            summary.files_count += 1;
+    for result in walker {
+        let entry = result.map_err(io::Error::other)?;
+        let entry_path = entry.path();
 
-            if is_supported_text_file(&entry.path()) {
-                let count_file_lines = count_file_lines(&entry.path())?;
-                summary.total_lines += count_file_lines;
-                summary.text_files_count += 1;
-            }
+        if entry_path == path {
+            continue;
         }
 
-        if metadata.is_dir() {
-            let entry_path = entry.path();
-
-            if is_ignored_directory(&entry_path) {
-                continue;
-            }
-
+        if entry_path.is_dir() {
             summary.directories_count += 1;
-            scan_directory(&entry_path, summary)?;
+            continue;
+        }
+
+        if entry_path.is_file() {
+            scan_file(entry_path, summary, languages)?;
         }
     }
 
     Ok(())
 }
 
-fn is_ignored_directory(path: &Path) -> bool {
-    let Some(directory_name) = path.file_name().and_then(|name| name.to_str()) else {
-        return false;
+fn scan_file(
+    path: &Path,
+    summary: &mut ScanSummary,
+    languages: &mut HashMap<String, usize>,
+) -> io::Result<()> {
+    summary.files_count += 1;
+
+    if let Some(language) = detect_language(path) {
+        *languages.entry(language.to_string()).or_insert(0) += 1;
+    }
+
+    let Ok(content) = fs::read_to_string(path) else {
+        return Ok(());
     };
 
-    IGNORED_DIRECTORIES.contains(&directory_name)
+    summary.lines_of_code += count_lines_of_code(&content);
+    summary.markers.extend(detect_markers(path, &content));
+
+    Ok(())
 }
 
-fn count_file_lines(path: &Path) -> io::Result<usize> {
-    let content = fs::read_to_string(path)?;
-    Ok(content.lines().count())
+fn count_lines_of_code(content: &str) -> usize {
+    content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count()
 }
 
-fn is_supported_text_file(path: &Path) -> bool {
-    let Some(extension) = path.extension().and_then(|ext| ext.to_str()) else {
-        return false;
-    };
+fn build_language_summary(languages: HashMap<String, usize>) -> Vec<LanguageSummary> {
+    let mut summary: Vec<LanguageSummary> = languages
+        .into_iter()
+        .map(|(name, files_count)| LanguageSummary { name, files_count })
+        .collect();
 
-    SUPPORTED_TEXT_EXTENSIONS.contains(&extension)
+    summary.sort_by(|left, right| right.files_count.cmp(&left.files_count));
+
+    summary
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -1,7 +1,42 @@
+use std::path::PathBuf;
+
 #[derive(Debug, Default)]
 pub struct ScanSummary {
+    pub root_path: PathBuf,
     pub files_count: usize,
     pub directories_count: usize,
-    pub total_lines: usize,
-    pub text_files_count: usize,
+    pub lines_of_code: usize,
+    pub languages: Vec<LanguageSummary>,
+    pub markers: Vec<CodeMarker>,
+}
+
+#[derive(Debug)]
+pub struct LanguageSummary {
+    pub name: String,
+    pub files_count: usize,
+}
+
+#[derive(Debug)]
+pub struct CodeMarker {
+    pub kind: MarkerKind,
+    pub path: PathBuf,
+    pub line_number: usize,
+    pub text: String,
+}
+
+#[derive(Debug)]
+pub enum MarkerKind {
+    Todo,
+    Fixme,
+    Hack,
+}
+
+impl std::fmt::Display for MarkerKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MarkerKind::Todo => write!(formatter, "TODO"),
+            MarkerKind::Fixme => write!(formatter, "FIXME"),
+            MarkerKind::Hack => write!(formatter, "HACK"),
+        }
+    }
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -2,4 +2,5 @@
 pub struct ScanSummary {
     pub files_count: usize,
     pub directories_count: usize,
+    pub total_lines: usize,
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -3,4 +3,5 @@ pub struct ScanSummary {
     pub files_count: usize,
     pub directories_count: usize,
     pub total_lines: usize,
+    pub text_files_count: usize,
 }


### PR DESCRIPTION
## Summary

Adds the first RepoPilot v0.1 scan slice.

This PR introduces a simple local-first scan command that can analyse a file or directory and print a console summary.

## What changed

- Added `ignore` crate for gitignore-aware file walking
- Added `scan` command support for files and folders
- Counted analyzed files and directories
- Counted non-empty lines of code
- Added basic language detection by file extension
- Added TODO/FIXME/HACK marker detection
- Added evidence for each marker:
  - file path
  - line number
  - source line text

## Why

This creates the foundation for future architecture/code quality/testing/security/performance audits.

Every future finding should follow the same evidence-first model.

## Verification

```bash
cargo fmt
cargo check
cargo run -- scan .