### PR TITLE
feat: add versioned JSON report schema

### DIFF
--- a/docs/reports.md
+++ b/docs/reports.md
@@ -1,0 +1,110 @@
+# Reports
+
+RepoPilot can render scan results as console, JSON, Markdown, HTML, and SARIF.
+
+Use JSON when another tool, CI job, script, or future RepoPilot command needs to
+read scan output.
+
+```bash
+repopilot scan . --format json --output repopilot-report.json
+```
+
+## JSON report schema
+
+Starting with RepoPilot 0.9, JSON scan reports include explicit schema metadata:
+
+```json
+{
+  "schema_version": "0.9",
+  "repopilot_version": "0.9.0",
+  "root_path": ".",
+  "files_count": 42,
+  "directories_count": 12,
+  "lines_of_code": 3200,
+  "languages": [],
+  "findings": []
+}
+```
+
+### Top-level metadata
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | string | RepoPilot JSON report schema version. |
+| `repopilot_version` | string | RepoPilot binary version that produced the report. |
+
+`schema_version` is intentionally separate from the binary version. Patch releases
+may fix bugs without changing the report schema, while future minor releases can
+evolve the schema in a documented way.
+
+### Compatibility
+
+RepoPilot 0.9 keeps the existing scan summary fields at the top level of the JSON
+document. The schema metadata is additive:
+
+- existing consumers can continue reading fields such as `findings`,
+  `files_count`, and `lines_of_code`;
+- `repopilot compare` continues to read older JSON reports that do not contain
+  `schema_version`;
+- future tools can branch on `schema_version` when parsing reports.
+
+## Baseline JSON reports
+
+When a scan is rendered with a baseline, the JSON report also includes the same
+schema metadata:
+
+```bash
+repopilot scan . \
+  --baseline .repopilot/baseline.json \
+  --format json \
+  --output repopilot-baseline-report.json
+```
+
+Example shape:
+
+```json
+{
+  "schema_version": "0.9",
+  "repopilot_version": "0.9.0",
+  "root_path": ".",
+  "files_count": 42,
+  "baseline": {
+    "path": ".repopilot/baseline.json",
+    "new_findings": 2,
+    "existing_findings": 10
+  },
+  "findings": []
+}
+```
+
+## Finding fields
+
+Every finding includes stable fields documented in [rulesets.md](rulesets.md):
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Stable finding ID derived from rule, path, and line. |
+| `rule_id` | string | Stable rule identifier, for example `security.secret-candidate`. |
+| `title` | string | Short human-readable summary. |
+| `description` | string | Explanation of why the finding matters. |
+| `category` | string | Finding category. |
+| `severity` | string | One of `INFO`, `LOW`, `MEDIUM`, `HIGH`, or `CRITICAL`. |
+| `docs_url` | string? | Optional documentation link for the rule. |
+| `workspace_package` | string? | Optional monorepo package name. |
+| `evidence` | array | One or more evidence locations. |
+
+## Recommended usage
+
+For local review:
+
+```bash
+repopilot scan . --format markdown --output repopilot-report.md
+```
+
+For scripts and comparisons:
+
+```bash
+repopilot scan . --format json --output before.json
+repopilot scan . --format json --output after.json
+repopilot compare before.json after.json --format markdown
+```

--- a/src/commands/compare.rs
+++ b/src/commands/compare.rs
@@ -70,3 +70,52 @@ impl Error for CompareInputError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::read_summary;
+    use repopilot::output::json;
+    use repopilot::scan::types::ScanSummary;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    #[test]
+    fn read_summary_accepts_versioned_json_report() {
+        let summary = ScanSummary {
+            root_path: PathBuf::from("."),
+            files_count: 7,
+            lines_of_code: 42,
+            ..ScanSummary::default()
+        };
+        let rendered = json::render(&summary).expect("json render should succeed");
+        let dir = tempdir().expect("tempdir should be created");
+        let path = dir.path().join("report.json");
+        fs::write(&path, rendered).expect("report should be written");
+
+        let parsed = read_summary(&path).expect("versioned report should parse");
+
+        assert_eq!(parsed.files_count, 7);
+        assert_eq!(parsed.lines_of_code, 42);
+    }
+
+    #[test]
+    fn read_summary_still_accepts_legacy_scan_summary_json() {
+        let summary = ScanSummary {
+            root_path: PathBuf::from("."),
+            files_count: 3,
+            lines_of_code: 21,
+            ..ScanSummary::default()
+        };
+        let rendered =
+            serde_json::to_string_pretty(&summary).expect("legacy json render should succeed");
+        let dir = tempdir().expect("tempdir should be created");
+        let path = dir.path().join("legacy-report.json");
+        fs::write(&path, rendered).expect("report should be written");
+
+        let parsed = read_summary(&path).expect("legacy report should parse");
+
+        assert_eq!(parsed.files_count, 3);
+        assert_eq!(parsed.lines_of_code, 21);
+    }
+}

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -5,8 +5,25 @@ use crate::scan::types::LanguageSummary;
 use crate::scan::types::ScanSummary;
 use serde::Serialize;
 
+pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.9";
+pub const REPOPILOT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub fn render(summary: &ScanSummary) -> Result<String, serde_json::Error> {
-    serde_json::to_string_pretty(summary)
+    let output = JsonScanReport {
+        schema_version: SCAN_REPORT_SCHEMA_VERSION,
+        repopilot_version: REPOPILOT_VERSION,
+        summary,
+    };
+
+    serde_json::to_string_pretty(&output)
+}
+
+#[derive(Serialize)]
+struct JsonScanReport<'a> {
+    schema_version: &'static str,
+    repopilot_version: &'static str,
+    #[serde(flatten)]
+    summary: &'a ScanSummary,
 }
 
 pub fn render_with_baseline(
@@ -25,6 +42,8 @@ pub fn render_with_baseline(
         .collect::<Vec<_>>();
 
     let output = BaselineJsonReport {
+        schema_version: SCAN_REPORT_SCHEMA_VERSION,
+        repopilot_version: REPOPILOT_VERSION,
         root_path: report.summary.root_path.to_string_lossy().to_string(),
         files_count: report.summary.files_count,
         directories_count: report.summary.directories_count,
@@ -49,6 +68,8 @@ pub fn render_with_baseline(
 
 #[derive(Serialize)]
 struct BaselineJsonReport<'a> {
+    schema_version: &'static str,
+    repopilot_version: &'static str,
     root_path: String,
     files_count: usize,
     directories_count: usize,
@@ -91,4 +112,52 @@ struct FindingWithBaselineStatus<'a> {
     #[serde(flatten)]
     finding: &'a Finding,
     baseline_status: BaselineStatus,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::baseline::diff::{BaselineScanReport, FindingBaselineStatus};
+    use serde_json::Value;
+    use std::path::PathBuf;
+
+    #[test]
+    fn json_scan_report_includes_schema_and_tool_versions() {
+        let summary = ScanSummary {
+            root_path: PathBuf::from("."),
+            files_count: 1,
+            ..ScanSummary::default()
+        };
+
+        let rendered = render(&summary).expect("json render should succeed");
+        let value: Value = serde_json::from_str(&rendered).expect("json should parse");
+
+        assert_eq!(value["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
+        assert_eq!(value["repopilot_version"], REPOPILOT_VERSION);
+        assert_eq!(value["files_count"], 1);
+        assert!(value.get("findings").is_some());
+    }
+
+    #[test]
+    fn baseline_json_report_includes_schema_and_tool_versions() {
+        let summary = ScanSummary {
+            root_path: PathBuf::from("."),
+            files_count: 2,
+            ..ScanSummary::default()
+        };
+        let report = BaselineScanReport {
+            summary,
+            baseline_path: Some(PathBuf::from(".repopilot/baseline.json")),
+            findings: Vec::<FindingBaselineStatus>::new(),
+        };
+
+        let rendered =
+            render_with_baseline(&report, None).expect("baseline json render should succeed");
+        let value: Value = serde_json::from_str(&rendered).expect("json should parse");
+
+        assert_eq!(value["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
+        assert_eq!(value["repopilot_version"], REPOPILOT_VERSION);
+        assert_eq!(value["files_count"], 2);
+        assert!(value.get("baseline").is_some());
+    }
 }


### PR DESCRIPTION
## Summary

Adds explicit JSON report schema metadata to RepoPilot scan outputs.

## Changes

- Added `schema_version` and `repopilot_version` to JSON scan reports
- Added the same schema metadata to baseline JSON reports
- Kept existing scan summary fields at the top level for compatibility
- Added tests for versioned JSON output
- Added tests ensuring compare still accepts both new and legacy JSON reports
- Added `docs/reports.md` with JSON schema documentation
- Linked report schema docs from README and ruleset docs

## Why

This prepares RepoPilot for stable CI, compare, baseline, and external tool integrations as the project moves toward 0.9.0 and eventually 1.0.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`