### PR TITLE
feat(workspaces): add workspace-aware scanning foundation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,3 +153,66 @@ jobs:
       - name: Publish to npm
         if: ${{ env.NODE_AUTH_TOKEN != '' }}
         run: npm publish
+
+  publish-crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs:
+      - release
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish
+        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+
+  update-homebrew-tap:
+    name: Update Homebrew tap
+    runs-on: ubuntu-latest
+    needs:
+      - release
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: dist
+          merge-multiple: true
+
+      - name: Extract checksums
+        run: |
+          V="${{ github.ref_name }}"
+          echo "MACOS_ARM=$(awk '{print $1}' dist/repopilot-${V}-aarch64-apple-darwin.tar.gz.sha256)" >> $GITHUB_ENV
+          echo "MACOS_X86=$(awk '{print $1}' dist/repopilot-${V}-x86_64-apple-darwin.tar.gz.sha256)" >> $GITHUB_ENV
+          echo "LINUX_ARM=$(awk '{print $1}' dist/repopilot-${V}-aarch64-unknown-linux-gnu.tar.gz.sha256)" >> $GITHUB_ENV
+          echo "LINUX_X86=$(awk '{print $1}' dist/repopilot-${V}-x86_64-unknown-linux-gnu.tar.gz.sha256)" >> $GITHUB_ENV
+          echo "VER=${V#v}" >> $GITHUB_ENV
+
+      - name: Checkout homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: MykytaStel/homebrew-repopilot
+          path: tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Write formula
+        run: |
+          sed -e "s/{{VERSION}}/${{ env.VER }}/g" \
+              -e "s/{{MACOS_ARM_SHA}}/${{ env.MACOS_ARM }}/g" \
+              -e "s/{{MACOS_X86_SHA}}/${{ env.MACOS_X86 }}/g" \
+              -e "s/{{LINUX_ARM_SHA}}/${{ env.LINUX_ARM }}/g" \
+              -e "s/{{LINUX_X86_SHA}}/${{ env.LINUX_X86 }}/g" \
+              Formula/repopilot.rb > tap/Formula/repopilot.rb
+
+      - name: Push formula update
+        working-directory: tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/repopilot.rb
+          git diff --cached --quiet || git commit -m "repopilot ${{ env.VER }}"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,19 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-08
+
 ### Added
 
-- Planned AI-ready review context export.
-- Planned Change Risk Map.
+- Added per-workspace scans: `--workspace` flag on `scan` command detects npm, yarn, pnpm, and Cargo workspace packages and runs audits scoped to each package root.
+- Added React Native dependency health audits: `framework.rn-navigation-compat`, `framework.rn-async-storage-legacy`, `framework.rn-reanimated-compat`, `framework.rn-gesture-handler-old`, and `framework.rn-new-arch-incompatible-dep`.
+- Added first-party GitHub Action (`action.yml`) for running RepoPilot audits in CI with optional SARIF upload to GitHub Code Scanning.
+- Automated crates.io publishing in the release workflow via `CRATES_IO_TOKEN` secret.
+- Automated Homebrew tap formula updates in the release workflow via `HOMEBREW_TAP_TOKEN` secret.
+
+### Changed
+
+- Version 0.6.0 was published to npm without a matching git tag; v0.7.0 is the first fully tagged release since v0.5.0 and restores version consistency across crates.io, npm, and GitHub Releases.
 
 ## [0.6.0] - 2026-05-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repopilot"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Local-first CLI for repository audit, architecture risk detection, baseline tracking, and CI-friendly code review."

--- a/Formula/repopilot.rb
+++ b/Formula/repopilot.rb
@@ -1,39 +1,41 @@
-# Homebrew formula template for repopilot.
+# Template used by the release workflow to auto-update the Homebrew tap.
+# {{VERSION}}, {{MACOS_ARM_SHA}}, {{MACOS_X86_SHA}}, {{LINUX_ARM_SHA}},
+# {{LINUX_X86_SHA}} are replaced by the update-homebrew-tap CI job.
 #
-# To publish via Homebrew tap:
-#   1. Create a new GitHub repo: MykytaStel/homebrew-repopilot
-#   2. Copy this file to Formula/repopilot.rb in that repo
-#   3. Replace each PLACEHOLDER_SHA256 with the real sha256 from the GitHub release
-#      (found in repopilot-checksums.txt attached to the release)
-#   4. Users can then install with:
-#        brew tap mykytastel/repopilot
-#        brew install repopilot
+# Manual setup (one-time):
+#   1. Create repo MykytaStel/homebrew-repopilot with a Formula/ directory.
+#   2. Add HOMEBREW_TAP_TOKEN (PAT with repo write scope) to the main repo secrets.
+#   After that, every v* tag triggers an automatic formula update.
+#
+# Manual install:
+#   brew tap mykytastel/repopilot
+#   brew install repopilot
 
 class Repopilot < Formula
   desc "Local-first CLI for repository audit and architecture risk detection"
   homepage "https://github.com/MykytaStel/repopilot"
-  version "0.4.0"
+  version "{{VERSION}}"
   license "MIT OR Apache-2.0"
 
   on_macos do
     on_arm do
       url "https://github.com/MykytaStel/repopilot/releases/download/v#{version}/repopilot-v#{version}-aarch64-apple-darwin.tar.gz"
-      sha256 "PLACEHOLDER_SHA256"
+      sha256 "{{MACOS_ARM_SHA}}"
     end
     on_intel do
       url "https://github.com/MykytaStel/repopilot/releases/download/v#{version}/repopilot-v#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "PLACEHOLDER_SHA256"
+      sha256 "{{MACOS_X86_SHA}}"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/MykytaStel/repopilot/releases/download/v#{version}/repopilot-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "PLACEHOLDER_SHA256"
+      sha256 "{{LINUX_ARM_SHA}}"
     end
     on_intel do
       url "https://github.com/MykytaStel/repopilot/releases/download/v#{version}/repopilot-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "PLACEHOLDER_SHA256"
+      sha256 "{{LINUX_X86_SHA}}"
     end
   end
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,59 @@
+name: RepoPilot
+description: "Run RepoPilot static analysis on your repository"
+author: "MykytaStel"
+
+branding:
+  icon: shield
+  color: blue
+
+inputs:
+  command:
+    description: "Command to run: scan | review | compare"
+    required: false
+    default: "scan"
+  format:
+    description: "Output format: console | json | markdown | sarif"
+    required: false
+    default: "sarif"
+  args:
+    description: "Extra CLI arguments passed verbatim to repopilot"
+    required: false
+    default: ""
+  version:
+    description: "npm version tag to install (e.g. latest, 0.7.0)"
+    required: false
+    default: "latest"
+  upload-sarif:
+    description: "Automatically upload SARIF output to GitHub Code Scanning"
+    required: false
+    default: "true"
+
+outputs:
+  sarif-file:
+    description: "Path to the generated SARIF file (only set when format is sarif)"
+    value: ${{ steps.run.outputs.sarif_file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install repopilot
+      shell: bash
+      run: npm install -g repopilot@${{ inputs.version }}
+
+    - name: Run repopilot
+      id: run
+      shell: bash
+      run: |
+        OUTFILE="repopilot-results.sarif"
+        if [[ "${{ inputs.format }}" == "sarif" ]]; then
+          repopilot ${{ inputs.command }} --format sarif --output "$OUTFILE" ${{ inputs.args }}
+          echo "sarif_file=$OUTFILE" >> $GITHUB_OUTPUT
+        else
+          repopilot ${{ inputs.command }} --format ${{ inputs.format }} ${{ inputs.args }}
+        fi
+
+    - name: Upload SARIF to GitHub Code Scanning
+      if: inputs.upload-sarif == 'true' && inputs.format == 'sarif'
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ steps.run.outputs.sarif_file }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repopilot",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Local-first CLI for repository audit, architecture risk detection, baseline tracking, and CI-friendly code review.",
   "license": "MIT OR Apache-2.0",
   "repository": {

--- a/src/audits/architecture/deep_nesting.rs
+++ b/src/audits/architecture/deep_nesting.rs
@@ -46,5 +46,6 @@ fn build_finding(deepest_path: PathBuf, depth: usize, threshold: usize) -> Findi
             line_end: None,
             snippet: format!("Nesting depth: {depth}; threshold is {threshold}."),
         }],
+        workspace_package: None,
     }
 }

--- a/src/audits/architecture/import_coupling.rs
+++ b/src/audits/architecture/import_coupling.rs
@@ -82,6 +82,7 @@ fn excessive_fan_out_finding(metric: &FileMetrics, root: &Path, threshold: usize
                 metric.fan_out
             ),
         }],
+        workspace_package: None,
     }
 }
 
@@ -116,6 +117,7 @@ fn high_instability_hub_finding(
                 instability_pct
             ),
         }],
+        workspace_package: None,
     }
 }
 
@@ -147,6 +149,7 @@ fn circular_dependency_finding(cycle: &[PathBuf], root: &Path) -> Finding {
             line_end: None,
             snippet: format!("Cycle ({file_count} files): {cycle_path}."),
         }],
+        workspace_package: None,
     }
 }
 

--- a/src/audits/architecture/large_file.rs
+++ b/src/audits/architecture/large_file.rs
@@ -42,6 +42,7 @@ pub fn detect_large_file_finding(
                 config.large_file_loc_threshold
             ),
         }],
+        workspace_package: None,
     })
 }
 

--- a/src/audits/architecture/too_many_modules.rs
+++ b/src/audits/architecture/too_many_modules.rs
@@ -41,5 +41,6 @@ fn build_finding(dir: PathBuf, file_count: usize, threshold: usize) -> Finding {
             line_end: None,
             snippet: format!("{file_count} files in directory; threshold is {threshold}."),
         }],
+        workspace_package: None,
     }
 }

--- a/src/audits/code_quality/code_markers.rs
+++ b/src/audits/code_quality/code_markers.rs
@@ -50,6 +50,7 @@ fn build_marker_finding(marker: &Marker) -> Finding {
             line_end: None,
             snippet: marker.text.trim().to_string(),
         }],
+        workspace_package: None,
     }
 }
 

--- a/src/audits/code_quality/complexity.rs
+++ b/src/audits/code_quality/complexity.rs
@@ -50,6 +50,7 @@ impl FileAudit for ComplexityAudit {
                     file.branch_count, file.lines_of_code
                 ),
             }],
+            workspace_package: None,
         }]
     }
 }

--- a/src/audits/code_quality/long_function.rs
+++ b/src/audits/code_quality/long_function.rs
@@ -304,5 +304,6 @@ fn build_finding(
             line_end: Some(end_line),
             snippet: format!("function spans lines {start_line}–{end_line} ({fn_len} lines)"),
         }],
+        workspace_package: None,
     }
 }

--- a/src/audits/framework/js_common.rs
+++ b/src/audits/framework/js_common.rs
@@ -58,6 +58,7 @@ impl ProjectAudit for VarDeclarationAudit {
                             line_end: None,
                             snippet: trimmed.to_string(),
                         }],
