### PR TITLE
feat: add SARIF export model and finding mapper

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,6 +4,7 @@ pub mod html;
 pub mod json;
 pub mod markdown;
 pub(crate) mod render_helpers;
+pub mod sarif;
 
 use crate::baseline::diff::BaselineScanReport;
 use crate::baseline::gate::CiGateResult;

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -1,0 +1,197 @@
+use crate::findings::types::{Finding, Severity};
+use crate::scan::types::ScanSummary;
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+
+const SARIF_VERSION: &str = "2.1.0";
+const SARIF_SCHEMA: &str = "https://json.schemastore.org/sarif-2.1.0.json";
+const TOOL_NAME: &str = "RepoPilot";
+const TOOL_INFORMATION_URI: &str = "https://github.com/MykytaStel/repopilot";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifLog {
+    pub version: String,
+    #[serde(rename = "$schema")]
+    pub schema: String,
+    pub runs: Vec<SarifRun>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifRun {
+    pub tool: SarifTool,
+    pub results: Vec<SarifResult>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifTool {
+    pub driver: SarifDriver,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifDriver {
+    pub name: String,
+    #[serde(rename = "informationUri")]
+    pub information_uri: String,
+    pub rules: Vec<SarifRule>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifRule {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "shortDescription")]
+    pub short_description: SarifMessage,
+    #[serde(rename = "fullDescription", skip_serializing_if = "Option::is_none")]
+    pub full_description: Option<SarifMessage>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifResult {
+    #[serde(rename = "ruleId")]
+    pub rule_id: String,
+    pub level: String,
+    pub message: SarifMessage,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub locations: Vec<SarifLocation>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifMessage {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifLocation {
+    #[serde(rename = "physicalLocation")]
+    pub physical_location: SarifPhysicalLocation,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifPhysicalLocation {
+    #[serde(rename = "artifactLocation")]
+    pub artifact_location: SarifArtifactLocation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<SarifRegion>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifArtifactLocation {
+    pub uri: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifRegion {
+    #[serde(rename = "startLine")]
+    pub start_line: usize,
+}
+
+pub fn scan_summary_to_sarif(summary: &ScanSummary, root: &Path) -> SarifLog {
+    findings_to_sarif(&summary.findings, root)
+}
+
+pub fn findings_to_sarif(findings: &[Finding], root: &Path) -> SarifLog {
+    SarifLog {
+        version: SARIF_VERSION.to_string(),
+        schema: SARIF_SCHEMA.to_string(),
+        runs: vec![SarifRun {
+            tool: SarifTool {
+                driver: SarifDriver {
+                    name: TOOL_NAME.to_string(),
+                    information_uri: TOOL_INFORMATION_URI.to_string(),
+                    rules: sarif_rules(findings),
+                },
+            },
+            results: findings
+                .iter()
+                .map(|finding| sarif_result(finding, root))
+                .collect(),
+        }],
+    }
+}
+
+fn sarif_result(finding: &Finding, root: &Path) -> SarifResult {
+    SarifResult {
+        rule_id: finding.rule_id.clone(),
+        level: sarif_level(finding.severity).to_string(),
+        message: SarifMessage {
+            text: finding_message(finding),
+        },
+        locations: finding
+            .evidence
+            .iter()
+            .filter_map(|evidence| {
+                let uri = sarif_uri(&evidence.path, root)?;
+
+                Some(SarifLocation {
+                    physical_location: SarifPhysicalLocation {
+                        artifact_location: SarifArtifactLocation { uri },
+                        region: (evidence.line_start > 0).then_some(SarifRegion {
+                            start_line: evidence.line_start,
+                        }),
+                    },
+                })
+            })
+            .collect(),
+    }
+}
+
+fn sarif_rules(findings: &[Finding]) -> Vec<SarifRule> {
+    let rule_ids = findings
+        .iter()
+        .map(|finding| finding.rule_id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    rule_ids
+        .into_iter()
+        .map(|rule_id| SarifRule {
+            id: rule_id.to_string(),
+            name: rule_id.to_string(),
+            short_description: SarifMessage {
+                text: format!("RepoPilot rule {rule_id}"),
+            },
+            full_description: None,
+        })
+        .collect()
+}
+
+fn sarif_level(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Critical | Severity::High => "error",
+        Severity::Medium => "warning",
+        Severity::Low | Severity::Info => "note",
+    }
+}
+
+fn finding_message(finding: &Finding) -> String {
+    if finding.title.is_empty() {
+        finding.description.clone()
+    } else {
+        finding.title.clone()
+    }
+}
+
+fn sarif_uri(path: &Path, root: &Path) -> Option<String> {
+    if path.as_os_str().is_empty() {
+        return None;
+    }
+
+    let relative = root_relative_path(path, root);
+    Some(path_to_forward_slash_uri(&relative))
+}
+
+fn root_relative_path(path: &Path, root: &Path) -> PathBuf {
+    path.strip_prefix(root).unwrap_or(path).to_path_buf()
+}
+
+fn path_to_forward_slash_uri(path: &Path) -> String {
+    path.components()
+        .map(component_to_string)
+        .filter(|component| !component.is_empty())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn component_to_string(component: Component<'_>) -> String {
+    component.as_os_str().to_string_lossy().replace('\\', "/")
+}

--- a/tests/sarif_mapping.rs
+++ b/tests/sarif_mapping.rs
@@ -1,0 +1,158 @@
+use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use repopilot::output::sarif::{findings_to_sarif, scan_summary_to_sarif};
+use repopilot::scan::types::ScanSummary;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn scan_summary_maps_to_minimal_sarif_log() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("/repo"),
+        findings: vec![finding(
+            "architecture.large-file",
+            Severity::High,
+            Some("/repo/src/main.rs"),
+            12,
+        )],
+        ..ScanSummary::default()
+    };
+
+    let sarif = scan_summary_to_sarif(&summary, Path::new("/repo"));
+
+    assert_eq!(sarif.version, "2.1.0");
+    assert_eq!(
+        sarif.schema,
+        "https://json.schemastore.org/sarif-2.1.0.json"
+    );
+    assert_eq!(sarif.runs.len(), 1);
+    assert_eq!(sarif.runs[0].tool.driver.name, "RepoPilot");
+    assert_eq!(
+        sarif.runs[0].tool.driver.information_uri,
+        "https://github.com/MykytaStel/repopilot"
+    );
+    assert_eq!(sarif.runs[0].results[0].rule_id, "architecture.large-file");
+    assert_eq!(sarif.runs[0].results[0].message.text, "Finding title");
+}
+
+#[test]
+fn maps_severity_to_sarif_level() {
+    let sarif = findings_to_sarif(
+        &[
+            finding("rule.high", Severity::High, Some("src/high.rs"), 1),
+            finding(
+                "rule.critical",
+                Severity::Critical,
+                Some("src/critical.rs"),
+                1,
+            ),
+            finding("rule.medium", Severity::Medium, Some("src/medium.rs"), 1),
+            finding("rule.low", Severity::Low, Some("src/low.rs"), 1),
+            finding("rule.info", Severity::Info, Some("src/info.rs"), 1),
+        ],
+        Path::new("."),
+    );
+
+    let levels = sarif.runs[0]
+        .results
+        .iter()
+        .map(|result| result.level.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(levels, ["error", "error", "warning", "note", "note"]);
+}
+
+#[test]
+fn duplicate_rule_ids_produce_one_sorted_sarif_rule() {
+    let sarif = findings_to_sarif(
+        &[
+            finding(
+                "security.secret-candidate",
+                Severity::High,
+                Some("src/a.rs"),
+                1,
+            ),
+            finding("code-marker.todo", Severity::Low, Some("src/b.rs"), 2),
+            finding(
+                "security.secret-candidate",
+                Severity::High,
+                Some("src/c.rs"),
+                3,
+            ),
+        ],
+        Path::new("."),
+    );
+
+    let rules = &sarif.runs[0].tool.driver.rules;
+
+    assert_eq!(rules.len(), 2);
+    assert_eq!(rules[0].id, "code-marker.todo");
+    assert_eq!(rules[0].name, "code-marker.todo");
+    assert_eq!(
+        rules[0].short_description.text,
+        "RepoPilot rule code-marker.todo"
+    );
+    assert_eq!(rules[1].id, "security.secret-candidate");
+}
+
+#[test]
+fn finding_path_is_emitted_as_relative_forward_slash_uri() {
+    let sarif = findings_to_sarif(
+        &[finding(
+            "code-marker.todo",
+            Severity::Low,
+            Some("/repo/src/main.rs"),
+            7,
+        )],
+        Path::new("/repo"),
+    );
+
+    let location = &sarif.runs[0].results[0].locations[0].physical_location;
+
+    assert_eq!(location.artifact_location.uri, "src/main.rs");
+    assert_eq!(
+        location.region.as_ref().map(|region| region.start_line),
+        Some(7)
+    );
+}
+
+#[test]
+fn finding_without_path_has_no_locations() {
+    let sarif = findings_to_sarif(
+        &[finding("architecture.deep-nesting", Severity::Low, None, 0)],
+        Path::new("."),
+    );
+
+    assert!(sarif.runs[0].results[0].locations.is_empty());
+}
+
+#[test]
+fn empty_locations_are_omitted_from_serialized_result() {
+    let sarif = findings_to_sarif(
+        &[finding("architecture.deep-nesting", Severity::Low, None, 0)],
+        Path::new("."),
+    );
+
+    let json = serde_json::to_value(&sarif).expect("SARIF should serialize");
+
+    assert!(json["runs"][0]["results"][0].get("locations").is_none());
+}
+
+fn finding(rule_id: &str, severity: Severity, path: Option<&str>, line_start: usize) -> Finding {
+    Finding {
+        id: format!("{rule_id}:1"),
+        rule_id: rule_id.to_string(),
+        title: "Finding title".to_string(),
+        description: "Finding description".to_string(),
+        category: FindingCategory::Architecture,
+        severity,
+        evidence: path
+            .map(|path| {
+                vec![Evidence {
+                    path: PathBuf::from(path),
+                    line_start,
+                    line_end: None,
+                    snippet: "evidence".to_string(),
+                }]
+            })
+            .unwrap_or_default(),
+    }
+}


### PR DESCRIPTION
## Summary

Adds the internal SARIF export foundation for RepoPilot.

This PR introduces a focused SARIF 2.1.0 data model and maps RepoPilot findings into SARIF results. It does not yet expose SARIF through the CLI; it only prepares the reusable conversion layer.

## Type of change

- Feature
- Refactor
- Tests

## What changed

- Added internal SARIF model types.
- Added conversion from RepoPilot findings to SARIF results.
- Added severity mapping:
  - High -> error
  - Medium -> warning
  - Low / Info -> note
- Added SARIF rule metadata generation from RepoPilot rule IDs.
- Added tests for SARIF structure and finding mapping.

## Why

SARIF makes RepoPilot results compatible with code scanning tools and CI workflows. This is the first step toward allowing RepoPilot findings to appear in GitHub Code Scanning.

## Architecture notes

- SARIF logic is isolated in a dedicated module.
- Existing scan, audit, JSON, Markdown, and review behavior is preserved.
- No CLI behavior changes are introduced in this PR.
- No GitHub Actions workflow is added yet.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all