### PR TITLE
Add output file support for scan reports

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,13 @@ Markdown output:
 ```bash
 cargo run -- scan . --format markdown
 ```
+Write report to file:
+
+```bash
+cargo run -- scan . --format markdown --output report.md
+cargo run -- scan . --format json --output report.json
+cargo run -- scan . --format console --output report.txt
+```
 
 ```md
 RepoPilot currently supports:
@@ -43,4 +50,5 @@ RepoPilot currently supports:
 - printing console output
 - printing JSON output
 - printing Markdown output
+- writing reports to files with `--output`
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,14 +1,19 @@
 use crate::cli::{Cli, Commands};
 use repopilot::output::render_scan_summary;
+use repopilot::report::writer::write_report;
 use repopilot::scan::scanner::scan_path;
 
 pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
-        Commands::Scan { path, format } => {
+        Commands::Scan {
+            path,
+            format,
+            output,
+        } => {
             let summary = scan_path(&path)?;
-            let output = render_scan_summary(&summary, format.into())?;
+            let rendered_report = render_scan_summary(&summary, format.into())?;
 
-            println!("{output}");
+            write_report(&rendered_report, output.as_deref())?;
 
             Ok(())
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,10 @@ pub enum Commands {
         /// Output format
         #[arg(long, value_enum, default_value = "console")]
         format: OutputFormatArg,
+
+        /// Write report to a file instead of stdout
+        #[arg(short, long)]
+        output: Option<PathBuf>,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod output;
+pub mod report;
 pub mod scan;

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,0 +1,1 @@
+pub mod writer;

--- a/src/report/writer.rs
+++ b/src/report/writer.rs
@@ -1,0 +1,25 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+pub fn write_report(content: &str, output_path: Option<&Path>) -> io::Result<()> {
+    match output_path {
+        Some(path) => write_to_file(content, path),
+        None => write_to_stdout(content),
+    }
+}
+
+fn write_to_file(content: &str, path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
+    fs::write(path, content)
+}
+
+fn write_to_stdout(content: &str) -> io::Result<()> {
+    println!("{content}");
+    Ok(())
+}

--- a/tests/report_writer.rs
+++ b/tests/report_writer.rs
@@ -1,0 +1,32 @@
+use repopilot::report::writer::write_report;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn writes_report_to_file() {
+    let temp = tempdir().expect("failed to create temp dir");
+    let output_path = temp.path().join("report.md");
+
+    write_report("# RepoPilot Report", Some(&output_path)).expect("failed to write report");
+
+    let saved = fs::read_to_string(output_path).expect("failed to read saved report");
+
+    assert_eq!(saved, "# RepoPilot Report");
+}
+
+#[test]
+fn creates_parent_directories_when_writing_report() {
+    let temp = tempdir().expect("failed to create temp dir");
+    let output_path = temp.path().join("reports").join("scan").join("report.md");
+
+    write_report("nested report", Some(&output_path)).expect("failed to write nested report");
+
+    let saved = fs::read_to_string(output_path).expect("failed to read saved report");
+
+    assert_eq!(saved, "nested report");
+}
+
+#[test]
+fn stdout_report_without_output_file_does_not_fail() {
+    write_report("console report", None).expect("stdout report should not fail");
+}


### PR DESCRIPTION
## Summary

Adds `--output` support for scan reports.

RepoPilot can now write rendered scan reports to files instead of only printing them to stdout.

## What changed

- Added `--output` / `-o` option to the `scan` command
- Added `src/report/` module
- Added report writer for stdout/file output
- Automatically creates missing parent directories for output files
- Added tests for report writing
- Updated README usage docs
- Updated architecture docs

## Why

RepoPilot will support multiple report formats: console, JSON, Markdown, HTML, and PDF.

Before adding more formats, we need a clean way to write generated reports to disk.

This PR keeps responsibilities separated:

- `scan` collects facts
- `output` renders reports
- `report` writes rendered content
- `app` orchestrates the flow

## Verification

```bash
cargo fmt
cargo check
cargo test

cargo run -- scan .
cargo run -- scan . --format json
cargo run -- scan . --format markdown

cargo run -- scan . --format markdown --output report.md
cargo run -- scan . --format json --output report.json
cargo run -- scan . --format console --output report.txt