### PR TITLE
perf(scan): add input controls and scan accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- Added scan input controls on `repopilot scan`: `--exclude`, `--include-low-signal`, `--max-file-size`, and `--max-files`.
+- Added JSON scan accounting fields: `files_discovered`, `files_skipped_low_signal`, and `binary_files_skipped`.
+- Added default ignores for `.nuxt`, `.cache`, `vendor`, `Pods`, and `DerivedData`.
+
+### Changed
+
+- `files_count` now represents analyzed text files; skipped large, binary, low-signal, and capped files are tracked separately.
+- Console scan input reporting now labels files skipped by `--max-files` as limit-skipped instead of ignore-skipped.
+
 ## [0.8.0] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ repopilot vibe . | pbcopy   # macOS: paste into Claude Code and start fixing
 ## Features
 
 - Repository scanning for projects, folders, and individual files
-- Gitignore-aware walking with built-in ignores for common build and service directories
+- Gitignore-aware walking with built-in ignores for common build, cache, vendor, and native platform directories
 - Architecture findings: oversized files, deep nesting, too many modules per directory
 - Coupling analysis: excessive fan-out, high-instability hubs, circular dependencies
 - Code quality findings: cyclomatic complexity density, long functions, TODO/FIXME/HACK markers
@@ -114,7 +114,10 @@ Reduce scan noise while iterating:
 ```bash
 repopilot scan . --min-severity high
 repopilot scan . --workspace --min-severity medium
+repopilot scan . --exclude fixtures --max-file-size 1mb --max-files 500
 ```
+
+By default, RepoPilot skips low-signal audit paths such as tests, fixtures, examples, generated files, and benchmarks. Use `--include-low-signal` when you want those paths analyzed too.
 
 ## Vibe Check (new in v0.8)
 
@@ -238,7 +241,12 @@ ignore = [
   "dist",
   "build",
   ".next",
-  "coverage"
+  ".nuxt",
+  ".cache",
+  "coverage",
+  "vendor",
+  "Pods",
+  "DerivedData"
 ]
 max_file_bytes = 2097152
 
@@ -268,7 +276,15 @@ CLI threshold overrides:
 repopilot scan . --max-file-loc 500
 repopilot scan . --max-directory-modules 25
 repopilot scan . --max-directory-depth 6
+repopilot scan . --max-file-size 1mb
+repopilot scan . --max-files 1000
+repopilot scan . --exclude generated
+repopilot scan . --include-low-signal
 ```
+
+`--max-file-size` accepts raw bytes or `kb`, `mb`, and `gb` suffixes. `--exclude` matches an exact path relative to the scan root or a file/directory name; repeat it for multiple paths.
+
+JSON output includes scan input accounting fields: `files_discovered` for files found after ignore/exclude filters, `files_count` for analyzed text files, `files_skipped_low_signal` for default low-signal skips, and `binary_files_skipped` for unreadable/binary files.
 
 ## Baseline Workflow
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,10 +71,16 @@ repopilot s <PATH> [OPTIONS]
 | `--max-file-loc` | integer | `300` | Maximum non-empty LOC before a file is flagged as large |
 | `--max-directory-modules` | integer | `20` | Maximum files per directory before flagging |
 | `--max-directory-depth` | integer | `5` | Maximum nesting depth before flagging |
+| `--exclude` | path/name | — | Exclude an exact path relative to the scan root or a file/directory name; repeatable |
+| `--include-low-signal` | flag | — | Analyze test, fixture, example, generated, and benchmark paths that are skipped by default |
+| `--max-file-size` | size | `2097152` | Skip files larger than this size; accepts bytes, `kb`, `mb`, or `gb`; `0` disables the guard |
+| `--max-files` | integer | — | Analyze at most this many discovered files after ignore and exclude filters |
 | `-w, --workspace` | flag | — | Scan each detected workspace package separately and group findings by package |
 | `--min-severity` | `info\|low\|medium\|high\|critical` | — | Only show findings at or above this severity |
 | `--verbose` | flag | — | Print scan phase timing breakdown after the report |
 | `--preset` | `strict\|balanced\|lenient` | `balanced` | Apply a threshold preset without editing config |
+
+`files_discovered` in JSON output means files found after gitignore, `.repopilotignore`, built-in ignores, and `--exclude` filters. `files_count` means analyzed text files; skipped large files, low-signal paths, binary/unreadable files, and files beyond `--max-files` are not included. JSON also includes `files_skipped_low_signal` and `binary_files_skipped`.
 
 ### Exit codes
 
@@ -107,6 +113,11 @@ repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
 
 # Override thresholds at the command line
 repopilot scan . --max-file-loc 500 --max-directory-modules 30 --max-directory-depth 8
+
+# Limit scan input
+repopilot scan . --exclude generated --exclude fixtures
+repopilot scan . --max-file-size 1mb --max-files 1000
+repopilot scan . --include-low-signal
 
 # Monorepo scan with less noise
 repopilot scan . --workspace --min-severity medium

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -25,6 +25,7 @@ repopilot review . --base origin/main --baseline .repopilot/baseline.json --fail
 `repopilot scan` is the primary command. It walks the target path, runs all audit rules, and prints a report.
 For JavaScript workspaces, the summary includes detected framework projects and React Native architecture metadata when present.
 Python projects are scanned for Django, Flask, and FastAPI (detected from `requirements.txt`); Go projects for Gin, Echo, and Fiber (detected from `go.mod`). Detected frameworks appear in the tech-stack summary produced by `repopilot vibe`.
+The walker respects gitignore, `.repopilotignore`, and built-in ignores for common build, cache, vendor, and platform directories, including `.git`, `target`, `node_modules`, `dist`, `build`, `.next`, `.nuxt`, `.cache`, `coverage`, `vendor`, `Pods`, and `DerivedData`.
 
 ```bash
 repopilot scan .
