### PR TITLE
feat: implement blast radius computation and rendering in review reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ repopilot review . --base origin/main
 repopilot review . --base origin/main --head HEAD --format markdown
 ```
 
-Review mode still scans the repository with the normal rules, but separates findings into in-diff and out-of-diff groups. When `--fail-on` is used, the CI gate evaluates only in-diff findings.
+Review mode still scans the repository with the normal rules, but separates findings into in-diff and out-of-diff groups. When import coupling data is available, it also shows blast radius: files that import changed files and may need extra review. When `--fail-on` is used, the CI gate evaluates only in-diff findings.
 
 ## Output Formats
 

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -12,6 +12,7 @@ use crate::findings::types::Finding;
 use crate::review::diff::{ChangedFile, DiffTarget, load_changed_files, resolve_git_root};
 use crate::review::model::{ReviewFindingStatus, ReviewReport};
 use crate::scan::types::ScanSummary;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 pub fn build_review_report(
@@ -42,6 +43,7 @@ fn classify_findings(
     changed_files: Vec<ChangedFile>,
 ) -> ReviewReport {
     let summary = baseline_report.summary;
+    let blast_radius = compute_blast_radius(&summary, &repo_root, &changed_files);
     let findings = summary
         .findings
         .iter()
@@ -64,8 +66,51 @@ fn classify_findings(
         repo_root,
         baseline_path: baseline_report.baseline_path,
         changed_files,
+        blast_radius,
         findings,
     }
+}
+
+pub fn compute_blast_radius(
+    summary: &ScanSummary,
+    repo_root: &Path,
+    changed_files: &[ChangedFile],
+) -> Vec<PathBuf> {
+    let graph = match &summary.coupling_graph {
+        Some(graph) => graph,
+        None => return Vec::new(),
+    };
+
+    let changed_paths: BTreeSet<PathBuf> = changed_files
+        .iter()
+        .map(|file| normalized_review_path(&file.path, repo_root))
+        .collect();
+
+    let mut importers_by_target: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
+
+    for (source, targets) in &graph.edges {
+        let source = normalized_review_path(source, repo_root);
+        for target in targets {
+            importers_by_target
+                .entry(normalized_review_path(target, repo_root))
+                .or_default()
+                .insert(source.clone());
+        }
+    }
+
+    let mut impacted = BTreeSet::new();
+
+    for changed in &changed_paths {
+        if let Some(importers) = importers_by_target.get(changed) {
+            for importer in importers {
+                if !changed_paths.contains(importer) {
+                    impacted.insert(importer.clone());
+                }
+            }
+        }
+    }
+
+    impacted.into_iter().collect()
 }
 
 pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
@@ -111,11 +156,28 @@ fn finding_is_in_diff(finding: &Finding, repo_root: &Path, changed_files: &[Chan
 }
 
 fn pathspec_for_scan_path(scan_path: &Path, repo_root: &Path) -> Option<String> {
-    let relative = normalized_relative_path(scan_path, repo_root);
+    let relative = normalized_review_path(scan_path, repo_root)
+        .to_string_lossy()
+        .to_string();
 
     if relative == "." || relative.is_empty() {
         None
     } else {
         Some(relative)
     }
+}
+
+fn normalized_review_path(path: &Path, repo_root: &Path) -> PathBuf {
+    let repo_root = repo_root
+        .canonicalize()
+        .unwrap_or_else(|_| repo_root.to_path_buf());
+
+    let path = if path.is_absolute() {
+        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    } else {
+        let repo_path = repo_root.join(path);
+        repo_path.canonicalize().unwrap_or(repo_path)
+    };
+
+    PathBuf::from(normalized_relative_path(&path, &repo_root))
 }

--- a/src/review/model.rs
+++ b/src/review/model.rs
@@ -11,6 +11,7 @@ pub struct ReviewReport {
     pub repo_root: PathBuf,
     pub baseline_path: Option<PathBuf>,
     pub changed_files: Vec<ChangedFile>,
+    pub blast_radius: Vec<PathBuf>,
     pub findings: Vec<ReviewFindingStatus>,
 }
 

--- a/src/review/render.rs
+++ b/src/review/render.rs
@@ -53,6 +53,8 @@ pub fn render_console(report: &ReviewReport, ci_gate: Option<&CiGateResult>) -> 
         }
     }
 
+    render_blast_radius(&mut output, report);
+
     render_findings_group(&mut output, "In-diff findings", &report.in_diff_findings());
     render_findings_group(
         &mut output,
@@ -91,6 +93,11 @@ pub fn render_json(
         directories_count: report.summary.directories_count,
         lines_of_code: report.summary.lines_of_code,
         changed_files: &report.changed_files,
+        blast_radius: report
+            .blast_radius
+            .iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect(),
         review: ReviewJsonMetadata {
             in_diff_findings: report.in_diff_count(),
             out_of_diff_findings: report.out_of_diff_count(),
@@ -174,6 +181,8 @@ pub fn render_markdown(report: &ReviewReport, ci_gate: Option<&CiGateResult>) ->
         output.push('\n');
     }
 
+    render_markdown_blast_radius(&mut output, report);
+
     render_markdown_findings_group(
         &mut output,
         "In-Diff Findings",
@@ -196,6 +205,34 @@ pub fn render_markdown(report: &ReviewReport, ci_gate: Option<&CiGateResult>) ->
     );
 
     output
+}
+
+fn render_blast_radius(output: &mut String, report: &ReviewReport) {
+    if report.blast_radius.is_empty() {
+        return;
+    }
+
+    output.push_str("\nBlast radius:\n");
+    output.push_str("  The following files import changed files and may need extra review:\n");
+
+    for path in &report.blast_radius {
+        output.push_str(&format!("  - {}\n", path.display()));
+    }
+}
+
+fn render_markdown_blast_radius(output: &mut String, report: &ReviewReport) {
+    if report.blast_radius.is_empty() {
+        return;
+    }
+
+    output.push_str("## Blast Radius\n\n");
+    output.push_str("The following files import changed files and may need extra review:\n\n");
+
+    for path in &report.blast_radius {
+        output.push_str(&format!("- `{}`\n", path.display()));
+    }
+
+    output.push('\n');
 }
 
 fn render_findings_group(output: &mut String, label: &str, findings: &[&Finding]) {
@@ -313,6 +350,7 @@ struct ReviewJsonReport<'a> {
     directories_count: usize,
     lines_of_code: usize,
     changed_files: &'a [ChangedFile],
+    blast_radius: Vec<String>,
     review: ReviewJsonMetadata,
     baseline: ReviewBaselineJsonMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/review_blast_radius.rs
+++ b/tests/review_blast_radius.rs
@@ -1,0 +1,196 @@
+use repopilot::graph::CouplingGraph;
+use repopilot::review::diff::{ChangeStatus, ChangedFile};
+use repopilot::review::model::ReviewReport;
+use repopilot::review::render::{render_console, render_json};
+use repopilot::review::{build_review_report, compute_blast_radius};
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::scanner::scan_path_with_config;
+use repopilot::scan::types::ScanSummary;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn review_blast_radius_includes_files_that_import_changed_file() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_file(&temp, "src/a.ts", "export const a = 1;\n");
+    write_file(
+        &temp,
+        "src/b.ts",
+        "import { a } from \"./a\";\nexport const b = a;\n",
+    );
+    write_file(
+        &temp,
+        "src/c.ts",
+        "import { a } from \"./a\";\nexport const c = a;\n",
+    );
+    commit_all(temp.path(), "initial");
+
+    write_file(&temp, "src/a.ts", "export const a = 2;\n");
+
+    let json = run_review_json(temp.path());
+    let blast_radius = json["blast_radius"].as_array().expect("blast radius array");
+
+    assert!(blast_radius.iter().any(|path| path == "src/b.ts"));
+    assert!(blast_radius.iter().any(|path| path == "src/c.ts"));
+    assert!(!blast_radius.iter().any(|path| path == "src/a.ts"));
+}
+
+#[test]
+fn review_blast_radius_is_empty_for_changed_leaf_file() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_file(&temp, "src/b.ts", "export const b = 1;\n");
+    write_file(
+        &temp,
+        "src/a.ts",
+        "import { b } from \"./b\";\nexport const a = b;\n",
+    );
+    commit_all(temp.path(), "initial");
+
+    write_file(
+        &temp,
+        "src/a.ts",
+        "import { b } from \"./b\";\nexport const a = b + 1;\n",
+    );
+
+    let json = run_review_json(temp.path());
+
+    assert_eq!(json["blast_radius"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn review_blast_radius_excludes_changed_importers() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_file(&temp, "src/a.ts", "export const a = 1;\n");
+    write_file(
+        &temp,
+        "src/b.ts",
+        "import { a } from \"./a\";\nexport const b = a;\n",
+    );
+    write_file(
+        &temp,
+        "src/c.ts",
+        "import { a } from \"./a\";\nexport const c = a;\n",
+    );
+    commit_all(temp.path(), "initial");
+
+    write_file(&temp, "src/a.ts", "export const a = 2;\n");
+    write_file(
+        &temp,
+        "src/b.ts",
+        "import { a } from \"./a\";\nexport const b = a + 1;\n",
+    );
+
+    let json = run_review_json(temp.path());
+    let blast_radius = json["blast_radius"].as_array().expect("blast radius array");
+
+    assert!(blast_radius.iter().any(|path| path == "src/c.ts"));
+    assert!(!blast_radius.iter().any(|path| path == "src/b.ts"));
+    assert!(!blast_radius.iter().any(|path| path == "src/a.ts"));
+}
+
+#[test]
+fn blast_radius_is_empty_without_coupling_graph() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    write_file(&temp, "src/a.ts", "export const a = 1;\n");
+
+    let summary = ScanSummary {
+        root_path: temp.path().to_path_buf(),
+        coupling_graph: None,
+        ..ScanSummary::default()
+    };
+    let changed_files = vec![changed_file("src/a.ts")];
+
+    let blast_radius = compute_blast_radius(&summary, temp.path(), &changed_files);
+
+    assert!(blast_radius.is_empty());
+}
+
+#[test]
+fn render_console_includes_blast_radius_section_when_present() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    write_file(&temp, "src/a.ts", "export const a = 1;\n");
+    write_file(
+        &temp,
+        "src/b.ts",
+        "import { a } from \"./a\";\nexport const b = a;\n",
+    );
+
+    let report = ReviewReport {
+        summary: ScanSummary {
+            root_path: temp.path().to_path_buf(),
+            coupling_graph: Some(CouplingGraph {
+                edges: BTreeMap::new(),
+                nodes: BTreeSet::new(),
+            }),
+            ..ScanSummary::default()
+        },
+        repo_root: temp.path().to_path_buf(),
+        baseline_path: None,
+        changed_files: vec![changed_file("src/a.ts")],
+        blast_radius: vec![PathBuf::from("src/b.ts")],
+        findings: vec![],
+    };
+
+    let output = render_console(&report, None);
+
+    assert!(output.contains("Blast radius"));
+    assert!(output.contains("src/b.ts"));
+}
+
+fn run_review_json(root: &Path) -> Value {
+    let summary = scan_path_with_config(root, &ScanConfig::default()).expect("failed to scan");
+    let report =
+        build_review_report(summary, root, None, None, None).expect("failed to build review");
+    let output = render_json(&report, None).expect("failed to render review json");
+
+    serde_json::from_str(&output).expect("expected JSON output")
+}
+
+fn changed_file(path: &str) -> ChangedFile {
+    ChangedFile {
+        path: PathBuf::from(path),
+        status: ChangeStatus::Modified,
+        ranges: Vec::new(),
+    }
+}
+
+fn write_file(temp: &TempDir, relative_path: &str, content: &str) {
+    let path = temp.path().join(relative_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create parent dir");
+    }
+    fs::write(path, content).expect("failed to write file");
+}
+
+fn init_repo(root: &Path) {
+    git(root, &["init"]);
+    git(root, &["config", "user.email", "repopilot@example.invalid"]);
+    git(root, &["config", "user.name", "RepoPilot Test"]);
+}
+
+fn commit_all(root: &Path, message: &str) {
+    git(root, &["add", "."]);
+    git(root, &["commit", "-m", message]);
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("failed to run git");
+
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

Adds blast-radius analysis to the `review` command using the import coupling graph.

This PR reuses the coupling graph introduced in previous v0.5 work to show which project files may be affected by changed files. When other files import a changed file, RepoPilot now reports those importers as the review blast radius.

## Type of change

- Feature
- Refactor
- Tests
- Documentation

## What changed

- Added blast-radius computation for changed files.
- Reused the existing `coupling_graph` from `ScanSummary`.
- Added `blast_radius` data to the review report model.
- Rendered a new blast-radius section in review output.
- Added tests for impacted files and leaf-file behavior.
- Preserved existing review scoring and finding behavior.

## Why

RepoPilot can now answer a practical review question:

> “If I changed this file, what else might break?”

This makes the `review` command more useful for real pull-request analysis. Instead of only listing changed files and findings, RepoPilot can now show indirect risk based on project imports.

This is especially useful for files that look small but are imported by many other files.

## Architecture notes

- Coupling graph construction stays inside `src/graph`.
- Review only consumes the graph; it does not rebuild graph logic.
- Blast-radius logic is isolated in the review module.
- Rendering is kept separate from computation.
- No new architecture findings are added in this PR.
- Existing scan and audit behavior is preserved.

## Changelog

- Added review blast-radius computation.
- Added blast-radius field to review reports.
- Added blast-radius rendering to review output.
- Added tests for changed-file impact analysis.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- review