### PR TITLE
Add evidence-backed finding model

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,9 +13,35 @@ RepoPilot currently supports:
 - counting files and directories
 - counting non-empty lines of code
 - detecting basic languages by file extension
-- detecting TODO/FIXME/HACK markers
+- detecting TODO/FIXME/HACK markers as evidence-backed findings
 - printing console output
 - printing JSON output
+## Findings
+
+RepoPilot uses an evidence-first finding model.
+
+Every finding should include:
+
+- stable rule id
+- title
+- description
+- category
+- severity
+- evidence
+
+Current finding categories:
+
+- architecture
+- code quality
+- testing
+- security
+- performance
+
+Current evidence includes:
+
+- file path
+- line number
+- source snippet
 
 ## Usage
 

--- a/src/findings/types.rs
+++ b/src/findings/types.rs
@@ -1,0 +1,59 @@
+use serde::Serialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Finding {
+    pub id: String,
+    pub rule_id: String,
+    pub title: String,
+    pub description: String,
+    pub category: FindingCategory,
+    pub severity: Severity,
+    pub evidence: Vec<Evidence>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum FindingCategory {
+    Architecture,
+    CodeQuality,
+    Testing,
+    Security,
+    Performance,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Severity {
+    Info,
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Evidence {
+    pub path: PathBuf,
+    pub line_start: usize,
+    pub line_end: Option<usize>,
+    pub snippet: String,
+}
+
+impl Finding {
+    pub fn severity_label(&self) -> &'static str {
+        self.severity.label()
+    }
+}
+
+impl Severity {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Severity::Info => "INFO",
+            Severity::Low => "LOW",
+            Severity::Medium => "MEDIUM",
+            Severity::High => "HIGH",
+            Severity::Critical => "CRITICAL",
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod findings;
 pub mod output;
 pub mod report;
 pub mod scan;

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -26,19 +26,27 @@ pub fn render(summary: &ScanSummary) -> String {
         }
     }
 
-    output.push_str("\nCode markers:\n");
+    output.push_str("\nFindings:\n");
 
-    if summary.markers.is_empty() {
-        output.push_str("  No TODO/FIXME/HACK markers found\n");
+    if summary.findings.is_empty() {
+        output.push_str("  No findings found\n");
     } else {
-        for marker in &summary.markers {
+        for finding in &summary.findings {
             output.push_str(&format!(
-                "  [{}] {}:{} — {}\n",
-                marker.kind,
-                marker.path.display(),
-                marker.line_number,
-                marker.text.trim()
+                "  [{}] {} — {}\n",
+                finding.severity_label(),
+                finding.rule_id,
+                finding.title
             ));
+
+            for evidence in &finding.evidence {
+                output.push_str(&format!(
+                    "    Evidence: {}:{} — {}\n",
+                    evidence.path.display(),
+                    evidence.line_start,
+                    evidence.snippet.trim()
+                ));
+            }
         }
     }
 

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -36,21 +36,34 @@ pub fn render(summary: &ScanSummary) -> String {
         output.push('\n');
     }
 
-    output.push_str("## Code Markers\n\n");
+    output.push_str("## Findings\n\n");
 
-    if summary.markers.is_empty() {
-        output.push_str("No TODO/FIXME/HACK markers found.\n");
+    if summary.findings.is_empty() {
+        output.push_str("No findings found.\n");
     } else {
-        output.push_str("| Type | File | Line | Evidence |\n");
-        output.push_str("| --- | --- | ---: | --- |\n");
+        output.push_str("| Severity | Rule | Title | Evidence |\n");
+        output.push_str("| --- | --- | --- | --- |\n");
 
-        for marker in &summary.markers {
+        for finding in &summary.findings {
+            let evidence = finding
+                .evidence
+                .first()
+                .map(|evidence| {
+                    format!(
+                        "`{}:{}` — {}",
+                        evidence.path.display(),
+                        evidence.line_start,
+                        evidence.snippet.trim()
+                    )
+                })
+                .unwrap_or_else(|| "No evidence".to_string());
+
             output.push_str(&format!(
                 "| {} | `{}` | {} | {} |\n",
-                marker.kind,
-                marker.path.display(),
-                marker.line_number,
-                escape_table_cell(marker.text.trim())
+                finding.severity_label(),
+                finding.rule_id,
+                escape_table_cell(&finding.title),
+                escape_table_cell(&evidence)
             ));
         }
     }

--- a/src/scan/markers.rs
+++ b/src/scan/markers.rs
@@ -1,31 +1,53 @@
-use crate::scan::types::{CodeMarker, MarkerKind};
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use std::path::Path;
 
-pub fn detect_markers(path: &Path, content: &str) -> Vec<CodeMarker> {
-    let mut markers = Vec::new();
+pub fn detect_marker_findings(path: &Path, content: &str) -> Vec<Finding> {
+    let mut findings = Vec::new();
 
     for (index, line) in content.lines().enumerate() {
         if line.contains("TODO") {
-            markers.push(build_marker(path, index, line, MarkerKind::Todo));
+            findings.push(build_marker_finding(path, index, line, "todo"));
         }
 
         if line.contains("FIXME") {
-            markers.push(build_marker(path, index, line, MarkerKind::Fixme));
+            findings.push(build_marker_finding(path, index, line, "fixme"));
         }
 
         if line.contains("HACK") {
-            markers.push(build_marker(path, index, line, MarkerKind::Hack));
+            findings.push(build_marker_finding(path, index, line, "hack"));
         }
     }
 
-    markers
+    findings
 }
 
-fn build_marker(path: &Path, index: usize, line: &str, kind: MarkerKind) -> CodeMarker {
-    CodeMarker {
-        kind,
-        path: path.to_path_buf(),
-        line_number: index + 1,
-        text: line.to_string(),
+fn build_marker_finding(path: &Path, index: usize, line: &str, marker: &str) -> Finding {
+    let line_number = index + 1;
+    let uppercase_marker = marker.to_uppercase();
+
+    Finding {
+        id: format!("code-marker.{}.{}:{}", marker, path.display(), line_number),
+        rule_id: format!("code-marker.{marker}"),
+        title: format!("{uppercase_marker} marker found"),
+        description: format!(
+            "A {uppercase_marker} marker was found in the codebase and should be reviewed."
+        ),
+        category: FindingCategory::CodeQuality,
+        severity: marker_severity(marker),
+        evidence: vec![Evidence {
+            path: path.to_path_buf(),
+            line_start: line_number,
+            line_end: None,
+            snippet: line.trim().to_string(),
+        }],
+    }
+}
+
+fn marker_severity(marker: &str) -> Severity {
+    match marker {
+        "fixme" => Severity::Medium,
+        "hack" => Severity::Medium,
+        "todo" => Severity::Low,
+        _ => Severity::Info,
     }
 }

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -1,5 +1,5 @@
 use crate::scan::language::detect_language;
-use crate::scan::markers::detect_markers;
+use crate::scan::markers::detect_marker_findings;
 use crate::scan::types::{LanguageSummary, ScanSummary};
 
 use ignore::WalkBuilder;
@@ -87,7 +87,9 @@ fn scan_file(
     };
 
     summary.lines_of_code += count_lines_of_code(&content);
-    summary.markers.extend(detect_markers(path, &content));
+    summary
+        .findings
+        .extend(detect_marker_findings(path, &content));
 
     Ok(())
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -1,3 +1,4 @@
+use crate::findings::types::Finding;
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -8,37 +9,11 @@ pub struct ScanSummary {
     pub directories_count: usize,
     pub lines_of_code: usize,
     pub languages: Vec<LanguageSummary>,
-    pub markers: Vec<CodeMarker>,
+    pub findings: Vec<Finding>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct LanguageSummary {
     pub name: String,
     pub files_count: usize,
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub struct CodeMarker {
-    pub kind: MarkerKind,
-    pub path: PathBuf,
-    pub line_number: usize,
-    pub text: String,
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum MarkerKind {
-    Todo,
-    Fixme,
-    Hack,
-}
-
-impl std::fmt::Display for MarkerKind {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            MarkerKind::Todo => write!(formatter, "TODO"),
-            MarkerKind::Fixme => write!(formatter, "FIXME"),
-            MarkerKind::Hack => write!(formatter, "HACK"),
-        }
-    }
 }

--- a/tests/finding_model.rs
+++ b/tests/finding_model.rs
@@ -1,0 +1,27 @@
+use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use std::path::PathBuf;
+
+#[test]
+fn finding_contains_evidence() {
+    let finding = Finding {
+        id: "code-marker.todo.src/main.rs:10".to_string(),
+        rule_id: "code-marker.todo".to_string(),
+        title: "TODO marker found".to_string(),
+        description: "A TODO marker was found.".to_string(),
+        category: FindingCategory::CodeQuality,
+        severity: Severity::Low,
+        evidence: vec![Evidence {
+            path: PathBuf::from("src/main.rs"),
+            line_start: 10,
+            line_end: None,
+            snippet: "// TODO: improve this".to_string(),
+        }],
+    };
+
+    assert_eq!(finding.rule_id, "code-marker.todo");
+    assert_eq!(finding.category, FindingCategory::CodeQuality);
+    assert_eq!(finding.severity, Severity::Low);
+    assert_eq!(finding.severity_label(), "LOW");
+    assert_eq!(finding.evidence.len(), 1);
+    assert_eq!(finding.evidence[0].line_start, 10);
+}

--- a/tests/marker_findings.rs
+++ b/tests/marker_findings.rs
@@ -1,0 +1,33 @@
+use repopilot::findings::types::{FindingCategory, Severity};
+use repopilot::scan::markers::detect_marker_findings;
+use std::path::Path;
+
+#[test]
+fn converts_code_markers_into_evidence_backed_findings() {
+    let content = "\
+fn main() {}
+
+// TODO: improve scanner
+// FIXME: handle edge case
+// HACK: temporary workaround
+";
+
+    let findings = detect_marker_findings(Path::new("src/main.rs"), content);
+
+    assert_eq!(findings.len(), 3);
+
+    assert_eq!(findings[0].rule_id, "code-marker.todo");
+    assert_eq!(findings[0].category, FindingCategory::CodeQuality);
+    assert_eq!(findings[0].severity, Severity::Low);
+    assert_eq!(findings[0].evidence[0].path, Path::new("src/main.rs"));
+    assert_eq!(findings[0].evidence[0].line_start, 3);
+    assert!(findings[0].evidence[0].snippet.contains("TODO"));
+
+    assert_eq!(findings[1].rule_id, "code-marker.fixme");
+    assert_eq!(findings[1].severity, Severity::Medium);
+    assert_eq!(findings[1].evidence[0].line_start, 4);
+
+    assert_eq!(findings[2].rule_id, "code-marker.hack");
+    assert_eq!(findings[2].severity, Severity::Medium);
+    assert_eq!(findings[2].evidence[0].line_start, 5);
+}

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -13,7 +13,7 @@ fn renders_valid_json_scan_summary() {
             name: "Rust".to_string(),
             files_count: 1,
         }],
-        markers: vec![],
+        findings: vec![],
     };
 
     let output =

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -1,6 +1,6 @@
-
+use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use repopilot::output::{OutputFormat, render_scan_summary};
-use repopilot::scan::types::{CodeMarker, LanguageSummary, MarkerKind, ScanSummary};
+use repopilot::scan::types::{LanguageSummary, ScanSummary};
 use std::path::PathBuf;
 
 #[test]
@@ -20,11 +20,20 @@ fn renders_markdown_scan_summary() {
                 files_count: 1,
             },
         ],
-        markers: vec![CodeMarker {
-            kind: MarkerKind::Todo,
-            path: PathBuf::from("src/main.rs"),
-            line_number: 7,
-            text: "// TODO: improve architecture".to_string(),
+        findings: vec![Finding {
+            id: "code-marker.todo.src/main.rs:7".to_string(),
+            rule_id: "code-marker.todo".to_string(),
+            title: "TODO marker found".to_string(),
+            description: "A TODO marker was found in the codebase and should be reviewed."
+                .to_string(),
+            category: FindingCategory::CodeQuality,
+            severity: Severity::Low,
+            evidence: vec![Evidence {
+                path: PathBuf::from("src/main.rs"),
+                line_start: 7,
+                line_end: None,
+                snippet: "// TODO: improve architecture".to_string(),
+            }],
         }],
     };
 
@@ -34,8 +43,9 @@ fn renders_markdown_scan_summary() {
     assert!(output.contains("# RepoPilot Scan Report"));
     assert!(output.contains("## Summary"));
     assert!(output.contains("## Languages"));
-    assert!(output.contains("## Code Markers"));
-
+    assert!(output.contains("## Findings"));
+    assert!(output.contains("| LOW | `code-marker.todo` | TODO marker found |"));
+    assert!(output.contains("`src/main.rs:7`"));
     assert!(output.contains("- **Path:** `demo-project`"));
     assert!(output.contains("- **Files analyzed:** 2"));
     assert!(output.contains("| Rust | 1 |"));
@@ -51,12 +61,13 @@ fn renders_empty_markdown_sections() {
         directories_count: 0,
         lines_of_code: 0,
         languages: vec![],
-        markers: vec![],
+        findings: vec![],
     };
 
     let output = render_scan_summary(&summary, OutputFormat::Markdown)
         .expect("failed to render markdown summary");
 
     assert!(output.contains("No languages detected."));
+    assert!(output.contains("No findings found."));
     assert!(output.contains("No TODO/FIXME/HACK markers found."));
 }

--- a/tests/scan_summary.rs
+++ b/tests/scan_summary.rs
@@ -25,7 +25,9 @@ fn scans_directory_with_counts_languages_and_markers() {
     assert_eq!(summary.directories_count, 1);
     assert_eq!(summary.files_count, 3);
     assert_eq!(summary.lines_of_code, 4);
-    assert_eq!(summary.markers.len(), 1);
+    assert_eq!(summary.findings.len(), 1);
+    assert_eq!(summary.findings[0].rule_id, "code-marker.todo");
+    assert_eq!(summary.findings[0].evidence[0].line_start, 3);
 
     assert!(
         summary


### PR DESCRIPTION
## Summary

Adds a shared evidence-backed finding model and converts TODO/FIXME/HACK markers into first-class findings.

## What changed

- Added `src/findings/` module
- Added shared `Finding`, `Evidence`, `FindingCategory`, and `Severity` types
- Replaced raw scan markers with evidence-backed findings
- Converted TODO/FIXME/HACK detection into finding generation
- Updated console output to display findings and evidence
- Updated Markdown output to display findings and evidence
- Updated JSON output through the new scan summary structure
- Added tests for the finding model
- Added tests for marker-to-finding conversion
- Updated existing output and scan tests
- Updated README and architecture docs

## Why

RepoPilot’s core product rule is:

> Every finding must have evidence.

This PR introduces that foundation early, before adding more audit categories or report formats.

Instead of treating TODO/FIXME/HACK as raw markers, they now become structured findings with:

- stable rule ids
- category
- severity
- description
- source evidence

## Architecture notes

The finding model is separated into its own module because it will be reused by future audit modules:

- architecture
- code quality
- testing
- security
- performance

The scanner still collects facts from files, while findings represent audit results.

## Verification

```bash
cargo fmt
cargo check
cargo test

cargo run -- scan .
cargo run -- scan . --format json
cargo run -- scan . --format markdown
cargo run -- scan . --format markdown --output report.md