### PR TITLE
feat(explain): inspect knowledge rule decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 - Added a bundled RepoPilot Knowledge Engine foundation for language, framework, runtime, paradigm, and rule applicability decisions.
 - Added a tiered language corpus covering rule-aware, context-aware, import-aware, and detect-only support levels across common and emerging languages.
+- Added `repopilot explain` for inspecting file context classification and optional Knowledge Engine rule decisions.
 
 ### Changed
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -288,6 +288,44 @@ repopilot prompt . --output prompt.md"
         output: Option<PathBuf>,
     },
 
+    /// Explain RepoPilot context classification and knowledge rule decisions (alias: e)
+    #[command(
+        alias = "e",
+        about = "Explain file context classification and rule decisions",
+        long_about = "Explains how RepoPilot classifies a single file before applying audits.\n\n\
+The output shows detected language, language support level, frameworks, file roles,\n\
+programming paradigms, runtimes, test/production context, and optionally the\n\
+Knowledge Engine decision for a specific rule.\n\n\
+Use this when improving rules, debugging false positives, or learning why a pattern\n\
+is acceptable in one paradigm/runtime but risky in another.",
+        after_help = "EXAMPLES:\n  \
+repopilot explain src/main.rs\n  \
+repopilot explain src/main.rs --rule language.rust.panic-risk --signal rust.unwrap\n  \
+repopilot explain src/domain/user.rs --rule language.rust.panic-risk --signal rust.panic --format json\n  \
+repopilot explain src/App.tsx --format markdown --output explain.md"
+    )]
+    Explain {
+        path: PathBuf,
+
+        /// Rule ID to evaluate against the file context
+        #[arg(long)]
+        rule: Option<String>,
+
+        /// Optional rule signal, for example rust.unwrap or rust.panic
+        #[arg(long)]
+        signal: Option<String>,
+
+        /// Base severity used before Knowledge Engine overrides
+        #[arg(long, value_enum, default_value = "medium")]
+        severity: SeverityArg,
+
+        #[arg(long, value_enum, default_value = "console")]
+        format: CompareOutputFormatArg,
+
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
+
     /// Generate a default repopilot.toml configuration file
     #[command(
         about = "Generate a default repopilot.toml configuration file",

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -1,0 +1,27 @@
+use crate::cli::{CompareOutputFormatArg, SeverityArg};
+use crate::commands::severity_arg_into;
+use repopilot::explain::{build_explain_report, render_explain_report};
+use repopilot::output::OutputFormat;
+use repopilot::report::writer::write_report;
+use std::path::PathBuf;
+
+pub fn run(
+    path: PathBuf,
+    rule: Option<String>,
+    signal: Option<String>,
+    severity: SeverityArg,
+    format: CompareOutputFormatArg,
+    output: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let report = build_explain_report(
+        &path,
+        rule.as_deref(),
+        signal.as_deref(),
+        severity_arg_into(severity),
+    )?;
+    let rendered = render_explain_report(&report, OutputFormat::from(format))?;
+
+    write_report(&rendered, output.as_deref())?;
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod baseline;
 pub mod compare;
 pub mod doctor;
+pub mod explain;
 pub mod harden;
 pub mod init;
 mod llm;
@@ -115,6 +116,15 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             budget,
             output,
         } => prompt::run(path, config, focus, budget, output),
+
+        Commands::Explain {
+            path,
+            rule,
+            signal,
+            severity,
+            format,
+            output,
+        } => explain::run(path, rule, signal, severity, format, output),
 
         Commands::Vibe {
             path,

--- a/src/explain/builder.rs
+++ b/src/explain/builder.rs
@@ -1,0 +1,113 @@
+use crate::audits::context::classify_file;
+use crate::explain::model::{ExplainContext, ExplainDecision, ExplainReport, ExplainSource};
+use crate::findings::types::Severity;
+use crate::knowledge::decision::decide_for_file;
+use crate::knowledge::language::{detect_language_for_path, profile_by_id};
+use crate::knowledge::model::{RuleDecisionAction, SupportLevel};
+use crate::scan::facts::FileFacts;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+pub fn build_explain_report(
+    path: &Path,
+    rule_id: Option<&str>,
+    signal: Option<&str>,
+    base_severity: Severity,
+) -> Result<ExplainReport, io::Error> {
+    let content = fs::read_to_string(path)?;
+    let language_name = detect_language_for_path(path).map(str::to_string);
+    let lines_of_code = count_non_empty_lines(&content);
+    let has_inline_tests = content.contains("#[cfg(test)]");
+
+    let file = FileFacts {
+        path: path.to_path_buf(),
+        language: language_name.clone(),
+        lines_of_code,
+        branch_count: 0,
+        imports: Vec::new(),
+        content: Some(content),
+        has_inline_tests,
+    };
+
+    let audit_context = classify_file(&file);
+    let language_id = audit_context.language_id();
+    let language_support =
+        profile_by_id(language_id).map(|profile| support_level_label(profile.support).to_string());
+
+    let context = ExplainContext {
+        language: language_id.to_string(),
+        language_support,
+        frameworks: audit_context
+            .framework_ids()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        roles: audit_context
+            .role_ids()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        paradigms: audit_context
+            .paradigm_ids()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        runtimes: audit_context
+            .runtime_ids()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        is_test: audit_context.is_test,
+        is_production_code: audit_context.is_production_code(),
+    };
+
+    let decision = rule_id.map(|rule_id| {
+        let decision = decide_for_file(rule_id, &file, base_severity, signal);
+
+        ExplainDecision {
+            rule_id: rule_id.to_string(),
+            signal: signal.map(str::to_string),
+            base_severity,
+            action: decision_action_label(decision.action).to_string(),
+            final_severity: decision.severity,
+            reason: decision.reason,
+        }
+    });
+
+    Ok(ExplainReport {
+        path: path.display().to_string(),
+        source: ExplainSource {
+            language_name,
+            lines_of_code,
+            has_inline_tests,
+        },
+        context,
+        decision,
+    })
+}
+
+fn count_non_empty_lines(content: &str) -> usize {
+    content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count()
+}
+
+fn support_level_label(level: SupportLevel) -> &'static str {
+    match level {
+        SupportLevel::DetectOnly => "detect-only",
+        SupportLevel::ImportAware => "import-aware",
+        SupportLevel::ContextAware => "context-aware",
+        SupportLevel::RuleAware => "rule-aware",
+    }
+}
+
+fn decision_action_label(action: RuleDecisionAction) -> &'static str {
+    match action {
+        RuleDecisionAction::Apply => "apply",
+        RuleDecisionAction::Suppress => "suppress",
+        RuleDecisionAction::Downgrade => "downgrade",
+        RuleDecisionAction::Upgrade => "upgrade",
+    }
+}

--- a/src/explain/mod.rs
+++ b/src/explain/mod.rs
@@ -1,0 +1,7 @@
+pub mod builder;
+pub mod model;
+pub mod render;
+
+pub use builder::build_explain_report;
+pub use model::{ExplainContext, ExplainDecision, ExplainReport, ExplainSource};
+pub use render::render_explain_report;

--- a/src/explain/model.rs
+++ b/src/explain/model.rs
@@ -1,0 +1,43 @@
+use crate::findings::types::Severity;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExplainReport {
+    pub path: String,
+    pub source: ExplainSource,
+    pub context: ExplainContext,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision: Option<ExplainDecision>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExplainSource {
+    pub language_name: Option<String>,
+    pub lines_of_code: usize,
+    pub has_inline_tests: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExplainContext {
+    pub language: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language_support: Option<String>,
+    pub frameworks: Vec<String>,
+    pub roles: Vec<String>,
+    pub paradigms: Vec<String>,
+    pub runtimes: Vec<String>,
+    pub is_test: bool,
+    pub is_production_code: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExplainDecision {
+    pub rule_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal: Option<String>,
+    pub base_severity: Severity,
+    pub action: String,
+    pub final_severity: Severity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}

--- a/src/explain/render.rs
+++ b/src/explain/render.rs
@@ -1,0 +1,201 @@
+use crate::explain::model::{ExplainDecision, ExplainReport};
+use crate::output::OutputFormat;
+
+pub fn render_explain_report(
+    report: &ExplainReport,
+    format: OutputFormat,
+) -> Result<String, serde_json::Error> {
+    match format {
+        OutputFormat::Console => Ok(render_console(report)),
+        OutputFormat::Markdown => Ok(render_markdown(report)),
+        OutputFormat::Json | OutputFormat::Html | OutputFormat::Sarif => {
+            serde_json::to_string_pretty(report)
+        }
+    }
+}
+
+fn render_console(report: &ExplainReport) -> String {
+    let mut output = String::new();
+
+    output.push_str("RepoPilot Explain\n\n");
+    output.push_str(&format!("File: {}\n", report.path));
+    output.push_str(&format!(
+        "Language: {}\n",
+        report.source.language_name.as_deref().unwrap_or("unknown")
+    ));
+    output.push_str(&format!("Lines of code: {}\n", report.source.lines_of_code));
+    output.push_str(&format!(
+        "Inline tests: {}\n\n",
+        yes_no(report.source.has_inline_tests)
+    ));
+
+    output.push_str("Audit context:\n");
+    output.push_str(&format!(" Language: {}\n", report.context.language));
+    output.push_str(&format!(
+        " Language support: {}\n",
+        report
+            .context
+            .language_support
+            .as_deref()
+            .unwrap_or("unknown")
+    ));
+    output.push_str(&format!(
+        " Frameworks: {}\n",
+        comma_or_none(&report.context.frameworks)
+    ));
+    output.push_str(&format!(
+        " Roles: {}\n",
+        comma_or_none(&report.context.roles)
+    ));
+    output.push_str(&format!(
+        " Paradigms: {}\n",
+        comma_or_none(&report.context.paradigms)
+    ));
+    output.push_str(&format!(
+        " Runtimes: {}\n",
+        comma_or_none(&report.context.runtimes)
+    ));
+    output.push_str(&format!(" Test code: {}\n", yes_no(report.context.is_test)));
+    output.push_str(&format!(
+        " Production code: {}\n",
+        yes_no(report.context.is_production_code)
+    ));
+
+    output.push_str("\nRule decision:\n");
+    match &report.decision {
+        Some(decision) => output.push_str(&render_console_decision(decision)),
+        None => output.push_str(" not requested; pass --rule <RULE_ID> to evaluate one\n"),
+    }
+
+    output
+}
+
+fn render_console_decision(decision: &ExplainDecision) -> String {
+    let mut output = String::new();
+
+    output.push_str(&format!(" Rule: {}\n", decision.rule_id));
+    output.push_str(&format!(
+        " Signal: {}\n",
+        decision.signal.as_deref().unwrap_or("none")
+    ));
+    output.push_str(&format!(
+        " Base severity: {}\n",
+        decision.base_severity.label()
+    ));
+    output.push_str(&format!(" Action: {}\n", decision.action));
+    output.push_str(&format!(
+        " Final severity: {}\n",
+        decision.final_severity.label()
+    ));
+    if let Some(reason) = &decision.reason {
+        output.push_str(&format!(" Reason: {reason}\n"));
+    }
+
+    output
+}
+
+fn render_markdown(report: &ExplainReport) -> String {
+    let mut output = String::new();
+
+    output.push_str("# RepoPilot Explain\n\n");
+    output.push_str(&format!("- **File:** `{}`\n", report.path));
+    output.push_str(&format!(
+        "- **Language:** `{}`\n",
+        report.source.language_name.as_deref().unwrap_or("unknown")
+    ));
+    output.push_str(&format!(
+        "- **Lines of code:** {}\n",
+        report.source.lines_of_code
+    ));
+    output.push_str(&format!(
+        "- **Inline tests:** {}\n\n",
+        yes_no(report.source.has_inline_tests)
+    ));
+
+    output.push_str("## Audit context\n\n");
+    output.push_str(&format!("- **Language:** `{}`\n", report.context.language));
+    output.push_str(&format!(
+        "- **Language support:** `{}`\n",
+        report
+            .context
+            .language_support
+            .as_deref()
+            .unwrap_or("unknown")
+    ));
+    output.push_str(&format!(
+        "- **Frameworks:** {}\n",
+        markdown_list(&report.context.frameworks)
+    ));
+    output.push_str(&format!(
+        "- **Roles:** {}\n",
+        markdown_list(&report.context.roles)
+    ));
+    output.push_str(&format!(
+        "- **Paradigms:** {}\n",
+        markdown_list(&report.context.paradigms)
+    ));
+    output.push_str(&format!(
+        "- **Runtimes:** {}\n",
+        markdown_list(&report.context.runtimes)
+    ));
+    output.push_str(&format!(
+        "- **Test code:** {}\n",
+        yes_no(report.context.is_test)
+    ));
+    output.push_str(&format!(
+        "- **Production code:** {}\n\n",
+        yes_no(report.context.is_production_code)
+    ));
+
+    output.push_str("## Rule decision\n\n");
+    match &report.decision {
+        Some(decision) => {
+            output.push_str(&format!("- **Rule:** `{}`\n", decision.rule_id));
+            output.push_str(&format!(
+                "- **Signal:** `{}`\n",
+                decision.signal.as_deref().unwrap_or("none")
+            ));
+            output.push_str(&format!(
+                "- **Base severity:** `{}`\n",
+                decision.base_severity.label()
+            ));
+            output.push_str(&format!("- **Action:** `{}`\n", decision.action));
+            output.push_str(&format!(
+                "- **Final severity:** `{}`\n",
+                decision.final_severity.label()
+            ));
+            if let Some(reason) = &decision.reason {
+                output.push_str(&format!("- **Reason:** {reason}\n"));
+            }
+        }
+        None => {
+            output.push_str("No rule was requested. Pass `--rule <RULE_ID>` to evaluate one.\n");
+        }
+    }
+
+    output
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
+}
+
+fn comma_or_none(values: &[String]) -> String {
+    if values.is_empty() {
+        "none".to_string()
+    } else {
+        values.join(", ")
+    }
+}
+
+fn markdown_list(values: &[String]) -> String {
+    if values.is_empty() {
+        "none".to_string()
+    } else {
+        values
+            .iter()
+            .map(|value| format!("`{value}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod baseline;
 pub mod compare;
 pub mod config;
 pub mod doctor;
+pub mod explain;
 pub mod findings;
 pub mod frameworks;
 pub mod graph;

--- a/tests/explain_cli.rs
+++ b/tests/explain_cli.rs
@@ -1,0 +1,90 @@
+use serde_json::Value;
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+#[test]
+fn explain_outputs_context_json_for_functional_rust_code() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    let src = root.join("src").join("domain");
+    fs::create_dir_all(&src).expect("create src dir");
+    fs::write(
+        src.join("users.rs"),
+        "pub fn active_names(users: Vec<User>) -> Vec<String> {\n\
+            users.into_iter().filter(|user| user.active).map(|user| user.name).collect()\n\
+        }\n",
+    )
+    .expect("write rust file");
+
+    let output = repopilot()
+        .args(["explain", "src/domain/users.rs", "--format", "json"])
+        .current_dir(root)
+        .output()
+        .expect("run explain");
+
+    assert!(
+        output.status.success(),
+        "explain should pass, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("valid json");
+
+    assert_eq!(json["context"]["language"], "rust");
+    assert_eq!(json["context"]["language_support"], "rule-aware");
+
+    let paradigms = json["context"]["paradigms"]
+        .as_array()
+        .expect("paradigms array");
+    assert!(paradigms.iter().any(|value| value == "functional"));
+
+    let roles = json["context"]["roles"].as_array().expect("roles array");
+    assert!(roles.iter().any(|value| value == "domain"));
+}
+
+#[test]
+fn explain_can_show_suppressed_rule_decision_for_rust_tests() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    let tests = root.join("tests");
+    fs::create_dir_all(&tests).expect("create tests dir");
+    fs::write(
+        tests.join("parser_test.rs"),
+        "#[test]\nfn parses() { let value = Some(1).unwrap(); assert_eq!(value, 1); }\n",
+    )
+    .expect("write rust test");
+
+    let output = repopilot()
+        .args([
+            "explain",
+            "tests/parser_test.rs",
+            "--rule",
+            "language.rust.panic-risk",
+            "--signal",
+            "rust.unwrap",
+            "--severity",
+            "medium",
+            "--format",
+            "json",
+        ])
+        .current_dir(root)
+        .output()
+        .expect("run explain");
+
+    assert!(
+        output.status.success(),
+        "explain should pass, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("valid json");
+
+    assert_eq!(json["decision"]["rule_id"], "language.rust.panic-risk");
+    assert_eq!(json["decision"]["signal"], "rust.unwrap");
+    assert_eq!(json["decision"]["action"], "suppress");
+}


### PR DESCRIPTION
## Summary

Adds a new `repopilot explain` command for inspecting how RepoPilot classifies a single file and how the Knowledge Engine decides whether a rule should apply, be suppressed, downgraded, or upgraded.

This helps debug false positives and makes the 0.9.0 context-aware audit model easier to understand.

## What changed

- Added new `src/explain/` module:
  - model
  - builder
  - renderer

- Added new CLI command:

  ```bash
  repopilot explain <file>
  repopilot explain <file> --rule language.rust.panic-risk --signal rust.unwrap
  repopilot explain <file> --format json
  repopilot explain <file> --format markdown --output explain.md
  ```
  
- Added output for:

  - detected language
  - language support level
  - frameworks
  - file roles
  - programming paradigms
  - runtimes
  - test/production context
  - optional rule decision

- Added CLI integration tests for:

  - functional Rust code classification
  - suppressed Rust unwrap decision in test code

- Updated CHANGELOG.md.

## Why

RepoPilot 0.9.0 is moving toward context-aware audits.

Before this command, the Knowledge Engine could make decisions internally, but users could not easily inspect why a rule applied or why it was suppressed.

This command makes the rule engine explainable.

It is especially useful for avoiding false positives like treating functional programming style as a code smell.

## Verification

```
cargo fmt --all
cargo test --test explain_cli
cargo test --all
cargo clippy --all-targets --all-features -- -D warnings
```