### PR TITLE
feat(audits): add context-aware confidence to long function and Rust panic checks

### DIFF
--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -145,12 +145,26 @@ Files with fewer than 10 non-empty LOC are skipped. Supported languages: Rust, G
 | Field | Value |
 |---|---|
 | Category | `CODE_QUALITY` |
-| Severity | `MEDIUM` |
-| Default threshold | 50 lines per function body |
+| Severity | Context-aware: usually `MEDIUM`; `LOW` in React components/hooks, tests, controllers, and framework lifecycle code |
+| Confidence | Context-aware: usually `HIGH` for production functions; `LOW` when file role makes length more likely to be acceptable noise |
+| Default threshold | 50 lines per function body, expanded for roles such as React components/hooks and framework lifecycle methods |
 | Config key | `[architecture] max_function_lines` |
-| Description | A function body exceeds the configured line threshold. Long functions are harder to test, review, and reason about — consider extracting helpers or splitting logic into smaller units. |
+| Description | A function body exceeds the context-aware threshold. Findings explain why confidence is high or low for the detected file role, then recommend splitting only when responsibilities are mixed. |
 
-Supported languages: Rust, Go, Python, TypeScript, JavaScript.
+Examples: a long Rust production function is usually `severity: MEDIUM`, `confidence: HIGH`; a very long React component can be `severity: LOW`, `confidence: LOW` because JSX, hooks, and layout markup often make component files longer without necessarily mixing responsibilities.
+
+Supported languages: Rust, Go, Python, TypeScript, JavaScript, Java, Kotlin, C#.
+
+### `language.rust.panic-risk`
+
+| Field | Value |
+|---|---|
+| Category | `CODE_QUALITY` |
+| Severity | Context-aware: `MEDIUM` for `unwrap()`, `expect()`, and `panic!`; `HIGH` for placeholders and upgraded domain/library panics; `LOW` at acceptable test/CLI boundaries |
+| Confidence | Context-aware: `HIGH` in reusable production/library/domain code; `LOW` for test scaffolding and some CLI boundary fail-fast paths |
+| Description | Rust panic-style operations (`unwrap()`, `expect()`, `panic!`, `todo!`, `unimplemented!`) can terminate execution or hide recoverable errors. Findings explain the detected context and why the confidence score was chosen. |
+
+Suggested action is signal-specific. For production `unwrap()`, return `Result` or propagate with `?`; convert to `expect()` only when failure is impossible and the message documents the invariant.
 
 ### `architecture.excessive-fan-out`
 

--- a/src/audits/code_quality/long_function/mod.rs
+++ b/src/audits/code_quality/long_function/mod.rs
@@ -20,6 +20,7 @@ pub(super) struct LongFunctionPolicy {
     pub severity: Severity,
     pub confidence: Confidence,
     pub context_label: &'static str,
+    pub confidence_reason: &'static str,
     pub recommendation: &'static str,
 }
 
@@ -73,6 +74,7 @@ fn long_function_policy(context: &AuditContext, base_threshold: usize) -> LongFu
             severity: Severity::Info,
             confidence: Confidence::Low,
             context_label: "configuration file",
+            confidence_reason: "configuration files often encode declarative setup rather than executable business logic",
             recommendation: "Configuration files are not evaluated with the generic long-function threshold.",
         };
     }
@@ -83,7 +85,8 @@ fn long_function_policy(context: &AuditContext, base_threshold: usize) -> LongFu
             severity: Severity::Low,
             confidence: Confidence::Low,
             context_label: "React component",
-            recommendation: "For large React components, prefer extracting child components, hooks, or view-model helpers instead of treating JSX layout as a regular long function.",
+            confidence_reason: "JSX, hooks, and layout markup often make component files longer without implying mixed responsibilities",
+            recommendation: "Split only if state, effects, rendering, or data-shaping concerns are mixed. Prefer extracting child components, hooks, or view-model helpers at clear boundaries.",
         };
     }
 
@@ -93,6 +96,7 @@ fn long_function_policy(context: &AuditContext, base_threshold: usize) -> LongFu
             severity: Severity::Low,
             confidence: Confidence::Low,
             context_label: "React hook",
+            confidence_reason: "hooks often combine state and effect orchestration that can be longer than a pure helper function",
             recommendation: "For large hooks, consider splitting state/effect orchestration from data mapping or side-effect helpers.",
         };
     }