+                        workspace_package: None,
                     });
                     break;
                 }
@@ -112,6 +113,7 @@ impl ProjectAudit for ConsoleLogAudit {
                             line_end: None,
                             snippet: trimmed.to_string(),
                         }],
+                        workspace_package: None,
                     });
                     break;
                 }

--- a/src/audits/framework/mod.rs
+++ b/src/audits/framework/mod.rs
@@ -1,3 +1,4 @@
 pub mod js_common;
 pub mod react;
 pub mod react_native;
+pub mod rn_dep_health;

--- a/src/audits/framework/react.rs
+++ b/src/audits/framework/react.rs
@@ -50,6 +50,7 @@ impl ProjectAudit for ReactClassComponentAudit {
                             line_end: None,
                             snippet: trimmed.to_string(),
                         }],
+                        workspace_package: None,
                     });
                     break; // one finding per file
                 }
@@ -108,6 +109,7 @@ impl ProjectAudit for ReactPropTypesAudit {
                             line_end: None,
                             snippet: trimmed.to_string(),
                         }],
+                        workspace_package: None,
                     });
                     break; // one finding per file
                 }

--- a/src/audits/framework/react_native.rs
+++ b/src/audits/framework/react_native.rs
@@ -40,6 +40,7 @@ impl ProjectAudit for ReactNativeOldArchAudit {
                 line_end: None,
                 snippet,
             }],
+            workspace_package: None,
         }]
     }
 }
@@ -136,6 +137,7 @@ impl ProjectAudit for ReactNativeArchitectureMismatchAudit {
                     format_bool(profile.expo_new_arch_enabled)
                 ),
             }],
+            workspace_package: None,
         }]
     }
 }
@@ -174,6 +176,7 @@ impl ProjectAudit for HermesMismatchAudit {
                     format_bool(profile.ios_hermes_enabled)
                 ),
             }],
+            workspace_package: None,
         }]
     }
 }
@@ -229,6 +232,7 @@ impl ProjectAudit for AsyncStorageFromCoreAudit {
                             .trim()
                             .to_string(),
                     }],
+                    workspace_package: None,
                 });
             }
         }
@@ -366,6 +370,7 @@ impl ProjectAudit for ReactNativeCodegenMissingAudit {
                 line_end: None,
                 snippet: "codegenConfig missing while Codegen usage was detected".to_string(),
             }],
+            workspace_package: None,
         }]
     }
 }
@@ -429,6 +434,7 @@ fn hermes_finding(path: PathBuf, snippet: &str) -> Finding {
             line_end: None,
             snippet: snippet.to_string(),
         }],
+        workspace_package: None,
     }
 }
 
@@ -482,6 +488,7 @@ impl ProjectAudit for ReactNavigationV4Audit {
                             line_end: None,
                             snippet: trimmed.to_string(),
                         }],
+                        workspace_package: None,
                     });
                     break;
                 }
@@ -538,6 +545,7 @@ impl ProjectAudit for DirectStateMutationAudit {
                             line_end: None,
                             snippet: trimmed.to_string(),
                         }],
+                        workspace_package: None,
                     });
                     break;
                 }

