### PR TITLE
feat(knowledge): add context-aware rule decision engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- Added a bundled RepoPilot Knowledge Engine foundation for language, framework, runtime, paradigm, and rule applicability decisions.
+- Added a tiered language corpus covering rule-aware, context-aware, import-aware, and detect-only support levels across common and emerging languages.
+
+### Changed
+
+- Language detection now uses the Knowledge Engine corpus instead of a hardcoded extension table.
+- Context-aware audits can suppress or adjust findings based on file role, runtime, paradigm, test/config/generated status, and rule applicability.
+
 ## [0.8.0] - 2026-05-11
 
 ### Added

--- a/src/audits/architecture/large_file.rs
+++ b/src/audits/architecture/large_file.rs
@@ -1,49 +1,19 @@
 use crate::audits::traits::FileAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::knowledge::decision::apply_file_decision;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
-use crate::scan::path_classification::is_low_signal_audit_path;
 use std::path::Path;
 
 pub struct LargeFileAudit;
 
 impl FileAudit for LargeFileAudit {
     fn audit(&self, file: &FileFacts, config: &ScanConfig) -> Vec<Finding> {
-        if is_low_signal_audit_path(&file.path) {
-            return vec![];
-        }
-        if !is_code_file(file.language.as_deref()) {
-            return vec![];
-        }
         detect_large_file_finding(&file.path, file.lines_of_code, config)
+            .and_then(|finding| apply_file_decision("architecture.large-file", file, finding, None))
             .into_iter()
             .collect()
     }
-}
-
-/// Only applies the size limit to actual programming-language source files.
-/// Documentation, config, and data formats (Markdown, YAML, JSON, TOML…)
-/// are not subject to this rule because their length is driven by content, not code complexity.
-fn is_code_file(language: Option<&str>) -> bool {
-    matches!(
-        language,
-        Some(
-            "Rust"
-                | "Go"
-                | "Python"
-                | "TypeScript"
-                | "TypeScript React"
-                | "JavaScript"
-                | "JavaScript React"
-                | "Java"
-                | "Kotlin"
-                | "Swift"
-                | "C#"
-                | "C++"
-                | "C"
-                | "C/C++ Header"
-        )
-    )
 }
 
 pub fn detect_large_file_finding(

--- a/src/audits/code_quality/code_markers.rs
+++ b/src/audits/code_quality/code_markers.rs
@@ -1,5 +1,6 @@
 use crate::audits::traits::FileAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::knowledge::decision::apply_file_decision;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
 use crate::scan::markers::detect_markers;
@@ -15,7 +16,11 @@ impl FileAudit for CodeMarkerAudit {
 
         detect_markers(&file.path, file.content.as_deref().unwrap_or(""))
             .iter()
-            .map(build_marker_finding)
+            .filter_map(|marker| {
+                let finding = build_marker_finding(marker);
+                let rule_id = finding.rule_id.clone();
+                apply_file_decision(&rule_id, file, finding, None)
+            })
             .collect()
     }
 }
