### PR TITLE
feat(rules): add metadata registry for React Native findings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,4 +23,5 @@ pub mod graph;
 pub mod output;
 pub mod report;
 pub mod review;
+pub mod rules;
 pub mod scan;

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -46,6 +46,8 @@ pub struct SarifRule {
     pub short_description: SarifMessage,
     #[serde(rename = "fullDescription", skip_serializing_if = "Option::is_none")]
     pub full_description: Option<SarifMessage>,
+    #[serde(rename = "helpUri", skip_serializing_if = "Option::is_none")]
+    pub help_uri: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -216,22 +218,27 @@ fn sarif_result(
 }
 
 fn sarif_rules(findings: &[Finding]) -> Vec<SarifRule> {
-    let mut rule_map: BTreeMap<&str, &str> = BTreeMap::new();
+    let mut rule_map: BTreeMap<&str, &Finding> = BTreeMap::new();
     for finding in findings {
-        rule_map
-            .entry(finding.rule_id.as_str())
-            .or_insert(finding.description.as_str());
+        rule_map.entry(finding.rule_id.as_str()).or_insert(finding);
     }
 
     rule_map
         .into_iter()
-        .map(|(rule_id, description)| SarifRule {
-            id: rule_id.to_string(),
-            name: rule_id.to_string(),
-            short_description: SarifMessage {
-                text: description.to_string(),
-            },
-            full_description: None,
+        .map(|(rule_id, finding)| {
+            let help_uri = crate::rules::lookup_rule_metadata(rule_id)
+                .and_then(|m| m.docs_url)
+                .map(str::to_owned)
+                .or_else(|| finding.docs_url.clone());
+            SarifRule {
+                id: rule_id.to_string(),
+                name: rule_id.to_string(),
+                short_description: SarifMessage {
+                    text: finding.description.clone(),
+                },
+                full_description: None,
+                help_uri,
+            }
         })
         .collect()
 }

--- a/src/rules/metadata.rs
+++ b/src/rules/metadata.rs
@@ -1,0 +1,12 @@
+use crate::findings::types::{FindingCategory, Severity};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuleMetadata {
+    pub rule_id: &'static str,
+    pub title: &'static str,
+    pub category: FindingCategory,
+    pub default_severity: Severity,
+    pub docs_url: Option<&'static str>,
+    pub description: &'static str,
+    pub recommendation: Option<&'static str>,
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,0 +1,5 @@
+pub mod metadata;
+pub mod registry;
+
+pub use metadata::RuleMetadata;
+pub use registry::lookup_rule_metadata;

--- a/src/rules/registry.rs
+++ b/src/rules/registry.rs
@@ -1,0 +1,226 @@
+use crate::findings::types::{FindingCategory, Severity};
+use crate::rules::metadata::RuleMetadata;
+
+static RULES: &[RuleMetadata] = &[
+    RuleMetadata {
+        rule_id: "framework.react-native.inline-style",
+        title: "Inline style object in JSX",
+        category: FindingCategory::Framework,
+        default_severity: Severity::Medium,
+        docs_url: Some("https://reactnative.dev/docs/stylesheet"),
+        description: "Inline style objects create a new object on every render, defeating memoization in React.memo and PureComponent children.",
+        recommendation: Some("Extract styles into a StyleSheet.create call outside the component."),
+    },
+    RuleMetadata {
+        rule_id: "framework.react-native.deprecated-api",
+        title: "Deprecated React Native API",
+        category: FindingCategory::Framework,
+        default_severity: Severity::High,
+        docs_url: Some("https://reactnative.dev/docs/out-of-tree-platforms"),
+        description: "A React Native API removed from core is in use. Replace with the community package equivalent.",
+        recommendation: Some(
+            "Replace the deprecated API with its @react-native-community package equivalent.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "framework.react-native.flatlist-missing-key",
+        title: "FlatList is missing keyExtractor",
+        category: FindingCategory::Framework,
+        default_severity: Severity::Low,
+        docs_url: Some("https://reactnative.dev/docs/flatlist#keyextractor"),
+        description: "A FlatList without keyExtractor falls back to array index keys, breaking list reconciliation when items are reordered or removed.",
+        recommendation: Some(
+            "Add keyExtractor={(item) => item.id.toString()} or an equivalent unique key.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "framework.react-native.async-storage-from-core",
+        title: "AsyncStorage imported from 'react-native' core",
+        category: FindingCategory::Framework,
+        default_severity: Severity::High,
+        docs_url: Some("https://react-native-async-storage.github.io/async-storage/docs/install"),
+        description: "AsyncStorage was removed from react-native core in v0.60 and throws a runtime error on modern versions.",
+        recommendation: Some(
+            "Replace with `import AsyncStorage from '@react-native-async-storage/async-storage'`.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "framework.react-native.old-react-navigation",
+        title: "React Navigation v4 (unscoped package) detected",
+        category: FindingCategory::Framework,
+        default_severity: Severity::Medium,
+        docs_url: Some("https://reactnavigation.org/docs/getting-started"),
+        description: "react-navigation (v4) is no longer maintained and is incompatible with React Native 0.70+.",
+        recommendation: Some(
+            "Migrate to @react-navigation/native v5/v6 following the official migration guide.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "framework.react-native.direct-state-mutation",
+        title: "Direct mutation of this.state detected",
+        category: FindingCategory::Framework,
+        default_severity: Severity::High,
+        docs_url: Some("https://react.dev/reference/react/Component#setstate"),
+        description: "Directly assigning to this.state bypasses React change detection; the component will not re-render.",
+        recommendation: Some(
+            "Use this.setState({ key: value }) in class components or the useState setter in function components.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "framework.react-native.old-architecture",
+        title: "React Native New Architecture is not enabled",
+        category: FindingCategory::Framework,
+        default_severity: Severity::Medium,
+        docs_url: Some("https://reactnative.dev/docs/new-architecture-intro"),
+        description: "The project does not have newArchEnabled set. The New Architecture eliminates the async JS bridge and is required by an increasing number of libraries.",
+        recommendation: Some(
+            "Set `\"newArchEnabled\": true` in app.json or react-native.config.js.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "framework.react-native.architecture-mismatch",
+        title: "React Native New Architecture settings differ by platform",
+        category: FindingCategory::Framework,
+        default_severity: Severity::High,
+        docs_url: None,
+        description: "Android, iOS, or Expo configuration disagree about React Native New Architecture. Mismatched platforms produce inconsistent runtime behavior.",
+        recommendation: Some(
+            "Align newArchEnabled across android/gradle.properties, ios/Podfile.properties.json, and app.json.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "framework.react-native.hermes-mismatch",
+        title: "Hermes settings differ between Android and iOS",
+        category: FindingCategory::Framework,
+        default_severity: Severity::Medium,
+        docs_url: Some("https://reactnative.dev/docs/hermes"),
+        description: "Hermes is configured differently across platforms, causing platform-specific runtime and performance behavior.",
+        recommendation: Some(
+            "Align Hermes settings so both Android and iOS use the same JS engine.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "framework.react-native.hermes-disabled",
+        title: "Hermes JavaScript engine is disabled",
+        category: FindingCategory::Framework,
+        default_severity: Severity::Low,
+        docs_url: Some("https://reactnative.dev/docs/hermes"),
+        description: "Hermes is explicitly disabled. Hermes reduces startup time by 2-3x and is the default engine since React Native 0.70.",
+        recommendation: Some(
+            "Remove the hermes_enabled: false / enableHermes: false flag to enable Hermes.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "framework.react-native.codegen-missing",
+        title: "React Native Codegen config is missing",
+        category: FindingCategory::Framework,
+        default_severity: Severity::Medium,
+        docs_url: Some("https://reactnative.dev/docs/the-new-architecture/codegen"),
+        description: "The project uses Turbo Native Modules or Fabric components but package.json does not define codegenConfig.",
+        recommendation: Some(
+            "Add codegenConfig to package.json so React Native can generate native interfaces consistently.",
+        ),
+    },
+];
+
+pub fn lookup_rule_metadata(rule_id: &str) -> Option<&'static RuleMetadata> {
+    RULES.iter().find(|r| r.rule_id == rule_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::findings::types::{FindingCategory, Severity};
+
+    #[test]
+    fn known_rn_rule_returns_metadata() {
+        let meta = lookup_rule_metadata("framework.react-native.inline-style");
+        assert!(meta.is_some(), "inline-style rule must be in the registry");
+        let meta = meta.unwrap();
+        assert_eq!(meta.rule_id, "framework.react-native.inline-style");
+        assert_eq!(meta.category, FindingCategory::Framework);
+        assert_eq!(meta.default_severity, Severity::Medium);
+    }
+
+    #[test]
+    fn unknown_rule_returns_none() {
+        assert!(lookup_rule_metadata("nonexistent.rule.id").is_none());
+        assert!(lookup_rule_metadata("").is_none());
+    }
+
+    #[test]
+    fn inline_style_docs_url_matches_official_stylesheet_docs() {
+        let meta = lookup_rule_metadata("framework.react-native.inline-style").unwrap();
+        assert_eq!(
+            meta.docs_url,
+            Some("https://reactnative.dev/docs/stylesheet")
+        );
+    }
+
+    #[test]
+    fn async_storage_docs_url_matches_official_install_docs() {
+        let meta = lookup_rule_metadata("framework.react-native.async-storage-from-core").unwrap();
+        assert_eq!(
+            meta.docs_url,
+            Some("https://react-native-async-storage.github.io/async-storage/docs/install")
+        );
+    }
+
+    #[test]
+    fn flatlist_missing_key_docs_url_matches_flatlist_keyextractor() {
+        let meta = lookup_rule_metadata("framework.react-native.flatlist-missing-key").unwrap();
+        assert_eq!(
+            meta.docs_url,
+            Some("https://reactnative.dev/docs/flatlist#keyextractor")
+        );
+    }
+
+    #[test]
+    fn old_react_navigation_docs_url_matches_getting_started() {
+        let meta = lookup_rule_metadata("framework.react-native.old-react-navigation").unwrap();
+        assert_eq!(
+            meta.docs_url,
+            Some("https://reactnavigation.org/docs/getting-started")
+        );
+    }
+
+    #[test]
+    fn deprecated_api_severity_is_high() {
+        let meta = lookup_rule_metadata("framework.react-native.deprecated-api").unwrap();
+        assert_eq!(meta.default_severity, Severity::High);
+    }
+
+    #[test]
+    fn direct_state_mutation_severity_is_high() {
+        let meta = lookup_rule_metadata("framework.react-native.direct-state-mutation").unwrap();
+        assert_eq!(meta.default_severity, Severity::High);
+    }
+
+    #[test]
+    fn all_registered_rules_have_non_empty_description_and_title() {
+        for rule in RULES {
+            assert!(
+                !rule.title.is_empty(),
+                "rule {} has empty title",
+                rule.rule_id
+            );
+            assert!(
+                !rule.description.is_empty(),
+                "rule {} has empty description",
+                rule.rule_id
+            );
+        }
+    }
+
+    #[test]
+    fn all_registered_rule_ids_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for rule in RULES {
+            assert!(
+                seen.insert(rule.rule_id),
+                "duplicate rule_id: {}",
+                rule.rule_id
+            );
+        }
+    }
+}

--- a/tests/rule_registry.rs
+++ b/tests/rule_registry.rs
@@ -1,0 +1,165 @@
+use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use repopilot::output::sarif::findings_to_sarif;
+use repopilot::rules::{RuleMetadata, lookup_rule_metadata};
+use std::path::PathBuf;
+
+// ── lookup correctness ────────────────────────────────────────────────────────
+
+#[test]
+fn known_rn_rule_returns_some() {
+    let meta = lookup_rule_metadata("framework.react-native.inline-style");
+    assert!(
+        meta.is_some(),
+        "inline-style must be present in the registry"
+    );
+}
+
+#[test]
+fn unknown_rule_returns_none() {
+    assert!(lookup_rule_metadata("does.not.exist").is_none());
+}
+
+#[test]
+fn empty_rule_id_returns_none() {
+    assert!(lookup_rule_metadata("").is_none());
+}
+
+// ── metadata field correctness ────────────────────────────────────────────────
+
+#[test]
+fn inline_style_metadata_fields() {
+    let meta: &RuleMetadata = lookup_rule_metadata("framework.react-native.inline-style").unwrap();
+    assert_eq!(meta.category, FindingCategory::Framework);
+    assert_eq!(meta.default_severity, Severity::Medium);
+    assert_eq!(
+        meta.docs_url,
+        Some("https://reactnative.dev/docs/stylesheet")
+    );
+    assert!(meta.recommendation.is_some());
+}
+
+#[test]
+fn async_storage_docs_url_matches_official_docs() {
+    let meta = lookup_rule_metadata("framework.react-native.async-storage-from-core").unwrap();
+    assert_eq!(
+        meta.docs_url,
+        Some("https://react-native-async-storage.github.io/async-storage/docs/install")
+    );
+}
+
+#[test]
+fn flatlist_missing_key_docs_url_matches_flatlist_keyextractor() {
+    let meta = lookup_rule_metadata("framework.react-native.flatlist-missing-key").unwrap();
+    assert_eq!(
+        meta.docs_url,
+        Some("https://reactnative.dev/docs/flatlist#keyextractor")
+    );
+}
+
+#[test]
+fn old_react_navigation_docs_url_matches_getting_started() {
+    let meta = lookup_rule_metadata("framework.react-native.old-react-navigation").unwrap();
+    assert_eq!(
+        meta.docs_url,
+        Some("https://reactnavigation.org/docs/getting-started")
+    );
+}
+
+#[test]
+fn deprecated_api_severity_is_high() {
+    let meta = lookup_rule_metadata("framework.react-native.deprecated-api").unwrap();
+    assert_eq!(meta.default_severity, Severity::High);
+}
+
+#[test]
+fn direct_state_mutation_severity_is_high() {
+    let meta = lookup_rule_metadata("framework.react-native.direct-state-mutation").unwrap();
+    assert_eq!(meta.default_severity, Severity::High);
+}
+
+// ── SARIF integration ─────────────────────────────────────────────────────────
+
+fn make_finding(rule_id: &str) -> Finding {
+    Finding {
+        id: String::new(),
+        rule_id: rule_id.to_owned(),
+        title: "Test finding".to_owned(),
+        description: "A test description.".to_owned(),
+        category: FindingCategory::Framework,
+        severity: Severity::Medium,
+        evidence: vec![Evidence {
+            path: PathBuf::from("src/App.tsx"),
+            line_start: 5,
+            line_end: None,
+            snippet: "style={{ color: 'red' }}".to_owned(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+    }
+}
+
+#[test]
+fn sarif_rule_includes_help_uri_from_registry() {
+    let finding = make_finding("framework.react-native.inline-style");
+    let root = PathBuf::from(".");
+    let sarif = findings_to_sarif(&[finding], &root);
+    let value = serde_json::to_value(&sarif).unwrap();
+
+    let help_uri = &value["runs"][0]["tool"]["driver"]["rules"][0]["helpUri"];
+    assert_eq!(
+        help_uri.as_str(),
+        Some("https://reactnative.dev/docs/stylesheet"),
+        "helpUri must come from the registry for a known rule"
+    );
+}
+
+#[test]
+fn sarif_rule_includes_help_uri_from_finding_when_not_in_registry() {
+    let mut finding = make_finding("custom.rule.not.in.registry");
+    finding.docs_url = Some("https://example.com/my-rule".to_owned());
+    let root = PathBuf::from(".");
+    let sarif = findings_to_sarif(&[finding], &root);
+    let value = serde_json::to_value(&sarif).unwrap();
+
+    let help_uri = &value["runs"][0]["tool"]["driver"]["rules"][0]["helpUri"];
+    assert_eq!(
+        help_uri.as_str(),
+        Some("https://example.com/my-rule"),
+        "helpUri should fall back to finding.docs_url when the rule is not in the registry"
+    );
+}
+
+#[test]
+fn sarif_finding_without_metadata_serializes_safely() {
+    let finding = make_finding("totally.unknown.rule");
+    let root = PathBuf::from(".");
+    let sarif = findings_to_sarif(&[finding], &root);
+    let value = serde_json::to_value(&sarif).expect("serialization must not panic");
+
+    // Rule entry present but helpUri must be absent (null or missing)
+    let rules = &value["runs"][0]["tool"]["driver"]["rules"];
+    assert!(rules.is_array() && !rules.as_array().unwrap().is_empty());
+    let rule = &rules[0];
+    assert!(
+        rule["helpUri"].is_null(),
+        "helpUri must be absent when neither registry nor finding.docs_url has a value"
+    );
+}
+
+#[test]
+fn sarif_registry_rule_overrides_finding_docs_url() {
+    // Even if the finding carries its own docs_url, the registry's authoritative
+    // URL should take precedence.
+    let mut finding = make_finding("framework.react-native.inline-style");
+    finding.docs_url = Some("https://example.com/wrong-url".to_owned());
+    let root = PathBuf::from(".");
+    let sarif = findings_to_sarif(&[finding], &root);
+    let value = serde_json::to_value(&sarif).unwrap();
+
+    let help_uri = &value["runs"][0]["tool"]["driver"]["rules"][0]["helpUri"];
+    assert_eq!(
+        help_uri.as_str(),
+        Some("https://reactnative.dev/docs/stylesheet"),
+        "registry docs_url must take precedence over finding.docs_url"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a rule metadata foundation for RepoPilot findings, starting with React Native framework rules.

This PR introduces a structured metadata layer for findings so rule IDs can be connected with titles, descriptions, recommendations, severity, and documentation links. It helps keep rule information consistent across CLI output, Markdown/HTML reports, SARIF, and documentation.

## Type of change

- Feature
- Refactor
- Tests
- Documentation

## What changed

- Added rule metadata structures.
- Added a rule metadata registry.
- Registered metadata for React Native framework findings.
- Connected React Native rule IDs with human-readable titles and descriptions.
- Added documentation URLs / references for supported React Native rules.
- Prepared output layers to consume richer rule metadata.
- Added or updated tests for metadata lookup and registry behavior.

## Why

RepoPilot v0.7 is moving from simple findings toward repository intelligence.

As more framework-aware rules are added, rule information should not be duplicated across audit code, documentation, SARIF output, Markdown reports, and HTML reports. A centralized metadata registry makes the rules easier to maintain and helps future reports explain not only what was found, but also why it matters and how to fix it.

This is especially important for React Native audits because many findings need ecosystem context, upgrade guidance, or links to official documentation.

## Architecture notes

- Rule metadata is separated from audit detection logic.
- Audits still emit findings; the registry enriches those findings with metadata.
- Missing metadata should not break scan execution.
- React Native rule metadata is added first as the initial use case.
- This creates a reusable foundation for future JavaScript, React, workspace, test, CI, and risk rules.
- Existing scanner, audit, and renderer responsibilities remain separated.

## Changelog

- Added rule metadata model.
- Added rule registry lookup.
- Added metadata for React Native findings.
- Added documentation/recommendation support for rules.
- Updated tests for rule metadata behavior.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .