### PR TITLE
Add CI, release docs, and markers module

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,6 +32,10 @@
 - [ ] Scanner, audits, output, and report responsibilities remain separated
 - [ ] Findings include evidence where applicable
 
+## Changelog
+
+- [ ] `CHANGELOG.md` updated (skip for CI-only or doc changes with no user-visible effect)
+
 ## Verification
 
 <!-- Paste the commands you ran. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+## Summary
+
+<!-- What changed in this PR? Keep it short and practical. -->
+
+## Type of change
+
+- [ ] Feature
+- [ ] Refactor
+- [ ] Bug fix
+- [ ] Tests
+- [ ] Documentation
+- [ ] CI / repository maintenance
+
+## What changed
+
+<!-- List the main changes. -->
+
+-
+-
+-
+
+## Why
+
+<!-- Why is this change needed? What problem does it solve? -->
+
+## Architecture notes
+
+<!-- Explain module boundaries if this touches architecture. -->
+
+- [ ] No god files introduced
+- [ ] Logic is split into focused modules
+- [ ] Scanner, audits, output, and report responsibilities remain separated
+- [ ] Findings include evidence where applicable
+
+## Verification
+
+<!-- Paste the commands you ran. -->
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+cargo run -- scan .
+```

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  rust:
+    name: Rust checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Test
+        run: cargo test --all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Gitignore-aware file walker using the `ignore` crate
+- File and directory counting with non-empty lines-of-code measurement
+- Language detection by file extension (Rust, Python, JavaScript, TypeScript, Go, Java, C/C++, HTML, CSS, TOML, YAML, Markdown)
+- Code marker detection: `TODO`, `FIXME`, `HACK` with per-line evidence
+- Evidence-backed finding model — stable rule IDs, categories, severity levels, and source snippets
+- `architecture.large-file` finding with configurable LOC threshold (`--max-file-loc`)
+- File facts audit pipeline separating scan, audit, and report responsibilities
+- Console, JSON, and Markdown output formats
+- `--output` flag to write reports to a file
+- CI workflow running `cargo fmt`, `cargo clippy`, and `cargo test` on every PR and push to `main`
+- Repository governance docs: release process, distribution channels, audit rulesets, GitHub ruleset setup
+
+[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/MykytaStel/repopilot/releases/tag/v0.1.0

--- a/Readme.md
+++ b/Readme.md
@@ -1,94 +1,59 @@
 # RepoPilot
 
+[![CI](https://github.com/MykytaStel/repopilot/actions/workflows/ci.yaml/badge.svg)](https://github.com/MykytaStel/repopilot/actions/workflows/ci.yaml)
+
 RepoPilot is a local-first CLI for auditing codebases.
 
 The long-term goal is to scan projects, folders, or files and produce evidence-backed reports about architecture, code quality, tests, security, and performance.
 
-```md
-RepoPilot currently supports:
+## Features
 
-- scanning a file or directory
-- walking files with gitignore-aware rules
-- counting files and directories
-- counting non-empty lines of code
-- detecting basic languages by file extension
-- detecting TODO/FIXME/HACK markers
-- printing console output
-- printing JSON output
-- printing Markdown output
-- writing reports to files with `--output`
-- configuring large-file threshold with `--max-file-loc`
-```
-## Findings
+- Gitignore-aware file walker
+- File and directory counting with non-empty LOC measurement
+- Language detection by file extension
+- `TODO` / `FIXME` / `HACK` marker detection with per-line evidence
+- Evidence-backed finding model (stable rule IDs, categories, severity, source snippets)
+- `architecture.large-file` finding with configurable LOC threshold
+- Console, JSON, and Markdown output formats
+- `--output` flag to write reports to a file
 
-RepoPilot uses an evidence-first finding model.
+See [docs/rulesets.md](docs/rulesets.md) for the full list of audit rules and severity levels.
 
-Every finding should include:
+## Installation
 
-- stable rule id
-- title
-- description
-- category
-- severity
-- evidence
-
-Current finding categories:
-
-- architecture
-- code quality
-- testing
-- security
-- performance
-
-Current evidence includes:
-
-- file path
-- line number
-- source snippet
-
-Current rules:
-
-- `code-marker.todo`
-- `code-marker.fixme`
-- `code-marker.hack`
-- `architecture.large-file`
-
-### Configurable thresholds
-
-The `architecture.large-file` rule uses a default threshold of 300 non-empty LOC.
-
-You can override it:
+RepoPilot is not yet published to crates.io. Install from source:
 
 ```bash
-cargo run -- scan . --max-file-loc 500
+git clone https://github.com/MykytaStel/repopilot.git
+cd repopilot
+cargo build --release
+# binary: ./target/release/repopilot
 ```
 
-## Example
+Or install directly with cargo:
 
 ```bash
-cargo run -- scan . --format markdown --output report.md
+cargo install --git https://github.com/MykytaStel/repopilot.git
 ```
+
+See [docs/distribution.md](docs/distribution.md) for planned distribution channels (crates.io, pre-built binaries, Homebrew).
 
 ## Usage
 
 ```bash
 cargo run -- scan .
 cargo run -- scan . --format json
+cargo run -- scan . --format markdown
 cargo run -- --help
 cargo run -- scan --help
 ```
-Custom large file threshold:
+
+Custom large-file threshold:
 
 ```bash
 cargo run -- scan . --max-file-loc 500
-cargo run -- scan . --max-file-loc 500 --format markdown --output report.md
 ```
 
-Markdown output:
-
-```bash
-cargo run -- scan . --format markdown
-```
 Write report to file:
 
 ```bash
@@ -96,3 +61,43 @@ cargo run -- scan . --format markdown --output report.md
 cargo run -- scan . --format json --output report.json
 cargo run -- scan . --format console --output report.txt
 ```
+
+## Findings
+
+RepoPilot uses an evidence-first finding model. Every finding includes:
+
+- Stable rule ID
+- Title and description
+- Category and severity
+- Evidence (file path, line number, source snippet)
+
+Current finding categories: `ARCHITECTURE`, `CODE_QUALITY`, `TESTING`, `SECURITY`, `PERFORMANCE`.
+
+Current rules:
+
+| Rule ID | Category | Severity |
+|---|---|---|
+| `code-marker.todo` | CODE_QUALITY | LOW |
+| `code-marker.fixme` | CODE_QUALITY | MEDIUM |
+| `code-marker.hack` | CODE_QUALITY | MEDIUM |
+| `architecture.large-file` | ARCHITECTURE | MEDIUM / HIGH |
+
+The `architecture.large-file` rule uses a default threshold of 300 non-empty LOC. Override with `--max-file-loc`.
+
+See [docs/rulesets.md](docs/rulesets.md) for full rule documentation.
+
+## Documentation
+
+| Document | Description |
+|---|---|
+| [docs/rulesets.md](docs/rulesets.md) | All audit rules, categories, and severity levels |
+| [docs/release.md](docs/release.md) | How to cut a release |
+| [docs/distribution.md](docs/distribution.md) | Distribution channels (current and planned) |
+| [docs/github-ruleset.md](docs/github-ruleset.md) | GitHub branch ruleset configuration |
+| [CHANGELOG.md](CHANGELOG.md) | Version history |
+
+## Contributing
+
+- Open a PR against `main`. All PRs require CI to pass and at least one review.
+- Follow the [pull request template](.github/pull_request_template.md).
+- Update `CHANGELOG.md` for any user-visible change.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,57 @@
+# Distribution
+
+This document describes how RepoPilot is currently distributed and what future channels are planned.
+
+## Current: source build
+
+RepoPilot is not yet published to crates.io or distributed as pre-built binaries.
+
+**Clone and build:**
+
+```bash
+git clone https://github.com/MykytaStel/repopilot.git
+cd repopilot
+cargo build --release
+# binary: ./target/release/repopilot
+```
+
+**Install directly with cargo:**
+
+```bash
+cargo install --git https://github.com/MykytaStel/repopilot.git
+```
+
+## Planned: crates.io
+
+Once the CLI surface stabilizes at `0.1.0`, RepoPilot will be published to crates.io:
+
+```bash
+cargo install repopilot
+```
+
+Before publishing:
+
+- Confirm `Cargo.toml` metadata fields (`description`, `license`, `repository`, `keywords`, `categories`).
+- Run `cargo publish --dry-run` to catch packaging issues.
+
+## Planned: GitHub Releases (pre-built binaries)
+
+A release workflow will build binaries for the following targets on every version tag:
+
+| Target | Platform |
+|---|---|
+| `x86_64-unknown-linux-gnu` | Linux x86-64 |
+| `aarch64-unknown-linux-gnu` | Linux ARM64 |
+| `x86_64-apple-darwin` | macOS Intel |
+| `aarch64-apple-darwin` | macOS Apple Silicon |
+| `x86_64-pc-windows-msvc` | Windows x86-64 |
+
+Binaries will be attached to each GitHub Release. Users will be able to download and run without installing Rust.
+
+## Planned: Homebrew
+
+A Homebrew formula will be added once the crates.io release is stable. Users will be able to install with:
+
+```bash
+brew install repopilot
+```

--- a/docs/github-ruleset.md
+++ b/docs/github-ruleset.md
@@ -1,0 +1,58 @@
+# GitHub Branch Ruleset Configuration
+
+This document describes the GitHub repository ruleset that protects the `main` branch.
+
+## Why rulesets instead of branch protection rules
+
+GitHub Rulesets (available on all plans) supersede the legacy branch protection UI. Advantages:
+
+- Layered rules (org-level + repo-level)
+- Bypass lists for specific actors
+- Rule insights (per-rule audit log)
+
+## Setting up the `protect-main` ruleset
+
+Go to **Settings → Rules → Rulesets → New ruleset** and configure the following.
+
+### Target
+
+| Setting | Value |
+|---|---|
+| Name | `protect-main` |
+| Enforcement status | Active |
+| Target branches | `refs/heads/main` |
+
+### Rules
+
+| Rule | Setting |
+|---|---|
+| Restrict deletions | Enabled |
+| Require linear history | Enabled |
+| Require a pull request before merging | Enabled |
+| — Required approvals | `1` |
+| — Dismiss stale approvals when new commits are pushed | Enabled |
+| — Require review from Code Owners | Disabled (no `CODEOWNERS` file yet) |
+| Require status checks to pass | Enabled |
+| — Required status check | `Rust checks` (job name in `ci.yaml`) |
+| — Require branches to be up to date before merging | Enabled |
+| Block force pushes | Enabled |
+
+### Bypass list
+
+Add **Repository admin** to the bypass list. This allows merging hotfixes in an emergency without being blocked by the ruleset. Keep the bypass list minimal.
+
+## CODEOWNERS (future)
+
+When the project has more contributors, add `.github/CODEOWNERS` to require domain-owner review:
+
+```
+# Audit rules require review from the core team
+src/audits/   @MykytaStel
+```
+
+## Verifying the ruleset is active
+
+Open a draft PR targeting `main` and confirm:
+
+- The `Rust checks` status check is listed as required.
+- Merging is blocked until the check passes and at least one approval is given.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,57 @@
+# Release Process
+
+RepoPilot follows [Semantic Versioning](https://semver.org/).
+
+## Versioning policy
+
+| Increment | When to use |
+|---|---|
+| Patch `0.1.x` | Bug fixes, doc corrections, minor CI changes with no user-visible behavior change |
+| Minor `0.x.0` | New findings, new output formats, new flags, non-breaking behavior changes |
+| Major `x.0.0` | Breaking CLI changes, output schema changes, removed flags or features |
+
+## Steps to cut a release
+
+### 1. Bump the version
+
+In `Cargo.toml`, update the `version` field:
+
+```toml
+[package]
+version = "0.2.0"
+```
+
+Run `cargo build` to regenerate `Cargo.lock` with the new version.
+
+### 2. Update `CHANGELOG.md`
+
+- Rename the `[Unreleased]` heading to `[0.2.0] - YYYY-MM-DD`.
+- Add a new empty `[Unreleased]` section at the top.
+- Update the comparison links at the bottom of the file.
+
+### 3. Open a release PR
+
+Title: `chore: release v0.2.0`
+
+Include only the `Cargo.toml`, `Cargo.lock`, and `CHANGELOG.md` changes. CI must pass before merge.
+
+### 4. Tag after merge
+
+```bash
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+Tag only commits that are on `main`. A tag on an unmerged commit creates confusion.
+
+### 5. Create a GitHub Release
+
+- Go to **Releases → Draft a new release**.
+- Select the tag created above.
+- Paste the CHANGELOG entry for this version as the release description.
+- Attach pre-built binaries when the release workflow is in place (see `docs/distribution.md`).
+
+## Notes
+
+- A release workflow that produces pre-built binaries on tag push will be added in a future PR.
+- Do not skip CI (`--no-verify`) or amend published commits.

--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -1,0 +1,72 @@
+# Audit Rulesets
+
+RepoPilot findings are identified by a stable `rule_id`. Each rule belongs to a category and carries a fixed severity.
+
+## Categories
+
+| Category | Serialized value | Description |
+|---|---|---|
+| Architecture | `ARCHITECTURE` | Structural or design concerns |
+| Code quality | `CODE_QUALITY` | Hygiene and maintainability issues |
+| Testing | `TESTING` | Test coverage or quality gaps |
+| Security | `SECURITY` | Potential vulnerabilities |
+| Performance | `PERFORMANCE` | Performance-related concerns |
+
+## Severity levels
+
+| Level | Serialized value |
+|---|---|
+| Info | `INFO` |
+| Low | `LOW` |
+| Medium | `MEDIUM` |
+| High | `HIGH` |
+| Critical | `CRITICAL` |
+
+## Rules
+
+### `code-marker.todo`
+
+| Field | Value |
+|---|---|
+| Category | `CODE_QUALITY` |
+| Severity | `LOW` |
+| Description | A `TODO` comment was found. Review whether it represents outstanding work that should be tracked. |
+
+### `code-marker.fixme`
+
+| Field | Value |
+|---|---|
+| Category | `CODE_QUALITY` |
+| Severity | `MEDIUM` |
+| Description | A `FIXME` comment was found. These typically indicate known bugs or broken behavior. |
+
+### `code-marker.hack`
+
+| Field | Value |
+|---|---|
+| Category | `CODE_QUALITY` |
+| Severity | `MEDIUM` |
+| Description | A `HACK` comment was found. These indicate workarounds that should be replaced with proper solutions. |
+
+### `architecture.large-file`
+
+| Field | Value |
+|---|---|
+| Category | `ARCHITECTURE` |
+| Severity | `MEDIUM` when LOC ≥ threshold; `HIGH` when LOC ≥ huge threshold |
+| Default threshold | 300 non-empty LOC |
+| Override | `--max-file-loc <n>` |
+| Description | A file exceeds the configured LOC threshold. Consider splitting responsibilities into smaller modules. |
+
+The *huge* threshold defaults to `max(threshold × 3, threshold + 1)`. When `--max-file-loc` is set, the huge threshold adjusts automatically.
+
+## Evidence
+
+Every finding includes structured evidence:
+
+| Field | Type | Description |
+|---|---|---|
+| `path` | path | File that triggered the finding |
+| `line_start` | usize | First relevant line (1-based) |
+| `line_end` | usize? | Last relevant line (optional) |
+| `snippet` | string | Source text at that location |

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -39,7 +39,7 @@ pub fn render(summary: &ScanSummary) -> String {
     output.push_str("## Findings\n\n");
 
     if summary.findings.is_empty() {
-        output.push_str("No findings found.\n");
+        output.push_str("No findings found.\n\n");
     } else {
         output.push_str("| Severity | Rule | Title | Evidence |\n");
         output.push_str("| --- | --- | --- | --- |\n");
@@ -65,6 +65,41 @@ pub fn render(summary: &ScanSummary) -> String {
                 escape_table_cell(&finding.title),
                 escape_table_cell(&evidence)
             ));
+        }
+
+        output.push('\n');
+    }
+
+    output.push_str("## Markers\n\n");
+
+    let marker_findings: Vec<_> = summary
+        .findings
+        .iter()
+        .filter(|f| f.rule_id.starts_with("code-marker."))
+        .collect();
+
+    if marker_findings.is_empty() {
+        output.push_str("No TODO/FIXME/HACK markers found.\n");
+    } else {
+        output.push_str("| Type | File | Line | Snippet |\n");
+        output.push_str("| --- | --- | ---: | --- |\n");
+
+        for finding in marker_findings {
+            let kind = finding
+                .rule_id
+                .strip_prefix("code-marker.")
+                .unwrap_or("")
+                .to_uppercase();
+
+            if let Some(ev) = finding.evidence.first() {
+                output.push_str(&format!(
+                    "| {} | `{}` | {} | {} |\n",
+                    kind,
+                    ev.path.display(),
+                    ev.line_start,
+                    escape_table_cell(ev.snippet.trim())
+                ));
+            }
         }
     }
 

