### PR TITLE
fix: update release workflow to use actions/upload-artifact and impro…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,13 +78,14 @@ jobs:
           echo "ASSET=dist/${AssetName}.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "CHECKSUM=dist/${AssetName}.zip.sha256" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Upload packaged artifact
+        uses: actions/upload-artifact@v4
         with:
-          files: |
+          name: release-${{ matrix.target }}
+          path: |
             ${{ env.ASSET }}
             ${{ env.CHECKSUM }}
-          generate_release_notes: true
+          if-no-files-found: error
 
   verify-crates-package:
     name: Verify crates.io package
@@ -98,3 +99,26 @@ jobs:
 
       - name: Publish dry run
         run: cargo publish --dry-run
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - verify-crates-package
+    steps:
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: dist
+          merge-multiple: true
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.sha256
+          generate_release_notes: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -16,9 +16,9 @@ Use the current date for the release entry in `CHANGELOG.md`.
 ## 2. Verify locally
 
 ```bash
-cargo fmt --check
+cargo fmt --all -- --check
 cargo clippy --all-targets --all-features -- -D warnings
-cargo test
+cargo test --all
 cargo package --list
 cargo publish --dry-run
 ```
@@ -51,7 +51,7 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-The tag workflow builds GitHub Release artifacts and runs `cargo publish --dry-run`. It does not publish to crates.io.
+The tag workflow builds GitHub Release artifacts, creates or updates the GitHub Release once, and runs `cargo publish --dry-run`. It does not publish to crates.io.
 
 ## 7. Publish to crates.io
 
@@ -63,7 +63,7 @@ cargo publish
 
 Do not publish from a dirty worktree. Publish from the exact tagged commit.
 
-## 8. Create GitHub Release
+## 8. Review GitHub Release
 
 Title:
 


### PR DESCRIPTION
## Summary

Fixes the RepoPilot release workflow so GitHub Release creation happens only once after all matrix builds finish.

Previously, the release workflow could update the same GitHub Release from matrix jobs, which caused duplicated generated release notes such as repeated `Full Changelog` entries.

## Type of change

- CI / repository maintenance
- Documentation

## What changed

- Updated the release workflow to upload packaged binaries and checksums with `actions/upload-artifact`.
- Added a separate `release` job that downloads all packaged artifacts.
- Moved `softprops/action-gh-release` into the final release job so it runs only once.
- Kept `generate_release_notes: true` only in the single release step.
- Kept `cargo publish --dry-run` as release verification.
- Updated `docs/release.md` to describe the actual release process more clearly.

## Why

The v0.4.0 GitHub Release body had duplicated generated changelog entries because release creation was not isolated from the matrix build flow.

This PR makes the release workflow deterministic:

1. build jobs create binaries;
2. build jobs upload artifacts;
3. verification runs `cargo publish --dry-run`;
4. one final release job creates or updates the GitHub Release.

## Notes

This PR does not change RepoPilot runtime behavior.

No crate version bump is included because this is only a release automation fix. It should not be published to crates.io as a new version by itself.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```