--- a/src/audits/framework/rn_dep_health.rs
+++ b/src/audits/framework/rn_dep_health.rs
@@ -1,0 +1,237 @@
+use crate::audits::traits::ProjectAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::ScanFacts;
+
+pub struct RnDepHealthAudit;
+
+impl ProjectAudit for RnDepHealthAudit {
+    fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let deps = match read_all_deps(&facts.root_path) {
+            Some(d) => d,
+            None => return vec![],
+        };
+
+        let rn_ver = deps
+            .get("react-native")
+            .and_then(|v| v.as_str())
+            .and_then(parse_version);
+
+        let mut findings = Vec::new();
+
+        // 1. @react-native-community/async-storage (legacy, unmaintained)
+        if deps.contains_key("@react-native-community/async-storage") {
+            findings.push(Finding {
+                id: String::new(),
+                rule_id: "framework.rn-async-storage-legacy".to_string(),
+                title: "Deprecated async-storage package in use".to_string(),
+                description: concat!(
+                    "`@react-native-community/async-storage` is unmaintained. ",
+                    "Migrate to `@react-native-async-storage/async-storage` which is the actively maintained fork. ",
+                    "Run: `npm remove @react-native-community/async-storage && npm install @react-native-async-storage/async-storage`"
+                ).to_string(),
+                category: FindingCategory::Framework,
+                severity: Severity::Medium,
+                evidence: vec![Evidence {
+                    path: facts.root_path.join("package.json"),
+                    line_start: 1,
+                    line_end: None,
+                    snippet: "@react-native-community/async-storage is deprecated".to_string(),
+                }],
+                workspace_package: None,
+            });
+        }
+
+        // 2. @react-navigation/native v4/v5 with RN >= 0.73 (needs v6+)
+        let nav_ver = deps
+            .get("@react-navigation/native")
+            .and_then(|v| v.as_str())
+            .and_then(parse_version);
+        if let Some(nav_ver) = nav_ver {
+            if nav_ver.0 < 6 && rn_ver.map(|rn| rn >= (0, 73, 0)).unwrap_or(false) {
+                findings.push(Finding {
+                    id: String::new(),
+                    rule_id: "framework.rn-navigation-compat".to_string(),
+                    title: "React Navigation version is incompatible with this React Native version"
+                        .to_string(),
+                    description: format!(
+                        "`@react-navigation/native` v{}.x is not compatible with `react-native` ≥0.73. \
+                         Upgrade to v6 or later: `npm install @react-navigation/native@latest`",
+                        nav_ver.0
+                    ),
+                    category: FindingCategory::Framework,
+                    severity: Severity::High,
+                    evidence: vec![Evidence {
+                        path: facts.root_path.join("package.json"),
+                        line_start: 1,
+                        line_end: None,
+                        snippet: format!(
+                            "@react-navigation/native: v{}.{}.{} — upgrade to v6+",
+                            nav_ver.0, nav_ver.1, nav_ver.2
+                        ),
+                    }],
+                    workspace_package: None,
+                });
+            }
+        }
+
+        // 3. react-native-reanimated <3 with RN >= 0.73
+        let rea_ver = deps
+            .get("react-native-reanimated")
+            .and_then(|v| v.as_str())
+            .and_then(parse_version);
+        if let Some(rea_ver) = rea_ver {
+            if rea_ver.0 < 3 && rn_ver.map(|rn| rn >= (0, 73, 0)).unwrap_or(false) {
+                findings.push(Finding {
+                    id: String::new(),
+                    rule_id: "framework.rn-reanimated-compat".to_string(),
+                    title:
+                        "react-native-reanimated version is incompatible with this React Native version"
+                            .to_string(),
+                    description: format!(
+                        "`react-native-reanimated` v{}.x requires React Native <0.73. \
+                         Upgrade to v3+: `npm install react-native-reanimated@latest`",
+                        rea_ver.0
+                    ),
+                    category: FindingCategory::Framework,
+                    severity: Severity::High,
+                    evidence: vec![Evidence {
+                        path: facts.root_path.join("package.json"),
+                        line_start: 1,
+                        line_end: None,
+                        snippet: format!(
+                            "react-native-reanimated: v{}.{}.{} — upgrade to v3+",
+                            rea_ver.0, rea_ver.1, rea_ver.2
+                        ),
+                    }],
+                    workspace_package: None,
+                });
+            }
+        }
+
+        // 4. react-native-gesture-handler <2 with RN >= 0.72
+        let gh_ver = deps
+            .get("react-native-gesture-handler")
+            .and_then(|v| v.as_str())
+            .and_then(parse_version);
+        if let Some(gh_ver) = gh_ver {
+            if gh_ver.0 < 2 && rn_ver.map(|rn| rn >= (0, 72, 0)).unwrap_or(false) {
+                findings.push(Finding {
+                    id: String::new(),
+                    rule_id: "framework.rn-gesture-handler-old".to_string(),
+                    title: "react-native-gesture-handler v1 is incompatible with this React Native version"
+                        .to_string(),
+                    description: format!(
+                        "`react-native-gesture-handler` v{}.x does not support React Native ≥0.72. \
+                         Upgrade to v2+: `npm install react-native-gesture-handler@latest`",
+                        gh_ver.0
+                    ),
+                    category: FindingCategory::Framework,
+                    severity: Severity::High,
+                    evidence: vec![Evidence {
+                        path: facts.root_path.join("package.json"),
+                        line_start: 1,
+                        line_end: None,
+                        snippet: format!(
+                            "react-native-gesture-handler: v{}.{}.{} — upgrade to v2+",
+                            gh_ver.0, gh_ver.1, gh_ver.2
+                        ),
+                    }],
+                    workspace_package: None,
+                });
+            }
+        }
+
+        // 5. Known New Architecture incompatible packages (when RN >= 0.71)
+        if rn_ver.map(|rn| rn >= (0, 71, 0)).unwrap_or(false) {
+            for pkg in NEW_ARCH_INCOMPATIBLE {
+                if deps.contains_key(*pkg) {
+                    findings.push(Finding {
+                        id: String::new(),
+                        rule_id: "framework.rn-new-arch-incompatible-dep".to_string(),
+                        title: format!("`{pkg}` does not support React Native New Architecture"),
+                        description: format!(
+                            "`{pkg}` has no New Architecture support. \
+                             Check the library's GitHub issues for a migration path or switch to an alternative."
+                        ),
+                        category: FindingCategory::Framework,
+                        severity: Severity::Medium,
+                        evidence: vec![Evidence {
+                            path: facts.root_path.join("package.json"),
+                            line_start: 1,
+                            line_end: None,
+                            snippet: format!("{pkg} lacks New Architecture support"),
+                        }],
+                        workspace_package: None,
+                    });
+                }
+            }
+        }
+
+        findings
+    }
+}
+
+/// Packages known to lack React Native New Architecture (Fabric/TurboModules) support.
+const NEW_ARCH_INCOMPATIBLE: &[&str] = &[
+    "react-native-camera",
+    "react-native-firebase",
+    "react-native-linear-gradient",
+    "react-native-maps",
+    "react-native-svg",
+    "react-native-video",
+    "rn-fetch-blob",
+    "@react-native-community/cameraroll",
+    "@react-native-community/netinfo",
+    "react-native-share",
+    "react-native-splash-screen",
+];
+
+fn read_all_deps(root: &std::path::Path) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let content = std::fs::read_to_string(root.join("package.json")).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let mut merged = serde_json::Map::new();
+    for key in ["dependencies", "devDependencies"] {
+        if let Some(obj) = value.get(key).and_then(|v| v.as_object()) {
+            for (k, v) in obj {
+                merged.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+        }
+    }
+    if merged.is_empty() { None } else { Some(merged) }
+}
+
+/// Parse a semver-like version string into (major, minor, patch).
+/// Strips leading `^`, `~`, `>=`, `>`, `=`.
+fn parse_version(s: &str) -> Option<(u64, u64, u64)> {
+    let s = s
+        .trim()
+        .trim_start_matches(['^', '~', '=', '>', '<'])
+        .trim();
+    let parts: Vec<&str> = s.splitn(4, '.').collect();
+    let major = parts.first()?.parse::<u64>().ok()?;
+    let minor = parts.get(1).unwrap_or(&"0").parse::<u64>().ok().unwrap_or(0);
+    let patch = parts
+        .get(2)
+        .map(|p| p.split('-').next().unwrap_or("0"))
+        .unwrap_or("0")
+        .parse::<u64>()
+        .ok()
+        .unwrap_or(0);
+    Some((major, minor, patch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_semver_variations() {
+        assert_eq!(parse_version("^0.74.0"), Some((0, 74, 0)));
+        assert_eq!(parse_version("~3.0.0"), Some((3, 0, 0)));
+        assert_eq!(parse_version("2.0.0-rc.1"), Some((2, 0, 0)));
+        assert_eq!(parse_version("1"), Some((1, 0, 0)));
+        assert_eq!(parse_version(">=0.73.0"), Some((0, 73, 0)));
+        assert_eq!(parse_version("not-a-version"), None);
+    }
+}

--- a/src/audits/framework/rn_dep_health.rs
+++ b/src/audits/framework/rn_dep_health.rs
@@ -198,7 +198,11 @@ fn read_all_deps(root: &std::path::Path) -> Option<serde_json::Map<String, serde
             }
         }
     }
