### PR TITLE
feat(react-native): add architecture detection and reporting

### DIFF
--- a/src/audits/framework/react_native.rs
+++ b/src/audits/framework/react_native.rs
@@ -207,6 +207,7 @@ impl ProjectAudit for HermesDisabledAudit {
             }
         }
 
+        // Legacy location (< RN 0.70): android/app/build.gradle
         let gradle = facts.root_path.join("android/app/build.gradle");
         if let Ok(content) = std::fs::read_to_string(&gradle) {
             if content.contains("enableHermes: false") || content.contains("enableHermes : false") {
@@ -214,8 +215,39 @@ impl ProjectAudit for HermesDisabledAudit {
             }
         }
 
+        // Modern location (>= RN 0.70): android/gradle.properties
+        let gradle_props = facts.root_path.join("android/gradle.properties");
+        if let Ok(content) = std::fs::read_to_string(&gradle_props) {
+            if gradle_properties_hermes_disabled(&content) {
+                findings.push(hermes_finding(gradle_props, "hermesEnabled=false"));
+            }
+        }
+
         findings
     }
+}
+
+/// Returns true when gradle.properties explicitly disables Hermes.
+/// Tolerates spaces around `=` and ignores inline comments.
+fn gradle_properties_hermes_disabled(content: &str) -> bool {
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with('#') {
+            continue;
+        }
+        let Some((key, rest)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        if key != "hermesEnabled" && key != "enableHermes" {
+            continue;
+        }
+        let value = rest.split_once('#').map(|(v, _)| v).unwrap_or(rest).trim();
+        if value == "false" {
+            return true;
+        }
+    }
+    false
 }
 
 fn hermes_finding(path: PathBuf, snippet: &str) -> Finding {
@@ -552,5 +584,56 @@ mod tests {
         ));
         let findings = DirectStateMutationAudit.audit(&facts, &ScanConfig::default());
         assert!(findings.is_empty());
+    }
+
+    // ── Hermes disabled via gradle.properties ─────────────────────────────────
+
+    #[test]
+    fn hermes_disabled_in_gradle_properties_is_flagged() {
+        let dir = tempdir().unwrap();
+        let android = dir.path().join("android");
+        std::fs::create_dir(&android).unwrap();
+        write!(
+            std::fs::File::create(android.join("gradle.properties")).unwrap(),
+            "hermesEnabled=false\nnewArchEnabled=true\n"
+        )
+        .unwrap();
+
+        let findings = HermesDisabledAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(
+            findings[0].rule_id,
+            "framework.react-native.hermes-disabled"
+        );
+    }
+
+    #[test]
+    fn hermes_enabled_in_gradle_properties_is_not_flagged() {
+        let dir = tempdir().unwrap();
+        let android = dir.path().join("android");
+        std::fs::create_dir(&android).unwrap();
+        writeln!(
+            std::fs::File::create(android.join("gradle.properties")).unwrap(),
+            "hermesEnabled=true"
+        )
+        .unwrap();
+
+        let findings = HermesDisabledAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn hermes_disabled_gradle_properties_with_inline_comment_is_flagged() {
+        let dir = tempdir().unwrap();
+        let android = dir.path().join("android");
+        std::fs::create_dir(&android).unwrap();
+        writeln!(
+            std::fs::File::create(android.join("gradle.properties")).unwrap(),
+            "hermesEnabled=false   # JSC is faster for our use case"
+        )
+        .unwrap();
+
+        let findings = HermesDisabledAudit.audit(&facts_for(dir.path()), &ScanConfig::default());
+        assert_eq!(findings.len(), 1);
     }
 }

