### PR TITLE
feat(install): harden curl installer with SHA256 verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - CLI runtime errors now exit with code 3, invalid user input uses code 2, and findings threshold failures use code 1.
 - GitHub Action inputs now prefer typed arguments for common scan, review, and AI workflow options while retaining `args` for advanced use.
 - Release verification now delegates end-to-end binary smoke checks to the product-readiness smoke suite.
+- The curl installer now fails closed when the release checksum file cannot be downloaded, no SHA256 tool is available, or checksum verification fails.
 
 ## [0.8.0] - 2026-05-11
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ brew install MykytaStel/repopilot/repopilot
 Install with curl (Linux/macOS):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MykytaStel/repopilot/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MykytaStel/repopilot/main/install.sh | bash
 ```
+
+The curl installer verifies the GitHub Release SHA256 checksum and aborts if the checksum cannot be downloaded or verified.
 
 Upgrade:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,4 +17,6 @@ Include:
 
 RepoPilot runtime commands analyze files on disk and write reports to stdout or explicit output paths. They do not upload source code, call AI services, or send telemetry.
 
+The curl installer downloads the selected GitHub Release archive and its matching `.sha256` file, verifies the SHA256 checksum with `sha256sum` or `shasum`, and fails closed if the checksum file, verification tool, or checksum match is unavailable. Installation is aborted for safety instead of using an unverified archive.
+
 The npm package installer downloads a matching GitHub Release binary during `postinstall` and verifies the release `.sha256` checksum. Set `REPOPILOT_SKIP_DOWNLOAD=1` to skip this download, or `REPOPILOT_BINARY_PATH` to use a user-managed binary.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -74,6 +74,7 @@ Binaries and `.sha256` checksum files are attached to GitHub Releases.
 - Runtime scans read files from disk and write reports to stdout or an explicit `--output` path.
 - Runtime commands do not call AI providers, telemetry endpoints, or RepoPilot servers.
 - AI workflow commands (`ai context`, `ai plan`, `ai prompt`) only format local scan findings as Markdown.
+- The curl installer downloads a GitHub Release artifact and its `.sha256` checksum, then fails closed if the checksum file cannot be downloaded, no SHA256 tool is available, or verification fails.
 - npm installation downloads a GitHub Release artifact and verifies its SHA256 checksum before placing the binary in `vendor/`.
 - `REPOPILOT_BINARY_PATH` can point the npm wrapper at a user-managed binary when download policy is restricted.
 
@@ -142,4 +143,6 @@ curl -fsSL https://raw.githubusercontent.com/MykytaStel/repopilot/main/install.s
 ```
 
 The script detects OS and architecture, downloads the correct pre-built binary from GitHub
-Releases, verifies the SHA256 checksum, and installs to `~/.local/bin`.
+Releases, verifies the SHA256 checksum, and installs to `~/.local/bin`. The checksum
+file and a local SHA256 tool (`sha256sum` or `shasum`) are required; installation
+aborts for safety if verification cannot be completed.

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,6 +22,8 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all
 cargo package --list
 cargo publish --dry-run
+bash -n install.sh
+if command -v shellcheck >/dev/null; then shellcheck install.sh; fi
 npm run test:npm
 npm pack --dry-run
 ```

--- a/install.sh
+++ b/install.sh
@@ -80,37 +80,73 @@ echo "Installing repopilot v$VERSION for $TARGET ..."
 
 ARCHIVE="${BINARY}-v${VERSION}-${TARGET}.${EXT}"
 BASE_URL="https://github.com/$REPO/releases/download/v$VERSION"
+ARCHIVE_URL="$BASE_URL/$ARCHIVE"
+CHECKSUM="$ARCHIVE.sha256"
+CHECKSUM_URL="$BASE_URL/$CHECKSUM"
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-download_file "$BASE_URL/$ARCHIVE" "$TMP_DIR/$ARCHIVE"
+if ! download_file "$ARCHIVE_URL" "$TMP_DIR/$ARCHIVE"; then
+  echo "Failed to download release archive: $ARCHIVE_URL" >&2
+  echo "Installation aborted." >&2
+  exit 1
+fi
+
+if ! download_file "$CHECKSUM_URL" "$TMP_DIR/$CHECKSUM"; then
+  echo "Failed to download required checksum file: $CHECKSUM_URL" >&2
+  echo "Installation aborted for safety; cannot verify $ARCHIVE." >&2
+  exit 1
+fi
 
 verify_checksum() {
-  archive_path="$1"
-  checksum_path="$2"
+  local archive_path="$1"
+  local checksum_path="$2"
+  local archive_name
+  local expected
+  local actual
+
+  if ! archive_name="$(basename "$archive_path")"; then
+    echo "Could not determine archive name for checksum verification: $archive_path" >&2
+    return 1
+  fi
+
+  if ! expected="$(awk 'NF { print $1; exit }' "$checksum_path")"; then
+    echo "Could not read SHA256 checksum file: $checksum_path" >&2
+    return 1
+  fi
+
+  if [[ ! "$expected" =~ ^[[:xdigit:]]{64}$ ]]; then
+    echo "Invalid SHA256 checksum file: $checksum_path" >&2
+    return 1
+  fi
 
   if command -v sha256sum >/dev/null 2>&1; then
-    (cd "$(dirname "$archive_path")" && sha256sum -c "$(basename "$checksum_path")" >/dev/null 2>&1)
-    return
+    if ! actual="$(sha256sum "$archive_path" | awk '{ print $1 }')"; then
+      echo "Could not compute SHA256 for $archive_name with sha256sum." >&2
+      return 1
+    fi
+  elif command -v shasum >/dev/null 2>&1; then
+    if ! actual="$(shasum -a 256 "$archive_path" | awk '{ print $1 }')"; then
+      echo "Could not compute SHA256 for $archive_name with shasum." >&2
+      return 1
+    fi
+  else
+    echo "No SHA256 verification tool found. Install sha256sum or shasum and re-run." >&2
+    return 1
   fi
 
-  if command -v shasum >/dev/null 2>&1; then
-    expected="$(awk '{print $1}' "$checksum_path")"
-    actual="$(shasum -a 256 "$archive_path" | awk '{print $1}')"
-    [ "$expected" = "$actual" ]
-    return
+  if [[ "$expected" != "$actual" ]]; then
+    echo "SHA256 verification failed for $archive_name." >&2
+    echo "Expected: $expected" >&2
+    echo "Actual:   $actual" >&2
+    return 1
   fi
-
-  echo "No SHA256 tool found; skipping checksum verification." >&2
-  return 0
 }
 
-if download_file "$BASE_URL/$ARCHIVE.sha256" "$TMP_DIR/$ARCHIVE.sha256" 2>/dev/null; then
-  if ! verify_checksum "$TMP_DIR/$ARCHIVE" "$TMP_DIR/$ARCHIVE.sha256"; then
-    echo "SHA256 verification failed — aborting." >&2
-    exit 1
-  fi
+if ! verify_checksum "$TMP_DIR/$ARCHIVE" "$TMP_DIR/$CHECKSUM"; then
+  echo "Installation aborted for safety." >&2
+  exit 1
 fi
 
 # ── Extract and install ───────────────────────────────────────────────────────

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -15,6 +15,16 @@ cargo clippy --all-targets --all-features -- -D warnings
 echo "==> Rust tests"
 cargo test --all
 
+echo "==> Installer syntax"
+bash -n install.sh
+
+if command -v shellcheck >/dev/null 2>&1; then
+  echo "==> Installer shellcheck"
+  shellcheck install.sh
+else
+  echo "==> shellcheck not installed; skipping installer lint"
+fi
+
 echo "==> CLI release smoke tests"
 cargo test --test cli_release_smoke
 

--- a/tests/install_script.rs
+++ b/tests/install_script.rs
@@ -1,0 +1,275 @@
+#![cfg(unix)]
+
+use std::env;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn install_script() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh")
+}
+
+fn write_executable(path: &Path, content: &str) {
+    fs::write(path, content).unwrap_or_else(|error| {
+        panic!("failed to write {}: {error}", path.display());
+    });
+
+    let mut permissions = fs::metadata(path)
+        .unwrap_or_else(|error| panic!("failed to stat {}: {error}", path.display()))
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap_or_else(|error| {
+        panic!("failed to chmod {}: {error}", path.display());
+    });
+}
+
+fn fake_curl_script() -> &'static str {
+    r#"#!/bin/sh
+set -eu
+
+out=""
+url=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+case "$url" in
+  *api.github.com*)
+    printf '{"tag_name":"v0.9.0"}\n'
+    ;;
+  *.sha256)
+    if [ "${REPOPILOT_FAKE_CURL_MODE:-}" = "missing-checksum" ]; then
+      exit 22
+    fi
+    printf '%s  repopilot-test.tar.gz\n' "${REPOPILOT_FAKE_EXPECTED_SHA:-0000000000000000000000000000000000000000000000000000000000000000}" > "$out"
+    ;;
+  *.tar.gz)
+    if [ "${REPOPILOT_FAKE_CURL_MODE:-}" = "success" ]; then
+      cat "$REPOPILOT_FAKE_ARCHIVE" > "$out"
+    else
+      printf 'not a tarball\n' > "$out"
+    fi
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+"#
+}
+
+fn fake_sha256sum_script() -> &'static str {
+    r#"#!/bin/sh
+set -eu
+
+printf '%s  %s\n' "${REPOPILOT_FAKE_ACTUAL_SHA:-1111111111111111111111111111111111111111111111111111111111111111}" "$1"
+"#
+}
+
+fn run_install_with_path(path: &str, mode: &str) -> Output {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+
+    Command::new(find_executable("bash"))
+        .arg(install_script())
+        .env("PATH", path)
+        .env("INSTALL_DIR", temp.path().join("bin"))
+        .env("REPOPILOT_FAKE_CURL_MODE", mode)
+        .output()
+        .expect("failed to run install.sh")
+}
+
+fn path_with_fake_tools(fake_tools_dir: &Path) -> String {
+    let old_path = env::var("PATH").unwrap_or_default();
+    format!("{}:{old_path}", fake_tools_dir.display())
+}
+
+fn find_executable(name: &str) -> PathBuf {
+    env::var_os("PATH")
+        .and_then(|paths| {
+            env::split_paths(&paths)
+                .map(|dir| dir.join(name))
+                .find(|candidate| candidate.is_file())
+        })
+        .unwrap_or_else(|| panic!("failed to find required test tool: {name}"))
+}
+
+fn isolated_path_without_sha_tools(fake_tools_dir: &Path) -> String {
+    for tool in ["awk", "basename", "grep", "mktemp", "rm", "sed", "uname"] {
+        symlink(find_executable(tool), fake_tools_dir.join(tool))
+            .unwrap_or_else(|error| panic!("failed to link {tool}: {error}"));
+    }
+
+    fake_tools_dir.display().to_string()
+}
+
+fn create_release_archive(root: &Path) -> PathBuf {
+    let payload = root.join("payload");
+    fs::create_dir(&payload).expect("failed to create payload dir");
+    write_executable(
+        &payload.join("repopilot"),
+        "#!/bin/sh\nprintf 'repopilot 0.9.0\\n'\n",
+    );
+
+    let archive = root.join("repopilot.tar.gz");
+    let output = Command::new(find_executable("tar"))
+        .args([
+            "-czf",
+            archive.to_str().expect("non-utf8 archive path"),
+            "-C",
+            payload.to_str().expect("non-utf8 payload path"),
+            "repopilot",
+        ])
+        .output()
+        .expect("failed to create release archive");
+
+    assert!(
+        output.status.success(),
+        "failed to create release archive\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    archive
+}
+
+#[test]
+fn install_script_passes_bash_syntax_check() {
+    let output = Command::new(find_executable("bash"))
+        .arg("-n")
+        .arg(install_script())
+        .output()
+        .expect("failed to run bash -n install.sh");
+
+    assert!(
+        output.status.success(),
+        "install.sh should pass bash -n\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn install_script_aborts_when_checksum_download_fails() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let fake_bin = temp.path().join("bin");
+    fs::create_dir(&fake_bin).expect("failed to create fake bin");
+    write_executable(&fake_bin.join("curl"), fake_curl_script());
+
+    let output = run_install_with_path(&path_with_fake_tools(&fake_bin), "missing-checksum");
+
+    assert!(
+        !output.status.success(),
+        "install.sh should fail when checksum download fails"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Failed to download required checksum file"),
+        "stderr should name the missing checksum\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Installation aborted for safety"),
+        "stderr should explain the safety abort\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn install_script_installs_when_checksum_verification_succeeds() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let fake_bin = temp.path().join("bin");
+    let install_dir = temp.path().join("install");
+    let archive = create_release_archive(temp.path());
+    let fake_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    fs::create_dir(&fake_bin).expect("failed to create fake bin");
+    write_executable(&fake_bin.join("curl"), fake_curl_script());
+    write_executable(&fake_bin.join("sha256sum"), fake_sha256sum_script());
+
+    let output = Command::new(find_executable("bash"))
+        .arg(install_script())
+        .env("PATH", path_with_fake_tools(&fake_bin))
+        .env("INSTALL_DIR", &install_dir)
+        .env("REPOPILOT_FAKE_CURL_MODE", "success")
+        .env("REPOPILOT_FAKE_ARCHIVE", archive)
+        .env("REPOPILOT_FAKE_EXPECTED_SHA", fake_sha)
+        .env("REPOPILOT_FAKE_ACTUAL_SHA", fake_sha)
+        .output()
+        .expect("failed to run install.sh");
+
+    assert!(
+        output.status.success(),
+        "install.sh should install when checksum verification succeeds\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        install_dir.join("repopilot").is_file(),
+        "installer should place repopilot in INSTALL_DIR"
+    );
+}
+
+#[test]
+fn install_script_aborts_when_sha256_tool_is_missing() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let fake_bin = temp.path().join("bin");
+    fs::create_dir(&fake_bin).expect("failed to create fake bin");
+    write_executable(&fake_bin.join("curl"), fake_curl_script());
+
+    let output = run_install_with_path(
+        &isolated_path_without_sha_tools(&fake_bin),
+        "invalid-checksum",
+    );
+
+    assert!(
+        !output.status.success(),
+        "install.sh should fail when no SHA256 tool is available"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No SHA256 verification tool found"),
+        "stderr should explain the missing SHA256 tool\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Installation aborted for safety"),
+        "stderr should explain the safety abort\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn install_script_aborts_when_checksum_verification_fails() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let fake_bin = temp.path().join("bin");
+    fs::create_dir(&fake_bin).expect("failed to create fake bin");
+    write_executable(&fake_bin.join("curl"), fake_curl_script());
+    write_executable(&fake_bin.join("sha256sum"), fake_sha256sum_script());
+
+    let output = run_install_with_path(&path_with_fake_tools(&fake_bin), "invalid-checksum");
+
+    assert!(
+        !output.status.success(),
+        "install.sh should fail when checksum verification fails"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("SHA256 verification failed"),
+        "stderr should explain the checksum mismatch\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Installation aborted for safety"),
+        "stderr should explain the safety abort\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

This PR hardens the RepoPilot curl installer by requiring SHA256 checksum verification before installing a downloaded GitHub Release archive.

The installer now fails closed when the release archive cannot be downloaded, the checksum file is missing, no SHA256 tool is available, or the computed checksum does not match.

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [x] CI / repository maintenance

## What changed

- Hardened `install.sh` to download both the release archive and its matching `.sha256` file.
- Added explicit checksum verification using `sha256sum` or `shasum`.
- Changed installer behavior to abort safely instead of continuing with an unverified binary.
- Improved installer error messages for:
  - failed archive download
  - missing checksum file
  - invalid checksum format
  - missing SHA256 verification tool
  - checksum mismatch
- Added installer validation to the release verification flow:
  - `bash -n install.sh`
  - optional `shellcheck install.sh`
- Added installer-focused tests.
- Updated `README.md`, `SECURITY.md`, `docs/distribution.md`, `docs/release.md`, and `CHANGELOG.md` to document the safer installation flow.

## Why

RepoPilot is distributed through prebuilt release binaries, so the curl installer must not silently install an archive that cannot be verified.

This improves supply-chain safety and makes the installation process more trustworthy for users who install RepoPilot directly from GitHub Releases.

## Architecture notes

- No god files introduced.
- Installer logic remains isolated in `install.sh`.
- Release verification remains centralized in `scripts/verify-release.sh`.
- Documentation was updated together with the behavior change.
- Runtime RepoPilot behavior is unchanged; this only affects distribution/install safety.

## Changelog

- `CHANGELOG.md` updated with the new fail-closed checksum verification behavior.

## Verification

Run from repository root:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
bash -n install.sh
if command -v shellcheck >/dev/null; then shellcheck install.sh; fi
cargo test --test cli_release_smoke
npm run test:npm
npm pack --dry-run