-    if merged.is_empty() { None } else { Some(merged) }
+    if merged.is_empty() {
+        None
+    } else {
+        Some(merged)
+    }
 }
 
 /// Parse a semver-like version string into (major, minor, patch).
@@ -210,7 +214,12 @@ fn parse_version(s: &str) -> Option<(u64, u64, u64)> {
         .trim();
     let parts: Vec<&str> = s.splitn(4, '.').collect();
     let major = parts.first()?.parse::<u64>().ok()?;
-    let minor = parts.get(1).unwrap_or(&"0").parse::<u64>().ok().unwrap_or(0);
+    let minor = parts
+        .get(1)
+        .unwrap_or(&"0")
+        .parse::<u64>()
+        .ok()
+        .unwrap_or(0);
     let patch = parts
         .get(2)
         .map(|p| p.split('-').next().unwrap_or("0"))

--- a/src/audits/pipeline.rs
+++ b/src/audits/pipeline.rs
@@ -11,6 +11,7 @@ use crate::audits::framework::react_native::{
     ReactNativeArchitectureMismatchAudit, ReactNativeCodegenMissingAudit, ReactNativeOldArchAudit,
     ReactNavigationV4Audit,
 };
+use crate::audits::framework::rn_dep_health::RnDepHealthAudit;
 use crate::audits::security::env_file_committed::EnvFileCommittedAudit;
 use crate::audits::security::private_key_candidate::PrivateKeyCandidateAudit;
 use crate::audits::security::secret_candidate::SecretCandidateAudit;
@@ -113,6 +114,7 @@ pub fn run_framework_audits(facts: &ScanFacts, config: &ScanConfig) -> Vec<Findi
         findings.extend(ReactNativeCodegenMissingAudit.audit(facts, config));
         findings.extend(ReactNavigationV4Audit.audit(facts, config));
         findings.extend(DirectStateMutationAudit.audit(facts, config));
+        findings.extend(RnDepHealthAudit.audit(facts, config));
     }
     if has_react_only {
         findings.extend(ReactClassComponentAudit.audit(facts, config));

--- a/src/audits/security/env_file_committed.rs
+++ b/src/audits/security/env_file_committed.rs
@@ -48,5 +48,6 @@ fn build_finding(path: &std::path::Path) -> Finding {
             line_end: None,
             snippet: format!("`{name}` should not be committed; add it to .gitignore."),
         }],
+        workspace_package: None,
     }
 }

--- a/src/audits/security/private_key_candidate.rs
+++ b/src/audits/security/private_key_candidate.rs
@@ -72,5 +72,6 @@ fn build_finding(path: &std::path::Path, line_number: usize, header: &str) -> Fi
             // Show only the header line — never the actual key bytes
             snippet: header.to_string(),
         }],
+        workspace_package: None,
     }
 }

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -112,6 +112,7 @@ fn build_finding(
             line_end: None,
             snippet,
         }],
+        workspace_package: None,
     }
 }
 

--- a/src/audits/testing/missing_test_folder.rs
+++ b/src/audits/testing/missing_test_folder.rs
@@ -36,6 +36,7 @@ impl ProjectAudit for MissingTestFolderAudit {
                 line_end: None,
                 snippet: "No tests/, test/, __tests__/, or spec/ directory found.".to_string(),
             }],
+            workspace_package: None,
         }]
     }
 }

--- a/src/audits/testing/source_without_test.rs
+++ b/src/audits/testing/source_without_test.rs
@@ -190,5 +190,6 @@ fn build_finding(source: &Path) -> Finding {
             line_end: None,
             snippet: format!("No test found; expected e.g. `{expected}`"),
         }],
+        workspace_package: None,
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -141,6 +141,10 @@ repopilot scan . --max-file-loc 500 --max-directory-modules 30"
         /// Maximum directory nesting depth before flagging (default: 5)
         #[arg(long)]
         max_directory_depth: Option<usize>,
+
+        /// Scan each workspace package separately and group findings by package
+        #[arg(long, short = 'w')]
+        workspace: bool,
     },
 
     /// Review findings that touch changed Git diff lines (alias: r)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             max_file_loc,
             max_directory_modules,
             max_directory_depth,
+            workspace,
         } => scan::run(
             path,
             format,
@@ -31,6 +32,7 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             max_file_loc,
             max_directory_modules,
             max_directory_depth,
+            workspace,
         ),
 
         Commands::Review {

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -7,6 +7,7 @@ use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::output::{render_baseline_scan_report, render_scan_summary};
 use repopilot::report::writer::write_report;
 use repopilot::scan::scanner::scan_path_with_config;
+use repopilot::scan::workspace::detect_workspace_packages;
 use std::path::PathBuf;
 
 #[allow(clippy::too_many_arguments)]
@@ -20,6 +21,7 @@ pub fn run(
     max_file_loc: Option<usize>,
     max_directory_modules: Option<usize>,
     max_directory_depth: Option<usize>,
+    workspace: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let repo_config = match config {
         Some(config_path) => load_optional_config(&config_path)?,
@@ -34,7 +36,40 @@ pub fn run(
     let output_format = format
         .map(Into::into)
         .unwrap_or(repo_config.output.default_format);
-    let summary = scan_path_with_config(&path, &scan_config)?;
+
+    let summary = if workspace {
+        let packages = detect_workspace_packages(&path);
+        if packages.is_empty() {
+            eprintln!(
+                "Warning: --workspace specified but no workspace packages found under {}. \
+                 Falling back to single-package scan.",
+                path.display()
+            );
+            scan_path_with_config(&path, &scan_config)?
+        } else {
+            let mut merged = scan_path_with_config(&path, &scan_config)?;
+            for pkg in &packages {
+                match scan_path_with_config(&pkg.root, &scan_config) {
+                    Ok(mut pkg_summary) => {
+                        for finding in &mut pkg_summary.findings {
+                            finding.workspace_package = Some(pkg.name.clone());
+                        }
+                        merged.findings.extend(pkg_summary.findings);
+                        merged.files_count += pkg_summary.files_count;
+                        merged.directories_count += pkg_summary.directories_count;
+                        merged.lines_of_code += pkg_summary.lines_of_code;
+                    }
+                    Err(err) => eprintln!(
+                        "Warning: failed to scan workspace package '{}': {err}",
+                        pkg.name
+                    ),
+                }
+            }
+            merged
+        }
+    } else {
+        scan_path_with_config(&path, &scan_config)?
+    };
 
     if baseline.is_some() || fail_on.is_some() {
         let baseline_report = match baseline {

--- a/src/findings/types.rs
+++ b/src/findings/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Finding {
     pub id: String,
     pub rule_id: String,
@@ -10,11 +10,14 @@ pub struct Finding {
     pub category: FindingCategory,
     pub severity: Severity,
     pub evidence: Vec<Evidence>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_package: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FindingCategory {
+    #[default]
     Architecture,
     CodeQuality,
     Testing,
@@ -22,9 +25,10 @@ pub enum FindingCategory {
     Framework,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Severity {
+    #[default]
     Info,
     Low,
     Medium,

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -135,16 +135,38 @@ fn render_findings_section(output: &mut String, findings: &[Finding]) {
     render_severity_summary(output, findings);
     output.push('\n');
 
+    let has_workspace = findings.iter().any(|f| f.workspace_package.is_some());
+    if has_workspace {
+        let mut groups: Vec<(Option<&str>, Vec<&Finding>)> = Vec::new();
+        for finding in findings {
+            let key = finding.workspace_package.as_deref();
+            if let Some(group) = groups.iter_mut().find(|(k, _)| *k == key) {
+                group.1.push(finding);
+            } else {
+                groups.push((key, vec![finding]));
+            }
+        }
+        for (pkg, group_findings) in &groups {
+            let header = pkg.unwrap_or("(root)");
+            output.push_str(&format!("  [{header}]\n"));
+            render_findings_list(output, group_findings, "    ");
+            output.push('\n');
+        }
+    } else {
+        render_findings_list(output, &findings.iter().collect::<Vec<_>>(), "  ");
+    }
+}
+
+fn render_findings_list(output: &mut String, findings: &[&Finding], indent: &str) {
     for finding in findings {
         let label = color::severity_label(finding.severity_label());
         output.push_str(&format!(
-            "  [{}] {} \u{2014} {}\n",
+            "{indent}[{}] {} \u{2014} {}\n",
             label, finding.rule_id, finding.title
         ));
-
         for evidence in &finding.evidence {
             output.push_str(&format!(
-                "    Evidence: {}:{} \u{2014} {}\n",
+                "{indent}  Evidence: {}:{} \u{2014} {}\n",
                 evidence.path.display(),
                 evidence.line_start,
                 evidence.snippet.trim()

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -4,3 +4,4 @@ pub mod language;
 pub mod markers;
 pub mod scanner;
 pub mod types;
+pub mod workspace;

--- a/src/scan/workspace.rs
+++ b/src/scan/workspace.rs
@@ -1,0 +1,205 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct WorkspacePackage {
+    pub name: String,
+    pub root: PathBuf,
+}
+
+/// Detect workspace packages under `root`.
+///
+/// Checks (in order): npm/yarn workspaces (`package.json`), pnpm workspaces
+/// (`pnpm-workspace.yaml`), Cargo workspace (`Cargo.toml`). Returns the first
+/// non-empty list found. Returns an empty vec when the root is not a workspace.
+pub fn detect_workspace_packages(root: &Path) -> Vec<WorkspacePackage> {
+    let npm = from_npm_workspaces(root);
+    if !npm.is_empty() {
+        return npm;
+    }
+
+    let pnpm = from_pnpm_workspaces(root);
+    if !pnpm.is_empty() {
+        return pnpm;
+    }
+
+    from_cargo_workspace(root)
+}
+
+fn from_npm_workspaces(root: &Path) -> Vec<WorkspacePackage> {
+    let content = match std::fs::read_to_string(root.join("package.json")) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    let patterns = workspace_glob_patterns(&value);
+    packages_from_patterns(root, &patterns)
+}
+
+fn from_pnpm_workspaces(root: &Path) -> Vec<WorkspacePackage> {
+    let content = match std::fs::read_to_string(root.join("pnpm-workspace.yaml")) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    let patterns = parse_pnpm_packages_yaml(&content);
+    packages_from_patterns(root, &patterns)
+}
+
+fn from_cargo_workspace(root: &Path) -> Vec<WorkspacePackage> {
+    let content = match std::fs::read_to_string(root.join("Cargo.toml")) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let value: toml::Value = match toml::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    let members = value
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    if members.is_empty() {
+        return Vec::new();
+    }
+
+    let mut packages = Vec::new();
+    for member in &members {
+        let trimmed = member.trim_end_matches('/');
+        if trimmed.contains('*') {
+            let prefix = trimmed.trim_end_matches("/*").trim_end_matches("/**");
+            let base = root.join(prefix);
+            let Ok(entries) = std::fs::read_dir(&base) else {
+                continue;
+            };
+            for entry in entries.filter_map(Result::ok) {
+                let path = entry.path();
+                if path.is_dir() && path.join("Cargo.toml").is_file() {
+                    if let Some(name) = package_name_from_path(&path) {
+                        packages.push(WorkspacePackage { name, root: path });
+                    }
+                }
+            }
+        } else {
+            let path = root.join(trimmed);
+            if path.join("Cargo.toml").is_file() {
+                if let Some(name) = package_name_from_path(&path) {
+                    packages.push(WorkspacePackage { name, root: path });
+                }
+            }
+        }
+    }
+    packages
+}
+
+fn package_name_from_path(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path.join("Cargo.toml")).ok()?;
+    let value: toml::Value = toml::from_str(&content).ok()?;
+    value
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(str::to_string)
+        .or_else(|| path.file_name().and_then(|n| n.to_str()).map(str::to_string))
+}
+
+fn workspace_glob_patterns(value: &serde_json::Value) -> Vec<String> {
+    match value.get("workspaces") {
+        Some(serde_json::Value::Array(items)) => items
+            .iter()
+            .filter_map(|i| i.as_str().map(str::to_string))
+            .collect(),
+        Some(serde_json::Value::Object(obj)) => obj
+            .get("packages")
+            .and_then(|v| v.as_array())
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|i| i.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+fn parse_pnpm_packages_yaml(content: &str) -> Vec<String> {
+    let mut patterns = Vec::new();
+    let mut in_packages = false;
+    for line in content.lines() {
+        if line.trim_start().starts_with("packages:") {
+            in_packages = true;
+            continue;
+        }
+        if in_packages {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || (!trimmed.starts_with('-') && !line.starts_with(' ')) {
+                break;
+            }
+            if let Some(stripped) = trimmed.strip_prefix("- ") {
+                let val = stripped.trim_matches('\'').trim_matches('"');
+                if !val.is_empty() {
+                    patterns.push(val.to_string());
+                }
+            }
+        }
+    }
+    patterns
+}
+
+fn packages_from_patterns(root: &Path, patterns: &[String]) -> Vec<WorkspacePackage> {
+    let mut packages = Vec::new();
+    for pattern in patterns {
+        if pattern.contains("node_modules") || pattern.starts_with('!') {
+            continue;
+        }
+        let trimmed = pattern.trim_end_matches('/');
+        let dirs = if let Some(prefix) = trimmed
+            .strip_suffix("/*")
+            .or_else(|| trimmed.strip_suffix("/**"))
+        {
+            child_dirs(&root.join(prefix))
+        } else if trimmed.contains('*') {
+            continue;
+        } else {
+            vec![root.join(trimmed)]
+        };
+
+        for dir in dirs {
+            if dir.join("package.json").is_file() {
+                let name = npm_package_name(&dir)
+                    .unwrap_or_else(|| dir.file_name().unwrap_or_default().to_string_lossy().into_owned());
+                packages.push(WorkspacePackage { name, root: dir });
+            }
+        }
+    }
+    packages
+}
+
+fn npm_package_name(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path.join("package.json")).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&content).ok()?;
+    value.get("name").and_then(|n| n.as_str()).map(str::to_string)
+}
+
+fn child_dirs(path: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect()
+}

--- a/src/scan/workspace.rs
+++ b/src/scan/workspace.rs
@@ -111,7 +111,11 @@ fn package_name_from_path(path: &Path) -> Option<String> {
         .and_then(|p| p.get("name"))
         .and_then(|n| n.as_str())
         .map(str::to_string)
-        .or_else(|| path.file_name().and_then(|n| n.to_str()).map(str::to_string))
+        .or_else(|| {
+            path.file_name()
+                .and_then(|n| n.to_str())
+                .map(str::to_string)
+        })
 }
 
 fn workspace_glob_patterns(value: &serde_json::Value) -> Vec<String> {
@@ -178,8 +182,12 @@ fn packages_from_patterns(root: &Path, patterns: &[String]) -> Vec<WorkspacePack
 
         for dir in dirs {
             if dir.join("package.json").is_file() {
-                let name = npm_package_name(&dir)
-                    .unwrap_or_else(|| dir.file_name().unwrap_or_default().to_string_lossy().into_owned());
+                let name = npm_package_name(&dir).unwrap_or_else(|| {
+                    dir.file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .into_owned()
+                });
                 packages.push(WorkspacePackage { name, root: dir });
             }
         }
@@ -190,7 +198,10 @@ fn packages_from_patterns(root: &Path, patterns: &[String]) -> Vec<WorkspacePack
 fn npm_package_name(path: &Path) -> Option<String> {
     let content = std::fs::read_to_string(path.join("package.json")).ok()?;
     let value: serde_json::Value = serde_json::from_str(&content).ok()?;
-    value.get("name").and_then(|n| n.as_str()).map(str::to_string)
+    value
+        .get("name")
+        .and_then(|n| n.as_str())
+        .map(str::to_string)
 }
 
 fn child_dirs(path: &Path) -> Vec<PathBuf> {

--- a/tests/baseline_key.rs
+++ b/tests/baseline_key.rs
@@ -59,5 +59,6 @@ fn finding(rule_id: &str, path: &str, line: usize) -> Finding {
             line_end: None,
             snippet: "snippet".to_string(),
         }],
+        workspace_package: None,
     }
 }

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -92,5 +92,6 @@ fn finding(id: &str, rule_id: &str, path: &str, line: usize, severity: Severity)
             line_end: None,
             snippet: "snippet".to_string(),
         }],
+        workspace_package: None,
     }
 }

--- a/tests/finding_model.rs
+++ b/tests/finding_model.rs
@@ -16,6 +16,7 @@ fn finding_contains_evidence() {
             line_end: None,
             snippet: "// TODO: improve this".to_string(),
         }],
+        workspace_package: None,
     };
 
     assert_eq!(finding.rule_id, "code-marker.todo");

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -28,6 +28,7 @@ fn html_output_escapes_snippets_and_renders_summary() {
                 line_end: None,
                 snippet: "API_KEY = \"abc<123>\"".to_string(),
             }],
+            workspace_package: None,
         }],
         react_native: None,
         coupling_graph: None,

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -37,6 +37,7 @@ fn renders_markdown_scan_summary() {
                 line_end: None,
                 snippet: "// TODO: improve architecture".to_string(),
             }],
+            workspace_package: None,
         }],
         detected_frameworks: vec![],
         framework_projects: vec![],

--- a/tests/output_sarif.rs
+++ b/tests/output_sarif.rs
@@ -52,6 +52,7 @@ fn sarif_rule_uses_real_description_not_generic() {
             line_end: None,
             snippet: "let x = 1;".to_string(),
         }],
+        workspace_package: None,
     };
 
     let root = PathBuf::from(".");