@@ -104,6 +108,7 @@ fn long_function_policy(context: &AuditContext, base_threshold: usize) -> LongFu
             severity: Severity::Low,
             confidence: Confidence::Low,
             context_label: "Unity MonoBehaviour",
+            confidence_reason: "engine lifecycle methods can accumulate setup and event wiring that is not always business logic",
             recommendation: "For large Unity behaviours, consider moving domain logic out of lifecycle methods and into smaller services or components.",
         };
     }
@@ -114,6 +119,7 @@ fn long_function_policy(context: &AuditContext, base_threshold: usize) -> LongFu
             severity: Severity::Low,
             confidence: Confidence::Low,
             context_label: ".NET controller",
+            confidence_reason: "controller actions often include request/response wiring that can be longer than domain logic",
             recommendation: "For large controllers, prefer moving business logic into services, handlers, or application-layer use cases.",
         };
     }
@@ -124,6 +130,7 @@ fn long_function_policy(context: &AuditContext, base_threshold: usize) -> LongFu
             severity: Severity::Medium,
             confidence: Confidence::High,
             context_label: ".NET service",
+            confidence_reason: "service classes usually carry reusable production orchestration where long methods signal mixed responsibilities",
             recommendation: "For large services, consider splitting orchestration, validation, persistence, and external integration logic.",
         };
     }
@@ -134,6 +141,7 @@ fn long_function_policy(context: &AuditContext, base_threshold: usize) -> LongFu
             severity: Severity::Low,
             confidence: Confidence::Low,
             context_label: "test code",
+            confidence_reason: "tests often include setup and assertions that are naturally longer than production helpers",
             recommendation: "For large tests, consider extracting builders, fixtures, or assertion helpers, but test setup can be naturally longer than production logic.",
         };
     }
@@ -144,6 +152,7 @@ fn long_function_policy(context: &AuditContext, base_threshold: usize) -> LongFu
             severity: Severity::Medium,
             confidence: Confidence::High,
             context_label: "Rust production code",
+            confidence_reason: "production Rust functions are usually explicit control-flow units where length increases review and error-handling risk",
             recommendation: "Consider extracting smaller functions or methods to isolate parsing, validation, IO, or transformation steps.",
         };
     }
@@ -153,7 +162,8 @@ fn long_function_policy(context: &AuditContext, base_threshold: usize) -> LongFu
         severity: Severity::Medium,
         confidence: Confidence::High,
         context_label: "generic production code",
-        recommendation: "Long functions are harder to test and reason about — consider extracting helper functions.",
+        confidence_reason: "production functions that exceed the threshold are more likely to mix responsibilities",
+        recommendation: "Long functions are harder to test and reason about; consider extracting helper functions.",
     }
 }
 
@@ -183,7 +193,9 @@ fn build_finding(
         recommendation: policy.recommendation.to_string(),
         title,
         description: format!(
-            "Function {name_display} spans {fn_len} lines, exceeding the context-aware {threshold}-line threshold for {context_label}. Large functions are harder to review, test, and safely change.",
+            "This is a long function in {context_label}; confidence is {confidence} because {confidence_reason}. Function {name_display} spans {fn_len} lines, exceeding the context-aware {threshold}-line threshold. Large functions are harder to review, test, and safely change.",
+            confidence = policy.confidence.label(),
+            confidence_reason = policy.confidence_reason,
             threshold = policy.threshold,
             context_label = policy.context_label,
         ),
@@ -254,6 +266,12 @@ mod tests {
         assert_eq!(findings[0].severity, Severity::Low);
         assert_eq!(findings[0].confidence, Confidence::Low);
         assert!(findings[0].title.contains("React component"));
+        assert!(
+            findings[0]
+                .description
+                .contains("confidence is LOW because JSX")
+        );
+        assert!(findings[0].recommendation.contains("Split only if state"));
     }
 
     #[test]

--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -1,7 +1,7 @@
 use crate::audits::code_quality::sanitize::sanitize_c_style;
 use crate::audits::context::{FileRole, LanguageKind, RuntimeKind, classify_file};
 use crate::audits::traits::FileAudit;
-use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use crate::knowledge::decision::decide_for_audit_context;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
@@ -142,6 +142,8 @@ fn build_finding(
 ) -> Finding {
     let context_label = context_label(context);
     let recommendation = recommendation_for(context, pattern);
+    let confidence = confidence_for(context, pattern, severity);
+    let confidence_reason = confidence_reason_for(context, pattern);
 
     Finding {
         id: String::new(),
@@ -149,13 +151,15 @@ fn build_finding(
         recommendation: recommendation.to_string(),
         title: format!("Risky Rust {} usage in {}", pattern.label(), context_label),
         description: format!(
-            "Rust `{}` was found in {}. Unhandled panic paths can terminate execution or hide recoverable errors in production code.",
+            "Rust `{}` was found in {}; confidence is {} because {}. Unhandled panic paths can terminate execution or hide recoverable errors in production code.",
             pattern.label(),
             context_label,
+            confidence.label(),
+            confidence_reason,
         ),
         category: FindingCategory::CodeQuality,
         severity,
-        confidence: Default::default(),
+        confidence,
         evidence: vec![Evidence {
             path: file.path.clone(),
             line_start: line_number,
@@ -187,6 +191,81 @@ fn context_label(context: &crate::audits::context::AuditContext) -> &'static str
     "Rust production code"
 }
 
+fn confidence_for(
+    context: &crate::audits::context::AuditContext,
+    pattern: RustPanicPattern,
+    severity: Severity,
+) -> Confidence {
+    if context.is_test {
+        return Confidence::Low;
+    }
+
+    if matches!(
+        pattern,
+        RustPanicPattern::Todo | RustPanicPattern::Unimplemented
+    ) {
+        return Confidence::High;
+    }
+
+    if context.has_runtime(RuntimeKind::RustCli) {
+        return match pattern {
+            RustPanicPattern::Unwrap | RustPanicPattern::Expect => Confidence::Low,
+            RustPanicPattern::Panic => Confidence::Medium,
+            RustPanicPattern::Todo | RustPanicPattern::Unimplemented => Confidence::High,
+        };
+    }
+
+    if context.has_role(FileRole::Domain) || context.has_runtime(RuntimeKind::RustLibrary) {
+        return Confidence::High;
+    }
+
+    match severity {
+        Severity::High | Severity::Critical => Confidence::High,
+        Severity::Info | Severity::Low => Confidence::Low,
+        Severity::Medium => Confidence::Medium,
+    }
+}
+
+fn confidence_reason_for(
+    context: &crate::audits::context::AuditContext,
+    pattern: RustPanicPattern,
+) -> &'static str {
+    if context.is_test {
+        return "test code often uses panic-style macros for assertion setup or unfinished test scaffolding";
+    }
+
+    if matches!(
+        pattern,
+        RustPanicPattern::Todo | RustPanicPattern::Unimplemented
+    ) {
+        return "placeholder macros always panic if this path is reached";
+    }
+
+    if context.has_runtime(RuntimeKind::RustCli) {
+        return match pattern {
+            RustPanicPattern::Unwrap | RustPanicPattern::Expect => {
+                "CLI boundary code may intentionally fail fast, but user-facing errors are usually better"
+            }
+            RustPanicPattern::Panic => {
+                "CLI boundary code can terminate the process intentionally, but panic output is rarely a good user-facing error"
+            }
+            RustPanicPattern::Todo | RustPanicPattern::Unimplemented => {
+                "placeholder macros always panic if this path is reached"
+            }
+        };
+    }
+
+    if context.has_role(FileRole::Domain) {
+        return "domain code is usually reusable production logic, so callers cannot recover from this panic path";
+    }
+
+    if context.has_runtime(RuntimeKind::RustLibrary) {
+        return "library code is reused by callers, so panics become part of its public failure behavior";
+    }
+
+    "this is production Rust code and the panic path is not locally handled"
+}
+
 fn recommendation_for(
     context: &crate::audits::context::AuditContext,
     pattern: RustPanicPattern,
@@ -196,11 +275,18 @@ fn recommendation_for(
     }
 
     match pattern {
-        RustPanicPattern::Unwrap | RustPanicPattern::Expect => {
+        RustPanicPattern::Unwrap => {
             if context.has_runtime(RuntimeKind::RustCli) {
                 "At CLI boundaries this may be acceptable for prototype code, but prefer returning a user-friendly error with context."
             } else {
-                "Prefer propagating errors with `?`, returning `Result`, or converting the failure into a domain-specific error."
+                "Return `Result` or propagate with `?`; convert to `expect()` only when failure is impossible and the message documents the invariant."
+            }
+        }
+        RustPanicPattern::Expect => {
+            if context.has_runtime(RuntimeKind::RustCli) {
+                "At CLI boundaries this may be acceptable for prototype code, but prefer returning a user-friendly error with context."
+            } else {
+                "Prefer `Result`/`?` for recoverable errors. Keep `expect()` only for impossible states, with a message that names the invariant."
             }
         }
         RustPanicPattern::Panic => {
@@ -244,7 +330,14 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].rule_id, RULE_ID);
         assert_eq!(findings[0].severity, Severity::Medium);
+        assert_eq!(findings[0].confidence, Confidence::High);
         assert!(findings[0].title.contains("unwrap()"));
+        assert!(
+            findings[0]
+                .description
+                .contains("confidence is HIGH because")
+        );
+        assert!(findings[0].recommendation.contains("Return `Result`"));
     }
 
     #[test]
@@ -285,6 +378,7 @@ mod tests {
 
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].severity, Severity::Low);
+        assert_eq!(findings[0].confidence, Confidence::Low);
         assert!(findings[0].description.contains("CLI boundary"));
     }
 
@@ -339,6 +433,7 @@ mod tests {
 
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].severity, Severity::Medium);
+        assert_eq!(findings[0].confidence, Confidence::High);
         assert!(findings[0].title.contains("expect()"));
         assert!(findings[0].description.contains("Rust domain code"));
     }

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -297,6 +297,12 @@ fn render_finding(output: &mut String, finding: &Finding, status: Option<&str>) 
         )
         .unwrap();
     }
+    writeln!(
+        output,
+        "        Recommendation: {}",
+        first_sentence(finding.recommendation_or_default(), 180)
+    )
+    .unwrap();
     if let Some(url) = &finding.docs_url {
         writeln!(output, "        Docs: {url}").unwrap();
     }

--- a/src/output/html/finding.rs
+++ b/src/output/html/finding.rs
@@ -83,6 +83,18 @@ fn render_finding_card(finding: &Finding, status: Option<&str>) -> String {
             }
         })
         .unwrap_or_default();
+    let context = if finding.description.trim().is_empty() {
+        String::new()
+    } else {
+        format!(
+            r#"<p class="finding-meta"><strong>Context:</strong> {}</p>"#,
+            escape_html(finding.description.trim())
+        )
+    };
+    let recommendation = format!(
+        r#"<p class="finding-meta"><strong>Recommendation:</strong> {}</p>"#,
+        escape_html(finding.recommendation_or_default())
+    );
     let docs = finding
         .docs_url
         .as_ref()
@@ -102,6 +114,8 @@ fn render_finding_card(finding: &Finding, status: Option<&str>) -> String {
   {}
   {}
   {}
+  {}
+  {}
 </article>"#,
         finding.severity.lowercase_label(),
         finding.confidence.lowercase_label(),
@@ -115,6 +129,8 @@ fn render_finding_card(finding: &Finding, status: Option<&str>) -> String {
         escape_html(&finding.rule_id),
         location,
         evidence,
+        context,
+        recommendation,
         docs
     )
 }

--- a/src/output/vibe/findings.rs
+++ b/src/output/vibe/findings.rs
@@ -2,6 +2,7 @@ use crate::findings::types::{Finding, FindingCategory, Severity};
 use crate::output::finding_helpers::{
     finding_location, finding_location_key, finding_recommendation,
 };
+use crate::output::report_text::first_sentence;
 use crate::output::vibe::budget::{CategoryAllocation, allocate_categories, category_weight};
 use std::fmt::Write as FmtWrite;
 
@@ -178,6 +179,16 @@ pub(super) fn render_finding_entry(
                 let _ = writeln!(out, "```\n{snippet}\n```");
             }
         }
+    }
+
+    let _ = writeln!(out, "> **Confidence:** {}", finding.confidence.label());
+
+    if !finding.description.trim().is_empty() {
+        let _ = writeln!(
+            out,
+            "> **Context:** {}",
+            first_sentence(&finding.description, 220)
+        );
     }
 
     let _ = writeln!(out, "> **Fix:** {}", finding_recommendation(finding));

--- a/src/output/vibe/tests.rs
+++ b/src/output/vibe/tests.rs
@@ -142,6 +142,29 @@ fn focus_quality_includes_testing_and_code_quality() {
 }
 
 #[test]
+fn finding_entries_include_context_confidence_and_fix() {
+    let findings = vec![make_finding(
+        "code-quality.long-function",
+        "Long React component",
+        Severity::Low,
+        FindingCategory::CodeQuality,
+        "src/Profile.tsx",
+        12,
+    )];
+    let summary = make_summary(findings);
+    let opts = VibeOptions {
+        no_header: true,
+        ..Default::default()
+    };
+
+    let output = render(&summary, &opts);
+
+    assert!(output.contains("> **Confidence:** MEDIUM"));
+    assert!(output.contains("> **Context:** Description for Long React component"));
+    assert!(output.contains("> **Fix:**"));
+}
+
+#[test]
 fn small_budget_renders_truncation_notice() {
     let findings: Vec<Finding> = (0..8)
         .map(|i| {

--- a/tests/output_console.rs
+++ b/tests/output_console.rs
@@ -44,6 +44,7 @@ fn console_output_includes_versioned_summary_and_grouped_findings() {
     assert!(output.contains("Security:"));
     assert!(output.contains("security.secret-candidate (1)"));
     assert!(output.contains("src/config.rs:7"));
+    assert!(output.contains("Recommendation:"));
 }
 
 #[test]

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -62,6 +62,8 @@ fn html_output_escapes_snippets_and_renders_summary() {
     assert!(html.contains("class=\"finding-group\""));
     assert!(html.contains("class=\"finding-card\""));
     assert!(html.contains("security.secret-candidate"));
+    assert!(html.contains("<strong>Context:</strong> description"));
+    assert!(html.contains("<strong>Recommendation:</strong>"));
     assert!(html.contains("API_KEY = &quot;abc&lt;123&gt;&quot;"));
     assert!(!html.contains("API_KEY = \"abc<123>\""));
 }


### PR DESCRIPTION
## Summary

This PR improves RepoPilot's context-aware audit reporting for long functions and Rust panic-risk findings.

Findings now explain not only what was detected, but also why RepoPilot assigned a specific confidence level based on file role, runtime, framework context, and production/test boundaries.

The PR also improves console, HTML, and AI context output so users and AI assistants can see both the finding context and the recommended fix more clearly.

## Type of change

- [x] Feature
- [x] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- Improved `code-quality.long-function` policy with explicit confidence reasons.
- Added context-aware long-function descriptions for:
  - React components
  - React hooks
  - Unity MonoBehaviour files
  - .NET controllers
  - .NET services
  - test files
  - config files
  - Rust production code
  - generic production code
- Improved long-function recommendations to avoid treating all long functions equally.
- Improved `language.rust.panic-risk` findings with context-aware confidence.
- Added confidence reasoning for Rust panic-style patterns:
  - `unwrap()`
  - `expect()`
  - `panic!`
  - `todo!`
  - `unimplemented!`
- Improved Rust panic-risk recommendations:
  - `unwrap()` now recommends `Result` / `?` for recoverable errors.
  - `expect()` is treated as acceptable only when documenting an impossible invariant.
  - CLI boundary panic-style usage receives lower confidence where fail-fast behavior may be intentional.
  - domain/library panic paths receive higher confidence because callers cannot recover.
- Updated console output to render finding recommendations.
- Updated HTML output to render finding context and recommendations.
- Updated AI context output to include:
  - confidence
  - context
  - fix recommendation
- Updated ruleset documentation for:
  - `code-quality.long-function`
  - `language.rust.panic-risk`
- Added tests for context-aware confidence, descriptions, recommendations, console output, HTML output, and AI context rendering.

## Why

RepoPilot should reduce false positives by explaining audit findings in context.

A long function in production Rust code is not the same as a long React component, test setup, controller action, or framework lifecycle method.

The same applies to Rust panic-style operations. `unwrap()` in reusable domain/library code is much riskier than some fail-fast CLI boundary code or test scaffolding.

This PR makes findings more useful by answering:

```text
What was found?
Where was it found?
How confident is RepoPilot?
Why is confidence high or low?
What should I do next?