### PR TITLE
feat(findings): add remediation recommendations to audit results

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -214,8 +214,8 @@ repopilot review . --min-severity high
 
 Scans the repository and formats findings as structured Markdown for pasting into Claude Code, Cursor, ChatGPT, or another LLM assistant.
 
-The output includes a risk summary, tech stack signals, findings grouped by category, evidence snippets, fix recommendations, and an approximate token count.
-`ai context` emits Markdown only; it does not accept `--format` and does not change JSON or SARIF schemas.
+The output includes a risk summary, tech stack signals, findings grouped by category, evidence snippets, finding recommendations, and an approximate token count.
+`ai context` emits Markdown only and does not accept `--format`.
 
 The legacy `repopilot vibe` command still works in 0.x for compatibility, but `repopilot ai context` is the stable command shape.
 
@@ -254,9 +254,9 @@ repopilot ai context . --no-header | pbcopy
 
 ## `ai plan`
 
-Scans the repository and formats findings as a Markdown hardening plan with P0/P1/P2/P3 priorities, locations, rule IDs, fix recommendations, and verification commands.
+Scans the repository and formats findings as a Markdown hardening plan with P0/P1/P2/P3 priorities, locations, rule IDs, finding recommendations, and verification commands.
 
-`ai plan` emits Markdown only; it does not accept `--format` and does not change JSON or SARIF schemas.
+`ai plan` emits Markdown only and does not accept `--format`.
 
 The legacy `repopilot harden` command still works in 0.x for compatibility, but `repopilot ai plan` is the stable command shape.
 
@@ -289,7 +289,7 @@ repopilot ai plan . --output harden.md
 
 Scans the repository and emits a Markdown prompt for a coding assistant, including remediation instructions and embedded RepoPilot context.
 
-`ai prompt` emits Markdown only; it does not call an AI service, accept `--format`, or change JSON/SARIF schemas.
+`ai prompt` emits Markdown only; it does not call an AI service or accept `--format`.
 
 The legacy `repopilot prompt` command still works in 0.x for compatibility, but `repopilot ai prompt` is the stable command shape.
 

--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -368,7 +368,8 @@ Every finding includes these top-level fields:
 | `id` | string | Stable finding ID derived from rule + path + line |
 | `rule_id` | string | Stable rule identifier (e.g. `security.private-key-candidate`) |
 | `title` | string | Short human-readable summary |