@@ -86,6 +87,7 @@ fn sarif_result_includes_partial_fingerprints() {
             line_end: None,
             snippet: String::new(),
         }],
+        workspace_package: None,
     };
 
     let root = PathBuf::from(".");

--- a/tests/sarif_mapping.rs
+++ b/tests/sarif_mapping.rs
@@ -154,5 +154,6 @@ fn finding(rule_id: &str, severity: Severity, path: Option<&str>, line_start: us
                 }]
             })
             .unwrap_or_default(),
+        workspace_package: None,
     }
 }


### PR DESCRIPTION
## Summary

Adds the first major RepoPilot v0.7 foundation: workspace-aware scanning.

This PR introduces workspace detection for npm, pnpm, and Cargo projects, attaches workspace package context to findings, and improves scan output so findings can be grouped by workspace package. It also adds React Native dependency health checks and updates release/distribution assets for the new version line.

## Type of change

- Feature
- Refactor
- Bug fix
- Tests
- Documentation
- CI / repository maintenance

## What changed

- Added workspace detection for:
  - npm workspaces
  - pnpm workspaces
  - Cargo workspaces
- Updated scan flow to process findings with workspace package context.
- Added `workspace_package` to the finding structure.
- Updated audits to populate workspace package metadata where applicable.
- Added React Native dependency health audit.
- Improved console output to group findings by workspace.
- Refactored finding rendering for better readability.
- Updated Homebrew formula to support dynamic versioning.
- Added GitHub Action configuration for running RepoPilot.
- Bumped package/version metadata for the v0.7 line.
- Updated dependencies where needed.