--- a/src/report/writer.rs
+++ b/src/report/writer.rs
@@ -10,10 +10,10 @@ pub fn write_report(content: &str, output_path: Option<&Path>) -> io::Result<()>
 }
 
 fn write_to_file(content: &str, path: &Path) -> io::Result<()> {
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            fs::create_dir_all(parent)?;
-        }
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
     }
 
     fs::write(path, content)

--- a/src/scan/markers.rs
+++ b/src/scan/markers.rs
@@ -1,0 +1,36 @@
+use crate::scan::types::{Marker, MarkerKind};
+use std::path::Path;
+
+pub fn detect_markers(path: &Path, content: &str) -> Vec<Marker> {
+    let mut markers = Vec::new();
+
+    for (index, line) in content.lines().enumerate() {
+        let line_number = index + 1;
+        if line.contains("TODO") {
+            markers.push(Marker {
+                kind: MarkerKind::Todo,
+                line_number,
+                path: path.to_path_buf(),
+                text: line.to_string(),
+            });
+        }
+        if line.contains("FIXME") {
+            markers.push(Marker {
+                kind: MarkerKind::Fixme,
+                line_number,
+                path: path.to_path_buf(),
+                text: line.to_string(),
+            });
+        }
+        if line.contains("HACK") {
+            markers.push(Marker {
+                kind: MarkerKind::Hack,
+                line_number,
+                path: path.to_path_buf(),
+                text: line.to_string(),
+            });
+        }
+    }
+
+    markers
+}

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod facts;
 pub mod language;
+pub mod markers;
 pub mod scanner;
 pub mod types;

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -2,6 +2,21 @@ use crate::findings::types::Finding;
 use serde::Serialize;
 use std::path::PathBuf;
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum MarkerKind {
+    Todo,
+    Fixme,
+    Hack,
+}
+
+#[derive(Debug)]
+pub struct Marker {
+    pub kind: MarkerKind,
+    pub line_number: usize,
+    pub path: PathBuf,
+    pub text: String,
+}
+
 #[derive(Debug, Default, Serialize, PartialEq, Eq)]
 pub struct ScanSummary {
     pub root_path: PathBuf,


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yaml` — runs `cargo fmt`, `cargo clippy`, `cargo test` on every PR and push to `main`
- Add `docs/` — release process, distribution channels, audit rulesets, GitHub ruleset setup
- Add `CHANGELOG.md` following Keep a Changelog format
- Add `src/scan/markers.rs` — low-level marker detection (TODO/FIXME/HACK) as a reusable scan primitive
- Add `MarkerKind` / `Marker` types to `src/scan/types.rs`
- Fix `src/output/markdown.rs` — add `## Markers` section with dedicated table; repairs 2 previously failing tests
- Update `README.md` and `PR template` for clarity and changelog requirement

## Type of change

- [x] New feature (non-breaking)
- [x] Documentation
- [x] CI/Infrastructure

## Verification

```
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all   # 20/20 passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)