### PR TITLE
feat(audits): add JavaScript, React, and React Native audits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repopilot"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Local-first CLI for repository audit, architecture risk detection, baseline tracking, and CI-friendly code review."

--- a/src/audits/framework/js_common.rs
+++ b/src/audits/framework/js_common.rs
@@ -135,7 +135,7 @@ pub fn is_test_path(path: &std::path::Path) -> bool {
     path.components().any(|c| {
         c.as_os_str()
             .to_str()
-            .map(|s| TEST_PATH_SEGMENTS.iter().any(|seg| s == *seg))
+            .map(|s| TEST_PATH_SEGMENTS.contains(&s))
             .unwrap_or(false)
     })
 }
@@ -228,7 +228,7 @@ mod tests {
         let test_dir = dir.path().join("__tests__");
         std::fs::create_dir(&test_dir).unwrap();
         let file_path = test_dir.join("utils.test.ts");
-        write!(std::fs::File::create(&file_path).unwrap(), "var x = 1;\n").unwrap();
+        writeln!(std::fs::File::create(&file_path).unwrap(), "var x = 1;").unwrap();
         let mut facts = ScanFacts {
             root_path: dir.path().to_path_buf(),
             ..ScanFacts::default()

--- a/src/audits/framework/js_common.rs
+++ b/src/audits/framework/js_common.rs
@@ -1,0 +1,277 @@
+use crate::audits::traits::ProjectAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::ScanFacts;
+
+pub const JS_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx"];
+const TEST_PATH_SEGMENTS: &[&str] = &[
+    "test", "__tests__", "spec", "fixture", "fixtures", "mock", "mocks",
+];
+
+// ── VarDeclarationAudit ───────────────────────────────────────────────────────
+
+pub struct VarDeclarationAudit;
+
+impl ProjectAudit for VarDeclarationAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        for file in &facts.files {
+            if !is_js_file(&file.path) || is_test_path(&file.path) {
+                continue;
+            }
+
+            let content = match std::fs::read_to_string(&file.path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            for (idx, line) in content.lines().enumerate() {
+                let trimmed = line.trim();
+
+                if is_comment_line(trimmed) {
+                    continue;
+                }
+
+                if has_var_declaration(trimmed) {
+                    findings.push(Finding {
+                        id: String::new(),
+                        rule_id: "framework.js.var-declaration".to_string(),
+                        title: "var declaration found".to_string(),
+                        description: concat!(
+                            "`var` has function-level scope and is hoisted to the top of its function, ",
+                            "which can cause subtle bugs when variables are accessed before assignment or escape block scope unexpectedly. ",
+                            "Replace `var` with `const` (for values that do not change) or `let` (for values that do). ",
+                            "Both are block-scoped and behave predictably."
+                        ).to_string(),
+                        category: FindingCategory::Framework,
+                        severity: Severity::Low,
+                        evidence: vec![Evidence {
+                            path: file.path.clone(),
+                            line_start: idx + 1,
+                            line_end: None,
+                            snippet: trimmed.to_string(),
+                        }],
+                    });
+                    break;
+                }
+            }
+        }
+
+        findings
+    }
+}
+
+// ── ConsoleLogAudit ───────────────────────────────────────────────────────────
+
+pub struct ConsoleLogAudit;
+
+impl ProjectAudit for ConsoleLogAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        for file in &facts.files {
+            if !is_js_file(&file.path) || is_test_path(&file.path) {
+                continue;
+            }
+
+            let content = match std::fs::read_to_string(&file.path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            for (idx, line) in content.lines().enumerate() {
+                let trimmed = line.trim();
+
+                if is_comment_line(trimmed) {
+                    continue;
+                }
+
+                if trimmed.contains("console.log(") {
+                    findings.push(Finding {
+                        id: String::new(),
+                        rule_id: "framework.js.console-log".to_string(),
+                        title: "console.log found in production source".to_string(),
+                        description: concat!(
+                            "`console.log` statements left in production code expose internal state and data to the device console, ",
+                            "add unnecessary serialisation overhead, and are a minor security concern. ",
+                            "Use a logging library that can be silenced in production builds ",
+                            "(e.g. `react-native-logs` or `loglevel`), or wrap calls in `if (__DEV__)`."
+                        ).to_string(),
+                        category: FindingCategory::Framework,
+                        severity: Severity::Low,
+                        evidence: vec![Evidence {
+                            path: file.path.clone(),
+                            line_start: idx + 1,
+                            line_end: None,
+                            snippet: trimmed.to_string(),
+                        }],
+                    });
+                    break;
+                }
+            }
+        }
+
+        findings
+    }
+}
+
+// ── Shared helpers (pub so react_native.rs can reuse) ─────────────────────────
+
+pub fn is_js_file(path: &std::path::Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| JS_EXTENSIONS.contains(&e))
+        .unwrap_or(false)
+}
+
+pub fn is_test_path(path: &std::path::Path) -> bool {
+    path.components().any(|c| {
+        c.as_os_str()
+            .to_str()
+            .map(|s| TEST_PATH_SEGMENTS.iter().any(|seg| s == *seg))
+            .unwrap_or(false)
+    })
+}
+
+pub fn is_comment_line(trimmed: &str) -> bool {
+    trimmed.starts_with("//")
+        || trimmed.starts_with('*')
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with("<!--")
+}
+
+fn has_var_declaration(trimmed: &str) -> bool {
+    if trimmed.starts_with("var ") {
+        return true;
+    }
+    // Token-based: split on whitespace/punctuation and check for exact "var" token.
+    // This avoids false positives on identifiers like `typeVar` or `varName`.
+    trimmed
+        .split(|c: char| c.is_whitespace() || matches!(c, ';' | '(' | ',' | '{' | '}' | '='))
+        .any(|token| token == "var")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::config::ScanConfig;
+    use crate::scan::facts::{FileFacts, ScanFacts};
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    fn make_file_facts(path: std::path::PathBuf) -> FileFacts {
+        FileFacts {
+            path,
+            language: Some("TypeScript".to_string()),
+            lines_of_code: 2,
+            branch_count: 0,
+            imports: vec![],
+            content: String::new(),
+        }
+    }
+
+    // ── VarDeclarationAudit ───────────────────────────────────────────────────
+
+    #[test]
+    fn var_declaration_flagged() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("utils.ts");
+        write!(
+            std::fs::File::create(&file_path).unwrap(),
+            "var x = 1;\nconst y = 2;\n"
+        )
+        .unwrap();
+        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        facts.files.push(make_file_facts(file_path));
+        let findings = VarDeclarationAudit.audit(&facts, &ScanConfig::default());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "framework.js.var-declaration");
+    }
+
+    #[test]
+    fn var_inside_identifier_not_flagged() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("utils.ts");
+        // "typeVar", "localStorage", "varName" should NOT trigger
+        write!(
+            std::fs::File::create(&file_path).unwrap(),
+            "const typeVar = 1;\nconst localStorage = {{}};\nconst varName = 3;\n"
+        )
+        .unwrap();
+        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        facts.files.push(make_file_facts(file_path));
+        let findings = VarDeclarationAudit.audit(&facts, &ScanConfig::default());
+        assert!(findings.is_empty(), "identifiers containing 'var' must not be flagged");
+    }
+
+    #[test]
+    fn var_in_test_file_skipped() {
+        let dir = tempdir().unwrap();
+        let test_dir = dir.path().join("__tests__");
+        std::fs::create_dir(&test_dir).unwrap();
+        let file_path = test_dir.join("utils.test.ts");
+        write!(std::fs::File::create(&file_path).unwrap(), "var x = 1;\n").unwrap();
+        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        facts.files.push(make_file_facts(file_path));
+        let findings = VarDeclarationAudit.audit(&facts, &ScanConfig::default());
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn no_var_no_finding() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("utils.ts");
+        write!(
+            std::fs::File::create(&file_path).unwrap(),
+            "const x = 1;\nlet y = 2;\n"
+        )
+        .unwrap();
+        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        facts.files.push(make_file_facts(file_path));
+        let findings = VarDeclarationAudit.audit(&facts, &ScanConfig::default());
+        assert!(findings.is_empty());
+    }
+
+    // ── ConsoleLogAudit ───────────────────────────────────────────────────────
+
+    #[test]
+    fn console_log_flagged() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("Screen.tsx");
+        write!(
+            std::fs::File::create(&file_path).unwrap(),
+            "const x = 1;\nconsole.log(x);\n"
+        )
+        .unwrap();
+        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        facts.files.push(FileFacts {
+            path: file_path,
+            language: Some("TypeScript React".to_string()),
+            lines_of_code: 2,
+            branch_count: 0,
+            imports: vec![],
+            content: String::new(),
+        });
+        let findings = ConsoleLogAudit.audit(&facts, &ScanConfig::default());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "framework.js.console-log");
+    }
+
+    #[test]
+    fn console_log_in_comment_not_flagged() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("utils.ts");
+        write!(
+            std::fs::File::create(&file_path).unwrap(),
+            "// console.log(debug)\nconst x = 1;\n"
+        )
+        .unwrap();
+        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        facts.files.push(make_file_facts(file_path));
+        let findings = ConsoleLogAudit.audit(&facts, &ScanConfig::default());
+        assert!(findings.is_empty());
+    }
+}

--- a/src/audits/framework/js_common.rs
+++ b/src/audits/framework/js_common.rs
@@ -5,7 +5,13 @@ use crate::scan::facts::ScanFacts;
 
 pub const JS_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx"];
 const TEST_PATH_SEGMENTS: &[&str] = &[
-    "test", "__tests__", "spec", "fixture", "fixtures", "mock", "mocks",
+    "test",
+    "__tests__",
+    "spec",
+    "fixture",
+    "fixtures",
+    "mock",
+    "mocks",
 ];
 
 // ── VarDeclarationAudit ───────────────────────────────────────────────────────
@@ -184,7 +190,10 @@ mod tests {
             "var x = 1;\nconst y = 2;\n"
         )
         .unwrap();
-        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        let mut facts = ScanFacts {
+            root_path: dir.path().to_path_buf(),
+            ..ScanFacts::default()
+        };
         facts.files.push(make_file_facts(file_path));
         let findings = VarDeclarationAudit.audit(&facts, &ScanConfig::default());
         assert_eq!(findings.len(), 1);
@@ -201,10 +210,16 @@ mod tests {
             "const typeVar = 1;\nconst localStorage = {{}};\nconst varName = 3;\n"
         )
         .unwrap();
-        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        let mut facts = ScanFacts {
+            root_path: dir.path().to_path_buf(),
+            ..ScanFacts::default()
+        };
         facts.files.push(make_file_facts(file_path));
         let findings = VarDeclarationAudit.audit(&facts, &ScanConfig::default());
-        assert!(findings.is_empty(), "identifiers containing 'var' must not be flagged");
+        assert!(
+            findings.is_empty(),
+            "identifiers containing 'var' must not be flagged"
+        );
     }
 
     #[test]
@@ -214,7 +229,10 @@ mod tests {
         std::fs::create_dir(&test_dir).unwrap();
         let file_path = test_dir.join("utils.test.ts");
         write!(std::fs::File::create(&file_path).unwrap(), "var x = 1;\n").unwrap();
-        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        let mut facts = ScanFacts {
+            root_path: dir.path().to_path_buf(),
+            ..ScanFacts::default()
+        };
         facts.files.push(make_file_facts(file_path));
         let findings = VarDeclarationAudit.audit(&facts, &ScanConfig::default());
         assert!(findings.is_empty());
@@ -229,7 +247,10 @@ mod tests {
             "const x = 1;\nlet y = 2;\n"
         )
         .unwrap();
-        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        let mut facts = ScanFacts {
+            root_path: dir.path().to_path_buf(),
+            ..ScanFacts::default()
+        };
         facts.files.push(make_file_facts(file_path));
         let findings = VarDeclarationAudit.audit(&facts, &ScanConfig::default());
         assert!(findings.is_empty());
@@ -246,7 +267,10 @@ mod tests {
             "const x = 1;\nconsole.log(x);\n"
         )
         .unwrap();
-        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        let mut facts = ScanFacts {
+            root_path: dir.path().to_path_buf(),
+            ..ScanFacts::default()
+        };
         facts.files.push(FileFacts {
             path: file_path,
             language: Some("TypeScript React".to_string()),
@@ -269,7 +293,10 @@ mod tests {
             "// console.log(debug)\nconst x = 1;\n"
         )
         .unwrap();
-        let mut facts = ScanFacts { root_path: dir.path().to_path_buf(), ..ScanFacts::default() };
+        let mut facts = ScanFacts {
+            root_path: dir.path().to_path_buf(),
+            ..ScanFacts::default()
+        };
         facts.files.push(make_file_facts(file_path));
         let findings = ConsoleLogAudit.audit(&facts, &ScanConfig::default());
         assert!(findings.is_empty());

--- a/src/audits/framework/mod.rs
+++ b/src/audits/framework/mod.rs
@@ -1,0 +1,3 @@
+pub mod js_common;
+pub mod react;
+pub mod react_native;

--- a/src/audits/framework/react.rs
+++ b/src/audits/framework/react.rs
@@ -1,0 +1,217 @@
+use crate::audits::framework::js_common::is_comment_line;
+use crate::audits::traits::ProjectAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::ScanFacts;
+
+// ── Class components ──────────────────────────────────────────────────────────
+
+pub struct ReactClassComponentAudit;
+
+impl ProjectAudit for ReactClassComponentAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        for file in &facts.files {
+            let ext = file
+                .path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            if ext != "tsx" && ext != "jsx" {
+                continue;
+            }
+
+            let content = match std::fs::read_to_string(&file.path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            for (idx, line) in content.lines().enumerate() {
+                let trimmed = line.trim();
+                if is_comment_line(trimmed) {
+                    continue;
+                }
+                if trimmed.contains("extends")
+                    && (trimmed.contains("React.Component")
+                        || trimmed.contains("React.PureComponent"))
+                {
+                    findings.push(Finding {
+                        id: String::new(),
+                        rule_id: "framework.react.class-component".to_string(),
+                        title: "Class component found".to_string(),
+                        description: concat!(
+                            "This file uses a class-based React component (`extends React.Component` or `React.PureComponent`). ",
+                            "Class components are a legacy pattern — the React team recommends migrating to function components with hooks. ",
+                            "Hooks provide the same lifecycle and state capabilities with less boilerplate, ",
+                            "better tree-shaking, and simpler testing."
+                        ).to_string(),
+                        category: FindingCategory::Framework,
+                        severity: Severity::Low,
+                        evidence: vec![Evidence {
+                            path: file.path.clone(),
+                            line_start: idx + 1,
+                            line_end: None,
+                            snippet: trimmed.to_string(),
+                        }],
+                    });
+                    break; // one finding per file
+                }
+            }
+        }
+
+        findings
+    }
+}
+
+// ── PropTypes ─────────────────────────────────────────────────────────────────
+
+pub struct ReactPropTypesAudit;
+
+impl ProjectAudit for ReactPropTypesAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let has_typescript = facts.languages.iter().any(|l| {
+            l.name == "TypeScript" || l.name == "TypeScript React"
+        });
+        if !has_typescript {
+            return vec![];
+        }
+
+        let mut findings = Vec::new();
+
+        for file in &facts.files {
+            let ext = file
+                .path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            if ext != "tsx" && ext != "jsx" && ext != "ts" && ext != "js" {
+                continue;
+            }
+
+            let content = match std::fs::read_to_string(&file.path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            for (idx, line) in content.lines().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.contains("from 'prop-types'") || trimmed.contains("from \"prop-types\"")
+                {
+                    findings.push(Finding {
+                        id: String::new(),
+                        rule_id: "framework.react.prop-types".to_string(),
+                        title: "PropTypes used in TypeScript project".to_string(),
+                        description: concat!(
+                            "This project already uses TypeScript, which provides static type checking at compile time. ",
+                            "`prop-types` adds redundant runtime overhead — it validates types in production builds and duplicates ",
+                            "what TypeScript already enforces. Remove the `prop-types` package and replace PropTypes with TypeScript interface or type definitions."
+                        ).to_string(),
+                        category: FindingCategory::Framework,
+                        severity: Severity::Low,
+                        evidence: vec![Evidence {
+                            path: file.path.clone(),
+                            line_start: idx + 1,
+                            line_end: None,
+                            snippet: trimmed.to_string(),
+                        }],
+                    });
+                    break; // one finding per file
+                }
+            }
+        }
+
+        findings
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::config::ScanConfig;
+    use crate::scan::facts::{FileFacts, ScanFacts};
+    use crate::scan::types::LanguageSummary;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn class_component_detected() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("App.tsx");
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        write!(f, "class MyComp extends React.Component {{\n  render() {{ return null; }}\n}}\n").unwrap();
+
+        let mut facts = ScanFacts {
+            root_path: dir.path().to_path_buf(),
+            ..ScanFacts::default()
+        };
+        facts.files.push(FileFacts {
+            path: file_path,
+            language: Some("TypeScript React".to_string()),
+            lines_of_code: 3,
+            branch_count: 0,
+            imports: vec![],
+            content: String::new(),
+        });
+
+        let findings = ReactClassComponentAudit.audit(&facts, &ScanConfig::default());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "framework.react.class-component");
+    }
+
+    #[test]
+    fn prop_types_skipped_without_typescript() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("Comp.jsx");
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        write!(f, "import PropTypes from 'prop-types';\n").unwrap();
+
+        let mut facts = ScanFacts {
+            root_path: dir.path().to_path_buf(),
+            ..ScanFacts::default()
+        };
+        facts.files.push(FileFacts {
+            path: file_path,
+            language: Some("JavaScript React".to_string()),
+            lines_of_code: 1,
+            branch_count: 0,
+            imports: vec![],
+            content: String::new(),
+        });
+        // no TypeScript in languages list
+
+        let findings = ReactPropTypesAudit.audit(&facts, &ScanConfig::default());
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn prop_types_flagged_in_typescript_project() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("Comp.tsx");
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        write!(f, "import PropTypes from 'prop-types';\n").unwrap();
+
+        let mut facts = ScanFacts {
+            root_path: dir.path().to_path_buf(),
+            ..ScanFacts::default()
+        };
+        facts.languages.push(LanguageSummary {
+            name: "TypeScript React".to_string(),
+            files_count: 5,
+        });
+        facts.files.push(FileFacts {
+            path: file_path,
+            language: Some("TypeScript React".to_string()),
+            lines_of_code: 1,
+            branch_count: 0,
+            imports: vec![],
+            content: String::new(),
+        });
+
+        let findings = ReactPropTypesAudit.audit(&facts, &ScanConfig::default());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "framework.react.prop-types");
+    }
+}