## Why

RepoPilot v0.7 is moving toward deeper repository intelligence.

Many real projects are not single-package repositories. They are monorepos, workspaces, or mixed stacks with multiple apps/packages/crates. Without workspace awareness, findings are harder to understand because users cannot easily tell which package or subproject owns a problem.

This PR makes RepoPilot more useful for real-world repositories by preserving package context in findings and reports.

Instead of only saying:

> this file has a problem

RepoPilot can now move toward saying:

> this file has a problem inside this workspace package

That is an important foundation for future v0.7 features such as package-level risk scoring, dependency drift detection, workspace summaries, and review intelligence.

## Architecture notes

- Workspace detection is introduced as a reusable foundation.
- Findings now carry workspace package context instead of relying only on file paths.
- Rendering is improved to consume workspace metadata rather than duplicating grouping logic.
- React Native dependency health is kept as a focused framework-aware audit.
- Scanner, audits, output, and distribution metadata remain separated.
- This PR prepares the project for deeper workspace-level analysis in future v0.7 work.

## Changelog

- Added workspace-aware scan support.
- Added workspace package metadata to findings.
- Added grouped console output by workspace.
- Added React Native dependency health audit.
- Updated Homebrew formula version handling.
- Added GitHub Action configuration for RepoPilot usage.
- Bumped version metadata to the v0.7 line.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .