### PR TITLE
Add configurable scan thresholds

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,8 +4,7 @@ RepoPilot is a local-first CLI for auditing codebases.
 
 The long-term goal is to scan projects, folders, or files and produce evidence-backed reports about architecture, code quality, tests, security, and performance.
 
-## Current v0.1 scope
-
+```md
 RepoPilot currently supports:
 
 - scanning a file or directory
@@ -13,11 +12,13 @@ RepoPilot currently supports:
 - counting files and directories
 - counting non-empty lines of code
 - detecting basic languages by file extension
-- detecting TODO/FIXME/HACK markers as evidence-backed findings
+- detecting TODO/FIXME/HACK markers
 - printing console output
 - printing JSON output
-- detecting large files as architecture findings
-
+- printing Markdown output
+- writing reports to files with `--output`
+- configuring large-file threshold with `--max-file-loc`
+```
 ## Findings
 
 RepoPilot uses an evidence-first finding model.
@@ -52,6 +53,16 @@ Current rules:
 - `code-marker.hack`
 - `architecture.large-file`
 
+### Configurable thresholds
+
+The `architecture.large-file` rule uses a default threshold of 300 non-empty LOC.
+
+You can override it:
+
+```bash
+cargo run -- scan . --max-file-loc 500
+```
+
 ## Example
 
 ```bash
@@ -66,6 +77,13 @@ cargo run -- scan . --format json
 cargo run -- --help
 cargo run -- scan --help
 ```