--- a/src/frameworks/detector.rs
+++ b/src/frameworks/detector.rs
@@ -80,7 +80,7 @@ pub fn detect_frameworks(root: &Path) -> Vec<DetectedFramework> {
 
 /// Extracts a displayable version string from a package.json version field.
 /// Returns None for non-version specifiers: workspace:*, file:…, *, or empty.
-fn extract_version(s: &str) -> Option<String> {
+pub(crate) fn extract_version(s: &str) -> Option<String> {
     if s.is_empty()
         || s == "*"
         || s.starts_with("workspace:")

--- a/src/frameworks/mod.rs
+++ b/src/frameworks/mod.rs
@@ -1,5 +1,7 @@
 pub mod detector;
+pub mod react_native;
 pub mod types;
 
 pub use detector::detect_frameworks;
+pub use react_native::{ReactNativeArchitectureProfile, detect_react_native_architecture};
 pub use types::DetectedFramework;

--- a/src/frameworks/react_native/detector.rs
+++ b/src/frameworks/react_native/detector.rs
@@ -117,10 +117,8 @@ fn parse_gradle_properties(content: &str) -> (Option<bool>, Option<bool>) {
         };
         match key {
             "newArchEnabled" => new_arch = parsed,
-            "hermesEnabled" | "enableHermes" => {
-                if hermes.is_none() {
-                    hermes = parsed;
-                }
+            "hermesEnabled" | "enableHermes" if hermes.is_none() => {
+                hermes = parsed;
             }
             _ => {}
         }

--- a/src/frameworks/react_native/detector.rs
+++ b/src/frameworks/react_native/detector.rs
@@ -1,0 +1,395 @@
+use crate::frameworks::detector::extract_version;
+use crate::frameworks::react_native::profile::ReactNativeArchitectureProfile;
+use std::path::Path;
+
+pub fn detect_react_native_architecture(root: &Path) -> ReactNativeArchitectureProfile {
+    let pkg_path = root.join("package.json");
+    let content = match std::fs::read_to_string(&pkg_path) {
+        Ok(c) => c,
+        Err(_) => return ReactNativeArchitectureProfile::default(),
+    };
+    let value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return ReactNativeArchitectureProfile::default(),
+    };
+
+    let mut deps = serde_json::Map::new();
+    for key in ["dependencies", "devDependencies"] {
+        if let Some(obj) = value.get(key).and_then(|v| v.as_object()) {
+            for (k, v) in obj {
+                deps.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+        }
+    }
+
+    if !deps.contains_key("react-native") {
+        return ReactNativeArchitectureProfile::default();
+    }
+
+    let react_native_version = deps
+        .get("react-native")
+        .and_then(|v| v.as_str())
+        .and_then(extract_version);
+
+    let has_codegen_config = value.get("codegenConfig").is_some();
+
+    let has_ios = root.join("ios").is_dir();
+    let has_android = root.join("android").is_dir();
+
+    let has_metro_config = ["metro.config.js", "metro.config.cjs", "metro.config.mjs"]
+        .iter()
+        .any(|name| root.join(name).is_file());
+
+    let has_react_native_config = ["react-native.config.js", "react-native.config.ts"]
+        .iter()
+        .any(|name| root.join(name).is_file());
+
+    let gradle_path = root.join("android").join("gradle.properties");
+    let android_gradle_properties_found = gradle_path.is_file();
+    let (android_new_arch_enabled, android_hermes) = if android_gradle_properties_found {
+        match std::fs::read_to_string(&gradle_path) {
+            Ok(c) => parse_gradle_properties(&c),
+            Err(_) => (None, None),
+        }
+    } else {
+        (None, None)
+    };
+
+    let podfile_path = root.join("ios").join("Podfile");
+    let ios_podfile_found = podfile_path.is_file();
+    let (ios_new_arch_enabled, ios_hermes) = if ios_podfile_found {
+        match std::fs::read_to_string(&podfile_path) {
+            Ok(c) => parse_podfile(&c),
+            Err(_) => (None, None),
+        }
+    } else {
+        (None, None)
+    };
+
+    // Prefer None when android and iOS hermes signals conflict.
+    // TODO: emit a mismatch finding in a future audit when platforms disagree.
+    let hermes_enabled = match (android_hermes, ios_hermes) {
+        (Some(a), Some(b)) if a == b => Some(a),
+        (Some(_), Some(_)) => None,
+        (Some(v), None) | (None, Some(v)) => Some(v),
+        (None, None) => None,
+    };
+
+    ReactNativeArchitectureProfile {
+        detected: true,
+        react_native_version,
+        has_ios,
+        has_android,
+        has_metro_config,
+        has_react_native_config,
+        has_codegen_config,
+        android_new_arch_enabled,
+        ios_new_arch_enabled,
+        hermes_enabled,
+        android_gradle_properties_found,
+        ios_podfile_found,
+    }
+}
+
+fn parse_gradle_properties(content: &str) -> (Option<bool>, Option<bool>) {
+    let mut new_arch = None;
+    let mut hermes = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        // Strip trailing inline comment before matching (e.g. "true # required for Fabric")
+        let value = value
+            .split_once('#')
+            .map(|(v, _)| v)
+            .unwrap_or(value)
+            .trim();
+        let parsed = match value {
+            "true" => Some(true),
+            "false" => Some(false),
+            _ => None,
+        };
+        match key {
+            "newArchEnabled" => new_arch = parsed,
+            "hermesEnabled" | "enableHermes" => {
+                if hermes.is_none() {
+                    hermes = parsed;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    (new_arch, hermes)
+}
+
+fn parse_podfile(content: &str) -> (Option<bool>, Option<bool>) {
+    let mut new_arch = None;
+    let mut hermes = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+        // Skip Ruby comment lines to avoid parsing commented-out configuration
+        if line.starts_with('#') {
+            continue;
+        }
+
+        if new_arch.is_none() && line.contains("RCT_NEW_ARCH_ENABLED") {
+            if line.contains("'1'")
+                || line.contains("\"1\"")
+                || line.contains("= 1")
+                || line.ends_with("=1")
+            {
+                new_arch = Some(true);
+            } else if line.contains("'0'")
+                || line.contains("\"0\"")
+                || line.contains("= 0")
+                || line.ends_with("=0")
+            {
+                new_arch = Some(false);
+            }
+        }
+
+        if new_arch.is_none() && line.contains("new_arch_enabled") {
+            if line.contains("=> true") {
+                new_arch = Some(true);
+            } else if line.contains("=> false") {
+                new_arch = Some(false);
+            }
+        }
+
+        if hermes.is_none() && line.contains(":hermes_enabled") {
+            if line.contains("=> true") {
+                hermes = Some(true);
+            } else if line.contains("=> false") {
+                hermes = Some(false);
+            }
+        }
+    }
+
+    (new_arch, hermes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn detects_react_native_project() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        let mut f = fs::File::create(root.join("package.json")).unwrap();
+        write!(
+            f,
+            r#"{{"dependencies": {{"react-native": "^0.73.0", "react": "18.2.0"}}}}"#
+        )
+        .unwrap();
+        fs::create_dir(root.join("ios")).unwrap();
+        fs::create_dir(root.join("android")).unwrap();
+
+        let profile = detect_react_native_architecture(root);
+
+        assert!(profile.detected);
+        assert_eq!(profile.react_native_version, Some("0.73.0".to_string()));
+        assert!(profile.has_ios);
+        assert!(profile.has_android);
+    }
+
+    #[test]
+    fn detects_android_new_arch_enabled_and_hermes() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        let mut f = fs::File::create(root.join("package.json")).unwrap();
+        write!(f, r#"{{"dependencies": {{"react-native": "0.73.0"}}}}"#).unwrap();
+
+        fs::create_dir(root.join("android")).unwrap();
+        let mut gp = fs::File::create(root.join("android/gradle.properties")).unwrap();
+        writeln!(gp, "newArchEnabled=true").unwrap();
+        writeln!(gp, "hermesEnabled=true").unwrap();
+
+        let profile = detect_react_native_architecture(root);
+
+        assert_eq!(profile.android_new_arch_enabled, Some(true));
+        assert_eq!(profile.hermes_enabled, Some(true));
+        assert!(profile.android_gradle_properties_found);
+    }
+
+    #[test]
+    fn detects_android_new_arch_disabled_with_spaces() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        let mut f = fs::File::create(root.join("package.json")).unwrap();
+        write!(f, r#"{{"dependencies": {{"react-native": "0.73.0"}}}}"#).unwrap();
+
+        fs::create_dir(root.join("android")).unwrap();
+        let mut gp = fs::File::create(root.join("android/gradle.properties")).unwrap();
+        writeln!(gp, "newArchEnabled = false").unwrap();
+
+        let profile = detect_react_native_architecture(root);
+
+        assert_eq!(profile.android_new_arch_enabled, Some(false));
+    }
+
+    #[test]
+    fn detects_codegen_config() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        let mut f = fs::File::create(root.join("package.json")).unwrap();
+        write!(
+            f,
+            r#"{{
+                "dependencies": {{"react-native": "0.73.0"}},
+                "codegenConfig": {{"name": "ExampleSpec"}}
+            }}"#
+        )
+        .unwrap();
+
+        let profile = detect_react_native_architecture(root);
+
+        assert!(profile.has_codegen_config);
+    }
+
+    #[test]
+    fn detects_ios_podfile_signals() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        let mut f = fs::File::create(root.join("package.json")).unwrap();
+        write!(f, r#"{{"dependencies": {{"react-native": "0.73.0"}}}}"#).unwrap();
+
+        fs::create_dir(root.join("ios")).unwrap();
+        let mut pf = fs::File::create(root.join("ios/Podfile")).unwrap();
+        writeln!(pf, "ENV['RCT_NEW_ARCH_ENABLED'] = '1'").unwrap();
+        writeln!(pf, "use_react_native!(").unwrap();
+        writeln!(pf, "  :hermes_enabled => true").unwrap();
+        writeln!(pf, ")").unwrap();
+
+        let profile = detect_react_native_architecture(root);
+
+        assert_eq!(profile.ios_new_arch_enabled, Some(true));
+        assert_eq!(profile.hermes_enabled, Some(true));
+        assert!(profile.ios_podfile_found);
+    }
+
+    #[test]
+    fn malformed_package_json_does_not_panic() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        let mut f = fs::File::create(root.join("package.json")).unwrap();
+        write!(f, "{{ broken json").unwrap();
+
+        let profile = detect_react_native_architecture(root);
+
+        assert!(!profile.detected);
+        assert_eq!(profile.react_native_version, None);
+    }
+
+    #[test]
+    fn non_rn_project_returns_not_detected() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        let mut f = fs::File::create(root.join("package.json")).unwrap();
+        write!(
+            f,
+            r#"{{"dependencies": {{"react": "18.0.0", "next": "14.0.0"}}}}"#
+        )
+        .unwrap();
+
+        let profile = detect_react_native_architecture(root);
+
+        assert!(!profile.detected);
+    }
+
+    #[test]
+    fn detects_metro_config_and_rn_config() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        let mut f = fs::File::create(root.join("package.json")).unwrap();
+        write!(f, r#"{{"dependencies": {{"react-native": "0.73.0"}}}}"#).unwrap();
+        fs::File::create(root.join("metro.config.js")).unwrap();
+        fs::File::create(root.join("react-native.config.js")).unwrap();
+
+        let profile = detect_react_native_architecture(root);
+
+        assert!(profile.has_metro_config);
+        assert!(profile.has_react_native_config);
+    }
+
+    #[test]
+    fn hermes_conflict_between_platforms_yields_none() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        let mut f = fs::File::create(root.join("package.json")).unwrap();
+        write!(f, r#"{{"dependencies": {{"react-native": "0.73.0"}}}}"#).unwrap();
+
+        fs::create_dir(root.join("android")).unwrap();
+        let mut gp = fs::File::create(root.join("android/gradle.properties")).unwrap();
+        writeln!(gp, "hermesEnabled=true").unwrap();
+
+        fs::create_dir(root.join("ios")).unwrap();
+        let mut pf = fs::File::create(root.join("ios/Podfile")).unwrap();
+        writeln!(pf, ":hermes_enabled => false").unwrap();
+
+        let profile = detect_react_native_architecture(root);
+
+        assert_eq!(profile.hermes_enabled, None);
+    }
+
+    #[test]
+    fn gradle_properties_inline_comment_does_not_break_detection() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        let mut f = fs::File::create(root.join("package.json")).unwrap();
+        write!(f, r#"{{"dependencies": {{"react-native": "0.73.0"}}}}"#).unwrap();
+
+        fs::create_dir(root.join("android")).unwrap();
+        let mut gp = fs::File::create(root.join("android/gradle.properties")).unwrap();
+        writeln!(gp, "newArchEnabled=true   # required for Fabric").unwrap();
+        writeln!(gp, "hermesEnabled=false # we use JSC").unwrap();
+
+        let profile = detect_react_native_architecture(root);
+
+        assert_eq!(profile.android_new_arch_enabled, Some(true));
+        assert_eq!(profile.hermes_enabled, Some(false));
+    }
+
+    #[test]
+    fn podfile_comment_lines_are_not_parsed_as_config() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        let mut f = fs::File::create(root.join("package.json")).unwrap();
+        write!(f, r#"{{"dependencies": {{"react-native": "0.73.0"}}}}"#).unwrap();
+
+        fs::create_dir(root.join("ios")).unwrap();
+        let mut pf = fs::File::create(root.join("ios/Podfile")).unwrap();
+        // These commented-out lines must not affect detection
+        writeln!(pf, "# ENV['RCT_NEW_ARCH_ENABLED'] = '1'").unwrap();
+        writeln!(pf, "# :hermes_enabled => true").unwrap();
+        // Only the real setting below counts
+        writeln!(pf, "ENV['RCT_NEW_ARCH_ENABLED'] = '0'").unwrap();
+
+        let profile = detect_react_native_architecture(root);
+
+        assert_eq!(profile.ios_new_arch_enabled, Some(false));
+        assert_eq!(profile.hermes_enabled, None);
+    }
+}

--- a/src/frameworks/react_native/mod.rs
+++ b/src/frameworks/react_native/mod.rs
@@ -1,0 +1,5 @@
+pub mod detector;
+pub mod profile;
+
+pub use detector::detect_react_native_architecture;
+pub use profile::ReactNativeArchitectureProfile;

--- a/src/frameworks/react_native/profile.rs
+++ b/src/frameworks/react_native/profile.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReactNativeArchitectureProfile {
+    pub detected: bool,
+    pub react_native_version: Option<String>,
+
+    pub has_ios: bool,
+    pub has_android: bool,
+
+    pub has_metro_config: bool,
+    pub has_react_native_config: bool,
+    pub has_codegen_config: bool,
+
+    pub android_new_arch_enabled: Option<bool>,
+    pub ios_new_arch_enabled: Option<bool>,
+
+    pub hermes_enabled: Option<bool>,
+
+    pub android_gradle_properties_found: bool,
+    pub ios_podfile_found: bool,
+}

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -2,6 +2,7 @@ use crate::baseline::diff::{BaselineScanReport, BaselineStatus};
 use crate::baseline::gate::CiGateResult;
 use crate::findings::types::{Finding, Severity};
 use crate::frameworks::DetectedFramework;
+use crate::frameworks::ReactNativeArchitectureProfile;
 use crate::output::color;
 use crate::scan::types::ScanSummary;
 
@@ -39,6 +40,9 @@ pub fn render(summary: &ScanSummary) -> String {
 
     output.push('\n');
     render_frameworks_section(&mut output, &summary.detected_frameworks);
+    if let Some(rn) = &summary.react_native {
+        render_react_native_section(&mut output, rn);
+    }
     render_findings_section(&mut output, &summary.findings);
 
     output
@@ -92,6 +96,9 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
 
     output.push('\n');
     render_frameworks_section(&mut output, &summary.detected_frameworks);
+    if let Some(rn) = &summary.react_native {
+        render_react_native_section(&mut output, rn);
+    }
 
     if summary.findings.is_empty() {
         output.push_str("Findings: none\n");
@@ -206,4 +213,31 @@ fn render_frameworks_section(output: &mut String, frameworks: &[DetectedFramewor
     }
     let labels: Vec<String> = frameworks.iter().map(|f| f.label()).collect();
     output.push_str(&format!("Frameworks: {}\n\n", labels.join(" \u{00b7} ")));
+}
+
+fn render_react_native_section(output: &mut String, rn: &ReactNativeArchitectureProfile) {
+    let version = rn.react_native_version.as_deref().unwrap_or("unknown");
+    let ios = if rn.has_ios { "yes" } else { "no" };
+    let android = if rn.has_android { "yes" } else { "no" };
+    let new_arch_android = tristate_label(rn.android_new_arch_enabled);
+    let new_arch_ios = tristate_label(rn.ios_new_arch_enabled);
+    let hermes = tristate_label(rn.hermes_enabled);
+    let codegen = if rn.has_codegen_config { "yes" } else { "no" };
+
+    output.push_str("React Native:\n");
+    output.push_str(&format!(
+        "  Version: {version}  iOS: {ios}  Android: {android}\n"
+    ));
+    output.push_str(&format!(
+        "  New Arch (Android): {new_arch_android}  New Arch (iOS): {new_arch_ios}\n"
+    ));
+    output.push_str(&format!("  Hermes: {hermes}  Codegen: {codegen}\n\n"));
+}
+
+fn tristate_label(value: Option<bool>) -> &'static str {
+    match value {
+        Some(true) => "enabled",
+        Some(false) => "disabled",
+        None => "unknown",
+    }
 }

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -1,6 +1,7 @@
 use crate::baseline::diff::BaselineScanReport;
 use crate::baseline::gate::CiGateResult;
 use crate::frameworks::DetectedFramework;
+use crate::frameworks::ReactNativeArchitectureProfile;
 use crate::output::render_helpers::escape_table_cell;
 use crate::scan::types::ScanSummary;
 
@@ -47,6 +48,9 @@ pub fn render(summary: &ScanSummary) -> String {
     }
 
     render_frameworks_section(&mut output, &summary.detected_frameworks);
+    if let Some(rn) = &summary.react_native {
+        render_react_native_section(&mut output, rn);
+    }
 
     output.push_str("## Findings\n\n");
 
@@ -176,6 +180,9 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
     }
 
     render_frameworks_section(&mut output, &summary.detected_frameworks);
+    if let Some(rn) = &summary.react_native {
+        render_react_native_section(&mut output, rn);
+    }
 
     output.push_str("## Findings\n\n");
 
@@ -240,6 +247,58 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
     }
 
     output