@@ -70,6 +71,20 @@ Use presets for one-shot tuning without editing config:
 repopilot scan . --preset strict
 repopilot scan . --preset lenient
 ```
+
+### Limiting scan input
+
+Use `--exclude` for exact relative paths or file/directory names, `--max-file-size` to skip large files, and `--max-files` to cap how many discovered files are analyzed:
+
+```bash
+repopilot scan . --exclude generated --exclude fixtures
+repopilot scan . --max-file-size 1mb
+repopilot scan . --max-files 1000
+```
+
+Size values accept raw bytes plus `kb`, `mb`, and `gb` suffixes. By default, low-signal audit paths such as tests, fixtures, examples, generated files, and benchmarks are skipped; pass `--include-low-signal` to analyze them.
+
+JSON reports expose this accounting with `files_discovered`, `files_count` (analyzed text files), `files_skipped_low_signal`, `binary_files_skipped`, `skipped_files_count`, and `skipped_bytes`.
 
 ### Filtering by severity
 

--- a/src/audits/code_quality/code_markers.rs
+++ b/src/audits/code_quality/code_markers.rs
@@ -13,7 +13,7 @@ impl FileAudit for CodeMarkerAudit {
             return vec![];
         }
 
-        detect_markers(&file.path, &file.content)
+        detect_markers(&file.path, file.content.as_deref().unwrap_or(""))
             .iter()
             .map(build_marker_finding)
             .collect()
@@ -21,7 +21,7 @@ impl FileAudit for CodeMarkerAudit {
 }
 
 pub fn detect_code_marker_findings(file: &FileFacts) -> Vec<Finding> {
-    detect_markers(&file.path, &file.content)
+    detect_markers(&file.path, file.content.as_deref().unwrap_or(""))
         .iter()
         .map(build_marker_finding)
         .collect()

--- a/src/audits/code_quality/long_function/mod.rs
+++ b/src/audits/code_quality/long_function/mod.rs
@@ -15,7 +15,8 @@ impl FileAudit for LongFunctionAudit {
         if is_low_signal_audit_path(&file.path) {
             return vec![];
         }
-        if file.content.is_empty() {
+        let content = file.content.as_deref().unwrap_or("");
+        if content.is_empty() {
             return vec![];
         }
         let language = match file.language.as_deref() {
@@ -23,7 +24,7 @@ impl FileAudit for LongFunctionAudit {
             _ => return vec![],
         };
         detect_long_functions(
-            &file.content,
+            content,
             language,
             &file.path,
             config.long_function_loc_threshold,

--- a/src/audits/framework/js_common.rs
+++ b/src/audits/framework/js_common.rs
@@ -179,7 +179,7 @@ mod tests {
             lines_of_code: 2,
             branch_count: 0,
             imports: vec![],
-            content: String::new(),
+            content: None,
             has_inline_tests: false,
         }
     }
@@ -282,7 +282,7 @@ mod tests {
             lines_of_code: 2,
             branch_count: 0,
             imports: vec![],
-            content: String::new(),
+            content: None,
             has_inline_tests: false,
         });
         let findings = ConsoleLogAudit.audit(&facts, &ScanConfig::default());

--- a/src/audits/framework/react.rs
+++ b/src/audits/framework/react.rs
@@ -154,7 +154,7 @@ mod tests {
             lines_of_code: 3,
             branch_count: 0,
             imports: vec![],
-            content: String::new(),
+            content: None,
             has_inline_tests: false,
         });
 
@@ -180,7 +180,7 @@ mod tests {
             lines_of_code: 1,
             branch_count: 0,
             imports: vec![],
-            content: String::new(),
+            content: None,
             has_inline_tests: false,
         });
         // no TypeScript in languages list
@@ -210,7 +210,7 @@ mod tests {
             lines_of_code: 1,
             branch_count: 0,
             imports: vec![],
-            content: String::new(),
+            content: None,
             has_inline_tests: false,
         });
 

--- a/src/audits/framework/react_native/mod.rs
+++ b/src/audits/framework/react_native/mod.rs
@@ -43,7 +43,7 @@ mod tests {
             lines_of_code: content.lines().count(),
             branch_count: 0,
             imports: vec![],
-            content: String::new(),
+            content: None,
             has_inline_tests: false,
         }
     }

--- a/src/audits/security/private_key_candidate.rs
+++ b/src/audits/security/private_key_candidate.rs
@@ -20,6 +20,8 @@ impl FileAudit for PrivateKeyCandidateAudit {
         }
 
         file.content
+            .as_deref()
+            .unwrap_or("")
             .lines()
             .enumerate()
             .filter_map(|(index, line)| {

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -54,6 +54,8 @@ impl FileAudit for SecretCandidateAudit {
         }
 
         file.content
+            .as_deref()
+            .unwrap_or("")
             .lines()
             .enumerate()
             .filter_map(|(index, line)| detect_secret_line(line, index + 1, &file.path))

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -94,3 +94,31 @@ pub fn parse_vibe_budget(value: &str) -> Result<usize, String> {
 
     Ok(tokens)
 }
+
+pub fn parse_byte_size(value: &str) -> Result<u64, String> {
+    let s = value.to_lowercase();
+    if let Some(n) = s.strip_suffix("gb") {
+        return n
+            .trim()
+            .parse::<u64>()
+            .map(|n| n << 30)
+            .map_err(|_| format!("invalid: {value}"));
+    }
+    if let Some(n) = s.strip_suffix("mb") {
+        return n
+            .trim()
+            .parse::<u64>()
+            .map(|n| n << 20)
+            .map_err(|_| format!("invalid: {value}"));
+    }
+    if let Some(n) = s.strip_suffix("kb") {
+        return n
+            .trim()
+            .parse::<u64>()
+            .map(|n| n << 10)
+            .map_err(|_| format!("invalid: {value}"));
+    }
+    value
+        .parse::<u64>()
+        .map_err(|_| "expected bytes, e.g. 512, 1mb, 2gb".to_string())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,8 @@
 mod args;
 
 pub use args::{
-    CompareOutputFormatArg, FailOnArg, OutputFormatArg, SeverityArg, parse_vibe_budget,
+    CompareOutputFormatArg, FailOnArg, OutputFormatArg, SeverityArg, parse_byte_size,
+    parse_vibe_budget,
 };
 
 use clap::{Parser, Subcommand};
@@ -88,7 +89,9 @@ Coupling      — excessive fan-out, high-instability hubs, circular dependencie
 Code quality  — cyclomatic complexity, long functions, TODO/FIXME/HACK markers\n  \
 Security      — hardcoded secret candidates, committed private keys, .env files\n  \
 Testing       — missing test folder, source files without test counterparts\n\n\
-The scan respects .gitignore and built-in ignore rules for common build directories.\n\n\
+The scan respects .gitignore, .repopilotignore, built-in ignores, and --exclude.\n\
+Low-signal test, fixture, example, generated, and benchmark paths are skipped by\n\
+default unless --include-low-signal is passed.\n\n\
 Use `--baseline` to mark findings as new or existing. Use `--fail-on` to set a\n\
 CI failure threshold. Use `--format sarif` to upload results to GitHub Code Scanning.",
         after_help = "EXAMPLES:\n  \
@@ -100,7 +103,8 @@ repopilot scan . --format html --output report.html\n  \
 repopilot scan . --config repopilot.toml\n  \
 repopilot scan . --baseline .repopilot/baseline.json\n  \
 repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high\n  \
-repopilot scan . --max-file-loc 500 --max-directory-modules 30"
+repopilot scan . --max-file-loc 500 --max-directory-modules 30\n  \
+repopilot scan . --exclude generated --max-file-size 1mb --max-files 1000"
     )]
     Scan {
         path: PathBuf,
@@ -120,6 +124,18 @@ repopilot scan . --max-file-loc 500 --max-directory-modules 30"
         max_directory_modules: Option<usize>,
         #[arg(long)]
         max_directory_depth: Option<usize>,
+        /// Exclude a path or file/directory name after gitignore processing; repeatable
+        #[arg(long, value_name = "PATH_OR_NAME")]
+        exclude: Vec<String>,
+        /// Analyze test, fixture, example, generated, and benchmark paths that are skipped by default
+        #[arg(long)]
+        include_low_signal: bool,
+        /// Skip files larger than SIZE (bytes, kb, mb, or gb; 0 disables the guard)
+        #[arg(long, value_name = "SIZE", value_parser = parse_byte_size)]
+        max_file_size: Option<u64>,
+        /// Analyze at most N discovered files after ignore and exclude filters
+        #[arg(long, value_name = "N")]
+        max_files: Option<usize>,
         #[arg(long, short = 'w')]
         workspace: bool,
         #[arg(long, value_enum)]

--- a/src/commands/harden.rs
+++ b/src/commands/harden.rs
@@ -1,6 +1,6 @@
 use crate::commands::CliExit;
-use crate::commands::build_scan_config;
 use crate::commands::scan::{finish_spinner, make_spinner};
+use crate::commands::{ScanConfigOverrides, build_scan_config};
 use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::output::harden::{HardenOptions, render as render_harden};
 use repopilot::output::vibe::VibeCategory;
@@ -19,7 +19,7 @@ pub fn run(
         Some(config_path) => load_optional_config(&config_path)?,
         None => load_default_config()?,
     };
-    let scan_config = build_scan_config(&repo_config, None, None, None);
+    let scan_config = build_scan_config(&repo_config, ScanConfigOverrides::default());
     let focus_category = parse_focus(focus.as_deref())?;
 
     let pb = make_spinner();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -26,6 +26,10 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             max_file_loc,
             max_directory_modules,
             max_directory_depth,
+            exclude,
+            include_low_signal,
+            max_file_size,
+            max_files,
             workspace,
             min_severity,
             verbose,
@@ -40,6 +44,10 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             max_file_loc,
             max_directory_modules,
             max_directory_depth,
+            exclude,
+            include_low_signal,
+            max_file_size,
+            max_files,
             workspace,
             min_severity.map(severity_arg_into),
             verbose,
@@ -136,25 +144,41 @@ pub fn severity_arg_into(arg: SeverityArg) -> Severity {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct ScanConfigOverrides {
+    pub max_file_loc: Option<usize>,
+    pub max_directory_modules: Option<usize>,
+    pub max_directory_depth: Option<usize>,
+    pub exclude_patterns: Vec<String>,
+    pub include_low_signal: bool,
+    pub max_file_size: Option<u64>,
+    pub max_files: Option<usize>,
+}
+
 pub fn build_scan_config(
     repo_config: &RepoPilotConfig,
-    max_file_loc: Option<usize>,
-    max_directory_modules: Option<usize>,
-    max_directory_depth: Option<usize>,
+    overrides: ScanConfigOverrides,
 ) -> ScanConfig {
     let mut config = repo_config.to_scan_config();
 
-    if let Some(threshold) = max_file_loc {
+    if let Some(threshold) = overrides.max_file_loc {
         config = config.with_large_file_loc_threshold(threshold);
     }
 
-    if let Some(modules) = max_directory_modules {
+    if let Some(modules) = overrides.max_directory_modules {
         config.max_directory_modules = modules;
     }
 
-    if let Some(depth) = max_directory_depth {
+    if let Some(depth) = overrides.max_directory_depth {
         config.max_directory_depth = depth;
     }
+
+    config.exclude_patterns = overrides.exclude_patterns;
+    config.include_low_signal = overrides.include_low_signal;
+    if let Some(bytes) = overrides.max_file_size {
+        config.max_file_bytes = bytes;
+    }
+    config.max_files = overrides.max_files;
 
     config
 }

--- a/src/commands/prompt.rs
+++ b/src/commands/prompt.rs
@@ -1,6 +1,6 @@
 use crate::commands::CliExit;
-use crate::commands::build_scan_config;
 use crate::commands::scan::{finish_spinner, make_spinner};
+use crate::commands::{ScanConfigOverrides, build_scan_config};
 use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::output::prompt::{PromptOptions, render as render_prompt};
 use repopilot::output::vibe::VibeCategory;
@@ -19,7 +19,7 @@ pub fn run(
         Some(config_path) => load_optional_config(&config_path)?,
         None => load_default_config()?,
     };
-    let scan_config = build_scan_config(&repo_config, None, None, None);
+    let scan_config = build_scan_config(&repo_config, ScanConfigOverrides::default());
     let focus_category = parse_focus(focus.as_deref())?;
 
     let pb = make_spinner();

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -1,5 +1,5 @@
 use crate::cli::{CompareOutputFormatArg, FailOnArg};
-use crate::commands::{CliExit, apply_min_severity_filter, build_scan_config};
+use crate::commands::{CliExit, ScanConfigOverrides, apply_min_severity_filter, build_scan_config};
 use indicatif::{ProgressBar, ProgressStyle};
 use repopilot::baseline::gate::evaluate_ci_gate;
 use repopilot::baseline::reader::read_baseline;
@@ -41,9 +41,12 @@ pub fn run(
     };
     let scan_config = build_scan_config(
         &repo_config,
-        max_file_loc,
-        max_directory_modules,
-        max_directory_depth,
+        ScanConfigOverrides {
+            max_file_loc,
+            max_directory_modules,
+            max_directory_depth,
+            ..ScanConfigOverrides::default()
+        },
     );
 
     let pb = make_spinner();

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -1,5 +1,5 @@
 use crate::cli::{FailOnArg, OutputFormatArg};
-use crate::commands::{CliExit, apply_min_severity_filter, build_scan_config};
+use crate::commands::{CliExit, ScanConfigOverrides, apply_min_severity_filter, build_scan_config};
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
 use repopilot::baseline::diff::{all_findings_new, diff_summary_against_baseline};
@@ -30,6 +30,10 @@ pub fn run(
     max_file_loc: Option<usize>,
     max_directory_modules: Option<usize>,
     max_directory_depth: Option<usize>,
+    exclude: Vec<String>,
+    include_low_signal: bool,
+    max_file_size: Option<u64>,
+    max_files: Option<usize>,
     workspace: bool,
     min_severity: Option<Severity>,
     verbose: bool,
@@ -56,9 +60,15 @@ pub fn run(
 
     let scan_config = build_scan_config(
         &repo_config,
-        max_file_loc,
-        max_directory_modules,
-        max_directory_depth,
+        ScanConfigOverrides {
+            max_file_loc,
+            max_directory_modules,
+            max_directory_depth,
+            exclude_patterns: exclude,
+            include_low_signal,
+            max_file_size,
+            max_files,
+        },
     );
     let output_format = format
         .map(Into::into)
@@ -201,9 +211,12 @@ fn merge_package_summary(merged: &mut ScanSummary, mut package: ScanSummary, pac
     }
 
     merged.files_count += package.files_count;
+    merged.files_discovered += package.files_discovered;
     merged.directories_count += package.directories_count;
     merged.lines_of_code += package.lines_of_code;
     merged.skipped_files_count += package.skipped_files_count;
+    merged.files_skipped_low_signal += package.files_skipped_low_signal;
+    merged.binary_files_skipped += package.binary_files_skipped;
     merged.skipped_bytes = merged.skipped_bytes.saturating_add(package.skipped_bytes);
     merged.scan_duration_us = merged
         .scan_duration_us

--- a/src/commands/vibe.rs
+++ b/src/commands/vibe.rs
@@ -1,6 +1,6 @@
 use crate::commands::CliExit;
-use crate::commands::build_scan_config;
 use crate::commands::scan::{finish_spinner, make_spinner};
+use crate::commands::{ScanConfigOverrides, build_scan_config};
 use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::output::vibe::{VibeCategory, VibeOptions, render as render_vibe};
 use repopilot::report::writer::write_report;
@@ -19,7 +19,7 @@ pub fn run(
         Some(config_path) => load_optional_config(&config_path)?,
         None => load_default_config()?,
     };
-    let scan_config = build_scan_config(&repo_config, None, None, None);
+    let scan_config = build_scan_config(&repo_config, ScanConfigOverrides::default());
 
     let focus_category = match focus.as_deref() {
         Some(s) => Some(s.parse::<VibeCategory>().map_err(|_| {

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -9,7 +9,12 @@ pub const DEFAULT_IGNORED_PATHS: &[&str] = &[
     "dist",
     "build",
     ".next",
+    ".nuxt",
+    ".cache",
     "coverage",
+    "vendor",
+    "Pods",
+    "DerivedData",
 ];
 
 pub const DEFAULT_MAX_FILE_LINES: usize = 300;

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -80,22 +80,61 @@ fn render_header(output: &mut String, summary: &ScanSummary, stats: &ReportStats
         stats.total_findings, stats.finding_density
     ));
     output.push_str(&format!(
-        "Files analyzed: {} | Directories analyzed: {} | Lines of code: {}\n",
-        summary.files_count, summary.directories_count, summary.lines_of_code
+        "Directories analyzed: {} | Lines of code: {}\n",
+        summary.directories_count, summary.lines_of_code
     ));
+    render_scan_input(output, summary);
     if summary.scan_duration_us > 0 {
         output.push_str(&format!(
             "Scan time: {:.2}s\n",
             summary.scan_duration_us as f64 / 1_000_000.0
         ));
     }
-    if summary.skipped_files_count > 0 {
+    output.push('\n');
+}
+
+fn render_scan_input(output: &mut String, summary: &ScanSummary) {
+    let skipped_by_limit = summary.files_discovered.saturating_sub(
+        summary
+            .files_count
+            .saturating_add(summary.skipped_files_count)
+            .saturating_add(summary.binary_files_skipped)
+            .saturating_add(summary.files_skipped_low_signal),
+    );
+
+    output.push_str("Scan input:\n");
+    output.push_str(&format!(
+        "  Files discovered:       {:>7}\n",
+        summary.files_discovered
+    ));
+    if skipped_by_limit > 0 {
         output.push_str(&format!(
-            "Files skipped: {} ({} bytes)\n",
-            summary.skipped_files_count, summary.skipped_bytes
+            "  Files skipped (limit):  {:>7}\n",
+            skipped_by_limit
         ));
     }
-    output.push('\n');
+    output.push_str(&format!(
+        "  Files analyzed:         {:>7}\n",
+        summary.files_count
+    ));
+    if summary.skipped_files_count > 0 {
+        output.push_str(&format!(
+            "  Large files skipped:    {:>7}\n",
+            summary.skipped_files_count
+        ));
+    }
+    if summary.binary_files_skipped > 0 {
+        output.push_str(&format!(
+            "  Binary files skipped:   {:>7}\n",
+            summary.binary_files_skipped
+        ));
+    }
+    if summary.files_skipped_low_signal > 0 {
+        output.push_str(&format!(
+            "  Low-signal files skipped:{:>7}\n",
+            summary.files_skipped_low_signal
+        ));
+    }
 }
 
 fn render_risk_summary(output: &mut String, stats: &ReportStats) {

--- a/src/output/vibe.rs
+++ b/src/output/vibe.rs
@@ -145,6 +145,7 @@ mod tests {
     fn make_summary(findings: Vec<Finding>) -> ScanSummary {
         ScanSummary {
             root_path: PathBuf::from("/my-project"),
+            files_discovered: 0,
             files_count: 42,
             lines_of_code: 3000,
             directories_count: 10,

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -134,10 +134,13 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
     BaselineScanReport {
         summary: ScanSummary {
             root_path: report.summary.root_path.clone(),
+            files_discovered: report.summary.files_discovered,
             files_count: report.summary.files_count,
             directories_count: report.summary.directories_count,
             lines_of_code: report.summary.lines_of_code,
             skipped_files_count: report.summary.skipped_files_count,
+            files_skipped_low_signal: report.summary.files_skipped_low_signal,
+            binary_files_skipped: report.summary.binary_files_skipped,
             skipped_bytes: report.summary.skipped_bytes,
             languages: report.summary.languages.clone(),
             detected_frameworks: report.summary.detected_frameworks.clone(),

--- a/src/scan/config.rs
+++ b/src/scan/config.rs
@@ -9,7 +9,10 @@ use crate::config::defaults::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScanConfig {
     pub ignored_paths: Vec<String>,
+    pub exclude_patterns: Vec<String>,
     pub max_file_bytes: u64,
+    pub include_low_signal: bool,
+    pub max_files: Option<usize>,
     pub detect_missing_tests: bool,
     pub detect_secret_like_names: bool,
     pub large_file_loc_threshold: usize,
@@ -28,7 +31,10 @@ impl Default for ScanConfig {
     fn default() -> Self {
         Self {
             ignored_paths: default_ignored_paths(),
+            exclude_patterns: Vec::new(),
             max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            include_low_signal: false,
+            max_files: None,
             detect_missing_tests: true,
             detect_secret_like_names: true,
             large_file_loc_threshold: DEFAULT_MAX_FILE_LINES,

--- a/src/scan/facts.rs
+++ b/src/scan/facts.rs
@@ -7,10 +7,13 @@ use std::path::PathBuf;
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ScanFacts {
     pub root_path: PathBuf,
+    pub files_discovered: usize,
     pub files_count: usize,
     pub directories_count: usize,
     pub lines_of_code: usize,
     pub skipped_files_count: usize,
+    pub files_skipped_low_signal: usize,
+    pub binary_files_skipped: usize,
     pub skipped_bytes: u64,
     pub languages: Vec<LanguageSummary>,
     pub files: Vec<FileFacts>,
@@ -26,7 +29,9 @@ pub struct FileFacts {
     pub lines_of_code: usize,
     pub branch_count: usize,
     pub imports: Vec<String>,
-    pub content: String,
+    /// Source text while file audits are running. `None` means the file was skipped,
+    /// binary/unreadable, or retained only as summary metadata after auditing.
+    pub content: Option<String>,
     /// True if the file contains a `#[cfg(test)]` block (Rust inline unit tests).
     /// Computed while content is available; preserved after content is dropped.
     pub has_inline_tests: bool,

--- a/src/scan/scanner.rs
+++ b/src/scan/scanner.rs
@@ -12,6 +12,7 @@ use crate::graph::imports::extract_imports;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::{FileFacts, ScanFacts};
 use crate::scan::language::detect_language;
+use crate::scan::path_classification::is_low_signal_audit_path;
 use crate::scan::types::{LanguageSummary, ScanSummary};
 
 use ignore::WalkBuilder;
@@ -82,10 +83,13 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
 
     Ok(ScanSummary {
         root_path: facts.root_path,
+        files_discovered: facts.files_discovered,
         files_count: facts.files_count,
         directories_count: facts.directories_count,
         lines_of_code: facts.lines_of_code,
         skipped_files_count: facts.skipped_files_count,
+        files_skipped_low_signal: facts.files_skipped_low_signal,
+        binary_files_skipped: facts.binary_files_skipped,
         skipped_bytes: facts.skipped_bytes,
         languages: facts.languages,
         detected_frameworks: facts.detected_frameworks,
@@ -104,8 +108,16 @@ struct PerFileResult {
     file_facts: FileFacts,
     findings: Vec<Finding>,
     language: Option<String>,
-    is_skipped: bool,
+    skip_reason: SkipReason,
     skipped_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkipReason {
+    None,
+    LargeFile,
+    Binary,
+    LowSignal,
 }
 
 /// Processes a single file: reads content, runs all file audits, returns findings.
@@ -128,15 +140,34 @@ fn process_file(
                     lines_of_code: 0,
                     branch_count: 0,
                     imports: Vec::new(),
-                    content: String::new(),
+                    content: None,
                     has_inline_tests: false,
                 },
                 findings: Vec::new(),
                 language,
-                is_skipped: true,
+                skip_reason: SkipReason::LargeFile,
                 skipped_bytes: file_size,
             });
         }
