### PR TITLE
chore(product): add product readiness smoke suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added stable AI command family: `repopilot ai context`, `repopilot ai plan`, and `repopilot ai prompt`.
 - Added advanced inspection command family: `repopilot inspect explain` and `repopilot inspect knowledge`.
 - Added CLI stabilization tests covering help surface, legacy AI/inspect compatibility, exit codes, and high-severity self-audit cleanliness.
+- Added `scripts/smoke-product.sh` for product-readiness smoke checks across first-run, scan, review, AI, inspect, and legacy compatibility flows.
+- Added `docs/product-readiness.md` to document release gates, CLI stability expectations, CI behavior, local-first guarantees, and distribution checks.
 
 ### Changed
 
@@ -25,6 +27,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Top-level `vibe`, `harden`, `prompt`, `explain`, and `knowledge` commands are hidden from primary help while remaining available as 0.x compatibility commands.
 - CLI runtime errors now exit with code 3, invalid user input uses code 2, and findings threshold failures use code 1.
 - GitHub Action inputs now prefer typed arguments for common scan, review, and AI workflow options while retaining `args` for advanced use.
+- Release verification now delegates end-to-end binary smoke checks to the product-readiness smoke suite.
 
 ## [0.8.0] - 2026-05-11
 

--- a/docs/product-readiness.md
+++ b/docs/product-readiness.md
@@ -1,0 +1,247 @@
+# Product Readiness
+
+RepoPilot is moving from an experimental CLI into a product that should be safe to install, easy to understand, stable in CI, and useful after the first five minutes.
+
+This document defines the release gates for product quality.
+
+RepoPilot's product promise:
+
+```text
+local-first repository audit
+→ evidence-based findings
+→ diff-aware review
+→ baseline adoption
+→ AI-ready remediation context
+→ stable CI integration
+```
+
+RepoPilot should not become a random collection of commands or rules. Every release should improve at least one of these product qualities:
+
+- lower false-positive noise;
+- faster scans;
+- clearer findings;
+- more stable CLI behavior;
+- better first-run onboarding;
+- safer CI and release behavior;
+- stronger local-first trust.
+
+---
+
+## Product readiness smoke suite
+
+Run the product smoke suite from the repository root:
+
+```bash
+./scripts/smoke-product.sh
+```
+
+Run it against an already built binary:
+
+```bash
+./scripts/smoke-product.sh --binary ./target/release/repopilot
+```
+
+Run it against a different repository:
+
+```bash
+./scripts/smoke-product.sh --repo /path/to/project
+```
+
+Keep generated smoke artifacts:
+
+```bash
+./scripts/smoke-product.sh --keep-tmp
+```
+
+Skip legacy compatibility checks:
+
+```bash
+./scripts/smoke-product.sh --skip-legacy
+```
+
+The script checks the main product workflows:
+
+```text
+version
+help
+init
+doctor
+scan JSON
+scan Markdown
+review Markdown
+ai context
+ai plan
+ai prompt
+inspect knowledge
+inspect explain
+legacy vibe
+legacy harden
+legacy prompt
+legacy knowledge
+legacy explain
+```
+
+`review` is skipped when the target path is not inside a Git repository.
+
+---
+
+## CLI stability gates
+
+Before a release, these commands must work:
+
+```bash
+repopilot --help
+repopilot --version
+repopilot init --path /tmp/repopilot.toml
+repopilot doctor .
+repopilot scan .
+repopilot scan . --format json --output /tmp/repopilot-scan.json
+repopilot scan . --format markdown --output /tmp/repopilot-scan.md
+repopilot review .
+repopilot ai context .
+repopilot ai plan .
+repopilot ai prompt .
+repopilot inspect knowledge
+repopilot inspect explain src/main.rs
+```
+
+Legacy 0.x commands must continue to work until a documented breaking release:
+
+```bash
+repopilot vibe .
+repopilot harden .
+repopilot prompt .
+repopilot knowledge
+repopilot explain src/main.rs
+```
+
+The primary help surface should prefer the stable command shape:
+
+```text
+repopilot scan
+repopilot review
+repopilot baseline
+repopilot compare
+repopilot doctor
+repopilot ai ...
+repopilot inspect ...
+```
+
+Legacy commands may stay hidden from primary help while still being executable.
+
+---
+
+## Exit code contract
+
+RepoPilot's exit codes are part of the product contract:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Findings exceeded the configured threshold |
+| `2` | Invalid CLI/config/user input |
+| `3` | Runtime or environment failure |
+
+CI users should be able to rely on these codes.
+
+Examples:
+
+```bash
+repopilot scan . --fail-on new-high
+```
+
+Expected behavior:
+
+- exit `0` when there is no threshold breach;
+- exit `1` when new high or critical findings are present;
+- exit `2` for invalid CLI input;
+- exit `3` for runtime/environment failures.
+
+---
+
+## Local-first trust gates
+
+RepoPilot runtime commands must stay local-first:
+
+- scans read files from disk;
+- reports write to stdout or explicit output paths;
+- no source code is uploaded;
+- no telemetry is sent;
+- AI commands do not call AI providers;
+- `ai context`, `ai plan`, and `ai prompt` only format local scan output as Markdown.
+
+The npm installer is allowed to download a matching GitHub Release binary during `postinstall`, but this must stay documented and controllable:
+
+```bash
+REPOPILOT_SKIP_DOWNLOAD=1 npm install -g repopilot
+REPOPILOT_BINARY_PATH=/path/to/repopilot npm install -g repopilot
+```
+
+The installer must verify the release checksum before using a downloaded binary.
+
+---
+
+## CI readiness gates
+
+Before release, verify:
+
+- `cargo fmt --all -- --check` passes;
+- `cargo clippy --all-targets --all-features -- -D warnings` passes;
+- `cargo test --all` passes;
+- `cargo package --list` looks correct;
+- `cargo publish --dry-run` passes;
+- `npm run test:npm` passes;
+- `npm pack --dry-run` looks correct;
+- `scripts/smoke-product.sh` passes against the release binary.
+
+The GitHub Action should support:
+
+```yaml
+with:
+  command: scan
+```
+
+```yaml
+with:
+  command: review
+```
+
+```yaml
+with:
+  command: ai-context
+```
+
+Legacy action command names may remain available for compatibility:
+
+```yaml
+with:
+  command: vibe
+```
+
+---
+
+## What should not block a release
+
+Do not block a release only because RepoPilot does not yet have more rules.
+
+Rules are useful only when they produce low-noise, evidence-backed findings.
+
+For a product-quality release, prefer:
+
+```text
+stable CLI
+fast scan
+clear docs
+predictable CI
+low false positives
+safe distribution
+```
+
+over:
+
+```text
+more commands
+more rules
+more output formats
+more internal abstractions
+```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 	"scripts": {
 		"postinstall": "node scripts/install.js",
 		"test:npm": "node --test tests/npm_wrapper.test.js",
-		"release:check": "bash scripts/verify-release.sh"
+		"release:check": "bash scripts/verify-release.sh",
+		"product:smoke": "bash scripts/smoke-product.sh"
 	},
 	"files": [
 		"bin",

--- a/scripts/smoke-product.sh
+++ b/scripts/smoke-product.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BINARY=""
+REPO_PATH="$ROOT_DIR"
+TMP_DIR=""
+TMP_CREATED=0
+KEEP_TMP=0
+RUN_LEGACY=1
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/smoke-product.sh [OPTIONS]
+
+Run product-readiness smoke checks against RepoPilot.
+
+Options:
+  --binary PATH      Use an already built repopilot binary.
+  --repo PATH        Repository or project path to smoke test. Defaults to this repo.
+  --tmp-dir PATH     Directory for generated smoke artifacts. Defaults to mktemp.
+  --keep-tmp         Keep generated smoke artifacts when using a temporary directory.
+  --skip-legacy      Skip hidden 0.x compatibility command checks.
+  -h, --help         Show this help message.
+
+Examples:
+  scripts/smoke-product.sh
+  scripts/smoke-product.sh --binary ./target/release/repopilot
+  scripts/smoke-product.sh --repo /path/to/project --keep-tmp
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --binary)
+      BINARY="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      REPO_PATH="${2:-}"
+      shift 2
+      ;;
+    --tmp-dir)
+      TMP_DIR="${2:-}"
+      shift 2
+      ;;
+    --keep-tmp)
+      KEEP_TMP=1
+      shift
+      ;;
+    --skip-legacy)
+      RUN_LEGACY=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$REPO_PATH" ]]; then
+  echo "--repo cannot be empty" >&2
+  exit 2
+fi
+
+REPO_PATH="$(cd "$REPO_PATH" && pwd)"
+
+if [[ -z "$BINARY" ]]; then
+  if [[ ! -x "$ROOT_DIR/target/debug/repopilot" ]]; then
+    echo "==> Building debug binary for product smoke checks" >&2
+    cargo build --manifest-path "$ROOT_DIR/Cargo.toml"
+  fi
+  BINARY="$ROOT_DIR/target/debug/repopilot"
+else
+  case "$BINARY" in
+    /*) ;;
+    *)
+      BINARY="$(cd "$(dirname "$BINARY")" && pwd)/$(basename "$BINARY")"
+      ;;
+  esac
+fi
+
+if [[ ! -x "$BINARY" ]]; then
+  echo "RepoPilot binary is not executable: $BINARY" >&2
+  exit 3
+fi
+
+if [[ -z "$TMP_DIR" ]]; then
+  TMP_DIR="$(mktemp -d)"
+  TMP_CREATED=1
+else
+  rm -rf "$TMP_DIR"
+  mkdir -p "$TMP_DIR"
+  TMP_DIR="$(cd "$TMP_DIR" && pwd)"
+fi
+
+cleanup() {
+  if [[ "$TMP_CREATED" -eq 1 && "$KEEP_TMP" -eq 0 ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+run_repopilot() {
+  echo "==> repopilot $*" >&2
+  (
+    cd "$REPO_PATH"
+    "$BINARY" "$@"
+  )
+}
+
+assert_non_empty() {
+  local file="$1"
+  if [[ ! -s "$file" ]]; then
+    echo "Expected non-empty file: $file" >&2
+    exit 3
+  fi
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq "$expected" "$file"; then
+    echo "Expected '$file' to contain: $expected" >&2
+    echo "---- file content ----" >&2
+    cat "$file" >&2 || true
+    echo "----------------------" >&2
+    exit 3
+  fi
+}
+
+validate_json_if_possible() {
+  local file="$1"
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -m json.tool "$file" >/dev/null
+  fi
+}
+
+find_explain_file() {
+  local preferred="$REPO_PATH/src/main.rs"
+
+  if [[ -f "$preferred" ]]; then
+    printf '%s\n' "$preferred"
+    return 0
+  fi
+
+  local discovered=""
+  while IFS= read -r candidate; do
+    discovered="$candidate"
+    break
+  done < <(
+    find "$REPO_PATH" \
+      -path "$REPO_PATH/.git" -prune -o \
+      -path "$REPO_PATH/target" -prune -o \
+      -path "$REPO_PATH/node_modules" -prune -o \
+      -type f \( \
+        -name '*.rs' -o \
+        -name '*.ts' -o \
+        -name '*.tsx' -o \
+        -name '*.js' -o \
+        -name '*.jsx' -o \
+        -name '*.py' -o \
+        -name '*.go' \
+      \) \
+      -print
+  )
+
+  if [[ -n "$discovered" && -f "$discovered" ]]; then
+    printf '%s\n' "$discovered"
+    return 0
+  fi
+
+  printf '%s\n' "$REPO_PATH/Cargo.toml"
+}
+
+EXPLAIN_FILE="$(find_explain_file)"
+
+echo "==> RepoPilot product smoke suite"
+echo "Binary: $BINARY"
+echo "Repo:   $REPO_PATH"
+echo "Tmp:    $TMP_DIR"
+echo
+
+run_repopilot --version > "$TMP_DIR/version.txt"
+assert_non_empty "$TMP_DIR/version.txt"
+
+run_repopilot --help > "$TMP_DIR/help.txt"
+assert_non_empty "$TMP_DIR/help.txt"
+assert_contains "$TMP_DIR/help.txt" "scan"
+assert_contains "$TMP_DIR/help.txt" "review"
+assert_contains "$TMP_DIR/help.txt" "ai"
+assert_contains "$TMP_DIR/help.txt" "inspect"
+
+run_repopilot init --force --path "$TMP_DIR/repopilot.toml"
+assert_non_empty "$TMP_DIR/repopilot.toml"
+
+run_repopilot doctor . --format markdown --output "$TMP_DIR/doctor.md"
+assert_non_empty "$TMP_DIR/doctor.md"
+
+run_repopilot scan . --format json --output "$TMP_DIR/scan.json"
+assert_non_empty "$TMP_DIR/scan.json"
+validate_json_if_possible "$TMP_DIR/scan.json"
+
+run_repopilot scan . --format markdown --output "$TMP_DIR/scan.md"
+assert_non_empty "$TMP_DIR/scan.md"
+
+if git -C "$REPO_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  run_repopilot review . --format markdown --output "$TMP_DIR/review.md"
+  assert_non_empty "$TMP_DIR/review.md"
+else
+  echo "==> Skipping review smoke check because repo path is not inside a Git worktree" >&2
+fi
+
+run_repopilot ai context . --focus security --budget 2k --output "$TMP_DIR/ai-context.md"
+assert_non_empty "$TMP_DIR/ai-context.md"
+
+run_repopilot ai plan . --focus all --budget 2k --output "$TMP_DIR/ai-plan.md"
+assert_non_empty "$TMP_DIR/ai-plan.md"
+
+run_repopilot ai prompt . --focus quality --budget 2k --output "$TMP_DIR/ai-prompt.md"
+assert_non_empty "$TMP_DIR/ai-prompt.md"
+
+run_repopilot inspect knowledge --format json --output "$TMP_DIR/inspect-knowledge.json"
+assert_non_empty "$TMP_DIR/inspect-knowledge.json"
+validate_json_if_possible "$TMP_DIR/inspect-knowledge.json"
+
+run_repopilot inspect knowledge --section rules --format markdown --output "$TMP_DIR/inspect-knowledge-rules.md"
+assert_non_empty "$TMP_DIR/inspect-knowledge-rules.md"
+
+run_repopilot inspect explain "$EXPLAIN_FILE" --format json --output "$TMP_DIR/inspect-explain.json"
+assert_non_empty "$TMP_DIR/inspect-explain.json"
+validate_json_if_possible "$TMP_DIR/inspect-explain.json"
+
+if [[ "$RUN_LEGACY" -eq 1 ]]; then
+  run_repopilot vibe . --focus security --budget 2k --output "$TMP_DIR/legacy-vibe.md"
+  assert_non_empty "$TMP_DIR/legacy-vibe.md"
+
+  run_repopilot harden . --focus all --budget 2k --output "$TMP_DIR/legacy-harden.md"
+  assert_non_empty "$TMP_DIR/legacy-harden.md"
+
+  run_repopilot prompt . --focus quality --budget 2k --output "$TMP_DIR/legacy-prompt.md"
+  assert_non_empty "$TMP_DIR/legacy-prompt.md"
+
+  run_repopilot knowledge --format json --output "$TMP_DIR/legacy-knowledge.json"
+  assert_non_empty "$TMP_DIR/legacy-knowledge.json"
+  validate_json_if_possible "$TMP_DIR/legacy-knowledge.json"
+
+  run_repopilot explain "$EXPLAIN_FILE" --format json --output "$TMP_DIR/legacy-explain.json"
+  assert_non_empty "$TMP_DIR/legacy-explain.json"
+  validate_json_if_possible "$TMP_DIR/legacy-explain.json"
+fi
+
+echo
+echo "==> Product smoke suite passed"
+echo "Artifacts: $TMP_DIR"

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -33,20 +33,10 @@ npm pack --dry-run
 echo "==> Build release binary"
 cargo build --release
 
-echo "==> Verify built binary"
-./target/release/repopilot --version
-./target/release/repopilot scan . --format markdown --output /tmp/repopilot-release-scan.md
-./target/release/repopilot doctor . --format markdown --output /tmp/repopilot-release-doctor.md
-./target/release/repopilot ai context . --focus security --budget 2k --output /tmp/repopilot-release-vibe.md
-./target/release/repopilot ai plan . --focus all --budget 4k --output /tmp/repopilot-release-harden.md
-./target/release/repopilot ai prompt . --focus quality --budget 4k --output /tmp/repopilot-release-prompt.md
-./target/release/repopilot inspect knowledge --section rules --format markdown --output /tmp/repopilot-release-knowledge.md
-
-test -s /tmp/repopilot-release-scan.md
-test -s /tmp/repopilot-release-doctor.md
-test -s /tmp/repopilot-release-vibe.md
-test -s /tmp/repopilot-release-harden.md
-test -s /tmp/repopilot-release-prompt.md
-test -s /tmp/repopilot-release-knowledge.md
+echo "==> Product readiness smoke suite"
+./scripts/smoke-product.sh \
+  --binary ./target/release/repopilot \
+  --repo . \
+  --tmp-dir /tmp/repopilot-release-smoke
 
 echo "==> Release verification passed"

--- a/tests/cli_release_smoke.rs
+++ b/tests/cli_release_smoke.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 use std::ffi::OsStr;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Command, Output};
 
 fn repopilot_bin() -> &'static str {
@@ -134,14 +134,15 @@ fn scan_writes_valid_json_report() {
 }
 
 #[test]
-fn vibe_writes_llm_ready_markdown() {
+fn stable_ai_context_writes_llm_ready_markdown() {
     let project = create_demo_project();
-    let output_path = project.path().join("vibe.md");
+    let output_path = project.path().join("ai-context.md");
 
     run_ok(
         project.path(),
         [
-            "vibe",
+            "ai",
+            "context",
             ".",
             "--focus",
             "security",
@@ -156,7 +157,7 @@ fn vibe_writes_llm_ready_markdown() {
 
     assert!(
         content.contains("RepoPilot") || content.contains("Vibe"),
-        "vibe output should identify RepoPilot/vibe context\n{}",
+        "ai context output should identify RepoPilot context\n{}",
         content
     );
 
@@ -165,20 +166,21 @@ fn vibe_writes_llm_ready_markdown() {
             || content.contains("Security")
             || content.contains("API_TOKEN")
             || content.contains("token"),
-        "vibe output should include security-focused context\n{}",
+        "ai context output should include security-focused context\n{}",
         content
     );
 }
 
 #[test]
-fn harden_writes_prioritized_remediation_plan() {
+fn stable_ai_plan_writes_prioritized_remediation_plan() {
     let project = create_demo_project();
-    let output_path = project.path().join("harden.md");
+    let output_path = project.path().join("ai-plan.md");
 
     run_ok(
         project.path(),
         [
-            "harden",
+            "ai",
+            "plan",
             ".",
             "--focus",
             "all",
@@ -196,19 +198,20 @@ fn harden_writes_prioritized_remediation_plan() {
             || content.contains("P1")
             || content.contains("Priority")
             || content.contains("Remediation"),
-        "harden output should look like a remediation plan\n{}",
+        "ai plan output should look like a remediation plan\n{}",
         content
     );
 }
 
 #[test]
-fn prompt_writes_ai_ready_prompt() {
+fn stable_ai_prompt_writes_ai_ready_prompt() {
     let project = create_demo_project();
-    let output_path: PathBuf = project.path().join("prompt.md");
+    let output_path = project.path().join("ai-prompt.md");
 
     run_ok(
         project.path(),
         [
+            "ai",
             "prompt",
             ".",
             "--focus",
@@ -230,4 +233,120 @@ fn prompt_writes_ai_ready_prompt() {
         "prompt output should include AI remediation context\n{}",
         content
     );
+}
+
+#[test]
+fn inspect_knowledge_writes_valid_json() {
+    let project = create_demo_project();
+    let output_path = project.path().join("knowledge.json");
+
+    run_ok(
+        project.path(),
+        [
+            "inspect",
+            "knowledge",
+            "--section",
+            "languages",
+            "--format",
+            "json",
+            "--output",
+            output_path.to_str().expect("non-utf8 output path"),
+        ],
+    );
+
+    let content = read_non_empty(&output_path);
+    let json: Value =
+        serde_json::from_str(&content).expect("knowledge output should be valid JSON");
+
+    assert!(
+        json["languages"].is_array(),
+        "knowledge JSON should include languages array\n{}",
+        content
+    );
+}
+
+#[test]
+fn inspect_explain_writes_valid_json() {
+    let project = create_demo_project();
+    let output_path = project.path().join("explain.json");
+
+    run_ok(
+        project.path(),
+        [
+            "inspect",
+            "explain",
+            "src/index.ts",
+            "--format",
+            "json",
+            "--output",
+            output_path.to_str().expect("non-utf8 output path"),
+        ],
+    );
+
+    let content = read_non_empty(&output_path);
+    let json: Value = serde_json::from_str(&content).expect("explain output should be valid JSON");
+
+    assert!(
+        json["source"].is_object(),
+        "explain JSON should include source object\n{}",
+        content
+    );
+    assert!(
+        json["context"].is_object(),
+        "explain JSON should include context object\n{}",
+        content
+    );
+}
+
+#[test]
+fn legacy_ai_commands_remain_available_for_compatibility() {
+    let project = create_demo_project();
+
+    let vibe_path = project.path().join("legacy-vibe.md");
+    run_ok(
+        project.path(),
+        [
+            "vibe",
+            ".",
+            "--focus",
+            "security",
+            "--budget",
+            "2k",
+            "--output",
+            vibe_path.to_str().expect("non-utf8 output path"),
+        ],
+    );
+    assert!(read_non_empty(&vibe_path).contains("RepoPilot"));
+
+    let harden_path = project.path().join("legacy-harden.md");
+    run_ok(
+        project.path(),
+        [
+            "harden",
+            ".",
+            "--focus",
+            "all",
+            "--budget",
+            "2k",
+            "--output",
+            harden_path.to_str().expect("non-utf8 output path"),
+        ],
+    );
+    assert!(read_non_empty(&harden_path).contains("RepoPilot"));
+
+    let prompt_path = project.path().join("legacy-prompt.md");
+    run_ok(
+        project.path(),
+        [
+            "prompt",
+            ".",
+            "--focus",
+            "quality",
+            "--budget",
+            "2k",
+            "--output",
+            prompt_path.to_str().expect("non-utf8 output path"),
+        ],
+    );
+    assert!(read_non_empty(&prompt_path).contains("RepoPilot"));
 }


### PR DESCRIPTION
## Summary

Adds a product-readiness smoke suite for RepoPilot release hardening.

This PR focuses on stability, first-run behavior, CLI compatibility, and release confidence before adding more audit rules or larger product features.

## What changed

- Added `scripts/smoke-product.sh`.
- Added `docs/product-readiness.md`.
- Added `npm run product:smoke`.
- Updated release verification to reuse the product smoke suite against the built release binary.
- Updated CLI release smoke tests to prefer stable command groups:
  - `repopilot ai context`
  - `repopilot ai plan`
  - `repopilot ai prompt`
  - `repopilot inspect knowledge`
  - `repopilot inspect explain`
- Kept explicit legacy compatibility checks for:
  - `repopilot vibe`
  - `repopilot harden`
  - `repopilot prompt`

## Why

RepoPilot is moving from an experimental CLI toward a product-quality local-first audit tool.

Before expanding the rule set further, the release path needs a clear product contract:

- first-run commands should work;
- scan/review/doctor flows should be smoke-tested;
- AI workflows should produce usable Markdown;
- inspect workflows should produce valid JSON;
- legacy 0.x commands should remain compatible;
- release verification should test the actual built binary;
- product readiness expectations should be documented.

## Verification

```bash
cargo fmt --all -- --check
cargo test --test cli_release_smoke
./scripts/smoke-product.sh --keep-tmp
cargo test --all
cargo clippy --all-targets --all-features -- -D warnings
./scripts/verify-release.sh