+Custom large file threshold:
+
+```bash
+cargo run -- scan . --max-file-loc 500
+cargo run -- scan . --max-file-loc 500 --format markdown --output report.md
+```
+
 Markdown output:
 
 ```bash
@@ -77,19 +95,4 @@ Write report to file:
 cargo run -- scan . --format markdown --output report.md
 cargo run -- scan . --format json --output report.json
 cargo run -- scan . --format console --output report.txt
-```
-
-```md
-RepoPilot currently supports:
-
-- scanning a file or directory
-- walking files with gitignore-aware rules
-- counting files and directories
-- counting non-empty lines of code
-- detecting basic languages by file extension
-- detecting TODO/FIXME/HACK markers
-- printing console output
-- printing JSON output
-- printing Markdown output
-- writing reports to files with `--output`
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,8 @@
 use crate::cli::{Cli, Commands};
 use repopilot::output::render_scan_summary;
 use repopilot::report::writer::write_report;
-use repopilot::scan::scanner::scan_path;
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::scanner::scan_path_with_config;
 
 pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
@@ -9,13 +10,22 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             path,
             format,
             output,
+            max_file_loc,
         } => {
-            let summary = scan_path(&path)?;
+            let config = build_scan_config(max_file_loc);
+            let summary = scan_path_with_config(&path, &config)?;
             let rendered_report = render_scan_summary(&summary, format.into())?;
 
             write_report(&rendered_report, output.as_deref())?;
 
             Ok(())
         }
+    }
+}
+
+fn build_scan_config(max_file_loc: Option<usize>) -> ScanConfig {
+    match max_file_loc {
+        Some(threshold) => ScanConfig::default().with_large_file_loc_threshold(threshold),
+        None => ScanConfig::default(),
     }
 }

--- a/src/audits/architecture/large_file.rs
+++ b/src/audits/architecture/large_file.rs
@@ -1,11 +1,13 @@
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
 use std::path::Path;
 
-pub const LARGE_FILE_LOC_THRESHOLD: usize = 300;
-const HIGH_SEVERITY_LOC_THRESHOLD: usize = 1000;
-
-pub fn detect_large_file_finding(path: &Path, lines_of_code: usize) -> Option<Finding> {
-    if lines_of_code <= LARGE_FILE_LOC_THRESHOLD {
+pub fn detect_large_file_finding(
+    path: &Path,
+    lines_of_code: usize,
+    config: &ScanConfig,
+) -> Option<Finding> {
+    if lines_of_code <= config.large_file_loc_threshold {
         return None;
     }
 
@@ -14,23 +16,25 @@ pub fn detect_large_file_finding(path: &Path, lines_of_code: usize) -> Option<Fi
         rule_id: "architecture.large-file".to_string(),
         title: "Large file detected".to_string(),
         description: format!(
-            "This file has {lines_of_code} non-empty lines of code, which is above the recommended threshold of {LARGE_FILE_LOC_THRESHOLD}. Consider splitting responsibilities into smaller modules."
+            "This file has {lines_of_code} non-empty lines of code, which is above the configured threshold of {}. Consider splitting responsibilities into smaller modules.",
+            config.large_file_loc_threshold
         ),
         category: FindingCategory::Architecture,
-        severity: severity_for_loc(lines_of_code),
+        severity: severity_for_loc(lines_of_code, config),
         evidence: vec![Evidence {
             path: path.to_path_buf(),
             line_start: 1,
             line_end: None,
             snippet: format!(
-                "File has {lines_of_code} non-empty lines of code; threshold is {LARGE_FILE_LOC_THRESHOLD}."
+                "File has {lines_of_code} non-empty lines of code; configured threshold is {}.",
+                config.large_file_loc_threshold
             ),
         }],
     })
 }
 
-fn severity_for_loc(lines_of_code: usize) -> Severity {
-    if lines_of_code >= HIGH_SEVERITY_LOC_THRESHOLD {
+fn severity_for_loc(lines_of_code: usize, config: &ScanConfig) -> Severity {
+    if lines_of_code >= config.huge_file_loc_threshold {
         Severity::High
     } else {
         Severity::Medium

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,10 @@ pub enum Commands {
         /// Write report to a file instead of stdout
         #[arg(short, long)]
         output: Option<PathBuf>,
+
+        /// Maximum non-empty LOC before a file is reported as large
+        #[arg(long)]
+        max_file_loc: Option<usize>,
     },
 }
 

--- a/src/scan/config.rs
+++ b/src/scan/config.rs
@@ -1,0 +1,26 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScanConfig {
+    pub large_file_loc_threshold: usize,
+    pub huge_file_loc_threshold: usize,
+}
+
+impl Default for ScanConfig {
+    fn default() -> Self {
+        Self {
+            large_file_loc_threshold: 300,
+            huge_file_loc_threshold: 1000,
+        }
+    }
+}
+
+impl ScanConfig {
+    pub fn with_large_file_loc_threshold(mut self, threshold: usize) -> Self {
+        self.large_file_loc_threshold = threshold;
+
+        if self.huge_file_loc_threshold <= threshold {
+            self.huge_file_loc_threshold = threshold.saturating_mul(3).max(threshold + 1);
+        }
+
+        self
+    }
+}

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod language;
 pub mod markers;
 pub mod scanner;

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -1,4 +1,5 @@
 use crate::audits::architecture::large_file::detect_large_file_finding;
+use crate::scan::config::ScanConfig;
 use crate::scan::language::detect_language;
 use crate::scan::markers::detect_marker_findings;
 use crate::scan::types::{LanguageSummary, ScanSummary};
@@ -10,6 +11,10 @@ use std::io;
 use std::path::Path;
 
 pub fn scan_path(path: &Path) -> io::Result<ScanSummary> {
+    scan_path_with_config(path, &ScanConfig::default())
+}
+
+pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<ScanSummary> {
     if !path.exists() {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
@@ -25,9 +30,9 @@ pub fn scan_path(path: &Path) -> io::Result<ScanSummary> {
     let mut languages: HashMap<String, usize> = HashMap::new();
 
     if path.is_file() {
-        scan_file(path, &mut summary, &mut languages)?;
+        scan_file(path, &mut summary, &mut languages, config)?;
     } else {
-        scan_directory(path, &mut summary, &mut languages)?;
+        scan_directory(path, &mut summary, &mut languages, config)?;
     }
 
     summary.languages = build_language_summary(languages);
@@ -39,6 +44,7 @@ fn scan_directory(
     path: &Path,
     summary: &mut ScanSummary,
     languages: &mut HashMap<String, usize>,
+    config: &ScanConfig,
 ) -> io::Result<()> {
     let walker = WalkBuilder::new(path)
         .hidden(false)
@@ -65,7 +71,7 @@ fn scan_directory(
         }
 
         if file_type.is_file() {
-            scan_file(entry_path, summary, languages)?;
+            scan_file(entry_path, summary, languages, config)?;
         }
     }
 
@@ -76,6 +82,7 @@ fn scan_file(
     path: &Path,
     summary: &mut ScanSummary,
     languages: &mut HashMap<String, usize>,
+    config: &ScanConfig,
 ) -> io::Result<()> {
     summary.files_count += 1;
 
@@ -90,7 +97,7 @@ fn scan_file(
     let lines_of_code = count_lines_of_code(&content);
     summary.lines_of_code += lines_of_code;
 
-    if let Some(finding) = detect_large_file_finding(path, lines_of_code) {
+    if let Some(finding) = detect_large_file_finding(path, lines_of_code, config) {
         summary.findings.push(finding);
     }
 

--- a/tests/large_file_architecture.rs
+++ b/tests/large_file_architecture.rs
@@ -1,21 +1,27 @@
-use repopilot::audits::architecture::large_file::{
-    LARGE_FILE_LOC_THRESHOLD, detect_large_file_finding,
-};
+use repopilot::audits::architecture::large_file::detect_large_file_finding;
 use repopilot::findings::types::{FindingCategory, Severity};
+use repopilot::scan::config::ScanConfig;
 use std::path::Path;
 
 #[test]
 fn does_not_create_finding_when_file_is_under_threshold() {
-    let finding = detect_large_file_finding(Path::new("src/small.rs"), LARGE_FILE_LOC_THRESHOLD);
+    let config = ScanConfig::default();
+
+    let finding = detect_large_file_finding(
+        Path::new("src/small.rs"),
+        config.large_file_loc_threshold,
+        &config,
+    );
 
     assert!(finding.is_none());
 }
 
 #[test]
 fn creates_architecture_finding_when_file_is_above_threshold() {
-    let lines_of_code = LARGE_FILE_LOC_THRESHOLD + 1;
+    let config = ScanConfig::default();
+    let lines_of_code = config.large_file_loc_threshold + 1;
 
-    let finding = detect_large_file_finding(Path::new("src/large.rs"), lines_of_code)
+    let finding = detect_large_file_finding(Path::new("src/large.rs"), lines_of_code, &config)
         .expect("expected large file finding");
 
     assert_eq!(finding.rule_id, "architecture.large-file");
@@ -28,13 +34,32 @@ fn creates_architecture_finding_when_file_is_above_threshold() {
     assert_eq!(evidence.path, Path::new("src/large.rs"));
     assert_eq!(evidence.line_start, 1);
     assert!(evidence.snippet.contains("301"));
-    assert!(evidence.snippet.contains("threshold"));
+    assert!(evidence.snippet.contains("configured threshold"));
 }
 
 #[test]
 fn uses_high_severity_for_very_large_files() {
-    let finding = detect_large_file_finding(Path::new("src/huge.rs"), 1000)
-        .expect("expected huge file finding");
+    let config = ScanConfig::default();
+
+    let finding = detect_large_file_finding(
+        Path::new("src/huge.rs"),
+        config.huge_file_loc_threshold,
+        &config,
+    )
+    .expect("expected huge file finding");
 
     assert_eq!(finding.severity, Severity::High);
+}
+
+#[test]
+fn respects_custom_large_file_threshold() {
+    let config = ScanConfig::default().with_large_file_loc_threshold(500);
+
+    let below_custom_threshold =
+        detect_large_file_finding(Path::new("src/not_large.rs"), 400, &config);
+
+    let above_custom_threshold = detect_large_file_finding(Path::new("src/large.rs"), 501, &config);
+
+    assert!(below_custom_threshold.is_none());
+    assert!(above_custom_threshold.is_some());
 }

--- a/tests/scan_config.rs
+++ b/tests/scan_config.rs
@@ -1,0 +1,25 @@
+use repopilot::scan::config::ScanConfig;
+
+#[test]
+fn default_scan_config_uses_expected_thresholds() {
+    let config = ScanConfig::default();
+
+    assert_eq!(config.large_file_loc_threshold, 300);
+    assert_eq!(config.huge_file_loc_threshold, 1000);
+}
+
+#[test]
+fn custom_large_file_threshold_updates_config() {
+    let config = ScanConfig::default().with_large_file_loc_threshold(500);
+
+    assert_eq!(config.large_file_loc_threshold, 500);
+    assert_eq!(config.huge_file_loc_threshold, 1000);
+}
+
+#[test]
+fn custom_threshold_keeps_huge_threshold_above_large_threshold() {
+    let config = ScanConfig::default().with_large_file_loc_threshold(1200);
+
+    assert_eq!(config.large_file_loc_threshold, 1200);
+    assert!(config.huge_file_loc_threshold > config.large_file_loc_threshold);
+}

--- a/tests/scan_custom_threshold.rs
+++ b/tests/scan_custom_threshold.rs
@@ -1,0 +1,52 @@
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::scanner::scan_path_with_config;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn scan_respects_custom_large_file_threshold() {
+    let temp = tempdir().expect("failed to create temp dir");
+    let file_path = temp.path().join("medium.rs");
+
+    let content = (0..301)
+        .map(|index| format!("fn function_{index}() {{}}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    fs::write(file_path, content).expect("failed to write file");
+
+    let config = ScanConfig::default().with_large_file_loc_threshold(500);
+    let summary = scan_path_with_config(temp.path(), &config).expect("failed to scan temp project");
+
+    assert!(
+        summary
+            .findings
+            .iter()
+            .all(|finding| finding.rule_id != "architecture.large-file")
+    );
+}
+
+#[test]
+fn scan_still_reports_file_above_custom_threshold() {
+    let temp = tempdir().expect("failed to create temp dir");
+    let file_path = temp.path().join("large.rs");
+
+    let content = (0..501)
+        .map(|index| format!("fn function_{index}() {{}}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    fs::write(file_path, content).expect("failed to write file");
+
+    let config = ScanConfig::default().with_large_file_loc_threshold(500);
+    let summary = scan_path_with_config(temp.path(), &config).expect("failed to scan temp project");
+
+    let finding = summary
+        .findings
+        .iter()
+        .find(|finding| finding.rule_id == "architecture.large-file")
+        .expect("expected large file finding");
+
+    assert!(finding.evidence[0].snippet.contains("501"));
+    assert!(finding.evidence[0].snippet.contains("500"));
+}


### PR DESCRIPTION
## Summary

Adds configurable scan thresholds for architecture rules.

RepoPilot now supports overriding the large-file LOC threshold through the CLI with `--max-file-loc`.

## What changed

- Added `ScanConfig`
- Added default scan thresholds:
  - large file: 300 non-empty LOC
  - huge file: 1000 non-empty LOC
- Added `scan_path_with_config()`
- Kept `scan_path()` as the default-config helper
- Updated `architecture.large-file` to use `ScanConfig`
- Added `--max-file-loc` CLI option
- Added config tests
- Added custom threshold scan tests
- Updated README

## Why

The large-file threshold should not be permanently hardcoded.

Different projects have different acceptable file sizes, so RepoPilot needs a clean configuration path before adding more audit rules.

## Architecture notes

The new flow is:

```txt
CLI args
  ↓
ScanConfig
  ↓
scanner
  ↓
audit rules
  ↓
findings