### PR TITLE
feat(doctor): add audit readiness diagnostics

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -295,6 +295,40 @@ repopilot init --path ./config/repopilot.toml"
         #[arg(long, default_value = "repopilot.toml")]
         path: PathBuf,
     },
+    /// Diagnose RepoPilot audit readiness for a repository
+    #[command(
+        alias = "d",
+        about = "Diagnose RepoPilot audit readiness",
+        long_about = "Runs a lightweight audit readiness check for a repository.\n\n\
+It scans the target path, reports audit scope accounting, checks whether RepoPilot\n\
+configuration, .repopilotignore, baseline, Git, and GitHub workflows are present,\n\
+then recommends the next command to run.",
+        after_help = "EXAMPLES:\n  \
+repopilot doctor .\n  \
+repopilot doctor . --format json\n  \
+repopilot doctor . --format markdown --output doctor.md"
+    )]
+    Doctor {
+        #[arg(default_value = ".")]
+        path: PathBuf,
+
+        #[arg(long)]
+        config: Option<PathBuf>,
+
+        #[arg(long, value_enum, default_value = "console")]
+        format: CompareOutputFormatArg,
+
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Analyze test, fixture, example, generated, and benchmark paths that are skipped by default
+        #[arg(long)]
+        include_low_signal: bool,
+
+        /// Analyze at most N discovered files after ignore and exclude filters
+        #[arg(long, value_name = "N")]
+        max_files: Option<usize>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,0 +1,39 @@
+use crate::cli::CompareOutputFormatArg;
+use crate::commands::{ScanConfigOverrides, build_scan_config};
+use repopilot::config::loader::{load_default_config, load_optional_config};
+use repopilot::doctor::{build_doctor_report, render_doctor_report};
+use repopilot::output::OutputFormat;
+use repopilot::report::writer::write_report;
+use std::path::PathBuf;
+
+pub fn run(
+    path: PathBuf,
+    config: Option<PathBuf>,
+    format: CompareOutputFormatArg,
+    output: Option<PathBuf>,
+    include_low_signal: bool,
+    max_files: Option<usize>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let repo_config = match &config {
+        Some(config_path) => load_optional_config(config_path)?,
+        None => load_default_config()?,
+    };
+
+    let scan_config = build_scan_config(
+        &repo_config,
+        ScanConfigOverrides {
+            include_low_signal,
+            max_files,
+            ..ScanConfigOverrides::default()
+        },
+    );
+
+    let output_format: OutputFormat = format.into();
+
+    let report = build_doctor_report(&path, config.as_deref(), &scan_config)?;
+    let rendered = render_doctor_report(&report, output_format)?;
+
+    write_report(&rendered, output.as_deref())?;
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod baseline;
 pub mod compare;
+pub mod doctor;
 pub mod harden;
 pub mod init;
 mod llm;
@@ -121,6 +122,15 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             output,
             no_header,
         } => vibe::run(path, config, focus, budget, output, no_header),
+
+        Commands::Doctor {
+            path,
+            config,
+            format,
+            output,
+            include_low_signal,
+            max_files,
+        } => doctor::run(path, config, format, output, include_low_signal, max_files),
     }
 }
 

--- a/src/doctor/checks.rs
+++ b/src/doctor/checks.rs
@@ -1,0 +1,328 @@
+use crate::doctor::model::{
+    DoctorCheck, DoctorProject, DoctorReport, DoctorScanScope, DoctorStatus,
+};
+use crate::scan::config::ScanConfig;
+use crate::scan::scanner::scan_path_with_config;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+const CONFIG_FILE_NAME: &str = "repopilot.toml";
+const BASELINE_FILE_PATH: &str = ".repopilot/baseline.json";
+
+pub fn build_doctor_report(
+    path: &Path,
+    explicit_config_path: Option<&Path>,
+    config: &ScanConfig,
+) -> io::Result<DoctorReport> {
+    let summary = scan_path_with_config(path, config)?;
+    let root = summary.root_path.clone();
+
+    let config_path = explicit_config_path
+        .filter(|path| path.is_file())
+        .map(Path::to_path_buf)
+        .or_else(|| find_upward(&root, CONFIG_FILE_NAME));
+
+    let git_dir = find_upward(&root, ".git");
+    let baseline_path = root.join(BASELINE_FILE_PATH);
+    let github_workflows_dir = root.join(".github").join("workflows");
+
+    let has_repopilotignore = summary.repopilotignore_path.is_some();
+    let has_baseline = baseline_path.is_file();
+    let has_github_workflows = has_github_workflows(&github_workflows_dir);
+
+    let project = DoctorProject {
+        languages: summary
+            .languages
+            .iter()
+            .map(|language| language.name.clone())
+            .collect(),
+        frameworks: summary
+            .detected_frameworks
+            .iter()
+            .map(|framework| format!("{framework:?}"))
+            .collect(),
+        react_native_detected: summary.react_native.is_some(),
+    };
+
+    let scan = DoctorScanScope {
+        files_discovered: summary.files_discovered,
+        files_analyzed: summary.files_count,
+        files_skipped_low_signal: summary.files_skipped_low_signal,
+        binary_files_skipped: summary.binary_files_skipped,
+        large_files_skipped: summary.skipped_files_count,
+        files_skipped_by_limit: summary.files_skipped_by_limit,
+        files_skipped_repopilotignore: summary.files_skipped_repopilotignore,
+    };
+
+    let checks = vec![
+        check_git_repo(git_dir.as_deref()),
+        check_config(config_path.as_deref()),
+        check_repopilotignore(has_repopilotignore, summary.files_skipped_repopilotignore),
+        check_baseline(has_baseline),
+        check_github_workflows(has_github_workflows),
+        check_scan_scope(summary.files_count),
+        check_scan_limit(summary.files_skipped_by_limit),
+    ];
+
+    let recommendations = build_recommendations(
+        config_path.is_some(),
+        has_repopilotignore,
+        has_baseline,
+        has_github_workflows,
+        summary.files_count,
+        summary.files_skipped_by_limit,
+    );
+
+    Ok(DoctorReport {
+        root_path: root.display().to_string(),
+        project,
+        scan,
+        checks,
+        recommendations,
+        next_command: build_next_command(path, has_baseline),
+    })
+}
+
+fn check_git_repo(git_dir: Option<&Path>) -> DoctorCheck {
+    match git_dir {
+        Some(path) => DoctorCheck {
+            id: "git".to_string(),
+            status: DoctorStatus::Pass,
+            title: "Git repository detected".to_string(),
+            detail: format!("Found {}", path.display()),
+        },
+        None => DoctorCheck {
+            id: "git".to_string(),
+            status: DoctorStatus::Warn,
+            title: "Git repository not detected".to_string(),
+            detail: "Review and baseline workflows work best inside a Git repository.".to_string(),
+        },
+    }
+}
+
+fn check_config(config_path: Option<&Path>) -> DoctorCheck {
+    match config_path {
+        Some(path) => DoctorCheck {
+            id: "config".to_string(),
+            status: DoctorStatus::Pass,
+            title: "RepoPilot config found".to_string(),
+            detail: format!("Using {}", path.display()),
+        },
+        None => DoctorCheck {
+            id: "config".to_string(),
+            status: DoctorStatus::Warn,
+            title: "RepoPilot config missing".to_string(),
+            detail: "Run `repopilot init` to create repopilot.toml.".to_string(),
+        },
+    }
+}
+
+fn check_repopilotignore(has_repopilotignore: bool, skipped_files: usize) -> DoctorCheck {
+    if has_repopilotignore {
+        DoctorCheck {
+            id: "repopilotignore".to_string(),
+            status: DoctorStatus::Pass,
+            title: ".repopilotignore found".to_string(),
+            detail: format!("{skipped_files} files skipped by .repopilotignore."),
+        }
+    } else {
+        DoctorCheck {
+            id: "repopilotignore".to_string(),
+            status: DoctorStatus::Warn,
+            title: ".repopilotignore missing".to_string(),
+            detail: "Add .repopilotignore to keep generated, fixture, and vendor files out of audit scope."
+                .to_string(),
+        }
+    }
+}
+
+fn check_baseline(has_baseline: bool) -> DoctorCheck {
+    if has_baseline {
+        DoctorCheck {
+            id: "baseline".to_string(),
+            status: DoctorStatus::Pass,
+            title: "Baseline found".to_string(),
+            detail: format!("Found {BASELINE_FILE_PATH}."),
+        }
+    } else {
+        DoctorCheck {
+            id: "baseline".to_string(),
+            status: DoctorStatus::Warn,
+            title: "Baseline missing".to_string(),
+            detail: "Run `repopilot baseline create .` before enabling CI failure gates."
+                .to_string(),
+        }
+    }
+}
+
+fn check_github_workflows(has_github_workflows: bool) -> DoctorCheck {
+    if has_github_workflows {
+        DoctorCheck {
+            id: "github_workflows".to_string(),
+            status: DoctorStatus::Pass,
+            title: "GitHub workflows found".to_string(),
+            detail: "Repository has GitHub Actions workflow files.".to_string(),
+        }
+    } else {
+        DoctorCheck {
+            id: "github_workflows".to_string(),
+            status: DoctorStatus::Warn,
+            title: "GitHub workflows missing".to_string(),
+            detail: "Add a RepoPilot workflow when you are ready to enforce scan/review checks."
+                .to_string(),
+        }
+    }
+}
+
+fn check_scan_scope(files_analyzed: usize) -> DoctorCheck {
+    if files_analyzed > 0 {
+        DoctorCheck {
+            id: "scan_scope".to_string(),
+            status: DoctorStatus::Pass,
+            title: "Scan scope is not empty".to_string(),
+            detail: format!("{files_analyzed} files analyzed."),
+        }
+    } else {
+        DoctorCheck {
+            id: "scan_scope".to_string(),
+            status: DoctorStatus::Fail,
+            title: "Scan scope is empty".to_string(),
+            detail: "No files were analyzed. Check ignore rules, path, file size limits, and low-signal filtering."
+                .to_string(),
+        }
+    }
+}
+
+fn check_scan_limit(files_skipped_by_limit: usize) -> DoctorCheck {
+    if files_skipped_by_limit == 0 {
+        DoctorCheck {
+            id: "scan_limit".to_string(),
+            status: DoctorStatus::Pass,
+            title: "No scan limit truncation".to_string(),
+            detail: "No files were skipped by --max-files.".to_string(),
+        }
+    } else {
+        DoctorCheck {
+            id: "scan_limit".to_string(),
+            status: DoctorStatus::Warn,
+            title: "Scan was truncated by max-files".to_string(),
+            detail: format!("{files_skipped_by_limit} files were skipped by the scan limit."),
+        }
+    }
+}
+
+fn build_recommendations(
+    has_config: bool,
+    has_repopilotignore: bool,
+    has_baseline: bool,
+    has_github_workflows: bool,
+    files_analyzed: usize,
+    files_skipped_by_limit: usize,
+) -> Vec<String> {
+    let mut recommendations = Vec::new();
+
+    if !has_config {
+        recommendations
+            .push("Run `repopilot init` to create an explicit audit configuration.".to_string());
+    }
+
+    if !has_repopilotignore {
+        recommendations.push(
+            "Add `.repopilotignore` for generated files, fixtures, snapshots, and vendor folders."
+                .to_string(),
+        );
+    }
+
+    if !has_baseline {
+        recommendations.push(
+            "Create a baseline with `repopilot baseline create .` before enforcing CI gates."
+                .to_string(),
+        );
+    }
+
+    if !has_github_workflows {
+        recommendations.push(
+            "Add a GitHub Actions workflow for `repopilot scan` or `repopilot review`.".to_string(),
+        );
+    }
+
+    if files_analyzed == 0 {
+        recommendations.push(
+            "Relax ignore rules or run with `--include-low-signal` if the target only contains tests/examples."
+                .to_string(),
+        );
+    }
+
+    if files_skipped_by_limit > 0 {
+        recommendations.push(
+            "Increase `--max-files` or remove the limit to audit the full repository scope."
+                .to_string(),
+        );
+    }
+
+    if recommendations.is_empty() {
+        recommendations
+            .push("Repository audit setup looks ready for regular scan/review usage.".to_string());
+    }
+
+    recommendations
+}
+
+fn build_next_command(path: &Path, has_baseline: bool) -> String {
+    let path = command_path(path);
+
+    if has_baseline {
+        format!(
+            "repopilot review {path} --base origin/main --baseline .repopilot/baseline.json --fail-on new-high"
+        )
+    } else {
+        format!("repopilot scan {path} --format markdown --output repopilot-report.md")
+    }
+}
+
+fn command_path(path: &Path) -> String {
+    let value = path.display().to_string();
+
+    if value.is_empty() {
+        ".".to_string()
+    } else {
+        value
+    }
+}
+
+fn find_upward(start: &Path, name: &str) -> Option<PathBuf> {
+    let mut current = if start.is_file() {
+        start.parent()?.to_path_buf()
+    } else {
+        start.to_path_buf()
+    };
+
+    loop {
+        let candidate = current.join(name);
+
+        if candidate.exists() {
+            return Some(candidate);
+        }
+
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+fn has_github_workflows(workflows_dir: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(workflows_dir) else {
+        return false;
+    };
+
+    entries.filter_map(Result::ok).any(|entry| {
+        let path = entry.path();
+
+        path.is_file()
+            && path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| matches!(extension, "yml" | "yaml"))
+    })
+}

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -1,0 +1,7 @@
+pub mod checks;
+pub mod model;
+pub mod render;
+
+pub use checks::build_doctor_report;
+pub use model::{DoctorCheck, DoctorProject, DoctorReport, DoctorScanScope, DoctorStatus};
+pub use render::render_doctor_report;

--- a/src/doctor/model.rs
+++ b/src/doctor/model.rs
@@ -1,0 +1,63 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DoctorReport {
+    pub root_path: String,
+    pub project: DoctorProject,
+    pub scan: DoctorScanScope,
+    pub checks: Vec<DoctorCheck>,
+    pub recommendations: Vec<String>,
+    pub next_command: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DoctorProject {
+    pub languages: Vec<String>,
+    pub frameworks: Vec<String>,
+    pub react_native_detected: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DoctorScanScope {
+    pub files_discovered: usize,
+    pub files_analyzed: usize,
+    pub files_skipped_low_signal: usize,
+    pub binary_files_skipped: usize,
+    pub large_files_skipped: usize,
+    pub files_skipped_by_limit: usize,
+    pub files_skipped_repopilotignore: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DoctorCheck {
+    pub id: String,
+    pub status: DoctorStatus,
+    pub title: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DoctorStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+impl DoctorStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Pass => "PASS",
+            Self::Warn => "WARN",
+            Self::Fail => "FAIL",
+        }
+    }
+
+    pub fn icon(self) -> &'static str {
+        match self {
+            Self::Pass => "✅",
+            Self::Warn => "⚠️",
+            Self::Fail => "❌",
+        }
+    }
+}

--- a/src/doctor/render.rs
+++ b/src/doctor/render.rs
@@ -1,0 +1,200 @@
+use crate::doctor::model::{DoctorCheck, DoctorReport, DoctorStatus};
+use crate::output::OutputFormat;
+
+pub fn render_doctor_report(
+    report: &DoctorReport,
+    format: OutputFormat,
+) -> Result<String, serde_json::Error> {
+    match format {
+        OutputFormat::Console => Ok(render_console(report)),
+        OutputFormat::Markdown => Ok(render_markdown(report)),
+        OutputFormat::Json | OutputFormat::Html | OutputFormat::Sarif => {
+            serde_json::to_string_pretty(report)
+        }
+    }
+}
+
+fn render_console(report: &DoctorReport) -> String {
+    let mut output = String::new();
+
+    output.push_str("RepoPilot Doctor\n\n");
+    output.push_str(&format!("Root: {}\n\n", report.root_path));
+
+    output.push_str("Project:\n");
+    output.push_str(&format!(
+        " Languages: {}\n",
+        format_list(&report.project.languages)
+    ));
+    output.push_str(&format!(
+        " Frameworks: {}\n",
+        format_list(&report.project.frameworks)
+    ));
+    output.push_str(&format!(
+        " React Native: {}\n\n",
+        if report.project.react_native_detected {
+            "detected"
+        } else {
+            "not detected"
+        }
+    ));
+
+    output.push_str("Audit scope:\n");
+    output.push_str(&format!(
+        " Files discovered: {}\n",
+        report.scan.files_discovered
+    ));
+    output.push_str(&format!(
+        " Files analyzed: {}\n",
+        report.scan.files_analyzed
+    ));
+    output.push_str(&format!(
+        " Files skipped (.repopilotignore): {}\n",
+        report.scan.files_skipped_repopilotignore
+    ));
+    output.push_str(&format!(
+        " Files skipped (limit): {}\n",
+        report.scan.files_skipped_by_limit
+    ));
+    output.push_str(&format!(
+        " Files skipped (low-signal): {}\n",
+        report.scan.files_skipped_low_signal
+    ));
+    output.push_str(&format!(
+        " Binary files skipped: {}\n",
+        report.scan.binary_files_skipped
+    ));
+    output.push_str(&format!(
+        " Large files skipped: {}\n\n",
+        report.scan.large_files_skipped
+    ));
+
+    output.push_str("Checks:\n");
+    for check in &report.checks {
+        output.push_str(&format_check_line(check));
+    }
+
+    output.push_str("\nRecommendations:\n");
+    for recommendation in &report.recommendations {
+        output.push_str(&format!(" - {recommendation}\n"));
+    }
+
+    output.push_str("\nRecommended next command:\n");
+    output.push_str(&format!(" {}\n", report.next_command));
+
+    output
+}
+
+fn render_markdown(report: &DoctorReport) -> String {
+    let mut output = String::new();
+
+    output.push_str("# RepoPilot Doctor\n\n");
+    output.push_str(&format!("- **Root:** `{}`\n", report.root_path));
+    output.push_str(&format!(
+        "- **Languages:** {}\n",
+        markdown_list(&report.project.languages)
+    ));
+    output.push_str(&format!(
+        "- **Frameworks:** {}\n",
+        markdown_list(&report.project.frameworks)
+    ));
+    output.push_str(&format!(
+        "- **React Native:** {}\n\n",
+        if report.project.react_native_detected {
+            "detected"
+        } else {
+            "not detected"
+        }
+    ));
+
+    output.push_str("## Audit scope\n\n");
+    output.push_str(&format!(
+        "- **Files discovered:** {}\n",
+        report.scan.files_discovered
+    ));
+    output.push_str(&format!(
+        "- **Files analyzed:** {}\n",
+        report.scan.files_analyzed
+    ));
+    output.push_str(&format!(
+        "- **Skipped by `.repopilotignore`:** {}\n",
+        report.scan.files_skipped_repopilotignore
+    ));
+    output.push_str(&format!(
+        "- **Skipped by limit:** {}\n",
+        report.scan.files_skipped_by_limit
+    ));
+    output.push_str(&format!(
+        "- **Skipped low-signal files:** {}\n",
+        report.scan.files_skipped_low_signal
+    ));
+    output.push_str(&format!(
+        "- **Binary files skipped:** {}\n",
+        report.scan.binary_files_skipped
+    ));
+    output.push_str(&format!(
+        "- **Large files skipped:** {}\n\n",
+        report.scan.large_files_skipped
+    ));
+
+    output.push_str("## Checks\n\n");
+    for check in &report.checks {
+        output.push_str(&format!(
+            "- {} **{}** — {}\n  - {}\n",
+            check.status.icon(),
+            check.title,
+            markdown_status(check.status),
+            check.detail
+        ));
+    }
+
+    output.push_str("\n## Recommendations\n\n");
+    for recommendation in &report.recommendations {
+        output.push_str(&format!("- {recommendation}\n"));
+    }
+
+    output.push_str("\n## Recommended next command\n\n");
+    output.push_str("```bash\n");
+    output.push_str(&report.next_command);
+    output.push('\n');
+    output.push_str("```\n");
+
+    output
+}
+
+fn format_check_line(check: &DoctorCheck) -> String {
+    format!(
+        " {} {:<4} {} — {}\n",
+        check.status.icon(),
+        check.status.label(),
+        check.title,
+        check.detail
+    )
+}
+
+fn format_list(values: &[String]) -> String {
+    if values.is_empty() {
+        "none".to_string()
+    } else {
+        values.join(", ")
+    }
+}
+
+fn markdown_list(values: &[String]) -> String {
+    if values.is_empty() {
+        "none".to_string()
+    } else {
+        values
+            .iter()
+            .map(|value| format!("`{value}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+fn markdown_status(status: DoctorStatus) -> &'static str {
+    match status {
+        DoctorStatus::Pass => "pass",
+        DoctorStatus::Warn => "warning",
+        DoctorStatus::Fail => "failed",
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod audits;
 pub mod baseline;
 pub mod compare;
 pub mod config;
+pub mod doctor;
 pub mod findings;
 pub mod frameworks;
 pub mod graph;

--- a/src/scan/scanner/walker.rs
+++ b/src/scan/scanner/walker.rs
@@ -56,7 +56,7 @@ fn collect_paths_with_custom_ignore(
 
         if file_type.is_dir() {
             directories_count += 1;
-        } else if file_type.is_file() && !is_repopilotignore_file(entry_path) {
+        } else if file_type.is_file() && !is_repopilot_control_file(entry_path) {
             file_paths.push(entry_path.to_path_buf());
         }
     }
@@ -88,7 +88,7 @@ fn count_files_with_custom_ignore(
             continue;
         };
 
-        if file_type.is_file() && !is_repopilotignore_file(entry_path) {
+        if file_type.is_file() && !is_repopilot_control_file(entry_path) {
             files_count += 1;
         }
     }
@@ -169,9 +169,9 @@ fn is_ignored_path(path: &Path, root: &Path, ignored_paths: &[String]) -> bool {
     })
 }
 
-fn is_repopilotignore_file(path: &Path) -> bool {
+fn is_repopilot_control_file(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
-        .map(|name| name == REPOPILOT_IGNORE_FILENAME)
+        .map(|name| matches!(name, REPOPILOT_IGNORE_FILENAME | "repopilot.toml"))
         .unwrap_or(false)
 }

--- a/tests/config_scan_cli.rs
+++ b/tests/config_scan_cli.rs
@@ -50,7 +50,7 @@ fn scan_uses_explicit_config_path_and_default_output_format() {
 
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("expected JSON output");
-    assert_eq!(json["files_count"], 2);
+    assert_eq!(json["files_count"], 1);
 }
 
 #[test]

--- a/tests/doctor_cli.rs
+++ b/tests/doctor_cli.rs
@@ -1,0 +1,108 @@
+use serde_json::Value;
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+#[test]
+fn doctor_outputs_json_with_scope_accounting() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+
+    fs::write(root.join("repopilot.toml"), "").expect("write config");
+    fs::write(root.join(".repopilotignore"), "ignored.rs\n").expect("write repopilotignore");
+    fs::write(root.join("kept.rs"), "fn kept() {}\n").expect("write kept file");
+    fs::write(root.join("ignored.rs"), "fn ignored() {}\n").expect("write ignored file");
+
+    let output = repopilot()
+        .args(["doctor", ".", "--format", "json"])
+        .current_dir(root)
+        .output()
+        .expect("run doctor");
+
+    assert!(
+        output.status.success(),
+        "doctor should pass, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("valid json");
+
+    assert_eq!(json["scan"]["files_discovered"], 1);
+    assert_eq!(json["scan"]["files_analyzed"], 1);
+    assert_eq!(json["scan"]["files_skipped_repopilotignore"], 1);
+
+    let checks = json["checks"].as_array().expect("checks array");
+
+    assert!(
+        checks
+            .iter()
+            .any(|check| { check["id"] == "config" && check["status"] == "pass" })
+    );
+
+    assert!(
+        checks
+            .iter()
+            .any(|check| { check["id"] == "repopilotignore" && check["status"] == "pass" })
+    );
+}
+
+#[test]
+fn doctor_console_recommends_next_command() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+
+    fs::write(root.join("main.rs"), "fn main() {}\n").expect("write file");
+
+    let output = repopilot()
+        .args(["doctor", "."])
+        .current_dir(root)
+        .output()
+        .expect("run doctor");
+
+    assert!(
+        output.status.success(),
+        "doctor should pass, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+
+    assert!(stdout.contains("RepoPilot Doctor"));
+    assert!(stdout.contains("Audit scope:"));
+    assert!(stdout.contains("Checks:"));
+    assert!(stdout.contains("Recommended next command:"));
+    assert!(stdout.contains("repopilot scan ."));
+}
+
+#[test]
+fn doctor_marks_empty_scope_as_failed_check() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+
+    fs::create_dir(root.join("tests")).expect("create tests dir");
+    fs::write(root.join("tests").join("sample.rs"), "fn sample() {}\n").expect("write test file");
+
+    let output = repopilot()
+        .args(["doctor", ".", "--format", "json"])
+        .current_dir(root)
+        .output()
+        .expect("run doctor");
+
+    assert!(
+        output.status.success(),
+        "doctor command should render diagnostics even when a check fails"
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    let checks = json["checks"].as_array().expect("checks array");
+
+    assert!(
+        checks
+            .iter()
+            .any(|check| { check["id"] == "scan_scope" && check["status"] == "fail" })
+    );
+}


### PR DESCRIPTION
## Summary

Adds the first version of repopilot doctor, a new audit readiness command for diagnosing whether a repository is ready for reliable RepoPilot scans and CI usage.

This command builds on the new scan scope accounting work and gives users a clearer answer to:

- what RepoPilot scanned
- what was skipped
- whether the repository has basic audit setup files
- whether baseline/CI adoption is ready
- which RepoPilot command should be run next

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests

## What changed

Added a new CLI command: `repopilot doctor .`
Added output support for:
```
repopilot doctor . --format json
repopilot doctor . --format markdown --output doctor.md
```
Added a new doctor domain module split into focused files:

  - src/doctor/model.rs
  - src/doctor/checks.rs
  - src/doctor/render.rs
  - src/doctor/mod.rs

Added command wiring through:

  - src/cli/mod.rs
  - src/commands/doctor.rs
  - src/commands/mod.rs
  - src/lib.rs

Doctor report now checks:

  - Git repository presence
  - repopilot.toml presence
  - .repopilotignore presence
  - baseline presence
  - GitHub workflow presence
  - scan scope status
  - max-files truncation status

Doctor report now includes scan scope accounting:

  - files discovered
  - files analyzed
  - files skipped by .repopilotignore
  - files skipped by --max-files
  - low-signal files skipped
  - binary files skipped
  - large files skipped
  - Added recommendations and a recommended next command based on the repository state.

Added CLI integration tests for:

  - JSON doctor output
  - console doctor output
  - empty scan scope diagnostics
  - Updated scan/config tests to account for RepoPilot control files being excluded from scan scope.

## Why

RepoPilot should not only report findings. It should also help users understand whether the audit itself is trustworthy.

Before this change, a user could run scan, but had limited guidance about whether the repository was configured correctly, whether important setup files were missing, or which command should be used next.

After this change, repopilot doctor gives a lightweight readiness report before deeper scan/review workflows.

This improves the onboarding path:

```
repopilot init
repopilot doctor .
repopilot scan .
repopilot review .
```

## Example

Command:

`repopilot doctor .`

Example output:

```
RepoPilot Doctor

Project:
 Languages: Rust
 Frameworks: none
 React Native: not detected

Audit scope:
 Files discovered: 120
 Files analyzed: 87
 Files skipped (.repopilotignore): 4
 Files skipped (limit): 0

Checks:
 ✅ PASS Git repository detected
 ✅ PASS RepoPilot config found
 ✅ PASS .repopilotignore found
 ⚠️ WARN Baseline missing

Recommended next command:
 repopilot scan . --format markdown --output repopilot-report.md
```

## Verification

Run:

```
cargo fmt --all
cargo test --test doctor_cli
cargo test --all
cargo clippy --all-targets --all-features -- -D warnings
```

Additional smoke checks:

```
cargo run -- doctor .
cargo run -- doctor . --format json
cargo run -- doctor . --format markdown --output /tmp/repopilot-doctor.md
```