--- a/src/audits/framework/react.rs
+++ b/src/audits/framework/react.rs
@@ -163,7 +163,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("Comp.jsx");
         let mut f = std::fs::File::create(&file_path).unwrap();
-        write!(f, "import PropTypes from 'prop-types';\n").unwrap();
+        writeln!(f, "import PropTypes from 'prop-types';").unwrap();
 
         let mut facts = ScanFacts {
             root_path: dir.path().to_path_buf(),
@@ -188,7 +188,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("Comp.tsx");
         let mut f = std::fs::File::create(&file_path).unwrap();
-        write!(f, "import PropTypes from 'prop-types';\n").unwrap();
+        writeln!(f, "import PropTypes from 'prop-types';").unwrap();
 
         let mut facts = ScanFacts {
             root_path: dir.path().to_path_buf(),

--- a/src/audits/framework/react.rs
+++ b/src/audits/framework/react.rs
@@ -13,11 +13,7 @@ impl ProjectAudit for ReactClassComponentAudit {
         let mut findings = Vec::new();
 
         for file in &facts.files {
-            let ext = file
-                .path
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or("");
+            let ext = file.path.extension().and_then(|e| e.to_str()).unwrap_or("");
             if ext != "tsx" && ext != "jsx" {
                 continue;
             }
@@ -70,9 +66,10 @@ pub struct ReactPropTypesAudit;
 
 impl ProjectAudit for ReactPropTypesAudit {
     fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
-        let has_typescript = facts.languages.iter().any(|l| {
-            l.name == "TypeScript" || l.name == "TypeScript React"
-        });
+        let has_typescript = facts
+            .languages
+            .iter()
+            .any(|l| l.name == "TypeScript" || l.name == "TypeScript React");
         if !has_typescript {
             return vec![];
         }
@@ -80,11 +77,7 @@ impl ProjectAudit for ReactPropTypesAudit {
         let mut findings = Vec::new();
 
         for file in &facts.files {
-            let ext = file
-                .path
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or("");
+            let ext = file.path.extension().and_then(|e| e.to_str()).unwrap_or("");
             if ext != "tsx" && ext != "jsx" && ext != "ts" && ext != "js" {
                 continue;
             }
@@ -141,7 +134,11 @@ mod tests {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("App.tsx");
         let mut f = std::fs::File::create(&file_path).unwrap();
-        write!(f, "class MyComp extends React.Component {{\n  render() {{ return null; }}\n}}\n").unwrap();
+        write!(
+            f,
+            "class MyComp extends React.Component {{\n  render() {{ return null; }}\n}}\n"
+        )
+        .unwrap();
 
         let mut facts = ScanFacts {
             root_path: dir.path().to_path_buf(),

--- a/src/audits/framework/react_native.rs
+++ b/src/audits/framework/react_native.rs
@@ -309,11 +309,7 @@ impl ProjectAudit for DirectStateMutationAudit {
         let mut findings = Vec::new();
 
         for file in &facts.files {
-            let ext = file
-                .path
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or("");
+            let ext = file.path.extension().and_then(|e| e.to_str()).unwrap_or("");
             if ext != "tsx" && ext != "jsx" {
                 continue;
             }
@@ -409,9 +405,13 @@ mod tests {
     #[test]
     fn old_arch_flagged_when_no_app_json() {
         let dir = tempdir().unwrap();
-        let findings = ReactNativeOldArchAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
+        let findings =
+            ReactNativeOldArchAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
         assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].rule_id, "framework.react-native.old-architecture");
+        assert_eq!(
+            findings[0].rule_id,
+            "framework.react-native.old-architecture"
+        );
     }
 
     #[test]
@@ -422,19 +422,21 @@ mod tests {
             r#"{{"expo": {{"newArchEnabled": true}}}}"#
         )
         .unwrap();
-        let findings = ReactNativeOldArchAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
+        let findings =
+            ReactNativeOldArchAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
         assert!(findings.is_empty());
     }
 
     #[test]
     fn old_arch_not_flagged_when_enabled_in_rn_config() {
         let dir = tempdir().unwrap();
-        write!(
+        writeln!(
             std::fs::File::create(dir.path().join("react-native.config.js")).unwrap(),
-            "module.exports = {{ newArchEnabled: true }};\n"
+            "module.exports = {{ newArchEnabled: true }};"
         )
         .unwrap();
-        let findings = ReactNativeOldArchAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
+        let findings =
+            ReactNativeOldArchAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
         assert!(findings.is_empty());
     }
 
@@ -451,7 +453,10 @@ mod tests {
         ));
         let findings = AsyncStorageFromCoreAudit.audit(&facts, &ScanConfig::default());
         assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].rule_id, "framework.react-native.async-storage-from-core");
+        assert_eq!(
+            findings[0].rule_id,
+            "framework.react-native.async-storage-from-core"
+        );
         assert_eq!(findings[0].severity, Severity::High);
     }
 
@@ -495,7 +500,10 @@ mod tests {
         ));
         let findings = ReactNavigationV4Audit.audit(&facts, &ScanConfig::default());
         assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].rule_id, "framework.react-native.old-react-navigation");
+        assert_eq!(
+            findings[0].rule_id,
+            "framework.react-native.old-react-navigation"
+        );
         assert_eq!(findings[0].severity, Severity::Medium);
     }
 
@@ -525,7 +533,10 @@ mod tests {
         ));
         let findings = DirectStateMutationAudit.audit(&facts, &ScanConfig::default());
         assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].rule_id, "framework.react-native.direct-state-mutation");
+        assert_eq!(
+            findings[0].rule_id,
+            "framework.react-native.direct-state-mutation"
+        );
         assert_eq!(findings[0].severity, Severity::High);
     }
 

--- a/src/audits/framework/react_native.rs
+++ b/src/audits/framework/react_native.rs
@@ -143,10 +143,11 @@ fn find_async_storage_from_core(content: &str) -> Option<usize> {
         let trimmed = lines[i].trim();
 
         // Single-line: import { ..., AsyncStorage, ... } from 'react-native'
-        if trimmed.starts_with("import") && is_from_rn_core(trimmed) {
-            if trimmed.contains("AsyncStorage") {
-                return Some(i + 1);
-            }
+        if trimmed.starts_with("import")
+            && is_from_rn_core(trimmed)
+            && trimmed.contains("AsyncStorage")
+        {
+            return Some(i + 1);
         }
 
         // Multi-line: import { starts here, accumulate until the `from 'react-native'` line

--- a/src/audits/framework/react_native.rs
+++ b/src/audits/framework/react_native.rs
@@ -1,0 +1,544 @@
+use crate::audits::framework::js_common::{is_comment_line, is_js_file};
+use crate::audits::traits::ProjectAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::ScanFacts;
+use std::path::PathBuf;
+
+// ── Old Architecture ──────────────────────────────────────────────────────────
+
+pub struct ReactNativeOldArchAudit;
+
+impl ProjectAudit for ReactNativeOldArchAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        if check_new_arch_enabled(&facts.root_path) {
+            return vec![];
+        }
+
+        let (evidence_path, snippet) = config_file_evidence(&facts.root_path);
+
+        vec![Finding {
+            id: String::new(),
+            rule_id: "framework.react-native.old-architecture".to_string(),
+            title: "React Native New Architecture is not enabled".to_string(),
+            description: concat!(
+                "This project does not have `newArchEnabled: true` in its app.json / app.config.js / react-native.config.js. ",
+                "The New Architecture (Fabric renderer + TurboModules) eliminates the asynchronous JS bridge, ",
+                "delivers faster UI updates, and is required by an increasing number of third-party libraries. ",
+                "Enable it by setting `\"newArchEnabled\": true` in your app.json `expo` block or in react-native.config.js."
+            ).to_string(),
+            category: FindingCategory::Framework,
+            severity: Severity::Medium,
+            evidence: vec![Evidence {
+                path: evidence_path,
+                line_start: 1,
+                line_end: None,
+                snippet,
+            }],
+        }]
+    }
+}
+
+fn check_new_arch_enabled(root: &std::path::Path) -> bool {
+    // Check both Expo (app.json/app.config.*) and bare RN (react-native.config.js)
+    for name in [
+        "app.json",
+        "app.config.js",
+        "app.config.ts",
+        "react-native.config.js",
+    ] {
+        if let Ok(content) = std::fs::read_to_string(root.join(name)) {
+            if content.contains("\"newArchEnabled\": true")
+                || content.contains("\"newArchEnabled\":true")
+                || content.contains("newArchEnabled: true")
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn config_file_evidence(root: &std::path::Path) -> (PathBuf, String) {
+    for name in [
+        "app.json",
+        "app.config.js",
+        "app.config.ts",
+        "react-native.config.js",
+    ] {
+        let path = root.join(name);
+        if path.exists() {
+            return (path, format!("newArchEnabled not set to true in {name}"));
+        }
+    }
+    (
+        root.to_path_buf(),
+        "No app.json / app.config.js / react-native.config.js found; newArchEnabled not configured"
+            .to_string(),
+    )
+}
+
+// ── AsyncStorage from core ────────────────────────────────────────────────────
+
+pub struct AsyncStorageFromCoreAudit;
+
+impl ProjectAudit for AsyncStorageFromCoreAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        for file in &facts.files {
+            if !is_js_file(&file.path) {
+                continue;
+            }
+
+            let content = match std::fs::read_to_string(&file.path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            if let Some(line_start) = find_async_storage_from_core(&content) {
+                findings.push(Finding {
+                    id: String::new(),
+                    rule_id: "framework.react-native.async-storage-from-core".to_string(),
+                    title: "AsyncStorage imported from 'react-native' core".to_string(),
+                    description: concat!(
+                        "`AsyncStorage` was removed from `react-native` core in v0.60 and will throw ",
+                        "a runtime error on modern React Native versions. ",
+                        "Replace with `import AsyncStorage from '@react-native-async-storage/async-storage'` ",
+                        "and add `@react-native-async-storage/async-storage` to your dependencies."
+                    )
+                    .to_string(),
+                    category: FindingCategory::Framework,
+                    severity: Severity::High,
+                    evidence: vec![Evidence {
+                        path: file.path.clone(),
+                        line_start,
+                        line_end: None,
+                        snippet: content
+                            .lines()
+                            .nth(line_start - 1)
+                            .unwrap_or("")
+                            .trim()
+                            .to_string(),
+                    }],
+                });
+            }
+        }
+
+        findings
+    }
+}
+
+/// Returns the 1-based line number of the import start if AsyncStorage is imported from react-native.
+/// Handles both single-line and multi-line imports:
+///   import { View, AsyncStorage } from 'react-native';
+///   import {
+///     AsyncStorage,
+///   } from 'react-native';
+fn find_async_storage_from_core(content: &str) -> Option<usize> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        // Single-line: import { ..., AsyncStorage, ... } from 'react-native'
+        if trimmed.starts_with("import") && is_from_rn_core(trimmed) {
+            if trimmed.contains("AsyncStorage") {
+                return Some(i + 1);
+            }
+        }
+
+        // Multi-line: import { starts here, accumulate until the `from 'react-native'` line
+        if trimmed.starts_with("import") && trimmed.contains('{') && !trimmed.contains('}') {
+            let start_line = i;
+            let mut block = trimmed.to_string();
+            let mut j = i + 1;
+
+            while j < lines.len() && j - i <= 20 {
+                let next = lines[j].trim();
+                block.push(' ');
+                block.push_str(next);
+
+                if is_from_rn_core(next) {
+                    if block.contains("AsyncStorage") {
+                        return Some(start_line + 1);
+                    }
+                    break;
+                }
+                // Closing brace without react-native → not our import
+                if next.starts_with('}') && !is_from_rn_core(next) {
+                    break;
+                }
+                j += 1;
+            }
+            i = j + 1;
+            continue;
+        }
+
+        i += 1;
+    }
+
+    None
+}
+
+fn is_from_rn_core(line: &str) -> bool {
+    line.contains("from 'react-native'")
+        || line.contains("from \"react-native\"")
+        || line.contains("from 'react-native';")
+        || line.contains("from \"react-native\";")
+}
+
+// ── Hermes disabled ───────────────────────────────────────────────────────────
+
+pub struct HermesDisabledAudit;
+
+impl ProjectAudit for HermesDisabledAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        let podfile = facts.root_path.join("ios/Podfile");
+        if let Ok(content) = std::fs::read_to_string(&podfile) {
+            if content.contains("hermes_enabled: false")
+                || content.contains("hermes_enabled => false")
+            {
+                findings.push(hermes_finding(podfile, "hermes_enabled: false"));
+            }
+        }
+
+        let gradle = facts.root_path.join("android/app/build.gradle");
+        if let Ok(content) = std::fs::read_to_string(&gradle) {
+            if content.contains("enableHermes: false") || content.contains("enableHermes : false") {
+                findings.push(hermes_finding(gradle, "enableHermes: false"));
+            }
+        }
+
+        findings
+    }
+}
+
+fn hermes_finding(path: PathBuf, snippet: &str) -> Finding {
+    Finding {
+        id: String::new(),
+        rule_id: "framework.react-native.hermes-disabled".to_string(),
+        title: "Hermes JavaScript engine is disabled".to_string(),
+        description: concat!(
+            "Hermes is explicitly disabled in this project. ",
+            "Hermes compiles JavaScript to bytecode at build time, reducing startup time by 2–3× ",
+            "and lowering memory usage. It has been the recommended and default JS engine since React Native 0.70. ",
+            "Remove the `hermes_enabled: false` / `enableHermes: false` flag to enable it."
+        )
+        .to_string(),
+        category: FindingCategory::Framework,
+        severity: Severity::Low,
+        evidence: vec![Evidence {
+            path,
+            line_start: 1,
+            line_end: None,
+            snippet: snippet.to_string(),
+        }],
+    }
+}
+
+// ── Old React Navigation v4 ───────────────────────────────────────────────────
+
+pub struct ReactNavigationV4Audit;
+
+impl ProjectAudit for ReactNavigationV4Audit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        for file in &facts.files {
+            if !is_js_file(&file.path) {
+                continue;
+            }
+
+            let content = match std::fs::read_to_string(&file.path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            for (idx, line) in content.lines().enumerate() {
+                let trimmed = line.trim();
+
+                if is_comment_line(trimmed) {
+                    continue;
+                }
+
+                if trimmed.starts_with("import")
+                    && !trimmed.contains("@react-navigation")
+                    && (trimmed.contains("from 'react-navigation'")
+                        || trimmed.contains("from \"react-navigation\""))
+                {
+                    findings.push(Finding {
+                        id: String::new(),
+                        rule_id: "framework.react-native.old-react-navigation".to_string(),
+                        title: "React Navigation v4 (unscoped package) detected".to_string(),
+                        description: concat!(
+                            "`react-navigation` (v4) is no longer maintained and incompatible with React Native 0.70+. ",
+                            "The modern API is `@react-navigation/native` (v5/v6), which uses hooks, ",
+                            "has full TypeScript support, and is actively maintained. ",
+                            "Migrate: replace `from 'react-navigation'` imports with `from '@react-navigation/native'` ",
+                            "and update navigator definitions. Migration guide: https://reactnavigation.org/docs/upgrading-from-4.x"
+                        )
+                        .to_string(),
+                        category: FindingCategory::Framework,
+                        severity: Severity::Medium,
+                        evidence: vec![Evidence {
+                            path: file.path.clone(),
+                            line_start: idx + 1,
+                            line_end: None,
+                            snippet: trimmed.to_string(),
+                        }],
+                    });
+                    break;
+                }
+            }
+        }
+
+        findings
+    }
+}
+
+// ── Direct state mutation in class components ─────────────────────────────────
+
+pub struct DirectStateMutationAudit;
+
+impl ProjectAudit for DirectStateMutationAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        for file in &facts.files {
+            let ext = file
+                .path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            if ext != "tsx" && ext != "jsx" {
+                continue;
+            }
+
+            let content = match std::fs::read_to_string(&file.path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            for (idx, line) in content.lines().enumerate() {
+                let trimmed = line.trim();
+
+                if is_comment_line(trimmed) {
+                    continue;
+                }
+
+                if is_direct_state_mutation(trimmed) {
+                    findings.push(Finding {
+                        id: String::new(),
+                        rule_id: "framework.react-native.direct-state-mutation".to_string(),
+                        title: "Direct mutation of this.state detected".to_string(),
+                        description: concat!(
+                            "Directly assigning to `this.state` bypasses React's change detection — ",
+                            "the component will not re-render and the UI will fall out of sync with the actual state. ",
+                            "Always use `this.setState({ key: value })` to update state in class components. ",
+                            "In function components, use the setter returned by `useState`."
+                        )
+                        .to_string(),
+                        category: FindingCategory::Framework,
+                        severity: Severity::High,
+                        evidence: vec![Evidence {
+                            path: file.path.clone(),
+                            line_start: idx + 1,
+                            line_end: None,
+                            snippet: trimmed.to_string(),
+                        }],
+                    });
+                    break;
+                }
+            }
+        }
+
+        findings
+    }
+}
+
+/// Returns true if the line looks like `this.state.someKey = value` (not `==` or `===`).
+fn is_direct_state_mutation(trimmed: &str) -> bool {
+    let Some(pos) = trimmed.find("this.state.") else {
+        return false;
+    };
+    let after_prefix = &trimmed[pos + "this.state.".len()..];
+    // skip the property name (alphanumeric + underscore)
+    let rest = after_prefix.trim_start_matches(|c: char| c.is_alphanumeric() || c == '_');
+    // skip optional whitespace
+    let rest = rest.trim_start();
+    // must be `=` but NOT `==` or `===`
+    rest.starts_with('=') && !rest.starts_with("==")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::config::ScanConfig;
+    use crate::scan::facts::{FileFacts, ScanFacts};
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    fn facts_for(root: &std::path::Path) -> ScanFacts {
+        ScanFacts {
+            root_path: root.to_path_buf(),
+            ..ScanFacts::default()
+        }
+    }
+
+    fn jsx_file(dir: &tempfile::TempDir, name: &str, content: &str) -> FileFacts {
+        let path = dir.path().join(name);
+        write!(std::fs::File::create(&path).unwrap(), "{content}").unwrap();
+        FileFacts {
+            path,
+            language: Some("TypeScript React".to_string()),
+            lines_of_code: content.lines().count(),
+            branch_count: 0,
+            imports: vec![],
+            content: String::new(),
+        }
+    }
+
+    // ── Old architecture ──────────────────────────────────────────────────────
+
+    #[test]
+    fn old_arch_flagged_when_no_app_json() {
+        let dir = tempdir().unwrap();
+        let findings = ReactNativeOldArchAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "framework.react-native.old-architecture");
+    }
+
+    #[test]
+    fn old_arch_not_flagged_when_enabled() {
+        let dir = tempdir().unwrap();
+        write!(
+            std::fs::File::create(dir.path().join("app.json")).unwrap(),
+            r#"{{"expo": {{"newArchEnabled": true}}}}"#
+        )
+        .unwrap();
+        let findings = ReactNativeOldArchAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn old_arch_not_flagged_when_enabled_in_rn_config() {
+        let dir = tempdir().unwrap();
+        write!(
+            std::fs::File::create(dir.path().join("react-native.config.js")).unwrap(),
+            "module.exports = {{ newArchEnabled: true }};\n"
+        )
+        .unwrap();
+        let findings = ReactNativeOldArchAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
+        assert!(findings.is_empty());
+    }
+
+    // ── AsyncStorage ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn async_storage_single_line_detected() {
+        let dir = tempdir().unwrap();
+        let mut facts = facts_for(dir.path());
+        facts.files.push(jsx_file(
+            &dir,
+            "Screen.tsx",
+            "import { View, AsyncStorage, Text } from 'react-native';\n",
+        ));
+        let findings = AsyncStorageFromCoreAudit.audit(&facts, &ScanConfig::default());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "framework.react-native.async-storage-from-core");
+        assert_eq!(findings[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn async_storage_multi_line_detected() {
+        let dir = tempdir().unwrap();
+        let mut facts = facts_for(dir.path());
+        facts.files.push(jsx_file(
+            &dir,
+            "Screen.tsx",
+            "import {\n  View,\n  AsyncStorage,\n  Text,\n} from 'react-native';\n",
+        ));
+        let findings = AsyncStorageFromCoreAudit.audit(&facts, &ScanConfig::default());
+        assert_eq!(findings.len(), 1, "multi-line import must be detected");
+        assert_eq!(findings[0].evidence[0].line_start, 1);
+    }
+
+    #[test]
+    fn async_storage_from_own_package_not_flagged() {
+        let dir = tempdir().unwrap();
+        let mut facts = facts_for(dir.path());
+        facts.files.push(jsx_file(
+            &dir,
+            "Screen.tsx",
+            "import AsyncStorage from '@react-native-async-storage/async-storage';\n",
+        ));
+        let findings = AsyncStorageFromCoreAudit.audit(&facts, &ScanConfig::default());
+        assert!(findings.is_empty());
+    }
+
+    // ── React Navigation v4 ───────────────────────────────────────────────────
+
+    #[test]
+    fn old_react_navigation_detected() {
+        let dir = tempdir().unwrap();
+        let mut facts = facts_for(dir.path());
+        facts.files.push(jsx_file(
+            &dir,
+            "Navigator.tsx",
+            "import { createStackNavigator } from 'react-navigation';\n",
+        ));
+        let findings = ReactNavigationV4Audit.audit(&facts, &ScanConfig::default());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "framework.react-native.old-react-navigation");
+        assert_eq!(findings[0].severity, Severity::Medium);
+    }
+
+    #[test]
+    fn modern_react_navigation_not_flagged() {
+        let dir = tempdir().unwrap();
+        let mut facts = facts_for(dir.path());
+        facts.files.push(jsx_file(
+            &dir,
+            "Navigator.tsx",
+            "import { NavigationContainer } from '@react-navigation/native';\n",
+        ));
+        let findings = ReactNavigationV4Audit.audit(&facts, &ScanConfig::default());
+        assert!(findings.is_empty());
+    }
+
+    // ── Direct state mutation ─────────────────────────────────────────────────
+
+    #[test]
+    fn direct_state_mutation_detected() {
+        let dir = tempdir().unwrap();
+        let mut facts = facts_for(dir.path());
+        facts.files.push(jsx_file(
+            &dir,
+            "Comp.tsx",
+            "class MyComp extends React.Component {\n  handleClick() {\n    this.state.count = 5;\n  }\n}\n",
+        ));
+        let findings = DirectStateMutationAudit.audit(&facts, &ScanConfig::default());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "framework.react-native.direct-state-mutation");
+        assert_eq!(findings[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn state_equality_check_not_flagged() {
+        let dir = tempdir().unwrap();
+        let mut facts = facts_for(dir.path());
+        facts.files.push(jsx_file(
+            &dir,
+            "Comp.tsx",
+            "if (this.state.count === 5) { doSomething(); }\n",
+        ));
+        let findings = DirectStateMutationAudit.audit(&facts, &ScanConfig::default());
+        assert!(findings.is_empty());
+    }
+}

--- a/src/audits/mod.rs
+++ b/src/audits/mod.rs
@@ -1,5 +1,6 @@
 pub mod architecture;
 pub mod code_quality;
+pub mod framework;
 pub mod pipeline;
 pub mod security;
 pub mod testing;

--- a/src/audits/pipeline.rs
+++ b/src/audits/pipeline.rs
@@ -4,6 +4,12 @@ use crate::audits::architecture::too_many_modules::TooManyModulesAudit;
 use crate::audits::code_quality::code_markers::CodeMarkerAudit;
 use crate::audits::code_quality::complexity::ComplexityAudit;
 use crate::audits::code_quality::long_function::LongFunctionAudit;
+use crate::audits::framework::js_common::{ConsoleLogAudit, VarDeclarationAudit};
+use crate::audits::framework::react::{ReactClassComponentAudit, ReactPropTypesAudit};
+use crate::audits::framework::react_native::{
+    AsyncStorageFromCoreAudit, DirectStateMutationAudit, HermesDisabledAudit,
+    ReactNativeOldArchAudit, ReactNavigationV4Audit,
+};
 use crate::audits::security::env_file_committed::EnvFileCommittedAudit;
 use crate::audits::security::private_key_candidate::PrivateKeyCandidateAudit;
 use crate::audits::security::secret_candidate::SecretCandidateAudit;
@@ -11,6 +17,7 @@ use crate::audits::testing::missing_test_folder::MissingTestFolderAudit;
 use crate::audits::testing::source_without_test::SourceWithoutTestAudit;
 use crate::audits::traits::{FileAudit, ProjectAudit};
 use crate::findings::types::Finding;
+use crate::frameworks::DetectedFramework;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
 
@@ -46,4 +53,54 @@ pub fn run_project_audits(scan_facts: &ScanFacts, config: &ScanConfig) -> Vec<Fi
         .iter()
         .flat_map(|a| a.audit(scan_facts, config))
         .collect()
+}
+
+pub fn run_framework_audits(facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
+    let has_rn = facts
+        .detected_frameworks
+        .iter()
+        .any(|f| matches!(f, DetectedFramework::ReactNative { .. }));
+    let has_react = facts
+        .detected_frameworks
+        .iter()
+        .any(|f| matches!(f, DetectedFramework::React { .. }));
+    // React web audits run only when React is present but React Native is not —
+    // RN projects always declare `react` as a peer dep, so without this guard
+    // web-focused checks (class components, prop-types) would run on every RN project.
+    let has_react_only = has_react && !has_rn;
+
+    let has_js = facts.detected_frameworks.iter().any(|f| {
+        matches!(
+            f,
+            DetectedFramework::ReactNative { .. }
+                | DetectedFramework::Expo { .. }
+                | DetectedFramework::React { .. }
+                | DetectedFramework::NextJs { .. }
+                | DetectedFramework::Vue { .. }
+                | DetectedFramework::Angular { .. }
+                | DetectedFramework::Svelte { .. }
+                | DetectedFramework::NestJs { .. }
+                | DetectedFramework::Express { .. }
+        )
+    });
+
+    let mut findings = Vec::new();
+
+    if has_rn {
+        findings.extend(ReactNativeOldArchAudit.audit(facts, config));
+        findings.extend(AsyncStorageFromCoreAudit.audit(facts, config));
+        findings.extend(HermesDisabledAudit.audit(facts, config));
+        findings.extend(ReactNavigationV4Audit.audit(facts, config));
+        findings.extend(DirectStateMutationAudit.audit(facts, config));
+    }
+    if has_react_only {
+        findings.extend(ReactClassComponentAudit.audit(facts, config));
+        findings.extend(ReactPropTypesAudit.audit(facts, config));
+    }
+    if has_js {
+        findings.extend(VarDeclarationAudit.audit(facts, config));
+        findings.extend(ConsoleLogAudit.audit(facts, config));
+    }
+
+    findings
 }

--- a/src/findings/types.rs
+++ b/src/findings/types.rs
@@ -19,6 +19,7 @@ pub enum FindingCategory {
     CodeQuality,
     Testing,
     Security,
+    Framework,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/frameworks/detector.rs
+++ b/src/frameworks/detector.rs
@@ -1,0 +1,169 @@
+use crate::frameworks::types::DetectedFramework;
+use std::path::Path;
+
+pub fn detect_frameworks(root: &Path) -> Vec<DetectedFramework> {
+    let pkg_path = root.join("package.json");
+    let content = match std::fs::read_to_string(&pkg_path) {
+        Ok(c) => c,
+        Err(_) => return vec![],
+    };
+    let value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return vec![],
+    };
+
+    let mut deps = serde_json::Map::new();
+    for key in ["dependencies", "devDependencies"] {
+        if let Some(obj) = value.get(key).and_then(|v| v.as_object()) {
+            for (k, v) in obj {
+                deps.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+        }
+    }
+
+    let version_of = |pkg: &str| -> Option<String> {
+        deps.get(pkg)
+            .and_then(|v| v.as_str())
+            .and_then(extract_version)
+    };
+
+    let mut frameworks = Vec::new();
+
+    if deps.contains_key("react-native") {
+        frameworks.push(DetectedFramework::ReactNative {
+            version: version_of("react-native"),
+        });
+    }
+    if deps.contains_key("expo") {
+        frameworks.push(DetectedFramework::Expo {
+            version: version_of("expo"),
+        });
+    }
+    if deps.contains_key("next") {
+        frameworks.push(DetectedFramework::NextJs {
+            version: version_of("next"),
+        });
+    }
+    if deps.contains_key("react") {
+        frameworks.push(DetectedFramework::React {
+            version: version_of("react"),
+        });
+    }
+    if deps.contains_key("vue") {
+        frameworks.push(DetectedFramework::Vue {
+            version: version_of("vue"),
+        });
+    }
+    if deps.contains_key("@angular/core") {
+        frameworks.push(DetectedFramework::Angular {
+            version: version_of("@angular/core"),
+        });
+    }
+    if deps.contains_key("svelte") {
+        frameworks.push(DetectedFramework::Svelte {
+            version: version_of("svelte"),
+        });
+    }
+    if deps.contains_key("@nestjs/core") {
+        frameworks.push(DetectedFramework::NestJs {
+            version: version_of("@nestjs/core"),
+        });
+    }
+    if deps.contains_key("express") {
+        frameworks.push(DetectedFramework::Express {
+            version: version_of("express"),
+        });
+    }
+
+    frameworks
+}
+
+/// Extracts a displayable version string from a package.json version field.
+/// Returns None for non-version specifiers: workspace:*, file:…, *, or empty.
+fn extract_version(s: &str) -> Option<String> {
+    if s.is_empty()
+        || s == "*"
+        || s.starts_with("workspace:")
+        || s.starts_with("file:")
+        || s.starts_with("link:")
+        || s.starts_with("git+")
+        || s.starts_with("github:")
+        || s.starts_with("http")
+    {
+        return None;
+    }
+    let stripped = s.trim_start_matches(|c: char| matches!(c, '^' | '~' | '=' | '>'));
+    Some(stripped.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn detects_react_native_and_expo() {
+        let dir = tempdir().unwrap();
+        let pkg = dir.path().join("package.json");
+        let mut f = std::fs::File::create(&pkg).unwrap();
+        write!(
+            f,
+            r#"{{"dependencies": {{"react-native": "^0.74.0", "expo": "~51.0.0", "react": "18.2.0"}}}}"#
+        )
+        .unwrap();
+
+        let frameworks = detect_frameworks(dir.path());
+        assert!(frameworks
+            .iter()
+            .any(|f| matches!(f, DetectedFramework::ReactNative { version: Some(v) } if v == "0.74.0")));
+        assert!(frameworks
+            .iter()
+            .any(|f| matches!(f, DetectedFramework::Expo { version: Some(v) } if v == "51.0.0")));
+        assert!(frameworks
+            .iter()
+            .any(|f| matches!(f, DetectedFramework::React { .. })));
+    }
+
+    #[test]
+    fn returns_empty_without_package_json() {
+        let dir = tempdir().unwrap();
+        assert!(detect_frameworks(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn workspace_and_file_refs_produce_no_version() {
+        let dir = tempdir().unwrap();
+        let pkg = dir.path().join("package.json");
+        let mut f = std::fs::File::create(&pkg).unwrap();
+        write!(
+            f,
+            r#"{{"dependencies": {{"react-native": "workspace:*", "react": "file:../react"}}}}"#
+        )
+        .unwrap();
+
+        let frameworks = detect_frameworks(dir.path());
+        assert!(frameworks
+            .iter()
+            .any(|f| matches!(f, DetectedFramework::ReactNative { version: None })));
+        assert!(frameworks
+            .iter()
+            .any(|f| matches!(f, DetectedFramework::React { version: None })));
+    }
+
+    #[test]
+    fn detects_nextjs() {
+        let dir = tempdir().unwrap();
+        let pkg = dir.path().join("package.json");
+        let mut f = std::fs::File::create(&pkg).unwrap();
+        write!(f, r#"{{"dependencies": {{"next": "14.0.0", "react": "18.0.0"}}}}"#).unwrap();
+
+        let frameworks = detect_frameworks(dir.path());
+        assert!(frameworks
+            .iter()
+            .any(|f| matches!(f, DetectedFramework::NextJs { .. })));
+        assert!(frameworks
+            .iter()
+            .any(|f| matches!(f, DetectedFramework::React { .. })));
+    }
+}

--- a/src/frameworks/detector.rs
+++ b/src/frameworks/detector.rs
@@ -114,15 +114,19 @@ mod tests {
         .unwrap();
 
         let frameworks = detect_frameworks(dir.path());
-        assert!(frameworks
-            .iter()
-            .any(|f| matches!(f, DetectedFramework::ReactNative { version: Some(v) } if v == "0.74.0")));
-        assert!(frameworks
-            .iter()
-            .any(|f| matches!(f, DetectedFramework::Expo { version: Some(v) } if v == "51.0.0")));
-        assert!(frameworks
-            .iter()
-            .any(|f| matches!(f, DetectedFramework::React { .. })));
+        assert!(frameworks.iter().any(
+            |f| matches!(f, DetectedFramework::ReactNative { version: Some(v) } if v == "0.74.0")
+        ));
+        assert!(
+            frameworks.iter().any(
+                |f| matches!(f, DetectedFramework::Expo { version: Some(v) } if v == "51.0.0")
+            )
+        );
+        assert!(
+            frameworks
+                .iter()
+                .any(|f| matches!(f, DetectedFramework::React { .. }))
+        );
     }
 
     #[test]
@@ -143,12 +147,16 @@ mod tests {
         .unwrap();
 
         let frameworks = detect_frameworks(dir.path());
-        assert!(frameworks
-            .iter()
-            .any(|f| matches!(f, DetectedFramework::ReactNative { version: None })));
-        assert!(frameworks
-            .iter()
-            .any(|f| matches!(f, DetectedFramework::React { version: None })));
+        assert!(
+            frameworks
+                .iter()
+                .any(|f| matches!(f, DetectedFramework::ReactNative { version: None }))
+        );
+        assert!(
+            frameworks
+                .iter()
+                .any(|f| matches!(f, DetectedFramework::React { version: None }))
+        );
     }
 
     #[test]
@@ -156,14 +164,22 @@ mod tests {
         let dir = tempdir().unwrap();
         let pkg = dir.path().join("package.json");
         let mut f = std::fs::File::create(&pkg).unwrap();
-        write!(f, r#"{{"dependencies": {{"next": "14.0.0", "react": "18.0.0"}}}}"#).unwrap();
+        write!(
+            f,
+            r#"{{"dependencies": {{"next": "14.0.0", "react": "18.0.0"}}}}"#
+        )
+        .unwrap();
 
         let frameworks = detect_frameworks(dir.path());
-        assert!(frameworks
-            .iter()
-            .any(|f| matches!(f, DetectedFramework::NextJs { .. })));
-        assert!(frameworks
-            .iter()
-            .any(|f| matches!(f, DetectedFramework::React { .. })));
+        assert!(
+            frameworks
+                .iter()
+                .any(|f| matches!(f, DetectedFramework::NextJs { .. }))
+        );
+        assert!(
+            frameworks
+                .iter()
+                .any(|f| matches!(f, DetectedFramework::React { .. }))
+        );
     }
 }

--- a/src/frameworks/detector.rs
+++ b/src/frameworks/detector.rs
@@ -92,7 +92,7 @@ fn extract_version(s: &str) -> Option<String> {
     {
         return None;
     }
-    let stripped = s.trim_start_matches(|c: char| matches!(c, '^' | '~' | '=' | '>'));
+    let stripped = s.trim_start_matches(['^', '~', '=', '>']);
     Some(stripped.to_string())
 }
 

--- a/src/frameworks/mod.rs
+++ b/src/frameworks/mod.rs
@@ -1,0 +1,5 @@
+pub mod detector;
+pub mod types;
+
+pub use detector::detect_frameworks;
+pub use types::DetectedFramework;

--- a/src/frameworks/types.rs
+++ b/src/frameworks/types.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "name", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum DetectedFramework {
+    ReactNative { version: Option<String> },
+    Expo { version: Option<String> },
+    NextJs { version: Option<String> },
+    React { version: Option<String> },
+    Vue { version: Option<String> },
+    Angular { version: Option<String> },
+    Svelte { version: Option<String> },
+    NestJs { version: Option<String> },
+    Express { version: Option<String> },
+}
+
+impl DetectedFramework {
+    pub fn label(&self) -> String {
+        let (name, version) = match self {
+            DetectedFramework::ReactNative { version } => ("React Native", version.as_deref()),
+            DetectedFramework::Expo { version } => ("Expo", version.as_deref()),
+            DetectedFramework::NextJs { version } => ("Next.js", version.as_deref()),
+            DetectedFramework::React { version } => ("React", version.as_deref()),
+            DetectedFramework::Vue { version } => ("Vue", version.as_deref()),
+            DetectedFramework::Angular { version } => ("Angular", version.as_deref()),
+            DetectedFramework::Svelte { version } => ("Svelte", version.as_deref()),
+            DetectedFramework::NestJs { version } => ("NestJS", version.as_deref()),
+            DetectedFramework::Express { version } => ("Express", version.as_deref()),
+        };
+        match version {
+            Some(v) => format!("{name} {v}"),
+            None => name.to_string(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod baseline;
 pub mod compare;
 pub mod config;
 pub mod findings;
+pub mod frameworks;
 pub mod graph;
 pub mod output;
 pub mod report;

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -205,8 +205,5 @@ fn render_frameworks_section(output: &mut String, frameworks: &[DetectedFramewor
         return;
     }
     let labels: Vec<String> = frameworks.iter().map(|f| f.label()).collect();
-    output.push_str(&format!(
-        "Frameworks: {}\n\n",
-        labels.join(" \u{00b7} ")
-    ));
+    output.push_str(&format!("Frameworks: {}\n\n", labels.join(" \u{00b7} ")));
 }

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -1,6 +1,7 @@
 use crate::baseline::diff::{BaselineScanReport, BaselineStatus};
 use crate::baseline::gate::CiGateResult;
 use crate::findings::types::{Finding, Severity};
+use crate::frameworks::DetectedFramework;
 use crate::output::color;
 use crate::scan::types::ScanSummary;
 
@@ -37,6 +38,7 @@ pub fn render(summary: &ScanSummary) -> String {
     }
 
     output.push('\n');
+    render_frameworks_section(&mut output, &summary.detected_frameworks);
     render_findings_section(&mut output, &summary.findings);
 
     output
@@ -89,6 +91,7 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
     }
 
     output.push('\n');
+    render_frameworks_section(&mut output, &summary.detected_frameworks);
 
     if summary.findings.is_empty() {
         output.push_str("Findings: none\n");
@@ -195,4 +198,15 @@ fn severity_index(s: Severity) -> usize {
         Severity::Low => 3,
         Severity::Info => 4,
     }
+}
+
+fn render_frameworks_section(output: &mut String, frameworks: &[DetectedFramework]) {
+    if frameworks.is_empty() {
+        return;
+    }
+    let labels: Vec<String> = frameworks.iter().map(|f| f.label()).collect();
+    output.push_str(&format!(
+        "Frameworks: {}\n\n",
+        labels.join(" \u{00b7} ")
+    ));
 }

--- a/src/output/html.rs
+++ b/src/output/html.rs
@@ -212,7 +212,12 @@ fn render_frameworks_section(summary: &ScanSummary) -> String {
     let labels: Vec<String> = summary
         .detected_frameworks
         .iter()
-        .map(|f| format!("<span class=\"badge low\">{}</span>", escape_html(&f.label())))
+        .map(|f| {
+            format!(
+                "<span class=\"badge low\">{}</span>",
+                escape_html(&f.label())
+            )
+        })
         .collect();
     format!(
         "<h2>Frameworks</h2><p class=\"meta\">{}</p>\n",

--- a/src/output/html.rs
+++ b/src/output/html.rs
@@ -5,12 +5,14 @@ use crate::scan::types::ScanSummary;
 pub fn render(summary: &ScanSummary) -> String {
     let cards = render_summary_cards(summary);
     let languages_section = render_languages_section(summary);
+    let frameworks_section = render_frameworks_section(summary);
     let findings_section = render_findings_section(summary);
     render_document(
         &summary.root_path.to_string_lossy(),
         "",
         &cards,
         &languages_section,
+        &frameworks_section,
         &findings_section,
     )
 }
@@ -18,6 +20,7 @@ pub fn render(summary: &ScanSummary) -> String {
 pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGateResult>) -> String {
     let cards = render_baseline_summary_cards(report);
     let languages_section = render_languages_section(&report.summary);
+    let frameworks_section = render_frameworks_section(&report.summary);
     let findings_section = render_baseline_findings_section(report);
     let baseline_meta = render_baseline_meta(report, ci_gate);
 
@@ -26,6 +29,7 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
         &baseline_meta,
         &cards,
         &languages_section,
+        &frameworks_section,
         &findings_section,
     )
 }
@@ -35,6 +39,7 @@ fn render_document(
     baseline_meta: &str,
     cards: &str,
     languages_section: &str,
+    frameworks_section: &str,
     findings_section: &str,
 ) -> String {
     format!(
@@ -84,7 +89,7 @@ fn render_document(
 
 <h2>Languages</h2>
 {languages_section}
-
+{frameworks_section}
 <h2>Findings</h2>
 <div class="filter-bar" id="filter-bar"></div>
 {findings_section}
@@ -116,6 +121,7 @@ fn render_document(
         baseline_meta = baseline_meta,
         cards = cards,
         languages_section = languages_section,
+        frameworks_section = frameworks_section,
         findings_section = findings_section,
     )
 }
@@ -196,6 +202,21 @@ fn render_languages_section(summary: &ScanSummary) -> String {
 
     format!(
         "<table><thead><tr><th>Language</th><th class=\"num\">Files</th></tr></thead><tbody>{rows}</tbody></table>"
+    )
+}
+
+fn render_frameworks_section(summary: &ScanSummary) -> String {
+    if summary.detected_frameworks.is_empty() {
+        return String::new();
+    }
+    let labels: Vec<String> = summary
+        .detected_frameworks
+        .iter()
+        .map(|f| format!("<span class=\"badge low\">{}</span>", escape_html(&f.label())))
+        .collect();
+    format!(
+        "<h2>Frameworks</h2><p class=\"meta\">{}</p>\n",
+        labels.join(" ")
     )
 }
 

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -1,5 +1,6 @@
 use crate::baseline::diff::BaselineScanReport;
 use crate::baseline::gate::CiGateResult;
+use crate::frameworks::DetectedFramework;
 use crate::output::render_helpers::escape_table_cell;
 use crate::scan::types::ScanSummary;
 
@@ -44,6 +45,8 @@ pub fn render(summary: &ScanSummary) -> String {
 
         output.push('\n');
     }
+
+    render_frameworks_section(&mut output, &summary.detected_frameworks);
 
     output.push_str("## Findings\n\n");
 
@@ -172,6 +175,8 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
         output.push('\n');
     }
 
+    render_frameworks_section(&mut output, &summary.detected_frameworks);
+
     output.push_str("## Findings\n\n");
 
     if summary.findings.is_empty() {
@@ -235,6 +240,15 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
     }
 
     output
+}
+
+fn render_frameworks_section(output: &mut String, frameworks: &[DetectedFramework]) {
+    if frameworks.is_empty() {
+        return;
+    }
+    let labels: Vec<String> = frameworks.iter().map(|f| f.label()).collect();
+    output.push_str("## Frameworks\n\n");
+    output.push_str(&format!("{}\n\n", labels.join(" · ")));
 }
 
 fn render_evidence(finding: &crate::findings::types::Finding) -> String {

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -137,6 +137,7 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
             skipped_files_count: report.summary.skipped_files_count,
             skipped_bytes: report.summary.skipped_bytes,
             languages: report.summary.languages.clone(),
+            detected_frameworks: report.summary.detected_frameworks.clone(),
             findings: report.in_diff_findings().into_iter().cloned().collect(),
             coupling_graph: report.summary.coupling_graph.clone(),
         },

--- a/src/scan/facts.rs
+++ b/src/scan/facts.rs
@@ -1,3 +1,4 @@
+use crate::frameworks::DetectedFramework;
 use crate::scan::types::LanguageSummary;
 use std::path::PathBuf;
 
@@ -11,6 +12,7 @@ pub struct ScanFacts {
     pub skipped_bytes: u64,
     pub languages: Vec<LanguageSummary>,
     pub files: Vec<FileFacts>,
+    pub detected_frameworks: Vec<DetectedFramework>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -1,9 +1,10 @@
 use crate::audits::architecture::import_coupling::ImportCouplingAudit;
 use crate::audits::code_quality::complexity::count_branches;
-use crate::audits::pipeline::{build_file_audits, run_project_audits};
+use crate::audits::pipeline::{build_file_audits, run_framework_audits, run_project_audits};
 use crate::audits::traits::FileAudit;
 use crate::baseline::key::stable_finding_key;
 use crate::findings::types::Finding;
+use crate::frameworks::detect_frameworks;
 use crate::graph::imports::extract_imports;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::{FileFacts, ScanFacts};
@@ -22,8 +23,12 @@ pub fn scan_path(path: &Path) -> io::Result<ScanSummary> {
 
 pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<ScanSummary> {
     let file_audits = build_file_audits(config);
-    let (facts, mut findings) = collect_and_audit_inline(path, config, &file_audits)?;
+    let (mut facts, mut findings) = collect_and_audit_inline(path, config, &file_audits)?;
+
+    facts.detected_frameworks = detect_frameworks(&facts.root_path);
+
     findings.extend(run_project_audits(&facts, config));
+    findings.extend(run_framework_audits(&facts, config));
     let (coupling_findings, coupling_graph) =
         ImportCouplingAudit.audit_with_graph(&facts, config, path);
     findings.extend(coupling_findings);
@@ -40,6 +45,7 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
         skipped_files_count: facts.skipped_files_count,
         skipped_bytes: facts.skipped_bytes,
         languages: facts.languages,
+        detected_frameworks: facts.detected_frameworks,
         findings,
         coupling_graph: Some(coupling_graph),
     })

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -1,4 +1,5 @@
 use crate::findings::types::Finding;
+use crate::frameworks::DetectedFramework;
 use crate::graph::CouplingGraph;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -30,6 +31,8 @@ pub struct ScanSummary {
     pub skipped_bytes: u64,
     pub languages: Vec<LanguageSummary>,
     pub findings: Vec<Finding>,
+    #[serde(default)]
+    pub detected_frameworks: Vec<DetectedFramework>,
     #[serde(default)]
     pub coupling_graph: Option<CouplingGraph>,
 }

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -71,6 +71,7 @@ fn summary(findings: Vec<Finding>) -> ScanSummary {
         skipped_bytes: 0,
         languages: vec![],
         findings,
+        detected_frameworks: vec![],
         coupling_graph: None,
     }
 }

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -13,6 +13,7 @@ fn html_output_escapes_snippets_and_renders_summary() {
         skipped_files_count: 0,
         skipped_bytes: 0,
         languages: vec![],
+        detected_frameworks: vec![],
         findings: vec![Finding {
             id: "finding-1".to_string(),
             rule_id: "security.secret-candidate".to_string(),

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -16,6 +16,7 @@ fn renders_valid_json_scan_summary() {
             files_count: 1,
         }],
         findings: vec![],
+        detected_frameworks: vec![],
         coupling_graph: None,
     };
 

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -37,6 +37,7 @@ fn renders_markdown_scan_summary() {
                 snippet: "// TODO: improve architecture".to_string(),
             }],
         }],
+        detected_frameworks: vec![],
         coupling_graph: None,
     };
 
@@ -67,6 +68,7 @@ fn renders_empty_markdown_sections() {
         skipped_bytes: 0,
         languages: vec![],
         findings: vec![],
+        detected_frameworks: vec![],
         coupling_graph: None,
     };
 


### PR DESCRIPTION
## Summary

Adds the first framework-aware audit layer for RepoPilot v0.6.

This PR introduces JavaScript, React, and React Native-specific audits, along with lightweight framework detection from `package.json`. It moves RepoPilot beyond generic repository checks and starts building the foundation for framework-aware repository intelligence.

## Type of change

- Feature
- Refactor
- Tests
- Documentation

## What changed

- Added JavaScript audits:
  - `VarDeclarationAudit`
  - `ConsoleLogAudit`
- Added React audits:
  - `ReactClassComponentAudit`
  - `ReactPropTypesAudit`
- Added React Native audits:
  - `ReactNativeOldArchAudit`
  - `AsyncStorageFromCoreAudit`
  - additional React Native framework checks
- Added framework detection from `package.json`.
- Updated scan/report output to include detected frameworks.
- Updated JSON output to expose framework information.
- Updated Markdown output to render detected frameworks.
- Added tests for new audits and framework detection behavior.

## Why

RepoPilot v0.6 is focused on repository intelligence and framework-aware analysis.

Generic checks are useful, but real projects often need stack-specific signals. A React Native project has different risks than a Rust CLI or a plain Node.js package. This PR starts that direction by adding targeted JavaScript, React, and React Native checks.

This gives RepoPilot a stronger product direction:

> detect the kind of repository being scanned, then run audits that understand that ecosystem.

## Architecture notes

- No god files introduced.
- Audit logic is split into focused modules.
- Framework detection is separated from individual audit rules.
- Scanner, audits, output, and report responsibilities remain separated.
- Existing generic audits continue to work.
- Existing output formats are preserved and extended with framework metadata.
- Findings include evidence where applicable.

## Changelog

- Added JavaScript framework audits.
- Added React framework audits.
- Added React Native framework audits.
- Added lightweight framework detection from `package.json`.
- Added detected framework output to JSON and Markdown reports.
- Added tests for new framework-aware audit behavior.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .