### PR TITLE
chore: stabilize v0.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,9 @@ jobs:
           cp target/${{ matrix.target }}/release/${BINARY_NAME} dist/
           cd dist
           tar -czf "${ASSET_NAME}.tar.gz" ${BINARY_NAME}
+          shasum -a 256 "${ASSET_NAME}.tar.gz" > "${ASSET_NAME}.tar.gz.sha256"
           echo "ASSET=dist/${ASSET_NAME}.tar.gz" >> $GITHUB_ENV
+          echo "CHECKSUM=dist/${ASSET_NAME}.tar.gz.sha256" >> $GITHUB_ENV
 
       - name: Package (Windows)
         if: matrix.archive == 'zip'
@@ -72,16 +74,21 @@ jobs:
           New-Item -ItemType Directory -Force -Path dist
           Copy-Item "target/${{ matrix.target }}/release/${BinaryName}.exe" dist/
           Compress-Archive -Path "dist/${BinaryName}.exe" -DestinationPath "dist/${AssetName}.zip"
+          Get-FileHash "dist/${AssetName}.zip" -Algorithm SHA256 | ForEach-Object { "$($_.Hash.ToLower())  ${AssetName}.zip" } | Out-File -Encoding ascii "dist/${AssetName}.zip.sha256"
           echo "ASSET=dist/${AssetName}.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "CHECKSUM=dist/${AssetName}.zip.sha256" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.ASSET }}
+          files: |
+            ${{ env.ASSET }}
+            ${{ env.CHECKSUM }}
           generate_release_notes: true
 
   publish-crates:
     name: Publish to crates.io
+    if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -89,6 +96,9 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish dry run
+        run: cargo publish --dry-run
 
       - name: Publish
         run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- `FileAudit` and `ProjectAudit` traits — audit rules now implement a trait instead of free functions, making it trivial to add new rules without modifying the pipeline
-- `Markdown ## Markers` section — dedicated table for `TODO`/`FIXME`/`HACK` findings in Markdown reports
-- `ScanConfig` fields: `max_directory_modules`, `max_directory_depth`, `long_function_loc_threshold` — groundwork for upcoming architecture and code-quality rules
-- `Cargo.toml` crates.io metadata: description, license, repository, keywords, categories
-- GitHub Actions release workflow — builds and uploads pre-built binaries for Linux x86_64/ARM64, macOS x86_64/ARM64, and Windows x86_64 on `v*` tags; publishes to crates.io
-
-### Changed
-
-- `code_markers` audit now reuses `scan::markers::detect_markers` instead of duplicating detection logic
-- `scan::markers` module promoted to a first-class scan primitive (`MarkerKind`, `Marker`, `detect_markers`)
+- Homebrew tap distribution remains planned after GitHub Release artifacts are available
 
 ## [0.1.0] - Unreleased
 
 ### Added
 
+- `FileAudit` and `ProjectAudit` traits — audit rules now implement a trait instead of free functions, making it trivial to add new rules without modifying the pipeline
+- `Markdown ## Markers` section — dedicated table for `TODO`/`FIXME`/`HACK` findings in Markdown reports
+- `ScanConfig` fields: `max_directory_modules`, `max_directory_depth`, `long_function_loc_threshold` — groundwork for upcoming architecture and code-quality rules
+- `Cargo.toml` crates.io metadata: description, license, repository, keywords, categories
 - Gitignore-aware file walker using the `ignore` crate
 - File and directory counting with non-empty lines-of-code measurement
 - Language detection by file extension (Rust, Python, JavaScript, TypeScript, Go, Java, C/C++, HTML, CSS, TOML, YAML, Markdown)
@@ -33,8 +28,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - File facts audit pipeline separating scan, audit, and report responsibilities
 - Console, JSON, and Markdown output formats
 - `--output` flag to write reports to a file
+- `architecture.too-many-modules` and `architecture.deep-nesting` audits
+- `testing.missing-test-folder` and `testing.source-without-test` audits
+- `security.secret-candidate`, `security.private-key-candidate`, and `security.env-file-committed` audits
+- HTML scan reports with inline filtering
+- `compare` command for console, Markdown, and JSON diffs between two JSON scan reports
 - CI workflow running `cargo fmt`, `cargo clippy`, and `cargo test` on every PR and push to `main`
+- GitHub Actions release workflow — builds and uploads pre-built binaries for Linux x86_64/ARM64, macOS x86_64/ARM64, and Windows x86_64 on `v*` tags; publishes to crates.io for release tags
 - Repository governance docs: release process, distribution channels, audit rulesets, GitHub ruleset setup
+
+### Changed
+
+- `code_markers` audit now reuses `scan::markers::detect_markers` instead of duplicating detection logic
+- `scan::markers` module promoted to a first-class scan primitive (`MarkerKind`, `Marker`, `detect_markers`)
+- Scanner now explicitly skips VCS/build/service directories such as `.git/`, `.github/`, `target/`, `node_modules/`, `dist/`, and `build/`
+- Compare matching now uses `rule_id + evidence path + evidence line` as the stable key, with finding `id` as fallback
+- Release workflow now uploads SHA-256 checksum files, runs `cargo publish --dry-run`, and skips crates.io publish for prerelease/test tags
 
 [Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/MykytaStel/repopilot/releases/tag/v0.1.0

--- a/Readme.md
+++ b/Readme.md
@@ -13,15 +13,17 @@ The long-term goal is to scan projects, folders, or files and produce evidence-b
 - Language detection by file extension
 - `TODO` / `FIXME` / `HACK` marker detection with per-line evidence
 - Evidence-backed finding model (stable rule IDs, categories, severity, source snippets)
-- `architecture.large-file` finding with configurable LOC threshold
-- Console, JSON, and Markdown output formats
+- Architecture, testing, and security audit rules with configurable thresholds
+- `compare` command for diffing two JSON scan reports
+- Console, JSON, Markdown, and HTML scan output formats
 - `--output` flag to write reports to a file
 
 See [docs/rulesets.md](docs/rulesets.md) for the full list of audit rules and severity levels.
 
 ## Installation
 
-RepoPilot is not yet published to crates.io. Install from source:
+RepoPilot v0.1.0 is prepared for source installs, GitHub Release binaries, and crates.io publishing.
+Until the first release is cut, install from source:
 
 ```bash
 git clone https://github.com/MykytaStel/repopilot.git
@@ -36,7 +38,7 @@ Or install directly with cargo:
 cargo install --git https://github.com/MykytaStel/repopilot.git
 ```
 
-See [docs/distribution.md](docs/distribution.md) for planned distribution channels (crates.io, pre-built binaries, Homebrew).
+See [docs/distribution.md](docs/distribution.md) for distribution channels. Homebrew support is planned after GitHub Release artifacts are available.
 
 ## Usage
 
@@ -44,14 +46,17 @@ See [docs/distribution.md](docs/distribution.md) for planned distribution channe
 cargo run -- scan .
 cargo run -- scan . --format json
 cargo run -- scan . --format markdown
+cargo run -- scan . --format html --output report.html
 cargo run -- --help
 cargo run -- scan --help
 ```
 
-Custom large-file threshold:
+Custom thresholds:
 
 ```bash
 cargo run -- scan . --max-file-loc 500
+cargo run -- scan . --max-directory-modules 25
+cargo run -- scan . --max-directory-depth 6
 ```
 
 Write report to file:
@@ -59,7 +64,18 @@ Write report to file:
 ```bash
 cargo run -- scan . --format markdown --output report.md
 cargo run -- scan . --format json --output report.json
+cargo run -- scan . --format html --output report.html
 cargo run -- scan . --format console --output report.txt
+```
+
+Compare two JSON reports:
+
+```bash
+cargo run -- scan . --format json --output before.json
+cargo run -- scan . --format json --output after.json
+cargo run -- compare before.json after.json
+cargo run -- compare before.json after.json --format markdown
+cargo run -- compare before.json after.json --format json --output diff.json
 ```
 
 ## Findings
@@ -81,8 +97,16 @@ Current rules:
 | `code-marker.fixme` | CODE_QUALITY | MEDIUM |
 | `code-marker.hack` | CODE_QUALITY | MEDIUM |
 | `architecture.large-file` | ARCHITECTURE | MEDIUM / HIGH |
+| `architecture.too-many-modules` | ARCHITECTURE | MEDIUM |
+| `architecture.deep-nesting` | ARCHITECTURE | LOW |
+| `testing.missing-test-folder` | TESTING | MEDIUM |
+| `testing.source-without-test` | TESTING | LOW |
+| `security.secret-candidate` | SECURITY | HIGH |
+| `security.private-key-candidate` | SECURITY | CRITICAL |
+| `security.env-file-committed` | SECURITY | HIGH |
 
 The `architecture.large-file` rule uses a default threshold of 300 non-empty LOC. Override with `--max-file-loc`.
+Directory architecture thresholds default to 20 files per directory and 5 directory levels below the scan root.
 
 See [docs/rulesets.md](docs/rulesets.md) for full rule documentation.
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -21,7 +21,7 @@ cargo build --release
 cargo install --git https://github.com/MykytaStel/repopilot.git
 ```
 
-## Planned: crates.io
+## Prepared: crates.io
 
 Once the CLI surface stabilizes at `0.1.0`, RepoPilot will be published to crates.io:
 
@@ -36,7 +36,7 @@ Before publishing:
 
 ## Planned: GitHub Releases (pre-built binaries)
 
-A release workflow will build binaries for the following targets on every version tag:
+The release workflow builds binaries for the following targets on every `v*` tag:
 
 | Target | Platform |
 |---|---|
@@ -46,11 +46,13 @@ A release workflow will build binaries for the following targets on every versio
 | `aarch64-apple-darwin` | macOS Apple Silicon |
 | `x86_64-pc-windows-msvc` | Windows x86-64 |
 
-Binaries will be attached to each GitHub Release. Users will be able to download and run without installing Rust.
+Binaries and `.sha256` checksum files are attached to each GitHub Release. Users can download and run without installing Rust.
+
+Tags containing a hyphen, such as `v0.1.0-test`, are treated as test/prerelease tags for workflow validation and do not publish to crates.io.
 
 ## Planned: Homebrew
 
-A Homebrew formula will be added once the crates.io release is stable. Users will be able to install with:
+A Homebrew formula will be added after GitHub Release artifacts are available. Users will be able to install with:
 
 ```bash
 brew install repopilot

--- a/docs/release.md
+++ b/docs/release.md
@@ -18,40 +18,49 @@ In `Cargo.toml`, update the `version` field:
 
 ```toml
 [package]
-version = "0.2.0"
+version = "0.1.0"
 ```
 
 Run `cargo build` to regenerate `Cargo.lock` with the new version.
 
 ### 2. Update `CHANGELOG.md`
 
-- Rename the `[Unreleased]` heading to `[0.2.0] - YYYY-MM-DD`.
+- Rename the `[Unreleased]` heading to the release version and date.
 - Add a new empty `[Unreleased]` section at the top.
 - Update the comparison links at the bottom of the file.
 
 ### 3. Open a release PR
 
-Title: `chore: release v0.2.0`
+Title: `chore: release v0.1.0`
 
 Include only the `Cargo.toml`, `Cargo.lock`, and `CHANGELOG.md` changes. CI must pass before merge.
+
+Before merging, run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+cargo publish --dry-run
+```
 
 ### 4. Tag after merge
 
 ```bash
-git tag v0.2.0
-git push origin v0.2.0
+git tag v0.1.0
+git push origin v0.1.0
 ```
 
 Tag only commits that are on `main`. A tag on an unmerged commit creates confusion.
 
-### 5. Create a GitHub Release
+### 5. Confirm the GitHub Release
 
-- Go to **Releases → Draft a new release**.
-- Select the tag created above.
-- Paste the CHANGELOG entry for this version as the release description.
-- Attach pre-built binaries when the release workflow is in place (see `docs/distribution.md`).
+- The release workflow creates the GitHub Release on `v*` tags.
+- Confirm all binary archives and `.sha256` files are attached.
+- Confirm crates.io publish ran only for a real release tag, not a prerelease/test tag containing `-`.
+- Paste or edit the CHANGELOG entry if generated release notes need cleanup.
 
 ## Notes
 
-- A release workflow that produces pre-built binaries on tag push will be added in a future PR.
+- Prerelease/test tags such as `v0.1.0-test` build artifacts but do not publish to crates.io.
 - Do not skip CI (`--no-verify`) or amend published commits.

--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -32,6 +32,8 @@ RepoPilot findings are identified by a stable `rule_id`. Each rule belongs to a 
 | Severity | `LOW` |
 | Description | A `TODO` comment was found. Review whether it represents outstanding work that should be tracked. |
 
+Markdown files and files under `tests/` or `test/` are skipped to avoid reporting documentation examples and test fixture strings as production debt.
+
 ### `code-marker.fixme`
 
 | Field | Value |
@@ -94,7 +96,9 @@ The *huge* threshold defaults to `max(threshold × 3, threshold + 1)`. When `--m
 |---|---|
 | Category | `TESTING` |
 | Severity | `LOW` |
-| Description | A source file has no detectable test counterpart. Looks for sibling files like `payment_test.rs`, `payment.test.ts`, `payment.spec.ts`, or entries in a `tests/` directory. |
+| Description | A source file has no detectable test counterpart. Looks for sibling files like `payment_test.rs`, `payment.test.ts`, `payment.spec.ts`, entries in a `tests/` directory, or Rust integration tests such as `tests/report_writer.rs` for `src/report/writer.rs`. |
+
+Low-signal wrapper entrypoints such as `mod.rs`, `lib.rs`, and `main.rs` are skipped.
 
 ### `security.secret-candidate`
 
@@ -113,6 +117,8 @@ Skipped for files whose path contains `test`, `fixture`, `example`, or `mock`.
 | Category | `SECURITY` |
 | Severity | `CRITICAL` |
 | Description | A PEM private key header (`-----BEGIN RSA PRIVATE KEY-----`, etc.) was found in a source file. The key content is never included in the evidence. |
+
+Markdown examples under `docs/` are skipped to avoid reporting documented rule examples as committed keys.
 
 ### `security.env-file-committed`
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,8 @@
-use crate::cli::{Cli, Commands, OutputFormatArg};
+use crate::cli::{Cli, Commands, CompareOutputFormatArg};
 use repopilot::compare::diff::diff_summaries;
 use repopilot::compare::render::{
-    render_console as compare_console, render_markdown as compare_markdown,
+    render_console as compare_console, render_json as compare_json,
+    render_markdown as compare_markdown,
 };
 use repopilot::output::render_scan_summary;
 use repopilot::report::writer::write_report;
@@ -46,9 +47,10 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             let diff = diff_summaries(&before_summary, &after_summary);
 
             let rendered = match format {
-                OutputFormatArg::Markdown => compare_markdown(&diff),
-                _ => compare_console(&diff),
-            };
+                CompareOutputFormatArg::Console => Ok(compare_console(&diff)),
+                CompareOutputFormatArg::Json => compare_json(&diff),
+                CompareOutputFormatArg::Markdown => Ok(compare_markdown(&diff)),
+            }?;
 
             write_report(&rendered, output.as_deref())?;
 

--- a/src/audits/code_quality/code_markers.rs
+++ b/src/audits/code_quality/code_markers.rs
@@ -9,6 +9,10 @@ pub struct CodeMarkerAudit;
 
 impl FileAudit for CodeMarkerAudit {
     fn audit(&self, file: &FileFacts, _config: &ScanConfig) -> Vec<Finding> {
+        if should_skip_marker_audit(&file.path) {
+            return vec![];
+        }
+
         detect_markers(&file.path, &file.content)
             .iter()
             .map(build_marker_finding)
@@ -61,4 +65,18 @@ fn marker_severity(marker: &str) -> Severity {
         "todo" => Severity::Low,
         _ => Severity::Info,
     }
+}
+
+fn should_skip_marker_audit(path: &std::path::Path) -> bool {
+    let is_markdown = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
+
+    is_markdown || has_component(path, "tests") || has_component(path, "test")
+}
+
+fn has_component(path: &std::path::Path, component: &str) -> bool {
+    path.components()
+        .any(|c| c.as_os_str().to_string_lossy() == component)
 }

--- a/src/audits/security/private_key_candidate.rs
+++ b/src/audits/security/private_key_candidate.rs
@@ -15,6 +15,10 @@ pub struct PrivateKeyCandidateAudit;
 
 impl FileAudit for PrivateKeyCandidateAudit {
     fn audit(&self, file: &FileFacts, _config: &ScanConfig) -> Vec<Finding> {
+        if should_skip_private_key_audit(&file.path) {
+            return vec![];
+        }
+
         file.content
             .lines()
             .enumerate()
@@ -22,11 +26,32 @@ impl FileAudit for PrivateKeyCandidateAudit {
                 let trimmed = line.trim();
                 PRIVATE_KEY_HEADERS
                     .iter()
-                    .find(|&&header| trimmed.contains(header))
+                    .find(|&&header| trimmed.starts_with(header))
                     .map(|header| build_finding(&file.path, index + 1, header))
             })
             .collect()
     }
+}
+
+fn should_skip_private_key_audit(path: &std::path::Path) -> bool {
+    let lower_path = path.to_string_lossy().to_lowercase();
+    if lower_path.contains("test")
+        || lower_path.contains("fixture")
+        || lower_path.contains("example")
+        || lower_path.contains("mock")
+    {
+        return true;
+    }
+
+    let is_markdown = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
+
+    is_markdown
+        && path
+            .components()
+            .any(|c| c.as_os_str().to_string_lossy() == "docs")
 }
 
 fn build_finding(path: &std::path::Path, line_number: usize, header: &str) -> Finding {

--- a/src/audits/testing/source_without_test.rs
+++ b/src/audits/testing/source_without_test.rs
@@ -19,6 +19,7 @@ impl ProjectAudit for SourceWithoutTestAudit {
             .iter()
             .filter(|file| is_source_file(&file.path))
             .filter(|file| !is_test_file(&file.path))
+            .filter(|file| !is_low_signal_wrapper(&file.path))
             .filter(|file| !has_nearby_test(&file.path, &all_paths))
             .map(|file| build_finding(&file.path))
             .collect()
@@ -49,6 +50,15 @@ fn is_test_file(path: &Path) -> bool {
         .and_then(|s| s.to_str())
         .unwrap_or_default();
     stem.ends_with("_test") || stem.ends_with(".test") || stem.ends_with(".spec")
+}
+
+fn is_low_signal_wrapper(path: &Path) -> bool {
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+
+    matches!(file_name, "mod.rs" | "lib.rs" | "main.rs")
 }
 
 fn has_nearby_test(source: &Path, all_paths: &HashSet<PathBuf>) -> bool {
@@ -86,9 +96,48 @@ fn has_nearby_test(source: &Path, all_paths: &HashSet<PathBuf>) -> bool {
     ];
 
     // Check if any existing path ends with these relative paths
-    tests_candidates
+    if tests_candidates
         .iter()
         .any(|candidate| all_paths.iter().any(|p| p.ends_with(candidate.as_path())))
+    {
+        return true;
+    }
+
+    // Rust integration tests commonly cover a module by feature name:
+    // src/report/writer.rs -> tests/report_writer.rs
+    if ext == "rs" {
+        let module_candidate =
+            PathBuf::from("tests").join(format!("{}.rs", module_test_name(source)));
+        return all_paths
+            .iter()
+            .any(|p| p.ends_with(module_candidate.as_path()));
+    }
+
+    false
+}
+
+fn module_test_name(source: &Path) -> String {
+    let Some(src_index) = source
+        .components()
+        .position(|c| c.as_os_str().to_string_lossy() == "src")
+    else {
+        return source
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default()
+            .to_string();
+    };
+
+    source
+        .components()
+        .skip(src_index + 1)
+        .filter_map(|c| {
+            let value = c.as_os_str().to_string_lossy();
+            let value = value.strip_suffix(".rs").unwrap_or(value.as_ref());
+            (value != "mod").then(|| value.to_string())
+        })
+        .collect::<Vec<_>>()
+        .join("_")
 }
 
 fn build_finding(source: &Path) -> Finding {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,7 @@ pub enum Commands {
 
         /// Output format
         #[arg(long, value_enum, default_value = "console")]
-        format: OutputFormatArg,
+        format: CompareOutputFormatArg,
 
         /// Write report to a file instead of stdout
         #[arg(short, long)]
@@ -60,6 +60,13 @@ pub enum Commands {
 pub enum OutputFormatArg {
     Console,
     Html,
+    Json,
+    Markdown,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum CompareOutputFormatArg {
+    Console,
     Json,
     Markdown,
 }

--- a/src/compare/diff.rs
+++ b/src/compare/diff.rs
@@ -1,8 +1,9 @@
 use crate::findings::types::{Finding, Severity};
 use crate::scan::types::ScanSummary;
+use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct CompareSummary {
     pub new_findings: Vec<Finding>,
     pub resolved_findings: Vec<Finding>,
@@ -14,14 +15,20 @@ pub struct CompareSummary {
 }
 
 pub fn diff_summaries(before: &ScanSummary, after: &ScanSummary) -> CompareSummary {
-    let before_map: HashMap<&str, &Finding> =
-        before.findings.iter().map(|f| (f.id.as_str(), f)).collect();
+    let before_map: HashMap<String, &Finding> = before
+        .findings
+        .iter()
+        .map(|f| (stable_finding_key(f), f))
+        .collect();
 
-    let after_map: HashMap<&str, &Finding> =
-        after.findings.iter().map(|f| (f.id.as_str(), f)).collect();
+    let after_map: HashMap<String, &Finding> = after
+        .findings
+        .iter()
+        .map(|f| (stable_finding_key(f), f))
+        .collect();
 
-    let before_ids: HashSet<&str> = before_map.keys().copied().collect();
-    let after_ids: HashSet<&str> = after_map.keys().copied().collect();
+    let before_ids: HashSet<String> = before_map.keys().cloned().collect();
+    let after_ids: HashSet<String> = after_map.keys().cloned().collect();
 
     let new_findings = after_ids
         .difference(&before_ids)
@@ -55,6 +62,21 @@ pub fn diff_summaries(before: &ScanSummary, after: &ScanSummary) -> CompareSumma
         before_loc: before.lines_of_code,
         after_loc: after.lines_of_code,
     }
+}
+
+fn stable_finding_key(finding: &Finding) -> String {
+    finding
+        .evidence
+        .first()
+        .map(|evidence| {
+            format!(
+                "{}:{}:{}",
+                finding.rule_id,
+                evidence.path.display(),
+                evidence.line_start
+            )
+        })
+        .unwrap_or_else(|| finding.id.clone())
 }
 
 fn severity_rank(s: &Severity) -> u8 {

--- a/src/compare/render.rs
+++ b/src/compare/render.rs
@@ -1,5 +1,9 @@
 use super::diff::CompareSummary;
 
+pub fn render_json(summary: &CompareSummary) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(summary)
+}
+
 pub fn render_console(summary: &CompareSummary) -> String {
     let mut out = String::new();
 

--- a/src/scan/markers.rs
+++ b/src/scan/markers.rs
@@ -5,8 +5,12 @@ pub fn detect_markers(path: &Path, content: &str) -> Vec<Marker> {
     let mut markers = Vec::new();
 
     for (index, line) in content.lines().enumerate() {
+        let Some(comment_text) = comment_text(line) else {
+            continue;
+        };
+
         let line_number = index + 1;
-        if line.contains("TODO") {
+        if comment_text.contains("TODO") {
             markers.push(Marker {
                 kind: MarkerKind::Todo,
                 line_number,
@@ -14,7 +18,7 @@ pub fn detect_markers(path: &Path, content: &str) -> Vec<Marker> {
                 text: line.to_string(),
             });
         }
-        if line.contains("FIXME") {
+        if comment_text.contains("FIXME") {
             markers.push(Marker {
                 kind: MarkerKind::Fixme,
                 line_number,
@@ -22,7 +26,7 @@ pub fn detect_markers(path: &Path, content: &str) -> Vec<Marker> {
                 text: line.to_string(),
             });
         }
-        if line.contains("HACK") {
+        if comment_text.contains("HACK") {
             markers.push(Marker {
                 kind: MarkerKind::Hack,
                 line_number,
@@ -33,4 +37,14 @@ pub fn detect_markers(path: &Path, content: &str) -> Vec<Marker> {
     }
 
     markers
+}
+
+fn comment_text(line: &str) -> Option<&str> {
+    const COMMENT_MARKERS: &[&str] = &["//", "#", "--", "/*", "*", "<!--"];
+
+    COMMENT_MARKERS
+        .iter()
+        .filter_map(|marker| line.find(marker).map(|index| (index, marker.len())))
+        .min_by_key(|(index, _)| *index)
+        .map(|(index, marker_len)| &line[index + marker_len..])
 }

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -10,6 +10,9 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+const EXCLUDED_DIRECTORY_NAMES: &[&str] =
+    &[".git", ".github", "target", "node_modules", "dist", "build"];
+
 pub fn scan_path(path: &Path) -> io::Result<ScanSummary> {
     scan_path_with_config(path, &ScanConfig::default())
 }
@@ -64,6 +67,7 @@ fn collect_directory_facts(
         .git_ignore(true)
         .git_global(true)
         .git_exclude(true)
+        .filter_entry(|entry| !is_excluded_directory(entry.path()))
         .build();
 
     for result in walker {
@@ -89,6 +93,13 @@ fn collect_directory_facts(
     }
 
     Ok(())
+}
+
+fn is_excluded_directory(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| EXCLUDED_DIRECTORY_NAMES.contains(&name))
+        .unwrap_or(false)
 }
 
 fn collect_file_facts(

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -1,0 +1,90 @@
+use repopilot::compare::diff::diff_summaries;
+use repopilot::compare::render::render_json;
+use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use repopilot::scan::types::ScanSummary;
+use std::path::PathBuf;
+
+#[test]
+fn compare_uses_rule_and_evidence_as_stable_key() {
+    let before = summary(vec![finding(
+        "old-generated-id",
+        "architecture.large-file",
+        "src/main.rs",
+        1,
+        Severity::Medium,
+    )]);
+    let after = summary(vec![finding(
+        "new-generated-id",
+        "architecture.large-file",
+        "src/main.rs",
+        1,
+        Severity::High,
+    )]);
+
+    let diff = diff_summaries(&before, &after);
+
+    assert!(diff.new_findings.is_empty());
+    assert!(diff.resolved_findings.is_empty());
+    assert_eq!(diff.severity_increased.len(), 1);
+}
+
+#[test]
+fn compare_reports_new_and_resolved_findings() {
+    let before = summary(vec![finding(
+        "a",
+        "code-marker.todo",
+        "src/old.rs",
+        2,
+        Severity::Low,
+    )]);
+    let after = summary(vec![finding(
+        "b",
+        "security.secret-candidate",
+        "src/new.rs",
+        4,
+        Severity::High,
+    )]);
+
+    let diff = diff_summaries(&before, &after);
+
+    assert_eq!(diff.new_findings.len(), 1);
+    assert_eq!(diff.resolved_findings.len(), 1);
+}
+
+#[test]
+fn compare_json_renders_valid_json() {
+    let diff = diff_summaries(&summary(vec![]), &summary(vec![]));
+
+    let rendered = render_json(&diff).expect("failed to render json");
+    let value: serde_json::Value = serde_json::from_str(&rendered).expect("invalid json");
+
+    assert_eq!(value["new_findings"].as_array().unwrap().len(), 0);
+}
+
+fn summary(findings: Vec<Finding>) -> ScanSummary {
+    ScanSummary {
+        root_path: PathBuf::from("demo"),
+        files_count: 1,
+        directories_count: 0,
+        lines_of_code: 10,
+        languages: vec![],
+        findings,
+    }
+}
+
+fn finding(id: &str, rule_id: &str, path: &str, line: usize, severity: Severity) -> Finding {
+    Finding {
+        id: id.to_string(),
+        rule_id: rule_id.to_string(),
+        title: "Finding".to_string(),
+        description: "Description".to_string(),
+        category: FindingCategory::Architecture,
+        severity,
+        evidence: vec![Evidence {
+            path: PathBuf::from(path),
+            line_start: line,
+            line_end: None,
+            snippet: "snippet".to_string(),
+        }],
+    }
+}

--- a/tests/new_architecture_rules.rs
+++ b/tests/new_architecture_rules.rs
@@ -1,0 +1,66 @@
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::scanner::scan_path_with_config;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn reports_directory_with_too_many_modules() {
+    let temp = tempdir().expect("failed to create temp dir");
+    let src = temp.path().join("src");
+    fs::create_dir(&src).expect("failed to create src dir");
+
+    for index in 0..3 {
+        fs::write(
+            src.join(format!("module_{index}.rs")),
+            "pub fn value() {}\n",
+        )
+        .expect("failed to write module");
+    }
+
+    let config = ScanConfig {
+        max_directory_modules: 2,
+        ..ScanConfig::default()
+    };
+
+    let summary = scan_path_with_config(temp.path(), &config).expect("failed to scan");
+
+    assert!(
+        summary
+            .findings
+            .iter()
+            .any(|finding| finding.rule_id == "architecture.too-many-modules")
+    );
+}
+
+#[test]
+fn reports_deep_nesting_only_above_threshold() {
+    let temp = tempdir().expect("failed to create temp dir");
+    let deep = temp.path().join("src/a/b/c");
+    fs::create_dir_all(&deep).expect("failed to create nested dirs");
+    fs::write(deep.join("feature.rs"), "pub fn value() {}\n").expect("failed to write file");
+
+    let config = ScanConfig {
+        max_directory_depth: 2,
+        ..ScanConfig::default()
+    };
+
+    let summary = scan_path_with_config(temp.path(), &config).expect("failed to scan");
+    assert!(
+        summary
+            .findings
+            .iter()
+            .any(|finding| finding.rule_id == "architecture.deep-nesting")
+    );
+
+    let config = ScanConfig {
+        max_directory_depth: 10,
+        ..ScanConfig::default()
+    };
+    let summary = scan_path_with_config(temp.path(), &config).expect("failed to scan");
+    assert!(
+        summary
+            .findings
+            .iter()
+            .all(|finding| finding.rule_id != "architecture.deep-nesting")
+    );
+}

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -1,0 +1,37 @@
+use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use repopilot::output::{OutputFormat, render_scan_summary};
+use repopilot::scan::types::ScanSummary;
+use std::path::PathBuf;
+
+#[test]
+fn html_output_escapes_snippets_and_renders_summary() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("demo"),
+        files_count: 1,
+        directories_count: 1,
+        lines_of_code: 3,
+        languages: vec![],
+        findings: vec![Finding {
+            id: "finding-1".to_string(),
+            rule_id: "security.secret-candidate".to_string(),
+            title: "Possible secret detected".to_string(),
+            description: "description".to_string(),
+            category: FindingCategory::Security,
+            severity: Severity::High,
+            evidence: vec![Evidence {
+                path: PathBuf::from("src/config.rs"),
+                line_start: 1,
+                line_end: None,
+                snippet: "API_KEY = \"abc<123>\"".to_string(),
+            }],
+        }],
+    };
+
+    let html = render_scan_summary(&summary, OutputFormat::Html).expect("failed to render html");
+
+    assert!(html.contains("RepoPilot Scan Report"));
+    assert!(html.contains("<div class=\"num\">1</div><div class=\"label\">Files</div>"));
+    assert!(html.contains("security.secret-candidate"));
+    assert!(html.contains("API_KEY = &quot;abc&lt;123&gt;&quot;"));
+    assert!(!html.contains("API_KEY = \"abc<123>\""));
+}

--- a/tests/scanner_exclusions.rs
+++ b/tests/scanner_exclusions.rs
@@ -1,0 +1,34 @@
+use repopilot::scan::scanner::scan_path;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn scanner_ignores_git_and_build_directories() {
+    let temp = tempdir().expect("failed to create temp dir");
+
+    fs::create_dir_all(temp.path().join(".git/hooks")).expect("failed to create git hooks");
+    fs::create_dir_all(temp.path().join("target/debug")).expect("failed to create target dir");
+    fs::create_dir_all(temp.path().join("src")).expect("failed to create src dir");
+
+    fs::write(
+        temp.path().join(".git/hooks/pre-commit.sample"),
+        "# TODO: this git hook must not be scanned\n",
+    )
+    .expect("failed to write hook");
+    fs::write(
+        temp.path().join("target/debug/generated.rs"),
+        "// TODO: generated file must not be scanned\n",
+    )
+    .expect("failed to write generated file");
+    fs::write(temp.path().join("src/lib.rs"), "pub fn live() {}\n").expect("failed to write src");
+
+    let summary = scan_path(temp.path()).expect("failed to scan");
+
+    assert_eq!(summary.files_count, 1);
+    assert!(summary.findings.iter().all(|finding| {
+        finding
+            .evidence
+            .iter()
+            .all(|evidence| !evidence.path.to_string_lossy().contains(".git"))
+    }));
+}

--- a/tests/security_rules.rs
+++ b/tests/security_rules.rs
@@ -1,0 +1,89 @@
+use repopilot::audits::security::env_file_committed::EnvFileCommittedAudit;
+use repopilot::audits::security::private_key_candidate::PrivateKeyCandidateAudit;
+use repopilot::audits::security::secret_candidate::SecretCandidateAudit;
+use repopilot::audits::traits::{FileAudit, ProjectAudit};
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::facts::{FileFacts, ScanFacts};
+use std::path::PathBuf;
+
+#[test]
+fn secret_candidate_masks_secret_values_and_skips_placeholders() {
+    let file = file(
+        "src/config.rs",
+        "API_KEY = \"abc123xyz987\"\npassword = \"\"\ntoken = \"${TOKEN}\"\n",
+    );
+
+    let findings = SecretCandidateAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, "security.secret-candidate");
+    assert!(findings[0].evidence[0].snippet.contains("abc...***"));
+    assert!(!findings[0].evidence[0].snippet.contains("abc123xyz987"));
+}
+
+#[test]
+fn secret_candidate_skips_test_and_fixture_paths() {
+    let file = file("tests/fixture.rs", "API_KEY = \"abc123xyz987\"\n");
+
+    let findings = SecretCandidateAudit.audit(&file, &ScanConfig::default());
+
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn private_key_candidate_reports_header_without_key_body() {
+    let file = file(
+        "src/key.pem",
+        "-----BEGIN RSA PRIVATE KEY-----\nvery-secret-key-bytes\n-----END RSA PRIVATE KEY-----\n",
+    );
+
+    let findings = PrivateKeyCandidateAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, "security.private-key-candidate");
+    assert_eq!(
+        findings[0].evidence[0].snippet,
+        "-----BEGIN RSA PRIVATE KEY-----"
+    );
+    assert!(
+        !findings[0].evidence[0]
+            .snippet
+            .contains("very-secret-key-bytes")
+    );
+}
+
+#[test]
+fn private_key_candidate_ignores_documented_examples() {
+    let file = file(
+        "docs/rulesets.md",
+        "Example: -----BEGIN RSA PRIVATE KEY-----\n",
+    );
+
+    let findings = PrivateKeyCandidateAudit.audit(&file, &ScanConfig::default());
+
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn env_file_committed_reports_env_files() {
+    let facts = ScanFacts {
+        root_path: PathBuf::from("demo"),
+        files: vec![file(".env.production", "TOKEN=value\n")],
+        files_count: 1,
+        ..ScanFacts::default()
+    };
+
+    let findings = EnvFileCommittedAudit.audit(&facts, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, "security.env-file-committed");
+}
+
+fn file(path: &str, content: &str) -> FileFacts {
+    FileFacts {
+        path: PathBuf::from(path),
+        language: None,
+        lines_of_code: content.lines().count(),
+        content: content.to_string(),
+    }
+}

--- a/tests/testing_rules.rs
+++ b/tests/testing_rules.rs
@@ -1,0 +1,65 @@
+use repopilot::audits::testing::source_without_test::SourceWithoutTestAudit;
+use repopilot::audits::traits::ProjectAudit;
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::facts::{FileFacts, ScanFacts};
+use std::path::PathBuf;
+
+#[test]
+fn reports_missing_test_folder() {
+    let facts = ScanFacts {
+        root_path: PathBuf::from("demo"),
+        files: vec![file("src/payment.rs")],
+        files_count: 1,
+        ..ScanFacts::default()
+    };
+
+    let findings = repopilot::audits::testing::missing_test_folder::MissingTestFolderAudit
+        .audit(&facts, &ScanConfig::default());
+
+    assert_eq!(findings[0].rule_id, "testing.missing-test-folder");
+}
+
+#[test]
+fn source_without_test_recognizes_integration_test_counterpart() {
+    let facts = ScanFacts {
+        root_path: PathBuf::from("demo"),
+        files: vec![file("src/report/writer.rs"), file("tests/report_writer.rs")],
+        files_count: 2,
+        ..ScanFacts::default()
+    };
+
+    let findings = SourceWithoutTestAudit.audit(&facts, &ScanConfig::default());
+
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn source_without_test_reports_uncovered_source_and_ignores_wrappers() {
+    let facts = ScanFacts {
+        root_path: PathBuf::from("demo"),
+        files: vec![
+            file("src/payment.rs"),
+            file("src/lib.rs"),
+            file("src/mod.rs"),
+        ],
+        files_count: 3,
+        ..ScanFacts::default()
+    };
+
+    let findings = SourceWithoutTestAudit.audit(&facts, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(
+        findings[0].evidence[0].path,
+        PathBuf::from("src/payment.rs")
+    );
+}
+
+fn file(path: &str) -> FileFacts {
+    FileFacts {
+        path: PathBuf::from(path),
+        language: Some("Rust".to_string()),
+        lines_of_code: 1,
+        content: "pub fn value() {}\n".to_string(),
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces the next architectural layer for RepoPilot audits by moving audit rules toward a trait-based model. New rules can now be implemented as focused `FileAudit` or `ProjectAudit` structs instead of adding more logic directly into the scan pipeline.

It also expands the current audit coverage with architecture, security, and testing rules, adds scan comparison support, introduces HTML report rendering, and prepares the project for public distribution through GitHub Releases and crates.io.

## Type of change

- Feature
- Refactor
- Tests
- Documentation
- CI / repository maintenance

## What changed

- Added `FileAudit` and `ProjectAudit` traits for a cleaner audit architecture.
- Refactored existing audits to use the new trait-based structure.
- Added architecture audits:
  - `architecture.deep-nesting`
  - `architecture.too-many-modules`
- Added security audits:
  - `security.env-file-committed`
  - `security.secret-candidate`
  - `security.private-key-candidate`
- Added testing audits:
  - `testing.missing-test-folder`
  - `testing.source-without-test`
- Added configurable scan thresholds:
  - `--max-directory-modules`
  - `--max-directory-depth`
- Added `compare` command for comparing two JSON scan reports.
- Added HTML report rendering for scan summaries.
- Updated finding types to support JSON deserialization for compare/report workflows.
- Updated `docs/rulesets.md` with the new rules and evidence behavior.
- Updated `CHANGELOG.md`.
- Added crates.io metadata to `Cargo.toml`.
- Added GitHub Actions release workflow for publishing tagged releases and prebuilt binaries.

## Why

This PR makes RepoPilot easier to extend.

Before this change, adding new audit rules could push more responsibility into the pipeline and make the project harder to scale. With the trait-based structure, each audit becomes a small, focused module with a clear responsibility.

This is important because RepoPilot is moving from a simple scanner toward a real codebase audit CLI that can support multiple categories of rules, configurable thresholds, report formats, and future rulesets.

## Architecture notes

- No god files introduced.
- Audit logic is split by domain:
  - architecture
  - security
  - testing
  - code quality
- Rule implementations are isolated from the scan pipeline.
- File-level and project-level audits are separated through traits.
- Scan configuration remains centralized in `ScanConfig`.
- Findings keep structured evidence for future JSON/HTML/Markdown consumers.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .
cargo run -- scan . --format json --output before.json
cargo run -- scan . --format json --output after.json
cargo run -- compare before.json after.json