### PR TITLE
docs: add SARIF code scanning workflow

### DIFF
--- a/.github/workflows/repopilot-sarif.yml.example
+++ b/.github/workflows/repopilot-sarif.yml.example
@@ -1,0 +1,30 @@
+name: RepoPilot SARIF
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  repopilot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install RepoPilot
+        run: cargo install repopilot
+
+      - name: Run RepoPilot SARIF scan
+        run: repopilot scan . --format sarif --output repopilot.sarif
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: repopilot.sarif
+          category: repopilot

--- a/README.md
+++ b/README.md
@@ -194,7 +194,15 @@ repopilot scan . --format sarif --output repopilot.sarif
 repopilot scan . --format sarif --output repopilot.sarif
 ```
 
-Use SARIF output when integrating RepoPilot with code scanning tools.
+If your installed RepoPilot version does not support `--output`, redirect stdout instead:
+
+```bash
+repopilot scan . --format sarif > repopilot.sarif
+```
+
+Use JSON when custom scripts need to parse RepoPilot results. Use Markdown for human-readable reports. Use SARIF for CI and code scanning integrations, including GitHub Code Scanning.
+
+See [docs/integrations/github-code-scanning.md](docs/integrations/github-code-scanning.md) for a copy-paste GitHub Actions workflow, required permissions, and local validation commands.
 
 Compare two JSON reports:
 
@@ -211,6 +219,8 @@ repopilot compare before.json after.json --format json --output diff.json
 Use `--fail-on new-high` to fail CI only when new high or critical findings are introduced. Supported new-finding thresholds are `new-low`, `new-medium`, `new-high`, and `new-critical`.
 
 When `--fail-on new-*` is used without `--baseline`, RepoPilot treats all current findings as new. For baseline-based adoption, commit an accepted baseline and scan against it in CI.
+
+To upload RepoPilot findings to GitHub Code Scanning, generate SARIF and use `github/codeql-action/upload-sarif`. The workflow must include `security-events: write`.
 
 ```yaml
 name: RepoPilot
@@ -242,13 +252,14 @@ These are planned ideas, not current features:
 - Change Risk Map
 - AI-ready review context export
 - Better architecture drift detection
-- GitHub Action integration
+- First-party GitHub Action integration
 
 ## Documentation
 
 | Document | Description |
 |---|---|
 | [docs/rulesets.md](docs/rulesets.md) | Implemented audit rules, categories, and severity levels |
+| [docs/integrations/github-code-scanning.md](docs/integrations/github-code-scanning.md) | GitHub Code Scanning SARIF workflow |
 | [docs/release.md](docs/release.md) | Manual release process |
 | [docs/distribution.md](docs/distribution.md) | Distribution channels |
 | [docs/github-ruleset.md](docs/github-ruleset.md) | GitHub branch ruleset configuration |

--- a/docs/integrations/github-code-scanning.md
+++ b/docs/integrations/github-code-scanning.md
@@ -1,0 +1,77 @@
+# GitHub Code Scanning
+
+RepoPilot can write SARIF so GitHub Code Scanning can display findings in the repository security tab and annotate pull requests.
+
+## Generate SARIF locally
+
+```bash
+repopilot scan . --format sarif --output repopilot.sarif
+```
+
+If your installed RepoPilot version does not support `--output`, redirect stdout instead:
+
+```bash
+repopilot scan . --format sarif > repopilot.sarif
+```
+
+When validating changes from a RepoPilot source checkout, use the local binary:
+
+```bash
+cargo run -- scan . --format sarif --output repopilot.sarif
+```
+
+## GitHub Actions
+
+Copy [`.github/workflows/repopilot-sarif.yml.example`](../../.github/workflows/repopilot-sarif.yml.example) to `.github/workflows/repopilot-sarif.yml` in a repository where you want RepoPilot findings uploaded to GitHub Code Scanning.
+
+```yaml
+name: RepoPilot SARIF
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  repopilot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install RepoPilot
+        run: cargo install repopilot
+
+      - name: Run RepoPilot SARIF scan
+        run: repopilot scan . --format sarif --output repopilot.sarif
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: repopilot.sarif
+          category: repopilot
+```
+
+The workflow needs `security-events: write`; without it, GitHub rejects the SARIF upload. `contents: read` is enough for checkout.
+
+For RepoPilot's own repository or another Rust project where installing from crates.io is too slow during CI, run the local checkout binary instead:
+
+```yaml
+      - name: Run RepoPilot SARIF scan
+        run: cargo run -- scan . --format sarif --output repopilot.sarif
+```
+
+Keep the SARIF file name consistent between the scan step and the upload step. The examples above write and upload `repopilot.sarif`.
+
+## Choosing an output format
+
+Use JSON when a script or service will parse RepoPilot results directly.
+
+Use Markdown when you want a human-readable report for pull request comments, job summaries, or issue descriptions.
+
+Use SARIF when you want CI and code scanning integrations, including GitHub Code Scanning.


### PR DESCRIPTION
## Summary

Documents how to use RepoPilot SARIF output with GitHub Code Scanning.

This PR adds a GitHub Actions example that runs RepoPilot, generates a SARIF report, and uploads it to GitHub Code Scanning.

## Type of change

- Documentation
- CI example

## What changed

- Added SARIF usage documentation.
- Added GitHub Actions workflow example.
- Documented required permissions for SARIF upload.
- Added example command for generating `repopilot.sarif`.
- Explained when to use SARIF vs JSON/Markdown output.

## Why

SARIF output is most useful when users know how to plug it into real CI workflows. This documentation makes RepoPilot easier to adopt in GitHub repositories.

## Verification

- Checked that the documented command matches the CLI.
- Checked that the workflow uses the generated SARIF file path.