+}
+
+fn render_react_native_section(output: &mut String, rn: &ReactNativeArchitectureProfile) {
+    output.push_str("### React Native\n\n");
+
+    let version = rn.react_native_version.as_deref().unwrap_or("unknown");
+    output.push_str(&format!("- **Version:** {version}\n"));
+
+    output.push_str(&format!(
+        "- **iOS:** {}\n",
+        if rn.has_ios {
+            "detected"
+        } else {
+            "not detected"
+        }
+    ));
+    output.push_str(&format!(
+        "- **Android:** {}\n",
+        if rn.has_android {
+            "detected"
+        } else {
+            "not detected"
+        }
+    ));
+    output.push_str(&format!(
+        "- **Android New Architecture:** {}\n",
+        format_tristate(rn.android_new_arch_enabled)
+    ));
+    output.push_str(&format!(
+        "- **iOS New Architecture:** {}\n",
+        format_tristate(rn.ios_new_arch_enabled)
+    ));
+    output.push_str(&format!(
+        "- **Hermes:** {}\n",
+        format_tristate(rn.hermes_enabled)
+    ));
+    output.push_str(&format!(
+        "- **Codegen config:** {}\n\n",
+        if rn.has_codegen_config {
+            "found"
+        } else {
+            "missing"
+        }
+    ));
+}
+
+fn format_tristate(value: Option<bool>) -> &'static str {
+    match value {
+        Some(true) => "enabled",
+        Some(false) => "disabled",
+        None => "unknown",
+    }
 }
 
 fn render_frameworks_section(output: &mut String, frameworks: &[DetectedFramework]) {

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -138,6 +138,7 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
             skipped_bytes: report.summary.skipped_bytes,
             languages: report.summary.languages.clone(),
             detected_frameworks: report.summary.detected_frameworks.clone(),
+            react_native: report.summary.react_native.clone(),
             findings: report.in_diff_findings().into_iter().cloned().collect(),
             coupling_graph: report.summary.coupling_graph.clone(),
         },

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -4,7 +4,7 @@ use crate::audits::pipeline::{build_file_audits, run_framework_audits, run_proje
 use crate::audits::traits::FileAudit;
 use crate::baseline::key::stable_finding_key;
 use crate::findings::types::Finding;
-use crate::frameworks::detect_frameworks;
+use crate::frameworks::{DetectedFramework, detect_frameworks, detect_react_native_architecture};
 use crate::graph::imports::extract_imports;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::{FileFacts, ScanFacts};
@@ -27,6 +27,21 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
 
     facts.detected_frameworks = detect_frameworks(&facts.root_path);
 
+    let react_native_profile = if facts
+        .detected_frameworks
+        .iter()
+        .any(|f| matches!(f, DetectedFramework::ReactNative { .. }))
+    {
+        let profile = detect_react_native_architecture(&facts.root_path);
+        if profile.detected {
+            Some(profile)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     findings.extend(run_project_audits(&facts, config));
     findings.extend(run_framework_audits(&facts, config));
     let (coupling_findings, coupling_graph) =
@@ -46,6 +61,7 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
         skipped_bytes: facts.skipped_bytes,
         languages: facts.languages,
         detected_frameworks: facts.detected_frameworks,
+        react_native: react_native_profile,
         findings,
         coupling_graph: Some(coupling_graph),
     })

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -1,5 +1,6 @@
 use crate::findings::types::Finding;
 use crate::frameworks::DetectedFramework;
+use crate::frameworks::ReactNativeArchitectureProfile;
 use crate::graph::CouplingGraph;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -33,6 +34,8 @@ pub struct ScanSummary {
     pub findings: Vec<Finding>,
     #[serde(default)]
     pub detected_frameworks: Vec<DetectedFramework>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub react_native: Option<ReactNativeArchitectureProfile>,
     #[serde(default)]
     pub coupling_graph: Option<CouplingGraph>,
 }

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -72,6 +72,7 @@ fn summary(findings: Vec<Finding>) -> ScanSummary {
         languages: vec![],
         findings,
         detected_frameworks: vec![],
+        react_native: None,
         coupling_graph: None,
     }
 }

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -28,6 +28,7 @@ fn html_output_escapes_snippets_and_renders_summary() {
                 snippet: "API_KEY = \"abc<123>\"".to_string(),
             }],
         }],
