### PR TITLE
Add Markdown output for scan reports

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,3 +25,22 @@ cargo run -- scan . --format json
 cargo run -- --help
 cargo run -- scan --help
 ```
+Markdown output:
+
+```bash
+cargo run -- scan . --format markdown
+```
+
+```md
+RepoPilot currently supports:
+
+- scanning a file or directory
+- walking files with gitignore-aware rules
+- counting files and directories
+- counting non-empty lines of code
+- detecting basic languages by file extension
+- detecting TODO/FIXME/HACK markers
+- printing console output
+- printing JSON output
+- printing Markdown output
+```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,7 @@ pub enum Commands {
 pub enum OutputFormatArg {
     Console,
     Json,
+    Markdown,
 }
 
 impl From<OutputFormatArg> for OutputFormat {
@@ -34,6 +35,7 @@ impl From<OutputFormatArg> for OutputFormat {
         match format {
             OutputFormatArg::Console => OutputFormat::Console,
             OutputFormatArg::Json => OutputFormat::Json,
+            OutputFormatArg::Markdown => OutputFormat::Markdown,
         }
     }
 }

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -1,0 +1,63 @@
+use crate::scan::types::ScanSummary;
+
+pub fn render(summary: &ScanSummary) -> String {
+    let mut output = String::new();
+
+    output.push_str("# RepoPilot Scan Report\n\n");
+
+    output.push_str("## Summary\n\n");
+    output.push_str(&format!("- **Path:** `{}`\n", summary.root_path.display()));
+    output.push_str(&format!("- **Files analyzed:** {}\n", summary.files_count));
+    output.push_str(&format!(
+        "- **Directories analyzed:** {}\n",
+        summary.directories_count
+    ));
+    output.push_str(&format!(
+        "- **Lines of code:** {}\n\n",
+        summary.lines_of_code
+    ));
+
+    output.push_str("## Languages\n\n");
+
+    if summary.languages.is_empty() {
+        output.push_str("No languages detected.\n\n");
+    } else {
+        output.push_str("| Language | Files |\n");
+        output.push_str("| --- | ---: |\n");
+
+        for language in &summary.languages {
+            output.push_str(&format!(
+                "| {} | {} |\n",
+                escape_table_cell(&language.name),
+                language.files_count
+            ));
+        }
+
+        output.push('\n');
+    }
+
+    output.push_str("## Code Markers\n\n");
+
+    if summary.markers.is_empty() {
+        output.push_str("No TODO/FIXME/HACK markers found.\n");
+    } else {
+        output.push_str("| Type | File | Line | Evidence |\n");
+        output.push_str("| --- | --- | ---: | --- |\n");
+
+        for marker in &summary.markers {
+            output.push_str(&format!(
+                "| {} | `{}` | {} | {} |\n",
+                marker.kind,
+                marker.path.display(),
+                marker.line_number,
+                escape_table_cell(marker.text.trim())
+            ));
+        }
+    }
+
+    output
+}
+
+fn escape_table_cell(value: &str) -> String {
+    value.replace('|', "\\|").replace('\n', " ")
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,6 @@
 pub mod console;
 pub mod json;
+pub mod markdown;
 
 use crate::scan::types::ScanSummary;
 
@@ -7,6 +8,7 @@ use crate::scan::types::ScanSummary;
 pub enum OutputFormat {
     Console,
     Json,
+    Markdown,
 }
 
 pub fn render_scan_summary(
@@ -16,5 +18,6 @@ pub fn render_scan_summary(
     match format {
         OutputFormat::Console => Ok(console::render(summary)),
         OutputFormat::Json => json::render(summary),
+        OutputFormat::Markdown => Ok(markdown::render(summary)),
     }
 }

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -1,0 +1,62 @@
+
+use repopilot::output::{OutputFormat, render_scan_summary};
+use repopilot::scan::types::{CodeMarker, LanguageSummary, MarkerKind, ScanSummary};
+use std::path::PathBuf;
+
+#[test]
+fn renders_markdown_scan_summary() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("demo-project"),
+        files_count: 2,
+        directories_count: 1,
+        lines_of_code: 10,
+        languages: vec![
+            LanguageSummary {
+                name: "Rust".to_string(),
+                files_count: 1,
+            },
+            LanguageSummary {
+                name: "TypeScript".to_string(),
+                files_count: 1,
+            },
+        ],
+        markers: vec![CodeMarker {
+            kind: MarkerKind::Todo,
+            path: PathBuf::from("src/main.rs"),
+            line_number: 7,
+            text: "// TODO: improve architecture".to_string(),
+        }],
+    };
+
+    let output = render_scan_summary(&summary, OutputFormat::Markdown)
+        .expect("failed to render markdown summary");
+
+    assert!(output.contains("# RepoPilot Scan Report"));
+    assert!(output.contains("## Summary"));
+    assert!(output.contains("## Languages"));
+    assert!(output.contains("## Code Markers"));
+
+    assert!(output.contains("- **Path:** `demo-project`"));
+    assert!(output.contains("- **Files analyzed:** 2"));
+    assert!(output.contains("| Rust | 1 |"));
+    assert!(output.contains("| TypeScript | 1 |"));
+    assert!(output.contains("| TODO | `src/main.rs` | 7 | // TODO: improve architecture |"));
+}
+
+#[test]
+fn renders_empty_markdown_sections() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("empty-project"),
+        files_count: 0,
+        directories_count: 0,
+        lines_of_code: 0,
+        languages: vec![],
+        markers: vec![],
+    };
+
+    let output = render_scan_summary(&summary, OutputFormat::Markdown)
+        .expect("failed to render markdown summary");
+
+    assert!(output.contains("No languages detected."));
+    assert!(output.contains("No TODO/FIXME/HACK markers found."));
+}


### PR DESCRIPTION
## Summary

Adds Markdown output support for scan reports.

This PR builds on the modular output architecture by adding a dedicated Markdown renderer without changing scanner logic.

## What changed

- Added `src/output/markdown.rs`
- Added `markdown` to supported output formats
- Updated CLI support for `--format markdown`
- Added Markdown output tests
- Updated README usage docs
- Updated architecture docs for report output formats

## Why

RepoPilot should eventually generate JSON, Markdown, HTML, and PDF reports from the same scan model.

Markdown is the next small step because it is easy to read, easy to commit, and useful for PR reviews, documentation, and local audit reports.

## Architecture notes

The scanner still only produces structured data.

The output layer is responsible for rendering that data into different formats:

- console
- JSON
- Markdown

This keeps the code modular and avoids turning scanner or main into god files.

## Verification

```bash
cargo fmt
cargo check
cargo test
cargo run -- scan .
cargo run -- scan . --format json
cargo run -- scan . --format markdown
cargo run -- scan --help