@@ -23,7 +28,11 @@ impl FileAudit for CodeMarkerAudit {
 pub fn detect_code_marker_findings(file: &FileFacts) -> Vec<Finding> {
     detect_markers(&file.path, file.content.as_deref().unwrap_or(""))
         .iter()
-        .map(build_marker_finding)
+        .filter_map(|marker| {
+            let finding = build_marker_finding(marker);
+            let rule_id = finding.rule_id.clone();
+            apply_file_decision(&rule_id, file, finding, None)
+        })
         .collect()
 }
 

--- a/src/audits/code_quality/complexity.rs
+++ b/src/audits/code_quality/complexity.rs
@@ -1,18 +1,18 @@
+use crate::audits::context::classify_file;
 use crate::audits::traits::FileAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::knowledge::decision::decide_for_audit_context;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
 
 pub struct ComplexityAudit;
 
+const RULE_ID: &str = "code-quality.complex-file";
 const MIN_HIGH_COMPLEXITY_LOC: usize = 25;
 
 impl FileAudit for ComplexityAudit {
     fn audit(&self, file: &FileFacts, config: &ScanConfig) -> Vec<Finding> {
         if file.lines_of_code < 10 {
-            return vec![];
-        }
-        if !is_code_language(file.language.as_deref()) {
             return vec![];
         }
 
@@ -28,6 +28,15 @@ impl FileAudit for ComplexityAudit {
             return vec![];
         };
 
+        let context = classify_file(file);
+        let decision = decide_for_audit_context(RULE_ID, &context, severity, None);
+
+        if decision.is_suppressed() {
+            return vec![];
+        }
+
+        let severity = decision.severity;
+
         let threshold = if severity == Severity::High {
             config.complexity_high_threshold
         } else {
@@ -36,7 +45,7 @@ impl FileAudit for ComplexityAudit {
 
         vec![Finding {
             id: String::new(),
-            rule_id: "code-quality.complex-file".to_string(),
+            rule_id: RULE_ID.to_string(),
             title: "High complexity density".to_string(),
             description: format!(
                 "This file has a complexity density of {density} (branch constructs × 1000 / LOC), \
@@ -58,25 +67,6 @@ impl FileAudit for ComplexityAudit {
             docs_url: None,
         }]
     }
-}
-
-fn is_code_language(language: Option<&str>) -> bool {
-    matches!(
-        language,
-        Some(
-            "Rust"
-                | "Go"
-                | "Python"
-                | "TypeScript"
-                | "TypeScript React"
-                | "JavaScript"
-                | "JavaScript React"
-                | "Java"
-                | "Kotlin"
-                | "C"
-                | "C++"
-        )
-    )
 }
 
 /// Counts branching constructs and logical operators as a heuristic complexity metric.

--- a/src/audits/code_quality/language_risk.rs
+++ b/src/audits/code_quality/language_risk.rs
@@ -1,0 +1,457 @@
+use crate::audits::traits::FileAudit;
+use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::knowledge::decision::decide_for_file;
+use crate::knowledge::language::language_id_for_name;
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::FileFacts;
+use std::path::Path;
+
+pub struct LanguageRiskAudit;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LanguageRiskPattern {
+    rule_id: &'static str,
+    signal: &'static str,
+    title: &'static str,
+    context_label: &'static str,
+    recommendation: &'static str,
+    base_severity: Severity,
+}
+
+impl FileAudit for LanguageRiskAudit {
+    fn audit(&self, file: &FileFacts, _config: &ScanConfig) -> Vec<Finding> {
+        let Some(content) = file
+            .content
+            .as_deref()
+            .filter(|content| !content.is_empty())
+        else {
+            return vec![];
+        };
+
+        let Some(language_id) = file.language.as_deref().and_then(language_id_for_name) else {
+            return vec![];
+        };
+
+        detect_language_risks(language_id, content, &file.path, file)
+    }
+}
+
+fn detect_language_risks(
+    language_id: &str,
+    content: &str,
+    path: &Path,
+    file: &FileFacts,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let mut in_block_comment = false;
+
+    for (line_index, raw_line) in content.lines().enumerate() {
+        let Some(line) = sanitized_code_line(raw_line, &mut in_block_comment) else {
+            continue;
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let patterns = patterns_for_line(language_id, trimmed, path);
+        for pattern in patterns {
+            let decision = decide_for_file(
+                pattern.rule_id,
+                file,
+                pattern.base_severity,
+                Some(pattern.signal),
+            );
+            if decision.is_suppressed() {
+                continue;
+            }
+
+            findings.push(build_finding(
+                path,
+                line_index + 1,
+                raw_line.trim(),
+                pattern,
+                decision.severity,
+            ));
+        }
+    }
+
+    findings
+}
+
+fn patterns_for_line(language_id: &str, trimmed: &str, path: &Path) -> Vec<LanguageRiskPattern> {
+    match language_id {
+        "go" => go_patterns(trimmed),
+        "python" => python_patterns(trimmed),
+        "typescript" | "typescript-react" | "javascript" | "javascript-react" => {
+            js_patterns(trimmed, path)
+        }
+        "java" | "kotlin" | "csharp" => managed_patterns(language_id, trimmed),
+        _ => Vec::new(),
+    }
+}
+
+fn go_patterns(trimmed: &str) -> Vec<LanguageRiskPattern> {
+    let mut patterns = Vec::new();
+    if trimmed.contains("panic(") {
+        patterns.push(pattern(
+            "language.go.panic-exit-risk",
+            "go.panic",
+            "Risky Go panic usage",
+            "Go panic call",
+            "Return an error from reusable Go code and let the caller decide how to recover.",
+            Severity::Medium,
+        ));
+    }
+    if trimmed.contains("log.Fatal(") || trimmed.contains("log.Fatalf(") {
+        patterns.push(pattern(
+            "language.go.panic-exit-risk",
+            "go.log-fatal",
+            "Risky Go log.Fatal usage",
+            "Go fatal logging call",
+            "Use returned errors outside the narrow CLI boundary so libraries remain recoverable.",
+            Severity::Medium,
+        ));
+    }
+    if trimmed.contains("os.Exit(") {
+        patterns.push(pattern(
+            "language.go.panic-exit-risk",
+            "go.os-exit",
+            "Risky Go os.Exit usage",
+            "Go process exit call",
+            "Centralise process exits at the CLI entrypoint and return errors elsewhere.",
+            Severity::Medium,
+        ));
+    }
+    patterns
+}
+
+fn python_patterns(trimmed: &str) -> Vec<LanguageRiskPattern> {
+    let mut patterns = Vec::new();
+    if is_broad_python_except(trimmed) {
+        patterns.push(pattern(
+            "language.python.exception-risk",
+            "python.broad-except",
+            "Broad Python except handler",
+            "Python broad exception handler",
+            "Catch specific exceptions so unrelated failures are not hidden.",
+            Severity::Medium,
+        ));
+    }
+    if trimmed.starts_with("assert ") || trimmed.starts_with("assert(") {
+        patterns.push(pattern(
+            "language.python.exception-risk",
+            "python.assert",
+            "Python assert in production path",
+            "Python assert statement",
+            "Use explicit runtime validation for production invariants because asserts can be disabled.",
+            Severity::Medium,
+        ));
+    }
+    if trimmed.contains("raise NotImplementedError")
+        || trimmed.contains("NotImplementedError(")
+        || trimmed == "raise NotImplementedError"
+    {
+        patterns.push(pattern(
+            "language.python.exception-risk",
+            "python.not-implemented",
+            "Python NotImplementedError placeholder",
+            "Python not-implemented placeholder",
+            "Replace placeholders before production release or guard them behind explicit feature flags.",
+            Severity::High,
+        ));
+    }
+    patterns
+}
+
+fn js_patterns(trimmed: &str, path: &Path) -> Vec<LanguageRiskPattern> {
+    let mut patterns = Vec::new();
+    if trimmed.contains("process.exit(") {
+        patterns.push(pattern(
+            "language.javascript.runtime-exit-risk",
+            "js.process-exit",
+            "JavaScript process.exit usage",
+            "JavaScript process exit call",
+            "Keep process exits at a CLI boundary and return errors from reusable modules.",
+            Severity::Medium,
+        ));
+    }
+    if trimmed.contains("throw new Error(") && is_library_boundary_path(path) {
+        patterns.push(pattern(
+            "language.javascript.runtime-exit-risk",
+            "js.throw-error",
+            "Generic JavaScript error at library boundary",
+            "JavaScript generic thrown error",
+            "Prefer typed errors or actionable error messages at reusable package boundaries.",
+            Severity::Medium,
+        ));
+    }
+    patterns
+}
+
+fn managed_patterns(language_id: &str, trimmed: &str) -> Vec<LanguageRiskPattern> {
+    let mut patterns = Vec::new();
+    let is_csharp = language_id == "csharp";
+
+    if trimmed.contains("throw new RuntimeException(")
+        || trimmed.contains("throw new IllegalStateException(")
+        || (is_csharp && trimmed.contains("throw new Exception("))
+    {
+        patterns.push(pattern(
+            "language.managed.fatal-exception-risk",
+            "managed.fatal-exception",
+            "Generic fatal exception in managed code",
+            "JVM/.NET generic fatal exception",
+            "Use domain-specific exception or result types when callers need precise recovery behaviour.",
+            Severity::Medium,
+        ));
+    }
+
+    if trimmed.contains("throw new NotImplementedException(")
+        || trimmed.contains("throw new NotImplementedError(")
+        || trimmed.contains("TODO(")
+        || trimmed.contains("TODO()")
+    {
+        patterns.push(pattern(
+            "language.managed.fatal-exception-risk",
+            "managed.not-implemented",
+            "Not-implemented placeholder in managed code",
+            "JVM/.NET placeholder failure",
+            "Replace placeholders before production release or isolate unfinished paths clearly.",
+            Severity::High,
+        ));
+    }
+
+    patterns
+}
+
+fn pattern(
+    rule_id: &'static str,
+    signal: &'static str,
+    title: &'static str,
+    context_label: &'static str,
+    recommendation: &'static str,
+    base_severity: Severity,
+) -> LanguageRiskPattern {
+    LanguageRiskPattern {
+        rule_id,
+        signal,
+        title,
+        context_label,
+        recommendation,
+        base_severity,
+    }
+}
+
+fn build_finding(
+    path: &Path,
+    line_number: usize,
+    snippet: &str,
+    pattern: LanguageRiskPattern,
+    severity: Severity,
+) -> Finding {
+    Finding {
+        id: String::new(),
+        rule_id: pattern.rule_id.to_string(),
+        title: pattern.title.to_string(),
+        description: format!(
+            "{} was found in {}. {}",
+            pattern.context_label,
+            path.display(),
+            pattern.recommendation
+        ),
+        category: FindingCategory::CodeQuality,
+        severity,
+        evidence: vec![Evidence {
+            path: path.to_path_buf(),
+            line_start: line_number,
+            line_end: None,
+            snippet: snippet.to_string(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+    }
+}
+
+fn sanitized_code_line(line: &str, in_block_comment: &mut bool) -> Option<String> {
+    let trimmed = line.trim();
+    if *in_block_comment {
+        if trimmed.contains("*/") {
+            *in_block_comment = false;
+        }
+        return None;
+    }
+    if trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("///")
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+    {
+        if trimmed.starts_with("/*") && !trimmed.contains("*/") {
+            *in_block_comment = true;
+        }
+        return None;
+    }
+
+    Some(strip_string_literals(line))
+}
+
+fn strip_string_literals(line: &str) -> String {
+    let mut result = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    let mut string_delimiter = None;
+    let mut escaped = false;
+
+    while let Some(character) = chars.next() {
+        if let Some(delimiter) = string_delimiter {
+            if escaped {
+                escaped = false;
+                result.push(' ');
+                continue;
+            }
+            if character == '\\' {
+                escaped = true;
+                result.push(' ');
+                continue;
+            }
+            if character == delimiter {
+                string_delimiter = None;
+                result.push(character);
+            } else {
+                result.push(' ');
+            }
+            continue;
+        }
+
+        if character == '/' && chars.peek() == Some(&'/') {
+            break;
+        }
+        if character == '#' {
+            break;
+        }
+        if matches!(character, '"' | '\'' | '`') {
+            string_delimiter = Some(character);
+            result.push(character);
+        } else {
+            result.push(character);
+        }
+    }
+
+    result
+}
+
+fn is_broad_python_except(trimmed: &str) -> bool {
+    let normalized = trimmed.replace(' ', "");
+    normalized == "except:" || normalized.starts_with("except:#")
+}
+
+fn is_library_boundary_path(path: &Path) -> bool {
+    path.components().any(|component| {
+        component
+            .as_os_str()
+            .to_str()
+            .map(|value| {
+                matches!(
+                    value.to_lowercase().as_str(),
+                    "domain"
+                        | "domains"
+                        | "core"
+                        | "model"
+                        | "models"
+                        | "lib"
+                        | "libs"
+                        | "packages"
+                )
+            })
+            .unwrap_or(false)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn reports_go_panic_in_domain_code_as_high() {
+        let file = facts(
+            "src/domain/user.go",
+            Some("Go"),
+            "package domain\nfunc Parse() { panic(\"bad\") }\n",
+        );
+
+        let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "language.go.panic-exit-risk");
+        assert_eq!(findings[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn downgrades_python_assert_in_tests() {
+        let file = facts(
+            "tests/test_user.py",
+            Some("Python"),
+            "assert user.is_valid\n",
+        );
+
+        let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Low);
+    }
+
+    #[test]
+    fn reports_js_process_exit_but_not_string_literal() {
+        let file = facts(
+            "src/cli/main.ts",
+            Some("TypeScript"),
+            "const text = \"process.exit(1)\";\nprocess.exit(1);\n",
+        );
+
+        let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "language.javascript.runtime-exit-risk");
+    }
+
+    #[test]
+    fn reports_csharp_not_implemented_placeholder() {
+        let file = facts(
+            "src/domain/UserService.cs",
+            Some("C#"),
+            "public void Run() { throw new NotImplementedException(); }\n",
+        );
+
+        let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "language.managed.fatal-exception-risk");
+        assert_eq!(findings[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn ignores_functional_iterator_style_without_risky_pattern() {
+        let file = facts(
+            "src/domain/users.ts",
+            Some("TypeScript"),
+            "export const names = users.filter(u => u.active).map(u => u.name);\n",
+        );
+
+        let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert!(findings.is_empty());
+    }
+
+    fn facts(path: &str, language: Option<&str>, content: &str) -> FileFacts {
+        FileFacts {
+            path: PathBuf::from(path),
+            language: language.map(str::to_string),
+            lines_of_code: content.lines().count(),
+            branch_count: 0,
+            imports: Vec::new(),
+            content: Some(content.to_string()),
+            has_inline_tests: false,
+        }
+    }
+}

--- a/src/audits/code_quality/long_function/mod.rs
+++ b/src/audits/code_quality/long_function/mod.rs
@@ -1,6 +1,7 @@
 use crate::audits::context::{AuditContext, FileRole, FrameworkKind, LanguageKind, classify_file};
 use crate::audits::traits::FileAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::knowledge::decision::decide_for_audit_context;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
 use crate::scan::path_classification::is_low_signal_audit_path;
@@ -8,6 +9,8 @@ use std::path::Path;
 
 mod brace;
 mod python;
+
+const RULE_ID: &str = "code-quality.long-function";
 
 pub struct LongFunctionAudit;
 
@@ -31,34 +34,22 @@ impl FileAudit for LongFunctionAudit {
             return vec![];
         }
 
-        let language = match file.language.as_deref() {
-            Some(language) if is_supported(language) => language,
-            _ => return vec![],
+        let Some(language) = file.language.as_deref() else {
+            return vec![];
         };
 
         let context = classify_file(file);
-        let policy = long_function_policy(&context, config.long_function_loc_threshold);
+        let decision = decide_for_audit_context(RULE_ID, &context, Severity::Medium, None);
+
+        if decision.is_suppressed() {
+            return vec![];
+        }
+
+        let mut policy = long_function_policy(&context, config.long_function_loc_threshold);
+        policy.severity = decision.severity.min(policy.severity);
 
         detect_long_functions(content, language, &file.path, policy)
     }
-}
-
-fn is_supported(language: &str) -> bool {
-    matches!(
-        language,
-        "Rust"
-            | "Go"
-            | "Python"
-            | "TypeScript"
-            | "TypeScript React"
-            | "JavaScript"
-            | "JavaScript React"
-            | "Java"
-            | "Kotlin"
-            | "CSharp"
-            | "C#"
-            | "CS"
-    )
 }
 
 fn detect_long_functions(
@@ -178,7 +169,7 @@ fn build_finding(
 
     Finding {
         id: String::new(),
-        rule_id: "code-quality.long-function".to_string(),
+        rule_id: RULE_ID.to_string(),
         title,
         description: format!(
             "Function {name_display} spans {fn_len} lines, exceeding the context-aware {threshold}-line threshold for {context_label}. {recommendation}",

--- a/src/audits/code_quality/mod.rs
+++ b/src/audits/code_quality/mod.rs
@@ -1,4 +1,5 @@
 pub mod code_markers;
 pub mod complexity;
+pub mod language_risk;
 pub mod long_function;
 pub mod rust_panic_risk;

--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -1,6 +1,7 @@
 use crate::audits::context::{FileRole, LanguageKind, RuntimeKind, classify_file};
 use crate::audits::traits::FileAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::knowledge::decision::decide_for_audit_context;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
 use crate::scan::path_classification::is_low_signal_audit_path;
@@ -25,26 +26,44 @@ impl FileAudit for RustPanicRiskAudit {
             return vec![];
         };
 
-        content
-            .lines()
-            .enumerate()
-            .filter_map(|(index, line)| {
-                let line_number = index + 1;
-                let trimmed = line.trim();
+        let mut findings = Vec::new();
+        let mut in_block_comment = false;
 
-                if should_skip_line(trimmed) {
-                    return None;
-                }
+        for (index, line) in content.lines().enumerate() {
+            let line_number = index + 1;
+            let trimmed = line.trim();
 
-                let pattern = detect_pattern(trimmed)?;
+            if trimmed.is_empty() {
+                continue;
+            }
 
-                if should_ignore_pattern(&context, pattern) {
-                    return None;
-                }
+            let sanitized = sanitize_rust_line(line, &mut in_block_comment);
+            let Some(pattern) = detect_pattern(sanitized.trim()) else {
+                continue;
+            };
 
-                Some(build_finding(file, line_number, trimmed, pattern, &context))
-            })
-            .collect()
+            let decision = decide_for_audit_context(
+                RULE_ID,
+                &context,
+                pattern.base_severity(),
+                Some(pattern.signal()),
+            );
+
+            if decision.is_suppressed() {
+                continue;
+            }
+
+            findings.push(build_finding(
+                file,
+                line_number,
+                trimmed,
+                pattern,
+                &context,
+                decision.severity,
+            ));
+        }
+
+        findings
     }
 }
 
@@ -67,15 +86,25 @@ impl RustPanicPattern {
             RustPanicPattern::Unimplemented => "unimplemented!",
         }
     }
-}
 
-fn should_skip_line(trimmed: &str) -> bool {
-    trimmed.is_empty()
-        || trimmed.starts_with("//")
-        || trimmed.starts_with("///")
-        || trimmed.starts_with("//!")
-        || trimmed.starts_with("/*")
-        || trimmed.starts_with('*')
+    fn signal(self) -> &'static str {
+        match self {
+            RustPanicPattern::Unwrap => "rust.unwrap",
+            RustPanicPattern::Expect => "rust.expect",
+            RustPanicPattern::Panic => "rust.panic",
+            RustPanicPattern::Todo => "rust.todo",
+            RustPanicPattern::Unimplemented => "rust.unimplemented",
+        }
+    }
+
+    fn base_severity(self) -> Severity {
+        match self {
+            RustPanicPattern::Todo | RustPanicPattern::Unimplemented => Severity::High,
+            RustPanicPattern::Unwrap | RustPanicPattern::Expect | RustPanicPattern::Panic => {
+                Severity::Medium
+            }
+        }
+    }
 }
 
 fn detect_pattern(trimmed: &str) -> Option<RustPanicPattern> {
@@ -102,11 +131,80 @@ fn detect_pattern(trimmed: &str) -> Option<RustPanicPattern> {
     None
 }
 
-fn should_ignore_pattern(
-    context: &crate::audits::context::AuditContext,
-    pattern: RustPanicPattern,
-) -> bool {
-    context.is_test && matches!(pattern, RustPanicPattern::Unwrap | RustPanicPattern::Expect)
+fn sanitize_rust_line(line: &str, in_block_comment: &mut bool) -> String {
+    // Lightweight scanner only; raw strings and nested block comments are a
+    // future parser-level improvement, not a dependency for this audit.
+    let mut output = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    let mut in_string = false;
+    let mut in_char = false;
+    let mut escaped = false;
+
+    while let Some(character) = chars.next() {
+        if *in_block_comment {
+            if character == '*' && chars.peek() == Some(&'/') {
+                chars.next();
+                *in_block_comment = false;
+                output.push(' ');
+                output.push(' ');
+            } else {
+                output.push(' ');
+            }
+            continue;
+        }
+
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_string = false;
+            }
+            output.push(' ');
+            continue;
+        }
+
+        if in_char {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '\'' {
+                in_char = false;
+            }
+            output.push(' ');
+            continue;
+        }
+
+        if character == '/' && chars.peek() == Some(&'/') {
+            break;
+        }
+
+        if character == '/' && chars.peek() == Some(&'*') {
+            chars.next();
+            *in_block_comment = true;
+            output.push(' ');
+            output.push(' ');
+            continue;
+        }
+
+        if character == '"' {
+            in_string = true;
+            output.push(' ');
+            continue;
+        }
+
+        if character == '\'' {
+            in_char = true;
+            output.push(' ');
+            continue;
+        }
+
+        output.push(character);
+    }
+
+    output
 }
 
 fn build_finding(
@@ -115,8 +213,8 @@ fn build_finding(
     snippet: &str,
     pattern: RustPanicPattern,
     context: &crate::audits::context::AuditContext,
+    severity: Severity,
 ) -> Finding {
-    let severity = severity_for(context, pattern);
     let context_label = context_label(context);
     let recommendation = recommendation_for(context, pattern);
 
@@ -141,40 +239,6 @@ fn build_finding(
         workspace_package: None,
         docs_url: None,
     }
-}
-
-fn severity_for(
-    context: &crate::audits::context::AuditContext,
-    pattern: RustPanicPattern,
-) -> Severity {
-    if context.is_test {
-        return Severity::Low;
-    }
-
-    if matches!(
-        pattern,
-        RustPanicPattern::Todo | RustPanicPattern::Unimplemented
-    ) {
-        return Severity::High;
-    }
-
-    if matches!(pattern, RustPanicPattern::Panic) {
-        if context.has_role(FileRole::Domain) || context.has_runtime(RuntimeKind::RustLibrary) {
-            return Severity::High;
-        }
-
-        return Severity::Medium;
-    }
-
-    if context.has_runtime(RuntimeKind::RustCli) {
-        return Severity::Low;
-    }
-
-    if context.has_role(FileRole::Domain) || context.has_runtime(RuntimeKind::RustLibrary) {
-        return Severity::Medium;
-    }
-
-    Severity::Low
 }
 
 fn context_label(context: &crate::audits::context::AuditContext) -> &'static str {
@@ -302,9 +366,82 @@ mod tests {
     fn ignores_commented_panic_patterns() {
         let file = facts(
             "src/lib.rs",
-            "// let value = parse().unwrap();\n// panic!(\"old code\");",
+            "// let value = parse().unwrap();\n/// panic!(\"example\");\n/*\n * value.unwrap()\n */\n// panic!(\"old code\");",
             false,
         );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn ignores_string_literal_panic_patterns() {
+        let file = facts(
+            "src/lib.rs",
+            "let text = \"value.unwrap() and panic!(\\\"example\\\")\";",
+            false,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn does_not_report_functional_iterator_pipeline_without_panic_risk() {
+        let file = facts(
+            "src/domain/users.rs",
+            "let names = users\n    .iter()\n    .filter(|user| user.is_active)\n    .map(|user| user.name.clone())\n    .collect::<Vec<_>>();\n",
+            false,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn reports_expect_in_domain_code() {
+        let file = facts(
+            "src/domain/parser.rs",
+            "let value = parse().expect(\"valid domain input\");",
+            false,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Medium);
+        assert!(findings[0].title.contains("expect()"));
+        assert!(findings[0].description.contains("Rust domain code"));
+    }
+
+    #[test]
+    fn reports_unimplemented_in_production_code() {
+        let file = facts("src/lib.rs", "unimplemented!(\"missing adapter\");", false);
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+        assert!(findings[0].title.contains("unimplemented!"));
+    }
+
+    #[test]
+    fn does_not_run_on_non_rust_files() {
+        let mut file = facts("src/app.ts", "panic!(\"not rust\");", false);
+        file.language = Some("TypeScript".to_string());
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn does_not_run_without_file_content() {
+        let mut file = facts("src/lib.rs", "panic!(\"missing content\");", false);
+        file.content = None;
 
         let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
 

--- a/src/audits/context/classify.rs
+++ b/src/audits/context/classify.rs
@@ -1,6 +1,7 @@
 use crate::audits::context::model::{
     AuditContext, FileRole, FrameworkKind, LanguageKind, ProgrammingParadigm, RuntimeKind,
 };
+use crate::knowledge::language::language_kind_for_file;
 use crate::scan::facts::FileFacts;
 use std::path::Path;
 
@@ -50,35 +51,7 @@ pub fn classify_file(file: &FileFacts) -> AuditContext {
 }
 
 fn classify_language(file: &FileFacts) -> LanguageKind {
-    if let Some(language) = &file.language {
-        let normalized = normalize(language);
-
-        match normalized.as_str() {
-            "rust" => return LanguageKind::Rust,
-            "typescript" | "typescript react" | "tsx" => return LanguageKind::TypeScript,
-            "javascript" | "javascript react" | "jsx" => return LanguageKind::JavaScript,
-            "csharp" | "c#" | "cs" | "c sharp" => return LanguageKind::CSharp,
-            "python" => return LanguageKind::Python,
-            "go" => return LanguageKind::Go,
-            _ => {}
-        }
-    }
-
-    match file
-        .path
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .map(normalize)
-        .as_deref()
-    {
-        Some("rs") => LanguageKind::Rust,
-        Some("ts") | Some("tsx") | Some("mts") => LanguageKind::TypeScript,
-        Some("js") | Some("jsx") | Some("mjs") | Some("cjs") => LanguageKind::JavaScript,
-        Some("cs") => LanguageKind::CSharp,
-        Some("py") => LanguageKind::Python,
-        Some("go") => LanguageKind::Go,
-        _ => LanguageKind::Unknown,
-    }
+    language_kind_for_file(file)
 }
 
 fn classify_frameworks(
@@ -94,6 +67,14 @@ fn classify_frameworks(
             push_unique(frameworks, FrameworkKind::ReactNative);
         }
 
+        if normalized_content.contains("from 'expo")
+            || normalized_content.contains("from \"expo")
+            || normalized_content.contains("expo-status-bar")
+            || normalized_content.contains("expo-router")
+        {
+            push_unique(frameworks, FrameworkKind::Expo);
+        }
+
         if is_react_file(path, &normalized_content) {
             push_unique(frameworks, FrameworkKind::React);
         }
@@ -104,10 +85,36 @@ fn classify_frameworks(
             push_unique(frameworks, FrameworkKind::NextJs);
         }
 
+        if normalized_content.contains("from 'vue'")
+            || normalized_content.contains("from \"vue\"")
+            || normalized_content.contains("@vue/")
+        {
+            push_unique(frameworks, FrameworkKind::Vue);
+        }
+
+        if normalized_content.contains("@angular/") {
+            push_unique(frameworks, FrameworkKind::Angular);
+        }
+
+        if normalized_content.contains("from 'svelte")
+            || normalized_content.contains("from \"svelte")
+        {
+            push_unique(frameworks, FrameworkKind::Svelte);
+        }
+
+        if normalized_content.contains("@nestjs/") {
+            push_unique(frameworks, FrameworkKind::NestJs);
+        }
+
+        if normalized_content.contains("express") {
+            push_unique(frameworks, FrameworkKind::Express);
+        }
+
         if normalized_content.contains("express")
             || normalized_content.contains("from 'node:")
             || normalized_content.contains("from \"node:")
             || normalized_content.contains("process.env")
+            || normalized_content.contains("process.exit")
         {
             push_unique(frameworks, FrameworkKind::NodeJs);
         }
@@ -121,6 +128,51 @@ fn classify_frameworks(
         if is_dotnet_file(path, &normalized_content) {
             push_unique(frameworks, FrameworkKind::DotNet);
         }
+    }
+
+    if language == LanguageKind::Python {
+        if normalized_content.contains("django") {
+            push_unique(frameworks, FrameworkKind::Django);
+        }
+        if normalized_content.contains("flask") {
+            push_unique(frameworks, FrameworkKind::Flask);
+        }
+        if normalized_content.contains("fastapi") {
+            push_unique(frameworks, FrameworkKind::FastApi);
+        }
+    }
+
+    if language == LanguageKind::Go {
+        if normalized_content.contains("github.com/gin-gonic/gin") {
+            push_unique(frameworks, FrameworkKind::Gin);
+        }
+        if normalized_content.contains("github.com/labstack/echo") {
+            push_unique(frameworks, FrameworkKind::Echo);
+        }
+        if normalized_content.contains("github.com/gofiber/fiber") {
+            push_unique(frameworks, FrameworkKind::Fiber);
+        }
+    }
+
+    if matches!(language, LanguageKind::Java | LanguageKind::Kotlin) {
+        if normalized_content.contains("org.springframework")
+            || normalized_content.contains("@springbootapplication")
+        {
+            push_unique(frameworks, FrameworkKind::Spring);
+        }
+        if normalized_content.contains("android.")
+            || normalized_content.contains("androidx.")
+            || path_contains_component(path, &["android"])
+        {
+            push_unique(frameworks, FrameworkKind::Android);
+        }
+    }
+
+    if language == LanguageKind::Dart
+        && (normalized_content.contains("package:flutter")
+            || path_contains_component(path, &["lib", "widgets"]))
+    {
+        push_unique(frameworks, FrameworkKind::Flutter);
     }
 }
 
@@ -138,6 +190,10 @@ fn classify_roles(
         push_unique(roles, FileRole::Config);
     }
 
+    if is_generated_file(path, &normalized_content) {
+        push_unique(roles, FileRole::Generated);
+    }
+
     if is_test {
         push_unique(roles, FileRole::Test);
 
@@ -149,10 +205,12 @@ fn classify_roles(
     if is_js_or_ts(language) {
         if is_react_hook_file(path, content) {
             push_unique(roles, FileRole::ReactHook);
+            push_unique(roles, FileRole::FrameworkHook);
         }
 
         if frameworks.contains(&FrameworkKind::React) && is_react_component_file(path, content) {
             push_unique(roles, FileRole::ReactComponent);
+            push_unique(roles, FileRole::FrameworkComponent);
         }
     }
 
@@ -165,11 +223,23 @@ fn classify_roles(
 
         if is_dotnet_controller(path, &normalized_content) {
             push_unique(roles, FileRole::DotNetController);
+            push_unique(roles, FileRole::FrameworkController);
         }
 
         if is_dotnet_service(path, &normalized_content) {
             push_unique(roles, FileRole::DotNetService);
+            push_unique(roles, FileRole::FrameworkService);
         }
+    }
+
+    if is_app_entrypoint(path, content, language) {
+        push_unique(roles, FileRole::AppEntrypoint);
+    }
+
+    if matches!(language, LanguageKind::Python | LanguageKind::Go)
+        && path_contains_component(path, &["cmd", "bin", "scripts"])
+    {
+        push_unique(roles, FileRole::Script);
     }
 
     if path_contains_component(
@@ -260,6 +330,24 @@ fn classify_paradigms(
         }
     }
 
+    if matches!(language, LanguageKind::Python | LanguageKind::Go)
+        && (normalized_content.contains("def main(")
+            || normalized_content.contains("func main(")
+            || path_contains_component(path, &["cmd", "scripts"]))
+    {
+        push_unique(paradigms, ProgrammingParadigm::Procedural);
+    }
+
+    if matches!(
+        language,
+        LanguageKind::Java | LanguageKind::Kotlin | LanguageKind::CSharp
+    ) && (normalized_content.contains("class ")
+        || normalized_content.contains("interface ")
+        || normalized_content.contains("record "))
+    {
+        push_unique(paradigms, ProgrammingParadigm::ObjectOriented);
+    }
+
     if paradigms.len() > 1 {
         push_unique(paradigms, ProgrammingParadigm::Mixed);
     }
@@ -278,10 +366,14 @@ fn classify_runtimes(
 ) {
     let normalized_content = content.to_lowercase();
 
-    if frameworks.contains(&FrameworkKind::ReactNative) {
+    if frameworks.contains(&FrameworkKind::ReactNative) || frameworks.contains(&FrameworkKind::Expo)
+    {
         push_unique(runtimes, RuntimeKind::ReactNative);
     } else if frameworks.contains(&FrameworkKind::React)
         || frameworks.contains(&FrameworkKind::NextJs)
+        || frameworks.contains(&FrameworkKind::Vue)
+        || frameworks.contains(&FrameworkKind::Angular)
+        || frameworks.contains(&FrameworkKind::Svelte)
     {
         push_unique(runtimes, RuntimeKind::Browser);
     }
@@ -313,6 +405,36 @@ fn classify_runtimes(
         } else {
             push_unique(runtimes, RuntimeKind::RustLibrary);
         }
+    }
+
+    if language == LanguageKind::Python {
+        push_unique(runtimes, RuntimeKind::Python);
+    }
+
+    if language == LanguageKind::Go {
+        push_unique(runtimes, RuntimeKind::Go);
+    }
+
+    if matches!(
+        language,
+        LanguageKind::Java | LanguageKind::Kotlin | LanguageKind::Scala
+    ) {
+        push_unique(runtimes, RuntimeKind::Jvm);
+    }
+
+    if language == LanguageKind::Shell || language == LanguageKind::PowerShell {
+        push_unique(runtimes, RuntimeKind::Shell);
+    }
+
+    if matches!(
+        language,
+        LanguageKind::C | LanguageKind::Cpp | LanguageKind::CHeader | LanguageKind::Swift
+    ) {
+        push_unique(runtimes, RuntimeKind::Native);
+    }
+
+    if frameworks.contains(&FrameworkKind::Android) {
+        push_unique(runtimes, RuntimeKind::Android);
     }
 
     if runtimes.is_empty() {
@@ -444,7 +566,59 @@ fn is_config_file(path: &Path) -> bool {
             | "cargo.toml"
             | "cargo.lock"
             | "projectsettings.asset"
+            | "dockerfile"
+            | "containerfile"
+            | "go.mod"
+            | "go.sum"
+            | "pyproject.toml"
+            | "requirements.txt"
+            | "build.gradle"
+            | "settings.gradle"
+            | "pom.xml"
     ) || (file_name.starts_with("appsettings") && file_name.ends_with(".json"))
+}
+
+fn is_app_entrypoint(path: &Path, content: &str, language: LanguageKind) -> bool {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(normalize)
+        .unwrap_or_default();
+    let normalized_content = content.to_lowercase();
+
+    matches!(
+        file_name.as_str(),
+        "main.rs"
+            | "main.go"
+            | "main.py"
+            | "app.py"
+            | "program.cs"
+            | "main.java"
+            | "main.kt"
+            | "index.ts"
+            | "index.js"
+            | "main.ts"
+            | "main.js"
+    ) || (language == LanguageKind::Python
+        && normalized_content.contains("if __name__ == \"__main__\""))
+        || (language == LanguageKind::Go && normalized_content.contains("func main("))
+        || (language == LanguageKind::Rust && normalized_content.contains("fn main("))
+}
+
+fn is_generated_file(path: &Path, content: &str) -> bool {
+    path_contains_component(
+        path,
+        &[
+            "generated",
+            "__generated__",
+            "gen",
+            "codegen",
+            "target",
+            "build",
+        ],
+    ) || content.contains("@generated")
+        || content.contains("code generated")
+        || content.contains("generated by")
 }
 
 fn is_test_file(path: &Path, has_inline_tests: bool) -> bool {
@@ -474,6 +648,14 @@ fn is_test_file(path: &Path, has_inline_tests: bool) -> bool {
         || file_name.ends_with(".spec.jsx")
         || file_name.ends_with("_test.rs")
         || file_name.ends_with("_test.go")
+        || file_name.ends_with("_test.py")
+        || file_name.starts_with("test_")
+        || file_name.ends_with("test.java")
+        || file_name.ends_with("tests.java")
+        || file_name.ends_with("test.kt")
+        || file_name.ends_with("tests.kt")
+        || file_name.ends_with("test.cs")
+        || file_name.ends_with("tests.cs")
 }
 
 fn path_contains_component(path: &Path, targets: &[&str]) -> bool {
@@ -548,6 +730,7 @@ mod tests {
         assert!(context.has_role(FileRole::ReactHook));
         assert!(context.has_paradigm(ProgrammingParadigm::Functional));
         assert!(context.has_paradigm(ProgrammingParadigm::Reactive));
+        assert!(context.has_runtime(RuntimeKind::Browser));
     }
 
     #[test]
@@ -636,6 +819,132 @@ mod tests {
         assert_eq!(context.language, LanguageKind::Rust);
         assert!(context.has_runtime(RuntimeKind::RustCli));
         assert!(context.has_paradigm(ProgrammingParadigm::Procedural));
+    }
+
+    #[test]
+    fn classifies_rust_lib_as_library_runtime() {
+        let file = facts("src/lib.rs", Some("Rust"), "pub fn parse() {}\n", false);
+
+        let context = classify_file(&file);
+
+        assert_eq!(context.language, LanguageKind::Rust);
+        assert!(context.has_runtime(RuntimeKind::RustLibrary));
+        assert!(!context.is_test);
+    }
+
+    #[test]
+    fn classifies_rust_domain_file_role() {
+        let file = facts(
+            "src/domain/user.rs",
+            Some("Rust"),
+            "pub struct User { id: String }\n",
+            false,
+        );
+
+        let context = classify_file(&file);
+
+        assert_eq!(context.language, LanguageKind::Rust);
+        assert!(context.has_role(FileRole::Domain));
+        assert!(context.has_runtime(RuntimeKind::RustLibrary));
+    }
+
+    #[test]
+    fn classifies_rust_test_path() {
+        let file = facts(
+            "tests/parser_test.rs",
+            Some("Rust"),
+            "#[test]\nfn parses() {}\n",
+            false,
+        );
+
+        let context = classify_file(&file);
+
+        assert_eq!(context.language, LanguageKind::Rust);
+        assert!(context.has_role(FileRole::Test));
+        assert!(context.has_role(FileRole::RustTest));
+        assert!(context.is_test);
+    }
+
+    #[test]
+    fn classifies_rust_iterator_pipeline_as_functional_without_marking_it_bad() {
+        let file = facts(
+            "src/domain/users.rs",
+            Some("Rust"),
+            "let names = users.iter().filter(|user| user.is_active).map(|user| user.name.clone()).collect::<Vec<_>>();\n",
+            false,
+        );
+
+        let context = classify_file(&file);
+
+        assert_eq!(context.language, LanguageKind::Rust);
+        assert!(context.is_functional_code());
+        assert!(!context.has_role(FileRole::Config));
+    }
+
+    #[test]
+    fn classifies_node_runtime_from_process_env_and_node_imports() {
+        for content in [
+            "const value = process.env.NODE_ENV;\n",
+            "import fs from \"node:fs\";\n",
+            "import path from 'node:path';\n",
+        ] {
+            let file = facts("src/server.ts", Some("TypeScript"), content, false);
+
+            let context = classify_file(&file);
+
+            assert!(context.has_framework(FrameworkKind::NodeJs));
+            assert!(context.has_runtime(RuntimeKind::Node));
+        }
+    }
+
+    #[test]
+    fn classifies_python_go_and_jvm_contexts() {
+        let python = classify_file(&facts(
+            "app/views.py",
+            Some("Python"),
+            "from fastapi import FastAPI\napp = FastAPI()\n",
+            false,
+        ));
+        assert_eq!(python.language, LanguageKind::Python);
+        assert!(python.has_framework(FrameworkKind::FastApi));
+        assert!(python.has_runtime(RuntimeKind::Python));
+
+        let go = classify_file(&facts(
+            "cmd/server/main.go",
+            Some("Go"),
+            "package main\nimport \"github.com/gin-gonic/gin\"\nfunc main() {}\n",
+            false,
+        ));
+        assert_eq!(go.language, LanguageKind::Go);
+        assert!(go.has_framework(FrameworkKind::Gin));
+        assert!(go.has_runtime(RuntimeKind::Go));
+        assert!(go.has_role(FileRole::Script));
+
+        let java = classify_file(&facts(
+            "src/main/java/com/acme/UserService.java",
+            Some("Java"),
+            "import org.springframework.stereotype.Service;\npublic class UserService {}\n",
+            false,
+        ));
+        assert_eq!(java.language, LanguageKind::Java);
+        assert!(java.has_framework(FrameworkKind::Spring));
+        assert!(java.has_paradigm(ProgrammingParadigm::ObjectOriented));
+        assert!(java.has_runtime(RuntimeKind::Jvm));
+    }
+
+    #[test]
+    fn classifies_generated_files_as_non_production() {
+        let file = facts(
+            "src/generated/schema.rs",
+            Some("Rust"),
+            "// generated by schema tool\npub fn value() {}\n",
+            false,
+        );
+
+        let context = classify_file(&file);
+
+        assert!(context.has_role(FileRole::Generated));
+        assert!(!context.is_production_code());
     }
 
     #[test]

--- a/src/audits/context/model.rs
+++ b/src/audits/context/model.rs
@@ -6,6 +6,41 @@ pub enum LanguageKind {
     CSharp,
     Python,
     Go,
+    Java,
+    Kotlin,
+    Swift,
+    C,
+    Cpp,
+    CHeader,
+    Php,
+    Ruby,
+    Dart,
+    Scala,
+    Shell,
+    PowerShell,
+    Sql,
+    Html,
+    Css,
+    Scss,
+    Elixir,
+    Erlang,
+    Haskell,
+    OCaml,
+    FSharp,
+    R,
+    Julia,
+    Lua,
+    Perl,
+    Zig,
+    Solidity,
+    ObjectiveC,
+    Terraform,
+    Dockerfile,
+    Nix,
+    Json,
+    Toml,
+    Yaml,
+    Markdown,
     Unknown,
 }
 
@@ -14,21 +49,42 @@ pub enum FrameworkKind {
     React,
     ReactNative,
     NextJs,
+    Expo,
+    Vue,
+    Angular,
+    Svelte,
+    NestJs,
+    Express,
     Unity,
     DotNet,
     NodeJs,
+    Django,
+    Flask,
+    FastApi,
+    Gin,
+    Echo,
+    Fiber,
+    Spring,
+    Android,
+    Flutter,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileRole {
     ReactComponent,
     ReactHook,
+    AppEntrypoint,
+    FrameworkComponent,
+    FrameworkHook,
+    FrameworkService,
+    FrameworkController,
     UnityMonoBehaviour,
     DotNetController,
     DotNetService,
     RustTest,
     Test,
     Config,
+    Generated,
     Domain,
     Script,
     Unknown,
@@ -55,6 +111,13 @@ pub enum RuntimeKind {
     Unity,
     RustCli,
     RustLibrary,
+    Python,
+    Go,
+    Jvm,
+    Android,
+    Ios,
+    Shell,
+    Native,
     Unknown,
 }
 
@@ -114,6 +177,173 @@ impl AuditContext {
     }
 
     pub fn is_production_code(&self) -> bool {
-        !self.is_test && !self.has_role(FileRole::Config)
+        !self.is_test && !self.has_role(FileRole::Config) && !self.has_role(FileRole::Generated)
+    }
+
+    pub fn language_id(&self) -> &'static str {
+        self.language.as_id()
+    }
+
+    pub fn framework_ids(&self) -> Vec<&'static str> {
+        self.frameworks
+            .iter()
+            .map(|framework| framework.as_id())
+            .collect()
+    }
+
+    pub fn role_ids(&self) -> Vec<&'static str> {
+        self.roles.iter().map(|role| role.as_id()).collect()
+    }
+
+    pub fn paradigm_ids(&self) -> Vec<&'static str> {
+        self.paradigms
+            .iter()
+            .map(|paradigm| paradigm.as_id())
+            .collect()
+    }
+
+    pub fn runtime_ids(&self) -> Vec<&'static str> {
+        self.runtimes
+            .iter()
+            .map(|runtime| runtime.as_id())
+            .collect()
+    }
+}
+
+impl LanguageKind {
+    pub fn as_id(self) -> &'static str {
+        match self {
+            LanguageKind::Rust => "rust",
+            LanguageKind::TypeScript => "typescript",
+            LanguageKind::JavaScript => "javascript",
+            LanguageKind::CSharp => "csharp",
+            LanguageKind::Python => "python",
+            LanguageKind::Go => "go",
+            LanguageKind::Java => "java",
+            LanguageKind::Kotlin => "kotlin",
+            LanguageKind::Swift => "swift",
+            LanguageKind::C => "c",
+            LanguageKind::Cpp => "cpp",
+            LanguageKind::CHeader => "c-header",
+            LanguageKind::Php => "php",
+            LanguageKind::Ruby => "ruby",
+            LanguageKind::Dart => "dart",
+            LanguageKind::Scala => "scala",
+            LanguageKind::Shell => "shell",
+            LanguageKind::PowerShell => "powershell",
+            LanguageKind::Sql => "sql",
+            LanguageKind::Html => "html",
+            LanguageKind::Css => "css",
+            LanguageKind::Scss => "scss",
+            LanguageKind::Elixir => "elixir",
+            LanguageKind::Erlang => "erlang",
+            LanguageKind::Haskell => "haskell",
+            LanguageKind::OCaml => "ocaml",
+            LanguageKind::FSharp => "fsharp",
+            LanguageKind::R => "r",
+            LanguageKind::Julia => "julia",
+            LanguageKind::Lua => "lua",
+            LanguageKind::Perl => "perl",
+            LanguageKind::Zig => "zig",
+            LanguageKind::Solidity => "solidity",
+            LanguageKind::ObjectiveC => "objective-c",
+            LanguageKind::Terraform => "terraform",
+            LanguageKind::Dockerfile => "dockerfile",
+            LanguageKind::Nix => "nix",
+            LanguageKind::Json => "json",
+            LanguageKind::Toml => "toml",
+            LanguageKind::Yaml => "yaml",
+            LanguageKind::Markdown => "markdown",
+            LanguageKind::Unknown => "unknown",
+        }
+    }
+}
+
+impl FrameworkKind {
+    pub fn as_id(self) -> &'static str {
+        match self {
+            FrameworkKind::React => "react",
+            FrameworkKind::ReactNative => "react-native",
+            FrameworkKind::NextJs => "nextjs",
+            FrameworkKind::Expo => "expo",
+            FrameworkKind::Vue => "vue",
+            FrameworkKind::Angular => "angular",
+            FrameworkKind::Svelte => "svelte",
+            FrameworkKind::NestJs => "nestjs",
+            FrameworkKind::Express => "express",
+            FrameworkKind::Unity => "unity",
+            FrameworkKind::DotNet => "dotnet",
+            FrameworkKind::NodeJs => "nodejs",
+            FrameworkKind::Django => "django",
+            FrameworkKind::Flask => "flask",
+            FrameworkKind::FastApi => "fastapi",
+            FrameworkKind::Gin => "gin",
+            FrameworkKind::Echo => "echo",
+            FrameworkKind::Fiber => "fiber",
+            FrameworkKind::Spring => "spring",
+            FrameworkKind::Android => "android",
+            FrameworkKind::Flutter => "flutter",
+        }
+    }
+}
+
+impl FileRole {
+    pub fn as_id(self) -> &'static str {
+        match self {
+            FileRole::ReactComponent => "react-component",
+            FileRole::ReactHook => "react-hook",
+            FileRole::AppEntrypoint => "app-entrypoint",
+            FileRole::FrameworkComponent => "framework-component",
+            FileRole::FrameworkHook => "framework-hook",
+            FileRole::FrameworkService => "framework-service",
+            FileRole::FrameworkController => "framework-controller",
+            FileRole::UnityMonoBehaviour => "unity-monobehaviour",
+            FileRole::DotNetController => "dotnet-controller",
+            FileRole::DotNetService => "dotnet-service",
+            FileRole::RustTest => "rust-test",
+            FileRole::Test => "test",
+            FileRole::Config => "config",
+            FileRole::Generated => "generated",
+            FileRole::Domain => "domain",
+            FileRole::Script => "script",
+            FileRole::Unknown => "unknown",
+        }
+    }
+}
+
+impl ProgrammingParadigm {
+    pub fn as_id(self) -> &'static str {
+        match self {
+            ProgrammingParadigm::Functional => "functional",
+            ProgrammingParadigm::ObjectOriented => "object-oriented",
+            ProgrammingParadigm::Procedural => "procedural",
+            ProgrammingParadigm::DeclarativeUi => "declarative-ui",
+            ProgrammingParadigm::Reactive => "reactive",
+            ProgrammingParadigm::DataOriented => "data-oriented",
+            ProgrammingParadigm::Mixed => "mixed",
+            ProgrammingParadigm::Unknown => "unknown",
+        }
+    }
+}
+
+impl RuntimeKind {
+    pub fn as_id(self) -> &'static str {
+        match self {
+            RuntimeKind::Browser => "browser",
+            RuntimeKind::Node => "node",
+            RuntimeKind::ReactNative => "react-native",
+            RuntimeKind::DotNet => "dotnet",
+            RuntimeKind::Unity => "unity",
+            RuntimeKind::RustCli => "rust-cli",
+            RuntimeKind::RustLibrary => "rust-library",
+            RuntimeKind::Python => "python",
+            RuntimeKind::Go => "go",
+            RuntimeKind::Jvm => "jvm",
+            RuntimeKind::Android => "android",
+            RuntimeKind::Ios => "ios",
+            RuntimeKind::Shell => "shell",
+            RuntimeKind::Native => "native",
+            RuntimeKind::Unknown => "unknown",
+        }
     }
 }

--- a/src/audits/framework/js_common.rs
+++ b/src/audits/framework/js_common.rs
@@ -1,5 +1,6 @@
 use crate::audits::traits::ProjectAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::knowledge::decision::apply_file_decision;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
 
@@ -40,7 +41,7 @@ impl ProjectAudit for VarDeclarationAudit {
                 }
 
                 if has_var_declaration(trimmed) {
-                    findings.push(Finding {
+                    let finding = Finding {
                         id: String::new(),
                         rule_id: "framework.js.var-declaration".to_string(),
                         title: "var declaration found".to_string(),
@@ -60,7 +61,12 @@ impl ProjectAudit for VarDeclarationAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
-                    });
+                    };
+                    if let Some(finding) =
+                        apply_file_decision("framework.js.var-declaration", file, finding, None)
+                    {
+                        findings.push(finding);
+                    }
                     break;
                 }
             }
@@ -96,7 +102,7 @@ impl ProjectAudit for ConsoleLogAudit {
                 }
 
                 if trimmed.contains("console.log(") {
-                    findings.push(Finding {
+                    let finding = Finding {
                         id: String::new(),
                         rule_id: "framework.js.console-log".to_string(),
                         title: "console.log found in production source".to_string(),
@@ -116,7 +122,12 @@ impl ProjectAudit for ConsoleLogAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
-                    });
+                    };
+                    if let Some(finding) =
+                        apply_file_decision("framework.js.console-log", file, finding, None)
+                    {
+                        findings.push(finding);
+                    }
                     break;
                 }
             }

--- a/src/audits/pipeline.rs
+++ b/src/audits/pipeline.rs
@@ -5,6 +5,7 @@ use crate::audits::architecture::large_file::LargeFileAudit;
 use crate::audits::architecture::too_many_modules::TooManyModulesAudit;
 use crate::audits::code_quality::code_markers::CodeMarkerAudit;
 use crate::audits::code_quality::complexity::ComplexityAudit;
+use crate::audits::code_quality::language_risk::LanguageRiskAudit;
 use crate::audits::code_quality::long_function::LongFunctionAudit;
 use crate::audits::code_quality::rust_panic_risk::RustPanicRiskAudit;
 use crate::audits::framework::js_common::{ConsoleLogAudit, VarDeclarationAudit};
@@ -23,6 +24,7 @@ use crate::audits::testing::source_without_test::SourceWithoutTestAudit;
 use crate::audits::traits::{FileAudit, ProjectAudit};
 use crate::findings::types::Finding;
 use crate::frameworks::DetectedFramework;
+use crate::knowledge::decision::apply_project_decisions;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
 
@@ -34,6 +36,7 @@ pub fn build_file_audits(config: &ScanConfig) -> Vec<Box<dyn FileAudit>> {
         Box::new(ComplexityAudit),
         Box::new(LongFunctionAudit),
         Box::new(RustPanicRiskAudit),
+        Box::new(LanguageRiskAudit),
     ];
 
     if config.detect_secret_like_names {
@@ -57,10 +60,12 @@ pub fn run_project_audits(scan_facts: &ScanFacts, config: &ScanConfig) -> Vec<Fi
         project_audits.insert(2, Box::new(MissingTestFolderAudit));
     }
 
-    project_audits
+    let findings = project_audits
         .iter()
         .flat_map(|a| a.audit(scan_facts, config))
-        .collect()
+        .collect();
+
+    apply_project_decisions(scan_facts, findings)
 }
 
 pub fn run_framework_audits(facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
@@ -134,5 +139,5 @@ pub fn run_framework_audits(facts: &ScanFacts, config: &ScanConfig) -> Vec<Findi
         findings.extend(ConsoleLogAudit.audit(facts, config));
     }
 
-    findings
+    apply_project_decisions(facts, findings)
 }

--- a/src/audits/security/private_key_candidate.rs
+++ b/src/audits/security/private_key_candidate.rs
@@ -1,5 +1,6 @@
 use crate::audits::traits::FileAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::knowledge::decision::apply_file_decision;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
 
@@ -29,7 +30,14 @@ impl FileAudit for PrivateKeyCandidateAudit {
                 PRIVATE_KEY_HEADERS
                     .iter()
                     .find(|&&header| trimmed.starts_with(header))
-                    .map(|header| build_finding(&file.path, index + 1, header))
+                    .and_then(|header| {
+                        apply_file_decision(
+                            "security.private-key-candidate",
+                            file,
+                            build_finding(&file.path, index + 1, header),
+                            None,
+                        )
+                    })
             })
             .collect()
     }

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -1,5 +1,6 @@
 use crate::audits::traits::FileAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::knowledge::decision::apply_file_decision;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
 
@@ -58,7 +59,11 @@ impl FileAudit for SecretCandidateAudit {
             .unwrap_or("")
             .lines()
             .enumerate()
-            .filter_map(|(index, line)| detect_secret_line(line, index + 1, &file.path))
+            .filter_map(|(index, line)| {
+                detect_secret_line(line, index + 1, &file.path).and_then(|finding| {
+                    apply_file_decision("security.secret-candidate", file, finding, None)
+                })
+            })
             .collect()
     }
 }

--- a/src/knowledge/decision.rs
+++ b/src/knowledge/decision.rs
@@ -1,0 +1,469 @@
+use crate::audits::context::{AuditContext, classify_file};
+use crate::findings::types::{Finding, Severity};
+use crate::frameworks::DetectedFramework;
+use crate::knowledge::bundled_knowledge;
+use crate::knowledge::language::{language_id_for_name, profile_by_id};
+use crate::knowledge::model::{
+    RuleApplicability, RuleDecision, RuleDecisionAction, RuleMatchContext, RuleOverride,
+};
+use crate::scan::facts::{FileFacts, ScanFacts};
+use crate::scan::path_classification::is_low_signal_audit_path;
+use std::collections::HashSet;
+
+pub fn decide(context: &RuleMatchContext<'_>) -> RuleDecision {
+    let Some(rule) = bundled_knowledge()
+        .rule_applicability
+        .iter()
+        .find(|rule| rule.rule_id == context.rule_id)
+    else {
+        return RuleDecision::apply(context.base_severity);
+    };
+
+    if !rule.languages.is_empty()
+        && !context
+            .languages
+            .iter()
+            .any(|language| contains_str(&rule.languages, language))
+    {
+        return RuleDecision::suppress("rule does not apply to this language");
+    }
+
+    if let Some(minimum_support) = rule.minimum_support
+        && !language_support_satisfies(rule, context.languages, minimum_support)
+    {
+        return RuleDecision::suppress("language support level is below this rule's minimum");
+    }
+
+    if !rule.frameworks.is_empty()
+        && !context
+            .frameworks
+            .iter()
+            .any(|framework| contains_str(&rule.frameworks, framework))
+    {
+        return RuleDecision::suppress("rule does not apply to this framework");
+    }
+
+    if !rule.runtimes.is_empty()
+        && !context
+            .runtimes
+            .iter()
+            .any(|runtime| contains_str(&rule.runtimes, runtime))
+    {
+        return RuleDecision::suppress("rule does not apply to this runtime");
+    }
+
+    if !rule.paradigms.is_empty()
+        && !context
+            .paradigms
+            .iter()
+            .any(|paradigm| contains_str(&rule.paradigms, paradigm))
+    {
+        return RuleDecision::suppress("rule does not apply to this paradigm");
+    }
+
+    if context.is_low_signal && rule.suppress_low_signal {
+        return RuleDecision::suppress("low-signal audit path");
+    }
+
+    if rule.suppress_config && context.roles.contains(&"config") {
+        return RuleDecision::suppress("configuration file");
+    }
+
+    if rule.suppress_generated && context.roles.contains(&"generated") {
+        return RuleDecision::suppress("generated file");
+    }
+
+    let mut decision = RuleDecision::apply(context.base_severity);
+
+    for override_rule in &rule.overrides {
+        if context.is_test && !is_test_override(override_rule) {
+            continue;
+        }
+        if override_matches(override_rule, context) {
+            decision = apply_override(override_rule, decision.severity);
+            if decision.is_suppressed() {
+                return decision;
+            }
+        }
+    }
+
+    decision
+}
+
+pub fn decide_for_audit_context(
+    rule_id: &str,
+    context: &AuditContext,
+    base_severity: Severity,
+    signal: Option<&str>,
+) -> RuleDecision {
+    let framework_ids = context.framework_ids();
+    let role_ids = context.role_ids();
+    let paradigm_ids = context.paradigm_ids();
+    let runtime_ids = context.runtime_ids();
+    let language_ids = [context.language_id()];
+
+    decide(&RuleMatchContext {
+        rule_id,
+        languages: &language_ids,
+        frameworks: &framework_ids,
+        roles: &role_ids,
+        paradigms: &paradigm_ids,
+        runtimes: &runtime_ids,
+        is_test: context.is_test,
+        is_low_signal: false,
+        signal,
+        base_severity,
+    })
+}
+
+pub fn decide_for_file(
+    rule_id: &str,
+    file: &FileFacts,
+    base_severity: Severity,
+    signal: Option<&str>,
+) -> RuleDecision {
+    let context = classify_file(file);
+    let mut language_ids = language_ids_for_file(file, &context);
+    dedup_static_ids(&mut language_ids);
+    let framework_ids = context.framework_ids();
+    let role_ids = context.role_ids();
+    let paradigm_ids = context.paradigm_ids();
+    let runtime_ids = context.runtime_ids();
+
+    decide(&RuleMatchContext {
+        rule_id,
+        languages: &language_ids,
+        frameworks: &framework_ids,
+        roles: &role_ids,
+        paradigms: &paradigm_ids,
+        runtimes: &runtime_ids,
+        is_test: context.is_test,
+        is_low_signal: is_low_signal_audit_path(&file.path) && !context.is_test,
+        signal,
+        base_severity,
+    })
+}
+
+pub fn apply_file_decision(
+    rule_id: &str,
+    file: &FileFacts,
+    mut finding: Finding,
+    signal: Option<&str>,
+) -> Option<Finding> {
+    let decision = decide_for_file(rule_id, file, finding.severity, signal);
+    if decision.is_suppressed() {
+        return None;
+    }
+    finding.severity = decision.severity;
+    Some(finding)
+}
+
+pub fn decide_for_project(
+    rule_id: &str,
+    facts: &ScanFacts,
+    base_severity: Severity,
+    signal: Option<&str>,
+) -> RuleDecision {
+    let mut language_ids = language_ids_for_project(facts);
+    dedup_static_ids(&mut language_ids);
+    let framework_ids = framework_ids_for_project(facts);
+
+    decide(&RuleMatchContext {
+        rule_id,
+        languages: &language_ids,
+        frameworks: &framework_ids,
+        roles: &[],
+        paradigms: &[],
+        runtimes: &[],
+        is_test: false,
+        is_low_signal: false,
+        signal,
+        base_severity,
+    })
+}
+
+pub fn apply_project_decisions(facts: &ScanFacts, findings: Vec<Finding>) -> Vec<Finding> {
+    findings
+        .into_iter()
+        .filter_map(|mut finding| {
+            let decision = decide_for_project(&finding.rule_id, facts, finding.severity, None);
+            if decision.is_suppressed() {
+                return None;
+            }
+            finding.severity = decision.severity;
+            Some(finding)
+        })
+        .collect()
+}
+
+fn override_matches(override_rule: &RuleOverride, context: &RuleMatchContext<'_>) -> bool {
+    if override_rule
+        .signal
+        .as_deref()
+        .is_some_and(|signal| Some(signal) != context.signal)
+    {
+        return false;
+    }
+
+    if override_rule
+        .language
+        .as_deref()
+        .is_some_and(|language| !context.languages.contains(&language))
+    {
+        return false;
+    }
+
+    if override_rule
+        .framework
+        .as_deref()
+        .is_some_and(|framework| !context.frameworks.contains(&framework))
+    {
+        return false;
+    }
+
+    if override_rule
+        .runtime
+        .as_deref()
+        .is_some_and(|runtime| !context.runtimes.contains(&runtime))
+    {
+        return false;
+    }
+
+    if override_rule
+        .paradigm
+        .as_deref()
+        .is_some_and(|paradigm| !context.paradigms.contains(&paradigm))
+    {
+        return false;
+    }
+
+    if override_rule
+        .role
+        .as_deref()
+        .is_some_and(|role| !context.roles.contains(&role))
+    {
+        return false;
+    }
+
+    true
+}
+
+fn is_test_override(override_rule: &RuleOverride) -> bool {
+    matches!(override_rule.role.as_deref(), Some("test" | "rust-test"))
+}
+
+fn apply_override(override_rule: &RuleOverride, current: Severity) -> RuleDecision {
+    match override_rule.action {
+        RuleDecisionAction::Apply => RuleDecision {
+            action: RuleDecisionAction::Apply,
+            severity: override_rule.severity.unwrap_or(current),
+            reason: override_rule.reason.clone(),
+        },
+        RuleDecisionAction::Suppress => RuleDecision {
+            action: RuleDecisionAction::Suppress,
+            severity: Severity::Info,
+            reason: override_rule.reason.clone(),
+        },
+        RuleDecisionAction::Downgrade => {
+            let severity = override_rule
+                .severity
+                .filter(|severity| *severity < current)
+                .unwrap_or(current);
+            RuleDecision {
+                action: RuleDecisionAction::Downgrade,
+                severity,
+                reason: override_rule.reason.clone(),
+            }
+        }
+        RuleDecisionAction::Upgrade => {
+            let severity = override_rule
+                .severity
+                .filter(|severity| *severity > current)
+                .unwrap_or(current);
+            RuleDecision {
+                action: RuleDecisionAction::Upgrade,
+                severity,
+                reason: override_rule.reason.clone(),
+            }
+        }
+    }
+}
+
+fn contains_str(values: &[String], needle: &str) -> bool {
+    values.iter().any(|value| value == needle)
+}
+
+fn language_support_satisfies(
+    rule: &RuleApplicability,
+    context_languages: &[&str],
+    minimum_support: crate::knowledge::model::SupportLevel,
+) -> bool {
+    context_languages.iter().any(|language| {
+        (rule.languages.is_empty() || contains_str(&rule.languages, language))
+            && profile_by_id(language).is_some_and(|profile| profile.support >= minimum_support)
+    })
+}
+
+fn language_ids_for_file(file: &FileFacts, context: &AuditContext) -> Vec<&'static str> {
+    let mut languages = Vec::new();
+    if let Some(language) = file
+        .language
+        .as_deref()
+        .and_then(language_id_for_name)
+        .filter(|language| *language != "unknown")
+    {
+        languages.push(language);
+    }
+
+    let context_language = context.language_id();
+    if context_language != "unknown" {
+        languages.push(context_language);
+    }
+
+    languages
+}
+
+fn language_ids_for_project(facts: &ScanFacts) -> Vec<&'static str> {
+    let mut languages = facts
+        .languages
+        .iter()
+        .filter_map(|language| language_id_for_name(&language.name))
+        .collect::<Vec<_>>();
+
+    if languages.is_empty() {
+        languages.extend(
+            facts
+                .files
+                .iter()
+                .filter_map(|file| file.language.as_deref())
+                .filter_map(language_id_for_name),
+        );
+    }
+
+    languages
+}
+
+fn framework_ids_for_project(facts: &ScanFacts) -> Vec<&'static str> {
+    let mut frameworks = facts
+        .detected_frameworks
+        .iter()
+        .filter_map(framework_id)
+        .collect::<Vec<_>>();
+
+    for project in &facts.framework_projects {
+        frameworks.extend(project.frameworks.iter().filter_map(framework_id));
+    }
+
+    dedup_static_ids(&mut frameworks);
+    frameworks
+}
+
+fn framework_id(framework: &DetectedFramework) -> Option<&'static str> {
+    match framework {
+        DetectedFramework::ReactNative { .. } => Some("react-native"),
+        DetectedFramework::Expo { .. } => Some("expo"),
+        DetectedFramework::NextJs { .. } => Some("nextjs"),
+        DetectedFramework::React { .. } => Some("react"),
+        DetectedFramework::Vue { .. } => Some("vue"),
+        DetectedFramework::Angular { .. } => Some("angular"),
+        DetectedFramework::Svelte { .. } => Some("svelte"),
+        DetectedFramework::NestJs { .. } => Some("nestjs"),
+        DetectedFramework::Express { .. } => Some("express"),
+        DetectedFramework::Django { .. } => Some("django"),
+        DetectedFramework::Flask { .. } => Some("flask"),
+        DetectedFramework::FastApi { .. } => Some("fastapi"),
+        DetectedFramework::Gin { .. } => Some("gin"),
+        DetectedFramework::Echo { .. } => Some("echo"),
+        DetectedFramework::Fiber { .. } => Some("fiber"),
+    }
+}
+
+fn dedup_static_ids(values: &mut Vec<&'static str>) {
+    let mut seen = HashSet::new();
+    values.retain(|value| seen.insert(*value));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audits::context::{
+        AuditContext, FileRole, LanguageKind, ProgrammingParadigm, RuntimeKind,
+    };
+
+    #[test]
+    fn suppresses_rust_unwrap_in_tests() {
+        let context = rust_context(vec![FileRole::Test], vec![RuntimeKind::RustLibrary]);
+
+        let decision = decide_for_audit_context(
+            "language.rust.panic-risk",
+            &context,
+            Severity::Medium,
+            Some("rust.unwrap"),
+        );
+
+        assert!(decision.is_suppressed());
+    }
+
+    #[test]
+    fn upgrades_rust_panic_in_domain_code() {
+        let context = rust_context(vec![FileRole::Domain], vec![RuntimeKind::RustLibrary]);
+
+        let decision = decide_for_audit_context(
+            "language.rust.panic-risk",
+            &context,
+            Severity::Medium,
+            Some("rust.panic"),
+        );
+
+        assert_eq!(decision.action, RuleDecisionAction::Upgrade);
+        assert_eq!(decision.severity, Severity::High);
+    }
+
+    #[test]
+    fn downgrades_rust_unwrap_at_cli_boundary() {
+        let context = rust_context(Vec::new(), vec![RuntimeKind::RustCli]);
+
+        let decision = decide_for_audit_context(
+            "language.rust.panic-risk",
+            &context,
+            Severity::Medium,
+            Some("rust.unwrap"),
+        );
+
+        assert_eq!(decision.action, RuleDecisionAction::Downgrade);
+        assert_eq!(decision.severity, Severity::Low);
+    }
+
+    #[test]
+    fn functional_paradigm_does_not_suppress_or_create_a_problem() {
+        let context = AuditContext {
+            language: LanguageKind::Rust,
+            frameworks: Vec::new(),
+            roles: vec![FileRole::Domain],
+            paradigms: vec![ProgrammingParadigm::Functional],
+            runtimes: vec![RuntimeKind::RustLibrary],
+            is_test: false,
+        };
+
+        let decision = decide_for_audit_context(
+            "code-quality.complex-file",
+            &context,
+            Severity::Medium,
+            None,
+        );
+
+        assert_eq!(decision.action, RuleDecisionAction::Apply);
+        assert_eq!(decision.severity, Severity::Medium);
+    }
+
+    fn rust_context(roles: Vec<FileRole>, runtimes: Vec<RuntimeKind>) -> AuditContext {
+        AuditContext {
+            language: LanguageKind::Rust,
+            frameworks: Vec::new(),
+            roles,
+            paradigms: vec![ProgrammingParadigm::Unknown],
+            runtimes,
+            is_test: false,
+        }
+    }
+}

--- a/src/knowledge/framework.rs
+++ b/src/knowledge/framework.rs
@@ -1,0 +1,9 @@
+use crate::knowledge::bundled_knowledge;
+use crate::knowledge::model::FrameworkProfile;
+
+pub fn profile_by_id(id: &str) -> Option<&'static FrameworkProfile> {
+    bundled_knowledge()
+        .frameworks
+        .iter()
+        .find(|framework| framework.id == id)
+}

--- a/src/knowledge/language.rs
+++ b/src/knowledge/language.rs
@@ -1,0 +1,151 @@
+use crate::audits::context::LanguageKind;
+use crate::knowledge::bundled_knowledge;
+use crate::knowledge::model::LanguageProfile;
+use crate::scan::facts::FileFacts;
+use std::path::Path;
+
+pub fn detect_language_for_path(path: &Path) -> Option<&'static str> {
+    let file_name = path.file_name().and_then(|name| name.to_str())?;
+    let extension = path.extension().and_then(|extension| extension.to_str());
+
+    bundled_knowledge().languages.iter().find_map(|language| {
+        let file_name_matches = language
+            .filenames
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(file_name));
+        let extension_matches = extension.is_some_and(|extension| {
+            language
+                .extensions
+                .iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(extension))
+        });
+
+        (file_name_matches || extension_matches).then_some(language.name.as_str())
+    })
+}
+
+pub fn profile_by_id(id: &str) -> Option<&'static LanguageProfile> {
+    bundled_knowledge()
+        .languages
+        .iter()
+        .find(|language| language.id == id)
+}
+
+pub fn language_id_for_name(name: &str) -> Option<&'static str> {
+    let normalized = normalize(name);
+    bundled_knowledge()
+        .languages
+        .iter()
+        .find(|language| {
+            normalize(&language.name) == normalized
+                || language
+                    .aliases
+                    .iter()
+                    .any(|alias| normalize(alias) == normalized)
+                || normalize(&language.id) == normalized
+        })
+        .map(|language| language.id.as_str())
+}
+
+pub fn language_kind_for_file(file: &FileFacts) -> LanguageKind {
+    if let Some(language) = &file.language
+        && let Some(kind) = language_kind_from_name(language)
+    {
+        return kind;
+    }
+
+    detect_language_for_path(&file.path)
+        .and_then(language_kind_from_name)
+        .unwrap_or(LanguageKind::Unknown)
+}
+
+pub fn language_kind_from_name(name: &str) -> Option<LanguageKind> {
+    let profile = language_id_for_name(name).and_then(profile_by_id)?;
+
+    Some(language_kind_from_id(&profile.id))
+}
+
+pub fn language_kind_from_id(id: &str) -> LanguageKind {
+    match id {
+        "rust" => LanguageKind::Rust,
+        "typescript" | "typescript-react" => LanguageKind::TypeScript,
+        "javascript" | "javascript-react" => LanguageKind::JavaScript,
+        "csharp" => LanguageKind::CSharp,
+        "python" => LanguageKind::Python,
+        "go" => LanguageKind::Go,
+        "java" => LanguageKind::Java,
+        "kotlin" => LanguageKind::Kotlin,
+        "swift" => LanguageKind::Swift,
+        "c" => LanguageKind::C,
+        "cpp" => LanguageKind::Cpp,
+        "c-header" => LanguageKind::CHeader,
+        "php" => LanguageKind::Php,
+        "ruby" => LanguageKind::Ruby,
+        "dart" => LanguageKind::Dart,
+        "scala" => LanguageKind::Scala,
+        "shell" => LanguageKind::Shell,
+        "powershell" => LanguageKind::PowerShell,
+        "sql" => LanguageKind::Sql,
+        "html" => LanguageKind::Html,
+        "css" => LanguageKind::Css,
+        "scss" => LanguageKind::Scss,
+        "elixir" => LanguageKind::Elixir,
+        "erlang" => LanguageKind::Erlang,
+        "haskell" => LanguageKind::Haskell,
+        "ocaml" => LanguageKind::OCaml,
+        "fsharp" => LanguageKind::FSharp,
+        "r" => LanguageKind::R,
+        "julia" => LanguageKind::Julia,
+        "lua" => LanguageKind::Lua,
+        "perl" => LanguageKind::Perl,
+        "zig" => LanguageKind::Zig,
+        "solidity" => LanguageKind::Solidity,
+        "objective-c" => LanguageKind::ObjectiveC,
+        "terraform" => LanguageKind::Terraform,
+        "dockerfile" => LanguageKind::Dockerfile,
+        "nix" => LanguageKind::Nix,
+        "json" => LanguageKind::Json,
+        "toml" => LanguageKind::Toml,
+        "yaml" => LanguageKind::Yaml,
+        "markdown" => LanguageKind::Markdown,
+        _ => LanguageKind::Unknown,
+    }
+}
+
+fn normalize(value: &str) -> String {
+    value.trim().to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::knowledge::model::SupportLevel;
+
+    #[test]
+    fn detects_language_from_bundled_extensions() {
+        assert_eq!(
+            detect_language_for_path(Path::new("src/main.rs")),
+            Some("Rust")
+        );
+        assert_eq!(
+            detect_language_for_path(Path::new("Dockerfile")),
+            Some("Dockerfile")
+        );
+        assert_eq!(
+            detect_language_for_path(Path::new("infra/main.tf")),
+            Some("Terraform")
+        );
+    }
+
+    #[test]
+    fn exposes_support_levels() {
+        assert_eq!(
+            profile_by_id("rust").map(|profile| profile.support),
+            Some(SupportLevel::RuleAware)
+        );
+        assert_eq!(
+            profile_by_id("zig").map(|profile| profile.support),
+            Some(SupportLevel::DetectOnly)
+        );
+    }
+}