-| `description` | string | Full explanation with remediation steps |
+| `description` | string | Why the finding matters |
+| `recommendation` | string | Explicit remediation guidance describing what to do next. Older JSON reports without this field still deserialize, but new reports always include it. |
 | `category` | string | One of `ARCHITECTURE`, `CODE_QUALITY`, `TESTING`, `SECURITY`, `FRAMEWORK` |
 | `severity` | string | One of `INFO`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` |
 | `confidence` | string | One of `LOW`, `MEDIUM`, `HIGH`; omitted values in old JSON reports are read as `MEDIUM` |

--- a/src/audits/architecture/barrel_file_risk.rs
+++ b/src/audits/architecture/barrel_file_risk.rs
@@ -115,6 +115,7 @@ fn build_finding(file: &FileFacts, stats: BarrelStats) -> Finding {
     Finding {
         id: String::new(),
         rule_id: RULE_ID.to_string(),
+        recommendation: Finding::recommendation_for_rule_id(RULE_ID),
         title: "Risky barrel file detected".to_string(),
         description: format!(
             "This index file re-exports {} modules, including {} wildcard exports. Large barrel files create unstable module hubs and can make dependency boundaries harder to understand.",

--- a/src/audits/architecture/deep_nesting.rs
+++ b/src/audits/architecture/deep_nesting.rs
@@ -34,6 +34,7 @@ fn build_finding(deepest_path: PathBuf, depth: usize, threshold: usize) -> Findi
     Finding {
         id: String::new(),
         rule_id: "architecture.deep-nesting".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("architecture.deep-nesting"),
         title: "Deeply nested directory structure detected".to_string(),
         description: format!(
             "The project contains files nested {depth} levels deep, exceeding the threshold of {threshold}. Deep nesting often indicates over-engineered module hierarchies."

--- a/src/audits/architecture/deep_relative_imports.rs
+++ b/src/audits/architecture/deep_relative_imports.rs
@@ -115,6 +115,7 @@ fn build_finding(file: &FileFacts, line_number: usize, snippet: &str, depth: usi
     Finding {
         id: String::new(),
         rule_id: RULE_ID.to_string(),
+        recommendation: Finding::recommendation_for_rule_id(RULE_ID),
         title: "Deep relative import found".to_string(),
         description: format!(
             "This file imports across {depth} parent levels. Deep relative imports make modules fragile during refactors and usually indicate missing boundaries, aliases, or facade modules."

--- a/src/audits/architecture/import_coupling.rs
+++ b/src/audits/architecture/import_coupling.rs
@@ -58,6 +58,7 @@ fn excessive_fan_out_finding(metric: &FileMetrics, root: &Path, threshold: usize
     Finding {
         id: String::new(),
         rule_id: "architecture.excessive-fan-out".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("architecture.excessive-fan-out"),
         title: "File imports too many project files".to_string(),
         description: format!(
             "This file imports {} project files, exceeding the configured fan-out threshold of {threshold}.",
@@ -93,6 +94,7 @@ fn high_instability_hub_finding(
     Finding {
         id: String::new(),
         rule_id: "architecture.high-instability-hub".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("architecture.high-instability-hub"),
         title: "Highly unstable import hub".to_string(),
         description: format!(
             "This file is imported by {} files while also importing {} files, making it a highly unstable hub.",
@@ -134,6 +136,7 @@ fn circular_dependency_finding(cycle: &[PathBuf], root: &Path) -> Finding {
     Finding {
         id: String::new(),
         rule_id: "architecture.circular-dependency".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("architecture.circular-dependency"),
         title: "Circular dependency detected".to_string(),
         description: format!(
             "A circular dependency was detected across {file_count} project files."

--- a/src/audits/architecture/large_file.rs
+++ b/src/audits/architecture/large_file.rs
@@ -28,6 +28,7 @@ pub fn detect_large_file_finding(
     Some(Finding {
         id: String::new(),
         rule_id: "architecture.large-file".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("architecture.large-file"),
         title: "Large file detected".to_string(),
         description: format!(
             "This file has {lines_of_code} non-empty lines of code, which is above the configured threshold of {}. Consider splitting responsibilities into smaller modules.",

--- a/src/audits/architecture/too_many_modules.rs
+++ b/src/audits/architecture/too_many_modules.rs
@@ -33,6 +33,7 @@ fn build_finding(dir: PathBuf, file_count: usize, threshold: usize) -> Finding {
     Finding {
         id: String::new(),
         rule_id: "architecture.too-many-modules".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("architecture.too-many-modules"),
         title: "Directory contains too many modules".to_string(),
         description: format!(
             "This directory has {file_count} files, exceeding the threshold of {threshold}. Consider splitting into sub-modules to reduce coupling."

--- a/src/audits/code_quality/code_markers.rs
+++ b/src/audits/code_quality/code_markers.rs
@@ -47,6 +47,7 @@ fn build_marker_finding(marker: &Marker) -> Finding {
     Finding {
         id: String::new(),
         rule_id: format!("code-marker.{marker_str}"),
+        recommendation: Finding::recommendation_for_rule_id(&format!("code-marker.{marker_str}")),
         title: format!("{uppercase} marker found"),
         description: format!(
             "A {uppercase} marker was found in the codebase and should be reviewed."

--- a/src/audits/code_quality/complexity.rs
+++ b/src/audits/code_quality/complexity.rs
@@ -46,6 +46,7 @@ impl FileAudit for ComplexityAudit {
         vec![Finding {
             id: String::new(),
             rule_id: RULE_ID.to_string(),
+            recommendation: Finding::recommendation_for_rule_id(RULE_ID),
             title: "High complexity density".to_string(),
             description: format!(
                 "This file has a complexity density of {density} (branch constructs × 1000 / LOC), \

--- a/src/audits/code_quality/language_risk.rs
+++ b/src/audits/code_quality/language_risk.rs
@@ -253,12 +253,12 @@ fn build_finding(
     Finding {
         id: String::new(),
         rule_id: pattern.rule_id.to_string(),
+        recommendation: pattern.recommendation.to_string(),
         title: pattern.title.to_string(),
         description: format!(
-            "{} was found in {}. {}",
+            "{} was found in {}. Runtime termination and placeholder exception paths can bypass normal error handling and make failures harder to recover from.",
             pattern.context_label,
             path.display(),
-            pattern.recommendation
         ),
         category: FindingCategory::CodeQuality,
         severity,

--- a/src/audits/code_quality/long_function/mod.rs
+++ b/src/audits/code_quality/long_function/mod.rs
@@ -180,12 +180,12 @@ fn build_finding(
     Finding {
         id: String::new(),
         rule_id: RULE_ID.to_string(),
+        recommendation: policy.recommendation.to_string(),
         title,
         description: format!(
-            "Function {name_display} spans {fn_len} lines, exceeding the context-aware {threshold}-line threshold for {context_label}. {recommendation}",
+            "Function {name_display} spans {fn_len} lines, exceeding the context-aware {threshold}-line threshold for {context_label}. Large functions are harder to review, test, and safely change.",
             threshold = policy.threshold,
             context_label = policy.context_label,
-            recommendation = policy.recommendation,
         ),
         category: FindingCategory::CodeQuality,
         severity: policy.severity,

--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -221,12 +221,12 @@ fn build_finding(
     Finding {
         id: String::new(),
         rule_id: RULE_ID.to_string(),
+        recommendation: recommendation.to_string(),
         title: format!("Risky Rust {} usage in {}", pattern.label(), context_label),
         description: format!(
-            "Rust `{}` was found in {}. {}",
+            "Rust `{}` was found in {}. Unhandled panic paths can terminate execution or hide recoverable errors in production code.",
             pattern.label(),
             context_label,
-            recommendation
         ),
         category: FindingCategory::CodeQuality,
         severity,

--- a/src/audits/framework/js_common.rs
+++ b/src/audits/framework/js_common.rs
@@ -44,6 +44,7 @@ impl ProjectAudit for VarDeclarationAudit {
                     let finding = Finding {
                         id: String::new(),
                         rule_id: "framework.js.var-declaration".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.js.var-declaration"),
                         title: "var declaration found".to_string(),
                         description: concat!(
                             "`var` has function-level scope and is hoisted to the top of its function, ",
@@ -106,6 +107,7 @@ impl ProjectAudit for ConsoleLogAudit {
                     let finding = Finding {
                         id: String::new(),
                         rule_id: "framework.js.console-log".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.js.console-log"),
                         title: "console.log found in production source".to_string(),
                         description: concat!(
                             "`console.log` statements left in production code expose internal state and data to the device console, ",

--- a/src/audits/framework/react.rs
+++ b/src/audits/framework/react.rs
@@ -35,6 +35,7 @@ impl ProjectAudit for ReactClassComponentAudit {
                     findings.push(Finding {
                         id: String::new(),
                         rule_id: "framework.react.class-component".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react.class-component"),
                         title: "Class component found".to_string(),
                         description: concat!(
                             "This file uses a class-based React component (`extends React.Component` or `React.PureComponent`). ",
@@ -97,6 +98,7 @@ impl ProjectAudit for ReactPropTypesAudit {
                     findings.push(Finding {
                         id: String::new(),
                         rule_id: "framework.react.prop-types".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react.prop-types"),
                         title: "PropTypes used in TypeScript project".to_string(),
                         description: concat!(
                             "This project already uses TypeScript, which provides static type checking at compile time. ",

--- a/src/audits/framework/react_native/architecture.rs
+++ b/src/audits/framework/react_native/architecture.rs
@@ -22,6 +22,7 @@ impl ProjectAudit for ReactNativeOldArchAudit {
         vec![Finding {
             id: String::new(),
             rule_id: "framework.react-native.old-architecture".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react-native.old-architecture"),
             title: "React Native New Architecture is not enabled".to_string(),
             description: concat!(
                 "This project does not have `newArchEnabled: true` in its app.json / app.config.js / react-native.config.js. ",
@@ -58,6 +59,7 @@ impl ProjectAudit for ReactNativeArchitectureMismatchAudit {
         vec![Finding {
             id: String::new(),
             rule_id: "framework.react-native.architecture-mismatch".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react-native.architecture-mismatch"),
             title: "React Native New Architecture settings differ by platform".to_string(),
             description: concat!(
                 "Android, iOS, or Expo configuration disagree about React Native New Architecture. ",
@@ -98,6 +100,7 @@ impl ProjectAudit for HermesMismatchAudit {
         vec![Finding {
             id: String::new(),
             rule_id: "framework.react-native.hermes-mismatch".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react-native.hermes-mismatch"),
             title: "Hermes settings differ between Android and iOS".to_string(),
             description: concat!(
                 "Hermes is configured differently across platforms. ",

--- a/src/audits/framework/react_native/async_storage.rs
+++ b/src/audits/framework/react_native/async_storage.rs
@@ -24,6 +24,7 @@ impl ProjectAudit for AsyncStorageFromCoreAudit {
                 findings.push(Finding {
                     id: String::new(),
                     rule_id: "framework.react-native.async-storage-from-core".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react-native.async-storage-from-core"),
                     title: "AsyncStorage imported from 'react-native' core".to_string(),
                     description: concat!(
                         "`AsyncStorage` was removed from `react-native` core in v0.60 and will throw ",

--- a/src/audits/framework/react_native/hermes.rs
+++ b/src/audits/framework/react_native/hermes.rs
@@ -52,6 +52,9 @@ impl ProjectAudit for ReactNativeCodegenMissingAudit {
         vec![Finding {
             id: String::new(),
             rule_id: "framework.react-native.codegen-missing".to_string(),
+            recommendation: Finding::recommendation_for_rule_id(
+                "framework.react-native.codegen-missing",
+            ),
             title: "React Native Codegen config is missing".to_string(),
             description: concat!(
                 "This project appears to use Turbo Native Modules or Fabric components, ",
@@ -101,6 +104,7 @@ fn hermes_finding(path: PathBuf, snippet: &str) -> Finding {
     Finding {
         id: String::new(),
         rule_id: "framework.react-native.hermes-disabled".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react-native.hermes-disabled"),
         title: "Hermes JavaScript engine is disabled".to_string(),
         description: concat!(
             "Hermes is explicitly disabled in this project. ",

--- a/src/audits/framework/react_native/navigation.rs
+++ b/src/audits/framework/react_native/navigation.rs
@@ -35,6 +35,7 @@ impl ProjectAudit for ReactNavigationV4Audit {
                     findings.push(Finding {
                         id: String::new(),
                         rule_id: "framework.react-native.old-react-navigation".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react-native.old-react-navigation"),
                         title: "React Navigation v4 (unscoped package) detected".to_string(),
                         description: concat!(
                             "`react-navigation` (v4) is no longer maintained and incompatible with React Native 0.70+. ",
@@ -95,6 +96,7 @@ impl ProjectAudit for DirectStateMutationAudit {
                     findings.push(Finding {
                         id: String::new(),
                         rule_id: "framework.react-native.direct-state-mutation".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react-native.direct-state-mutation"),
                         title: "Direct mutation of this.state detected".to_string(),
                         description: concat!(
                             "Directly assigning to `this.state` bypasses React's change detection — ",

--- a/src/audits/framework/react_native/styling.rs
+++ b/src/audits/framework/react_native/styling.rs
@@ -33,6 +33,7 @@ impl ProjectAudit for RnInlineStyleAudit {
                     findings.push(Finding {
                         id: String::new(),
                         rule_id: "framework.react-native.inline-style".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react-native.inline-style"),
                         title: "Inline style object in JSX".to_string(),
                         description: concat!(
                             "Inline style objects (`style={{ ... }}`) create a new object on every render, ",
@@ -115,6 +116,7 @@ impl ProjectAudit for RnDeprecatedApiAudit {
                         findings.push(Finding {
                             id: String::new(),
                             rule_id: "framework.react-native.deprecated-api".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react-native.deprecated-api"),
                             title: format!("Deprecated React Native API: {api}"),
                             description: format!(
                                 "`{api}` was removed from React Native core. \
@@ -177,6 +179,7 @@ impl ProjectAudit for RnFlatListMissingKeyAudit {
                         findings.push(Finding {
                             id: String::new(),
                             rule_id: "framework.react-native.flatlist-missing-key".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.react-native.flatlist-missing-key"),
                             title: "FlatList is missing keyExtractor".to_string(),
                             description: concat!(
                                 "A `FlatList` without `keyExtractor` falls back to array index keys, ",

--- a/src/audits/framework/rn_dep_health.rs
+++ b/src/audits/framework/rn_dep_health.rs
@@ -24,6 +24,7 @@ impl ProjectAudit for RnDepHealthAudit {
             findings.push(Finding {
                 id: String::new(),
                 rule_id: "framework.rn-async-storage-legacy".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.rn-async-storage-legacy"),
                 title: "Deprecated async-storage package in use".to_string(),
                 description: concat!(
                     "`@react-native-community/async-storage` is unmaintained. ",
@@ -54,6 +55,7 @@ impl ProjectAudit for RnDepHealthAudit {
                 findings.push(Finding {
                     id: String::new(),
                     rule_id: "framework.rn-navigation-compat".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.rn-navigation-compat"),
                     title: "React Navigation version is incompatible with this React Native version"
                         .to_string(),
                     description: format!(
@@ -89,6 +91,7 @@ impl ProjectAudit for RnDepHealthAudit {
                 findings.push(Finding {
                     id: String::new(),
                     rule_id: "framework.rn-reanimated-compat".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.rn-reanimated-compat"),
                     title:
                         "react-native-reanimated version is incompatible with this React Native version"
                             .to_string(),
@@ -125,6 +128,7 @@ impl ProjectAudit for RnDepHealthAudit {
                 findings.push(Finding {
                     id: String::new(),
                     rule_id: "framework.rn-gesture-handler-old".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.rn-gesture-handler-old"),
                     title: "react-native-gesture-handler v1 is incompatible with this React Native version"
                         .to_string(),
                     description: format!(
@@ -157,6 +161,7 @@ impl ProjectAudit for RnDepHealthAudit {
                     findings.push(Finding {
                         id: String::new(),
                         rule_id: "framework.rn-new-arch-incompatible-dep".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("framework.rn-new-arch-incompatible-dep"),
                         title: format!("`{pkg}` does not support React Native New Architecture"),
                         description: format!(
                             "`{pkg}` has no New Architecture support. \

--- a/src/audits/security/env_file_committed.rs
+++ b/src/audits/security/env_file_committed.rs
@@ -36,6 +36,7 @@ fn build_finding(path: &std::path::Path) -> Finding {
     Finding {
         id: String::new(),
         rule_id: "security.env-file-committed".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("security.env-file-committed"),
         title: "Environment file tracked in repository".to_string(),
         description: format!(
             "`{name}` is present in the scanned tree. Environment files often contain secrets and should be listed in `.gitignore`."

--- a/src/audits/security/private_key_candidate.rs
+++ b/src/audits/security/private_key_candidate.rs
@@ -68,6 +68,7 @@ fn build_finding(path: &std::path::Path, line_number: usize, header: &str) -> Fi
     Finding {
         id: String::new(),
         rule_id: "security.private-key-candidate".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("security.private-key-candidate"),
         title: "Private key detected in source file".to_string(),
         description: format!(
             "`{}` appears to contain a private key. Private keys must never be committed to version control.",

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -224,6 +224,7 @@ fn build_finding(
     Finding {
         id: String::new(),
         rule_id: "security.secret-candidate".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("security.secret-candidate"),
         title: "Possible secret detected".to_string(),
         description: format!(
             "Line {line_number} in `{}` looks like it may contain a hardcoded secret (matched key: `{matched_key}`). Review and move to environment variables or a secrets manager.",

--- a/src/audits/testing/missing_test_folder.rs
+++ b/src/audits/testing/missing_test_folder.rs
@@ -23,6 +23,7 @@ impl ProjectAudit for MissingTestFolderAudit {
         vec![Finding {
             id: String::new(),
             rule_id: "testing.missing-test-folder".to_string(),
+            recommendation: Finding::recommendation_for_rule_id("testing.missing-test-folder"),
             title: "No test folder found".to_string(),
             description: format!(
                 "No test directory (tests/, test/, __tests__/, spec/) was found under `{}`. Consider adding tests to improve confidence in refactoring.",

--- a/src/audits/testing/source_without_test.rs
+++ b/src/audits/testing/source_without_test.rs
@@ -52,6 +52,7 @@ fn build_finding(source: &Path) -> Finding {
     Finding {
         id: String::new(),
         rule_id: "testing.source-without-test".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("testing.source-without-test"),
         title: "Source file has no corresponding test".to_string(),
         description: format!(
             "`{}` has no nearby test file. Consider adding tests to cover its behaviour.",

--- a/src/findings/types.rs
+++ b/src/findings/types.rs
@@ -7,6 +7,8 @@ pub struct Finding {
     pub rule_id: String,
     pub title: String,
     pub description: String,
+    #[serde(default)]
+    pub recommendation: String,
     pub category: FindingCategory,
     pub severity: Severity,
     #[serde(default)]
@@ -70,12 +72,35 @@ impl FindingCategory {
 }
 
 impl Finding {
+    pub const GENERIC_RECOMMENDATION: &'static str = "Review the finding evidence, confirm the risk in context, and make the smallest safe change that addresses the underlying issue.";
+
     pub fn severity_label(&self) -> &'static str {
         self.severity.label()
     }
 
     pub fn confidence_label(&self) -> &'static str {
         self.confidence.label()
+    }
+
+    pub fn populate_recommendation(&mut self) {
+        if self.recommendation.trim().is_empty() {
+            self.recommendation = Self::recommendation_for_rule_id(&self.rule_id);
+        }
+    }
+
+    pub fn recommendation_for_rule_id(rule_id: &str) -> String {
+        crate::rules::lookup_rule_metadata(rule_id)
+            .and_then(|metadata| metadata.recommendation)
+            .unwrap_or(Self::GENERIC_RECOMMENDATION)
+            .to_string()
+    }
+
+    pub fn recommendation_or_default(&self) -> &str {
+        if self.recommendation.trim().is_empty() {
+            Self::GENERIC_RECOMMENDATION
+        } else {
+            self.recommendation.as_str()
+        }
     }
 }
 

--- a/src/output/finding_helpers.rs
+++ b/src/output/finding_helpers.rs
@@ -1,5 +1,4 @@
 use crate::findings::types::{Finding, FindingCategory, Severity};
-use crate::rules::lookup_rule_metadata;
 use std::collections::BTreeMap;
 
 pub(crate) struct RuleCluster<'a> {
@@ -49,14 +48,8 @@ pub(crate) fn category_rank(category: &FindingCategory) -> u8 {
     }
 }
 
-pub(crate) fn finding_recommendation(finding: &Finding) -> Option<&str> {
-    lookup_rule_metadata(&finding.rule_id)
-        .and_then(|meta| meta.recommendation)
-        .or(if finding.description.is_empty() {
-            None
-        } else {
-            Some(finding.description.as_str())
-        })
+pub(crate) fn finding_recommendation(finding: &Finding) -> &str {
+    finding.recommendation_or_default()
 }
 
 pub(crate) fn finding_location(finding: &Finding) -> Option<String> {
@@ -89,7 +82,7 @@ pub(crate) fn example_locations(findings: &[&Finding], limit: usize) -> Vec<Stri
 
 fn cluster_title(finding: &Finding, count: usize) -> &str {
     if count > 1 {
-        lookup_rule_metadata(&finding.rule_id)
+        crate::rules::lookup_rule_metadata(&finding.rule_id)
             .map(|metadata| metadata.title)
             .unwrap_or(finding.rule_id.as_str())
     } else {

--- a/src/output/harden.rs
+++ b/src/output/harden.rs
@@ -119,9 +119,7 @@ fn render_cluster_plan(out: &mut String, cluster: &RuleCluster<'_>, index: usize
         let _ = writeln!(out, "- Why: {}", first.description);
     }
 
-    if let Some(fix) = finding_recommendation(first) {
-        let _ = writeln!(out, "- Fix: {fix}");
-    }
+    let _ = writeln!(out, "- Fix: {}", finding_recommendation(first));
 }
 
 fn render_verification(out: &mut String) {

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -304,6 +304,10 @@ fn render_finding_detail(output: &mut String, finding: &Finding, status: Option<
             first_sentence(&finding.description, 180)
         ));
     }
+    output.push_str(&format!(
+        "  - Recommendation: {}\n",
+        first_sentence(finding.recommendation_or_default(), 220)
+    ));
     if let Some(url) = &finding.docs_url {
         output.push_str(&format!("  - Docs: {url}\n"));
     }

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -35,6 +35,7 @@ pub fn findings_to_sarif(findings: &[Finding], root: &Path) -> SarifLog {
             workspace_package: f.workspace_package.clone(),
             category: f.category.label().to_string(),
             confidence: f.confidence.label().to_string(),
+            recommendation: f.recommendation_or_default().to_string(),
         })
         .collect();
     findings_to_sarif_with_properties(findings, root, properties)
@@ -58,6 +59,7 @@ fn findings_to_sarif_with_baseline(report: &BaselineScanReport) -> SarifLog {
             workspace_package: finding.workspace_package.clone(),
             category: finding.category.label().to_string(),
             confidence: finding.confidence.label().to_string(),
+            recommendation: finding.recommendation_or_default().to_string(),
         })
         .collect();
 
@@ -153,16 +155,18 @@ fn sarif_rules(findings: &[Finding]) -> Vec<SarifRule> {
                 .and_then(|m| m.docs_url)
                 .map(str::to_owned)
                 .or_else(|| finding.docs_url.clone());
-            let help = meta.and_then(|m| m.recommendation).map(|rec| SarifMessage {
-                text: rec.to_string(),
+            let help = Some(SarifMessage {
+                text: finding.recommendation_or_default().to_string(),
             });
             SarifRule {
                 id: rule_id.to_string(),
                 name: rule_id.to_string(),
                 short_description: SarifMessage {
-                    text: finding.description.clone(),
+                    text: finding.title.clone(),
                 },
-                full_description: None,
+                full_description: Some(SarifMessage {
+                    text: finding.description.clone(),
+                }),
                 help_uri,
                 help,
             }

--- a/src/output/sarif/model.rs
+++ b/src/output/sarif/model.rs
@@ -70,6 +70,7 @@ pub struct SarifResultProperties {
     pub workspace_package: Option<String>,
     pub category: String,
     pub confidence: String,
+    pub recommendation: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/output/vibe/findings.rs
+++ b/src/output/vibe/findings.rs
@@ -124,9 +124,7 @@ pub(super) fn render_finding_entry(out: &mut String, finding: &Finding, index: u
         }
     }
 
-    if let Some(rec) = finding_recommendation(finding) {
-        let _ = writeln!(out, "> **Fix:** {rec}");
-    }
+    let _ = writeln!(out, "> **Fix:** {}", finding_recommendation(finding));
 
     if let Some(url) = &finding.docs_url {
         let _ = writeln!(out, "> **Docs:** {url}");

--- a/src/output/vibe/recommendations.rs
+++ b/src/output/vibe/recommendations.rs
@@ -22,7 +22,7 @@ pub(super) fn render_top_recommendations(out: &mut String, findings: &[&Finding]
         let recommendation = cluster
             .findings
             .first()
-            .and_then(|finding| finding_recommendation(finding))
+            .map(|finding| finding_recommendation(finding))
             .unwrap_or_default();
         let examples = example_locations(&cluster.findings, 3);
         let examples = if examples.is_empty() {
@@ -50,13 +50,7 @@ fn recommendation_clusters<'a>(
 ) -> Vec<RuleCluster<'a>> {
     let mut clusters = clusters_by_rule(findings)
         .into_iter()
-        .filter(|cluster| {
-            cluster.severity >= min_severity
-                && cluster
-                    .findings
-                    .first()
-                    .is_some_and(|finding| finding_recommendation(finding).is_some())
-        })
+        .filter(|cluster| cluster.severity >= min_severity && !cluster.findings.is_empty())
         .collect::<Vec<_>>();
 
     clusters.sort_by(|left, right| {

--- a/src/output/vibe/tests.rs
+++ b/src/output/vibe/tests.rs
@@ -15,6 +15,7 @@ fn make_finding(
     Finding {
         id: rule_id.to_string(),
         rule_id: rule_id.to_string(),
+        recommendation: Finding::recommendation_for_rule_id(rule_id),
         title: title.to_string(),
         description: format!("Description for {title}"),
         category,

--- a/src/rules/registry/mod.rs
+++ b/src/rules/registry/mod.rs
@@ -122,6 +122,12 @@ mod tests {
                 "rule {} has empty description",
                 rule.rule_id
             );
+            assert!(
+                rule.recommendation
+                    .is_some_and(|recommendation| !recommendation.trim().is_empty()),
+                "rule {} has empty recommendation",
+                rule.rule_id
+            );
         }
     }
 

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -55,6 +55,7 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
     findings.extend(apply_project_decisions(&facts, coupling_findings));
 
     for finding in &mut findings {
+        finding.populate_recommendation();
         finding.id = stable_finding_key(finding, path);
     }
     summary::sort_findings(&mut findings);

--- a/tests/baseline_key.rs
+++ b/tests/baseline_key.rs
@@ -49,6 +49,7 @@ fn finding(rule_id: &str, path: &str, line: usize) -> Finding {
     Finding {
         id: "generated-id".to_string(),
         rule_id: rule_id.to_string(),
+        recommendation: Finding::recommendation_for_rule_id(rule_id),
         title: "Finding".to_string(),
         description: "Description".to_string(),
         category: FindingCategory::Architecture,

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -90,6 +90,7 @@ fn finding(id: &str, rule_id: &str, path: &str, line: usize, severity: Severity)
     Finding {
         id: id.to_string(),
         rule_id: rule_id.to_string(),
+        recommendation: Finding::recommendation_for_rule_id(rule_id),
         title: "Finding".to_string(),
         description: "Description".to_string(),
         category: FindingCategory::Architecture,

--- a/tests/finding_model.rs
+++ b/tests/finding_model.rs
@@ -6,6 +6,7 @@ fn finding_contains_evidence() {
     let finding = Finding {
         id: "code-marker.todo.src/main.rs:10".to_string(),
         rule_id: "code-marker.todo".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("code-marker.todo"),
         title: "TODO marker found".to_string(),
         description: "A TODO marker was found.".to_string(),
         category: FindingCategory::CodeQuality,
@@ -22,6 +23,7 @@ fn finding_contains_evidence() {
     };
 
     assert_eq!(finding.rule_id, "code-marker.todo");
+    assert!(!finding.recommendation.is_empty());
     assert_eq!(finding.category, FindingCategory::CodeQuality);
     assert_eq!(finding.severity, Severity::Low);
     assert_eq!(finding.confidence, Confidence::Medium);
@@ -50,4 +52,26 @@ fn missing_confidence_deserializes_as_medium() {
     .expect("old finding JSON without confidence should deserialize");
 
     assert_eq!(finding.confidence, Confidence::Medium);
+}
+
+#[test]
+fn missing_recommendation_deserializes_as_empty_for_old_reports() {
+    let finding: Finding = serde_json::from_value(serde_json::json!({
+        "id": "code-marker.todo.src/main.rs:10",
+        "rule_id": "code-marker.todo",
+        "title": "TODO marker found",
+        "description": "A TODO marker was found.",
+        "category": "CODE_QUALITY",
+        "severity": "LOW",
+        "confidence": "MEDIUM",
+        "evidence": [{
+            "path": "src/main.rs",
+            "line_start": 10,
+            "line_end": null,
+            "snippet": "// TODO: improve this"
+        }]
+    }))
+    .expect("old finding JSON without recommendation should deserialize");
+
+    assert!(finding.recommendation.is_empty());
 }

--- a/tests/harden_prompt_command.rs
+++ b/tests/harden_prompt_command.rs
@@ -54,6 +54,7 @@ fn harden_default_output_succeeds() {
     assert!(stdout.contains("# RepoPilot Harden Plan"));
     assert!(stdout.contains("P0 - Immediate risk"));
     assert!(stdout.contains("Possible secret detected"));
+    assert!(stdout.contains("Move the value to an environment variable or secrets manager"));
     assert!(stdout.contains("## Verify"));
 }
 
@@ -114,6 +115,7 @@ fn prompt_default_output_succeeds() {
     assert!(stdout.contains("## Final Response Format"));
     assert!(stdout.contains("# RepoPilot Vibe Check"));
     assert!(stdout.contains("Possible secret detected"));
+    assert!(stdout.contains("Move the value to an environment variable or secrets manager"));
 }
 
 #[test]

--- a/tests/output_console.rs
+++ b/tests/output_console.rs
@@ -14,6 +14,7 @@ fn console_output_includes_versioned_summary_and_grouped_findings() {
         findings: vec![Finding {
             id: "finding-1".to_string(),
             rule_id: "security.secret-candidate".to_string(),
+            recommendation: Finding::recommendation_for_rule_id("security.secret-candidate"),
             title: "Possible secret detected".to_string(),
             description: "A real secret may be committed.".to_string(),
             category: FindingCategory::Security,

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -21,6 +21,7 @@ fn html_output_escapes_snippets_and_renders_summary() {
         findings: vec![Finding {
             id: "finding-1".to_string(),
             rule_id: "security.secret-candidate".to_string(),
+            recommendation: Finding::recommendation_for_rule_id("security.secret-candidate"),
             title: "Possible secret detected".to_string(),
             description: "description".to_string(),
             category: FindingCategory::Security,

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -54,6 +54,7 @@ fn json_findings_include_confidence() {
         findings: vec![Finding {
             id: "code-quality.long-function:src/lib.rs:1".to_string(),
             rule_id: "code-quality.long-function".to_string(),
+            recommendation: Finding::recommendation_for_rule_id("code-quality.long-function"),
             title: "Large Rust production function".to_string(),
             description: "Function spans more lines than the configured threshold.".to_string(),
             category: FindingCategory::CodeQuality,
@@ -77,6 +78,10 @@ fn json_findings_include_confidence() {
         serde_json::from_str(&output).expect("output should be valid json");
 
     assert_eq!(parsed["findings"][0]["confidence"], "HIGH");
+    assert_eq!(
+        parsed["findings"][0]["recommendation"],
+        Finding::recommendation_for_rule_id("code-quality.long-function")
+    );
 }
 
 #[test]

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -29,6 +29,7 @@ fn renders_markdown_scan_summary() {
         findings: vec![Finding {
             id: "code-marker.todo.src/main.rs:7".to_string(),
             rule_id: "code-marker.todo".to_string(),
+            recommendation: Finding::recommendation_for_rule_id("code-marker.todo"),
             title: "TODO marker found".to_string(),
             description: "A TODO marker was found in the codebase and should be reviewed."
                 .to_string(),
@@ -78,6 +79,8 @@ fn renders_markdown_scan_summary() {
     assert!(output.contains("| Rust | 1 |"));
     assert!(output.contains("| TypeScript | 1 |"));
     assert!(output.contains("Evidence: `src/main.rs:7` - // TODO: improve architecture"));
+    assert!(output.contains("Recommendation:"));
+    assert!(output.contains("Convert the TODO into a tracked issue"));
 }
 
 #[test]

--- a/tests/output_sarif.rs
+++ b/tests/output_sarif.rs
@@ -8,6 +8,7 @@ fn make_finding_with_package(rule_id: &str, pkg: Option<&str>) -> Finding {
     Finding {
         id: String::new(),
         rule_id: rule_id.to_owned(),
+        recommendation: Finding::recommendation_for_rule_id(rule_id),
         title: "Test".to_owned(),
         description: "desc".to_owned(),
         category: FindingCategory::Security,
@@ -58,10 +59,11 @@ fn sarif_driver_includes_version() {
 }
 
 #[test]
-fn sarif_rule_uses_real_description_not_generic() {
+fn sarif_rule_uses_title_and_full_description() {
     let finding = Finding {
         id: String::new(),
         rule_id: "test.rule".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("test.rule"),
         title: "Test finding".to_string(),
         description: "A real description for this rule.".to_string(),
         category: FindingCategory::CodeQuality,
@@ -81,15 +83,21 @@ fn sarif_rule_uses_real_description_not_generic() {
     let sarif = findings_to_sarif(&[finding], &root);
     let serialized = serde_json::to_value(&sarif).unwrap();
 
-    let rule_desc =
+    let short_desc =
         &serialized["runs"][0]["tool"]["driver"]["rules"][0]["shortDescription"]["text"];
+    let full_desc = &serialized["runs"][0]["tool"]["driver"]["rules"][0]["fullDescription"]["text"];
     assert_eq!(
-        rule_desc.as_str().unwrap(),
+        short_desc.as_str().unwrap(),
+        "Test finding",
+        "rule shortDescription should use the finding title"
+    );
+    assert_eq!(
+        full_desc.as_str().unwrap(),
         "A real description for this rule.",
-        "rule shortDescription should use the actual finding description"
+        "rule fullDescription should use the actual finding description"
     );
     assert!(
-        !rule_desc.as_str().unwrap().starts_with("RepoPilot rule"),
+        !full_desc.as_str().unwrap().starts_with("RepoPilot rule"),
         "should not use the generic fallback description"
     );
 }
@@ -99,6 +107,7 @@ fn sarif_result_includes_partial_fingerprints() {
     let finding = Finding {
         id: String::new(),
         rule_id: "test.rule".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("test.rule"),
         title: "Test".to_string(),
         description: "desc".to_string(),
         category: FindingCategory::CodeQuality,
@@ -154,6 +163,21 @@ fn sarif_result_properties_include_confidence() {
         confidence.as_str(),
         Some("MEDIUM"),
         "result properties must include the finding confidence label"
+    );
+}
+
+#[test]
+fn sarif_result_properties_include_recommendation() {
+    let finding = make_finding_with_package("security.secret-candidate", None);
+    let expected = finding.recommendation.clone();
+    let sarif = findings_to_sarif(&[finding], &PathBuf::from("."));
+    let value = serde_json::to_value(&sarif).unwrap();
+
+    let recommendation = &value["runs"][0]["results"][0]["properties"]["recommendation"];
+    assert_eq!(
+        recommendation.as_str(),
+        Some(expected.as_str()),
+        "result properties must include the finding recommendation"
     );
 }
 

--- a/tests/rule_registry.rs
+++ b/tests/rule_registry.rs
@@ -83,6 +83,7 @@ fn make_finding(rule_id: &str) -> Finding {
     Finding {
         id: String::new(),
         rule_id: rule_id.to_owned(),
+        recommendation: Finding::recommendation_for_rule_id(rule_id),
         title: "Test finding".to_owned(),
         description: "A test description.".to_owned(),
         category: FindingCategory::Framework,

--- a/tests/sarif_mapping.rs
+++ b/tests/sarif_mapping.rs
@@ -87,8 +87,13 @@ fn duplicate_rule_ids_produce_one_sorted_sarif_rule() {
     assert_eq!(rules[0].id, "code-marker.todo");
     assert_eq!(rules[0].name, "code-marker.todo");
     assert_eq!(
-        rules[0].short_description.text, "Finding description",
-        "rule shortDescription should come from the finding description"
+        rules[0].short_description.text, "Finding title",
+        "rule shortDescription should come from the finding title"
+    );
+    assert_eq!(
+        rules[0].full_description.as_ref().unwrap().text,
+        "Finding description",
+        "rule fullDescription should come from the finding description"
     );
     assert_eq!(rules[1].id, "security.secret-candidate");
 }
@@ -140,6 +145,7 @@ fn finding(rule_id: &str, severity: Severity, path: Option<&str>, line_start: us
     Finding {
         id: format!("{rule_id}:1"),
         rule_id: rule_id.to_string(),
+        recommendation: Finding::recommendation_for_rule_id(rule_id),
         title: "Finding title".to_string(),
         description: "Finding description".to_string(),
         category: FindingCategory::Architecture,

--- a/tests/scan_summary.rs
+++ b/tests/scan_summary.rs
@@ -107,6 +107,7 @@ fn health_score_decreases_with_severity() {
         Finding {
             id: String::new(),
             rule_id: "test".to_string(),
+            recommendation: Finding::recommendation_for_rule_id("test"),
             title: String::new(),
             description: String::new(),
             category: FindingCategory::Security,
@@ -134,6 +135,7 @@ fn health_score_is_clamped_at_zero_for_catastrophic_repos() {
         .map(|_| Finding {
             id: String::new(),
             rule_id: "test".to_string(),
+            recommendation: Finding::recommendation_for_rule_id("test"),
             title: String::new(),
             description: String::new(),
             category: FindingCategory::Security,

--- a/tests/workspace_risk.rs
+++ b/tests/workspace_risk.rs
@@ -7,6 +7,7 @@ fn make_finding(pkg: Option<&str>, severity: Severity) -> Finding {
     Finding {
         id: String::new(),
         rule_id: "security.secret-candidate".to_owned(),
+        recommendation: Finding::recommendation_for_rule_id("security.secret-candidate"),
         title: "Test".to_owned(),
         description: "desc".to_owned(),
         category: FindingCategory::Security,


### PR DESCRIPTION
## Summary

This PR adds explicit remediation recommendations to RepoPilot findings.

Findings now include a dedicated `recommendation` field that explains what the user should do next, separately from the finding description.

This improves report quality, AI-assisted remediation flows, and user-facing output because RepoPilot findings are no longer only diagnostic — they now also provide actionable next steps.

## Type of change

- [x] Feature
- [x] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- Added a `recommendation` field to the core `Finding` model.
- Added `Finding::recommendation_for_rule_id(...)` helper for rule-based remediation guidance.
- Updated multiple architecture audits to populate recommendations.
- Updated code quality audits to populate recommendations.
- Updated framework audits, including React and React Native checks, to populate recommendations.
- Updated security audits to include remediation guidance.
- Updated testing audits to include recommendation text.
- Updated Markdown output to render finding recommendations.
- Updated SARIF output to include recommendations.
- Updated Vibe / AI context output to include recommendations.
- Updated hardening output so generated plans include finding recommendations.
- Updated scan flow so recommendations are populated during report generation.
- Updated docs to describe the new `recommendation` field.
- Added and updated tests for:
  - finding model behavior
  - JSON output
  - Markdown output
  - HTML output
  - SARIF output
  - console output
  - rule registry behavior
  - harden / prompt command output
  - baseline and compare behavior

## Why

RepoPilot should not only say what is wrong. It should also guide the user toward the next correct action.

Before this change, remediation advice was mixed into descriptions or handled inconsistently across reports. That made findings harder to use in:

- Markdown reports
- SARIF reports
- AI context generation
- hardening plans
- AI remediation prompts
- future filtering and prioritization flows

A dedicated `recommendation` field makes findings more structured, more useful, and easier to consume by both humans and coding agents.

## Architecture notes

- No god files introduced.
- The core `Finding` model owns the recommendation metadata.
- Audit modules assign recommendations while creating findings.
- Rule-based recommendation fallback is centralized through `Finding::recommendation_for_rule_id(...)`.
- Output modules remain responsible only for rendering recommendations.
- Report responsibilities remain separated:
  - console
  - JSON
  - Markdown
  - HTML
  - SARIF
  - Vibe / AI context
  - harden / AI plan
  - prompt / AI remediation prompt

## Changelog

- Findings now include a dedicated `recommendation` field.
- Reports now render remediation recommendations.
- AI-oriented outputs now include clearer fix guidance.
- Ruleset documentation now describes the new finding field.

## Verification

Run from repository root:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo run -- scan . --format markdown --output /tmp/repopilot-recommendations.md
cargo run -- scan . --format json --output /tmp/repopilot-recommendations.json
cargo run -- scan . --format html --output /tmp/repopilot-recommendations.html
cargo run -- scan . --format sarif --output /tmp/repopilot-recommendations.sarif

cargo run -- ai context . --output /tmp/repopilot-ai-context.md
cargo run -- ai plan . --output /tmp/repopilot-ai-plan.md
cargo run -- ai prompt . --output /tmp/repopilot-ai-prompt.md