### PR TITLE
Add JSON output for scan summaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2024"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 ignore = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod scan;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use scan::scanner::scan_path;
 use scan::types::ScanSummary;
 use std::path::PathBuf;
@@ -19,17 +19,32 @@ enum Commands {
     Scan {
         /// Path to project, folder, or file
         path: PathBuf,
+
+        /// Output format
+        #[arg(long, value_enum, default_value_t = OutputFormat::Console)]
+        format: OutputFormat,
     },
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+enum OutputFormat {
+    Console,
+    Json,
 }
 
 fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Scan { path } => match scan_path(&path) {
-            Ok(summary) => {
-                print_summary(&summary);
-            }
+        Commands::Scan { path, format } => match scan_path(&path) {
+            Ok(summary) => match format {
+                OutputFormat::Console => {
+                    print_summary(&summary);
+                }
+                OutputFormat::Json => {
+                    print_json_summary(&summary);
+                }
+            },
             Err(error) => {
                 eprintln!("Failed to scan path: {error}");
                 std::process::exit(1);
@@ -70,6 +85,16 @@ fn print_summary(summary: &ScanSummary) {
                 marker.line_number,
                 marker.text.trim()
             );
+        }
+    }
+}
+
+fn print_json_summary(summary: &ScanSummary) {
+    match serde_json::to_string_pretty(summary) {
+        Ok(json) => println!("{json}"),
+        Err(error) => {
+            eprintln!("Failed to serialize scan summary to JSON: {error}");
+            std::process::exit(1);
         }
     }
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -1,6 +1,7 @@
+use serde::Serialize;
 use std::path::PathBuf;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize)]
 pub struct ScanSummary {
     pub root_path: PathBuf,
     pub files_count: usize,
@@ -10,13 +11,13 @@ pub struct ScanSummary {
     pub markers: Vec<CodeMarker>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct LanguageSummary {
     pub name: String,
     pub files_count: usize,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct CodeMarker {
     pub kind: MarkerKind,
     pub path: PathBuf,
@@ -24,7 +25,7 @@ pub struct CodeMarker {
     pub text: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub enum MarkerKind {
     Todo,
     Fixme,


### PR DESCRIPTION
## Summary

Adds structured JSON output for the `scan` command.

This is the next small v0.1 step after the baseline console scanner. The scan summary can now be printed either as a human-readable console report or as machine-readable JSON.

## What changed

- Added `serde` and `serde_json`
- Made scan summary types serializable
- Added `--format` option to the `scan` command
- Supported two output formats:
  - `console`
  - `json`
- Kept console output as the default behavior

## Why

RepoPilot will later generate Markdown, HTML, PDF, and comparison reports.

To support that cleanly, the scanner needs a stable structured data model first. JSON output also makes the CLI easier to test, pipe, store, and integrate with other tools.

## Verification

```bash
cargo fmt
cargo check
cargo run -- scan .
cargo run -- scan . --format json
cargo run -- scan --help