+        react_native: None,
         coupling_graph: None,
     };
 

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -1,3 +1,4 @@
+use repopilot::frameworks::ReactNativeArchitectureProfile;
 use repopilot::output::{OutputFormat, render_scan_summary};
 use repopilot::scan::types::{LanguageSummary, ScanSummary};
 use std::path::PathBuf;
@@ -17,6 +18,7 @@ fn renders_valid_json_scan_summary() {
         }],
         findings: vec![],
         detected_frameworks: vec![],
+        react_native: None,
         coupling_graph: None,
     };
 
@@ -31,4 +33,44 @@ fn renders_valid_json_scan_summary() {
     assert_eq!(parsed["directories_count"], 0);
     assert_eq!(parsed["lines_of_code"], 3);
     assert_eq!(parsed["languages"][0]["name"], "Rust");
+    // react_native must be absent when None
+    assert!(parsed.get("react_native").is_none());
+}
+
+#[test]
+fn react_native_profile_appears_in_json_when_present() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("rn-app"),
+        react_native: Some(ReactNativeArchitectureProfile {
+            detected: true,
+            react_native_version: Some("0.73.0".to_string()),
+            has_ios: true,
+            has_android: true,
+            has_metro_config: true,
+            has_react_native_config: false,
+            has_codegen_config: true,
+            android_new_arch_enabled: Some(true),
+            ios_new_arch_enabled: None,
+            hermes_enabled: Some(true),
+            android_gradle_properties_found: true,
+            ios_podfile_found: false,
+        }),
+        ..ScanSummary::default()
+    };
+
+    let output =
+        render_scan_summary(&summary, OutputFormat::Json).expect("failed to render json summary");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("output should be valid json");
+
+    let rn = &parsed["react_native"];
+    assert_eq!(rn["detected"], true);
+    assert_eq!(rn["react_native_version"], "0.73.0");
+    assert_eq!(rn["has_ios"], true);
+    assert_eq!(rn["has_android"], true);
+    assert_eq!(rn["android_new_arch_enabled"], true);
+    assert!(rn["ios_new_arch_enabled"].is_null());
+    assert_eq!(rn["hermes_enabled"], true);
+    assert_eq!(rn["has_codegen_config"], true);
 }

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -1,4 +1,5 @@
 use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use repopilot::frameworks::ReactNativeArchitectureProfile;
 use repopilot::output::{OutputFormat, render_scan_summary};
 use repopilot::scan::types::{LanguageSummary, ScanSummary};
 use std::path::PathBuf;