--- a/src/knowledge/loader.rs
+++ b/src/knowledge/loader.rs
@@ -1,0 +1,80 @@
+use crate::knowledge::model::{KnowledgeBase, KnowledgePack};
+use crate::knowledge::validate::{KnowledgeValidationError, validate_knowledge_base};
+use std::sync::OnceLock;
+
+const CORE_PACK: &str = include_str!("packs/core.toml");
+
+static KNOWLEDGE: OnceLock<KnowledgeBase> = OnceLock::new();
+
+pub fn bundled_knowledge() -> &'static KnowledgeBase {
+    KNOWLEDGE.get_or_init(|| {
+        load_from_str(CORE_PACK)
+            .unwrap_or_else(|error| panic!("bundled knowledge pack is invalid: {error}"))
+    })
+}
+
+pub fn load_from_str(content: &str) -> Result<KnowledgeBase, KnowledgeLoadError> {
+    let pack: KnowledgePack = toml::from_str(content).map_err(KnowledgeLoadError::Parse)?;
+    let base = KnowledgeBase::from(pack);
+    validate_knowledge_base(&base).map_err(KnowledgeLoadError::Invalid)?;
+    Ok(base)
+}
+
+#[derive(Debug)]
+pub enum KnowledgeLoadError {
+    Parse(toml::de::Error),
+    Invalid(KnowledgeValidationError),
+}
+
+impl std::fmt::Display for KnowledgeLoadError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KnowledgeLoadError::Parse(error) => write!(formatter, "failed to parse TOML: {error}"),
+            KnowledgeLoadError::Invalid(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for KnowledgeLoadError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_knowledge_pack_loads() {
+        let knowledge = bundled_knowledge();
+
+        assert!(
+            knowledge
+                .languages
+                .iter()
+                .any(|language| language.id == "rust")
+        );
+        assert!(
+            knowledge
+                .rule_applicability
+                .iter()
+                .any(|rule| rule.rule_id == "language.rust.panic-risk")
+        );
+    }
+
+    #[test]
+    fn invalid_pack_fixture_fails_validation() {
+        let invalid = r#"
+            [[languages]]
+            id = "rust"
+            name = "Rust"
+            extensions = ["rs"]
+            support = "rule-aware"
+
+            [[languages]]
+            id = "rust"
+            name = "Rust duplicate"
+            extensions = ["rs2"]
+            support = "detect-only"
+        "#;
+
+        assert!(load_from_str(invalid).is_err());
+    }
+}

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -1,0 +1,15 @@
+pub mod decision;
+pub mod framework;
+pub mod language;
+pub mod loader;
+pub mod model;
+pub mod paradigm;
+pub mod rule;
+pub mod runtime;
+pub mod validate;
+
+pub use loader::bundled_knowledge;
+pub use model::{
+    KnowledgeBase, LanguageProfile, RuleDecision, RuleDecisionAction, RuleMatchContext,
+    SupportLevel,
+};

--- a/src/knowledge/model.rs
+++ b/src/knowledge/model.rs
@@ -1,0 +1,173 @@
+use crate::findings::types::Severity;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SupportLevel {
+    DetectOnly,
+    ImportAware,
+    ContextAware,
+    RuleAware,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct LanguageProfile {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    #[serde(default)]
+    pub extensions: Vec<String>,
+    #[serde(default)]
+    pub filenames: Vec<String>,
+    pub support: SupportLevel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct FrameworkProfile {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct RuntimeProfile {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ParadigmProfile {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct RuleApplicability {
+    pub rule_id: String,
+    #[serde(default)]
+    pub minimum_support: Option<SupportLevel>,
+    #[serde(default)]
+    pub languages: Vec<String>,
+    #[serde(default)]
+    pub frameworks: Vec<String>,
+    #[serde(default)]
+    pub runtimes: Vec<String>,
+    #[serde(default)]
+    pub paradigms: Vec<String>,
+    #[serde(default)]
+    pub suppress_low_signal: bool,
+    #[serde(default)]
+    pub suppress_generated: bool,
+    #[serde(default)]
+    pub suppress_config: bool,
+    #[serde(default)]
+    pub overrides: Vec<RuleOverride>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct RuleOverride {
+    #[serde(default)]
+    pub signal: Option<String>,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub framework: Option<String>,
+    #[serde(default)]
+    pub runtime: Option<String>,
+    #[serde(default)]
+    pub paradigm: Option<String>,
+    #[serde(default)]
+    pub role: Option<String>,
+    pub action: RuleDecisionAction,
+    #[serde(default)]
+    pub severity: Option<Severity>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct KnowledgePack {
+    #[serde(default)]
+    pub languages: Vec<LanguageProfile>,
+    #[serde(default)]
+    pub frameworks: Vec<FrameworkProfile>,
+    #[serde(default)]
+    pub runtimes: Vec<RuntimeProfile>,
+    #[serde(default)]
+    pub paradigms: Vec<ParadigmProfile>,
+    #[serde(default, rename = "rules")]
+    pub rule_applicability: Vec<RuleApplicability>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KnowledgeBase {
+    pub languages: Vec<LanguageProfile>,
+    pub frameworks: Vec<FrameworkProfile>,
+    pub runtimes: Vec<RuntimeProfile>,
+    pub paradigms: Vec<ParadigmProfile>,
+    pub rule_applicability: Vec<RuleApplicability>,
+}
+
+impl From<KnowledgePack> for KnowledgeBase {
+    fn from(pack: KnowledgePack) -> Self {
+        Self {
+            languages: pack.languages,
+            frameworks: pack.frameworks,
+            runtimes: pack.runtimes,
+            paradigms: pack.paradigms,
+            rule_applicability: pack.rule_applicability,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RuleDecisionAction {
+    Apply,
+    Suppress,
+    Downgrade,
+    Upgrade,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuleDecision {
+    pub action: RuleDecisionAction,
+    pub severity: Severity,
+    pub reason: Option<String>,
+}
+
+impl RuleDecision {
+    pub fn apply(severity: Severity) -> Self {
+        Self {
+            action: RuleDecisionAction::Apply,
+            severity,
+            reason: None,
+        }
+    }
+
+    pub fn suppress(reason: impl Into<String>) -> Self {
+        Self {
+            action: RuleDecisionAction::Suppress,
+            severity: Severity::Info,
+            reason: Some(reason.into()),
+        }
+    }
+
+    pub fn is_suppressed(&self) -> bool {
+        self.action == RuleDecisionAction::Suppress
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuleMatchContext<'a> {
+    pub rule_id: &'a str,
+    pub languages: &'a [&'a str],
+    pub frameworks: &'a [&'a str],
+    pub roles: &'a [&'a str],
+    pub paradigms: &'a [&'a str],
+    pub runtimes: &'a [&'a str],
+    pub is_test: bool,
+    pub is_low_signal: bool,
+    pub signal: Option<&'a str>,
+    pub base_severity: Severity,
+}

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -1,0 +1,901 @@
+[[languages]]
+id = "rust"
+name = "Rust"
+aliases = ["rust"]
+extensions = ["rs"]
+support = "rule-aware"
+
+[[languages]]
+id = "typescript-react"
+name = "TypeScript React"
+aliases = ["tsx", "typescript react"]
+extensions = ["tsx"]
+support = "context-aware"
+
+[[languages]]
+id = "typescript"
+name = "TypeScript"
+aliases = ["ts", "mts"]
+extensions = ["ts", "mts"]
+support = "rule-aware"
+
+[[languages]]
+id = "javascript-react"
+name = "JavaScript React"
+aliases = ["jsx", "javascript react"]
+extensions = ["jsx"]
+support = "context-aware"
+
+[[languages]]
+id = "javascript"
+name = "JavaScript"
+aliases = ["js", "mjs", "cjs"]
+extensions = ["js", "mjs", "cjs"]
+support = "rule-aware"
+
+[[languages]]
+id = "python"
+name = "Python"
+extensions = ["py"]
+support = "rule-aware"
+
+[[languages]]
+id = "go"
+name = "Go"
+extensions = ["go"]
+support = "rule-aware"
+
+[[languages]]
+id = "java"
+name = "Java"
+extensions = ["java"]
+support = "rule-aware"
+
+[[languages]]
+id = "kotlin"
+name = "Kotlin"
+extensions = ["kt", "kts"]
+support = "rule-aware"
+
+[[languages]]
+id = "csharp"
+name = "C#"
+aliases = ["csharp", "cs", "c sharp"]
+extensions = ["cs"]
+support = "rule-aware"
+
+[[languages]]
+id = "c"
+name = "C"
+extensions = ["c"]
+support = "rule-aware"
+
+[[languages]]
+id = "cpp"
+name = "C++"
+aliases = ["cxx", "cc"]
+extensions = ["cpp", "cc", "cxx", "hpp", "hh", "hxx"]
+support = "rule-aware"
+
+[[languages]]
+id = "c-header"
+name = "C/C++ Header"
+extensions = ["h"]
+support = "import-aware"
+
+[[languages]]
+id = "swift"
+name = "Swift"
+extensions = ["swift"]
+support = "context-aware"
+
+[[languages]]
+id = "php"
+name = "PHP"
+extensions = ["php"]
+support = "context-aware"
+
+[[languages]]
+id = "ruby"
+name = "Ruby"
+extensions = ["rb"]
+support = "context-aware"
+
+[[languages]]
+id = "dart"
+name = "Dart"
+extensions = ["dart"]
+support = "context-aware"
+
+[[languages]]
+id = "scala"
+name = "Scala"
+extensions = ["scala", "sc"]
+support = "context-aware"
+
+[[languages]]
+id = "shell"
+name = "Shell"
+aliases = ["bash", "sh", "zsh"]
+extensions = ["sh", "bash", "zsh"]
+support = "context-aware"
+
+[[languages]]
+id = "powershell"
+name = "PowerShell"
+extensions = ["ps1", "psm1"]
+support = "context-aware"
+
+[[languages]]
+id = "sql"
+name = "SQL"
+extensions = ["sql"]
+support = "context-aware"
+
+[[languages]]
+id = "html"
+name = "HTML"
+extensions = ["html", "htm"]
+support = "context-aware"
+
+[[languages]]
+id = "css"
+name = "CSS"
+extensions = ["css"]
+support = "context-aware"
+
+[[languages]]
+id = "scss"
+name = "SCSS"
+extensions = ["scss", "sass"]
+support = "context-aware"
+
+[[languages]]
+id = "elixir"
+name = "Elixir"
+extensions = ["ex", "exs"]
+support = "detect-only"
+
+[[languages]]
+id = "erlang"
+name = "Erlang"
+extensions = ["erl", "hrl"]
+support = "detect-only"
+
+[[languages]]
+id = "haskell"
+name = "Haskell"
+extensions = ["hs", "lhs"]
+support = "detect-only"
+
+[[languages]]
+id = "ocaml"
+name = "OCaml"
+extensions = ["ml", "mli"]
+support = "detect-only"
+
+[[languages]]
+id = "fsharp"
+name = "F#"
+aliases = ["fsharp"]
+extensions = ["fs", "fsx"]
+support = "detect-only"
+
+[[languages]]
+id = "r"
+name = "R"
+extensions = ["r", "R"]
+support = "detect-only"
+
+[[languages]]
+id = "julia"
+name = "Julia"
+extensions = ["jl"]
+support = "detect-only"
+
+[[languages]]
+id = "lua"
+name = "Lua"
+extensions = ["lua"]
+support = "detect-only"
+
+[[languages]]
+id = "perl"
+name = "Perl"
+extensions = ["pl", "pm"]
+support = "detect-only"
+
+[[languages]]
+id = "zig"
+name = "Zig"
+extensions = ["zig"]
+support = "detect-only"
+
+[[languages]]
+id = "solidity"
+name = "Solidity"
+extensions = ["sol"]
+support = "detect-only"
+
+[[languages]]
+id = "objective-c"
+name = "Objective-C"
+aliases = ["objc"]
+extensions = ["m", "mm"]
+support = "detect-only"
+
+[[languages]]
+id = "terraform"
+name = "Terraform"
+aliases = ["hcl"]
+extensions = ["tf", "hcl"]
+support = "detect-only"
+
+[[languages]]
+id = "dockerfile"
+name = "Dockerfile"
+filenames = ["Dockerfile", "Containerfile"]
+support = "detect-only"
+
+[[languages]]
+id = "nix"
+name = "Nix"
+extensions = ["nix"]
+support = "detect-only"
+
+[[languages]]
+id = "yaml"
+name = "YAML"
+extensions = ["yaml", "yml"]
+support = "detect-only"
+
+[[languages]]
+id = "toml"
+name = "TOML"
+extensions = ["toml"]
+support = "detect-only"
+
+[[languages]]
+id = "json"
+name = "JSON"
+extensions = ["json"]
+support = "detect-only"
+
+[[languages]]
+id = "markdown"
+name = "Markdown"
+aliases = ["md"]
+extensions = ["md", "markdown"]
+support = "detect-only"
+
+[[frameworks]]
+id = "react"
+name = "React"
+
+[[frameworks]]
+id = "react-native"
+name = "React Native"
+
+[[frameworks]]
+id = "nextjs"
+name = "Next.js"
+
+[[frameworks]]
+id = "expo"
+name = "Expo"
+
+[[frameworks]]
+id = "nodejs"
+name = "Node.js"
+
+[[frameworks]]
+id = "vue"
+name = "Vue"
+
+[[frameworks]]
+id = "angular"
+name = "Angular"
+
+[[frameworks]]
+id = "svelte"
+name = "Svelte"
+
+[[frameworks]]
+id = "nestjs"
+name = "NestJS"
+
+[[frameworks]]
+id = "express"
+name = "Express"
+
+[[frameworks]]
+id = "dotnet"
+name = ".NET"
+
+[[frameworks]]
+id = "unity"
+name = "Unity"
+
+[[frameworks]]
+id = "django"
+name = "Django"
+
+[[frameworks]]
+id = "flask"
+name = "Flask"
+
+[[frameworks]]
+id = "fastapi"
+name = "FastAPI"
+
+[[frameworks]]
+id = "gin"
+name = "Gin"
+
+[[frameworks]]
+id = "echo"
+name = "Echo"
+
+[[frameworks]]
+id = "fiber"
+name = "Fiber"
+
+[[frameworks]]
+id = "spring"
+name = "Spring"
+
+[[frameworks]]
+id = "android"
+name = "Android"
+
+[[frameworks]]
+id = "flutter"
+name = "Flutter"
+
+[[runtimes]]
+id = "browser"
+name = "Browser"
+
+[[runtimes]]
+id = "node"
+name = "Node.js"
+
+[[runtimes]]
+id = "react-native"
+name = "React Native"
+
+[[runtimes]]
+id = "dotnet"
+name = ".NET"
+
+[[runtimes]]
+id = "unity"
+name = "Unity"
+
+[[runtimes]]
+id = "rust-cli"
+name = "Rust CLI"
+
+[[runtimes]]
+id = "rust-library"
+name = "Rust library"
+
+[[runtimes]]
+id = "python"
+name = "Python"
+
+[[runtimes]]
+id = "go"
+name = "Go"
+
+[[runtimes]]
+id = "jvm"
+name = "JVM"
+
+[[runtimes]]
+id = "android"
+name = "Android"
+
+[[runtimes]]
+id = "ios"
+name = "iOS"
+
+[[runtimes]]
+id = "shell"
+name = "Shell"
+
+[[runtimes]]
+id = "native"
+name = "Native"
+
+[[paradigms]]
+id = "functional"
+name = "Functional"
+
+[[paradigms]]
+id = "object-oriented"
+name = "Object-oriented"
+
+[[paradigms]]
+id = "procedural"
+name = "Procedural"
+
+[[paradigms]]
+id = "declarative-ui"
+name = "Declarative UI"
+
+[[paradigms]]
+id = "reactive"
+name = "Reactive"
+
+[[paradigms]]
+id = "data-oriented"
+name = "Data-oriented"
+
+[[paradigms]]
+id = "mixed"
+name = "Mixed"
+
+[[rules]]
+rule_id = "language.rust.panic-risk"
+minimum_support = "rule-aware"
+languages = ["rust"]
+suppress_low_signal = true
+suppress_config = true
+suppress_generated = true
+
+[[rules.overrides]]
+signal = "rust.unwrap"
+role = "test"
+action = "suppress"
+reason = "Rust unwrap in tests is usually assertion setup, not production panic risk."
+
+[[rules.overrides]]
+signal = "rust.expect"
+role = "test"
+action = "suppress"
+reason = "Rust expect in tests is usually assertion setup, not production panic risk."
+
+[[rules.overrides]]
+signal = "rust.panic"
+role = "test"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+signal = "rust.todo"
+role = "test"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+signal = "rust.unimplemented"
+role = "test"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+signal = "rust.unwrap"
+runtime = "rust-cli"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+signal = "rust.expect"
+runtime = "rust-cli"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+signal = "rust.panic"
+runtime = "rust-cli"
+action = "apply"
+severity = "MEDIUM"
+
+[[rules.overrides]]
+signal = "rust.panic"
+role = "domain"
+action = "upgrade"
+severity = "HIGH"
+
+[[rules.overrides]]
+signal = "rust.panic"
+runtime = "rust-library"
+action = "upgrade"
+severity = "HIGH"
+
+[[rules.overrides]]
+signal = "rust.todo"
+action = "upgrade"
+severity = "HIGH"
+
+[[rules.overrides]]
+signal = "rust.unimplemented"
+action = "upgrade"
+severity = "HIGH"
+
+[[rules]]
+rule_id = "language.go.panic-exit-risk"
+minimum_support = "rule-aware"
+languages = ["go"]
+suppress_low_signal = true
+suppress_config = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "suppress"
+
+[[rules.overrides]]
+role = "script"
+signal = "go.os-exit"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "app-entrypoint"
+signal = "go.os-exit"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "script"
+signal = "go.log-fatal"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "app-entrypoint"
+signal = "go.log-fatal"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "domain"
+action = "upgrade"
+severity = "HIGH"
+
+[[rules]]
+rule_id = "language.python.exception-risk"
+minimum_support = "rule-aware"
+languages = ["python"]
+suppress_low_signal = true
+suppress_config = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "script"
+signal = "python.assert"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "app-entrypoint"
+signal = "python.assert"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "domain"
+signal = "python.not-implemented"
+action = "upgrade"
+severity = "HIGH"
+
+[[rules]]
+rule_id = "language.javascript.runtime-exit-risk"
+minimum_support = "context-aware"
+languages = ["typescript", "typescript-react", "javascript", "javascript-react"]
+suppress_low_signal = true
+suppress_config = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "suppress"
+
+[[rules.overrides]]
+runtime = "node"
+role = "script"
+signal = "js.process-exit"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+runtime = "node"
+role = "app-entrypoint"
+signal = "js.process-exit"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "domain"
+signal = "js.throw-error"
+action = "upgrade"
+severity = "HIGH"
+
+[[rules]]
+rule_id = "language.managed.fatal-exception-risk"
+minimum_support = "rule-aware"
+languages = ["java", "kotlin", "csharp"]
+suppress_low_signal = true
+suppress_config = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "domain"
+action = "upgrade"
+severity = "HIGH"
+
+[[rules]]
+rule_id = "code-quality.long-function"
+minimum_support = "rule-aware"
+languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin", "csharp"]
+suppress_low_signal = true
+suppress_config = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "react-component"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "react-hook"
+action = "downgrade"
+severity = "LOW"
+
+[[rules]]
+rule_id = "architecture.large-file"
+minimum_support = "import-aware"
+languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin", "swift", "csharp", "c", "cpp", "c-header", "php", "ruby", "dart", "scala", "shell", "powershell", "sql", "html", "css", "scss"]
+suppress_low_signal = true
+suppress_config = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "suppress"
+
+[[rules]]
+rule_id = "architecture.deep-nesting"
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "architecture.too-many-modules"
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "architecture.deep-relative-imports"
+minimum_support = "rule-aware"
+languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin"]
+suppress_low_signal = true
+suppress_config = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "architecture.barrel-file-risk"
+minimum_support = "rule-aware"
+languages = ["typescript", "typescript-react", "javascript", "javascript-react"]
+suppress_low_signal = true
+suppress_config = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "architecture.circular-dependency"
+minimum_support = "rule-aware"
+languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "architecture.excessive-fan-out"
+minimum_support = "rule-aware"
+languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "architecture.high-instability-hub"
+minimum_support = "rule-aware"
+languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "code-marker.todo"
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "downgrade"
+severity = "LOW"
+
+[[rules]]
+rule_id = "code-marker.fixme"
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "downgrade"
+severity = "LOW"
+
+[[rules]]
+rule_id = "code-marker.hack"
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "downgrade"
+severity = "LOW"
+
+[[rules]]
+rule_id = "security.env-file-committed"
+
+[[rules]]
+rule_id = "security.private-key-candidate"
+suppress_low_signal = true
+
+[[rules]]
+rule_id = "security.secret-candidate"
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "testing.missing-test-folder"
+minimum_support = "context-aware"
+languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin", "swift", "csharp", "c", "cpp", "php", "ruby", "dart", "scala"]
+
+[[rules]]
+rule_id = "testing.source-without-test"
+minimum_support = "context-aware"
+languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin", "swift", "csharp", "c", "cpp", "php", "ruby", "dart", "scala"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "framework.react-native.inline-style"
+frameworks = ["react-native", "expo"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "framework.react-native.deprecated-api"
+frameworks = ["react-native", "expo"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "framework.react-native.flatlist-missing-key"
+frameworks = ["react-native", "expo"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "framework.react-native.async-storage-from-core"
+frameworks = ["react-native", "expo"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "framework.react-native.old-react-navigation"
+frameworks = ["react-native", "expo"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "framework.react-native.direct-state-mutation"
+frameworks = ["react-native", "expo"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "framework.react-native.old-architecture"
+frameworks = ["react-native", "expo"]
+
+[[rules]]
+rule_id = "framework.react-native.architecture-mismatch"
+frameworks = ["react-native", "expo"]
+
+[[rules]]
+rule_id = "framework.react-native.hermes-mismatch"
+frameworks = ["react-native", "expo"]
+
+[[rules]]
+rule_id = "framework.react-native.hermes-disabled"
+frameworks = ["react-native", "expo"]
+
+[[rules]]
+rule_id = "framework.react-native.codegen-missing"
+frameworks = ["react-native", "expo"]
+
+[[rules]]
+rule_id = "framework.js.var-declaration"
+minimum_support = "context-aware"
+languages = ["typescript", "typescript-react", "javascript", "javascript-react"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "suppress"
+
+[[rules]]
+rule_id = "framework.js.console-log"
+minimum_support = "context-aware"
+languages = ["typescript", "typescript-react", "javascript", "javascript-react"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "suppress"
+
+[[rules.overrides]]
+runtime = "node"
+action = "downgrade"
+severity = "LOW"
+
+[[rules]]
+rule_id = "framework.react.class-component"
+frameworks = ["react", "nextjs"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "framework.react.prop-types"
+frameworks = ["react", "nextjs"]
+suppress_low_signal = true
+suppress_generated = true
+
+[[rules]]
+rule_id = "framework.rn-async-storage-legacy"
+frameworks = ["react-native", "expo"]
+
+[[rules]]
+rule_id = "framework.rn-navigation-compat"
+frameworks = ["react-native", "expo"]
+
+[[rules]]
+rule_id = "framework.rn-reanimated-compat"
+frameworks = ["react-native", "expo"]
+
+[[rules]]
+rule_id = "framework.rn-gesture-handler-old"
+frameworks = ["react-native", "expo"]
+
+[[rules]]
+rule_id = "framework.rn-new-arch-incompatible-dep"
+frameworks = ["react-native", "expo"]
+
+[[rules]]
+rule_id = "code-quality.complex-file"
+minimum_support = "rule-aware"
+languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin", "c", "cpp", "csharp"]
+suppress_low_signal = true
+suppress_config = true
+suppress_generated = true
+
+[[rules.overrides]]
+role = "test"
+action = "downgrade"
+severity = "LOW"

--- a/src/knowledge/paradigm.rs
+++ b/src/knowledge/paradigm.rs
@@ -1,0 +1,9 @@
+use crate::knowledge::bundled_knowledge;
+use crate::knowledge::model::ParadigmProfile;
+
+pub fn profile_by_id(id: &str) -> Option<&'static ParadigmProfile> {
+    bundled_knowledge()
+        .paradigms
+        .iter()
+        .find(|paradigm| paradigm.id == id)
+}

--- a/src/knowledge/rule.rs
+++ b/src/knowledge/rule.rs
@@ -1,0 +1,9 @@
+use crate::knowledge::bundled_knowledge;
+use crate::knowledge::model::RuleApplicability;
+
+pub fn applicability_for_rule(rule_id: &str) -> Option<&'static RuleApplicability> {
+    bundled_knowledge()
+        .rule_applicability
+        .iter()
+        .find(|rule| rule.rule_id == rule_id)
+}

--- a/src/knowledge/runtime.rs
+++ b/src/knowledge/runtime.rs
@@ -1,0 +1,9 @@
+use crate::knowledge::bundled_knowledge;
+use crate::knowledge::model::RuntimeProfile;
+
+pub fn profile_by_id(id: &str) -> Option<&'static RuntimeProfile> {
+    bundled_knowledge()
+        .runtimes
+        .iter()
+        .find(|runtime| runtime.id == id)
+}

--- a/src/knowledge/validate.rs
+++ b/src/knowledge/validate.rs
@@ -1,0 +1,214 @@
+use crate::knowledge::model::KnowledgeBase;
+use crate::rules::lookup_rule_metadata;
+use std::collections::HashSet;
+
+pub fn validate_knowledge_base(base: &KnowledgeBase) -> Result<(), KnowledgeValidationError> {
+    validate_unique(
+        "language",
+        base.languages.iter().map(|language| language.id.as_str()),
+    )?;
+    validate_unique(
+        "framework",
+        base.frameworks
+            .iter()
+            .map(|framework| framework.id.as_str()),
+    )?;
+    validate_unique(
+        "runtime",
+        base.runtimes.iter().map(|runtime| runtime.id.as_str()),
+    )?;
+    validate_unique(
+        "paradigm",
+        base.paradigms.iter().map(|paradigm| paradigm.id.as_str()),
+    )?;
+    validate_unique(
+        "rule applicability",
+        base.rule_applicability
+            .iter()
+            .map(|rule| rule.rule_id.as_str()),
+    )?;
+
+    for language in &base.languages {
+        if language.extensions.is_empty() && language.filenames.is_empty() {
+            return Err(KnowledgeValidationError::MissingLanguageMatcher {
+                language_id: language.id.clone(),
+            });
+        }
+    }
+
+    let language_ids = id_set(base.languages.iter().map(|language| language.id.as_str()));
+    let framework_ids = id_set(
+        base.frameworks
+            .iter()
+            .map(|framework| framework.id.as_str()),
+    );
+    let runtime_ids = id_set(base.runtimes.iter().map(|runtime| runtime.id.as_str()));
+    let paradigm_ids = id_set(base.paradigms.iter().map(|paradigm| paradigm.id.as_str()));
+
+    for rule in &base.rule_applicability {
+        if lookup_rule_metadata(&rule.rule_id).is_none() {
+            return Err(KnowledgeValidationError::UnknownRule {
+                rule_id: rule.rule_id.clone(),
+            });
+        }
+
+        validate_refs("language", &rule.rule_id, &rule.languages, &language_ids)?;
+        validate_refs("framework", &rule.rule_id, &rule.frameworks, &framework_ids)?;
+        validate_refs("runtime", &rule.rule_id, &rule.runtimes, &runtime_ids)?;
+        validate_refs("paradigm", &rule.rule_id, &rule.paradigms, &paradigm_ids)?;
+
+        for override_rule in &rule.overrides {
+            if let Some(language) = &override_rule.language {
+                validate_ref("language", &rule.rule_id, language, &language_ids)?;
+            }
+            if let Some(framework) = &override_rule.framework {
+                validate_ref("framework", &rule.rule_id, framework, &framework_ids)?;
+            }
+            if let Some(runtime) = &override_rule.runtime {
+                validate_ref("runtime", &rule.rule_id, runtime, &runtime_ids)?;
+            }
+            if let Some(paradigm) = &override_rule.paradigm {
+                validate_ref("paradigm", &rule.rule_id, paradigm, &paradigm_ids)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_unique<'a>(
+    kind: &'static str,
+    ids: impl Iterator<Item = &'a str>,
+) -> Result<(), KnowledgeValidationError> {
+    let mut seen = HashSet::new();
+    for id in ids {
+        if !seen.insert(id) {
+            return Err(KnowledgeValidationError::DuplicateId {
+                kind,
+                id: id.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_refs(
+    kind: &'static str,
+    rule_id: &str,
+    values: &[String],
+    known: &HashSet<String>,
+) -> Result<(), KnowledgeValidationError> {
+    for value in values {
+        validate_ref(kind, rule_id, value, known)?;
+    }
+    Ok(())
+}
+
+fn validate_ref(
+    kind: &'static str,
+    rule_id: &str,
+    value: &str,
+    known: &HashSet<String>,
+) -> Result<(), KnowledgeValidationError> {
+    if known.contains(value) {
+        Ok(())
+    } else {
+        Err(KnowledgeValidationError::UnknownReference {
+            kind,
+            rule_id: rule_id.to_string(),
+            value: value.to_string(),
+        })
+    }
+}
+
+fn id_set<'a>(ids: impl Iterator<Item = &'a str>) -> HashSet<String> {
+    ids.map(str::to_string).collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KnowledgeValidationError {
+    DuplicateId {
+        kind: &'static str,
+        id: String,
+    },
+    MissingLanguageMatcher {
+        language_id: String,
+    },
+    UnknownRule {
+        rule_id: String,
+    },
+    UnknownReference {
+        kind: &'static str,
+        rule_id: String,
+        value: String,
+    },
+}
+
+impl std::fmt::Display for KnowledgeValidationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KnowledgeValidationError::DuplicateId { kind, id } => {
+                write!(formatter, "duplicate {kind} id `{id}`")
+            }
+            KnowledgeValidationError::MissingLanguageMatcher { language_id } => {
+                write!(
+                    formatter,
+                    "language `{language_id}` must have at least one extension or filename matcher"
+                )
+            }
+            KnowledgeValidationError::UnknownRule { rule_id } => {
+                write!(formatter, "knowledge references unknown rule `{rule_id}`")
+            }
+            KnowledgeValidationError::UnknownReference {
+                kind,
+                rule_id,
+                value,
+            } => write!(
+                formatter,
+                "rule `{rule_id}` references unknown {kind} `{value}`"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for KnowledgeValidationError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::knowledge::loader::bundled_knowledge;
+    use crate::rules::registry::all_rule_metadata;
+
+    #[test]
+    fn bundled_knowledge_is_valid() {
+        validate_knowledge_base(bundled_knowledge()).expect("bundled knowledge must validate");
+    }
+
+    #[test]
+    fn all_languages_have_support_and_matchers() {
+        for language in &bundled_knowledge().languages {
+            assert!(
+                !language.extensions.is_empty() || !language.filenames.is_empty(),
+                "{} must be discoverable",
+                language.id
+            );
+        }
+    }
+
+    #[test]
+    fn all_registered_rules_have_knowledge_applicability() {
+        let known_rules = bundled_knowledge()
+            .rule_applicability
+            .iter()
+            .map(|rule| rule.rule_id.as_str())
+            .collect::<HashSet<_>>();
+
+        for rule in all_rule_metadata() {
+            assert!(
+                known_rules.contains(rule.rule_id),
+                "{} must have a knowledge applicability entry",
+                rule.rule_id
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod doctor;
 pub mod findings;
 pub mod frameworks;
 pub mod graph;
+pub mod knowledge;
 pub mod output;
 pub mod receipt;
 pub mod report;

--- a/src/rules/registry/language.rs
+++ b/src/rules/registry/language.rs
@@ -1,14 +1,60 @@
 use crate::findings::types::{FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
 
-pub(super) static RULES: &[RuleMetadata] = &[RuleMetadata {
-    rule_id: "language.rust.panic-risk",
-    title: "Risky Rust panic or unwrap usage",
-    category: FindingCategory::CodeQuality,
-    default_severity: Severity::Medium,
-    docs_url: None,
-    description: "Rust panic-style operations such as unwrap(), expect(), panic!, todo!, and unimplemented! can be risky in reusable production code. Their severity depends on whether the code is test code, CLI boundary code, library code, or domain code.",
-    recommendation: Some(
-        "Use context-aware error handling. Prefer Result, ?, typed errors, validation, or explicit fallback behavior in production and library code.",
-    ),
-}];
+pub(super) static RULES: &[RuleMetadata] = &[
+    RuleMetadata {
+        rule_id: "language.rust.panic-risk",
+        title: "Risky Rust panic or unwrap usage",
+        category: FindingCategory::CodeQuality,
+        default_severity: Severity::Medium,
+        docs_url: None,
+        description: "Rust panic-style operations such as unwrap(), expect(), panic!, todo!, and unimplemented! can be risky in reusable production code. Their severity depends on whether the code is test code, CLI boundary code, library code, or domain code.",
+        recommendation: Some(
+            "Use context-aware error handling. Prefer Result, ?, typed errors, validation, or explicit fallback behavior in production and library code.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "language.go.panic-exit-risk",
+        title: "Risky Go panic or process exit usage",
+        category: FindingCategory::CodeQuality,
+        default_severity: Severity::Medium,
+        docs_url: None,
+        description: "Go panic and process-exit operations can terminate the program abruptly. Their risk depends on whether the file is test code, CLI boundary code, library code, or domain code.",
+        recommendation: Some(
+            "Return errors from reusable code and reserve panic/log.Fatal/os.Exit for narrow process boundaries where callers cannot recover.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "language.python.exception-risk",
+        title: "Risky Python exception or assertion pattern",
+        category: FindingCategory::CodeQuality,
+        default_severity: Severity::Medium,
+        docs_url: None,
+        description: "Broad exception handlers, production asserts, and NotImplementedError placeholders can hide failures or ship incomplete behaviour. Their severity depends on test, script, and domain context.",
+        recommendation: Some(
+            "Catch specific exceptions, use explicit runtime validation, and replace placeholders before production release.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "language.javascript.runtime-exit-risk",
+        title: "Risky JavaScript runtime exit or library throw",
+        category: FindingCategory::CodeQuality,
+        default_severity: Severity::Medium,
+        docs_url: None,
+        description: "Process exits and generic thrown errors have different risk at a CLI boundary than in reusable browser, Node, or package code.",
+        recommendation: Some(
+            "Prefer returning typed errors, rejecting promises with actionable context, or centralising CLI exit handling at the entrypoint.",
+        ),
+    },
+    RuleMetadata {
+        rule_id: "language.managed.fatal-exception-risk",
+        title: "Risky JVM or .NET fatal exception placeholder",
+        category: FindingCategory::CodeQuality,
+        default_severity: Severity::Medium,
+        docs_url: None,
+        description: "Generic fatal exceptions and not-implemented placeholders in Java, Kotlin, or C# domain/library code can become runtime failures that callers cannot handle precisely.",
+        recommendation: Some(
+            "Replace placeholders with implemented behaviour and use domain-specific exception or result types where callers need to recover.",
+        ),
+    },
+];

--- a/src/rules/registry/mod.rs
+++ b/src/rules/registry/mod.rs
@@ -20,6 +20,11 @@ pub fn lookup_rule_metadata(rule_id: &str) -> Option<&'static RuleMetadata> {
     all_rules().find(|rule| rule.rule_id == rule_id)
 }
 
+#[cfg(test)]
+pub(crate) fn all_rule_metadata() -> impl Iterator<Item = &'static RuleMetadata> {
+    all_rules()
+}
+
 fn all_rules() -> impl Iterator<Item = &'static RuleMetadata> {
     RULE_GROUPS.iter().flat_map(|rules| rules.iter())
 }
@@ -37,6 +42,17 @@ mod tests {
         assert_eq!(meta.rule_id, "framework.react-native.inline-style");
         assert_eq!(meta.category, FindingCategory::Framework);
         assert_eq!(meta.default_severity, Severity::Medium);
+    }
+
+    #[test]
+    fn rust_panic_risk_rule_returns_metadata() {
+        let meta = lookup_rule_metadata("language.rust.panic-risk").unwrap();
+
+        assert_eq!(meta.rule_id, "language.rust.panic-risk");
+        assert_eq!(meta.category, FindingCategory::CodeQuality);
+        assert_eq!(meta.default_severity, Severity::Medium);
+        assert!(!meta.title.is_empty());
+        assert!(!meta.description.is_empty());
     }
 
     #[test]

--- a/src/scan/language.rs
+++ b/src/scan/language.rs
@@ -1,30 +1,5 @@
 use std::path::Path;
 
 pub fn detect_language(path: &Path) -> Option<&'static str> {
-    let extension = path.extension()?.to_str()?;
-
-    match extension {
-        "rs" => Some("Rust"),
-        "js" => Some("JavaScript"),
-        "jsx" => Some("JavaScript React"),
-        "ts" => Some("TypeScript"),
-        "tsx" => Some("TypeScript React"),
-        "py" => Some("Python"),
-        "go" => Some("Go"),
-        "java" => Some("Java"),
-        "kt" => Some("Kotlin"),
-        "swift" => Some("Swift"),
-        "cs" => Some("C#"),
-        "cpp" | "cc" | "cxx" => Some("C++"),
-        "c" => Some("C"),
-        "h" | "hpp" => Some("C/C++ Header"),
-        "html" => Some("HTML"),
-        "css" => Some("CSS"),
-        "scss" => Some("SCSS"),
-        "json" => Some("JSON"),
-        "toml" => Some("TOML"),
-        "yaml" | "yml" => Some("YAML"),
-        "md" => Some("Markdown"),
-        _ => None,
-    }
+    crate::knowledge::language::detect_language_for_path(path)
 }

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -10,6 +10,7 @@ use crate::frameworks::{
     DetectedFramework, detect_framework_projects, detect_frameworks,
     detect_react_native_architecture,
 };
+use crate::knowledge::decision::apply_project_decisions;
 use crate::scan::config::ScanConfig;
 use crate::scan::types::ScanSummary;
 use std::io;
@@ -51,7 +52,7 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
     findings.extend(run_framework_audits(&facts, config));
     let (coupling_findings, coupling_graph) =
         ImportCouplingAudit.audit_with_graph(&facts, config, path);
-    findings.extend(coupling_findings);
+    findings.extend(apply_project_decisions(&facts, coupling_findings));
 
     for finding in &mut findings {
         finding.id = stable_finding_key(finding, path);

--- a/tests/knowledge_engine_integration.rs
+++ b/tests/knowledge_engine_integration.rs
@@ -1,0 +1,159 @@
+use repopilot::findings::types::Severity;
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::scanner::scan_path_with_config;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn polyglot_scan_uses_knowledge_engine_context_without_flagging_paradigms() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+
+    write(
+        root.join("src/domain/user.rs"),
+        "pub fn user_name() -> String { panic!(\"invalid domain state\") }\n",
+    );
+    write(
+        root.join("src/main.rs"),
+        "fn main() { let config = load_config().unwrap(); }\nfn load_config() -> Result<(), ()> { Ok(()) }\n",
+    );
+    write(
+        root.join("src/users.ts"),
+        "const names = users.filter(user => user.active).map(user => user.name);\n",
+    );
+    write(
+        root.join("app/views.py"),
+        "from fastapi import FastAPI\napp = FastAPI()\n",
+    );
+
+    let summary = scan_path_with_config(
+        root,
+        &ScanConfig {
+            detect_missing_tests: false,
+            ..ScanConfig::default()
+        },
+    )
+    .expect("scan");
+
+    assert!(
+        summary
+            .languages
+            .iter()
+            .any(|language| language.name == "Rust")
+    );
+    assert!(
+        summary
+            .languages
+            .iter()
+            .any(|language| language.name == "TypeScript")
+    );
+    assert!(
+        summary
+            .languages
+            .iter()
+            .any(|language| language.name == "Python")
+    );
+
+    let rust_findings: Vec<_> = summary
+        .findings
+        .iter()
+        .filter(|finding| finding.rule_id == "language.rust.panic-risk")
+        .collect();
+
+    assert_eq!(rust_findings.len(), 2);
+    assert!(
+        rust_findings
+            .iter()
+            .any(|finding| finding.severity == Severity::High)
+    );
+    assert!(
+        rust_findings
+            .iter()
+            .any(|finding| finding.severity == Severity::Low)
+    );
+    assert!(
+        summary
+            .findings
+            .iter()
+            .all(|finding| !finding.title.to_lowercase().contains("functional"))
+    );
+}
+
+#[test]
+fn node_cli_boundary_downgrades_process_exit() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+
+    write(root.join("src/main.js"), "process.exit(1);\n");
+
+    let summary = scan_path_with_config(
+        root,
+        &ScanConfig {
+            detect_missing_tests: false,
+            ..ScanConfig::default()
+        },
+    )
+    .expect("scan");
+
+    let finding = summary
+        .findings
+        .iter()
+        .find(|finding| finding.rule_id == "language.javascript.runtime-exit-risk")
+        .expect("process exit finding");
+
+    assert_eq!(finding.severity, Severity::Low);
+}
+
+#[test]
+fn generated_files_suppress_language_risk_noise() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+
+    write(
+        root.join("src/generated/client.go"),
+        "package generated\nfunc Parse() { panic(\"generated\") }\n",
+    );
+
+    let summary = scan_path_with_config(
+        root,
+        &ScanConfig {
+            detect_missing_tests: false,
+            ..ScanConfig::default()
+        },
+    )
+    .expect("scan");
+
+    assert!(
+        summary
+            .findings
+            .iter()
+            .all(|finding| finding.rule_id != "language.go.panic-exit-risk")
+    );
+}
+
+#[test]
+fn no_audit_uses_hardcoded_language_allowlist_for_applicability() {
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source_files = [
+        "src/audits/architecture/large_file.rs",
+        "src/audits/code_quality/complexity.rs",
+        "src/audits/code_quality/long_function/mod.rs",
+    ];
+
+    for relative_path in source_files {
+        let content = fs::read_to_string(root.join(relative_path)).expect("read source file");
+        for forbidden in ["fn is_supported", "fn is_code_language", "fn is_code_file"] {
+            assert!(
+                !content.contains(forbidden),
+                "{relative_path} still contains local applicability helper `{forbidden}`"
+            );
+        }
+    }
+}
+
+fn write(path: std::path::PathBuf, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dir");
+    }
+    fs::write(path, content).expect("write fixture");
+}


### PR DESCRIPTION
## Summary

This PR introduces the RepoPilot Knowledge Engine foundation for 0.9.0.

The main goal is to move RepoPilot from hardcoded, one-size-fits-all audit behavior toward context-aware rule decisions.

Instead of every audit deciding applicability on its own, RepoPilot now has a shared knowledge layer that understands languages, frameworks, runtimes, paradigms, support levels, rule applicability, and context-specific overrides.

This is the foundation for smarter findings with fewer false positives.

## What changed

- Added a new `src/knowledge/` module with:
  - knowledge model
  - bundled TOML loader
  - validation
  - language/framework/runtime/paradigm helpers
  - rule applicability decisions
  - file-level and project-level decision helpers

- Added bundled knowledge pack:

  - src/knowledge/packs/core.toml

- Added support levels for languages:

  - detect-only
  - import-aware
  - context-aware
  - rule-aware

- Added rule applicability checks based on:

  - language
  - framework
  - runtime
  - paradigm
  - file role
  - test/config/generated/low-signal context
  - signal-specific overrides

- Updated language detection to use the Knowledge Engine corpus instead of a hardcoded extension table.
- Integrated the Knowledge Engine decision layer into existing audits:

  - large file audit
  - code marker audit
  - complexity audit
  - long function audit
  - Rust panic risk audit
  - JS common audits
  - secret/private key candidate audits

- Added a generic language risk audit for common language-specific reliability risks:

  - Go panic, log.Fatal, os.Exit
  - Python broad except, production assert, NotImplementedError
  - JavaScript / TypeScript process.exit
  - generic managed-language fatal exceptions / not-implemented placeholders

- Added validation to ensure:

  - language IDs are unique
  - framework IDs are unique
  - runtime IDs are unique
  - paradigm IDs are unique
  - rule applicability IDs are unique
  - languages have matchers
  - knowledge rules reference existing rule metadata
  - rule references point to known languages/frameworks/runtimes/paradigms

- Updated CHANGELOG.md for the 0.9.0 unreleased direction.

## Why

RepoPilot needs to understand context before reporting a finding.

A simple pattern can mean different things depending on where it appears:

  - unwrap() in Rust test code can be acceptable.
  - panic! in Rust domain code is risky.
  - process.exit() in a CLI entrypoint may be acceptable, but not in a reusable library.
  - functional programming should not be reported as a smell just because it uses chains, functions, or transformations.
  - config, generated, test, and low-signal paths need different audit behavior.

Before this PR, many audit decisions were hardcoded inside individual audits.

This PR creates a shared decision layer so audits can ask:

```text
Does this rule apply here?
Should it be suppressed?
Should severity be downgraded?
Should severity be upgraded?
Is this language supported deeply enough for this rule?
Is this a known false-positive context?
```

## Architecture notes

The new design keeps responsibilities separated:

  - src/knowledge/model.rs defines the data model.
  - src/knowledge/loader.rs loads the bundled TOML knowledge pack.
  - src/knowledge/validate.rs validates knowledge integrity.
  - src/knowledge/decision.rs applies rule decisions.
  - src/knowledge/packs/core.toml stores the bundled knowledge corpus.
  - audits remain responsible for detecting evidence.
  - the Knowledge Engine is responsible for deciding applicability and severity changes.
  - the rule registry remains responsible for rule metadata.

This gives RepoPilot a clean path toward language-aware, framework-aware, paradigm-aware, and runtime-aware audits without turning individual audits into god files.

## Design direction

This PR establishes the 0.9.0 philosophy:

RepoPilot detects risk, not style preference.

RepoPilot should not enforce one universal programming style.

Different languages, paradigms, frameworks, and runtimes have different definitions of good code. A useful finding must be based on context, evidence, applicability, and a clear reason.

This is especially important for preventing false positives such as treating functional programming as a code smell.

## Verification

Run:

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan . --format markdown --output /tmp/repopilot-knowledge-engine.md
```