### PR TITLE
feat: add SARIF output format support with rendering and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ RepoPilot runs locally and does not upload your repository.
 - Baseline workflow for accepting existing findings in legacy repositories
 - CI-friendly failure thresholds with `--fail-on`
 - Git diff-aware review mode for prioritizing findings introduced by changed lines
-- Console, JSON, Markdown, and HTML scan output
+- Console, JSON, Markdown, HTML, and SARIF scan output
 - Compare mode for diffing two JSON scan reports
 
 See [docs/rulesets.md](docs/rulesets.md) for the implemented rules and severity levels.
@@ -185,7 +185,16 @@ repopilot scan . --format console
 repopilot scan . --format json --output report.json
 repopilot scan . --format markdown --output report.md
 repopilot scan . --format html --output report.html
+repopilot scan . --format sarif --output repopilot.sarif
 ```
+
+### SARIF output
+
+```bash
+repopilot scan . --format sarif --output repopilot.sarif
+```
+
+Use SARIF output when integrating RepoPilot with code scanning tools.
 
 Compare two JSON reports:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,6 +161,7 @@ pub enum OutputFormatArg {
     Html,
     Json,
     Markdown,
+    Sarif,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -199,6 +200,7 @@ impl From<OutputFormatArg> for OutputFormat {
             OutputFormatArg::Html => OutputFormat::Html,
             OutputFormatArg::Json => OutputFormat::Json,
             OutputFormatArg::Markdown => OutputFormat::Markdown,
+            OutputFormatArg::Sarif => OutputFormat::Sarif,
         }
     }
 }

--- a/src/compare/render.rs
+++ b/src/compare/render.rs
@@ -138,5 +138,6 @@ pub fn render(summary: &CompareSummary, format: OutputFormat) -> Result<String, 
         OutputFormat::Console | OutputFormat::Html => Ok(render_console(summary)),
         OutputFormat::Json => render_json(summary),
         OutputFormat::Markdown => Ok(render_markdown(summary)),
+        OutputFormat::Sarif => render_json(summary),
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -18,6 +18,7 @@ pub enum OutputFormat {
     Html,
     Json,
     Markdown,
+    Sarif,
 }
 
 pub fn render_scan_summary(
@@ -29,6 +30,7 @@ pub fn render_scan_summary(
         OutputFormat::Html => Ok(html::render(summary)),
         OutputFormat::Json => json::render(summary),
         OutputFormat::Markdown => Ok(markdown::render(summary)),
+        OutputFormat::Sarif => sarif::render(summary),
     }
 }
 
@@ -42,5 +44,6 @@ pub fn render_baseline_scan_report(
         OutputFormat::Html => Ok(html::render(&report.summary)),
         OutputFormat::Json => json::render_with_baseline(report, ci_gate),
         OutputFormat::Markdown => Ok(markdown::render(&report.summary)),
+        OutputFormat::Sarif => sarif::render(&report.summary),
     }
 }

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -90,6 +90,11 @@ pub fn scan_summary_to_sarif(summary: &ScanSummary, root: &Path) -> SarifLog {
     findings_to_sarif(&summary.findings, root)
 }
 
+pub fn render(summary: &ScanSummary) -> Result<String, serde_json::Error> {
+    let sarif = scan_summary_to_sarif(summary, &summary.root_path);
+    serde_json::to_string_pretty(&sarif)
+}
+
 pub fn findings_to_sarif(findings: &[Finding], root: &Path) -> SarifLog {
     SarifLog {
         version: SARIF_VERSION.to_string(),

--- a/src/review/render.rs
+++ b/src/review/render.rs
@@ -127,6 +127,7 @@ pub fn render(
         OutputFormat::Console | OutputFormat::Html => Ok(render_console(report, ci_gate)),
         OutputFormat::Json => render_json(report, ci_gate),
         OutputFormat::Markdown => Ok(render_markdown(report, ci_gate)),
+        OutputFormat::Sarif => render_json(report, ci_gate),
     }
 }
 

--- a/tests/output_sarif.rs
+++ b/tests/output_sarif.rs
@@ -1,0 +1,20 @@
+use repopilot::output::{OutputFormat, render_scan_summary};
+use repopilot::scan::types::ScanSummary;
+use std::path::PathBuf;
+
+#[test]
+fn renders_valid_sarif_scan_summary() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("demo"),
+        ..ScanSummary::default()
+    };
+
+    let output =
+        render_scan_summary(&summary, OutputFormat::Sarif).expect("failed to render SARIF summary");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("SARIF output should be valid JSON");
+
+    assert_eq!(parsed["version"], "2.1.0");
+    assert!(parsed["runs"].is_array());
+}

--- a/tests/scan_sarif_cli.rs
+++ b/tests/scan_sarif_cli.rs
@@ -1,0 +1,80 @@
+use serde_json::Value;
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+#[test]
+fn scan_accepts_sarif_format_and_writes_valid_json_to_stdout() {
+    let temp = tempdir().expect("failed to create temp dir");
+    fs::write(temp.path().join("lib.rs"), "fn main() {}\n").expect("failed to write file");
+
+    let output = repopilot()
+        .args(["scan", ".", "--format", "sarif"])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+
+    assert!(output.status.success());
+    let sarif: Value = serde_json::from_slice(&output.stdout).expect("expected SARIF JSON output");
+    assert_eq!(sarif["version"], "2.1.0");
+    assert!(sarif["runs"].is_array());
+}
+
+#[test]
+fn scan_sarif_output_file_is_written_without_stdout_report() {
+    let temp = tempdir().expect("failed to create temp dir");
+    fs::write(temp.path().join("lib.rs"), "fn main() {}\n").expect("failed to write file");
+    let output_path = temp.path().join("repopilot.sarif");
+
+    let output = repopilot()
+        .args(["scan", ".", "--format", "sarif", "--output"])
+        .arg(&output_path)
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+
+    let sarif = fs::read_to_string(output_path).expect("failed to read SARIF file");
+    let parsed: Value = serde_json::from_str(&sarif).expect("expected SARIF file to be valid JSON");
+    assert_eq!(parsed["version"], "2.1.0");
+    assert!(parsed["runs"].is_array());
+}
+
+#[test]
+fn scan_json_output_still_works() {
+    let temp = tempdir().expect("failed to create temp dir");
+    fs::write(temp.path().join("lib.rs"), "fn main() {}\n").expect("failed to write file");
+
+    let output = repopilot()
+        .args(["scan", ".", "--format", "json"])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).expect("expected JSON output");
+    assert!(json["files_count"].as_u64().is_some());
+}
+
+#[test]
+fn scan_default_text_output_still_works() {
+    let temp = tempdir().expect("failed to create temp dir");
+    fs::write(temp.path().join("lib.rs"), "fn main() {}\n").expect("failed to write file");
+
+    let output = repopilot()
+        .args(["scan", "."])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(stdout.contains("RepoPilot Scan"));
+    assert!(stdout.contains("Files analyzed:"));
+}


### PR DESCRIPTION
## Summary

Adds SARIF as a supported scan output format.

This PR wires the SARIF conversion layer into the CLI so users can run RepoPilot and export findings as a SARIF 2.1.0 file for CI and code scanning workflows.

## Type of change

- Feature
- Tests
- Documentation

## What changed

- Added `sarif` as a scan output format.
- Added SARIF serialization to CLI output.
- Added optional file output support if compatible with the existing CLI design.
- Added tests for SARIF CLI output.
- Preserved existing console, JSON, and Markdown behavior.

## Why

SARIF export allows RepoPilot findings to be consumed by tools such as GitHub Code Scanning. This makes RepoPilot more useful in CI and pull-request workflows.

## Example

```bash
repopilot scan . --format sarif --output repopilot.sarif