@@ -38,6 +39,7 @@ fn renders_markdown_scan_summary() {
             }],
         }],
         detected_frameworks: vec![],
+        react_native: None,
         coupling_graph: None,
     };
 
@@ -69,6 +71,7 @@ fn renders_empty_markdown_sections() {
         languages: vec![],
         findings: vec![],
         detected_frameworks: vec![],
+        react_native: None,
         coupling_graph: None,
     };
 
@@ -78,4 +81,62 @@ fn renders_empty_markdown_sections() {
     assert!(output.contains("No languages detected."));
     assert!(output.contains("No findings found."));
     assert!(output.contains("No TODO/FIXME/HACK markers found."));
+    // Non-RN project must not render the React Native architecture section
+    assert!(!output.contains("### React Native"));
+}
+
+#[test]
+fn renders_react_native_architecture_section_when_profile_present() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("rn-project"),
+        files_count: 5,
+        directories_count: 2,
+        lines_of_code: 100,
+        skipped_files_count: 0,
+        skipped_bytes: 0,
+        languages: vec![],
+        findings: vec![],
+        detected_frameworks: vec![],
+        react_native: Some(ReactNativeArchitectureProfile {
+            detected: true,
+            react_native_version: Some("0.73.0".to_string()),
+            has_ios: true,
+            has_android: true,
+            has_metro_config: false,
+            has_react_native_config: false,
+            has_codegen_config: false,
+            android_new_arch_enabled: Some(false),
+            ios_new_arch_enabled: None,
+            hermes_enabled: Some(true),
+            android_gradle_properties_found: true,
+            ios_podfile_found: false,
+        }),
+        coupling_graph: None,
+    };
+
+    let output = render_scan_summary(&summary, OutputFormat::Markdown)
+        .expect("failed to render markdown summary");
+
+    assert!(output.contains("### React Native"));
+    assert!(output.contains("0.73.0"));
+    assert!(output.contains("**iOS:** detected"));
+    assert!(output.contains("**Android:** detected"));
+    assert!(output.contains("**Android New Architecture:** disabled"));
+    assert!(output.contains("**iOS New Architecture:** unknown"));
+    assert!(output.contains("**Hermes:** enabled"));
+    assert!(output.contains("**Codegen config:** missing"));
+}
+
+#[test]
+fn react_native_section_absent_when_profile_is_none() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("web-project"),
+        react_native: None,
+        ..ScanSummary::default()
+    };
+
+    let output = render_scan_summary(&summary, OutputFormat::Markdown)
+        .expect("failed to render markdown summary");
+
+    assert!(!output.contains("### React Native"));
 }


### PR DESCRIPTION
## Summary

Adds deeper React Native architecture detection and reporting for RepoPilot v0.6.

This PR expands the framework-aware audit direction by introducing React Native architecture signals into scan output. RepoPilot can now detect and report common React Native project details such as iOS/Android presence, Metro config, React Native config, Codegen config, Hermes signals, and New Architecture signals from Android and iOS project files.

## Type of change

- Feature
- Refactor
- Tests
- Documentation

## What changed

- Added React Native architecture/profile detection.
- Detects React Native version from `package.json`.
- Detects iOS and Android project folders.
- Detects Metro config presence.
- Detects `react-native.config.js` / related config presence.
- Detects `codegenConfig` from `package.json`.
- Detects Android New Architecture signals from `android/gradle.properties`.
- Detects iOS New Architecture signals from `ios/Podfile`.
- Detects Hermes configuration signals where available.
- Extends scan/report output with React Native architecture data.
- Adds tests for React Native architecture detection and safe fallback behavior.

## Why

RepoPilot v0.6 is focused on repository intelligence and framework-aware analysis.

React Native projects have important architecture-specific risks that generic code scans cannot see. Before emitting deeper React Native findings, RepoPilot needs a reliable profile of the project’s native/runtime configuration.

This PR adds that foundation by collecting React Native architecture facts without requiring a build step, native compilation, or external services.

## Architecture notes

- React Native detection is kept separate from generic scan logic.
- Detection uses lightweight file existence and text heuristics.
- Missing native files are handled safely.
- Malformed `package.json` should not panic the scan.
- Existing JavaScript, React, React Native, and generic audits are preserved.
- This PR focuses on detection/reporting, not a full React Native risk catalog yet.

## Changelog

- Added React Native architecture profile detection.
- Added Android/iOS New Architecture signal detection.
- Added Hermes signal detection.
- Added Codegen config detection.
- Added React Native architecture data to reports.
- Added tests for React Native architecture profile behavior.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .