### PR TITLE
Add import extraction and coupling graph functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ ignore = [
   ".next",
   "coverage"
 ]
+max_file_bytes = 2097152
 
 [architecture]
 max_file_lines = 300

--- a/repopilot.toml
+++ b/repopilot.toml
@@ -13,6 +13,7 @@ ignore = [
   ".next",
   "coverage"
 ]
+max_file_bytes = 2097152
 
 [architecture]
 max_file_lines = 300

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -14,9 +14,12 @@ const SECRET_KEYS: &[&str] = &[
     "private_key",
     "auth_token",
     "access_token",
+    "refresh_token",
     "client_secret",
     "signing_key",
     "encryption_key",
+    "bearer",
+    "jwt",
 ];
 
 pub struct SecretCandidateAudit;
@@ -45,7 +48,7 @@ impl FileAudit for SecretCandidateAudit {
 fn detect_secret_line(line: &str, line_number: usize, path: &std::path::Path) -> Option<Finding> {
     let lower = line.to_lowercase();
 
-    let matched_key = SECRET_KEYS.iter().find(|&&key| {
+    if let Some(matched_key) = SECRET_KEYS.iter().find(|&&key| {
         if !lower.contains(key) {
             return false;
         }
@@ -60,6 +63,7 @@ fn detect_secret_line(line: &str, line_number: usize, path: &std::path::Path) ->
         let is_placeholder = value.is_empty()
             || value.starts_with("${")
             || value.starts_with("{{")
+            || value.starts_with("<")
             || value == "\"\""
             || value == "''"
             || value == "null"
@@ -68,9 +72,31 @@ fn detect_secret_line(line: &str, line_number: usize, path: &std::path::Path) ->
             || value == "your_key_here"
             || value == "changeme";
         !is_placeholder && value.len() > 4
-    })?;
+    }) {
+        return Some(build_finding(
+            line_number,
+            path,
+            matched_key,
+            mask_secret_value(line.trim()),
+        ));
+    }
 
-    Some(Finding {
+    let jwt = find_jwt_like_token(line)?;
+    Some(build_finding(
+        line_number,
+        path,
+        "jwt-like token",
+        mask_token_in_line(line.trim(), jwt),
+    ))
+}
+
+fn build_finding(
+    line_number: usize,
+    path: &std::path::Path,
+    matched_key: &str,
+    snippet: String,
+) -> Finding {
+    Finding {
         id: String::new(),
         rule_id: "security.secret-candidate".to_string(),
         title: "Possible secret detected".to_string(),
@@ -84,9 +110,35 @@ fn detect_secret_line(line: &str, line_number: usize, path: &std::path::Path) ->
             path: path.to_path_buf(),
             line_start: line_number,
             line_end: None,
-            snippet: mask_secret_value(line.trim()),
+            snippet,
         }],
-    })
+    }
+}
+
+fn find_jwt_like_token(line: &str) -> Option<&str> {
+    line.split(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_' && c != '.')
+        .find(|candidate| is_jwt_like_token(candidate))
+}
+
+fn is_jwt_like_token(candidate: &str) -> bool {
+    if candidate.len() < 40 || !candidate.starts_with("eyJ") {
+        return false;
+    }
+
+    let parts: Vec<_> = candidate.split('.').collect();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|part| part.len() >= 8 && part.chars().all(is_base64url_char))
+}
+
+fn is_base64url_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '-' || c == '_'
+}
+
+fn mask_token_in_line(line: &str, token: &str) -> String {
+    let visible_prefix = token.chars().take(8).collect::<String>();
+    line.replace(token, &format!("{visible_prefix}...***"))
 }
 
 fn mask_secret_value(line: &str) -> String {

--- a/src/audits/testing/source_without_test.rs
+++ b/src/audits/testing/source_without_test.rs
@@ -100,39 +100,42 @@ fn has_nearby_test(
 
     let parent = source.parent().unwrap_or(Path::new("."));
 
-    // Sibling test patterns: payment_test.rs, payment.test.ts, payment.spec.ts
-    let sibling_candidates = [
-        parent.join(format!("{stem}_test.{ext}")),
-        parent.join(format!("{stem}.test.{ext}")),
-        parent.join(format!("{stem}.spec.{ext}")),
-    ];
-
-    if sibling_candidates.iter().any(|p| all_paths.contains(p)) {
-        return true;
-    }
-
-    // tests/ directory alongside src/: tests/<stem>.rs, tests/<stem>_test.rs
-    // Uses pre-computed suffix set for O(1) lookup instead of O(n) scan
-    let tests_candidates = [
-        format!("tests/{stem}.{ext}"),
-        format!("tests/{stem}_test.{ext}"),
-    ];
-
-    if tests_candidates
-        .iter()
-        .any(|candidate| tests_suffixes.contains(candidate.as_str()))
+    if has_sibling_test(parent, stem, ext, all_paths)
+        || has_tests_directory_match(stem, ext, tests_suffixes)
+        || has_rust_integration_test(source, ext, tests_suffixes)
     {
         return true;
     }
 
-    // Rust integration tests commonly cover a module by feature name:
-    // src/report/writer.rs -> tests/report_writer.rs
-    if ext == "rs" {
-        let module_candidate = format!("tests/{}.rs", module_test_name(source));
-        return tests_suffixes.contains(module_candidate.as_str());
+    false
+}
+
+fn has_sibling_test(parent: &Path, stem: &str, ext: &str, all_paths: &HashSet<PathBuf>) -> bool {
+    [
+        parent.join(format!("{stem}_test.{ext}")),
+        parent.join(format!("{stem}.test.{ext}")),
+        parent.join(format!("{stem}.spec.{ext}")),
+    ]
+    .iter()
+    .any(|candidate| all_paths.contains(candidate))
+}
+
+fn has_tests_directory_match(stem: &str, ext: &str, tests_suffixes: &HashSet<String>) -> bool {
+    [
+        format!("tests/{stem}.{ext}"),
+        format!("tests/{stem}_test.{ext}"),
+    ]
+    .iter()
+    .any(|candidate| tests_suffixes.contains(candidate.as_str()))
+}
+
+fn has_rust_integration_test(source: &Path, ext: &str, tests_suffixes: &HashSet<String>) -> bool {
+    if ext != "rs" {
+        return false;
     }
 
-    false
+    let module_candidate = format!("tests/{}.rs", module_test_name(source));
+    tests_suffixes.contains(module_candidate.as_str())
 }
 
 fn module_test_name(source: &Path) -> String {

--- a/src/commands/compare.rs
+++ b/src/commands/compare.rs
@@ -3,8 +3,10 @@ use repopilot::compare::diff::diff_summaries;
 use repopilot::compare::render::render;
 use repopilot::report::writer::write_report;
 use repopilot::scan::types::ScanSummary;
+use std::error::Error;
 use std::fs;
-use std::path::PathBuf;
+use std::io;
+use std::path::{Path, PathBuf};
 
 pub fn run(
     before: PathBuf,
@@ -12,11 +14,8 @@ pub fn run(
     format: CompareOutputFormatArg,
     output: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let before_summary: ScanSummary = serde_json::from_str(&fs::read_to_string(&before)?)
-        .map_err(|e| format!("Failed to parse {}: {e}", before.display()))?;
-
-    let after_summary: ScanSummary = serde_json::from_str(&fs::read_to_string(&after)?)
-        .map_err(|e| format!("Failed to parse {}: {e}", after.display()))?;
+    let before_summary = read_summary(&before)?;
+    let after_summary = read_summary(&after)?;
 
     let diff = diff_summaries(&before_summary, &after_summary);
     let rendered = render(&diff, format.into())?;
@@ -24,4 +23,50 @@ pub fn run(
     write_report(&rendered, output.as_deref())?;
 
     Ok(())
+}
+
+fn read_summary(path: &Path) -> Result<ScanSummary, CompareInputError> {
+    let content = fs::read_to_string(path).map_err(|source| CompareInputError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    serde_json::from_str(&content).map_err(|source| CompareInputError::Parse {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[derive(Debug)]
+enum CompareInputError {
+    Read {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+}
+
+impl std::fmt::Display for CompareInputError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read { path, .. } => {
+                write!(f, "Failed to read scan summary {}", path.display())
+            }
+            Self::Parse { path, .. } => {
+                write!(f, "Failed to parse scan summary {}", path.display())
+            }
+        }
+    }
+}
+
+impl Error for CompareInputError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Read { source, .. } => Some(source),
+            Self::Parse { source, .. } => Some(source),
+        }
+    }
 }

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -14,6 +14,7 @@ pub const DEFAULT_IGNORED_PATHS: &[&str] = &[
 
 pub const DEFAULT_MAX_FILE_LINES: usize = 300;
 pub const DEFAULT_HUGE_FILE_LINES: usize = 1000;
+pub const DEFAULT_MAX_FILE_BYTES: u64 = 2 * 1024 * 1024;
 pub const DEFAULT_MAX_DIRECTORY_MODULES: usize = 20;
 pub const DEFAULT_MAX_DIRECTORY_DEPTH: usize = 5;
 pub const DEFAULT_LONG_FUNCTION_LINES: usize = 50;

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -1,7 +1,8 @@
 use crate::config::defaults::{
     DEFAULT_COMPLEXITY_HIGH_THRESHOLD, DEFAULT_COMPLEXITY_MEDIUM_THRESHOLD,
     DEFAULT_HUGE_FILE_LINES, DEFAULT_LONG_FUNCTION_LINES, DEFAULT_MAX_DIRECTORY_DEPTH,
-    DEFAULT_MAX_DIRECTORY_MODULES, DEFAULT_MAX_FILE_LINES, default_ignored_paths,
+    DEFAULT_MAX_DIRECTORY_MODULES, DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILE_LINES,
+    default_ignored_paths,
 };
 use crate::output::OutputFormat;
 use crate::scan::config::ScanConfig;
@@ -23,6 +24,7 @@ impl RepoPilotConfig {
         let mut config =
             ScanConfig::default().with_large_file_loc_threshold(self.architecture.max_file_lines);
         config.ignored_paths = self.scan.ignore.clone();
+        config.max_file_bytes = self.scan.max_file_bytes;
         config.huge_file_loc_threshold = self.architecture.huge_file_lines;
         if config.huge_file_loc_threshold <= config.large_file_loc_threshold {
             config.huge_file_loc_threshold = config
@@ -44,12 +46,14 @@ impl RepoPilotConfig {
 pub struct ScanSection {
     #[serde(default = "default_ignored_paths")]
     pub ignore: Vec<String>,
+    pub max_file_bytes: u64,
 }
 
 impl Default for ScanSection {
     fn default() -> Self {
         Self {
             ignore: default_ignored_paths(),
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
         }
     }
 }

--- a/src/config/template.rs
+++ b/src/config/template.rs
@@ -1,6 +1,6 @@
 use crate::config::defaults::{
     DEFAULT_HUGE_FILE_LINES, DEFAULT_IGNORED_PATHS, DEFAULT_MAX_DIRECTORY_DEPTH,
-    DEFAULT_MAX_DIRECTORY_MODULES, DEFAULT_MAX_FILE_LINES,
+    DEFAULT_MAX_DIRECTORY_MODULES, DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILE_LINES,
 };
 
 pub fn default_config_toml() -> String {
@@ -18,6 +18,7 @@ pub fn default_config_toml() -> String {
 ignore = [
 {ignored_paths}
 ]
+max_file_bytes = {DEFAULT_MAX_FILE_BYTES}
 
 [architecture]
 max_file_lines = {DEFAULT_MAX_FILE_LINES}

--- a/src/graph/imports.rs
+++ b/src/graph/imports.rs
@@ -1,0 +1,279 @@
+use std::collections::BTreeSet;
+
+/// Extracts raw import strings from file content based on language.
+/// Returns a sorted, deduplicated list.
+pub fn extract_imports(content: &str, language: Option<&str>) -> Vec<String> {
+    let set: BTreeSet<String> = match language {
+        Some("Rust") => extract_rust(content),
+        Some("TypeScript")
+        | Some("TypeScript React")
+        | Some("JavaScript")
+        | Some("JavaScript React") => extract_ts(content),
+        Some("Python") => extract_python(content),
+        Some("Go") => extract_go(content),
+        _ => return Vec::new(),
+    };
+    set.into_iter().collect()
+}
+
+// ── Rust ─────────────────────────────────────────────────────────────────────
+
+fn extract_rust(content: &str) -> BTreeSet<String> {
+    let mut result = BTreeSet::new();
+    let mut in_block_comment = false;
+    let mut pending: Option<String> = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Block comment tracking
+        if in_block_comment {
+            if trimmed.contains("*/") {
+                in_block_comment = false;
+            }
+            continue;
+        }
+        if trimmed.starts_with("/*") {
+            if !trimmed.contains("*/") {
+                in_block_comment = true;
+            }
+            continue;
+        }
+        if trimmed.starts_with("//") || trimmed.starts_with('*') {
+            continue;
+        }
+
+        // Continue accumulating multi-line use statement
+        if let Some(acc) = pending.take() {
+            let combined = acc + " " + trimmed;
+            if combined.contains(';') {
+                for imp in rust_use_imports(&combined) {
+                    result.insert(imp);
+                }
+            } else {
+                pending = Some(combined);
+            }
+            continue;
+        }
+
+        // Strip optional visibility modifier (pub, pub(crate), pub(super), …)
+        let effective = strip_rust_visibility(trimmed);
+
+        if let Some(rest) = effective.strip_prefix("use ") {
+            if rest.contains(';') {
+                for imp in rust_use_imports(effective) {
+                    result.insert(imp);
+                }
+            } else {
+                // Begin multi-line accumulation
+                pending = Some(effective.to_string());
+            }
+        } else if let Some(rest) = effective.strip_prefix("mod ") {
+            let rest = rest.trim();
+            if rest.ends_with(';') {
+                let name = rest.trim_end_matches(';').trim();
+                if !name.is_empty() && !name.contains('{') && !name.contains(' ') {
+                    result.insert(format!("mod::{name}"));
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Strips leading `pub`, `pub(crate)`, `pub(super)`, or `pub(in …)` from `s`.
+fn strip_rust_visibility(s: &str) -> &str {
+    if let Some(rest) = s.strip_prefix("pub(") {
+        if let Some(close) = rest.find(')') {
+            return rest[close + 1..].trim_start();
+        }
+    }
+    s.strip_prefix("pub ").unwrap_or(s)
+}
+
+/// Parses a single `use …;` statement (possibly reconstructed from multiple
+/// lines) and returns each imported path.
+fn rust_use_imports(stmt: &str) -> Vec<String> {
+    let stmt = stmt.trim();
+    // Strip leading `use ` (after visibility stripping was already done)
+    let body = stmt.strip_prefix("use ").unwrap_or(stmt);
+    // Strip trailing `;`
+    let body = body.trim_end_matches(';').trim();
+
+    // Handle group imports:  crate::foo::{Bar, Baz}
+    if let Some(brace_pos) = body.find('{') {
+        let prefix = body[..brace_pos].trim_end_matches(':');
+        let after = &body[brace_pos + 1..];
+        let inner = after.trim_end_matches('}').trim();
+        return inner
+            .split(',')
+            .filter_map(|item| {
+                let item = item.trim();
+                if item.is_empty() || item == "_" || item == "self" {
+                    return None;
+                }
+                // Strip `as alias`
+                let path = item.split(" as ").next().unwrap_or(item).trim();
+                if path.is_empty() {
+                    return None;
+                }
+                if prefix.is_empty() {
+                    Some(path.to_string())
+                } else {
+                    Some(format!("{prefix}::{path}"))
+                }
+            })
+            .collect();
+    }
+
+    // Simple import, possibly with `as alias`
+    let path = body.split(" as ").next().unwrap_or(body).trim();
+    if path.is_empty() {
+        vec![]
+    } else {
+        vec![path.to_string()]
+    }
+}
+
+// ── TypeScript / JavaScript ───────────────────────────────────────────────────
+
+fn extract_ts(content: &str) -> BTreeSet<String> {
+    let mut result = BTreeSet::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
+            continue;
+        }
+
+        // import … from "…"  /  export … from "…"
+        if (trimmed.starts_with("import ") || trimmed.starts_with("export "))
+            && trimmed.contains(" from ")
+        {
+            if let Some(path) = extract_from_path(trimmed) {
+                if is_relative(path) {
+                    result.insert(path.to_string());
+                }
+            }
+        }
+
+        // require("…")
+        if trimmed.contains("require(") {
+            if let Some(path) = extract_require_path(trimmed) {
+                if is_relative(path) {
+                    result.insert(path.to_string());
+                }
+            }
+        }
+    }
+
+    result
+}
+
+fn extract_from_path(line: &str) -> Option<&str> {
+    let pos = line.rfind(" from ")?;
+    let after = line[pos + 6..].trim();
+    extract_string_literal(after)
+}
+
+fn extract_require_path(line: &str) -> Option<&str> {
+    let pos = line.find("require(")?;
+    let after = line[pos + 8..].trim();
+    extract_string_literal(after)
+}
+
+fn extract_string_literal(s: &str) -> Option<&str> {
+    if let Some(rest) = s.strip_prefix('"') {
+        let end = rest.find('"')?;
+        Some(&rest[..end])
+    } else if let Some(rest) = s.strip_prefix('\'') {
+        let end = rest.find('\'')?;
+        Some(&rest[..end])
+    } else if let Some(rest) = s.strip_prefix('`') {
+        let end = rest.find('`')?;
+        Some(&rest[..end])
+    } else {
+        None
+    }
+}
+
+fn is_relative(path: &str) -> bool {
+    path.starts_with('.') || path.starts_with('/')
+}
+
+// ── Python ────────────────────────────────────────────────────────────────────
+
+fn extract_python(content: &str) -> BTreeSet<String> {
+    let mut result = BTreeSet::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('#') {
+            continue;
+        }
+
+        // from <module> import <names>
+        if let Some(rest) = trimmed.strip_prefix("from ") {
+            if let Some(import_pos) = rest.find(" import ") {
+                let module = rest[..import_pos].trim();
+                if !module.is_empty() {
+                    result.insert(module.to_string());
+                }
+            }
+        }
+    }
+
+    result
+}
+
+// ── Go ────────────────────────────────────────────────────────────────────────
+
+fn extract_go(content: &str) -> BTreeSet<String> {
+    let mut result = BTreeSet::new();
+    let mut in_import_block = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("//") {
+            continue;
+        }
+
+        if trimmed == "import (" {
+            in_import_block = true;
+            continue;
+        }
+
+        if in_import_block {
+            if trimmed == ")" {
+                in_import_block = false;
+                continue;
+            }
+            if let Some(path) = extract_go_import_path(trimmed) {
+                result.insert(path.to_string());
+            }
+            continue;
+        }
+
+        // Single-line: import "path"
+        if let Some(rest) = trimmed.strip_prefix("import ") {
+            if let Some(path) = extract_string_literal(rest.trim()) {
+                result.insert(path.to_string());
+            }
+        }
+    }
+
+    result
+}
+
+/// Extracts the import path string from a line inside a Go `import (…)` block.
+/// Handles: `"path"`, `alias "path"`, `_ "path"`.
+fn extract_go_import_path(line: &str) -> Option<&str> {
+    let start = line.find('"')?;
+    let rest = &line[start + 1..];
+    let end = rest.find('"')?;
+    Some(&rest[..end])
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,0 +1,180 @@
+pub mod imports;
+pub mod resolver;
+
+pub use imports::extract_imports;
+pub use resolver::resolve_import;
+
+use crate::scan::facts::ScanFacts;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+// ── Data structures ───────────────────────────────────────────────────────────
+
+pub struct CouplingGraph {
+    /// Outgoing edges: source file → set of files it imports.
+    pub edges: BTreeMap<PathBuf, BTreeSet<PathBuf>>,
+    /// Every scanned file, including those with no edges.
+    pub nodes: BTreeSet<PathBuf>,
+}
+
+pub struct FileMetrics {
+    pub path: PathBuf,
+    pub fan_in: usize,
+    pub fan_out: usize,
+    /// instability = fan_out / (fan_in + fan_out); 0.0 when both are zero.
+    pub instability: f32,
+}
+
+// ── Graph construction ────────────────────────────────────────────────────────
+
+pub fn build_coupling_graph(facts: &ScanFacts, root: &Path) -> CouplingGraph {
+    let known_files: BTreeSet<PathBuf> = facts.files.iter().map(|f| f.path.clone()).collect();
+
+    let mut edges: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
+    let mut nodes: BTreeSet<PathBuf> = BTreeSet::new();
+
+    for file in &facts.files {
+        nodes.insert(file.path.clone());
+        let outgoing = edges.entry(file.path.clone()).or_default();
+
+        for raw in &file.imports {
+            if let Some(target) = resolve_import(raw, &file.path, root, &known_files) {
+                if target != file.path {
+                    outgoing.insert(target);
+                }
+            }
+        }
+    }
+
+    CouplingGraph { edges, nodes }
+}
+
+// ── Metrics ───────────────────────────────────────────────────────────────────
+
+pub fn compute_metrics(graph: &CouplingGraph) -> Vec<FileMetrics> {
+    let mut fan_out: BTreeMap<PathBuf, usize> =
+        graph.nodes.iter().map(|p| (p.clone(), 0)).collect();
+    let mut fan_in: BTreeMap<PathBuf, usize> = graph.nodes.iter().map(|p| (p.clone(), 0)).collect();
+
+    for (from, targets) in &graph.edges {
+        if let Some(fo) = fan_out.get_mut(from) {
+            *fo = targets.len();
+        }
+        for target in targets {
+            if let Some(fi) = fan_in.get_mut(target) {
+                *fi += 1;
+            }
+        }
+    }
+
+    graph
+        .nodes
+        .iter()
+        .map(|path| {
+            let fo = fan_out.get(path).copied().unwrap_or(0);
+            let fi = fan_in.get(path).copied().unwrap_or(0);
+            let instability = if fo + fi == 0 {
+                0.0_f32
+            } else {
+                fo as f32 / (fi + fo) as f32
+            };
+            FileMetrics {
+                path: path.clone(),
+                fan_in: fi,
+                fan_out: fo,
+                instability,
+            }
+        })
+        .collect()
+}
+
+// ── Cycle detection ───────────────────────────────────────────────────────────
+
+const MAX_DFS_DEPTH: usize = 512;
+
+pub fn detect_cycles(graph: &CouplingGraph) -> Vec<Vec<PathBuf>> {
+    let nodes: Vec<&PathBuf> = graph.nodes.iter().collect();
+    let n = nodes.len();
+
+    // Map each node to a stable integer index
+    let index: BTreeMap<&PathBuf, usize> = nodes.iter().enumerate().map(|(i, p)| (*p, i)).collect();
+
+    // Adjacency list using indices
+    let adj: Vec<Vec<usize>> = nodes
+        .iter()
+        .map(|node| {
+            graph
+                .edges
+                .get(*node)
+                .map(|targets| {
+                    targets
+                        .iter()
+                        .filter_map(|t| index.get(t).copied())
+                        .collect()
+                })
+                .unwrap_or_default()
+        })
+        .collect();
+
+    // 0 = unvisited, 1 = in-progress, 2 = done
+    let mut state = vec![0u8; n];
+    let mut stack: Vec<usize> = Vec::new();
+    let mut cycles: Vec<Vec<PathBuf>> = Vec::new();
+
+    for start in 0..n {
+        if state[start] == 0 {
+            dfs(start, &adj, &mut state, &mut stack, &mut cycles, &nodes, 0);
+        }
+    }
+
+    // Canonicalize each cycle: rotate so the smallest path is first
+    for cycle in &mut cycles {
+        if let Some(min_pos) = cycle
+            .iter()
+            .enumerate()
+            .min_by(|a, b| a.1.cmp(b.1))
+            .map(|(i, _)| i)
+        {
+            cycle.rotate_left(min_pos);
+        }
+    }
+
+    cycles.sort();
+    cycles.dedup();
+    cycles
+}
+
+fn dfs(
+    node: usize,
+    adj: &[Vec<usize>],
+    state: &mut Vec<u8>,
+    stack: &mut Vec<usize>,
+    cycles: &mut Vec<Vec<PathBuf>>,
+    nodes: &[&PathBuf],
+    depth: usize,
+) {
+    if depth > MAX_DFS_DEPTH {
+        state[node] = 2;
+        return;
+    }
+
+    state[node] = 1;
+    stack.push(node);
+
+    for &neighbor in &adj[node] {
+        match state[neighbor] {
+            1 => {
+                // Back edge → cycle; extract the loop from the current stack
+                if let Some(pos) = stack.iter().position(|&n| n == neighbor) {
+                    let cycle = stack[pos..].iter().map(|&i| nodes[i].clone()).collect();
+                    cycles.push(cycle);
+                }
+            }
+            0 => dfs(neighbor, adj, state, stack, cycles, nodes, depth + 1),
+            _ => {}
+        }
+    }
+
+    stack.pop();
+    state[node] = 2;
+}

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -1,0 +1,166 @@
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+
+/// Resolves a raw import string extracted from `from_file` to a concrete path
+/// under `root`. Returns a path only when it exists in `known_files`.
+pub fn resolve_import(
+    raw_import: &str,
+    from_file: &Path,
+    root: &Path,
+    known_files: &BTreeSet<PathBuf>,
+) -> Option<PathBuf> {
+    let ext = from_file.extension().and_then(|e| e.to_str()).unwrap_or("");
+
+    match ext {
+        "rs" => resolve_rust(raw_import, from_file, root, known_files),
+        "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs" => {
+            resolve_ts(raw_import, from_file, known_files)
+        }
+        "py" => resolve_python(raw_import, from_file, known_files),
+        "go" => resolve_go(raw_import, root, known_files),
+        _ => None,
+    }
+}
+
+// ── Rust ─────────────────────────────────────────────────────────────────────
+
+fn resolve_rust(
+    raw: &str,
+    from_file: &Path,
+    root: &Path,
+    known_files: &BTreeSet<PathBuf>,
+) -> Option<PathBuf> {
+    // mod::child  →  <same-dir>/child.rs  or  <same-dir>/child/mod.rs
+    if let Some(name) = raw.strip_prefix("mod::") {
+        let dir = from_file.parent().unwrap_or(root);
+        return probe(
+            &[
+                dir.join(format!("{name}.rs")),
+                dir.join(name).join("mod.rs"),
+            ],
+            known_files,
+        );
+    }
+
+    // crate::a::b  →  root/src/a/b.rs  or  root/src/a/b/mod.rs
+    if let Some(rest) = raw.strip_prefix("crate::") {
+        let rel = rest.replace("::", "/");
+        let base = root.join("src").join(&rel);
+        return probe(
+            &[base.with_extension("rs"), base.join("mod.rs")],
+            known_files,
+        );
+    }
+
+    None
+}
+
+// ── TypeScript / JavaScript ───────────────────────────────────────────────────
+
+fn resolve_ts(raw: &str, from_file: &Path, known_files: &BTreeSet<PathBuf>) -> Option<PathBuf> {
+    if !raw.starts_with('.') && !raw.starts_with('/') {
+        return None;
+    }
+
+    let dir = from_file.parent()?;
+    let base = if raw.starts_with('/') {
+        PathBuf::from(raw)
+    } else {
+        dir.join(raw)
+    };
+    let base = normalize_path(&base);
+
+    const EXTS: &[&str] = &["ts", "tsx", "js", "jsx"];
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    for ext in EXTS {
+        candidates.push(base.with_extension(ext));
+    }
+    for ext in EXTS {
+        candidates.push(base.join(format!("index.{ext}")));
+    }
+
+    probe(&candidates, known_files)
+}
+
+// ── Python ────────────────────────────────────────────────────────────────────
+
+fn resolve_python(raw: &str, from_file: &Path, known_files: &BTreeSet<PathBuf>) -> Option<PathBuf> {
+    if !raw.starts_with('.') {
+        return None;
+    }
+
+    let dots = raw.chars().take_while(|c| *c == '.').count();
+    let module = &raw[dots..];
+
+    let mut dir = from_file.parent()?;
+    // One dot = current package (no parent navigation).
+    // Two dots = parent package (navigate up once), etc.
+    for _ in 0..dots.saturating_sub(1) {
+        dir = dir.parent().unwrap_or(dir);
+    }
+
+    let base = if module.is_empty() {
+        dir.to_path_buf()
+    } else {
+        let rel = module.replace('.', "/");
+        dir.join(rel)
+    };
+    let base = normalize_path(&base);
+
+    probe(
+        &[base.with_extension("py"), base.join("__init__.py")],
+        known_files,
+    )
+}
+
+// ── Go ────────────────────────────────────────────────────────────────────────
+
+fn resolve_go(raw: &str, root: &Path, known_files: &BTreeSet<PathBuf>) -> Option<PathBuf> {
+    // Skip single-segment paths (stdlib packages like "fmt", "os")
+    if !raw.contains('/') {
+        return None;
+    }
+
+    // Conservative: only attempt resolution when the import starts with the
+    // last path component of root (i.e., looks like an in-repo path).
+    let root_name = root.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if root_name.is_empty() {
+        return None;
+    }
+
+    if let Some(rest) = raw.strip_prefix(root_name) {
+        let rel = rest.trim_start_matches('/');
+        let base = normalize_path(&root.join(rel));
+        return probe(&[base.with_extension("go")], known_files);
+    }
+
+    None
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn probe(candidates: &[PathBuf], known_files: &BTreeSet<PathBuf>) -> Option<PathBuf> {
+    for candidate in candidates {
+        let normalized = normalize_path(candidate);
+        if known_files.contains(&normalized) {
+            return Some(normalized);
+        }
+    }
+    None
+}
+
+/// Resolves `.` and `..` components without touching the filesystem.
+pub(crate) fn normalize_path(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod baseline;
 pub mod compare;
 pub mod config;
 pub mod findings;
+pub mod graph;
 pub mod output;
 pub mod report;
 pub mod review;

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -16,6 +16,12 @@ pub fn render(summary: &ScanSummary) -> String {
         summary.directories_count
     ));
     output.push_str(&format!("Lines of code: {}\n\n", summary.lines_of_code));
+    if summary.skipped_files_count > 0 {
+        output.push_str(&format!(
+            "Files skipped: {} ({} bytes)\n\n",
+            summary.skipped_files_count, summary.skipped_bytes
+        ));
+    }
 
     output.push_str("Languages:\n");
 
@@ -54,6 +60,12 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
         summary.directories_count
     ));
     output.push_str(&format!("Lines of code: {}\n\n", summary.lines_of_code));
+    if summary.skipped_files_count > 0 {
+        output.push_str(&format!(
+            "Files skipped: {} ({} bytes)\n\n",
+            summary.skipped_files_count, summary.skipped_bytes
+        ));
+    }
 
     output.push_str(&format!("New findings: {}\n", report.new_count()));
     output.push_str(&format!("Existing findings: {}\n", report.existing_count()));

--- a/src/output/html.rs
+++ b/src/output/html.rs
@@ -1,74 +1,9 @@
 use crate::scan::types::ScanSummary;
 
 pub fn render(summary: &ScanSummary) -> String {
-    let findings_rows = summary
-        .findings
-        .iter()
-        .map(|f| {
-            let ev = f
-                .evidence
-                .first()
-                .map(|e| {
-                    format!(
-                        "<code>{}:{}</code>",
-                        escape_html(&e.path.to_string_lossy()),
-                        e.line_start
-                    )
-                })
-                .unwrap_or_default();
-
-            let snippet = f
-                .evidence
-                .first()
-                .map(|e| {
-                    format!(
-                        "<pre class=\"snippet\">{}</pre>",
-                        escape_html(e.snippet.trim())
-                    )
-                })
-                .unwrap_or_default();
-
-            let severity_class = f.severity_label().to_lowercase();
-
-            format!(
-                "<tr>\
-                    <td><span class=\"badge {severity_class}\">{}</span></td>\
-                    <td><code>{}</code></td>\
-                    <td>{}</td>\
-                    <td>{ev}{snippet}</td>\
-                 </tr>",
-                escape_html(f.severity_label()),
-                escape_html(&f.rule_id),
-                escape_html(&f.title),
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let lang_rows = summary
-        .languages
-        .iter()
-        .map(|l| {
-            format!(
-                "<tr><td>{}</td><td class=\"num\">{}</td></tr>",
-                escape_html(&l.name),
-                l.files_count
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let findings_empty = if summary.findings.is_empty() {
-        "<p class=\"empty\">No findings found.</p>"
-    } else {
-        ""
-    };
-
-    let lang_empty = if summary.languages.is_empty() {
-        "<p class=\"empty\">No languages detected.</p>"
-    } else {
-        ""
-    };
+    let cards = render_summary_cards(summary);
+    let languages_section = render_languages_section(summary);
+    let findings_section = render_findings_section(summary);
 
     format!(
         r#"<!DOCTYPE html>
@@ -108,20 +43,15 @@ pub fn render(summary: &ScanSummary) -> String {
 <p class="meta">Path: <code>{path}</code></p>
 
 <div class="cards">
-  <div class="card"><div class="num">{files}</div><div class="label">Files</div></div>
-  <div class="card"><div class="num">{dirs}</div><div class="label">Directories</div></div>
-  <div class="card"><div class="num">{loc}</div><div class="label">Lines of Code</div></div>
-  <div class="card"><div class="num">{finding_count}</div><div class="label">Findings</div></div>
+  {cards}
 </div>
 
 <h2>Languages</h2>
-{lang_empty}
-{lang_table}
+{languages_section}
 
 <h2>Findings</h2>
-{findings_empty}
 <div class="filter-bar" id="filter-bar"></div>
-{findings_table}
+{findings_section}
 
 <script>
   const rows = document.querySelectorAll('table#findings tbody tr');
@@ -147,26 +77,104 @@ pub fn render(summary: &ScanSummary) -> String {
 </body>
 </html>"#,
         path = escape_html(&summary.root_path.to_string_lossy()),
-        files = summary.files_count,
-        dirs = summary.directories_count,
-        loc = summary.lines_of_code,
-        finding_count = summary.findings.len(),
-        lang_empty = lang_empty,
-        lang_table = if summary.languages.is_empty() {
-            String::new()
-        } else {
+        cards = cards,
+        languages_section = languages_section,
+        findings_section = findings_section,
+    )
+}
+
+fn render_summary_cards(summary: &ScanSummary) -> String {
+    let mut cards = vec![
+        summary_card(summary.files_count, "Files"),
+        summary_card(summary.directories_count, "Directories"),
+        summary_card(summary.lines_of_code, "Lines of Code"),
+        summary_card(summary.findings.len(), "Findings"),
+    ];
+
+    if summary.skipped_files_count > 0 {
+        cards.push(summary_card(summary.skipped_files_count, "Skipped"));
+    }
+
+    cards.join("\n  ")
+}
+
+fn summary_card(value: usize, label: &str) -> String {
+    format!(
+        r#"<div class="card"><div class="num">{value}</div><div class="label">{label}</div></div>"#
+    )
+}
+
+fn render_languages_section(summary: &ScanSummary) -> String {
+    if summary.languages.is_empty() {
+        return "<p class=\"empty\">No languages detected.</p>".to_string();
+    }
+
+    let rows = summary
+        .languages
+        .iter()
+        .map(|language| {
             format!(
-                "<table><thead><tr><th>Language</th><th class=\"num\">Files</th></tr></thead><tbody>{lang_rows}</tbody></table>"
+                "<tr><td>{}</td><td class=\"num\">{}</td></tr>",
+                escape_html(&language.name),
+                language.files_count
             )
-        },
-        findings_empty = findings_empty,
-        findings_table = if summary.findings.is_empty() {
-            String::new()
-        } else {
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "<table><thead><tr><th>Language</th><th class=\"num\">Files</th></tr></thead><tbody>{rows}</tbody></table>"
+    )
+}
+
+fn render_findings_section(summary: &ScanSummary) -> String {
+    if summary.findings.is_empty() {
+        return "<p class=\"empty\">No findings found.</p>".to_string();
+    }
+
+    let rows = summary
+        .findings
+        .iter()
+        .map(render_finding_row)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "<table id=\"findings\"><thead><tr><th>Severity</th><th>Rule</th><th>Title</th><th>Evidence</th></tr></thead><tbody>{rows}</tbody></table>"
+    )
+}
+
+fn render_finding_row(finding: &crate::findings::types::Finding) -> String {
+    let evidence = finding.evidence.first();
+    let location = evidence
+        .map(|e| {
             format!(
-                "<table id=\"findings\"><thead><tr><th>Severity</th><th>Rule</th><th>Title</th><th>Evidence</th></tr></thead><tbody>{findings_rows}</tbody></table>"
+                "<code>{}:{}</code>",
+                escape_html(&e.path.to_string_lossy()),
+                e.line_start
             )
-        },
+        })
+        .unwrap_or_default();
+    let snippet = evidence
+        .map(|e| {
+            format!(
+                "<pre class=\"snippet\">{}</pre>",
+                escape_html(e.snippet.trim())
+            )
+        })
+        .unwrap_or_default();
+    let severity_class = finding.severity_label().to_lowercase();
+
+    format!(
+        "<tr>\
+            <td><span class=\"badge {severity_class}\">{}</span></td>\
+            <td><code>{}</code></td>\
+            <td>{}</td>\
+            <td>{location}{snippet}</td>\
+         </tr>",
+        escape_html(finding.severity_label()),
+        escape_html(&finding.rule_id),
+        escape_html(&finding.title),
     )
 }
 

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -29,6 +29,8 @@ pub fn render_with_baseline(
         files_count: report.summary.files_count,
         directories_count: report.summary.directories_count,
         lines_of_code: report.summary.lines_of_code,
+        skipped_files_count: report.summary.skipped_files_count,
+        skipped_bytes: report.summary.skipped_bytes,
         languages: &report.summary.languages,
         baseline: BaselineJsonMetadata {
             path: report
@@ -51,6 +53,8 @@ struct BaselineJsonReport<'a> {
     files_count: usize,
     directories_count: usize,
     lines_of_code: usize,
+    skipped_files_count: usize,
+    skipped_bytes: u64,
     languages: &'a [LanguageSummary],
     baseline: BaselineJsonMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -17,6 +17,12 @@ pub fn render(summary: &ScanSummary) -> String {
         "- **Lines of code:** {}\n\n",
         summary.lines_of_code
     ));
+    if summary.skipped_files_count > 0 {
+        output.push_str(&format!(
+            "- **Files skipped:** {} ({} bytes)\n\n",
+            summary.skipped_files_count, summary.skipped_bytes
+        ));
+    }
 
     output.push_str("## Languages\n\n");
 

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -89,6 +89,8 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
             files_count: report.summary.files_count,
             directories_count: report.summary.directories_count,
             lines_of_code: report.summary.lines_of_code,
+            skipped_files_count: report.summary.skipped_files_count,
+            skipped_bytes: report.summary.skipped_bytes,
             languages: report.summary.languages.clone(),
             findings: report.in_diff_findings().into_iter().cloned().collect(),
         },

--- a/src/scan/config.rs
+++ b/src/scan/config.rs
@@ -1,12 +1,14 @@
 use crate::config::defaults::{
     DEFAULT_COMPLEXITY_HIGH_THRESHOLD, DEFAULT_COMPLEXITY_MEDIUM_THRESHOLD,
     DEFAULT_HUGE_FILE_LINES, DEFAULT_LONG_FUNCTION_LINES, DEFAULT_MAX_DIRECTORY_DEPTH,
-    DEFAULT_MAX_DIRECTORY_MODULES, DEFAULT_MAX_FILE_LINES, default_ignored_paths,
+    DEFAULT_MAX_DIRECTORY_MODULES, DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILE_LINES,
+    default_ignored_paths,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScanConfig {
     pub ignored_paths: Vec<String>,
+    pub max_file_bytes: u64,
     pub large_file_loc_threshold: usize,
     pub huge_file_loc_threshold: usize,
     pub max_directory_modules: usize,
@@ -20,6 +22,7 @@ impl Default for ScanConfig {
     fn default() -> Self {
         Self {
             ignored_paths: default_ignored_paths(),
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
             large_file_loc_threshold: DEFAULT_MAX_FILE_LINES,
             huge_file_loc_threshold: DEFAULT_HUGE_FILE_LINES,
             max_directory_modules: DEFAULT_MAX_DIRECTORY_MODULES,

--- a/src/scan/facts.rs
+++ b/src/scan/facts.rs
@@ -7,6 +7,8 @@ pub struct ScanFacts {
     pub files_count: usize,
     pub directories_count: usize,
     pub lines_of_code: usize,
+    pub skipped_files_count: usize,
+    pub skipped_bytes: u64,
     pub languages: Vec<LanguageSummary>,
     pub files: Vec<FileFacts>,
 }
@@ -17,5 +19,6 @@ pub struct FileFacts {
     pub language: Option<String>,
     pub lines_of_code: usize,
     pub branch_count: usize,
+    pub imports: Vec<String>,
     pub content: String,
 }

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -3,6 +3,7 @@ use crate::audits::pipeline::{build_file_audits, run_project_audits};
 use crate::audits::traits::FileAudit;
 use crate::baseline::key::stable_finding_key;
 use crate::findings::types::Finding;
+use crate::graph::imports::extract_imports;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::{FileFacts, ScanFacts};
 use crate::scan::language::detect_language;
@@ -32,6 +33,8 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
         files_count: facts.files_count,
         directories_count: facts.directories_count,
         lines_of_code: facts.lines_of_code,
+        skipped_files_count: facts.skipped_files_count,
+        skipped_bytes: facts.skipped_bytes,
         languages: facts.languages,
         findings,
     })
@@ -118,12 +121,18 @@ fn audit_file_inline(
         *languages.entry(language_name.clone()).or_insert(0) += 1;
     }
 
+    if skip_oversized_file(path, facts, &language, config)? {
+        return Ok(());
+    }
+
     let Ok(content) = fs::read_to_string(path) else {
+        track_skipped_file(path, facts, 0);
         facts.files.push(FileFacts {
             path: path.to_path_buf(),
             language,
             lines_of_code: 0,
             branch_count: 0,
+            imports: Vec::new(),
             content: String::new(),
         });
         return Ok(());
@@ -131,6 +140,7 @@ fn audit_file_inline(
 
     let lines_of_code = count_lines_of_code(&content);
     let branch_count = count_branches(&content);
+    let imports = extract_imports(&content, language.as_deref());
     facts.lines_of_code += lines_of_code;
 
     let file_facts = FileFacts {
@@ -138,6 +148,7 @@ fn audit_file_inline(
         language,
         lines_of_code,
         branch_count,
+        imports,
         content,
     };
 
@@ -151,6 +162,7 @@ fn audit_file_inline(
         language: file_facts.language,
         lines_of_code: file_facts.lines_of_code,
         branch_count: file_facts.branch_count,
+        imports: file_facts.imports,
         content: String::new(),
     });
 
@@ -179,7 +191,7 @@ pub fn collect_scan_facts_with_config(path: &Path, config: &ScanConfig) -> io::R
     let mut languages: HashMap<String, usize> = HashMap::new();
 
     if path.is_file() {
-        collect_file_facts(path, &mut facts, &mut languages)?;
+        collect_file_facts(path, &mut facts, &mut languages, config)?;
     } else {
         collect_directory_facts(path, &mut facts, &mut languages, config)?;
     }
@@ -215,7 +227,7 @@ fn collect_directory_facts(
         }
 
         if file_type.is_file() {
-            collect_file_facts(entry_path, facts, languages)?;
+            collect_file_facts(entry_path, facts, languages, config)?;
         }
     }
 
@@ -263,6 +275,7 @@ fn collect_file_facts(
     path: &Path,
     facts: &mut ScanFacts,
     languages: &mut HashMap<String, usize>,
+    config: &ScanConfig,
 ) -> io::Result<()> {
     facts.files_count += 1;
 
@@ -272,7 +285,20 @@ fn collect_file_facts(
         *languages.entry(language_name.clone()).or_insert(0) += 1;
     }
 
+    if skip_oversized_file(path, facts, &language, config)? {
+        return Ok(());
+    }
+
     let Ok(content) = fs::read_to_string(path) else {
+        track_skipped_file(path, facts, 0);
+        facts.files.push(FileFacts {
+            path: path.to_path_buf(),
+            language,
+            lines_of_code: 0,
+            branch_count: 0,
+            imports: Vec::new(),
+            content: String::new(),
+        });
         return Ok(());
     };
 
@@ -281,13 +307,57 @@ fn collect_file_facts(
 
     facts.files.push(FileFacts {
         path: path.to_path_buf(),
+        imports: extract_imports(&content, language.as_deref()),
+        branch_count: count_branches(&content),
         language,
         lines_of_code,
-        branch_count: count_branches(&content),
         content,
     });
 
     Ok(())
+}
+
+fn skip_oversized_file(
+    path: &Path,
+    facts: &mut ScanFacts,
+    language: &Option<String>,
+    config: &ScanConfig,
+) -> io::Result<bool> {
+    if config.max_file_bytes == 0 {
+        return Ok(false);
+    }
+
+    let metadata = fs::metadata(path)?;
+    let file_size = metadata.len();
+
+    if file_size <= config.max_file_bytes {
+        return Ok(false);
+    }
+
+    track_skipped_file(path, facts, file_size);
+    facts.files.push(FileFacts {
+        path: path.to_path_buf(),
+        language: language.clone(),
+        lines_of_code: 0,
+        branch_count: 0,
+        imports: Vec::new(),
+        content: String::new(),
+    });
+
+    Ok(true)
+}
+
+fn track_skipped_file(path: &Path, facts: &mut ScanFacts, skipped_bytes: u64) {
+    facts.skipped_files_count += 1;
+    facts.skipped_bytes = facts.skipped_bytes.saturating_add(skipped_bytes);
+
+    if skipped_bytes > 0 {
+        return;
+    }
+
+    if let Ok(metadata) = fs::metadata(path) {
+        facts.skipped_bytes = facts.skipped_bytes.saturating_add(metadata.len());
+    }
 }
 
 fn count_lines_of_code(content: &str) -> usize {

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -23,6 +23,10 @@ pub struct ScanSummary {
     pub files_count: usize,
     pub directories_count: usize,
     pub lines_of_code: usize,
+    #[serde(default)]
+    pub skipped_files_count: usize,
+    #[serde(default)]
+    pub skipped_bytes: u64,
     pub languages: Vec<LanguageSummary>,
     pub findings: Vec<Finding>,
 }

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -67,6 +67,8 @@ fn summary(findings: Vec<Finding>) -> ScanSummary {
         files_count: 1,
         directories_count: 0,
         lines_of_code: 10,
+        skipped_files_count: 0,
+        skipped_bytes: 0,
         languages: vec![],
         findings,
     }

--- a/tests/complexity_audit.rs
+++ b/tests/complexity_audit.rs
@@ -11,6 +11,7 @@ fn make_file(lines_of_code: usize, branch_count: usize) -> FileFacts {
         language: Some("Rust".to_string()),
         lines_of_code,
         branch_count,
+        imports: Vec::new(),
         content: String::new(),
     }
 }
@@ -69,6 +70,7 @@ fn skips_unsupported_language() {
         language: Some("Markdown".to_string()),
         lines_of_code: 100,
         branch_count: 50,
+        imports: Vec::new(),
         content: String::new(),
     };
     let findings = ComplexityAudit.audit(&file, &ScanConfig::default());

--- a/tests/config_loader.rs
+++ b/tests/config_loader.rs
@@ -31,6 +31,7 @@ fn valid_config_is_parsed() {
     .expect("valid config should parse");
 
     assert_eq!(config.scan.ignore, vec!["vendor"]);
+    assert_eq!(config.scan.max_file_bytes, 2 * 1024 * 1024);
     assert_eq!(config.architecture.max_file_lines, 42);
     assert_eq!(config.architecture.huge_file_lines, 1000);
     assert_eq!(config.output.default_format, OutputFormat::Json);
@@ -59,4 +60,19 @@ fn explicit_config_path_is_loaded() {
     let config = load_optional_config(&config_path).expect("config should load");
 
     assert_eq!(config.scan.ignore, vec!["generated"]);
+}
+
+#[test]
+fn scan_max_file_bytes_is_parsed() {
+    let config = parse_config(
+        r#"
+        [scan]
+        max_file_bytes = 12345
+        "#,
+        None,
+    )
+    .expect("valid config should parse");
+
+    assert_eq!(config.scan.max_file_bytes, 12345);
+    assert_eq!(config.to_scan_config().max_file_bytes, 12345);
 }

--- a/tests/coupling_graph.rs
+++ b/tests/coupling_graph.rs
@@ -1,0 +1,282 @@
+use repopilot::graph::{build_coupling_graph, compute_metrics, detect_cycles};
+use repopilot::scan::scanner::collect_scan_facts;
+use std::fs;
+use tempfile::tempdir;
+
+// ── Rust graph ────────────────────────────────────────────────────────────────
+
+#[test]
+fn rust_graph_edge_from_main_to_foo() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    fs::create_dir(root.join("src")).unwrap();
+    fs::write(root.join("src/main.rs"), "use crate::foo;\nfn main() {}\n").unwrap();
+    fs::write(root.join("src/foo.rs"), "pub fn bar() {}\n").unwrap();
+
+    let facts = collect_scan_facts(root).unwrap();
+    let graph = build_coupling_graph(&facts, root);
+
+    let main_path = root.join("src/main.rs");
+    let foo_path = root.join("src/foo.rs");
+
+    assert!(graph.nodes.contains(&main_path), "main.rs must be a node");
+    assert!(graph.nodes.contains(&foo_path), "foo.rs must be a node");
+
+    let main_edges = graph
+        .edges
+        .get(&main_path)
+        .expect("main.rs must have an edge set");
+    assert!(
+        main_edges.contains(&foo_path),
+        "main.rs must have an edge to foo.rs"
+    );
+}
+
+#[test]
+fn rust_graph_no_spurious_edges() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    fs::create_dir(root.join("src")).unwrap();
+    // foo.rs imports nothing
+    fs::write(root.join("src/foo.rs"), "pub fn bar() {}\n").unwrap();
+
+    let facts = collect_scan_facts(root).unwrap();
+    let graph = build_coupling_graph(&facts, root);
+
+    let foo_edges = graph
+        .edges
+        .get(&root.join("src/foo.rs"))
+        .map(|s| s.len())
+        .unwrap_or(0);
+    assert_eq!(foo_edges, 0, "foo.rs must have no outgoing edges");
+}
+
+// ── TypeScript graph ──────────────────────────────────────────────────────────
+
+#[test]
+fn ts_graph_edge_from_app_to_format() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    let src = root.join("src");
+    let utils = src.join("utils");
+    fs::create_dir_all(&utils).unwrap();
+
+    fs::write(
+        src.join("App.tsx"),
+        "import { format } from \"./utils/format\";\n",
+    )
+    .unwrap();
+    fs::write(
+        utils.join("format.ts"),
+        "export function format(s: string) { return s; }\n",
+    )
+    .unwrap();
+
+    let facts = collect_scan_facts(root).unwrap();
+    let graph = build_coupling_graph(&facts, root);
+
+    let app_path = src.join("App.tsx");
+    let format_path = utils.join("format.ts");
+
+    let app_edges = graph
+        .edges
+        .get(&app_path)
+        .expect("App.tsx must have an edge set");
+    assert!(
+        app_edges.contains(&format_path),
+        "App.tsx must have an edge to utils/format.ts"
+    );
+}
+
+// ── Metrics ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn metrics_fan_in_and_fan_out() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).unwrap();
+
+    // shared.rs is imported by both a.rs and b.rs
+    // b.rs also imports a.rs
+    fs::write(src.join("shared.rs"), "pub fn shared() {}\n").unwrap();
+    fs::write(src.join("a.rs"), "use crate::shared;\npub fn a() {}\n").unwrap();
+    fs::write(
+        src.join("b.rs"),
+        "use crate::shared;\nuse crate::a;\npub fn b() {}\n",
+    )
+    .unwrap();
+
+    let facts = collect_scan_facts(root).unwrap();
+    let graph = build_coupling_graph(&facts, root);
+    let metrics = compute_metrics(&graph);
+
+    let shared_path = src.join("shared.rs");
+    let a_path = src.join("a.rs");
+    let b_path = src.join("b.rs");
+
+    let shared_m = metrics.iter().find(|m| m.path == shared_path).unwrap();
+    assert_eq!(shared_m.fan_in, 2, "shared.rs imported by a and b");
+    assert_eq!(shared_m.fan_out, 0);
+
+    let a_m = metrics.iter().find(|m| m.path == a_path).unwrap();
+    assert_eq!(a_m.fan_in, 1, "a.rs imported by b");
+    assert_eq!(a_m.fan_out, 1, "a.rs imports shared");
+
+    let b_m = metrics.iter().find(|m| m.path == b_path).unwrap();
+    assert_eq!(b_m.fan_in, 0);
+    assert_eq!(b_m.fan_out, 2, "b.rs imports shared and a");
+}
+
+#[test]
+fn instability_formula_is_correct() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).unwrap();
+
+    // stable.rs: fan_in=1, fan_out=0  → instability=0.0
+    // mid.rs:    fan_in=1, fan_out=1  → instability=0.5
+    // unstable.rs: fan_in=0, fan_out=1 → instability=1.0
+    fs::write(src.join("stable.rs"), "pub fn s() {}\n").unwrap();
+    fs::write(src.join("mid.rs"), "use crate::stable;\npub fn m() {}\n").unwrap();
+    fs::write(src.join("unstable.rs"), "use crate::mid;\npub fn u() {}\n").unwrap();
+
+    let facts = collect_scan_facts(root).unwrap();
+    let graph = build_coupling_graph(&facts, root);
+    let metrics = compute_metrics(&graph);
+
+    let stable_m = metrics
+        .iter()
+        .find(|m| m.path == src.join("stable.rs"))
+        .unwrap();
+    let mid_m = metrics
+        .iter()
+        .find(|m| m.path == src.join("mid.rs"))
+        .unwrap();
+    let unstable_m = metrics
+        .iter()
+        .find(|m| m.path == src.join("unstable.rs"))
+        .unwrap();
+
+    assert!((stable_m.instability - 0.0).abs() < f32::EPSILON);
+    assert!((mid_m.instability - 0.5).abs() < f32::EPSILON);
+    assert!((unstable_m.instability - 1.0).abs() < f32::EPSILON);
+}
+
+// ── Cycle detection ───────────────────────────────────────────────────────────
+
+#[test]
+fn two_node_cycle_is_detected() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).unwrap();
+
+    // a.rs ↔ b.rs
+    fs::write(src.join("a.rs"), "use crate::b;\n").unwrap();
+    fs::write(src.join("b.rs"), "use crate::a;\n").unwrap();
+
+    let facts = collect_scan_facts(root).unwrap();
+    let graph = build_coupling_graph(&facts, root);
+    let cycles = detect_cycles(&graph);
+
+    assert!(!cycles.is_empty(), "must detect at least one cycle");
+    let a_path = src.join("a.rs");
+    let b_path = src.join("b.rs");
+    assert!(
+        cycles
+            .iter()
+            .any(|c| c.contains(&a_path) && c.contains(&b_path)),
+        "cycle must include both a.rs and b.rs; got {cycles:?}"
+    );
+}
+
+#[test]
+fn no_cycle_in_acyclic_graph() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).unwrap();
+
+    fs::write(src.join("a.rs"), "use crate::b;\n").unwrap();
+    fs::write(src.join("b.rs"), "pub fn b() {}\n").unwrap();
+
+    let facts = collect_scan_facts(root).unwrap();
+    let graph = build_coupling_graph(&facts, root);
+    let cycles = detect_cycles(&graph);
+
+    assert!(
+        cycles.is_empty(),
+        "acyclic graph must have no cycles: {cycles:?}"
+    );
+}
+
+// ── Isolated file ─────────────────────────────────────────────────────────────
+
+#[test]
+fn isolated_file_has_zero_metrics() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("standalone.rs"), "pub fn hello() {}\n").unwrap();
+
+    let facts = collect_scan_facts(root).unwrap();
+    let graph = build_coupling_graph(&facts, root);
+    let metrics = compute_metrics(&graph);
+
+    let m = metrics
+        .iter()
+        .find(|m| m.path == src.join("standalone.rs"))
+        .unwrap();
+    assert_eq!(m.fan_in, 0);
+    assert_eq!(m.fan_out, 0);
+    assert!((m.instability - 0.0).abs() < f32::EPSILON);
+}
+
+#[test]
+fn isolated_file_is_a_graph_node() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("standalone.rs"), "pub fn hello() {}\n").unwrap();
+
+    let facts = collect_scan_facts(root).unwrap();
+    let graph = build_coupling_graph(&facts, root);
+
+    assert!(graph.nodes.contains(&src.join("standalone.rs")));
+}
+
+// ── Metrics output is stable ──────────────────────────────────────────────────
+
+#[test]
+fn metrics_are_returned_in_path_order() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("a.rs"), "pub fn a() {}\n").unwrap();
+    fs::write(src.join("b.rs"), "pub fn b() {}\n").unwrap();
+    fs::write(src.join("c.rs"), "pub fn c() {}\n").unwrap();
+
+    let facts = collect_scan_facts(root).unwrap();
+    let graph = build_coupling_graph(&facts, root);
+    let metrics = compute_metrics(&graph);
+
+    let paths: Vec<_> = metrics.iter().map(|m| &m.path).collect();
+    let mut sorted = paths.clone();
+    sorted.sort();
+    assert_eq!(paths, sorted, "metrics must be in stable path order");
+}

--- a/tests/file_facts_scan.rs
+++ b/tests/file_facts_scan.rs
@@ -1,4 +1,6 @@
+use repopilot::scan::config::ScanConfig;
 use repopilot::scan::scanner::collect_scan_facts;
+use repopilot::scan::scanner::collect_scan_facts_with_config;
 use std::fs;
 use tempfile::tempdir;
 
@@ -25,4 +27,26 @@ fn scanner_collects_file_facts_without_running_rules_directly() {
     assert_eq!(file.language.as_deref(), Some("Rust"));
     assert_eq!(file.lines_of_code, 2);
     assert!(file.content.contains("TODO"));
+}
+
+#[test]
+fn collector_reports_files_skipped_by_size_guard() {
+    let temp = tempdir().expect("failed to create temp dir");
+    let file_path = temp.path().join("large.rs");
+    let content = "pub fn large() {}\n".repeat(20);
+    fs::write(&file_path, &content).expect("failed to write large file");
+
+    let config = ScanConfig {
+        max_file_bytes: 16,
+        ..ScanConfig::default()
+    };
+
+    let facts =
+        collect_scan_facts_with_config(temp.path(), &config).expect("failed to collect scan facts");
+
+    assert_eq!(facts.files_count, 1);
+    assert_eq!(facts.skipped_files_count, 1);
+    assert_eq!(facts.skipped_bytes, content.len() as u64);
+    assert_eq!(facts.files.len(), 1);
+    assert!(facts.files[0].content.is_empty());
 }

--- a/tests/import_extraction.rs
+++ b/tests/import_extraction.rs
@@ -1,0 +1,175 @@
+use repopilot::graph::extract_imports;
+
+// ── Rust ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn rust_use_crate_path() {
+    let imports = extract_imports("use crate::foo::bar;\n", Some("Rust"));
+    assert!(
+        imports.contains(&"crate::foo::bar".to_string()),
+        "expected crate::foo::bar in {imports:?}"
+    );
+}
+
+#[test]
+fn rust_mod_child() {
+    let imports = extract_imports("mod child;\n", Some("Rust"));
+    assert!(
+        imports.contains(&"mod::child".to_string()),
+        "expected mod::child in {imports:?}"
+    );
+}
+
+#[test]
+fn rust_pub_mod_child() {
+    let imports = extract_imports("pub mod child;\n", Some("Rust"));
+    assert!(
+        imports.contains(&"mod::child".to_string()),
+        "expected mod::child from pub mod in {imports:?}"
+    );
+}
+
+#[test]
+fn rust_block_comment_not_extracted() {
+    let code = "/* use crate::foo; */\n";
+    let imports = extract_imports(code, Some("Rust"));
+    assert!(
+        imports.is_empty(),
+        "block comment must not produce imports: {imports:?}"
+    );
+}
+
+#[test]
+fn rust_line_comment_not_extracted() {
+    let code = "// use crate::bar;\n";
+    let imports = extract_imports(code, Some("Rust"));
+    assert!(
+        imports.is_empty(),
+        "line comment must not produce imports: {imports:?}"
+    );
+}
+
+#[test]
+fn rust_inline_group_import() {
+    let code = "use crate::{foo, bar};\n";
+    let imports = extract_imports(code, Some("Rust"));
+    assert!(imports.contains(&"crate::foo".to_string()), "{imports:?}");
+    assert!(imports.contains(&"crate::bar".to_string()), "{imports:?}");
+}
+
+#[test]
+fn rust_multiline_group_import() {
+    let code = "use crate::{\n    foo,\n    bar,\n};\n";
+    let imports = extract_imports(code, Some("Rust"));
+    assert!(imports.contains(&"crate::foo".to_string()), "{imports:?}");
+    assert!(imports.contains(&"crate::bar".to_string()), "{imports:?}");
+}
+
+#[test]
+fn rust_imports_are_deduplicated() {
+    let code = "use crate::foo;\nuse crate::foo;\n";
+    let imports = extract_imports(code, Some("Rust"));
+    assert_eq!(imports.iter().filter(|i| *i == "crate::foo").count(), 1);
+}
+
+// ── TypeScript / JavaScript ───────────────────────────────────────────────────
+
+#[test]
+fn ts_import_from_relative() {
+    let code = r#"import { foo } from "./utils";"#;
+    let imports = extract_imports(code, Some("TypeScript"));
+    assert!(imports.contains(&"./utils".to_string()), "{imports:?}");
+}
+
+#[test]
+fn ts_export_from_relative() {
+    let code = r#"export { bar } from "../lib";"#;
+    let imports = extract_imports(code, Some("TypeScript"));
+    assert!(imports.contains(&"../lib".to_string()), "{imports:?}");
+}
+
+#[test]
+fn ts_require_relative() {
+    let code = r#"const x = require("../lib");"#;
+    let imports = extract_imports(code, Some("TypeScript"));
+    assert!(imports.contains(&"../lib".to_string()), "{imports:?}");
+}
+
+#[test]
+fn ts_non_relative_import_skipped() {
+    // Bare specifiers and @-scoped aliases must not be emitted
+    let code = r#"import React from "react";"#;
+    let imports = extract_imports(code, Some("TypeScript React"));
+    assert!(
+        imports.is_empty(),
+        "bare specifier must be skipped: {imports:?}"
+    );
+}
+
+#[test]
+fn js_import_from_relative() {
+    let code = r#"import { fn } from "./helpers";"#;
+    let imports = extract_imports(code, Some("JavaScript"));
+    assert!(imports.contains(&"./helpers".to_string()), "{imports:?}");
+}
+
+// ── Python ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn python_relative_single_dot() {
+    let code = "from .models import User\n";
+    let imports = extract_imports(code, Some("Python"));
+    assert!(imports.contains(&".models".to_string()), "{imports:?}");
+}
+
+#[test]
+fn python_relative_double_dot() {
+    let code = "from ..base import Thing\n";
+    let imports = extract_imports(code, Some("Python"));
+    assert!(imports.contains(&"..base".to_string()), "{imports:?}");
+}
+
+#[test]
+fn python_comment_not_extracted() {
+    let code = "# from .models import User\n";
+    let imports = extract_imports(code, Some("Python"));
+    assert!(imports.is_empty(), "{imports:?}");
+}
+
+// ── Go ────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn go_single_import() {
+    let code = "import \"fmt\"\n";
+    let imports = extract_imports(code, Some("Go"));
+    assert!(imports.contains(&"fmt".to_string()), "{imports:?}");
+}
+
+#[test]
+fn go_import_block() {
+    let code = "import (\n\t\"fmt\"\n\t\"os\"\n)\n";
+    let imports = extract_imports(code, Some("Go"));
+    assert!(imports.contains(&"fmt".to_string()), "{imports:?}");
+    assert!(imports.contains(&"os".to_string()), "{imports:?}");
+}
+
+#[test]
+fn go_import_block_with_alias() {
+    let code = "import (\n\tfmt2 \"fmt\"\n)\n";
+    let imports = extract_imports(code, Some("Go"));
+    assert!(imports.contains(&"fmt".to_string()), "{imports:?}");
+}
+
+// ── Unknown language ──────────────────────────────────────────────────────────
+
+#[test]
+fn unknown_language_returns_empty() {
+    let imports = extract_imports("use crate::foo;\n", Some("TOML"));
+    assert!(imports.is_empty());
+}
+
+#[test]
+fn no_language_returns_empty() {
+    let imports = extract_imports("use crate::foo;\n", None);
+    assert!(imports.is_empty());
+}

--- a/tests/marker_findings.rs
+++ b/tests/marker_findings.rs
@@ -18,6 +18,7 @@ fn main() {}
         language: Some("Rust".to_string()),
         lines_of_code: 5,
         branch_count: 0,
+        imports: Vec::new(),
         content: content.to_string(),
     };
 

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -10,6 +10,8 @@ fn html_output_escapes_snippets_and_renders_summary() {
         files_count: 1,
         directories_count: 1,
         lines_of_code: 3,
+        skipped_files_count: 0,
+        skipped_bytes: 0,
         languages: vec![],
         findings: vec![Finding {
             id: "finding-1".to_string(),

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -9,6 +9,8 @@ fn renders_valid_json_scan_summary() {
         files_count: 1,
         directories_count: 0,
         lines_of_code: 3,
+        skipped_files_count: 0,
+        skipped_bytes: 0,
         languages: vec![LanguageSummary {
             name: "Rust".to_string(),
             files_count: 1,

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -10,6 +10,8 @@ fn renders_markdown_scan_summary() {
         files_count: 2,
         directories_count: 1,
         lines_of_code: 10,
+        skipped_files_count: 0,
+        skipped_bytes: 0,
         languages: vec![
             LanguageSummary {
                 name: "Rust".to_string(),
@@ -60,6 +62,8 @@ fn renders_empty_markdown_sections() {
         files_count: 0,
         directories_count: 0,
         lines_of_code: 0,
+        skipped_files_count: 0,
+        skipped_bytes: 0,
         languages: vec![],
         findings: vec![],
     };

--- a/tests/scan_config.rs
+++ b/tests/scan_config.rs
@@ -6,6 +6,7 @@ fn default_scan_config_uses_expected_thresholds() {
 
     assert_eq!(config.large_file_loc_threshold, 300);
     assert_eq!(config.huge_file_loc_threshold, 1000);
+    assert_eq!(config.max_file_bytes, 2 * 1024 * 1024);
 }
 
 #[test]

--- a/tests/scan_summary.rs
+++ b/tests/scan_summary.rs
@@ -1,4 +1,6 @@
+use repopilot::scan::config::ScanConfig;
 use repopilot::scan::scanner::scan_path;
+use repopilot::scan::scanner::scan_path_with_config;
 use std::fs;
 use tempfile::tempdir;
 
@@ -53,4 +55,24 @@ fn scans_directory_with_counts_languages_and_markers() {
             .iter()
             .any(|language| language.name == "Markdown" && language.files_count == 1)
     );
+}
+
+#[test]
+fn scan_reports_files_skipped_by_size_guard() {
+    let temp = tempdir().expect("failed to create temp dir");
+    let file_path = temp.path().join("large.rs");
+    let content = "fn large() {}\n".repeat(20);
+    fs::write(&file_path, &content).expect("failed to write large file");
+
+    let config = ScanConfig {
+        max_file_bytes: 16,
+        ..ScanConfig::default()
+    };
+
+    let summary = scan_path_with_config(temp.path(), &config).expect("failed to scan temp project");
+
+    assert_eq!(summary.files_count, 1);
+    assert_eq!(summary.skipped_files_count, 1);
+    assert_eq!(summary.skipped_bytes, content.len() as u64);
+    assert_eq!(summary.lines_of_code, 0);
 }

--- a/tests/security_rules.rs
+++ b/tests/security_rules.rs
@@ -31,6 +31,22 @@ fn secret_candidate_skips_test_and_fixture_paths() {
 }
 
 #[test]
+fn secret_candidate_detects_and_masks_jwt_like_tokens() {
+    let token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    let file = file(
+        "src/config.rs",
+        &format!("const TOKEN: &str = \"{token}\";\n"),
+    );
+
+    let findings = SecretCandidateAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, "security.secret-candidate");
+    assert!(findings[0].evidence[0].snippet.contains("eyJhbGci...***"));
+    assert!(!findings[0].evidence[0].snippet.contains(token));
+}
+
+#[test]
 fn private_key_candidate_reports_header_without_key_body() {
     let file = file(
         "src/key.pem",
@@ -85,6 +101,7 @@ fn file(path: &str, content: &str) -> FileFacts {
         language: None,
         lines_of_code: content.lines().count(),
         branch_count: 0,
+        imports: Vec::new(),
         content: content.to_string(),
     }
 }

--- a/tests/testing_rules.rs
+++ b/tests/testing_rules.rs
@@ -61,6 +61,7 @@ fn file(path: &str) -> FileFacts {
         language: Some("Rust".to_string()),
         lines_of_code: 1,
         branch_count: 0,
+        imports: Vec::new(),
         content: "pub fn value() {}\n".to_string(),
     }
 }


### PR DESCRIPTION
## Summary

Adds the core foundation for RepoPilot v0.5 import coupling analysis.

This PR introduces lightweight import extraction, path resolution, and coupling graph infrastructure. The scanner now preserves import metadata from already-loaded file content, allowing RepoPilot to build dependency relationships between project files without adding a parser, build step, or extra file I/O.

This is the internal graph layer needed before adding architecture findings such as excessive fan-out, unstable hubs, circular dependencies, and review blast-radius reporting.

## Type of change

- Feature
- Refactor
- Tests
- Documentation

## What changed

- Added import metadata to collected file facts.
- Added a new `graph` module for coupling analysis.
- Added per-language import extraction support.
- Added path resolution from raw imports to known project files.
- Added coupling graph construction.
- Added file-level graph metrics:
  - fan-in
  - fan-out
  - instability
- Added circular dependency detection support.
- Preserved import metadata when scanner content is stripped for memory efficiency.
- Updated config/docs/templates where needed.
- Added tests for import extraction and coupling graph behavior.

## Why

RepoPilot is moving from purely text-based audits toward more useful structural analysis.

Import coupling is a strong next step because it can show how files depend on each other and later help answer questions like:

- Which files are imported by many others?
- Which files have too many dependencies?
- Which changes have a large blast radius?
- Are there circular dependencies in the project?

The important part is that this is still local-first, lightweight, and source-text based. It does not require compilation, language servers, or build artifacts.

## Architecture notes

- No god files introduced.
- Graph logic is isolated under `src/graph`.
- Import extraction is separated from path resolution.
- Scanner remains responsible for collecting facts.
- Audit/report behavior remains separated from graph construction.
- Existing complexity audit behavior is preserved.
- This PR prepares graph infrastructure but does not yet emit coupling findings.

## Changelog

- Added import extraction infrastructure.
- Added coupling graph model and graph-building logic.
- Added dependency metrics support for scanned files.
- Added cycle detection foundation.
- Added tests for graph and import behavior.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .