### PR TITLE
feat(adoption): add audit receipts and doctor readiness checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-14
+
+### Added
+
+- Added doctor adoption checks for readable `repopilot.toml`, readable `.repopilot/baseline.json`, RepoPilot-specific CI gates, and default report/receipt output readiness.
+- Added `schema_version: 1` to audit receipt JSON produced by `repopilot scan --receipt`.
+- Added typed GitHub Action `receipt` input and `receipt-file` output for scan receipt generation.
+- Added `docs/release-checklist-0.10.md` for the adoption UX release.
+
+### Changed
+
+- `repopilot doctor` now distinguishes generic CI from a RepoPilot `--fail-on` gate and recommends an adoption path from config to report, baseline, CI gate, and AI context.
+- `repopilot doctor` now renders diagnostics for invalid config files using built-in scan defaults instead of aborting before the report.
+- Product smoke checks now generate and validate an audit receipt.
+
 ## [0.9.0] - 2026-05-13
 
 ### Added
@@ -181,7 +196,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added `compare` for diffing two JSON scan reports.
 - Added CI workflow, release workflow, distribution docs, release docs, and ruleset docs.
 
-[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/MykytaStel/repopilot/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/MykytaStel/repopilot/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/MykytaStel/repopilot/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/MykytaStel/repopilot/compare/v0.5.0...v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repopilot"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repopilot"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Local-first CLI for repository audit, architecture risk detection, baseline tracking, and CI-friendly code review."

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ repopilot ai context . | pbcopy   # macOS: paste into your coding assistant
 - Baseline workflow for accepting existing findings in legacy repositories
 - CI-friendly failure thresholds with `--fail-on`
 - Git diff-aware review mode for prioritizing findings introduced by changed lines
+- Doctor adoption guidance for config, baseline, CI gate, report, and receipt readiness
+- Audit receipt JSON from `repopilot scan --receipt` for reproducible scan evidence
 - Console, JSON, Markdown, HTML, and SARIF (2.1.0) scan output — SARIF includes per-result category and workspace package properties
-- First-party GitHub Action wrapper for `scan`, `review`, `compare`, and `ai` workflows, with optional SARIF upload for scans
+- First-party GitHub Action wrapper for `scan`, `review`, `compare`, and `ai` workflows, with optional SARIF upload and receipt output for scans
 - Compare mode for diffing two JSON scan reports
 - **`repopilot ai context`** — formats scan output as LLM-ready markdown, paste into Claude Code or ChatGPT to start remediating
 - **`repopilot ai plan`** — turns findings into a prioritized remediation plan
@@ -107,7 +109,9 @@ cargo build --release
 
 ```bash
 repopilot init
+repopilot doctor .
 repopilot scan .
+repopilot scan . --format markdown --output repopilot-report.md --receipt .repopilot/receipt.json
 repopilot ai context .
 repopilot review . --base origin/main --fail-on new-high
 ```
@@ -116,6 +120,7 @@ Save a shareable report:
 
 ```bash
 repopilot scan . --format markdown --output repopilot-report.md
+repopilot scan . --format markdown --output repopilot-report.md --receipt .repopilot/receipt.json
 ```
 
 Reduce scan noise while iterating:
@@ -357,6 +362,7 @@ repopilot scan . --format sarif > repopilot.sarif
 ```
 
 Use JSON when custom scripts need to parse RepoPilot results. Console, Markdown, and HTML reports include the RepoPilot version, risk summary, top rules, and grouped findings for human review. Use SARIF for CI and code scanning integrations, including GitHub Code Scanning.
+Use `--receipt <path>` with `scan` when CI or release processes need compact evidence of the exact RepoPilot version, git state, scan scope, finding counts, language counts, and health score.
 
 See [docs/integrations/github-code-scanning.md](docs/integrations/github-code-scanning.md) for a copy-paste GitHub Actions workflow, required permissions, and local validation commands.
 
@@ -377,7 +383,7 @@ Use `--fail-on new-high` to fail CI only when new high or critical findings are 
 When `--fail-on new-*` is used without `--baseline`, RepoPilot treats all current findings as new. For baseline-based adoption, commit an accepted baseline and scan against it in CI.
 
 To upload RepoPilot findings to GitHub Code Scanning, generate SARIF and use `github/codeql-action/upload-sarif`. The workflow must include `security-events: write`.
-The first-party action can also run `command: ai-context`, `command: ai-plan`, or `command: ai-prompt`; those commands emit Markdown and do not produce SARIF. Prefer typed action inputs such as `path`, `config`, `baseline`, `fail-on`, `focus`, `budget`, and `output`; `args` remains available for advanced flags.
+The first-party action can also run `command: ai-context`, `command: ai-plan`, or `command: ai-prompt`; those commands emit Markdown and do not produce SARIF. Prefer typed action inputs such as `path`, `config`, `baseline`, `fail-on`, `focus`, `budget`, `output`, and `receipt`; `args` remains available for advanced flags.
 
 ```yaml
 name: RepoPilot
@@ -403,7 +409,7 @@ jobs:
         run: cargo install repopilot
 
       - name: Run RepoPilot
-        run: repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
+        run: repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high --receipt repopilot-receipt.json
 
       - name: Run RepoPilot (SARIF)
         run: repopilot scan . --format sarif --output repopilot.sarif
@@ -413,6 +419,13 @@ jobs:
         if: always()
         with:
           sarif_file: repopilot.sarif
+
+      - name: Upload audit receipt
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: repopilot-receipt
+          path: repopilot-receipt.json
 ```
 
 ## Roadmap
@@ -438,6 +451,7 @@ These are planned ideas, not current features:
 | [docs/react-native.md](docs/react-native.md) | React Native and Expo detection, findings, and limitations |
 | [docs/integrations/github-code-scanning.md](docs/integrations/github-code-scanning.md) | GitHub Code Scanning SARIF workflow |
 | [docs/release.md](docs/release.md) | Manual release process |
+| [docs/release-checklist-0.10.md](docs/release-checklist-0.10.md) | 0.10.0 release readiness checklist |
 | [docs/release-checklist-0.9.md](docs/release-checklist-0.9.md) | 0.9.0 release readiness checklist |
 | [docs/distribution.md](docs/distribution.md) | Distribution channels |
 | [docs/github-ruleset.md](docs/github-ruleset.md) | GitHub branch ruleset configuration |

--- a/action.yml
+++ b/action.yml
@@ -55,12 +55,16 @@ inputs:
     description: "Optional output path for commands that write reports."
     required: false
     default: ""
+  receipt:
+    description: "Optional audit receipt JSON path for scan."
+    required: false
+    default: ""
   args:
     description: "Advanced extra CLI arguments appended after typed inputs. Prefer typed inputs for CI workflows."
     required: false
     default: ""
   version:
-    description: "npm version tag to install (e.g. latest, 0.9.0)"
+    description: "npm version tag to install (e.g. latest, 0.10.0)"
     required: false
     default: "latest"
   upload-sarif:
@@ -72,6 +76,9 @@ outputs:
   sarif-file:
     description: "Path to the generated SARIF file (only set when format is sarif)"
     value: ${{ steps.run.outputs.sarif_file }}
+  receipt-file:
+    description: "Path to the generated audit receipt JSON file (only set when receipt is provided for scan)"
+    value: ${{ steps.run.outputs.receipt_file }}
 
 runs:
   using: composite
@@ -97,6 +104,7 @@ runs:
         FOCUS="${{ inputs.focus }}"
         BUDGET="${{ inputs.budget }}"
         OUTPUT="${{ inputs.output }}"
+        RECEIPT="${{ inputs.receipt }}"
         ARGS="${{ inputs.args }}"
 
         case "$COMMAND" in
@@ -128,6 +136,10 @@ runs:
           echo "::error::SARIF output and upload are only supported by 'scan'. Use format=markdown for '$COMMAND'."
           exit 1
         fi
+        if [[ -n "$RECEIPT" && "$COMMAND" != "scan" ]]; then
+          echo "::error::Receipt output is only supported by 'scan'. Remove receipt or use command=scan."
+          exit 1
+        fi
 
         if [[ -n "$CONFIG" && "$COMMAND" != "compare" ]]; then RUN_ARGS+=(--config "$CONFIG"); fi
         if [[ "$COMMAND" == "scan" || "$COMMAND" == "review" ]]; then
@@ -140,6 +152,7 @@ runs:
         if [[ "$IS_AI" == "true" && -n "$FOCUS" ]]; then RUN_ARGS+=(--focus "$FOCUS"); fi
         if [[ "$IS_AI" == "true" && -n "$BUDGET" ]]; then RUN_ARGS+=(--budget "$BUDGET"); fi
         if [[ -n "$OUTPUT" && "$FORMAT" != "sarif" ]]; then RUN_ARGS+=(--output "$OUTPUT"); fi
+        if [[ -n "$RECEIPT" ]]; then RUN_ARGS+=(--receipt "$RECEIPT"); fi
 
         if [[ -n "$ARGS" ]]; then
           read -r -a EXTRA_ARGS <<< "$ARGS"
@@ -147,18 +160,32 @@ runs:
         fi
 
         OUTFILE="${OUTPUT:-repopilot-results.sarif}"
+        RUN_STATUS=0
         if [[ "$IS_AI" == "true" ]]; then
           if [[ "$FORMAT" != "markdown" ]]; then
             echo "::error::'$COMMAND' emits Markdown and does not accept --format. Use format=auto or format=markdown."
             exit 1
           fi
+          set +e
           repopilot "${RUN_ARGS[@]}"
+          RUN_STATUS=$?
+          set -e
         elif [[ "$FORMAT" == "sarif" ]]; then
+          set +e
           repopilot "${RUN_ARGS[@]}" --format sarif --output "$OUTFILE"
-          echo "sarif_file=$OUTFILE" >> $GITHUB_OUTPUT
+          RUN_STATUS=$?
+          set -e
+          echo "sarif_file=$OUTFILE" >> "$GITHUB_OUTPUT"
         else
+          set +e
           repopilot "${RUN_ARGS[@]}" --format "$FORMAT"
+          RUN_STATUS=$?
+          set -e
         fi
+        if [[ -n "$RECEIPT" ]]; then
+          echo "receipt_file=$RECEIPT" >> "$GITHUB_OUTPUT"
+        fi
+        exit "$RUN_STATUS"
 
     - name: Upload SARIF to GitHub Code Scanning
       if: inputs.upload-sarif == 'true' && steps.run.outputs.sarif_file != ''

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,6 +68,7 @@ repopilot s <PATH> [OPTIONS]
 |------|------|---------|-------------|
 | `--format` | `console\|json\|markdown\|html\|sarif` | `console` | Output format |
 | `-o, --output` | path | stdout | Write report to a file instead of stdout |
+| `--receipt` | path | — | Write a compact audit receipt JSON file with tool, git, scope, finding, language, and health metadata |
 | `--config` | path | auto-detected | Path to a `repopilot.toml` config file |
 | `--baseline` | path | — | Path to a baseline file; marks findings as new or existing |
 | `--fail-on` | threshold | — | Exit code 1 when findings meet this threshold (see [Thresholds](#thresholds)) |
@@ -106,6 +107,7 @@ repopilot scan . --format json --output report.json
 repopilot scan . --format markdown --output report.md
 repopilot scan . --format html --output report.html
 repopilot scan . --format sarif --output repopilot.sarif
+repopilot scan . --format markdown --output repopilot-report.md --receipt .repopilot/receipt.json
 
 # Use a custom config
 repopilot scan . --config repopilot.toml
@@ -478,7 +480,7 @@ repopilot baseline create . --force
 
 ## `doctor`
 
-Runs a lightweight audit-readiness check for a repository. It reports scan scope accounting, checks for config, `.repopilotignore`, baseline, Git, and GitHub workflows, then recommends the next command to run.
+Runs an audit-readiness check for a repository. It reports scan scope accounting, checks for config, `.repopilotignore`, baseline, Git, generic CI, RepoPilot-specific CI gates, and report/receipt output readiness, then recommends the next adoption command to run.
 
 ### Synopsis
 
@@ -504,6 +506,10 @@ repopilot doctor .
 repopilot doctor . --format json
 repopilot doctor . --format markdown --output doctor.md
 ```
+
+Doctor keeps its JSON shape additive: new readiness checks appear as extra
+`checks[]` entries such as `config_readable`, `baseline_readable`,
+`repopilot_ci`, and `report_receipt`.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,8 +7,9 @@ Task-oriented guide to RepoPilot commands. For a complete flag reference see [do
 ## Quick start
 
 ```bash
-repopilot init        # generate repopilot.toml
-repopilot scan .      # scan the current directory
+repopilot init          # generate repopilot.toml
+repopilot doctor .      # check adoption readiness
+repopilot scan .        # scan the current directory
 ```
 
 For React Native or Expo projects:
@@ -53,7 +54,12 @@ repopilot scan . --format json --output report.json
 repopilot scan . --format markdown --output report.md
 repopilot scan . --format html --output report.html
 repopilot scan . --format sarif --output repopilot.sarif
+repopilot scan . --format markdown --output repopilot-report.md --receipt .repopilot/receipt.json
 ```
+
+Use `--receipt` when you need compact JSON evidence for CI artifacts or release
+records. The receipt includes schema version, RepoPilot version, git state, scan
+scope, finding counts, language counts, and health score.
 
 ### Overriding thresholds
 

--- a/docs/integrations/github-code-scanning.md
+++ b/docs/integrations/github-code-scanning.md
@@ -69,6 +69,58 @@ For RepoPilot's own repository or another Rust project where installing from cra
 
 Keep the SARIF file name consistent between the scan step and the upload step. The examples above write and upload `repopilot.sarif`.
 
+## First-party action with receipt artifact
+
+The first-party action can generate SARIF and a compact audit receipt from the
+same scan. `receipt` is only valid with `command: scan`.
+
+```yaml
+name: RepoPilot
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  repopilot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run RepoPilot
+        id: repopilot
+        uses: MykytaStel/repopilot@v0.10.0
+        with:
+          command: scan
+          baseline: .repopilot/baseline.json
+          fail-on: new-high
+          receipt: repopilot-receipt.json
+
+      - name: Upload audit receipt
+        uses: actions/upload-artifact@v4
+        if: always() && steps.repopilot.outputs.receipt-file != ''
+        with:
+          name: repopilot-receipt
+          path: ${{ steps.repopilot.outputs.receipt-file }}
+```
+
+For review-only gates, use `command: review` without `receipt`:
+
+```yaml
+      - name: RepoPilot review gate
+        uses: MykytaStel/repopilot@v0.10.0
+        with:
+          command: review
+          base: origin/main
+          baseline: .repopilot/baseline.json
+          fail-on: new-high
+          upload-sarif: "false"
+```
+
 ## Choosing an output format
 
 Use JSON when a script or service will parse RepoPilot results directly.

--- a/docs/product-readiness.md
+++ b/docs/product-readiness.md
@@ -66,7 +66,7 @@ version
 help
 init
 doctor
-scan JSON
+scan JSON + receipt
 scan Markdown
 review Markdown
 ai context
@@ -96,6 +96,7 @@ repopilot init --path /tmp/repopilot.toml
 repopilot doctor .
 repopilot scan .
 repopilot scan . --format json --output /tmp/repopilot-scan.json
+repopilot scan . --format json --output /tmp/repopilot-scan.json --receipt /tmp/repopilot-receipt.json
 repopilot scan . --format markdown --output /tmp/repopilot-scan.md
 repopilot review .
 repopilot ai context .
@@ -165,6 +166,7 @@ RepoPilot runtime commands must stay local-first:
 
 - scans read files from disk;
 - reports write to stdout or explicit output paths;
+- scan receipts write only to explicit local paths;
 - no source code is uploaded;
 - no telemetry is sent;
 - AI commands do not call AI providers;
@@ -199,6 +201,7 @@ The GitHub Action should support:
 ```yaml
 with:
   command: scan
+  receipt: repopilot-receipt.json
 ```
 
 ```yaml
@@ -217,6 +220,9 @@ Legacy action command names may remain available for compatibility:
 with:
   command: vibe
 ```
+
+Receipt output is scan-only. The action should fail clearly when `receipt` is
+provided with `review`, `compare`, or AI commands.
 
 ---
 

--- a/docs/release-checklist-0.10.md
+++ b/docs/release-checklist-0.10.md
@@ -1,0 +1,117 @@
+# RepoPilot 0.10.0 Release Checklist
+
+RepoPilot 0.10.0 is the adoption UX release for moving a repository from first
+doctor run to a committed baseline, CI gate, and reproducible audit receipt.
+
+Main release promise:
+
+```text
+doctor -> scan report + receipt -> baseline -> CI gate -> AI context
+```
+
+## Release scope
+
+0.10.0 focuses on making RepoPilot easier to roll out in real repositories:
+
+- Doctor checks for readable config, readable baseline, RepoPilot CI gates, and report/receipt readiness.
+- First-class audit receipts through `repopilot scan --receipt`.
+- GitHub Action typed `receipt` input and `receipt-file` output.
+- Documentation for adoption workflows, receipt JSON, and CI receipt artifact upload.
+
+## Required local checks
+
+Run from the repository root:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+npm test
+npm pack --dry-run
+cargo package --list
+./scripts/verify-release.sh
+```
+
+All checks must pass before tagging. If checking a dirty release-prep branch before
+commit, use `cargo package --allow-dirty --list` only to inspect package contents.
+
+## Manual smoke checks
+
+```bash
+cargo run -- --version
+cargo run -- doctor . --format markdown --output /tmp/repopilot-doctor.md
+cargo run -- scan . --format markdown --output /tmp/repopilot-report.md --receipt /tmp/repopilot-receipt.json
+cargo run -- baseline create . --output /tmp/repopilot-baseline-source.json --force
+cargo run -- scan . --baseline /tmp/repopilot-baseline-source.json --fail-on new-high --format json --output /tmp/repopilot-baseline.json
+cargo run -- ai context . --budget 4k --output /tmp/repopilot-context.md
+```
+
+Check that all files exist and are not empty:
+
+```bash
+test -s /tmp/repopilot-doctor.md
+test -s /tmp/repopilot-report.md
+test -s /tmp/repopilot-receipt.json
+test -s /tmp/repopilot-baseline-source.json
+test -s /tmp/repopilot-baseline.json
+test -s /tmp/repopilot-context.md
+```
+
+## Version consistency
+
+Check:
+
+```bash
+grep '^version = "0.10.0"' Cargo.toml
+grep '"version": "0.10.0"' package.json
+grep '## \[0.10.0\]' CHANGELOG.md
+rg '0\.[[]9[]]\.0|release-checklist-0\.[[]9[]]' Cargo.toml package.json action.yml README.md docs .github scripts install.sh Formula
+```
+
+The final search should only report historical changelog entries, old release
+checklists, and example version text where intentionally retained.
+
+## Publishing order
+
+1. Merge the release preparation PR into `main`.
+2. Pull the latest `main`.
+
+```bash
+git checkout main
+git pull
+```
+
+3. Tag the release:
+
+```bash
+git tag v0.10.0
+git push origin v0.10.0
+```
+
+4. Wait for the GitHub Release workflow and npm publishing workflow to finish.
+5. Verify GitHub Release assets exist for Linux, macOS, Windows, and `.sha256` files.
+6. Verify the configured distribution channels:
+
+```bash
+cargo install repopilot --force
+npm install -g repopilot@0.10.0
+brew tap mykytastel/repopilot
+brew install repopilot
+repopilot --version
+brew test repopilot
+```
+
+## Post-release verification
+
+```bash
+repopilot doctor . --format markdown --output repopilot-doctor.md
+repopilot scan . --format markdown --output repopilot-report.md --receipt .repopilot/receipt.json
+repopilot scan . --format sarif --output repopilot.sarif
+repopilot ai context . --budget 4k --output repopilot-context.md
+```
+
+## Release note summary
+
+RepoPilot 0.10.0 makes adoption easier by turning doctor into a rollout guide,
+making audit receipts explicit and schema-versioned, and letting the first-party
+GitHub Action publish receipt artifacts from scan jobs.

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,7 +11,7 @@ Update:
 - `package.json` version
 - `CHANGELOG.md`
 - `README.md` if user-facing behavior changed
-- release checklist for the target version, for example `docs/release-checklist-0.9.md`
+- release checklist for the target version, for example `docs/release-checklist-0.10.md`
 
 Use the current date for the release entry in `CHANGELOG.md`.
 
@@ -25,6 +25,7 @@ cargo audit
 cargo deny check advisories licenses
 cargo package --list
 cargo publish --dry-run
+./scripts/smoke-product.sh --binary ./target/release/repopilot --repo . --tmp-dir /tmp/repopilot-release-smoke
 mapfile -d '' shell_scripts < <({ [[ -f install.sh ]] && printf '%s\0' install.sh; [[ -d scripts ]] && find scripts -maxdepth 1 -type f -name '*.sh' -print0; })
 ((${#shell_scripts[@]} == 0)) || bash -n "${shell_scripts[@]}"
 ((${#shell_scripts[@]} == 0)) || shellcheck "${shell_scripts[@]}"
@@ -37,6 +38,7 @@ npm pack --dry-run
 Review the package contents from `cargo package --list` before publishing.
 Install `cargo-audit`, `cargo-deny`, `shellcheck`, and `actionlint` before running the local release checks.
 For a version-specific gate list, use the current release checklist in `docs/release-checklist-*.md`.
+The product smoke suite validates the adoption flow, including receipt generation.
 
 ## 3. Create release branch
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -16,7 +16,7 @@ Starting with RepoPilot 0.9, JSON scan reports include explicit schema metadata:
 ```json
 {
   "schema_version": "0.9",
-  "repopilot_version": "0.9.0",
+  "repopilot_version": "0.10.0",
   "root_path": ".",
   "files_count": 42,
   "directories_count": 12,
@@ -65,7 +65,7 @@ Example shape:
 ```json
 {
   "schema_version": "0.9",
-  "repopilot_version": "0.9.0",
+  "repopilot_version": "0.10.0",
   "root_path": ".",
   "files_count": 42,
   "baseline": {
@@ -76,6 +76,56 @@ Example shape:
   "findings": []
 }
 ```
+
+## Audit receipt JSON
+
+Use `--receipt` when a CI job, release process, or audit trail needs compact
+evidence of what RepoPilot scanned without storing the full report:
+
+```bash
+repopilot scan . \
+  --format markdown \
+  --output repopilot-report.md \
+  --receipt .repopilot/receipt.json
+```
+
+Receipt JSON is intentionally smaller than a scan report and has its own schema:
+
+```json
+{
+  "schema_version": 1,
+  "tool": "repopilot",
+  "version": "0.10.0",
+  "generated_at": "2026-05-14T00:00:00Z",
+  "root_path": ".",
+  "git": {
+    "is_git_repo": true,
+    "branch": "main",
+    "commit": "abc123",
+    "dirty": false
+  },
+  "scope": {
+    "files_discovered": 42,
+    "files_analyzed": 40,
+    "directories_count": 12,
+    "lines_of_code": 3200
+  },
+  "findings": {
+    "total": 3,
+    "critical": 0,
+    "high": 1,
+    "medium": 2,
+    "low": 0,
+    "info": 0
+  },
+  "languages": [],
+  "health_score": 91
+}
+```
+
+Receipts do not replace reports. Use reports for human review or downstream
+finding details, and receipts for provenance, release evidence, and artifact
+upload.
 
 ## Finding fields
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repopilot",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"description": "Local-first CLI for repository audit, architecture risk detection, baseline tracking, and CI-friendly code review.",
 	"license": "MIT OR Apache-2.0",
 	"repository": {

--- a/scripts/smoke-product.sh
+++ b/scripts/smoke-product.sh
@@ -206,9 +206,11 @@ assert_non_empty "$TMP_DIR/repopilot.toml"
 run_repopilot doctor . --format markdown --output "$TMP_DIR/doctor.md"
 assert_non_empty "$TMP_DIR/doctor.md"
 
-run_repopilot scan . --format json --output "$TMP_DIR/scan.json"
+run_repopilot scan . --format json --output "$TMP_DIR/scan.json" --receipt "$TMP_DIR/receipt.json"
 assert_non_empty "$TMP_DIR/scan.json"
 validate_json_if_possible "$TMP_DIR/scan.json"
+assert_non_empty "$TMP_DIR/receipt.json"
+validate_json_if_possible "$TMP_DIR/receipt.json"
 
 run_repopilot scan . --format markdown --output "$TMP_DIR/scan.md"
 assert_non_empty "$TMP_DIR/scan.md"

--- a/src/audits/testing/source_without_test/matching.rs
+++ b/src/audits/testing/source_without_test/matching.rs
@@ -3,12 +3,13 @@ use std::path::{Path, PathBuf};
 
 const TEST_EXTENSIONS: &[&str] = &["rs", "ts", "tsx", "js", "jsx", "py", "go", "java", "kt"];
 
-/// Returns the path suffix starting at the `tests/` component, normalised to forward slashes.
+/// Returns the path suffix starting at the `tests/` or `__tests__/` component, normalised to forward slashes.
 pub(super) fn tests_dir_suffix(path: &Path) -> Option<String> {
     let components: Vec<_> = path.components().collect();
-    let idx = components
-        .iter()
-        .position(|c| c.as_os_str().to_string_lossy() == "tests")?;
+    let idx = components.iter().position(|c| {
+        let s = c.as_os_str().to_string_lossy();
+        s == "tests" || s == "__tests__"
+    })?;
     let suffix: PathBuf = components[idx..].iter().collect();
     Some(suffix.to_string_lossy().replace('\\', "/"))
 }
@@ -50,12 +51,15 @@ fn has_sibling_test(parent: &Path, stem: &str, ext: &str, all_paths: &HashSet<Pa
 }
 
 fn has_tests_directory_match(stem: &str, ext: &str, tests_suffixes: &HashSet<String>) -> bool {
-    [
-        format!("tests/{stem}.{ext}"),
-        format!("tests/{stem}_test.{ext}"),
-    ]
-    .iter()
-    .any(|candidate| tests_suffixes.contains(candidate.as_str()))
+    const DIRS: &[&str] = &["tests", "__tests__"];
+    const SUFFIXES: &[&str] = &["", "_test", ".test", ".spec"];
+    DIRS.iter()
+        .flat_map(|dir| {
+            SUFFIXES
+                .iter()
+                .map(move |suf| format!("{dir}/{stem}{suf}.{ext}"))
+        })
+        .any(|candidate| tests_suffixes.contains(&candidate))
 }
 
 fn has_rust_integration_test(source: &Path, ext: &str, tests_suffixes: &HashSet<String>) -> bool {

--- a/src/commands/baseline.rs
+++ b/src/commands/baseline.rs
@@ -17,15 +17,6 @@ pub fn run(command: BaselineCommands) -> Result<(), Box<dyn std::error::Error>> 
             let force = options.force;
             let output_path = output.unwrap_or_else(|| default_baseline_path(&path));
 
-            if output_path.exists() && !force {
-                return Err(format!(
-                    "Baseline already exists at {}. Use `repopilot baseline create {} --force` to overwrite it.",
-                    output_path.display(),
-                    path.display()
-                )
-                .into());
-            }
-
             let repo_config = load_default_config()?;
             let scan_config = repo_config.to_scan_config();
             let summary = scan_path_with_config(&path, &scan_config)?;

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,6 +1,7 @@
 use crate::cli::CompareOutputFormatArg;
 use crate::commands::{ScanConfigOverrides, build_scan_config};
 use repopilot::config::loader::{load_default_config, load_optional_config};
+use repopilot::config::model::RepoPilotConfig;
 use repopilot::doctor::{build_doctor_report, render_doctor_report};
 use repopilot::output::OutputFormat;
 use repopilot::report::writer::write_report;
@@ -14,10 +15,7 @@ pub fn run(
     include_low_signal: bool,
     max_files: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let repo_config = match &config {
-        Some(config_path) => load_optional_config(config_path)?,
-        None => load_default_config()?,
-    };
+    let repo_config = load_doctor_config(config.as_ref());
 
     let scan_config = build_scan_config(
         &repo_config,
@@ -36,4 +34,13 @@ pub fn run(
     write_report(&rendered, output.as_deref())?;
 
     Ok(())
+}
+
+fn load_doctor_config(config: Option<&PathBuf>) -> RepoPilotConfig {
+    let result = match config {
+        Some(config_path) => load_optional_config(config_path),
+        None => load_default_config(),
+    };
+
+    result.unwrap_or_default()
 }

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -17,7 +17,7 @@ use repopilot::scan::config::ScanConfig;
 use repopilot::scan::scanner::scan_path_with_config;
 use repopilot::scan::types::{LanguageSummary, ScanSummary};
 use repopilot::scan::workspace::{WorkspacePackage, detect_workspace_packages};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::Instant;
 
@@ -101,8 +101,8 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
             let total_ms = scan_elapsed.as_millis();
             let render_ms = render_elapsed.as_millis();
             eprintln!(
-                "\n[verbose] Scan: {total_ms}ms (engine: {:.0}ms) · Render: {render_ms}ms",
-                internal_us as f64 / 1000.0
+                "\n[verbose] Scan: {total_ms}ms (engine: {}ms) · Render: {render_ms}ms",
+                internal_us / 1000
             );
         }
 
@@ -149,10 +149,11 @@ fn scan_workspace(path: &Path, scan_config: &ScanConfig) -> Result<ScanSummary, 
         return scan_path_with_config(path, scan_config);
     }
 
+    let wall_start = Instant::now();
+
     let root_scan_config = workspace_root_config(scan_config, path, &packages);
     let mut merged = scan_path_with_config(path, &root_scan_config)?;
 
-    // Scan packages in parallel; collect (name, result) pairs then merge sequentially.
     let pkg_results: Vec<(String, Result<_, _>)> = packages
         .par_iter()
         .map(|pkg| {
@@ -170,6 +171,7 @@ fn scan_workspace(path: &Path, scan_config: &ScanConfig) -> Result<ScanSummary, 
         }
     }
 
+    merged.scan_duration_us = wall_start.elapsed().as_micros() as u64;
     Ok(merged)
 }
 
@@ -215,15 +217,12 @@ fn merge_package_summary(merged: &mut ScanSummary, mut package: ScanSummary, pac
         merged.repopilotignore_path = package.repopilotignore_path.clone();
     }
     merged.skipped_bytes = merged.skipped_bytes.saturating_add(package.skipped_bytes);
-    merged.scan_duration_us = merged
-        .scan_duration_us
-        .saturating_add(package.scan_duration_us);
     merge_language_summaries(&mut merged.languages, package.languages);
     merged.findings.extend(package.findings);
 }
 
 fn merge_language_summaries(target: &mut Vec<LanguageSummary>, source: Vec<LanguageSummary>) {
-    let mut counts: BTreeMap<String, usize> = target
+    let mut counts: HashMap<String, usize> = target
         .drain(..)
         .map(|language| (language.name, language.files_count))
         .collect();

--- a/src/doctor/checks.rs
+++ b/src/doctor/checks.rs
@@ -1,3 +1,5 @@
+use crate::baseline::reader::read_baseline;
+use crate::config::loader::parse_config;
 use crate::doctor::model::{
     DoctorCheck, DoctorNextStep, DoctorProject, DoctorReport, DoctorScanScope, DoctorStatus,
 };
@@ -9,6 +11,8 @@ use std::path::{Path, PathBuf};
 
 const CONFIG_FILE_NAME: &str = "repopilot.toml";
 const BASELINE_FILE_PATH: &str = ".repopilot/baseline.json";
+const REPORT_FILE_PATH: &str = "repopilot-report.md";
+const RECEIPT_FILE_PATH: &str = ".repopilot/receipt.json";
 
 pub fn build_doctor_report(
     path: &Path,
@@ -31,6 +35,10 @@ pub fn build_doctor_report(
     let has_baseline = baseline_path.is_file();
     let has_github_workflows = has_github_workflows(&github_workflows_dir);
     let has_ci_config = has_ci_config(&root, &github_workflows_dir);
+    let repopilot_ci = detect_repopilot_ci_config(&root, &github_workflows_dir);
+    let config_readable = config_path.as_deref().is_some_and(config_file_is_readable);
+    let baseline_readable = has_baseline && read_baseline(&baseline_path).is_ok();
+    let report_receipt_ready = report_receipt_paths_ready(&root).is_ok();
     let package_managers = detect_package_managers(&root);
 
     let project = DoctorProject {
@@ -58,30 +66,50 @@ pub fn build_doctor_report(
         files_skipped_repopilotignore: summary.files_skipped_repopilotignore,
     };
 
-    let checks = vec![
+    let mut checks = vec![
         check_git_repo(git_dir.as_deref()),
         check_config(config_path.as_deref()),
-        check_repopilotignore(has_repopilotignore, summary.files_skipped_repopilotignore),
-        check_baseline(has_baseline),
-        check_ci_config(has_ci_config, has_github_workflows),
-        check_scan_scope(summary.files_count),
-        check_scan_limit(summary.files_skipped_by_limit),
     ];
 
-    let recommendations = build_recommendations(
-        config_path.is_some(),
+    if let Some(path) = config_path.as_deref() {
+        checks.push(check_config_readable(path));
+    }
+
+    checks.extend([
+        check_repopilotignore(has_repopilotignore, summary.files_skipped_repopilotignore),
+        check_baseline(has_baseline),
+    ]);
+
+    if has_baseline {
+        checks.push(check_baseline_readable(&baseline_path));
+    }
+
+    checks.extend([
+        check_ci_config(has_ci_config, has_github_workflows),
+        check_repopilot_ci(&repopilot_ci, has_ci_config),
+        check_report_receipt_readiness(&root),
+        check_scan_scope(summary.files_count),
+        check_scan_limit(summary.files_skipped_by_limit),
+    ]);
+
+    let recommendations = build_recommendations(DoctorRecommendationState {
+        has_config: config_path.is_some(),
+        config_readable,
         has_repopilotignore,
         has_baseline,
+        baseline_readable,
         has_ci_config,
-        summary.files_count,
-        summary.files_skipped_by_limit,
-    );
+        has_repopilot_ci_gate: repopilot_ci.has_gate,
+        report_receipt_ready,
+        files_analyzed: summary.files_count,
+        files_skipped_by_limit: summary.files_skipped_by_limit,
+    });
 
     let next_steps = build_next_steps(
         path,
         config_path.is_some(),
         has_baseline,
-        has_ci_config,
+        repopilot_ci.has_gate,
         summary.files_count,
     );
     let next_command = next_steps
@@ -134,6 +162,23 @@ fn check_config(config_path: Option<&Path>) -> DoctorCheck {
     }
 }
 
+fn check_config_readable(config_path: &Path) -> DoctorCheck {
+    match read_config_file(config_path) {
+        Ok(()) => DoctorCheck {
+            id: "config_readable".to_string(),
+            status: DoctorStatus::Pass,
+            title: "RepoPilot config is readable".to_string(),
+            detail: format!("Parsed {} successfully.", config_path.display()),
+        },
+        Err(reason) => DoctorCheck {
+            id: "config_readable".to_string(),
+            status: DoctorStatus::Fail,
+            title: "RepoPilot config is not readable".to_string(),
+            detail: reason,
+        },
+    }
+}
+
 fn check_repopilotignore(has_repopilotignore: bool, skipped_files: usize) -> DoctorCheck {
     if has_repopilotignore {
         DoctorCheck {
@@ -172,6 +217,27 @@ fn check_baseline(has_baseline: bool) -> DoctorCheck {
     }
 }
 
+fn check_baseline_readable(baseline_path: &Path) -> DoctorCheck {
+    match read_baseline(baseline_path) {
+        Ok(baseline) => DoctorCheck {
+            id: "baseline_readable".to_string(),
+            status: DoctorStatus::Pass,
+            title: "Baseline is readable".to_string(),
+            detail: format!(
+                "Parsed {} with {} accepted findings.",
+                baseline_path.display(),
+                baseline.findings.len()
+            ),
+        },
+        Err(error) => DoctorCheck {
+            id: "baseline_readable".to_string(),
+            status: DoctorStatus::Fail,
+            title: "Baseline is not readable".to_string(),
+            detail: error.to_string().replace('\n', " "),
+        },
+    }
+}
+
 fn check_ci_config(has_ci_config: bool, has_github_workflows: bool) -> DoctorCheck {
     match (has_ci_config, has_github_workflows) {
         (true, true) => DoctorCheck {
@@ -192,6 +258,71 @@ fn check_ci_config(has_ci_config: bool, has_github_workflows: bool) -> DoctorChe
             title: "CI config missing".to_string(),
             detail: "Add a RepoPilot workflow when you are ready to enforce scan/review checks."
                 .to_string(),
+        },
+    }
+}
+
+fn check_repopilot_ci(detection: &RepopilotCiDetection, has_ci_config: bool) -> DoctorCheck {
+    if detection.has_gate {
+        return DoctorCheck {
+            id: "repopilot_ci".to_string(),
+            status: DoctorStatus::Pass,
+            title: "RepoPilot CI gate configured".to_string(),
+            detail: format!(
+                "Found a RepoPilot failure gate in {}.",
+                detection
+                    .path
+                    .as_deref()
+                    .map(Path::display)
+                    .map(|display| display.to_string())
+                    .unwrap_or_else(|| "CI configuration".to_string())
+            ),
+        };
+    }
+
+    if detection.has_repopilot {
+        return DoctorCheck {
+            id: "repopilot_ci".to_string(),
+            status: DoctorStatus::Warn,
+            title: "RepoPilot CI integration has no gate".to_string(),
+            detail: format!(
+                "Found RepoPilot in {}, but no `--fail-on`/`fail-on` threshold was detected.",
+                detection
+                    .path
+                    .as_deref()
+                    .map(Path::display)
+                    .map(|display| display.to_string())
+                    .unwrap_or_else(|| "CI configuration".to_string())
+            ),
+        };
+    }
+
+    DoctorCheck {
+        id: "repopilot_ci".to_string(),
+        status: DoctorStatus::Warn,
+        title: "RepoPilot CI gate missing".to_string(),
+        detail: if has_ci_config {
+            "Generic CI exists, but no RepoPilot scan/review failure gate was detected.".to_string()
+        } else {
+            "Add a RepoPilot scan or review gate when you are ready to enforce new findings."
+                .to_string()
+        },
+    }
+}
+
+fn check_report_receipt_readiness(root: &Path) -> DoctorCheck {
+    match report_receipt_paths_ready(root) {
+        Ok(detail) => DoctorCheck {
+            id: "report_receipt".to_string(),
+            status: DoctorStatus::Pass,
+            title: "Report and receipt paths are ready".to_string(),
+            detail,
+        },
+        Err(detail) => DoctorCheck {
+            id: "report_receipt".to_string(),
+            status: DoctorStatus::Fail,
+            title: "Report or receipt path is blocked".to_string(),
+            detail,
         },
     }
 }
@@ -233,48 +364,75 @@ fn check_scan_limit(files_skipped_by_limit: usize) -> DoctorCheck {
     }
 }
 
-fn build_recommendations(
+struct DoctorRecommendationState {
     has_config: bool,
+    config_readable: bool,
     has_repopilotignore: bool,
     has_baseline: bool,
+    baseline_readable: bool,
     has_ci_config: bool,
+    has_repopilot_ci_gate: bool,
+    report_receipt_ready: bool,
     files_analyzed: usize,
     files_skipped_by_limit: usize,
-) -> Vec<String> {
+}
+
+fn build_recommendations(state: DoctorRecommendationState) -> Vec<String> {
     let mut recommendations = Vec::new();
 
-    if !has_config {
+    if !state.has_config {
         recommendations
             .push("Run `repopilot init` to create an explicit audit configuration.".to_string());
+    } else if !state.config_readable {
+        recommendations.push(
+            "Fix `repopilot.toml` so RepoPilot can parse committed audit settings.".to_string(),
+        );
     }
 
-    if !has_repopilotignore {
+    if !state.has_repopilotignore {
         recommendations.push(
             "Add `.repopilotignore` for generated files, fixtures, snapshots, and vendor folders."
                 .to_string(),
         );
     }
 
-    if !has_baseline {
+    if !state.has_baseline {
         recommendations.push(
             "Create a baseline with `repopilot baseline create .` before enforcing CI gates."
                 .to_string(),
         );
+    } else if !state.baseline_readable {
+        recommendations.push(
+            "Fix or regenerate `.repopilot/baseline.json` before using new-finding gates."
+                .to_string(),
+        );
     }
 
-    if !has_ci_config {
+    if !state.has_repopilot_ci_gate {
+        recommendations.push(
+            "Add a RepoPilot CI gate with `--fail-on new-high` after committing a baseline."
+                .to_string(),
+        );
+    } else if !state.has_ci_config {
         recommendations
-            .push("Add a CI workflow for `repopilot scan` or `repopilot review`.".to_string());
+            .push("Keep the RepoPilot gate in a committed CI workflow file.".to_string());
     }
 
-    if files_analyzed == 0 {
+    if !state.report_receipt_ready {
+        recommendations.push(
+            "Clear the default report or receipt path conflict before generating adoption evidence."
+                .to_string(),
+        );
+    }
+
+    if state.files_analyzed == 0 {
         recommendations.push(
             "Relax ignore rules or run with `--include-low-signal` if the target only contains tests/examples."
                 .to_string(),
         );
     }
 
-    if files_skipped_by_limit > 0 {
+    if state.files_skipped_by_limit > 0 {
         recommendations.push(
             "Increase `--max-files` or remove the limit to audit the full repository scope."
                 .to_string(),
@@ -282,8 +440,9 @@ fn build_recommendations(
     }
 
     if recommendations.is_empty() {
-        recommendations
-            .push("Repository audit setup looks ready for regular scan/review usage.".to_string());
+        recommendations.push(
+            "Repository adoption setup looks ready for regular scan/review usage.".to_string(),
+        );
     }
 
     recommendations
@@ -297,7 +456,9 @@ fn build_next_command(path: &Path, has_baseline: bool) -> String {
             "repopilot review {path} --base origin/main --baseline .repopilot/baseline.json --fail-on new-high"
         )
     } else {
-        format!("repopilot scan {path} --format markdown --output repopilot-report.md")
+        format!(
+            "repopilot scan {path} --format markdown --output {REPORT_FILE_PATH} --receipt {RECEIPT_FILE_PATH}"
+        )
     }
 }
 
@@ -305,7 +466,7 @@ fn build_next_steps(
     path: &Path,
     has_config: bool,
     has_baseline: bool,
-    has_ci_config: bool,
+    has_repopilot_ci_gate: bool,
     files_analyzed: usize,
 ) -> Vec<DoctorNextStep> {
     let path = command_path(path);
@@ -328,13 +489,11 @@ fn build_next_steps(
     }
 
     steps.push(DoctorNextStep {
-        command: format!("repopilot scan {path} --format markdown --output repopilot-report.md"),
-        reason: "Generate a human-readable first audit report.".to_string(),
-    });
-
-    steps.push(DoctorNextStep {
-        command: format!("repopilot ai context {path} --budget 4k --output repopilot-context.md"),
-        reason: "Create AI-ready remediation context without uploading source code.".to_string(),
+        command: format!(
+            "repopilot scan {path} --format markdown --output {REPORT_FILE_PATH} --receipt {RECEIPT_FILE_PATH}"
+        ),
+        reason: "Generate a human-readable audit report plus a reproducible JSON receipt."
+            .to_string(),
     });
 
     if has_baseline {
@@ -353,14 +512,19 @@ fn build_next_steps(
         });
     }
 
-    if !has_ci_config {
+    if !has_repopilot_ci_gate {
         steps.push(DoctorNextStep {
             command: format!(
                 "repopilot scan {path} --baseline .repopilot/baseline.json --fail-on new-high"
             ),
-            reason: "Use this command in CI after committing a baseline.".to_string(),
+            reason: "Use this as the minimum CI gate after committing a baseline.".to_string(),
         });
     }
+
+    steps.push(DoctorNextStep {
+        command: format!("repopilot ai context {path} --budget 4k --output repopilot-context.md"),
+        reason: "Create AI-ready remediation context without uploading source code.".to_string(),
+    });
 
     steps
 }
@@ -448,12 +612,128 @@ fn detect_package_managers(root: &Path) -> Vec<String> {
     managers
 }
 
+fn read_config_file(path: &Path) -> Result<(), String> {
+    let contents = fs::read_to_string(path)
+        .map_err(|error| format!("Failed to read {}: {error}", path.display()))?;
+
+    parse_config(&contents, Some(path))
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+fn config_file_is_readable(path: &Path) -> bool {
+    read_config_file(path).is_ok()
+}
+
+fn report_receipt_paths_ready(root: &Path) -> Result<String, String> {
+    let report_path = root.join(REPORT_FILE_PATH);
+    let repopilot_dir = root.join(".repopilot");
+    let receipt_path = root.join(RECEIPT_FILE_PATH);
+
+    if report_path.is_dir() {
+        return Err(format!(
+            "{} is a directory; choose another report output path.",
+            report_path.display()
+        ));
+    }
+
+    if repopilot_dir.is_file() {
+        return Err(format!(
+            "{} is a file; RepoPilot needs a directory for receipt output.",
+            repopilot_dir.display()
+        ));
+    }
+
+    if receipt_path.is_dir() {
+        return Err(format!(
+            "{} is a directory; choose another receipt output path.",
+            receipt_path.display()
+        ));
+    }
+
+    Ok(format!(
+        "Default adoption outputs are available: `{REPORT_FILE_PATH}` and `{RECEIPT_FILE_PATH}`."
+    ))
+}
+
 fn has_ci_config(root: &Path, github_workflows_dir: &Path) -> bool {
     has_github_workflows(github_workflows_dir)
         || root.join(".gitlab-ci.yml").is_file()
         || root.join("azure-pipelines.yml").is_file()
         || root.join(".circleci").join("config.yml").is_file()
         || root.join("Jenkinsfile").is_file()
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RepopilotCiDetection {
+    has_repopilot: bool,
+    has_gate: bool,
+    path: Option<PathBuf>,
+}
+
+fn detect_repopilot_ci_config(root: &Path, github_workflows_dir: &Path) -> RepopilotCiDetection {
+    let mut integration_only = RepopilotCiDetection::default();
+
+    for path in ci_candidate_paths(root, github_workflows_dir) {
+        let Ok(contents) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let lower = contents.to_ascii_lowercase();
+
+        if !lower.contains("repopilot") {
+            continue;
+        }
+
+        let detection = RepopilotCiDetection {
+            has_repopilot: true,
+            has_gate: lower.contains("--fail-on")
+                || lower.contains("fail-on:")
+                || lower.contains("fail_on:"),
+            path: Some(path),
+        };
+
+        if detection.has_gate {
+            return detection;
+        }
+
+        if !integration_only.has_repopilot {
+            integration_only = detection;
+        }
+    }
+
+    integration_only
+}
+
+fn ci_candidate_paths(root: &Path, github_workflows_dir: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(github_workflows_dir) {
+        paths.extend(
+            entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|path| {
+                    path.is_file()
+                        && path
+                            .extension()
+                            .and_then(|extension| extension.to_str())
+                            .is_some_and(|extension| matches!(extension, "yml" | "yaml"))
+                }),
+        );
+    }
+
+    for path in [
+        root.join(".gitlab-ci.yml"),
+        root.join("azure-pipelines.yml"),
+        root.join(".circleci").join("config.yml"),
+        root.join("Jenkinsfile"),
+    ] {
+        if path.is_file() {
+            paths.push(path);
+        }
+    }
+
+    paths
 }
 
 fn has_github_workflows(workflows_dir: &Path) -> bool {
@@ -501,12 +781,91 @@ mod tests {
     }
 
     #[test]
+    fn detects_generic_ci_without_repopilot_gate() {
+        let dir = tempdir().expect("tempdir should be created");
+        let workflows = dir.path().join(".github").join("workflows");
+        fs::create_dir_all(&workflows).expect("workflow dir should be created");
+        fs::write(
+            workflows.join("ci.yml"),
+            "name: CI\njobs:\n  test:\n    runs-on: ubuntu-latest\n",
+        )
+        .expect("workflow should be written");
+
+        let detection = detect_repopilot_ci_config(dir.path(), &workflows);
+        let check = check_repopilot_ci(&detection, true);
+
+        assert!(!detection.has_repopilot);
+        assert_eq!(check.status, DoctorStatus::Warn);
+        assert_eq!(check.id, "repopilot_ci");
+    }
+
+    #[test]
+    fn detects_repopilot_ci_gate() {
+        let dir = tempdir().expect("tempdir should be created");
+        let workflows = dir.path().join(".github").join("workflows");
+        fs::create_dir_all(&workflows).expect("workflow dir should be created");
+        fs::write(
+            workflows.join("repopilot.yml"),
+            "name: RepoPilot\njobs:\n  scan:\n    steps:\n      - run: repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high\n",
+        )
+        .expect("workflow should be written");
+
+        let detection = detect_repopilot_ci_config(dir.path(), &workflows);
+        let check = check_repopilot_ci(&detection, true);
+
+        assert!(detection.has_repopilot);
+        assert!(detection.has_gate);
+        assert_eq!(check.status, DoctorStatus::Pass);
+    }
+
+    #[test]
+    fn flags_invalid_baseline_as_unreadable() {
+        let dir = tempdir().expect("tempdir should be created");
+        let baseline_dir = dir.path().join(".repopilot");
+        fs::create_dir(&baseline_dir).expect("baseline dir should be created");
+        let baseline_path = baseline_dir.join("baseline.json");
+        fs::write(&baseline_path, "{").expect("baseline should be written");
+
+        let check = check_baseline_readable(&baseline_path);
+
+        assert_eq!(check.status, DoctorStatus::Fail);
+        assert_eq!(check.id, "baseline_readable");
+    }
+
+    #[test]
+    fn flags_invalid_config_as_unreadable() {
+        let dir = tempdir().expect("tempdir should be created");
+        let config_path = dir.path().join("repopilot.toml");
+        fs::write(&config_path, "[scan").expect("config should be written");
+
+        let check = check_config_readable(&config_path);
+
+        assert_eq!(check.status, DoctorStatus::Fail);
+        assert_eq!(check.id, "config_readable");
+    }
+
+    #[test]
+    fn report_and_receipt_paths_are_ready_by_default() {
+        let dir = tempdir().expect("tempdir should be created");
+
+        let check = check_report_receipt_readiness(dir.path());
+
+        assert_eq!(check.status, DoctorStatus::Pass);
+        assert!(check.detail.contains(RECEIPT_FILE_PATH));
+    }
+
+    #[test]
     fn next_steps_start_with_init_when_config_is_missing() {
         let steps = build_next_steps(Path::new("."), false, false, false, 1);
 
         assert_eq!(
             steps.first().map(|step| step.command.as_str()),
             Some("repopilot init")
+        );
+        assert!(
+            steps
+                .iter()
+                .any(|step| step.command.contains("--receipt .repopilot/receipt.json"))
         );
         assert!(
             steps

--- a/src/output/harden.rs
+++ b/src/output/harden.rs
@@ -60,13 +60,21 @@ pub fn render(summary: &ScanSummary, opts: &HardenOptions) -> String {
             current_priority = Some(priority);
         }
 
-        let mut item = String::new();
-        render_cluster_plan(&mut item, cluster, index + 1);
-        if index > 0 && out.len().saturating_sub(content_start) + item.len() > budget_chars {
-            let _ = writeln!(out, "\n*[Plan truncated to stay within token budget]*");
+        let len_before = out.len();
+        render_cluster_plan(&mut out, cluster, index + 1);
+        let content_used = out.len().saturating_sub(content_start);
+        if content_used > budget_chars {
+            if index == 0 {
+                let _ = writeln!(
+                    out,
+                    "\n*[Single cluster exceeds token budget — output may be long]*"
+                );
+            } else {
+                out.truncate(len_before);
+                let _ = writeln!(out, "\n*[Plan truncated to stay within token budget]*");
+            }
             break;
         }
-        out.push_str(&item);
     }
 
     render_verification(&mut out);
@@ -87,9 +95,13 @@ fn render_summary(out: &mut String, findings: &[&Finding]) {
         .iter()
         .filter(|finding| finding.severity == Severity::Medium)
         .count();
+    let low = findings
+        .iter()
+        .filter(|finding| finding.severity == Severity::Low)
+        .count();
     let _ = writeln!(
         out,
-        "## Priority Summary\n\n- Total: {} findings\n- Critical: {critical}\n- High: {high}\n- Medium: {medium}",
+        "## Priority Summary\n\n- Total: {} findings\n- Critical: {critical}\n- High: {high}\n- Medium: {medium}\n- Low: {low}",
         findings.len()
     );
 }

--- a/src/output/prompt.rs
+++ b/src/output/prompt.rs
@@ -50,11 +50,15 @@ pub fn render(summary: &ScanSummary, opts: &PromptOptions) -> String {
     );
     let _ = writeln!(out, "## RepoPilot Context\n");
 
+    const PROMPT_PREFIX_OVERHEAD_TOKENS: usize = 200;
+    let vibe_budget = opts
+        .budget_tokens
+        .saturating_sub(PROMPT_PREFIX_OVERHEAD_TOKENS);
     let vibe = render_vibe(
         summary,
         &VibeOptions {
             focus: opts.focus.clone(),
-            budget_tokens: opts.budget_tokens,
+            budget_tokens: vibe_budget,
             no_header: false,
         },
     );

--- a/src/output/vibe/header.rs
+++ b/src/output/vibe/header.rs
@@ -81,7 +81,7 @@ pub(super) fn risk_level(findings: &[&Finding]) -> &'static str {
         "Elevated" => "🟠 ELEVATED",
         "Moderate" => "🟡 MODERATE",
         "Low" => "🟢 LOW",
-        _ => "🟢 CLEAN",
+        "Clean" | _ => "🟢 CLEAN",
     }
 }
 
@@ -93,13 +93,17 @@ fn build_tech_stack(summary: &ScanSummary) -> Vec<String> {
         .collect();
 
     if let Some(rn) = &summary.react_native {
-        let new_arch = match (
+        let archs = [
             rn.android_new_arch_enabled,
             rn.ios_new_arch_enabled,
             rn.expo_new_arch_enabled,
-        ) {
-            (Some(true), _, _) | (_, Some(true), _) | (_, _, Some(true)) => " (New Arch)",
-            (Some(false), _, _) | (_, Some(false), _) => " (Old Arch)",
+        ];
+        let new_count = archs.iter().filter(|v| **v == Some(true)).count();
+        let old_count = archs.iter().filter(|v| **v == Some(false)).count();
+        let new_arch = match (new_count > 0, old_count > 0) {
+            (true, true) => " (Mixed Arch)",
+            (true, false) => " (New Arch)",
+            (false, true) => " (Old Arch)",
             _ => "",
         };
 

--- a/src/output/vibe/header.rs
+++ b/src/output/vibe/header.rs
@@ -81,7 +81,8 @@ pub(super) fn risk_level(findings: &[&Finding]) -> &'static str {
         "Elevated" => "🟠 ELEVATED",
         "Moderate" => "🟡 MODERATE",
         "Low" => "🟢 LOW",
-        "Clean" | _ => "🟢 CLEAN",
+        "Clean" => "🟢 CLEAN",
+        _ => "🟢 CLEAN",
     }
 }
 

--- a/src/receipt/builder.rs
+++ b/src/receipt/builder.rs
@@ -1,11 +1,14 @@
 use crate::findings::types::Severity;
 use crate::receipt::git::collect_git_receipt;
-use crate::receipt::model::{AuditReceipt, ReceiptFindings, ReceiptLanguage, ReceiptScope};
+use crate::receipt::model::{
+    AUDIT_RECEIPT_SCHEMA_VERSION, AuditReceipt, ReceiptFindings, ReceiptLanguage, ReceiptScope,
+};
 use crate::scan::types::ScanSummary;
 use chrono::Utc;
 
 pub fn build_audit_receipt(summary: &ScanSummary) -> AuditReceipt {
     AuditReceipt {
+        schema_version: AUDIT_RECEIPT_SCHEMA_VERSION,
         tool: "repopilot".to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
         generated_at: Utc::now().to_rfc3339(),

--- a/src/receipt/model.rs
+++ b/src/receipt/model.rs
@@ -1,7 +1,10 @@
 use serde::Serialize;
 
+pub const AUDIT_RECEIPT_SCHEMA_VERSION: u32 = 1;
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AuditReceipt {
+    pub schema_version: u32,
     pub tool: String,
     pub version: String,
     pub generated_at: String,

--- a/tests/action_yml.rs
+++ b/tests/action_yml.rs
@@ -1,0 +1,15 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn action_exposes_typed_receipt_input_and_output() {
+    let action_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("action.yml");
+    let action = fs::read_to_string(action_path).expect("read action.yml");
+
+    assert!(action.contains("receipt:"));
+    assert!(action.contains("receipt-file:"));
+    assert!(action.contains("RECEIPT=\"${{ inputs.receipt }}\""));
+    assert!(action.contains("Receipt output is only supported by 'scan'"));
+    assert!(action.contains("RUN_ARGS+=(--receipt \"$RECEIPT\")"));
+    assert!(action.contains("receipt_file=$RECEIPT"));
+}

--- a/tests/cli_stabilization.rs
+++ b/tests/cli_stabilization.rs
@@ -190,11 +190,19 @@ fn exit_codes_distinguish_findings_usage_and_runtime_errors() {
 #[test]
 fn self_audit_stays_clean_at_high_severity() {
     let repo = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let output = run_ok(&["scan", ".", "--min-severity", "high"], repo);
-    let report = stdout(&output);
-
-    assert!(
-        report.contains("Findings: 0") || report.contains("Findings: 0 "),
-        "self-audit high severity should stay clean\n{report}"
+    let output = run_ok(
+        &["scan", ".", "--min-severity", "high", "--format", "json"],
+        repo,
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("json output from self-audit");
+    let finding_count = json["findings"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(usize::MAX);
+    assert_eq!(
+        finding_count,
+        0,
+        "self-audit high severity should stay clean\n{}",
+        serde_json::to_string_pretty(&json).unwrap_or_default()
     );
 }

--- a/tests/doctor_cli.rs
+++ b/tests/doctor_cli.rs
@@ -106,3 +106,64 @@ fn doctor_marks_empty_scope_as_failed_check() {
             .any(|check| { check["id"] == "scan_scope" && check["status"] == "fail" })
     );
 }
+
+#[test]
+fn doctor_reports_invalid_config_without_aborting() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+
+    fs::write(root.join("repopilot.toml"), "[scan").expect("write invalid config");
+    fs::write(root.join("main.rs"), "fn main() {}\n").expect("write file");
+
+    let output = repopilot()
+        .args(["doctor", ".", "--format", "json"])
+        .current_dir(root)
+        .output()
+        .expect("run doctor");
+
+    assert!(
+        output.status.success(),
+        "doctor should render diagnostics even with invalid config, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    let checks = json["checks"].as_array().expect("checks array");
+
+    assert!(
+        checks
+            .iter()
+            .any(|check| { check["id"] == "config_readable" && check["status"] == "fail" })
+    );
+}
+
+#[test]
+fn doctor_reports_invalid_baseline() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+
+    fs::write(root.join("main.rs"), "fn main() {}\n").expect("write file");
+    fs::create_dir(root.join(".repopilot")).expect("create repopilot dir");
+    fs::write(root.join(".repopilot").join("baseline.json"), "{").expect("write invalid baseline");
+
+    let output = repopilot()
+        .args(["doctor", ".", "--format", "json"])
+        .current_dir(root)
+        .output()
+        .expect("run doctor");
+
+    assert!(
+        output.status.success(),
+        "doctor should render diagnostics even with invalid baseline, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    let checks = json["checks"].as_array().expect("checks array");
+
+    assert!(
+        checks
+            .iter()
+            .any(|check| { check["id"] == "baseline_readable" && check["status"] == "fail" })
+    );
+}

--- a/tests/receipt_cli.rs
+++ b/tests/receipt_cli.rs
@@ -43,6 +43,7 @@ fn scan_writes_audit_receipt_json() {
     let receipt: Value = serde_json::from_slice(&fs::read(receipt_path).expect("read receipt"))
         .expect("valid receipt json");
 
+    assert_eq!(receipt["schema_version"], 1);
     assert_eq!(receipt["tool"], "repopilot");
     assert!(receipt["version"].as_str().is_some());
     assert!(receipt["generated_at"].as_str().is_some());


### PR DESCRIPTION
## Summary

This PR prepares RepoPilot `v0.10.0` as an adoption workflow release.

It improves the first-run path from local repository readiness checks to scan reports, audit receipts, baselines, CI gates, and AI context generation.

The main user-facing addition is audit receipt generation through `repopilot scan --receipt`, plus stronger `doctor` checks that guide users toward a complete RepoPilot rollout.

## Type of change

- [x] Feature
- [x] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [x] CI / repository maintenance
- [x] Release preparation

## What changed

- Bumped RepoPilot version to `0.10.0` in:
  - `Cargo.toml`
  - `Cargo.lock`
  - `package.json`
- Added audit receipt generation for scans through:

  ```bash
  repopilot scan . --receipt .repopilot/receipt.json
  ```
- Added schema_version: 1 to audit receipt JSON.
- Updated scan smoke checks to generate and validate receipt output.
- Improved repopilot doctor with adoption-readiness checks for:

  - readable repopilot.toml
  - readable .repopilot/baseline.json
  - generic CI detection
  - RepoPilot-specific CI gate detection
  - default report path readiness
  - default receipt path readiness

- Improved doctor behavior so invalid config diagnostics can be reported without aborting the whole doctor output.
- Added typed GitHub Action support for scan receipts:

  - receipt input
  - receipt-file output

- Added validation so receipt is only accepted for command: scan.
- Updated documentation for:

  - scan receipt usage
  - GitHub Action receipt artifacts
  - doctor adoption flow
  - report schema docs
  - command reference
  - README examples

- Added docs/release-checklist-0.10.md.
- Updated release documentation and changelog for v0.10.0.
- Updated tests for:

  - doctor invalid config handling
  - baseline readability handling
  - action receipt input/output exposure
  - scan receipt generation
  - source test directory detection for both tests/ and __tests__/

## Why

RepoPilot should be easy to adopt in real repositories.

Before this PR, users could scan a repository, but the rollout path was less explicit:

> 
init -> scan -> baseline -> CI gate -> AI context

This PR makes that workflow clearer and more reproducible.

Audit receipts are especially useful for CI, releases, and audit trails because they provide compact evidence of:

  - RepoPilot version
  - scan time
  - git branch / commit / dirty state
  - scan scope
  - finding counts
  - language counts
  - health score

Receipts do not replace full reports. They give teams a lightweight artifact they can upload, store, or attach to release verification.

## Architecture notes
- No god files introduced.
- Receipt generation stays part of scan/report output behavior.
- Doctor readiness checks remain isolated in doctor-related logic.
- GitHub Action receipt support is exposed through typed inputs instead of requiring raw args.
- Existing scan output formats remain compatible.
- Audit receipt JSON has its own schema version.
- Runtime behavior remains local-first:

  - no source code upload
  - no telemetry
  - receipt files are written only to explicit local paths

## Changelog

- Added v0.10.0 changelog entry.
- Updated [Unreleased] comparison link to start from v0.10.0.
- Added comparison link for v0.10.0.

## Verification

Run from repository root:

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

npm test
npm pack --dry-run

./scripts/verify-release.sh
./scripts/smoke-product.sh --keep-tmp
```

```
cargo run -- --version
cargo run -- doctor . --format markdown --output /tmp/repopilot-doctor.md
cargo run -- scan . --format markdown --output /tmp/repopilot-report.md --receipt /tmp/repopilot-receipt.json
cargo run -- baseline create . --output /tmp/repopilot-baseline-source.json --force
cargo run -- scan . --baseline /tmp/repopilot-baseline-source.json --fail-on new-high --format json --output /tmp/repopilot-baseline.json
cargo run -- ai context . --budget 4k --output /tmp/repopilot-context.md
```