### PR TITLE
Introduce file facts audit pipeline

### DIFF
--- a/src/audits/code_quality/code_markers.rs
+++ b/src/audits/code_quality/code_markers.rs
@@ -1,7 +1,7 @@
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use std::path::Path;
 
-pub fn detect_marker_findings(path: &Path, content: &str) -> Vec<Finding> {
+pub fn detect_code_marker_findings(path: &Path, content: &str) -> Vec<Finding> {
     let mut findings = Vec::new();
 
     for (index, line) in content.lines().enumerate() {

--- a/src/audits/code_quality/mod.rs
+++ b/src/audits/code_quality/mod.rs
@@ -1,0 +1,1 @@
+pub mod code_markers;

--- a/src/audits/mod.rs
+++ b/src/audits/mod.rs
@@ -1,1 +1,3 @@
 pub mod architecture;
+pub mod code_quality;
+pub mod pipeline;

--- a/src/audits/pipeline.rs
+++ b/src/audits/pipeline.rs
@@ -1,0 +1,27 @@
+use crate::audits::architecture::large_file::detect_large_file_finding;
+use crate::audits::code_quality::code_markers::detect_code_marker_findings;
+use crate::findings::types::Finding;
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::{FileFacts, ScanFacts};
+
+pub fn run_audits(scan_facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    for file in &scan_facts.files {
+        findings.extend(run_file_audits(file, config));
+    }
+
+    findings
+}
+
+fn run_file_audits(file: &FileFacts, config: &ScanConfig) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    if let Some(finding) = detect_large_file_finding(&file.path, file.lines_of_code, config) {
+        findings.push(finding);
+    }
+
+    findings.extend(detect_code_marker_findings(&file.path, &file.content));
+
+    findings
+}

--- a/src/scan/facts.rs
+++ b/src/scan/facts.rs
@@ -1,0 +1,20 @@
+use crate::scan::types::LanguageSummary;
+use std::path::PathBuf;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ScanFacts {
+    pub root_path: PathBuf,
+    pub files_count: usize,
+    pub directories_count: usize,
+    pub lines_of_code: usize,
+    pub languages: Vec<LanguageSummary>,
+    pub files: Vec<FileFacts>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileFacts {
+    pub path: PathBuf,
+    pub language: Option<String>,
+    pub lines_of_code: usize,
+    pub content: String,
+}

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -1,5 +1,5 @@
 pub mod config;
+pub mod facts;
 pub mod language;
-pub mod markers;
 pub mod scanner;
 pub mod types;

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -1,7 +1,7 @@
-use crate::audits::architecture::large_file::detect_large_file_finding;
+use crate::audits::pipeline::run_audits;
 use crate::scan::config::ScanConfig;
+use crate::scan::facts::{FileFacts, ScanFacts};
 use crate::scan::language::detect_language;
-use crate::scan::markers::detect_marker_findings;
 use crate::scan::types::{LanguageSummary, ScanSummary};
 
 use ignore::WalkBuilder;
@@ -15,6 +15,20 @@ pub fn scan_path(path: &Path) -> io::Result<ScanSummary> {
 }
 
 pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<ScanSummary> {
+    let facts = collect_scan_facts(path)?;
+    let findings = run_audits(&facts, config);
+
+    Ok(ScanSummary {
+        root_path: facts.root_path,
+        files_count: facts.files_count,
+        directories_count: facts.directories_count,
+        lines_of_code: facts.lines_of_code,
+        languages: facts.languages,
+        findings,
+    })
+}
+
+pub fn collect_scan_facts(path: &Path) -> io::Result<ScanFacts> {
     if !path.exists() {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
@@ -22,29 +36,28 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
         ));
     }
 
-    let mut summary = ScanSummary {
+    let mut facts = ScanFacts {
         root_path: path.to_path_buf(),
-        ..ScanSummary::default()
+        ..ScanFacts::default()
     };
 
     let mut languages: HashMap<String, usize> = HashMap::new();
 
     if path.is_file() {
-        scan_file(path, &mut summary, &mut languages, config)?;
+        collect_file_facts(path, &mut facts, &mut languages)?;
     } else {
-        scan_directory(path, &mut summary, &mut languages, config)?;
+        collect_directory_facts(path, &mut facts, &mut languages)?;
     }
 
-    summary.languages = build_language_summary(languages);
+    facts.languages = build_language_summary(languages);
 
-    Ok(summary)
+    Ok(facts)
 }
 
-fn scan_directory(
+fn collect_directory_facts(
     path: &Path,
-    summary: &mut ScanSummary,
+    facts: &mut ScanFacts,
     languages: &mut HashMap<String, usize>,
-    config: &ScanConfig,
 ) -> io::Result<()> {
     let walker = WalkBuilder::new(path)
         .hidden(false)
@@ -66,28 +79,29 @@ fn scan_directory(
         };
 
         if file_type.is_dir() {
-            summary.directories_count += 1;
+            facts.directories_count += 1;
             continue;
         }
 
         if file_type.is_file() {
-            scan_file(entry_path, summary, languages, config)?;
+            collect_file_facts(entry_path, facts, languages)?;
         }
     }
 
     Ok(())
 }
 
-fn scan_file(
+fn collect_file_facts(
     path: &Path,
-    summary: &mut ScanSummary,
+    facts: &mut ScanFacts,
     languages: &mut HashMap<String, usize>,
-    config: &ScanConfig,
 ) -> io::Result<()> {
-    summary.files_count += 1;
+    facts.files_count += 1;
 
-    if let Some(language) = detect_language(path) {
-        *languages.entry(language.to_string()).or_insert(0) += 1;
+    let language = detect_language(path).map(str::to_string);
+
+    if let Some(language_name) = &language {
+        *languages.entry(language_name.clone()).or_insert(0) += 1;
     }
 
     let Ok(content) = fs::read_to_string(path) else {
@@ -95,15 +109,14 @@ fn scan_file(
     };
 
     let lines_of_code = count_lines_of_code(&content);
-    summary.lines_of_code += lines_of_code;
+    facts.lines_of_code += lines_of_code;
 
-    if let Some(finding) = detect_large_file_finding(path, lines_of_code, config) {
-        summary.findings.push(finding);
-    }
-
-    summary
-        .findings
-        .extend(detect_marker_findings(path, &content));
+    facts.files.push(FileFacts {
+        path: path.to_path_buf(),
+        language,
+        lines_of_code,
+        content,
+    });
 
     Ok(())
 }

--- a/tests/audit_pipeline.rs
+++ b/tests/audit_pipeline.rs
@@ -1,0 +1,41 @@
+use repopilot::audits::pipeline::run_audits;
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::facts::{FileFacts, ScanFacts};
+use std::path::PathBuf;
+
+#[test]
+fn audit_pipeline_converts_file_facts_into_findings() {
+    let content = (0..301)
+        .map(|index| format!("fn function_{index}() {{}}"))
+        .chain(std::iter::once("// TODO: split this file".to_string()))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let scan_facts = ScanFacts {
+        root_path: PathBuf::from("demo"),
+        files_count: 1,
+        directories_count: 0,
+        lines_of_code: 302,
+        languages: vec![],
+        files: vec![FileFacts {
+            path: PathBuf::from("src/large.rs"),
+            language: Some("Rust".to_string()),
+            lines_of_code: 302,
+            content,
+        }],
+    };
+
+    let findings = run_audits(&scan_facts, &ScanConfig::default());
+
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding.rule_id == "architecture.large-file")
+    );
+
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding.rule_id == "code-marker.todo")
+    );
+}

--- a/tests/file_facts_scan.rs
+++ b/tests/file_facts_scan.rs
@@ -1,0 +1,28 @@
+use repopilot::scan::scanner::collect_scan_facts;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn scanner_collects_file_facts_without_running_rules_directly() {
+    let temp = tempdir().expect("failed to create temp dir");
+    let file_path = temp.path().join("main.rs");
+
+    fs::write(
+        &file_path,
+        "fn main() {}\n\n// TODO: this is only a fact at scan stage\n",
+    )
+    .expect("failed to write file");
+
+    let facts = collect_scan_facts(temp.path()).expect("failed to collect scan facts");
+
+    assert_eq!(facts.files_count, 1);
+    assert_eq!(facts.lines_of_code, 2);
+    assert_eq!(facts.files.len(), 1);
+
+    let file = &facts.files[0];
+
+    assert_eq!(file.path, file_path);
+    assert_eq!(file.language.as_deref(), Some("Rust"));
+    assert_eq!(file.lines_of_code, 2);
+    assert!(file.content.contains("TODO"));
+}

--- a/tests/marker_findings.rs
+++ b/tests/marker_findings.rs
@@ -1,5 +1,5 @@
+use repopilot::audits::code_quality::code_markers::detect_code_marker_findings;
 use repopilot::findings::types::{FindingCategory, Severity};
-use repopilot::scan::markers::detect_marker_findings;
 use std::path::Path;
 
 #[test]
@@ -12,7 +12,7 @@ fn main() {}
 // HACK: temporary workaround
 ";
 
-    let findings = detect_marker_findings(Path::new("src/main.rs"), content);
+    let findings = detect_code_marker_findings(Path::new("src/main.rs"), content);
 
     assert_eq!(findings.len(), 3);
 


### PR DESCRIPTION
## Summary

Introduces a file facts audit pipeline.

This refactor separates raw file scanning from audit rule execution.

## What changed

- Added `ScanFacts`
- Added `FileFacts`
- Added `collect_scan_facts()`
- Added `src/audits/pipeline.rs`
- Moved code marker detection from `scan` into `audits/code_quality`
- Updated scanner flow:
  - collect facts
  - run audit pipeline
  - build scan summary
- Added tests for file fact collection
- Added tests for audit pipeline execution
- Updated architecture docs
- Updated README docs

## Why

The scanner was starting to own too many responsibilities.

RepoPilot needs to support many future audit categories:

- architecture
- code quality
- testing
- security
- performance

To avoid god files, scanner should only collect facts. Audit modules should convert those facts into evidence-backed findings.

## Architecture notes

New flow:

```txt
scanner -> FileFacts -> audit pipeline -> Findings -> ScanSummary