### PR TITLE
feat(audits): introduce trait-based audits and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (Linux aarch64 only)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (cross)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Build (native)
+        if: matrix.target != 'aarch64-unknown-linux-gnu'
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package (Unix)
+        if: matrix.archive == 'tar.gz'
+        run: |
+          BINARY_NAME=repopilot
+          ASSET_NAME="${BINARY_NAME}-${{ github.ref_name }}-${{ matrix.target }}"
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/${BINARY_NAME} dist/
+          cd dist
+          tar -czf "${ASSET_NAME}.tar.gz" ${BINARY_NAME}
+          echo "ASSET=dist/${ASSET_NAME}.tar.gz" >> $GITHUB_ENV
+
+      - name: Package (Windows)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          $BinaryName = "repopilot"
+          $AssetName = "${BinaryName}-${{ github.ref_name }}-${{ matrix.target }}"
+          New-Item -ItemType Directory -Force -Path dist
+          Copy-Item "target/${{ matrix.target }}/release/${BinaryName}.exe" dist/
+          Compress-Archive -Path "dist/${BinaryName}.exe" -DestinationPath "dist/${AssetName}.zip"
+          echo "ASSET=dist/${AssetName}.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.ASSET }}
+          generate_release_notes: true
+
+  publish-crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish
+        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `FileAudit` and `ProjectAudit` traits — audit rules now implement a trait instead of free functions, making it trivial to add new rules without modifying the pipeline
+- `Markdown ## Markers` section — dedicated table for `TODO`/`FIXME`/`HACK` findings in Markdown reports
+- `ScanConfig` fields: `max_directory_modules`, `max_directory_depth`, `long_function_loc_threshold` — groundwork for upcoming architecture and code-quality rules
+- `Cargo.toml` crates.io metadata: description, license, repository, keywords, categories
+- GitHub Actions release workflow — builds and uploads pre-built binaries for Linux x86_64/ARM64, macOS x86_64/ARM64, and Windows x86_64 on `v*` tags; publishes to crates.io
+
+### Changed
+
+- `code_markers` audit now reuses `scan::markers::detect_markers` instead of duplicating detection logic
+- `scan::markers` module promoted to a first-class scan primitive (`MarkerKind`, `Marker`, `detect_markers`)
+
 ## [0.1.0] - Unreleased
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "repopilot"
 version = "0.1.0"
 edition = "2024"
+description = "Local-first codebase audit CLI with evidence-backed findings"
+license = "MIT"
+repository = "https://github.com/MykytaStel/repopilot"
+keywords = ["cli", "audit", "code-quality", "static-analysis"]
+categories = ["development-tools", "command-line-utilities"]
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -60,6 +60,68 @@ RepoPilot findings are identified by a stable `rule_id`. Each rule belongs to a 
 
 The *huge* threshold defaults to `max(threshold × 3, threshold + 1)`. When `--max-file-loc` is set, the huge threshold adjusts automatically.
 
+### `architecture.too-many-modules`
+
+| Field | Value |
+|---|---|
+| Category | `ARCHITECTURE` |
+| Severity | `MEDIUM` |
+| Default threshold | 20 files per directory |
+| Override | `--max-directory-modules <n>` |
+| Description | A directory contains more files than the threshold. Consider splitting it into sub-modules to reduce coupling. |
+
+### `architecture.deep-nesting`
+
+| Field | Value |
+|---|---|
+| Category | `ARCHITECTURE` |
+| Severity | `LOW` |
+| Default threshold | 5 directory levels below the scan root |
+| Override | `--max-directory-depth <n>` |
+| Description | The deepest file in the project exceeds the nesting threshold. Deep hierarchies often indicate over-engineered module structures. |
+
+### `testing.missing-test-folder`
+
+| Field | Value |
+|---|---|
+| Category | `TESTING` |
+| Severity | `MEDIUM` |
+| Description | No test directory (`tests/`, `test/`, `__tests__/`, `spec/`) was found at any level in the scanned tree. |
+
+### `testing.source-without-test`
+
+| Field | Value |
+|---|---|
+| Category | `TESTING` |
+| Severity | `LOW` |
+| Description | A source file has no detectable test counterpart. Looks for sibling files like `payment_test.rs`, `payment.test.ts`, `payment.spec.ts`, or entries in a `tests/` directory. |
+
+### `security.secret-candidate`
+
+| Field | Value |
+|---|---|
+| Category | `SECURITY` |
+| Severity | `HIGH` |
+| Description | A line matches a pattern indicating a hardcoded secret (`api_key`, `password`, `token`, `private_key`, etc.). The evidence snippet **masks the value** — only the key name and first 3 characters are shown. |
+
+Skipped for files whose path contains `test`, `fixture`, `example`, or `mock`.
+
+### `security.private-key-candidate`
+
+| Field | Value |
+|---|---|
+| Category | `SECURITY` |
+| Severity | `CRITICAL` |
+| Description | A PEM private key header (`-----BEGIN RSA PRIVATE KEY-----`, etc.) was found in a source file. The key content is never included in the evidence. |
+
+### `security.env-file-committed`
+
+| Field | Value |
+|---|---|
+| Category | `SECURITY` |
+| Severity | `HIGH` |
+| Description | A `.env`, `.env.local`, `.env.production`, `.env.staging`, or `.env.development` file is present in the scanned tree. Environment files often contain secrets and must not be committed. |
+
 ## Evidence
 
 Every finding includes structured evidence:

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,12 @@
-use crate::cli::{Cli, Commands};
+use crate::cli::{Cli, Commands, OutputFormatArg};
+use repopilot::compare::diff::diff_summaries;
+use repopilot::compare::render::{render_console as compare_console, render_markdown as compare_markdown};
 use repopilot::output::render_scan_summary;
 use repopilot::report::writer::write_report;
 use repopilot::scan::config::ScanConfig;
 use repopilot::scan::scanner::scan_path_with_config;
+use repopilot::scan::types::ScanSummary;
+use std::fs;
 
 pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
@@ -11,8 +15,11 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             format,
             output,
             max_file_loc,
+            max_directory_modules,
+            max_directory_depth,
         } => {
-            let config = build_scan_config(max_file_loc);
+            let config =
+                build_scan_config(max_file_loc, max_directory_modules, max_directory_depth);
             let summary = scan_path_with_config(&path, &config)?;
             let rendered_report = render_scan_summary(&summary, format.into())?;
 
@@ -20,12 +27,56 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
             Ok(())
         }
+
+        Commands::Compare {
+            before,
+            after,
+            format,
+            output,
+        } => {
+            let before_summary: ScanSummary =
+                serde_json::from_str(&fs::read_to_string(&before)?).map_err(|e| {
+                    format!("Failed to parse {}: {e}", before.display())
+                })?;
+
+            let after_summary: ScanSummary =
+                serde_json::from_str(&fs::read_to_string(&after)?).map_err(|e| {
+                    format!("Failed to parse {}: {e}", after.display())
+                })?;
+
+            let diff = diff_summaries(&before_summary, &after_summary);
+
+            let rendered = match format {
+                OutputFormatArg::Markdown => compare_markdown(&diff),
+                _ => compare_console(&diff),
+            };
+
+            write_report(&rendered, output.as_deref())?;
+
+            Ok(())
+        }
     }
 }
 
-fn build_scan_config(max_file_loc: Option<usize>) -> ScanConfig {
-    match max_file_loc {
-        Some(threshold) => ScanConfig::default().with_large_file_loc_threshold(threshold),
-        None => ScanConfig::default(),
+fn build_scan_config(
+    max_file_loc: Option<usize>,
+    max_directory_modules: Option<usize>,
+    max_directory_depth: Option<usize>,
+) -> ScanConfig {
+    let mut config = ScanConfig::default();
+
+    if let Some(threshold) = max_file_loc {
+        config = config.with_large_file_loc_threshold(threshold);
     }
+
+    if let Some(modules) = max_directory_modules {
+        config.max_directory_modules = modules;
+    }
+
+    if let Some(depth) = max_directory_depth {
+        config.max_directory_depth = depth;
+    }
+
+    config
 }
+

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,8 @@
 use crate::cli::{Cli, Commands, OutputFormatArg};
 use repopilot::compare::diff::diff_summaries;
-use repopilot::compare::render::{render_console as compare_console, render_markdown as compare_markdown};
+use repopilot::compare::render::{
+    render_console as compare_console, render_markdown as compare_markdown,
+};
 use repopilot::output::render_scan_summary;
 use repopilot::report::writer::write_report;
 use repopilot::scan::config::ScanConfig;
@@ -35,14 +37,11 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             output,
         } => {
             let before_summary: ScanSummary =
-                serde_json::from_str(&fs::read_to_string(&before)?).map_err(|e| {
-                    format!("Failed to parse {}: {e}", before.display())
-                })?;
+                serde_json::from_str(&fs::read_to_string(&before)?)
+                    .map_err(|e| format!("Failed to parse {}: {e}", before.display()))?;
 
-            let after_summary: ScanSummary =
-                serde_json::from_str(&fs::read_to_string(&after)?).map_err(|e| {
-                    format!("Failed to parse {}: {e}", after.display())
-                })?;
+            let after_summary: ScanSummary = serde_json::from_str(&fs::read_to_string(&after)?)
+                .map_err(|e| format!("Failed to parse {}: {e}", after.display()))?;
 
             let diff = diff_summaries(&before_summary, &after_summary);
 
@@ -79,4 +78,3 @@ fn build_scan_config(
 
     config
 }
-

--- a/src/audits/architecture/deep_nesting.rs
+++ b/src/audits/architecture/deep_nesting.rs
@@ -32,10 +32,7 @@ impl ProjectAudit for DeepNestingAudit {
 
 fn build_finding(deepest_path: PathBuf, depth: usize, threshold: usize) -> Finding {
     Finding {
-        id: format!(
-            "architecture.deep-nesting.{}",
-            deepest_path.display()
-        ),
+        id: format!("architecture.deep-nesting.{}", deepest_path.display()),
         rule_id: "architecture.deep-nesting".to_string(),
         title: "Deeply nested directory structure detected".to_string(),
         description: format!(

--- a/src/audits/architecture/deep_nesting.rs
+++ b/src/audits/architecture/deep_nesting.rs
@@ -1,0 +1,53 @@
+use crate::audits::traits::ProjectAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::ScanFacts;
+use std::path::PathBuf;
+
+pub struct DeepNestingAudit;
+
+impl ProjectAudit for DeepNestingAudit {
+    fn audit(&self, facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
+        let root_depth = facts.root_path.components().count();
+
+        let deepest = facts
+            .files
+            .iter()
+            .filter_map(|file| {
+                let depth = file.path.components().count().saturating_sub(root_depth);
+                if depth > config.max_directory_depth {
+                    Some((file.path.clone(), depth))
+                } else {
+                    None
+                }
+            })
+            .max_by_key(|(_, depth)| *depth);
+
+        match deepest {
+            None => vec![],
+            Some((path, depth)) => vec![build_finding(path, depth, config.max_directory_depth)],
+        }
+    }
+}
+
+fn build_finding(deepest_path: PathBuf, depth: usize, threshold: usize) -> Finding {
+    Finding {
+        id: format!(
+            "architecture.deep-nesting.{}",
+            deepest_path.display()
+        ),
+        rule_id: "architecture.deep-nesting".to_string(),
+        title: "Deeply nested directory structure detected".to_string(),
+        description: format!(
+            "The project contains files nested {depth} levels deep, exceeding the threshold of {threshold}. Deep nesting often indicates over-engineered module hierarchies."
+        ),
+        category: FindingCategory::Architecture,
+        severity: Severity::Low,
+        evidence: vec![Evidence {
+            path: deepest_path,
+            line_start: 1,
+            line_end: None,
+            snippet: format!("Nesting depth: {depth}; threshold is {threshold}."),
+        }],
+    }
+}

--- a/src/audits/architecture/large_file.rs
+++ b/src/audits/architecture/large_file.rs
@@ -1,6 +1,18 @@
+use crate::audits::traits::FileAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use crate::scan::config::ScanConfig;
+use crate::scan::facts::FileFacts;
 use std::path::Path;
+
+pub struct LargeFileAudit;
+
+impl FileAudit for LargeFileAudit {
+    fn audit(&self, file: &FileFacts, config: &ScanConfig) -> Vec<Finding> {
+        detect_large_file_finding(&file.path, file.lines_of_code, config)
+            .into_iter()
+            .collect()
+    }
+}
 
 pub fn detect_large_file_finding(
     path: &Path,

--- a/src/audits/architecture/mod.rs
+++ b/src/audits/architecture/mod.rs
@@ -1,1 +1,3 @@
+pub mod deep_nesting;
 pub mod large_file;
+pub mod too_many_modules;

--- a/src/audits/architecture/too_many_modules.rs
+++ b/src/audits/architecture/too_many_modules.rs
@@ -1,0 +1,45 @@
+use crate::audits::traits::ProjectAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::ScanFacts;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+pub struct TooManyModulesAudit;
+
+impl ProjectAudit for TooManyModulesAudit {
+    fn audit(&self, facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
+        let mut dir_file_counts: HashMap<PathBuf, usize> = HashMap::new();
+
+        for file in &facts.files {
+            if let Some(parent) = file.path.parent() {
+                *dir_file_counts.entry(parent.to_path_buf()).or_insert(0) += 1;
+            }
+        }
+
+        dir_file_counts
+            .into_iter()
+            .filter(|(_, count)| *count > config.max_directory_modules)
+            .map(|(dir, count)| build_finding(dir, count, config.max_directory_modules))
+            .collect()
+    }
+}
+
+fn build_finding(dir: PathBuf, file_count: usize, threshold: usize) -> Finding {
+    Finding {
+        id: format!("architecture.too-many-modules.{}", dir.display()),
+        rule_id: "architecture.too-many-modules".to_string(),
+        title: "Directory contains too many modules".to_string(),
+        description: format!(
+            "This directory has {file_count} files, exceeding the threshold of {threshold}. Consider splitting into sub-modules to reduce coupling."
+        ),
+        category: FindingCategory::Architecture,
+        severity: Severity::Medium,
+        evidence: vec![Evidence {
+            path: dir,
+            line_start: 1,
+            line_end: None,
+            snippet: format!("{file_count} files in directory; threshold is {threshold}."),
+        }],
+    }
+}

--- a/src/audits/code_quality/code_markers.rs
+++ b/src/audits/code_quality/code_markers.rs
@@ -1,44 +1,55 @@
+use crate::audits::traits::FileAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
-use std::path::Path;
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::FileFacts;
+use crate::scan::markers::detect_markers;
+use crate::scan::types::{Marker, MarkerKind};
 
-pub fn detect_code_marker_findings(path: &Path, content: &str) -> Vec<Finding> {
-    let mut findings = Vec::new();
+pub struct CodeMarkerAudit;
 
-    for (index, line) in content.lines().enumerate() {
-        if line.contains("TODO") {
-            findings.push(build_marker_finding(path, index, line, "todo"));
-        }
-
-        if line.contains("FIXME") {
-            findings.push(build_marker_finding(path, index, line, "fixme"));
-        }
-
-        if line.contains("HACK") {
-            findings.push(build_marker_finding(path, index, line, "hack"));
-        }
+impl FileAudit for CodeMarkerAudit {
+    fn audit(&self, file: &FileFacts, _config: &ScanConfig) -> Vec<Finding> {
+        detect_markers(&file.path, &file.content)
+            .iter()
+            .map(build_marker_finding)
+            .collect()
     }
-
-    findings
 }
 
-fn build_marker_finding(path: &Path, index: usize, line: &str, marker: &str) -> Finding {
-    let line_number = index + 1;
-    let uppercase_marker = marker.to_uppercase();
+pub fn detect_code_marker_findings(file: &FileFacts) -> Vec<Finding> {
+    detect_markers(&file.path, &file.content)
+        .iter()
+        .map(build_marker_finding)
+        .collect()
+}
+
+fn build_marker_finding(marker: &Marker) -> Finding {
+    let marker_str = match marker.kind {
+        MarkerKind::Todo => "todo",
+        MarkerKind::Fixme => "fixme",
+        MarkerKind::Hack => "hack",
+    };
+    let uppercase = marker_str.to_uppercase();
 
     Finding {
-        id: format!("code-marker.{}.{}:{}", marker, path.display(), line_number),
-        rule_id: format!("code-marker.{marker}"),
-        title: format!("{uppercase_marker} marker found"),
+        id: format!(
+            "code-marker.{}.{}:{}",
+            marker_str,
+            marker.path.display(),
+            marker.line_number
+        ),
+        rule_id: format!("code-marker.{marker_str}"),
+        title: format!("{uppercase} marker found"),
         description: format!(
-            "A {uppercase_marker} marker was found in the codebase and should be reviewed."
+            "A {uppercase} marker was found in the codebase and should be reviewed."
         ),
         category: FindingCategory::CodeQuality,
-        severity: marker_severity(marker),
+        severity: marker_severity(marker_str),
         evidence: vec![Evidence {
-            path: path.to_path_buf(),
-            line_start: line_number,
+            path: marker.path.clone(),
+            line_start: marker.line_number,
             line_end: None,
-            snippet: line.trim().to_string(),
+            snippet: marker.text.trim().to_string(),
         }],
     }
 }

--- a/src/audits/mod.rs
+++ b/src/audits/mod.rs
@@ -1,3 +1,4 @@
 pub mod architecture;
 pub mod code_quality;
 pub mod pipeline;
+pub mod traits;

--- a/src/audits/mod.rs
+++ b/src/audits/mod.rs
@@ -1,4 +1,6 @@
 pub mod architecture;
 pub mod code_quality;
 pub mod pipeline;
+pub mod security;
+pub mod testing;
 pub mod traits;

--- a/src/audits/pipeline.rs
+++ b/src/audits/pipeline.rs
@@ -1,15 +1,32 @@
+use crate::audits::architecture::deep_nesting::DeepNestingAudit;
 use crate::audits::architecture::large_file::LargeFileAudit;
+use crate::audits::architecture::too_many_modules::TooManyModulesAudit;
 use crate::audits::code_quality::code_markers::CodeMarkerAudit;
+use crate::audits::security::env_file_committed::EnvFileCommittedAudit;
+use crate::audits::security::private_key_candidate::PrivateKeyCandidateAudit;
+use crate::audits::security::secret_candidate::SecretCandidateAudit;
+use crate::audits::testing::missing_test_folder::MissingTestFolderAudit;
+use crate::audits::testing::source_without_test::SourceWithoutTestAudit;
 use crate::audits::traits::{FileAudit, ProjectAudit};
 use crate::findings::types::Finding;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
 
 pub fn run_audits(scan_facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
-    let file_audits: Vec<Box<dyn FileAudit>> =
-        vec![Box::new(LargeFileAudit), Box::new(CodeMarkerAudit)];
+    let file_audits: Vec<Box<dyn FileAudit>> = vec![
+        Box::new(LargeFileAudit),
+        Box::new(CodeMarkerAudit),
+        Box::new(SecretCandidateAudit),
+        Box::new(PrivateKeyCandidateAudit),
+    ];
 
-    let project_audits: Vec<Box<dyn ProjectAudit>> = vec![];
+    let project_audits: Vec<Box<dyn ProjectAudit>> = vec![
+        Box::new(TooManyModulesAudit),
+        Box::new(DeepNestingAudit),
+        Box::new(MissingTestFolderAudit),
+        Box::new(SourceWithoutTestAudit),
+        Box::new(EnvFileCommittedAudit),
+    ];
 
     let mut findings: Vec<Finding> = scan_facts
         .files

--- a/src/audits/pipeline.rs
+++ b/src/audits/pipeline.rs
@@ -1,27 +1,27 @@
-use crate::audits::architecture::large_file::detect_large_file_finding;
-use crate::audits::code_quality::code_markers::detect_code_marker_findings;
+use crate::audits::architecture::large_file::LargeFileAudit;
+use crate::audits::code_quality::code_markers::CodeMarkerAudit;
+use crate::audits::traits::{FileAudit, ProjectAudit};
 use crate::findings::types::Finding;
 use crate::scan::config::ScanConfig;
-use crate::scan::facts::{FileFacts, ScanFacts};
+use crate::scan::facts::ScanFacts;
 
 pub fn run_audits(scan_facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
-    let mut findings = Vec::new();
+    let file_audits: Vec<Box<dyn FileAudit>> =
+        vec![Box::new(LargeFileAudit), Box::new(CodeMarkerAudit)];
 
-    for file in &scan_facts.files {
-        findings.extend(run_file_audits(file, config));
-    }
+    let project_audits: Vec<Box<dyn ProjectAudit>> = vec![];
 
-    findings
-}
+    let mut findings: Vec<Finding> = scan_facts
+        .files
+        .iter()
+        .flat_map(|file| file_audits.iter().flat_map(|a| a.audit(file, config)))
+        .collect();
 
-fn run_file_audits(file: &FileFacts, config: &ScanConfig) -> Vec<Finding> {
-    let mut findings = Vec::new();
-
-    if let Some(finding) = detect_large_file_finding(&file.path, file.lines_of_code, config) {
-        findings.push(finding);
-    }
-
-    findings.extend(detect_code_marker_findings(&file.path, &file.content));
+    findings.extend(
+        project_audits
+            .iter()
+            .flat_map(|a| a.audit(scan_facts, config)),
+    );
 
     findings
 }

--- a/src/audits/security/env_file_committed.rs
+++ b/src/audits/security/env_file_committed.rs
@@ -31,10 +31,7 @@ impl ProjectAudit for EnvFileCommittedAudit {
 }
 
 fn build_finding(path: &std::path::Path) -> Finding {
-    let name = path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or(".env");
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or(".env");
 
     Finding {
         id: format!("security.env-file-committed.{}", path.display()),

--- a/src/audits/security/env_file_committed.rs
+++ b/src/audits/security/env_file_committed.rs
@@ -1,0 +1,55 @@
+use crate::audits::traits::ProjectAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::ScanFacts;
+
+const ENV_FILE_NAMES: &[&str] = &[
+    ".env",
+    ".env.local",
+    ".env.production",
+    ".env.staging",
+    ".env.development",
+];
+
+pub struct EnvFileCommittedAudit;
+
+impl ProjectAudit for EnvFileCommittedAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        facts
+            .files
+            .iter()
+            .filter(|file| {
+                file.path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|name| ENV_FILE_NAMES.contains(&name))
+                    .unwrap_or(false)
+            })
+            .map(|file| build_finding(&file.path))
+            .collect()
+    }
+}
+
+fn build_finding(path: &std::path::Path) -> Finding {
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(".env");
+
+    Finding {
+        id: format!("security.env-file-committed.{}", path.display()),
+        rule_id: "security.env-file-committed".to_string(),
+        title: "Environment file tracked in repository".to_string(),
+        description: format!(
+            "`{name}` is present in the scanned tree. Environment files often contain secrets and should be listed in `.gitignore`."
+        ),
+        category: FindingCategory::Security,
+        severity: Severity::High,
+        evidence: vec![Evidence {
+            path: path.to_path_buf(),
+            line_start: 1,
+            line_end: None,
+            snippet: format!("`{name}` should not be committed; add it to .gitignore."),
+        }],
+    }
+}

--- a/src/audits/security/mod.rs
+++ b/src/audits/security/mod.rs
@@ -1,0 +1,3 @@
+pub mod env_file_committed;
+pub mod private_key_candidate;
+pub mod secret_candidate;

--- a/src/audits/security/private_key_candidate.rs
+++ b/src/audits/security/private_key_candidate.rs
@@ -31,7 +31,11 @@ impl FileAudit for PrivateKeyCandidateAudit {
 
 fn build_finding(path: &std::path::Path, line_number: usize, header: &str) -> Finding {
     Finding {
-        id: format!("security.private-key-candidate.{}:{}", path.display(), line_number),
+        id: format!(
+            "security.private-key-candidate.{}:{}",
+            path.display(),
+            line_number
+        ),
         rule_id: "security.private-key-candidate".to_string(),
         title: "Private key detected in source file".to_string(),
         description: format!(

--- a/src/audits/security/private_key_candidate.rs
+++ b/src/audits/security/private_key_candidate.rs
@@ -1,0 +1,51 @@
+use crate::audits::traits::FileAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::FileFacts;
+
+const PRIVATE_KEY_HEADERS: &[&str] = &[
+    "-----BEGIN RSA PRIVATE KEY-----",
+    "-----BEGIN EC PRIVATE KEY-----",
+    "-----BEGIN PRIVATE KEY-----",
+    "-----BEGIN OPENSSH PRIVATE KEY-----",
+    "-----BEGIN PGP PRIVATE KEY BLOCK-----",
+];
+
+pub struct PrivateKeyCandidateAudit;
+
+impl FileAudit for PrivateKeyCandidateAudit {
+    fn audit(&self, file: &FileFacts, _config: &ScanConfig) -> Vec<Finding> {
+        file.content
+            .lines()
+            .enumerate()
+            .filter_map(|(index, line)| {
+                let trimmed = line.trim();
+                PRIVATE_KEY_HEADERS
+                    .iter()
+                    .find(|&&header| trimmed.contains(header))
+                    .map(|header| build_finding(&file.path, index + 1, header))
+            })
+            .collect()
+    }
+}
+
+fn build_finding(path: &std::path::Path, line_number: usize, header: &str) -> Finding {
+    Finding {
+        id: format!("security.private-key-candidate.{}:{}", path.display(), line_number),
+        rule_id: "security.private-key-candidate".to_string(),
+        title: "Private key detected in source file".to_string(),
+        description: format!(
+            "`{}` appears to contain a private key. Private keys must never be committed to version control.",
+            path.display()
+        ),
+        category: FindingCategory::Security,
+        severity: Severity::Critical,
+        evidence: vec![Evidence {
+            path: path.to_path_buf(),
+            line_start: line_number,
+            line_end: None,
+            // Show only the header line — never the actual key bytes
+            snippet: header.to_string(),
+        }],
+    }
+}

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -1,0 +1,103 @@
+use crate::audits::traits::FileAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::FileFacts;
+
+const SECRET_KEYS: &[&str] = &[
+    "api_key",
+    "apikey",
+    "api_secret",
+    "secret_key",
+    "secret",
+    "password",
+    "passwd",
+    "private_key",
+    "auth_token",
+    "access_token",
+    "client_secret",
+    "signing_key",
+    "encryption_key",
+];
+
+pub struct SecretCandidateAudit;
+
+impl FileAudit for SecretCandidateAudit {
+    fn audit(&self, file: &FileFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let lower_path = file.path.to_string_lossy().to_lowercase();
+
+        // Skip test and example files — likely contain fake credentials intentionally
+        if lower_path.contains("test")
+            || lower_path.contains("fixture")
+            || lower_path.contains("example")
+            || lower_path.contains("mock")
+        {
+            return vec![];
+        }
+
+        file.content
+            .lines()
+            .enumerate()
+            .filter_map(|(index, line)| detect_secret_line(line, index + 1, &file.path))
+            .collect()
+    }
+}
+
+fn detect_secret_line(
+    line: &str,
+    line_number: usize,
+    path: &std::path::Path,
+) -> Option<Finding> {
+    let lower = line.to_lowercase();
+
+    let matched_key = SECRET_KEYS.iter().find(|&&key| {
+        if !lower.contains(key) {
+            return false;
+        }
+        // Must be followed by = or : and a non-empty quoted or unquoted value
+        let after_key = lower.split(key).nth(1).unwrap_or_default().trim_start();
+        let starts_assignment = after_key.starts_with('=') || after_key.starts_with(':');
+        if !starts_assignment {
+            return false;
+        }
+        let value = after_key[1..].trim();
+        // Skip empty values, placeholders, and template vars
+        let is_placeholder = value.is_empty()
+            || value.starts_with("${")
+            || value.starts_with("{{")
+            || value == "\"\"" || value == "''"
+            || value == "null" || value == "nil"
+            || value == "none" || value == "your_key_here"
+            || value == "changeme";
+        !is_placeholder && value.len() > 4
+    })?;
+
+    Some(Finding {
+        id: format!("security.secret-candidate.{}:{}", path.display(), line_number),
+        rule_id: "security.secret-candidate".to_string(),
+        title: "Possible secret detected".to_string(),
+        description: format!(
+            "Line {line_number} in `{}` looks like it may contain a hardcoded secret (matched key: `{matched_key}`). Review and move to environment variables or a secrets manager.",
+            path.display()
+        ),
+        category: FindingCategory::Security,
+        severity: Severity::High,
+        evidence: vec![Evidence {
+            path: path.to_path_buf(),
+            line_start: line_number,
+            line_end: None,
+            snippet: mask_secret_value(line.trim()),
+        }],
+    })
+}
+
+fn mask_secret_value(line: &str) -> String {
+    // Find the first = or : assignment and mask everything after the first 3 chars of value
+    if let Some(pos) = line.find('=').or_else(|| line.find(':')) {
+        let (key_part, value_part) = line.split_at(pos + 1);
+        let value = value_part.trim().trim_matches('"').trim_matches('\'');
+        if value.len() > 3 {
+            return format!("{key_part} \"{}...***\"", &value[..3]);
+        }
+    }
+    format!("{line} [value masked]")
+}

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -42,11 +42,7 @@ impl FileAudit for SecretCandidateAudit {
     }
 }
 
-fn detect_secret_line(
-    line: &str,
-    line_number: usize,
-    path: &std::path::Path,
-) -> Option<Finding> {
+fn detect_secret_line(line: &str, line_number: usize, path: &std::path::Path) -> Option<Finding> {
     let lower = line.to_lowercase();
 
     let matched_key = SECRET_KEYS.iter().find(|&&key| {
@@ -64,15 +60,22 @@ fn detect_secret_line(
         let is_placeholder = value.is_empty()
             || value.starts_with("${")
             || value.starts_with("{{")
-            || value == "\"\"" || value == "''"
-            || value == "null" || value == "nil"
-            || value == "none" || value == "your_key_here"
+            || value == "\"\""
+            || value == "''"
+            || value == "null"
+            || value == "nil"
+            || value == "none"
+            || value == "your_key_here"
             || value == "changeme";
         !is_placeholder && value.len() > 4
     })?;
 
     Some(Finding {
-        id: format!("security.secret-candidate.{}:{}", path.display(), line_number),
+        id: format!(
+            "security.secret-candidate.{}:{}",
+            path.display(),
+            line_number
+        ),
         rule_id: "security.secret-candidate".to_string(),
         title: "Possible secret detected".to_string(),
         description: format!(

--- a/src/audits/testing/missing_test_folder.rs
+++ b/src/audits/testing/missing_test_folder.rs
@@ -1,0 +1,44 @@
+use crate::audits::traits::ProjectAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::ScanFacts;
+
+const TEST_FOLDER_NAMES: &[&str] = &["tests", "test", "__tests__", "spec"];
+
+pub struct MissingTestFolderAudit;
+
+impl ProjectAudit for MissingTestFolderAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let has_test_folder = facts.files.iter().any(|file| {
+            file.path.components().any(|c| {
+                let name = c.as_os_str().to_string_lossy();
+                TEST_FOLDER_NAMES.contains(&name.as_ref())
+            })
+        });
+
+        if has_test_folder {
+            return vec![];
+        }
+
+        vec![Finding {
+            id: format!(
+                "testing.missing-test-folder.{}",
+                facts.root_path.display()
+            ),
+            rule_id: "testing.missing-test-folder".to_string(),
+            title: "No test folder found".to_string(),
+            description: format!(
+                "No test directory (tests/, test/, __tests__/, spec/) was found under `{}`. Consider adding tests to improve confidence in refactoring.",
+                facts.root_path.display()
+            ),
+            category: FindingCategory::Testing,
+            severity: Severity::Medium,
+            evidence: vec![Evidence {
+                path: facts.root_path.clone(),
+                line_start: 1,
+                line_end: None,
+                snippet: "No tests/, test/, __tests__/, or spec/ directory found.".to_string(),
+            }],
+        }]
+    }
+}

--- a/src/audits/testing/missing_test_folder.rs
+++ b/src/audits/testing/missing_test_folder.rs
@@ -21,10 +21,7 @@ impl ProjectAudit for MissingTestFolderAudit {
         }
 
         vec![Finding {
-            id: format!(
-                "testing.missing-test-folder.{}",
-                facts.root_path.display()
-            ),
+            id: format!("testing.missing-test-folder.{}", facts.root_path.display()),
             rule_id: "testing.missing-test-folder".to_string(),
             title: "No test folder found".to_string(),
             description: format!(

--- a/src/audits/testing/mod.rs
+++ b/src/audits/testing/mod.rs
@@ -1,0 +1,2 @@
+pub mod missing_test_folder;
+pub mod source_without_test;

--- a/src/audits/testing/source_without_test.rs
+++ b/src/audits/testing/source_without_test.rs
@@ -86,11 +86,9 @@ fn has_nearby_test(source: &Path, all_paths: &HashSet<PathBuf>) -> bool {
     ];
 
     // Check if any existing path ends with these relative paths
-    tests_candidates.iter().any(|candidate| {
-        all_paths
-            .iter()
-            .any(|p| p.ends_with(candidate.as_path()))
-    })
+    tests_candidates
+        .iter()
+        .any(|candidate| all_paths.iter().any(|p| p.ends_with(candidate.as_path())))
 }
 
 fn build_finding(source: &Path) -> Finding {

--- a/src/audits/testing/source_without_test.rs
+++ b/src/audits/testing/source_without_test.rs
@@ -1,0 +1,125 @@
+use crate::audits::traits::ProjectAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::ScanFacts;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+const SOURCE_EXTENSIONS: &[&str] = &["rs", "ts", "tsx", "js", "jsx", "py", "go", "java", "kt"];
+const TEST_EXTENSIONS: &[&str] = &["rs", "ts", "tsx", "js", "jsx", "py", "go", "java", "kt"];
+
+pub struct SourceWithoutTestAudit;
+
+impl ProjectAudit for SourceWithoutTestAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let all_paths: HashSet<PathBuf> = facts.files.iter().map(|f| f.path.clone()).collect();
+
+        facts
+            .files
+            .iter()
+            .filter(|file| is_source_file(&file.path))
+            .filter(|file| !is_test_file(&file.path))
+            .filter(|file| !has_nearby_test(&file.path, &all_paths))
+            .map(|file| build_finding(&file.path))
+            .collect()
+    }
+}
+
+fn is_source_file(path: &Path) -> bool {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or_default();
+    if !SOURCE_EXTENSIONS.contains(&ext) {
+        return false;
+    }
+    // Skip files already inside a test folder
+    !path.components().any(|c| {
+        let name = c.as_os_str().to_string_lossy();
+        matches!(
+            name.as_ref(),
+            "tests" | "test" | "__tests__" | "spec" | "fixtures"
+        )
+    })
+}
+
+fn is_test_file(path: &Path) -> bool {
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    stem.ends_with("_test") || stem.ends_with(".test") || stem.ends_with(".spec")
+}
+
+fn has_nearby_test(source: &Path, all_paths: &HashSet<PathBuf>) -> bool {
+    let stem = source
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+
+    let ext = source
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or_default();
+
+    if !TEST_EXTENSIONS.contains(&ext) {
+        return true; // Non-standard extension — don't flag
+    }
+
+    let parent = source.parent().unwrap_or(Path::new("."));
+
+    // Sibling test patterns: payment_test.rs, payment.test.ts, payment.spec.ts
+    let sibling_candidates = [
+        parent.join(format!("{stem}_test.{ext}")),
+        parent.join(format!("{stem}.test.{ext}")),
+        parent.join(format!("{stem}.spec.{ext}")),
+    ];
+
+    if sibling_candidates.iter().any(|p| all_paths.contains(p)) {
+        return true;
+    }
+
+    // tests/ directory alongside src/: tests/<stem>.rs, tests/<stem>_test.rs
+    let tests_candidates = [
+        PathBuf::from("tests").join(format!("{stem}.{ext}")),
+        PathBuf::from("tests").join(format!("{stem}_test.{ext}")),
+    ];
+
+    // Check if any existing path ends with these relative paths
+    tests_candidates.iter().any(|candidate| {
+        all_paths
+            .iter()
+            .any(|p| p.ends_with(candidate.as_path()))
+    })
+}
+
+fn build_finding(source: &Path) -> Finding {
+    let stem = source
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    let ext = source
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or_default();
+
+    let expected = format!("{stem}_test.{ext}");
+
+    Finding {
+        id: format!("testing.source-without-test.{}", source.display()),
+        rule_id: "testing.source-without-test".to_string(),
+        title: "Source file has no corresponding test".to_string(),
+        description: format!(
+            "`{}` has no nearby test file. Consider adding tests to cover its behaviour.",
+            source.display()
+        ),
+        category: FindingCategory::Testing,
+        severity: Severity::Low,
+        evidence: vec![Evidence {
+            path: source.to_path_buf(),
+            line_start: 1,
+            line_end: None,
+            snippet: format!("No test found; expected e.g. `{expected}`"),
+        }],
+    }
+}

--- a/src/audits/traits.rs
+++ b/src/audits/traits.rs
@@ -1,0 +1,11 @@
+use crate::findings::types::Finding;
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::{FileFacts, ScanFacts};
+
+pub trait FileAudit {
+    fn audit(&self, file: &FileFacts, config: &ScanConfig) -> Vec<Finding>;
+}
+
+pub trait ProjectAudit {
+    fn audit(&self, facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding>;
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,23 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Compare two JSON scan reports and show what changed
+    Compare {
+        /// Path to the earlier scan report (JSON)
+        before: std::path::PathBuf,
+
+        /// Path to the more recent scan report (JSON)
+        after: std::path::PathBuf,
+
+        /// Output format
+        #[arg(long, value_enum, default_value = "console")]
+        format: OutputFormatArg,
+
+        /// Write report to a file instead of stdout
+        #[arg(short, long)]
+        output: Option<std::path::PathBuf>,
+    },
+
     /// Scan a project, folder, or file
     Scan {
         /// Path to project, folder, or file
@@ -25,15 +42,24 @@ pub enum Commands {
         #[arg(short, long)]
         output: Option<PathBuf>,
 
-        /// Maximum non-empty LOC before a file is reported as large
+        /// Maximum non-empty LOC before a file is reported as large (default: 300)
         #[arg(long)]
         max_file_loc: Option<usize>,
+
+        /// Maximum number of files in a single directory before flagging (default: 20)
+        #[arg(long)]
+        max_directory_modules: Option<usize>,
+
+        /// Maximum directory nesting depth before flagging (default: 5)
+        #[arg(long)]
+        max_directory_depth: Option<usize>,
     },
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 pub enum OutputFormatArg {
     Console,
+    Html,
     Json,
     Markdown,
 }
@@ -42,6 +68,7 @@ impl From<OutputFormatArg> for OutputFormat {
     fn from(format: OutputFormatArg) -> Self {
         match format {
             OutputFormatArg::Console => OutputFormat::Console,
+            OutputFormatArg::Html => OutputFormat::Html,
             OutputFormatArg::Json => OutputFormat::Json,
             OutputFormatArg::Markdown => OutputFormat::Markdown,
         }

--- a/src/compare/diff.rs
+++ b/src/compare/diff.rs
@@ -1,0 +1,74 @@
+use crate::findings::types::{Finding, Severity};
+use crate::scan::types::ScanSummary;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug)]
+pub struct CompareSummary {
+    pub new_findings: Vec<Finding>,
+    pub resolved_findings: Vec<Finding>,
+    pub severity_increased: Vec<(Finding, Severity)>,
+    pub before_files: usize,
+    pub after_files: usize,
+    pub before_loc: usize,
+    pub after_loc: usize,
+}
+
+pub fn diff_summaries(before: &ScanSummary, after: &ScanSummary) -> CompareSummary {
+    let before_map: HashMap<&str, &Finding> = before
+        .findings
+        .iter()
+        .map(|f| (f.id.as_str(), f))
+        .collect();
+
+    let after_map: HashMap<&str, &Finding> = after
+        .findings
+        .iter()
+        .map(|f| (f.id.as_str(), f))
+        .collect();
+
+    let before_ids: HashSet<&str> = before_map.keys().copied().collect();
+    let after_ids: HashSet<&str> = after_map.keys().copied().collect();
+
+    let new_findings = after_ids
+        .difference(&before_ids)
+        .map(|id| after_map[id].clone())
+        .collect();
+
+    let resolved_findings = before_ids
+        .difference(&after_ids)
+        .map(|id| before_map[id].clone())
+        .collect();
+
+    let severity_increased = after_ids
+        .intersection(&before_ids)
+        .filter_map(|id| {
+            let before_f = before_map[id];
+            let after_f = after_map[id];
+            if severity_rank(&after_f.severity) > severity_rank(&before_f.severity) {
+                Some((after_f.clone(), before_f.severity.clone()))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    CompareSummary {
+        new_findings,
+        resolved_findings,
+        severity_increased,
+        before_files: before.files_count,
+        after_files: after.files_count,
+        before_loc: before.lines_of_code,
+        after_loc: after.lines_of_code,
+    }
+}
+
+fn severity_rank(s: &Severity) -> u8 {
+    match s {
+        Severity::Info => 0,
+        Severity::Low => 1,
+        Severity::Medium => 2,
+        Severity::High => 3,
+        Severity::Critical => 4,
+    }
+}

--- a/src/compare/diff.rs
+++ b/src/compare/diff.rs
@@ -14,17 +14,11 @@ pub struct CompareSummary {
 }
 
 pub fn diff_summaries(before: &ScanSummary, after: &ScanSummary) -> CompareSummary {
-    let before_map: HashMap<&str, &Finding> = before
-        .findings
-        .iter()
-        .map(|f| (f.id.as_str(), f))
-        .collect();
+    let before_map: HashMap<&str, &Finding> =
+        before.findings.iter().map(|f| (f.id.as_str(), f)).collect();
 
-    let after_map: HashMap<&str, &Finding> = after
-        .findings
-        .iter()
-        .map(|f| (f.id.as_str(), f))
-        .collect();
+    let after_map: HashMap<&str, &Finding> =
+        after.findings.iter().map(|f| (f.id.as_str(), f)).collect();
 
     let before_ids: HashSet<&str> = before_map.keys().copied().collect();
     let after_ids: HashSet<&str> = after_map.keys().copied().collect();

--- a/src/compare/mod.rs
+++ b/src/compare/mod.rs
@@ -1,0 +1,2 @@
+pub mod diff;
+pub mod render;

--- a/src/compare/render.rs
+++ b/src/compare/render.rs
@@ -35,14 +35,24 @@ pub fn render_console(summary: &CompareSummary) -> String {
     if !summary.new_findings.is_empty() {
         out.push_str("\n── New findings ──────────────────────────\n");
         for f in &summary.new_findings {
-            out.push_str(&format!("  [{}] {} — {}\n", f.severity_label(), f.rule_id, f.title));
+            out.push_str(&format!(
+                "  [{}] {} — {}\n",
+                f.severity_label(),
+                f.rule_id,
+                f.title
+            ));
         }
     }
 
     if !summary.resolved_findings.is_empty() {
         out.push_str("\n── Resolved findings ─────────────────────\n");
         for f in &summary.resolved_findings {
-            out.push_str(&format!("  [{}] {} — {}\n", f.severity_label(), f.rule_id, f.title));
+            out.push_str(&format!(
+                "  [{}] {} — {}\n",
+                f.severity_label(),
+                f.rule_id,
+                f.title
+            ));
         }
     }
 

--- a/src/compare/render.rs
+++ b/src/compare/render.rs
@@ -1,0 +1,118 @@
+use super::diff::CompareSummary;
+
+pub fn render_console(summary: &CompareSummary) -> String {
+    let mut out = String::new();
+
+    out.push_str("RepoPilot Compare Report\n");
+    out.push_str(&"─".repeat(40));
+    out.push('\n');
+
+    let files_delta = summary.after_files as i64 - summary.before_files as i64;
+    let loc_delta = summary.after_loc as i64 - summary.before_loc as i64;
+
+    out.push_str(&format!(
+        "Files:       {} → {}  ({:+})\n",
+        summary.before_files, summary.after_files, files_delta
+    ));
+    out.push_str(&format!(
+        "LOC:         {} → {}  ({:+})\n",
+        summary.before_loc, summary.after_loc, loc_delta
+    ));
+    out.push('\n');
+    out.push_str(&format!(
+        "New findings:       {:>4}\n",
+        summary.new_findings.len()
+    ));
+    out.push_str(&format!(
+        "Resolved:           {:>4}\n",
+        summary.resolved_findings.len()
+    ));
+    out.push_str(&format!(
+        "Severity increased: {:>4}\n",
+        summary.severity_increased.len()
+    ));
+
+    if !summary.new_findings.is_empty() {
+        out.push_str("\n── New findings ──────────────────────────\n");
+        for f in &summary.new_findings {
+            out.push_str(&format!("  [{}] {} — {}\n", f.severity_label(), f.rule_id, f.title));
+        }
+    }
+
+    if !summary.resolved_findings.is_empty() {
+        out.push_str("\n── Resolved findings ─────────────────────\n");
+        for f in &summary.resolved_findings {
+            out.push_str(&format!("  [{}] {} — {}\n", f.severity_label(), f.rule_id, f.title));
+        }
+    }
+
+    if !summary.severity_increased.is_empty() {
+        out.push_str("\n── Severity increased ────────────────────\n");
+        for (f, old_sev) in &summary.severity_increased {
+            out.push_str(&format!(
+                "  {} → [{}] {}\n",
+                old_sev.label(),
+                f.severity_label(),
+                f.rule_id
+            ));
+        }
+    }
+
+    out
+}
+
+pub fn render_markdown(summary: &CompareSummary) -> String {
+    let mut out = String::new();
+
+    out.push_str("# RepoPilot Compare Report\n\n");
+    out.push_str("## Overview\n\n");
+    out.push_str("| Metric | Before | After | Delta |\n| --- | ---: | ---: | ---: |\n");
+
+    let files_delta = summary.after_files as i64 - summary.before_files as i64;
+    let loc_delta = summary.after_loc as i64 - summary.before_loc as i64;
+    let new_count = summary.new_findings.len() as i64;
+    let resolved_count = summary.resolved_findings.len() as i64;
+
+    out.push_str(&format!(
+        "| Files | {} | {} | {:+} |\n",
+        summary.before_files, summary.after_files, files_delta
+    ));
+    out.push_str(&format!(
+        "| LOC | {} | {} | {:+} |\n",
+        summary.before_loc, summary.after_loc, loc_delta
+    ));
+    out.push_str(&format!(
+        "| Findings | — | — | {:+} |\n\n",
+        new_count - resolved_count
+    ));
+
+    if !summary.new_findings.is_empty() {
+        out.push_str("## New findings\n\n");
+        out.push_str("| Severity | Rule | Title |\n| --- | --- | --- |\n");
+        for f in &summary.new_findings {
+            out.push_str(&format!(
+                "| {} | `{}` | {} |\n",
+                f.severity_label(),
+                f.rule_id,
+                f.title
+            ));
+        }
+        out.push('\n');
+    }
+
+    if !summary.resolved_findings.is_empty() {
+        out.push_str("## Resolved findings\n\n");
+        out.push_str("| Severity | Rule | Title |\n| --- | --- | --- |\n");
+        for f in &summary.resolved_findings {
+            out.push_str(&format!(
+                "| {} | `{}` | {} |\n",
+                f.severity_label(),
+                f.rule_id,
+                f.title
+            ));
+        }
+        out.push('\n');
+    }
+
+    out
+}

--- a/src/findings/types.rs
+++ b/src/findings/types.rs
@@ -1,7 +1,7 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Finding {
     pub id: String,
     pub rule_id: String,
@@ -12,7 +12,7 @@ pub struct Finding {
     pub evidence: Vec<Evidence>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FindingCategory {
     Architecture,
@@ -22,7 +22,7 @@ pub enum FindingCategory {
     Performance,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Severity {
     Info,
@@ -32,7 +32,7 @@ pub enum Severity {
     Critical,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Evidence {
     pub path: PathBuf,
     pub line_start: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audits;
+pub mod compare;
 pub mod findings;
 pub mod output;
 pub mod report;

--- a/src/output/html.rs
+++ b/src/output/html.rs
@@ -20,7 +20,12 @@ pub fn render(summary: &ScanSummary) -> String {
             let snippet = f
                 .evidence
                 .first()
-                .map(|e| format!("<pre class=\"snippet\">{}</pre>", escape_html(e.snippet.trim())))
+                .map(|e| {
+                    format!(
+                        "<pre class=\"snippet\">{}</pre>",
+                        escape_html(e.snippet.trim())
+                    )
+                })
                 .unwrap_or_default();
 
             let severity_class = f.severity_label().to_lowercase();

--- a/src/output/html.rs
+++ b/src/output/html.rs
@@ -1,0 +1,173 @@
+use crate::scan::types::ScanSummary;
+
+pub fn render(summary: &ScanSummary) -> String {
+    let findings_rows = summary
+        .findings
+        .iter()
+        .map(|f| {
+            let ev = f
+                .evidence
+                .first()
+                .map(|e| {
+                    format!(
+                        "<code>{}:{}</code>",
+                        escape_html(&e.path.to_string_lossy()),
+                        e.line_start
+                    )
+                })
+                .unwrap_or_default();
+
+            let snippet = f
+                .evidence
+                .first()
+                .map(|e| format!("<pre class=\"snippet\">{}</pre>", escape_html(e.snippet.trim())))
+                .unwrap_or_default();
+
+            let severity_class = f.severity_label().to_lowercase();
+
+            format!(
+                "<tr>\
+                    <td><span class=\"badge {severity_class}\">{}</span></td>\
+                    <td><code>{}</code></td>\
+                    <td>{}</td>\
+                    <td>{ev}{snippet}</td>\
+                 </tr>",
+                escape_html(f.severity_label()),
+                escape_html(&f.rule_id),
+                escape_html(&f.title),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let lang_rows = summary
+        .languages
+        .iter()
+        .map(|l| {
+            format!(
+                "<tr><td>{}</td><td class=\"num\">{}</td></tr>",
+                escape_html(&l.name),
+                l.files_count
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let findings_empty = if summary.findings.is_empty() {
+        "<p class=\"empty\">No findings found.</p>"
+    } else {
+        ""
+    };
+
+    let lang_empty = if summary.languages.is_empty() {
+        "<p class=\"empty\">No languages detected.</p>"
+    } else {
+        ""
+    };
+
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RepoPilot Scan Report</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; margin: 0; padding: 2rem; color: #1a1a1a; background: #f8f8f8; }}
+  h1 {{ font-size: 1.6rem; margin-bottom: 0.25rem; }}
+  h2 {{ font-size: 1.1rem; margin-top: 2rem; border-bottom: 1px solid #ddd; padding-bottom: 0.3rem; }}
+  .meta {{ color: #666; font-size: 0.9rem; margin-bottom: 1.5rem; }}
+  .cards {{ display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1.5rem; }}
+  .card {{ background: #fff; border: 1px solid #e0e0e0; border-radius: 6px; padding: 1rem 1.5rem; min-width: 120px; }}
+  .card .num {{ font-size: 1.8rem; font-weight: 700; }}
+  .card .label {{ font-size: 0.75rem; color: #888; text-transform: uppercase; letter-spacing: .05em; }}
+  table {{ width: 100%; border-collapse: collapse; background: #fff; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px #0001; }}
+  th {{ text-align: left; padding: 0.6rem 1rem; background: #f0f0f0; font-size: 0.8rem; text-transform: uppercase; letter-spacing: .05em; }}
+  td {{ padding: 0.6rem 1rem; border-top: 1px solid #eee; vertical-align: top; font-size: 0.88rem; }}
+  .num {{ text-align: right; }}
+  .badge {{ display: inline-block; padding: 0.15rem 0.55rem; border-radius: 3px; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; }}
+  .badge.info {{ background: #e8f4ff; color: #2563eb; }}
+  .badge.low {{ background: #f0fdf4; color: #16a34a; }}
+  .badge.medium {{ background: #fffbeb; color: #d97706; }}
+  .badge.high {{ background: #fff7ed; color: #ea580c; }}
+  .badge.critical {{ background: #fef2f2; color: #dc2626; }}
+  pre.snippet {{ margin: 0.3rem 0 0; font-size: 0.8rem; background: #f5f5f5; padding: 0.4rem 0.6rem; border-radius: 4px; overflow: auto; white-space: pre-wrap; }}
+  .empty {{ color: #999; font-style: italic; }}
+  .filter-bar {{ display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.75rem; }}
+  .filter-btn {{ padding: 0.25rem 0.75rem; border: 1px solid #ccc; border-radius: 20px; cursor: pointer; font-size: 0.8rem; background: #fff; }}
+  .filter-btn.active {{ background: #1a1a1a; color: #fff; border-color: #1a1a1a; }}
+</style>
+</head>
+<body>
+<h1>RepoPilot Scan Report</h1>
+<p class="meta">Path: <code>{path}</code></p>
+
+<div class="cards">
+  <div class="card"><div class="num">{files}</div><div class="label">Files</div></div>
+  <div class="card"><div class="num">{dirs}</div><div class="label">Directories</div></div>
+  <div class="card"><div class="num">{loc}</div><div class="label">Lines of Code</div></div>
+  <div class="card"><div class="num">{finding_count}</div><div class="label">Findings</div></div>
+</div>
+
+<h2>Languages</h2>
+{lang_empty}
+{lang_table}
+
+<h2>Findings</h2>
+{findings_empty}
+<div class="filter-bar" id="filter-bar"></div>
+{findings_table}
+
+<script>
+  const rows = document.querySelectorAll('table#findings tbody tr');
+  const bar = document.getElementById('filter-bar');
+  const severities = [...new Set([...rows].map(r => r.querySelector('.badge').textContent.trim()))];
+  let active = new Set();
+
+  severities.forEach(sev => {{
+    const btn = document.createElement('button');
+    btn.className = 'filter-btn';
+    btn.textContent = sev;
+    btn.onclick = () => {{
+      if (active.has(sev)) {{ active.delete(sev); btn.classList.remove('active'); }}
+      else {{ active.add(sev); btn.classList.add('active'); }}
+      rows.forEach(r => {{
+        const rowSev = r.querySelector('.badge').textContent.trim();
+        r.style.display = active.size === 0 || active.has(rowSev) ? '' : 'none';
+      }});
+    }};
+    bar.appendChild(btn);
+  }});
+</script>
+</body>
+</html>"#,
+        path = escape_html(&summary.root_path.to_string_lossy()),
+        files = summary.files_count,
+        dirs = summary.directories_count,
+        loc = summary.lines_of_code,
+        finding_count = summary.findings.len(),
+        lang_empty = lang_empty,
+        lang_table = if summary.languages.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "<table><thead><tr><th>Language</th><th class=\"num\">Files</th></tr></thead><tbody>{lang_rows}</tbody></table>"
+            )
+        },
+        findings_empty = findings_empty,
+        findings_table = if summary.findings.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "<table id=\"findings\"><thead><tr><th>Severity</th><th>Rule</th><th>Title</th><th>Evidence</th></tr></thead><tbody>{findings_rows}</tbody></table>"
+            )
+        },
+    )
+}
+
+fn escape_html(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,4 +1,5 @@
 pub mod console;
+pub mod html;
 pub mod json;
 pub mod markdown;
 
@@ -7,6 +8,7 @@ use crate::scan::types::ScanSummary;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OutputFormat {
     Console,
+    Html,
     Json,
     Markdown,
 }
@@ -17,6 +19,7 @@ pub fn render_scan_summary(
 ) -> Result<String, serde_json::Error> {
     match format {
         OutputFormat::Console => Ok(console::render(summary)),
+        OutputFormat::Html => Ok(html::render(summary)),
         OutputFormat::Json => json::render(summary),
         OutputFormat::Markdown => Ok(markdown::render(summary)),
     }

--- a/src/scan/config.rs
+++ b/src/scan/config.rs
@@ -2,6 +2,9 @@
 pub struct ScanConfig {
     pub large_file_loc_threshold: usize,
     pub huge_file_loc_threshold: usize,
+    pub max_directory_modules: usize,
+    pub max_directory_depth: usize,
+    pub long_function_loc_threshold: usize,
 }
 
 impl Default for ScanConfig {
@@ -9,6 +12,9 @@ impl Default for ScanConfig {
         Self {
             large_file_loc_threshold: 300,
             huge_file_loc_threshold: 1000,
+            max_directory_modules: 20,
+            max_directory_depth: 5,
+            long_function_loc_threshold: 50,
         }
     }
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -1,5 +1,5 @@
 use crate::findings::types::Finding;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -17,7 +17,7 @@ pub struct Marker {
     pub text: String,
 }
 
-#[derive(Debug, Default, Serialize, PartialEq, Eq)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ScanSummary {
     pub root_path: PathBuf,
     pub files_count: usize,
@@ -27,7 +27,7 @@ pub struct ScanSummary {
     pub findings: Vec<Finding>,
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LanguageSummary {
     pub name: String,
     pub files_count: usize,

--- a/tests/marker_findings.rs
+++ b/tests/marker_findings.rs
@@ -1,6 +1,7 @@
 use repopilot::audits::code_quality::code_markers::detect_code_marker_findings;
 use repopilot::findings::types::{FindingCategory, Severity};
-use std::path::Path;
+use repopilot::scan::facts::FileFacts;
+use std::path::{Path, PathBuf};
 
 #[test]
 fn converts_code_markers_into_evidence_backed_findings() {
@@ -12,7 +13,14 @@ fn main() {}
 // HACK: temporary workaround
 ";
 
-    let findings = detect_code_marker_findings(Path::new("src/main.rs"), content);
+    let file = FileFacts {
+        path: PathBuf::from("src/main.rs"),
+        language: Some("Rust".to_string()),
+        lines_of_code: 5,
+        content: content.to_string(),
+    };
+
+    let findings = detect_code_marker_findings(&file);
 
     assert_eq!(findings.len(), 3);
 

--- a/tests/scan_summary.rs
+++ b/tests/scan_summary.rs
@@ -25,9 +25,13 @@ fn scans_directory_with_counts_languages_and_markers() {
     assert_eq!(summary.directories_count, 1);
     assert_eq!(summary.files_count, 3);
     assert_eq!(summary.lines_of_code, 4);
-    assert_eq!(summary.findings.len(), 1);
-    assert_eq!(summary.findings[0].rule_id, "code-marker.todo");
-    assert_eq!(summary.findings[0].evidence[0].line_start, 3);
+
+    let todo_finding = summary
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "code-marker.todo")
+        .expect("expected a code-marker.todo finding");
+    assert_eq!(todo_finding.evidence[0].line_start, 3);
 
     assert!(
         summary


### PR DESCRIPTION
## Summary

This PR introduces the next architectural layer for RepoPilot audits by moving audit rules toward a trait-based model. New rules can now be implemented as focused `FileAudit` or `ProjectAudit` structs instead of adding more logic directly into the scan pipeline.

It also expands the current audit coverage with architecture, security, and testing rules, adds scan comparison support, introduces HTML report rendering, and prepares the project for public distribution through GitHub Releases and crates.io.

## Type of change

- Feature
- Refactor
- Tests
- Documentation
- CI / repository maintenance

## What changed

- Added `FileAudit` and `ProjectAudit` traits for a cleaner audit architecture.
- Refactored existing audits to use the new trait-based structure.
- Added architecture audits:
  - `architecture.deep-nesting`
  - `architecture.too-many-modules`
- Added security audits:
  - `security.env-file-committed`
  - `security.secret-candidate`
  - `security.private-key-candidate`
- Added testing audits:
  - `testing.missing-test-folder`
  - `testing.source-without-test`
- Added configurable scan thresholds:
  - `--max-directory-modules`
  - `--max-directory-depth`
- Added `compare` command for comparing two JSON scan reports.
- Added HTML report rendering for scan summaries.
- Updated finding types to support JSON deserialization for compare/report workflows.
- Updated `docs/rulesets.md` with the new rules and evidence behavior.
- Updated `CHANGELOG.md`.
- Added crates.io metadata to `Cargo.toml`.
- Added GitHub Actions release workflow for publishing tagged releases and prebuilt binaries.

## Why

This PR makes RepoPilot easier to extend.

Before this change, adding new audit rules could push more responsibility into the pipeline and make the project harder to scale. With the trait-based structure, each audit becomes a small, focused module with a clear responsibility.

This is important because RepoPilot is moving from a simple scanner toward a real codebase audit CLI that can support multiple categories of rules, configurable thresholds, report formats, and future rulesets.

## Architecture notes

- No god files introduced.
- Audit logic is split by domain:
  - architecture
  - security
  - testing
  - code quality
- Rule implementations are isolated from the scan pipeline.
- File-level and project-level audits are separated through traits.
- Scan configuration remains centralized in `ScanConfig`.
- Findings keep structured evidence for future JSON/HTML/Markdown consumers.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .
cargo run -- scan . --format json --output before.json
cargo run -- scan . --format json --output after.json
cargo run -- compare before.json after.json