+    }
+
+    if !config.include_low_signal && is_low_signal_audit_path(path) {
+        let skipped_bytes = fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+        return Ok(PerFileResult {
+            file_facts: FileFacts {
+                path: path.to_path_buf(),
+                language: language.clone(),
+                lines_of_code: 0,
+                branch_count: 0,
+                imports: Vec::new(),
+                content: None,
+                has_inline_tests: false,
+            },
+            findings: Vec::new(),
+            language,
+            skip_reason: SkipReason::LowSignal,
+            skipped_bytes,
+        });
     }
 
     let Ok(content) = fs::read_to_string(path) else {
@@ -148,12 +179,12 @@ fn process_file(
                 lines_of_code: 0,
                 branch_count: 0,
                 imports: Vec::new(),
-                content: String::new(),
+                content: None,
                 has_inline_tests: false,
             },
             findings: Vec::new(),
             language,
-            is_skipped: true,
+            skip_reason: SkipReason::Binary,
             skipped_bytes,
         });
     };
@@ -168,7 +199,7 @@ fn process_file(
         branch_count,
         imports: extract_imports(&content, language.as_deref()),
         has_inline_tests,
-        content,
+        content: Some(content),
     };
 
     let mut findings = Vec::new();
@@ -178,12 +209,12 @@ fn process_file(
 
     Ok(PerFileResult {
         file_facts: FileFacts {
-            content: String::new(),
+            content: None,
             ..full_facts
         },
         findings,
         language,
-        is_skipped: false,
+        skip_reason: SkipReason::None,
         skipped_bytes: 0,
     })
 }
@@ -239,6 +270,7 @@ fn collect_and_audit_inline(
     };
 
     if path.is_file() {
+        facts.files_discovered = 1;
         let mut languages: HashMap<String, usize> = HashMap::new();
         let mut findings: Vec<Finding> = Vec::new();
         audit_file_inline(
@@ -254,7 +286,11 @@ fn collect_and_audit_inline(
     }
 
     // Phase 1: sequential directory walk — metadata only, no file reads
-    let (file_paths, dirs_count) = collect_paths(path, config)?;
+    let (mut file_paths, dirs_count) = collect_paths(path, config)?;
+    facts.files_discovered = file_paths.len();
+    if let Some(max) = config.max_files {
+        file_paths.truncate(max);
+    }
     facts.directories_count = dirs_count;
 
     // Phase 2: parallel file processing
@@ -269,14 +305,26 @@ fn collect_and_audit_inline(
 
     for result in results {
         let per_file = result?;
-        facts.files_count += 1;
-        if let Some(ref lang) = per_file.language {
-            *languages.entry(lang.clone()).or_insert(0) += 1;
+        if per_file.skip_reason == SkipReason::None {
+            facts.files_count += 1;
+            if let Some(ref lang) = per_file.language {
+                *languages.entry(lang.clone()).or_insert(0) += 1;
+            }
         }
         facts.lines_of_code += per_file.file_facts.lines_of_code;
-        if per_file.is_skipped {
-            facts.skipped_files_count += 1;
-            facts.skipped_bytes = facts.skipped_bytes.saturating_add(per_file.skipped_bytes);
+        match per_file.skip_reason {
+            SkipReason::LargeFile => {
+                facts.skipped_files_count += 1;
+                facts.skipped_bytes = facts.skipped_bytes.saturating_add(per_file.skipped_bytes);
+            }
+            SkipReason::Binary => {
+                facts.binary_files_skipped += 1;
+                facts.skipped_bytes = facts.skipped_bytes.saturating_add(per_file.skipped_bytes);
+            }
+            SkipReason::LowSignal => {
+                facts.files_skipped_low_signal += 1;
+            }
+            SkipReason::None => {}
         }
         facts.files.push(per_file.file_facts);
         findings.extend(per_file.findings);
@@ -297,30 +345,44 @@ fn audit_file_inline(
     config: &ScanConfig,
     findings: &mut Vec<Finding>,
 ) -> io::Result<()> {
-    facts.files_count += 1;
-
     let language = detect_language(path).map(str::to_string);
-    if let Some(language_name) = &language {
-        *languages.entry(language_name.clone()).or_insert(0) += 1;
-    }
 
     if skip_oversized_file(path, facts, &language, config)? {
         return Ok(());
     }
 
-    let Ok(content) = fs::read_to_string(path) else {
-        track_skipped_file(path, facts, 0);
+    if !config.include_low_signal && is_low_signal_audit_path(path) {
+        facts.files_skipped_low_signal += 1;
         facts.files.push(FileFacts {
             path: path.to_path_buf(),
             language,
             lines_of_code: 0,
             branch_count: 0,
             imports: Vec::new(),
-            content: String::new(),
+            content: None,
+            has_inline_tests: false,
+        });
+        return Ok(());
+    }
+
+    let Ok(content) = fs::read_to_string(path) else {
+        track_binary_file(path, facts, 0);
+        facts.files.push(FileFacts {
+            path: path.to_path_buf(),
+            language,
+            lines_of_code: 0,
+            branch_count: 0,
+            imports: Vec::new(),
+            content: None,
             has_inline_tests: false,
         });
         return Ok(());
     };
+
+    facts.files_count += 1;
+    if let Some(language_name) = &language {
+        *languages.entry(language_name.clone()).or_insert(0) += 1;
+    }
 
     let lines_of_code = count_lines_of_code(&content);
     let branch_count = count_branches(&content);
@@ -335,7 +397,7 @@ fn audit_file_inline(
         branch_count,
         imports,
         has_inline_tests,
-        content,
+        content: Some(content),
     };
 
     for audit in file_audits {
@@ -350,7 +412,7 @@ fn audit_file_inline(
         branch_count: file_facts.branch_count,
         imports: file_facts.imports,
         has_inline_tests: file_facts.has_inline_tests,
-        content: String::new(),
+        content: None,
     });
 
     Ok(())
@@ -383,6 +445,7 @@ pub fn collect_scan_facts_with_config(path: &Path, config: &ScanConfig) -> io::R
     let mut languages: HashMap<String, usize> = HashMap::new();
 
     if path.is_file() {
+        facts.files_discovered = 1;
         collect_file_facts(path, &mut facts, &mut languages, config)?;
     } else {
         collect_directory_facts(path, &mut facts, &mut languages, config)?;
@@ -400,6 +463,7 @@ fn collect_directory_facts(
     config: &ScanConfig,
 ) -> io::Result<()> {
     let walker = build_walker(path, config);
+    let mut files_discovered = 0usize;
 
     for result in walker {
         let entry = result.map_err(io::Error::other)?;
@@ -419,21 +483,30 @@ fn collect_directory_facts(
         }
 
         if file_type.is_file() {
+            files_discovered += 1;
             collect_file_facts(entry_path, facts, languages, config)?;
         }
     }
 
+    facts.files_discovered = files_discovered;
     Ok(())
 }
 
 fn build_walker(path: &Path, config: &ScanConfig) -> ignore::Walk {
     let root = path.to_path_buf();
-    let ignored_paths = config.ignored_paths.clone();
+    let mut ignored_paths = config.ignored_paths.clone();
+    ignored_paths.extend(
+        config
+            .exclude_patterns
+            .iter()
+            .map(|pattern| pattern.trim_end_matches("/**").to_string()),
+    );
     WalkBuilder::new(path)
         .hidden(false)
         .git_ignore(true)
         .git_global(true)
         .git_exclude(true)
+        .add_custom_ignore_filename(".repopilotignore")
         .filter_entry(move |entry| !is_ignored_path(entry.path(), &root, &ignored_paths))
         .build()
 }
@@ -469,31 +542,44 @@ fn collect_file_facts(
     languages: &mut HashMap<String, usize>,
     config: &ScanConfig,
 ) -> io::Result<()> {
-    facts.files_count += 1;
-
     let language = detect_language(path).map(str::to_string);
-
-    if let Some(language_name) = &language {
-        *languages.entry(language_name.clone()).or_insert(0) += 1;
-    }
 
     if skip_oversized_file(path, facts, &language, config)? {
         return Ok(());
     }
 
-    let Ok(content) = fs::read_to_string(path) else {
-        track_skipped_file(path, facts, 0);
+    if !config.include_low_signal && is_low_signal_audit_path(path) {
+        facts.files_skipped_low_signal += 1;
         facts.files.push(FileFacts {
             path: path.to_path_buf(),
             language,
             lines_of_code: 0,
             branch_count: 0,
             imports: Vec::new(),
-            content: String::new(),
+            content: None,
+            has_inline_tests: false,
+        });
+        return Ok(());
+    }
+
+    let Ok(content) = fs::read_to_string(path) else {
+        track_binary_file(path, facts, 0);
+        facts.files.push(FileFacts {
+            path: path.to_path_buf(),
+            language,
+            lines_of_code: 0,
+            branch_count: 0,
+            imports: Vec::new(),
+            content: None,
             has_inline_tests: false,
         });
         return Ok(());
     };
+
+    facts.files_count += 1;
+    if let Some(language_name) = &language {
+        *languages.entry(language_name.clone()).or_insert(0) += 1;
+    }
 
     let lines_of_code = count_lines_of_code(&content);
     facts.lines_of_code += lines_of_code;
@@ -506,7 +592,7 @@ fn collect_file_facts(
         language,
         lines_of_code,
         has_inline_tests,
-        content,
+        content: Some(content),
     });
 
     Ok(())
@@ -536,7 +622,7 @@ fn skip_oversized_file(
         lines_of_code: 0,
         branch_count: 0,
         imports: Vec::new(),
-        content: String::new(),
+        content: None,
         has_inline_tests: false,
     });
 
@@ -545,6 +631,19 @@ fn skip_oversized_file(
 
 fn track_skipped_file(path: &Path, facts: &mut ScanFacts, skipped_bytes: u64) {
     facts.skipped_files_count += 1;
+    facts.skipped_bytes = facts.skipped_bytes.saturating_add(skipped_bytes);
+
+    if skipped_bytes > 0 {
+        return;
+    }
+
+    if let Ok(metadata) = fs::metadata(path) {
+        facts.skipped_bytes = facts.skipped_bytes.saturating_add(metadata.len());
+    }
+}
+
+fn track_binary_file(path: &Path, facts: &mut ScanFacts, skipped_bytes: u64) {
+    facts.binary_files_skipped += 1;
     facts.skipped_bytes = facts.skipped_bytes.saturating_add(skipped_bytes);
 
     if skipped_bytes > 0 {

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -24,11 +24,21 @@ pub struct Marker {
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ScanSummary {
     pub root_path: PathBuf,
+    /// Files found after gitignore, `.repopilotignore`, built-in ignores, and
+    /// `--exclude` path/name filters are applied.
+    #[serde(default)]
+    pub files_discovered: usize,
+    /// Text files actually analyzed. Skipped large, binary, low-signal, and
+    /// `--max-files` capped files are not included.
     pub files_count: usize,
     pub directories_count: usize,
     pub lines_of_code: usize,
     #[serde(default)]
     pub skipped_files_count: usize,
+    #[serde(default)]
+    pub files_skipped_low_signal: usize,
+    #[serde(default)]
+    pub binary_files_skipped: usize,
     #[serde(default)]
     pub skipped_bytes: u64,
     pub languages: Vec<LanguageSummary>,

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -64,10 +64,13 @@ fn compare_json_renders_valid_json() {
 fn summary(findings: Vec<Finding>) -> ScanSummary {
     ScanSummary {
         root_path: PathBuf::from("demo"),
+        files_discovered: 0,
         files_count: 1,
         directories_count: 0,
         lines_of_code: 10,
         skipped_files_count: 0,
+        files_skipped_low_signal: 0,
+        binary_files_skipped: 0,
         skipped_bytes: 0,
         languages: vec![],
         findings,

--- a/tests/complexity_audit.rs
+++ b/tests/complexity_audit.rs
@@ -12,7 +12,7 @@ fn make_file(lines_of_code: usize, branch_count: usize) -> FileFacts {
         lines_of_code,
         branch_count,
         imports: Vec::new(),
-        content: String::new(),
+        content: None,
         has_inline_tests: false,
     }
 }
@@ -81,7 +81,7 @@ fn skips_unsupported_language() {
         lines_of_code: 100,
         branch_count: 50,
         imports: Vec::new(),
-        content: String::new(),
+        content: None,
         has_inline_tests: false,
     };
     let findings = ComplexityAudit.audit(&file, &ScanConfig::default());

--- a/tests/config_scan_cli.rs
+++ b/tests/config_scan_cli.rs
@@ -154,3 +154,100 @@ fn min_severity_recomputes_health_score_for_markdown_output() {
     assert!(stdout.contains("- **Health score:** 100/100"));
     assert!(stdout.contains("- **Findings:** 0 (0.0/kloc)"));
 }
+
+#[test]
+fn scan_max_files_caps_analyzed_files_and_console_labels_limit() {
+    let temp = tempdir().expect("failed to create temp dir");
+    fs::write(temp.path().join("a.rs"), "fn a() {}\n").expect("failed to write file");
+    fs::write(temp.path().join("b.rs"), "fn b() {}\n").expect("failed to write file");
+
+    let output = repopilot()
+        .args(["scan", ".", "--max-files", "1"])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(stdout.contains("Files discovered:             2"));
+    assert!(stdout.contains("Files skipped (limit):        1"));
+    assert!(!stdout.contains("Files skipped (ignore):"));
+}
+
+#[test]
+fn scan_exclude_filters_path_or_name() {
+    let temp = tempdir().expect("failed to create temp dir");
+    fs::write(temp.path().join("keep.rs"), "fn keep() {}\n").expect("failed to write file");
+    fs::write(temp.path().join("skip.rs"), "fn skip() {}\n").expect("failed to write file");
+
+    let output = repopilot()
+        .args(["scan", ".", "--format", "json", "--exclude", "skip.rs"])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).expect("expected JSON output");
+    assert_eq!(json["files_discovered"], 1);
+    assert_eq!(json["files_count"], 1);
+    assert_eq!(json["coupling_graph"]["nodes"][0], "./keep.rs");
+}
+
+#[test]
+fn scan_include_low_signal_restores_test_path_analysis() {
+    let temp = tempdir().expect("failed to create temp dir");
+    fs::create_dir(temp.path().join("tests")).expect("failed to create tests dir");
+    fs::write(temp.path().join("tests/sample.rs"), "fn sample() {}\n")
+        .expect("failed to write file");
+
+    let default_output = repopilot()
+        .args(["scan", ".", "--format", "json"])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+    assert!(default_output.status.success());
+    let default_json: Value =
+        serde_json::from_slice(&default_output.stdout).expect("expected JSON output");
+    assert_eq!(default_json["files_count"], 0);
+    assert_eq!(default_json["files_skipped_low_signal"], 1);
+
+    let included_output = repopilot()
+        .args(["scan", ".", "--format", "json", "--include-low-signal"])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+    assert!(included_output.status.success());
+    let included_json: Value =
+        serde_json::from_slice(&included_output.stdout).expect("expected JSON output");
+    assert_eq!(included_json["files_count"], 1);
+    assert_eq!(included_json["files_skipped_low_signal"], 0);
+}
+
+#[test]
+fn scan_max_file_size_accepts_byte_units() {
+    let temp = tempdir().expect("failed to create temp dir");
+    fs::write(temp.path().join("large.rs"), "fn large() {}\n".repeat(200))
+        .expect("failed to write file");
+
+    let kb_output = repopilot()
+        .args(["scan", ".", "--format", "json", "--max-file-size", "1kb"])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+    assert!(kb_output.status.success());
+    let kb_json: Value = serde_json::from_slice(&kb_output.stdout).expect("expected JSON output");
+    assert_eq!(kb_json["files_count"], 0);
+    assert_eq!(kb_json["skipped_files_count"], 1);
+
+    for size in ["1mb", "1gb"] {
+        let output = repopilot()
+            .args(["scan", ".", "--format", "json", "--max-file-size", size])
+            .current_dir(temp.path())
+            .output()
+            .expect("failed to run repopilot scan");
+        assert!(output.status.success(), "{size} should be accepted");
+        let json: Value = serde_json::from_slice(&output.stdout).expect("expected JSON output");
+        assert_eq!(json["files_count"], 1, "{size} should not skip the file");
+        assert_eq!(json["skipped_files_count"], 0);
+    }
+}

--- a/tests/file_facts_scan.rs
+++ b/tests/file_facts_scan.rs
@@ -26,7 +26,7 @@ fn scanner_collects_file_facts_without_running_rules_directly() {
     assert_eq!(file.path, file_path);
     assert_eq!(file.language.as_deref(), Some("Rust"));
     assert_eq!(file.lines_of_code, 2);
-    assert!(file.content.contains("TODO"));
+    assert!(file.content.as_deref().unwrap_or("").contains("TODO"));
 }
 
 #[test]
@@ -44,9 +44,9 @@ fn collector_reports_files_skipped_by_size_guard() {
     let facts =
         collect_scan_facts_with_config(temp.path(), &config).expect("failed to collect scan facts");
 
-    assert_eq!(facts.files_count, 1);
+    assert_eq!(facts.files_count, 0);
     assert_eq!(facts.skipped_files_count, 1);
     assert_eq!(facts.skipped_bytes, content.len() as u64);
     assert_eq!(facts.files.len(), 1);
-    assert!(facts.files[0].content.is_empty());
+    assert!(facts.files[0].content.is_none());
 }

--- a/tests/large_file_architecture.rs
+++ b/tests/large_file_architecture.rs
@@ -81,7 +81,7 @@ fn large_file_audit_skips_non_code_files() {
             lines_of_code: 5_000,
             branch_count: 0,
             imports: Vec::new(),
-            content: String::new(),
+            content: None,
             has_inline_tests: false,
         };
 
@@ -102,7 +102,7 @@ fn large_file_audit_skips_test_and_fixture_paths() {
             lines_of_code: 5_000,
             branch_count: 0,
             imports: Vec::new(),
-            content: String::new(),
+            content: None,
             has_inline_tests: false,
         };
 

--- a/tests/long_function_audit.rs
+++ b/tests/long_function_audit.rs
@@ -16,7 +16,7 @@ fn make_file_at(path: &str, language: &str, content: &str) -> FileFacts {
         lines_of_code: content.lines().count(),
         branch_count: 0,
         imports: Vec::new(),
-        content: content.to_string(),
+        content: Some(content.to_string()),
         has_inline_tests: false,
     }
 }

--- a/tests/marker_findings.rs
+++ b/tests/marker_findings.rs
@@ -19,7 +19,7 @@ fn main() {}
         lines_of_code: 5,
         branch_count: 0,
         imports: Vec::new(),
-        content: content.to_string(),
+        content: Some(content.to_string()),
         has_inline_tests: false,
     };
 

--- a/tests/output_console.rs
+++ b/tests/output_console.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 fn console_output_includes_versioned_summary_and_grouped_findings() {
     let summary = ScanSummary {
         root_path: PathBuf::from("demo"),
+        files_discovered: 0,
         files_count: 1,
         directories_count: 1,
         lines_of_code: 100,
@@ -41,4 +42,23 @@ fn console_output_includes_versioned_summary_and_grouped_findings() {
     assert!(output.contains("Security:"));
     assert!(output.contains("security.secret-candidate (1)"));
     assert!(output.contains("src/config.rs:7"));
+}
+
+#[test]
+fn console_output_labels_max_files_remainder_as_limit_skipped() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("demo"),
+        files_discovered: 3,
+        files_count: 1,
+        directories_count: 1,
+        lines_of_code: 10,
+        health_score: 100,
+        ..ScanSummary::default()
+    };
+
+    let output = render_scan_summary(&summary, OutputFormat::Console)
+        .expect("failed to render console report");
+
+    assert!(output.contains("Files skipped (limit):"));
+    assert!(!output.contains("Files skipped (ignore):"));
 }

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -7,10 +7,13 @@ use std::path::PathBuf;
 fn html_output_escapes_snippets_and_renders_summary() {
     let summary = ScanSummary {
         root_path: PathBuf::from("demo"),
+        files_discovered: 0,
         files_count: 1,
         directories_count: 1,
         lines_of_code: 3,
         skipped_files_count: 0,
+        files_skipped_low_signal: 0,
+        binary_files_skipped: 0,
         skipped_bytes: 0,
         languages: vec![],
         detected_frameworks: vec![],

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -7,10 +7,13 @@ use std::path::PathBuf;
 fn renders_valid_json_scan_summary() {
     let summary = ScanSummary {
         root_path: PathBuf::from("demo"),
+        files_discovered: 0,
         files_count: 1,
         directories_count: 0,
         lines_of_code: 3,
         skipped_files_count: 0,
+        files_skipped_low_signal: 0,
+        binary_files_skipped: 0,
         skipped_bytes: 0,
         languages: vec![LanguageSummary {
             name: "Rust".to_string(),

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -8,10 +8,13 @@ use std::path::PathBuf;
 fn renders_markdown_scan_summary() {
     let summary = ScanSummary {
         root_path: PathBuf::from("demo-project"),
+        files_discovered: 0,
         files_count: 2,
         directories_count: 1,
         lines_of_code: 10,
         skipped_files_count: 0,
+        files_skipped_low_signal: 0,
+        binary_files_skipped: 0,
         skipped_bytes: 0,
         languages: vec![
             LanguageSummary {
@@ -77,10 +80,13 @@ fn renders_markdown_scan_summary() {
 fn renders_empty_markdown_sections() {
     let summary = ScanSummary {
         root_path: PathBuf::from("empty-project"),
+        files_discovered: 0,
         files_count: 0,
         directories_count: 0,
         lines_of_code: 0,
         skipped_files_count: 0,
+        files_skipped_low_signal: 0,
+        binary_files_skipped: 0,
         skipped_bytes: 0,
         languages: vec![],
         findings: vec![],
@@ -106,10 +112,13 @@ fn renders_empty_markdown_sections() {
 fn renders_react_native_architecture_section_when_profile_present() {
     let summary = ScanSummary {
         root_path: PathBuf::from("rn-project"),
+        files_discovered: 0,
         files_count: 5,
         directories_count: 2,
         lines_of_code: 100,
         skipped_files_count: 0,
+        files_skipped_low_signal: 0,
+        binary_files_skipped: 0,
         skipped_bytes: 0,
         languages: vec![],
         findings: vec![],

--- a/tests/scan_summary.rs
+++ b/tests/scan_summary.rs
@@ -73,7 +73,8 @@ fn scan_reports_files_skipped_by_size_guard() {
 
     let summary = scan_path_with_config(temp.path(), &config).expect("failed to scan temp project");
 
-    assert_eq!(summary.files_count, 1);
+    assert_eq!(summary.files_count, 0);
+    assert_eq!(summary.files_discovered, 1);
     assert_eq!(summary.skipped_files_count, 1);
     assert_eq!(summary.skipped_bytes, content.len() as u64);
     assert_eq!(summary.lines_of_code, 0);
@@ -87,8 +88,10 @@ fn scan_reports_binary_files_as_skipped_without_failing() {
 
     let summary = scan_path(temp.path()).expect("failed to scan temp project");
 
-    assert_eq!(summary.files_count, 1);
-    assert_eq!(summary.skipped_files_count, 1);
+    assert_eq!(summary.files_count, 0);
+    assert_eq!(summary.files_discovered, 1);
+    assert_eq!(summary.skipped_files_count, 0);
+    assert_eq!(summary.binary_files_skipped, 1);
     assert_eq!(summary.skipped_bytes, bytes.len() as u64);
     assert_eq!(summary.lines_of_code, 0);
 }

--- a/tests/security_rules.rs
+++ b/tests/security_rules.rs
@@ -193,7 +193,7 @@ fn file(path: &str, content: &str) -> FileFacts {
         lines_of_code: content.lines().count(),
         branch_count: 0,
         imports: Vec::new(),
-        content: content.to_string(),
+        content: Some(content.to_string()),
         has_inline_tests: false,
     }
 }

--- a/tests/testing_rules.rs
+++ b/tests/testing_rules.rs
@@ -223,7 +223,7 @@ fn python_init_and_infra_not_flagged() {
                 lines_of_code: 1,
                 branch_count: 0,
                 imports: Vec::new(),
-                content: String::new(),
+                content: None,
                 has_inline_tests: false,
             }],
             files_count: 1,
@@ -264,7 +264,7 @@ fn ts_file(path: &str) -> FileFacts {
         lines_of_code: 1,
         branch_count: 0,
         imports: Vec::new(),
-        content: String::new(),
+        content: None,
         has_inline_tests: false,
     }
 }
@@ -276,7 +276,7 @@ fn file(path: &str) -> FileFacts {
         lines_of_code: 1,
         branch_count: 0,
         imports: Vec::new(),
-        content: "pub fn value() {}\n".to_string(),
+        content: Some("pub fn value() {}\n".to_string()),
         has_inline_tests: false,
     }
 }


### PR DESCRIPTION
## Summary

This PR improves RepoPilot scan performance and signal quality by adding explicit scan input controls, low-signal path handling, file-size/file-count limits, and clearer scan accounting in reports.

The goal is to avoid reading and analyzing unnecessary files by default, while still allowing users to opt into broader scans when needed.

## Type of change

- Performance improvement
- Feature
- Refactor
- Tests
- Documentation

## What changed

- Added `ScanConfigOverrides` to group scan configuration options instead of passing many separate parameters.
- Updated `build_scan_config` to accept structured scan overrides.
- Updated scan-related commands to use the new config flow:
  - `scan`
  - `review`
  - `vibe`
  - `harden`
  - `prompt`
- Added scan input controls:
  - `--exclude`
  - `--include-low-signal`
  - `--max-file-size`
  - `--max-files`
- Added support for default ignore directories:
  - `.nuxt`
  - `.cache`
  - `vendor`
  - `Pods`
  - `DerivedData`
- Added scan accounting fields:
  - `files_discovered`
  - `files_skipped_low_signal`
  - `binary_files_skipped`
- Updated `files_count` semantics so it represents analyzed text files instead of all discovered files.
- Updated console output with clearer scan input reporting.
- Updated JSON output with scan accounting metadata.
- Updated README and CLI docs with the new scan controls.
- Added tests for:
  - max file size handling
  - exclusion patterns
  - low-signal path behavior
  - scan summary accounting
  - console/JSON output changes

## Why

RepoPilot should be fast, predictable, and useful on real projects.

Before this change, scans could include too many low-value files such as build artifacts, caches, generated files, native platform folders, fixtures, and other noisy paths. That made reports larger, slower, and less useful for `scan`, `vibe`, `harden`, and `prompt`.

This PR improves the signal-to-noise ratio by controlling what gets analyzed and making skipped/analyzed file counts visible to the user.

## Architecture notes

- Scan override options are grouped in `ScanConfigOverrides`.
- Command modules no longer need to pass scan config options as many separate parameters.
- Scan accounting is part of the scan summary instead of being hidden inside the walker.
- Output modules render scan accounting without owning scan logic.
- Existing scan, audit, output, and command responsibilities remain separated.
- No god files introduced.

## Example usage

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo run -- scan .
cargo run -- scan . --exclude generated --max-file-size 1mb --max-files 1000
cargo run -- scan . --include-low-signal
cargo run -- scan . --format json --output report.json
cargo run -- vibe .
cargo run -- harden .
cargo run -- prompt .