### PR TITLE
Add large file architecture finding

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,8 @@ RepoPilot currently supports:
 - detecting TODO/FIXME/HACK markers as evidence-backed findings
 - printing console output
 - printing JSON output
+- detecting large files as architecture findings
+
 ## Findings
 
 RepoPilot uses an evidence-first finding model.
@@ -42,6 +44,19 @@ Current evidence includes:
 - file path
 - line number
 - source snippet
+
+Current rules:
+
+- `code-marker.todo`
+- `code-marker.fixme`
+- `code-marker.hack`
+- `architecture.large-file`
+
+## Example
+
+```bash
+cargo run -- scan . --format markdown --output report.md
+```
 
 ## Usage
 

--- a/src/audits/architecture/large_file.rs
+++ b/src/audits/architecture/large_file.rs
@@ -1,0 +1,38 @@
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use std::path::Path;
+
+pub const LARGE_FILE_LOC_THRESHOLD: usize = 300;
+const HIGH_SEVERITY_LOC_THRESHOLD: usize = 1000;
+
+pub fn detect_large_file_finding(path: &Path, lines_of_code: usize) -> Option<Finding> {
+    if lines_of_code <= LARGE_FILE_LOC_THRESHOLD {
+        return None;
+    }
+
+    Some(Finding {
+        id: format!("architecture.large-file.{}", path.display()),
+        rule_id: "architecture.large-file".to_string(),
+        title: "Large file detected".to_string(),
+        description: format!(
+            "This file has {lines_of_code} non-empty lines of code, which is above the recommended threshold of {LARGE_FILE_LOC_THRESHOLD}. Consider splitting responsibilities into smaller modules."
+        ),
+        category: FindingCategory::Architecture,
+        severity: severity_for_loc(lines_of_code),
+        evidence: vec![Evidence {
+            path: path.to_path_buf(),
+            line_start: 1,
+            line_end: None,
+            snippet: format!(
+                "File has {lines_of_code} non-empty lines of code; threshold is {LARGE_FILE_LOC_THRESHOLD}."
+            ),
+        }],
+    })
+}
+
+fn severity_for_loc(lines_of_code: usize) -> Severity {
+    if lines_of_code >= HIGH_SEVERITY_LOC_THRESHOLD {
+        Severity::High
+    } else {
+        Severity::Medium
+    }
+}

--- a/src/audits/architecture/mod.rs
+++ b/src/audits/architecture/mod.rs
@@ -1,0 +1,1 @@
+pub mod large_file;

--- a/src/audits/mod.rs
+++ b/src/audits/mod.rs
@@ -1,0 +1,1 @@
+pub mod architecture;

--- a/src/findings/mod.rs
+++ b/src/findings/mod.rs
@@ -1,0 +1,1 @@
+pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod audits;
 pub mod findings;
 pub mod output;
 pub mod report;

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -1,3 +1,4 @@
+use crate::audits::architecture::large_file::detect_large_file_finding;
 use crate::scan::language::detect_language;
 use crate::scan::markers::detect_marker_findings;
 use crate::scan::types::{LanguageSummary, ScanSummary};
@@ -86,7 +87,13 @@ fn scan_file(
         return Ok(());
     };
 
-    summary.lines_of_code += count_lines_of_code(&content);
+    let lines_of_code = count_lines_of_code(&content);
+    summary.lines_of_code += lines_of_code;
+
+    if let Some(finding) = detect_large_file_finding(path, lines_of_code) {
+        summary.findings.push(finding);
+    }
+
     summary
         .findings
         .extend(detect_marker_findings(path, &content));

--- a/tests/large_file_architecture.rs
+++ b/tests/large_file_architecture.rs
@@ -1,0 +1,40 @@
+use repopilot::audits::architecture::large_file::{
+    LARGE_FILE_LOC_THRESHOLD, detect_large_file_finding,
+};
+use repopilot::findings::types::{FindingCategory, Severity};
+use std::path::Path;
+
+#[test]
+fn does_not_create_finding_when_file_is_under_threshold() {
+    let finding = detect_large_file_finding(Path::new("src/small.rs"), LARGE_FILE_LOC_THRESHOLD);
+
+    assert!(finding.is_none());
+}
+
+#[test]
+fn creates_architecture_finding_when_file_is_above_threshold() {
+    let lines_of_code = LARGE_FILE_LOC_THRESHOLD + 1;
+
+    let finding = detect_large_file_finding(Path::new("src/large.rs"), lines_of_code)
+        .expect("expected large file finding");
+
+    assert_eq!(finding.rule_id, "architecture.large-file");
+    assert_eq!(finding.category, FindingCategory::Architecture);
+    assert_eq!(finding.severity, Severity::Medium);
+    assert_eq!(finding.evidence.len(), 1);
+
+    let evidence = &finding.evidence[0];
+
+    assert_eq!(evidence.path, Path::new("src/large.rs"));
+    assert_eq!(evidence.line_start, 1);
+    assert!(evidence.snippet.contains("301"));
+    assert!(evidence.snippet.contains("threshold"));
+}
+
+#[test]
+fn uses_high_severity_for_very_large_files() {
+    let finding = detect_large_file_finding(Path::new("src/huge.rs"), 1000)
+        .expect("expected huge file finding");
+
+    assert_eq!(finding.severity, Severity::High);
+}

--- a/tests/scan_large_file_finding.rs
+++ b/tests/scan_large_file_finding.rs
@@ -1,0 +1,29 @@
+use repopilot::scan::scanner::scan_path;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn scan_adds_large_file_architecture_finding() {
+    let temp = tempdir().expect("failed to create temp dir");
+    let file_path = temp.path().join("large.rs");
+
+    let content = (0..301)
+        .map(|index| format!("fn function_{index}() {{}}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    fs::write(&file_path, content).expect("failed to write large file");
+
+    let summary = scan_path(temp.path()).expect("failed to scan temp project");
+
+    let finding = summary
+        .findings
+        .iter()
+        .find(|finding| finding.rule_id == "architecture.large-file")
+        .expect("expected large file finding");
+
+    assert_eq!(finding.title, "Large file detected");
+    assert_eq!(finding.evidence.len(), 1);
+    assert_eq!(finding.evidence[0].path, file_path);
+    assert!(finding.evidence[0].snippet.contains("301"));
+}


### PR DESCRIPTION
## Summary

Adds the first architecture audit rule: large file detection.

RepoPilot now detects files with more than 300 non-empty lines of code and reports them as evidence-backed architecture findings.

## What changed

- Added `src/audits/` module
- Added `src/audits/architecture/large_file.rs`
- Added `architecture.large-file` rule
- Integrated large file detection into scan flow
- Added tests for the large file rule
- Added scan-level integration test for large file findings
- Updated README documentation

## Why

RepoPilot should not only scan files but also produce useful audit findings.

This PR introduces the first real architecture rule while keeping the implementation modular:

- scanner reads files and counts LOC
- architecture audit module owns the large-file rule
- findings module provides the shared evidence-backed result model

## Rule behavior

`architecture.large-file`

- triggers when a file has more than 300 non-empty LOC
- severity is `MEDIUM` by default
- severity becomes `HIGH` at 1000+ non-empty LOC
- evidence includes file path and LOC summary

## Verification

```bash
cargo fmt
cargo check
cargo test

cargo run -- scan .
cargo run -- scan . --format json
cargo run -- scan . --format markdown
cargo run -- scan . --format markdown --output report.md