### PR TITLE
feat(rust): add context-aware panic risk audit

### DIFF
--- a/src/audits/code_quality/mod.rs
+++ b/src/audits/code_quality/mod.rs
@@ -1,3 +1,4 @@
 pub mod code_markers;
 pub mod complexity;
 pub mod long_function;
+pub mod rust_panic_risk;

--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -1,0 +1,325 @@
+use crate::audits::context::{FileRole, LanguageKind, RuntimeKind, classify_file};
+use crate::audits::traits::FileAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::FileFacts;
+use crate::scan::path_classification::is_low_signal_audit_path;
+
+const RULE_ID: &str = "language.rust.panic-risk";
+
+pub struct RustPanicRiskAudit;
+
+impl FileAudit for RustPanicRiskAudit {
+    fn audit(&self, file: &FileFacts, _config: &ScanConfig) -> Vec<Finding> {
+        if is_low_signal_audit_path(&file.path) {
+            return vec![];
+        }
+
+        let context = classify_file(file);
+
+        if context.language != LanguageKind::Rust {
+            return vec![];
+        }
+
+        let Some(content) = file.content.as_deref() else {
+            return vec![];
+        };
+
+        content
+            .lines()
+            .enumerate()
+            .filter_map(|(index, line)| {
+                let line_number = index + 1;
+                let trimmed = line.trim();
+
+                if should_skip_line(trimmed) {
+                    return None;
+                }
+
+                let pattern = detect_pattern(trimmed)?;
+
+                if should_ignore_pattern(&context, pattern) {
+                    return None;
+                }
+
+                Some(build_finding(file, line_number, trimmed, pattern, &context))
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RustPanicPattern {
+    Unwrap,
+    Expect,
+    Panic,
+    Todo,
+    Unimplemented,
+}
+
+impl RustPanicPattern {
+    fn label(self) -> &'static str {
+        match self {
+            RustPanicPattern::Unwrap => "unwrap()",
+            RustPanicPattern::Expect => "expect()",
+            RustPanicPattern::Panic => "panic!",
+            RustPanicPattern::Todo => "todo!",
+            RustPanicPattern::Unimplemented => "unimplemented!",
+        }
+    }
+}
+
+fn should_skip_line(trimmed: &str) -> bool {
+    trimmed.is_empty()
+        || trimmed.starts_with("//")
+        || trimmed.starts_with("///")
+        || trimmed.starts_with("//!")
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+}
+
+fn detect_pattern(trimmed: &str) -> Option<RustPanicPattern> {
+    if trimmed.contains("todo!(") {
+        return Some(RustPanicPattern::Todo);
+    }
+
+    if trimmed.contains("unimplemented!(") {
+        return Some(RustPanicPattern::Unimplemented);
+    }
+
+    if trimmed.contains("panic!(") {
+        return Some(RustPanicPattern::Panic);
+    }
+
+    if trimmed.contains(".unwrap()") {
+        return Some(RustPanicPattern::Unwrap);
+    }
+
+    if trimmed.contains(".expect(") {
+        return Some(RustPanicPattern::Expect);
+    }
+
+    None
+}
+
+fn should_ignore_pattern(
+    context: &crate::audits::context::AuditContext,
+    pattern: RustPanicPattern,
+) -> bool {
+    context.is_test && matches!(pattern, RustPanicPattern::Unwrap | RustPanicPattern::Expect)
+}
+
+fn build_finding(
+    file: &FileFacts,
+    line_number: usize,
+    snippet: &str,
+    pattern: RustPanicPattern,
+    context: &crate::audits::context::AuditContext,
+) -> Finding {
+    let severity = severity_for(context, pattern);
+    let context_label = context_label(context);
+    let recommendation = recommendation_for(context, pattern);
+
+    Finding {
+        id: String::new(),
+        rule_id: RULE_ID.to_string(),
+        title: format!("Risky Rust {} usage in {}", pattern.label(), context_label),
+        description: format!(
+            "Rust `{}` was found in {}. {}",
+            pattern.label(),
+            context_label,
+            recommendation
+        ),
+        category: FindingCategory::CodeQuality,
+        severity,
+        evidence: vec![Evidence {
+            path: file.path.clone(),
+            line_start: line_number,
+            line_end: None,
+            snippet: snippet.to_string(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+    }
+}
+
+fn severity_for(
+    context: &crate::audits::context::AuditContext,
+    pattern: RustPanicPattern,
+) -> Severity {
+    if context.is_test {
+        return Severity::Low;
+    }
+
+    if matches!(
+        pattern,
+        RustPanicPattern::Todo | RustPanicPattern::Unimplemented
+    ) {
+        return Severity::High;
+    }
+
+    if matches!(pattern, RustPanicPattern::Panic) {
+        if context.has_role(FileRole::Domain) || context.has_runtime(RuntimeKind::RustLibrary) {
+            return Severity::High;
+        }
+
+        return Severity::Medium;
+    }
+
+    if context.has_runtime(RuntimeKind::RustCli) {
+        return Severity::Low;
+    }
+
+    if context.has_role(FileRole::Domain) || context.has_runtime(RuntimeKind::RustLibrary) {
+        return Severity::Medium;
+    }
+
+    Severity::Low
+}
+
+fn context_label(context: &crate::audits::context::AuditContext) -> &'static str {
+    if context.is_test {
+        return "Rust test code";
+    }
+
+    if context.has_runtime(RuntimeKind::RustCli) {
+        return "Rust CLI boundary code";
+    }
+
+    if context.has_role(FileRole::Domain) {
+        return "Rust domain code";
+    }
+
+    if context.has_runtime(RuntimeKind::RustLibrary) {
+        return "Rust library code";
+    }
+
+    "Rust production code"
+}
+
+fn recommendation_for(
+    context: &crate::audits::context::AuditContext,
+    pattern: RustPanicPattern,
+) -> &'static str {
+    if context.is_test {
+        return "Panic-style helpers in tests can be acceptable, but keep them out of reusable test utilities when possible.";
+    }
+
+    match pattern {
+        RustPanicPattern::Unwrap | RustPanicPattern::Expect => {
+            if context.has_runtime(RuntimeKind::RustCli) {
+                "At CLI boundaries this may be acceptable for prototype code, but prefer returning a user-friendly error with context."
+            } else {
+                "Prefer propagating errors with `?`, returning `Result`, or converting the failure into a domain-specific error."
+            }
+        }
+        RustPanicPattern::Panic => {
+            "Avoid panics in reusable production code. Prefer typed errors, validation, or explicit fallback behavior."
+        }
+        RustPanicPattern::Todo | RustPanicPattern::Unimplemented => {
+            "Replace placeholder macros before release or guard them behind test-only code paths."
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::facts::FileFacts;
+    use std::path::PathBuf;
+
+    #[test]
+    fn ignores_unwrap_in_rust_tests() {
+        let file = facts(
+            "tests/parser_test.rs",
+            "let value = parse().unwrap();",
+            true,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn reports_unwrap_in_rust_library_code() {
+        let file = facts(
+            "src/domain/parser.rs",
+            "let value = parse().unwrap();",
+            false,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, RULE_ID);
+        assert_eq!(findings[0].severity, Severity::Medium);
+        assert!(findings[0].title.contains("unwrap()"));
+    }
+
+    #[test]
+    fn reports_panic_in_domain_code_as_high() {
+        let file = facts(
+            "src/domain/user.rs",
+            "panic!(\"invalid user state\");",
+            false,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        assert!(findings[0].title.contains("panic!"));
+    }
+
+    #[test]
+    fn reports_todo_in_production_code_as_high() {
+        let file = facts(
+            "src/service.rs",
+            "todo!(\"implement payment flow\");",
+            false,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        assert!(findings[0].title.contains("todo!"));
+    }
+
+    #[test]
+    fn lowers_unwrap_severity_in_rust_cli_boundary() {
+        let file = facts("src/main.rs", "let config = load_config().unwrap();", false);
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Low);
+        assert!(findings[0].description.contains("CLI boundary"));
+    }
+
+    #[test]
+    fn ignores_commented_panic_patterns() {
+        let file = facts(
+            "src/lib.rs",
+            "// let value = parse().unwrap();\n// panic!(\"old code\");",
+            false,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert!(findings.is_empty());
+    }
+
+    fn facts(path: &str, content: &str, has_inline_tests: bool) -> FileFacts {
+        FileFacts {
+            path: PathBuf::from(path),
+            language: Some("Rust".to_string()),
+            lines_of_code: content.lines().count(),
+            branch_count: 0,
+            imports: Vec::new(),
+            content: Some(content.to_string()),
+            has_inline_tests,
+        }
+    }
+}

--- a/src/audits/context/classify.rs
+++ b/src/audits/context/classify.rs
@@ -1,4 +1,6 @@
-use crate::audits::context::model::{AuditContext, FileRole, FrameworkKind, LanguageKind};
+use crate::audits::context::model::{
+    AuditContext, FileRole, FrameworkKind, LanguageKind, ProgrammingParadigm, RuntimeKind,
+};
 use crate::scan::facts::FileFacts;
 use std::path::Path;
 
@@ -24,10 +26,25 @@ pub fn classify_file(file: &FileFacts) -> AuditContext {
         roles.push(FileRole::Unknown);
     }
 
+    let mut paradigms = Vec::new();
+    classify_paradigms(
+        &mut paradigms,
+        &file.path,
+        content,
+        language,
+        &frameworks,
+        &roles,
+    );
+
+    let mut runtimes = Vec::new();
+    classify_runtimes(&mut runtimes, &file.path, content, language, &frameworks);
+
     AuditContext {
         language,
         frameworks,
         roles,
+        paradigms,
+        runtimes,
         is_test,
     }
 }
@@ -38,9 +55,9 @@ fn classify_language(file: &FileFacts) -> LanguageKind {
 
         match normalized.as_str() {
             "rust" => return LanguageKind::Rust,
-            "typescript" => return LanguageKind::TypeScript,
-            "javascript" => return LanguageKind::JavaScript,
-            "csharp" | "c#" | "cs" => return LanguageKind::CSharp,
+            "typescript" | "typescript react" | "tsx" => return LanguageKind::TypeScript,
+            "javascript" | "javascript react" | "jsx" => return LanguageKind::JavaScript,
+            "csharp" | "c#" | "cs" | "c sharp" => return LanguageKind::CSharp,
             "python" => return LanguageKind::Python,
             "go" => return LanguageKind::Go,
             _ => {}
@@ -82,7 +99,7 @@ fn classify_frameworks(
         }
 
         if normalized_content.contains("next/")
-            || path_contains_component(path, &["pages", "app"]) && is_tsx_or_jsx_file(path)
+            || (path_contains_component(path, &["pages", "app"]) && is_tsx_or_jsx_file(path))
         {
             push_unique(frameworks, FrameworkKind::NextJs);
         }
@@ -90,6 +107,7 @@ fn classify_frameworks(
         if normalized_content.contains("express")
             || normalized_content.contains("from 'node:")
             || normalized_content.contains("from \"node:")
+            || normalized_content.contains("process.env")
         {
             push_unique(frameworks, FrameworkKind::NodeJs);
         }
@@ -166,6 +184,142 @@ fn classify_roles(
     }
 }
 
+fn classify_paradigms(
+    paradigms: &mut Vec<ProgrammingParadigm>,
+    path: &Path,
+    content: &str,
+    language: LanguageKind,
+    frameworks: &[FrameworkKind],
+    roles: &[FileRole],
+) {
+    let normalized_content = content.to_lowercase();
+
+    if roles.contains(&FileRole::ReactComponent) {
+        push_unique(paradigms, ProgrammingParadigm::DeclarativeUi);
+        push_unique(paradigms, ProgrammingParadigm::Functional);
+    }
+
+    if roles.contains(&FileRole::ReactHook) {
+        push_unique(paradigms, ProgrammingParadigm::Functional);
+        push_unique(paradigms, ProgrammingParadigm::Reactive);
+    }
+
+    if frameworks.contains(&FrameworkKind::Unity) {
+        push_unique(paradigms, ProgrammingParadigm::ObjectOriented);
+        push_unique(paradigms, ProgrammingParadigm::DataOriented);
+    }
+
+    if language == LanguageKind::CSharp
+        && (normalized_content.contains("class ")
+            || normalized_content.contains("interface ")
+            || normalized_content.contains("record "))
+    {
+        push_unique(paradigms, ProgrammingParadigm::ObjectOriented);
+    }
+
+    if language == LanguageKind::Rust {
+        if normalized_content.contains("impl ")
+            || normalized_content.contains("trait ")
+            || normalized_content.contains("struct ")
+            || normalized_content.contains("enum ")
+        {
+            push_unique(paradigms, ProgrammingParadigm::ObjectOriented);
+        }
+
+        if normalized_content.contains(".map(")
+            || normalized_content.contains(".filter(")
+            || normalized_content.contains(".fold(")
+            || normalized_content.contains(".and_then(")
+            || normalized_content.contains(".unwrap_or_else(")
+        {
+            push_unique(paradigms, ProgrammingParadigm::Functional);
+        }
+
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name == "main.rs")
+            .unwrap_or(false)
+        {
+            push_unique(paradigms, ProgrammingParadigm::Procedural);
+        }
+    }
+
+    if is_js_or_ts(language) {
+        if normalized_content.contains("function ")
+            || normalized_content.contains("=>")
+            || normalized_content.contains(".map(")
+            || normalized_content.contains(".filter(")
+            || normalized_content.contains(".reduce(")
+        {
+            push_unique(paradigms, ProgrammingParadigm::Functional);
+        }
+
+        if normalized_content.contains("class ") {
+            push_unique(paradigms, ProgrammingParadigm::ObjectOriented);
+        }
+    }
+
+    if paradigms.len() > 1 {
+        push_unique(paradigms, ProgrammingParadigm::Mixed);
+    }
+
+    if paradigms.is_empty() {
+        push_unique(paradigms, ProgrammingParadigm::Unknown);
+    }
+}
+
+fn classify_runtimes(
+    runtimes: &mut Vec<RuntimeKind>,
+    path: &Path,
+    content: &str,
+    language: LanguageKind,
+    frameworks: &[FrameworkKind],
+) {
+    let normalized_content = content.to_lowercase();
+
+    if frameworks.contains(&FrameworkKind::ReactNative) {
+        push_unique(runtimes, RuntimeKind::ReactNative);
+    } else if frameworks.contains(&FrameworkKind::React)
+        || frameworks.contains(&FrameworkKind::NextJs)
+    {
+        push_unique(runtimes, RuntimeKind::Browser);
+    }
+
+    if frameworks.contains(&FrameworkKind::NodeJs)
+        || normalized_content.contains("process.env")
+        || normalized_content.contains("from 'node:")
+        || normalized_content.contains("from \"node:")
+    {
+        push_unique(runtimes, RuntimeKind::Node);
+    }
+
+    if frameworks.contains(&FrameworkKind::Unity) {
+        push_unique(runtimes, RuntimeKind::Unity);
+    }
+
+    if frameworks.contains(&FrameworkKind::DotNet) {
+        push_unique(runtimes, RuntimeKind::DotNet);
+    }
+
+    if language == LanguageKind::Rust {
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+
+        if file_name == "main.rs" {
+            push_unique(runtimes, RuntimeKind::RustCli);
+        } else {
+            push_unique(runtimes, RuntimeKind::RustLibrary);
+        }
+    }
+
+    if runtimes.is_empty() {
+        push_unique(runtimes, RuntimeKind::Unknown);
+    }
+}
+
 fn is_js_or_ts(language: LanguageKind) -> bool {
     matches!(
         language,
@@ -210,10 +364,12 @@ fn is_react_component_file(path: &Path, content: &str) -> bool {
 
     is_pascal_case(file_stem)
         && (content.contains("return <")
-            || content.contains("return (")
+            || content.contains("</")
             || content.contains("React.FC")
+            || content.contains("React.memo")
             || content.contains("memo(")
-            || content.contains("forwardRef("))
+            || content.contains("forwardRef(")
+            || content.contains("React.createElement"))
 }
 
 fn is_react_hook_file(path: &Path, content: &str) -> bool {
@@ -232,6 +388,7 @@ fn is_react_hook_file(path: &Path, content: &str) -> bool {
             || content.contains("useEffect")
             || content.contains("useMemo")
             || content.contains("useCallback")
+            || content.contains("useReducer")
             || content.contains("function use")
             || content.contains("const use"))
 }
@@ -264,9 +421,9 @@ fn is_dotnet_service(path: &Path, content: &str) -> bool {
         .and_then(|name| name.to_str())
         .map(|name| name.ends_with("Service.cs"))
         .unwrap_or(false)
-        || content.contains("class ")
+        || (content.contains("class ")
             && content.contains("service")
-            && path_contains_component(path, &["services"])
+            && path_contains_component(path, &["services"]))
 }
 
 fn is_config_file(path: &Path) -> bool {
@@ -286,10 +443,8 @@ fn is_config_file(path: &Path) -> bool {
             | "next.config.mjs"
             | "cargo.toml"
             | "cargo.lock"
-            | "appsettings.json"
-            | "appsettings.development.json"
             | "projectsettings.asset"
-    )
+    ) || (file_name.starts_with("appsettings") && file_name.ends_with(".json"))
 }
 
 fn is_test_file(path: &Path, has_inline_tests: bool) -> bool {
@@ -304,7 +459,8 @@ fn is_test_file(path: &Path, has_inline_tests: bool) -> bool {
         .map(|name| name.to_lowercase())
         .unwrap_or_default();
 
-    path_text.contains("/tests/")
+    path_text.starts_with("tests/")
+        || path_text.contains("/tests/")
         || path_text.contains("\\tests\\")
         || path_text.contains("/__tests__/")
         || path_text.contains("\\__tests__\\")
@@ -370,6 +526,9 @@ mod tests {
         assert_eq!(context.language, LanguageKind::TypeScript);
         assert!(context.has_framework(FrameworkKind::React));
         assert!(context.has_role(FileRole::ReactComponent));
+        assert!(context.has_paradigm(ProgrammingParadigm::DeclarativeUi));
+        assert!(context.has_paradigm(ProgrammingParadigm::Functional));
+        assert!(context.has_runtime(RuntimeKind::Browser));
         assert!(!context.is_test);
     }
 
@@ -387,6 +546,8 @@ mod tests {
         assert_eq!(context.language, LanguageKind::TypeScript);
         assert!(context.has_framework(FrameworkKind::React));
         assert!(context.has_role(FileRole::ReactHook));
+        assert!(context.has_paradigm(ProgrammingParadigm::Functional));
+        assert!(context.has_paradigm(ProgrammingParadigm::Reactive));
     }
 
     #[test]
@@ -403,6 +564,9 @@ mod tests {
         assert_eq!(context.language, LanguageKind::CSharp);
         assert!(context.has_framework(FrameworkKind::Unity));
         assert!(context.has_role(FileRole::UnityMonoBehaviour));
+        assert!(context.has_paradigm(ProgrammingParadigm::ObjectOriented));
+        assert!(context.has_paradigm(ProgrammingParadigm::DataOriented));
+        assert!(context.has_runtime(RuntimeKind::Unity));
     }
 
     #[test]
@@ -419,6 +583,8 @@ mod tests {
         assert_eq!(context.language, LanguageKind::CSharp);
         assert!(context.has_framework(FrameworkKind::DotNet));
         assert!(context.has_role(FileRole::DotNetController));
+        assert!(context.has_paradigm(ProgrammingParadigm::ObjectOriented));
+        assert!(context.has_runtime(RuntimeKind::DotNet));
     }
 
     #[test]
@@ -435,6 +601,7 @@ mod tests {
         assert_eq!(context.language, LanguageKind::CSharp);
         assert!(context.has_framework(FrameworkKind::DotNet));
         assert!(context.has_role(FileRole::DotNetService));
+        assert!(context.has_runtime(RuntimeKind::DotNet));
     }
 
     #[test]
@@ -451,7 +618,24 @@ mod tests {
         assert_eq!(context.language, LanguageKind::Rust);
         assert!(context.has_role(FileRole::RustTest));
         assert!(context.has_role(FileRole::Test));
+        assert!(context.has_runtime(RuntimeKind::RustLibrary));
         assert!(context.is_test);
+    }
+
+    #[test]
+    fn classifies_rust_main_as_cli_runtime() {
+        let file = facts(
+            "src/main.rs",
+            Some("Rust"),
+            "fn main() { println!(\"hello\"); }\n",
+            false,
+        );
+
+        let context = classify_file(&file);
+
+        assert_eq!(context.language, LanguageKind::Rust);
+        assert!(context.has_runtime(RuntimeKind::RustCli));
+        assert!(context.has_paradigm(ProgrammingParadigm::Procedural));
     }
 
     #[test]
@@ -466,6 +650,7 @@ mod tests {
         let context = classify_file(&file);
 
         assert!(context.has_role(FileRole::Config));
+        assert!(context.has_runtime(RuntimeKind::Unknown));
         assert!(!context.is_production_code());
     }
 

--- a/src/audits/context/mod.rs
+++ b/src/audits/context/mod.rs
@@ -2,4 +2,6 @@ pub mod classify;
 pub mod model;
 
 pub use classify::classify_file;
-pub use model::{AuditContext, FileRole, FrameworkKind, LanguageKind};
+pub use model::{
+    AuditContext, FileRole, FrameworkKind, LanguageKind, ProgrammingParadigm, RuntimeKind,
+};

--- a/src/audits/context/model.rs
+++ b/src/audits/context/model.rs
@@ -34,11 +34,37 @@ pub enum FileRole {
     Unknown,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProgrammingParadigm {
+    Functional,
+    ObjectOriented,
+    Procedural,
+    DeclarativeUi,
+    Reactive,
+    DataOriented,
+    Mixed,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeKind {
+    Browser,
+    Node,
+    ReactNative,
+    DotNet,
+    Unity,
+    RustCli,
+    RustLibrary,
+    Unknown,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditContext {
     pub language: LanguageKind,
     pub frameworks: Vec<FrameworkKind>,
     pub roles: Vec<FileRole>,
+    pub paradigms: Vec<ProgrammingParadigm>,
+    pub runtimes: Vec<RuntimeKind>,
     pub is_test: bool,
 }
 
@@ -51,6 +77,14 @@ impl AuditContext {
         self.roles.contains(&role)
     }
 
+    pub fn has_paradigm(&self, paradigm: ProgrammingParadigm) -> bool {
+        self.paradigms.contains(&paradigm)
+    }
+
+    pub fn has_runtime(&self, runtime: RuntimeKind) -> bool {
+        self.runtimes.contains(&runtime)
+    }
+
     pub fn is_react_component(&self) -> bool {
         self.has_role(FileRole::ReactComponent)
     }
@@ -60,11 +94,23 @@ impl AuditContext {
     }
 
     pub fn is_unity_file(&self) -> bool {
-        self.has_framework(FrameworkKind::Unity)
+        self.has_framework(FrameworkKind::Unity) || self.has_runtime(RuntimeKind::Unity)
     }
 
     pub fn is_dotnet_file(&self) -> bool {
-        self.has_framework(FrameworkKind::DotNet)
+        self.has_framework(FrameworkKind::DotNet) || self.has_runtime(RuntimeKind::DotNet)
+    }
+
+    pub fn is_oop_code(&self) -> bool {
+        self.has_paradigm(ProgrammingParadigm::ObjectOriented)
+    }
+
+    pub fn is_functional_code(&self) -> bool {
+        self.has_paradigm(ProgrammingParadigm::Functional)
+    }
+
+    pub fn is_declarative_ui(&self) -> bool {
+        self.has_paradigm(ProgrammingParadigm::DeclarativeUi)
     }
 
     pub fn is_production_code(&self) -> bool {

--- a/src/audits/pipeline.rs
+++ b/src/audits/pipeline.rs
@@ -6,6 +6,7 @@ use crate::audits::architecture::too_many_modules::TooManyModulesAudit;
 use crate::audits::code_quality::code_markers::CodeMarkerAudit;
 use crate::audits::code_quality::complexity::ComplexityAudit;
 use crate::audits::code_quality::long_function::LongFunctionAudit;
+use crate::audits::code_quality::rust_panic_risk::RustPanicRiskAudit;
 use crate::audits::framework::js_common::{ConsoleLogAudit, VarDeclarationAudit};
 use crate::audits::framework::react::{ReactClassComponentAudit, ReactPropTypesAudit};
 use crate::audits::framework::react_native::{
@@ -32,6 +33,7 @@ pub fn build_file_audits(config: &ScanConfig) -> Vec<Box<dyn FileAudit>> {
         Box::new(PrivateKeyCandidateAudit),
         Box::new(ComplexityAudit),
         Box::new(LongFunctionAudit),
+        Box::new(RustPanicRiskAudit),
     ];
 
     if config.detect_secret_like_names {

--- a/src/rules/registry/language.rs
+++ b/src/rules/registry/language.rs
@@ -1,0 +1,14 @@
+use crate::findings::types::{FindingCategory, Severity};
+use crate::rules::metadata::RuleMetadata;
+
+pub(super) static RULES: &[RuleMetadata] = &[RuleMetadata {
+    rule_id: "language.rust.panic-risk",
+    title: "Risky Rust panic or unwrap usage",
+    category: FindingCategory::CodeQuality,
+    default_severity: Severity::Medium,
+    docs_url: None,
+    description: "Rust panic-style operations such as unwrap(), expect(), panic!, todo!, and unimplemented! can be risky in reusable production code. Their severity depends on whether the code is test code, CLI boundary code, library code, or domain code.",
+    recommendation: Some(
+        "Use context-aware error handling. Prefer Result, ?, typed errors, validation, or explicit fallback behavior in production and library code.",
+    ),
+}];

--- a/src/rules/registry/mod.rs
+++ b/src/rules/registry/mod.rs
@@ -1,6 +1,7 @@
 mod architecture;
 mod code_quality;
 mod framework;
+mod language;
 mod security;
 mod testing;
 
@@ -10,6 +11,7 @@ const RULE_GROUPS: &[&[RuleMetadata]] = &[
     framework::RULES,
     architecture::RULES,
     code_quality::RULES,
+    language::RULES,
     security::RULES,
     testing::RULES,
 ];


### PR DESCRIPTION
## Summary

This PR introduces a context-aware Rust panic risk audit and extends RepoPilot's audit context model with programming paradigms and runtime classification.

The goal is to move RepoPilot away from simple pattern matching and toward smarter audit decisions based on language, file role, runtime, and programming style.

This is an important foundation for the 0.9.0 direction: RepoPilot should not blindly report every pattern as a problem. It should understand whether the code is test code, CLI boundary code, reusable library code, domain code, declarative UI code, functional code, or framework-specific code.

## What changed

- Added a new Rust audit for risky panic-style operations:
  - `unwrap()`
  - `expect()`
  - `panic!`
  - `todo!`
  - `unimplemented!`

- Added context-aware severity decisions:
  - test code can safely ignore common `unwrap()` / `expect()` usage
  - CLI boundary code is treated less aggressively
  - domain and library code receive stronger warnings
  - `todo!` and `unimplemented!` in production code are reported as high severity

- Extended `AuditContext` with:
  - `ProgrammingParadigm`
  - `RuntimeKind`
  - helper methods such as `is_functional_code`, `is_oop_code`, and `is_declarative_ui`

- Improved file classification for:
  - Rust CLI files
  - Rust library/domain files
  - React components
  - React hooks
  - Node.js files
  - .NET files
  - Unity files
  - test paths and config files

- Registered the new language rule metadata:
  - `language.rust.panic-risk`

- Added tests for:
  - Rust panic pattern detection
  - ignored panic-style usage in tests
  - severity differences between CLI, domain, library, and production code
  - context classification for paradigms and runtimes

## Why

RepoPilot needs to become more than a simple rule scanner.

A raw pattern such as `unwrap()` is not always equally dangerous. In Rust test code it can be acceptable. In CLI boundary code it may be tolerable with low severity. In reusable library or domain code it can cause real reliability problems.

This PR introduces the first practical version of context-aware audit behavior.

This also prepares RepoPilot for future 0.9.0 work where rules should understand:

- language semantics
- programming paradigms
- framework conventions
- runtime boundaries
- file roles
- known false-positive cases

## Architecture notes

- The new audit is isolated in `src/audits/code_quality/rust_panic_risk.rs`
- Context classification remains centralized in `src/audits/context/`
- Rule metadata remains in `src/rules/registry/`
- The audit pipeline only registers the new audit and does not own audit logic
- No god files are introduced
- Findings include concrete evidence with file path, line number, and snippet

## Important design direction

This PR is the first step toward context-aware RepoPilot rules.

RepoPilot should not enforce one universal programming style.

For example, functional programming should not be treated as a code smell simply because it uses many functions, closures, or chained transformations. A functional pipeline can be valid and clean when it is pure, single-purpose, and free from hidden side effects.

Future audits should follow the same principle:

```text
pattern detected
→ classify language
→ classify runtime
→ classify file role
→ classify paradigm
→ decide whether the rule applies
→ choose severity
→ explain why