### PR TITLE
feat: add explainable risk prioritization for findings

### DIFF
--- a/docs/reports.md
+++ b/docs/reports.md
@@ -11,11 +11,11 @@ repopilot scan . --format json --output repopilot-report.json
 
 ## JSON report schema
 
-Starting with RepoPilot 0.9, JSON scan reports include explicit schema metadata:
+JSON scan reports include explicit schema metadata. The current schema is 0.10:
 
 ```json
 {
-  "schema_version": "0.9",
+  "schema_version": "0.10",
   "repopilot_version": "0.10.0",
   "root_path": ".",
   "files_count": 42,
@@ -39,8 +39,8 @@ evolve the schema in a documented way.
 
 ### Compatibility
 
-RepoPilot 0.9 keeps the existing scan summary fields at the top level of the JSON
-document. The schema metadata is additive:
+RepoPilot keeps the existing scan summary fields at the top level of the JSON
+document. Schema metadata and finding risk assessments are additive:
 
 - existing consumers can continue reading fields such as `findings`,
   `files_count`, and `lines_of_code`;
@@ -64,7 +64,7 @@ Example shape:
 
 ```json
 {
-  "schema_version": "0.9",
+  "schema_version": "0.10",
   "repopilot_version": "0.10.0",
   "root_path": ".",
   "files_count": 42,
@@ -141,6 +141,7 @@ Every finding includes stable fields documented in [rulesets.md](rulesets.md):
 | `category` | string | Finding category. |
 | `severity` | string | One of `INFO`, `LOW`, `MEDIUM`, `HIGH`, or `CRITICAL`. |
 | `confidence` | string | One of `LOW`, `MEDIUM`, or `HIGH`; used to separate impact from certainty. |
+| `risk` | object | Explainable prioritization assessment with `score`, `priority`, stable `signals`, and `formula_version`. |
 | `docs_url` | string? | Optional documentation link for the rule. |
 | `workspace_package` | string? | Optional monorepo package name. |
 | `evidence` | array | One or more evidence locations. |

--- a/src/audits/architecture/barrel_file_risk.rs
+++ b/src/audits/architecture/barrel_file_risk.rs
@@ -135,6 +135,7 @@ fn build_finding(file: &FileFacts, stats: BarrelStats) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 

--- a/src/audits/architecture/deep_nesting.rs
+++ b/src/audits/architecture/deep_nesting.rs
@@ -50,5 +50,6 @@ fn build_finding(deepest_path: PathBuf, depth: usize, threshold: usize) -> Findi
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }

--- a/src/audits/architecture/deep_relative_imports.rs
+++ b/src/audits/architecture/deep_relative_imports.rs
@@ -131,6 +131,7 @@ fn build_finding(file: &FileFacts, line_number: usize, snippet: &str, depth: usi
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 

--- a/src/audits/architecture/import_coupling.rs
+++ b/src/audits/architecture/import_coupling.rs
@@ -79,6 +79,7 @@ fn excessive_fan_out_finding(metric: &FileMetrics, root: &Path, threshold: usize
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 
@@ -117,6 +118,7 @@ fn high_instability_hub_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 
@@ -152,6 +154,7 @@ fn circular_dependency_finding(cycle: &[PathBuf], root: &Path) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 

--- a/src/audits/architecture/large_file.rs
+++ b/src/audits/architecture/large_file.rs
@@ -48,6 +48,7 @@ pub fn detect_large_file_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     })
 }
 

--- a/src/audits/architecture/too_many_modules.rs
+++ b/src/audits/architecture/too_many_modules.rs
@@ -49,5 +49,6 @@ fn build_finding(dir: PathBuf, file_count: usize, threshold: usize) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }

--- a/src/audits/code_quality/code_markers.rs
+++ b/src/audits/code_quality/code_markers.rs
@@ -63,6 +63,7 @@ fn build_marker_finding(marker: &Marker) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 

--- a/src/audits/code_quality/complexity.rs
+++ b/src/audits/code_quality/complexity.rs
@@ -67,6 +67,7 @@ impl FileAudit for ComplexityAudit {
             }],
             workspace_package: None,
             docs_url: None,
+            risk: Default::default(),
         }]
     }
 }

--- a/src/audits/code_quality/language_risk.rs
+++ b/src/audits/code_quality/language_risk.rs
@@ -480,6 +480,7 @@ fn build_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 

--- a/src/audits/code_quality/long_function/mod.rs
+++ b/src/audits/code_quality/long_function/mod.rs
@@ -213,6 +213,7 @@ fn build_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 

--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -168,6 +168,7 @@ fn build_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 

--- a/src/audits/framework/django.rs
+++ b/src/audits/framework/django.rs
@@ -50,6 +50,7 @@ impl ProjectAudit for DjangoDebugTrueAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            risk: Default::default(),
                     });
                     break;
                 }
@@ -107,6 +108,7 @@ impl ProjectAudit for DjangoEmptyAllowedHostsAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            risk: Default::default(),
                     });
                     break;
                 }
@@ -170,6 +172,7 @@ impl ProjectAudit for DjangoRawSqlAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            risk: Default::default(),
                     });
                 }
             }

--- a/src/audits/framework/js_common.rs
+++ b/src/audits/framework/js_common.rs
@@ -63,6 +63,7 @@ impl ProjectAudit for VarDeclarationAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            risk: Default::default(),
                     };
                     if let Some(finding) =
                         apply_file_decision("framework.js.var-declaration", file, finding, None)
@@ -126,6 +127,7 @@ impl ProjectAudit for ConsoleLogAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            risk: Default::default(),
                     };
                     if let Some(finding) =
                         apply_file_decision("framework.js.console-log", file, finding, None)

--- a/src/audits/framework/react.rs
+++ b/src/audits/framework/react.rs
@@ -54,6 +54,7 @@ impl ProjectAudit for ReactClassComponentAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            risk: Default::default(),
                     });
                     break; // one finding per file
                 }
@@ -116,6 +117,7 @@ impl ProjectAudit for ReactPropTypesAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            risk: Default::default(),
                     });
                     break; // one finding per file
                 }

--- a/src/audits/framework/react_native/architecture.rs
+++ b/src/audits/framework/react_native/architecture.rs
@@ -41,6 +41,7 @@ impl ProjectAudit for ReactNativeOldArchAudit {
             }],
             workspace_package: None,
             docs_url: Some("https://reactnative.dev/docs/new-architecture-intro".to_string()),
+            risk: Default::default(),
         }]
     }
 }
@@ -82,6 +83,7 @@ impl ProjectAudit for ReactNativeArchitectureMismatchAudit {
             }],
             workspace_package: None,
             docs_url: None,
+            risk: Default::default(),
         }]
     }
 }
@@ -122,6 +124,7 @@ impl ProjectAudit for HermesMismatchAudit {
             }],
             workspace_package: None,
             docs_url: None,
+            risk: Default::default(),
         }]
     }
 }

--- a/src/audits/framework/react_native/async_storage.rs
+++ b/src/audits/framework/react_native/async_storage.rs
@@ -52,6 +52,7 @@ impl ProjectAudit for AsyncStorageFromCoreAudit {
                         "https://react-native-async-storage.github.io/async-storage/docs/install"
                             .to_string(),
                     ),
+                    risk: Default::default(),
                 });
             }
         }

--- a/src/audits/framework/react_native/hermes.rs
+++ b/src/audits/framework/react_native/hermes.rs
@@ -73,6 +73,7 @@ impl ProjectAudit for ReactNativeCodegenMissingAudit {
             }],
             workspace_package: None,
             docs_url: Some("https://reactnative.dev/docs/the-new-architecture/codegen".to_string()),
+            risk: Default::default(),
         }]
     }
 }
@@ -124,6 +125,7 @@ fn hermes_finding(path: PathBuf, snippet: &str) -> Finding {
         }],
         workspace_package: None,
         docs_url: Some("https://reactnative.dev/docs/hermes".to_string()),
+            risk: Default::default(),
     }
 }
 

--- a/src/audits/framework/react_native/navigation.rs
+++ b/src/audits/framework/react_native/navigation.rs
@@ -58,6 +58,7 @@ impl ProjectAudit for ReactNavigationV4Audit {
                         docs_url: Some(
                             "https://reactnavigation.org/docs/getting-started".to_string(),
                         ),
+                        risk: Default::default(),
                     });
                     break;
                 }
@@ -116,6 +117,7 @@ impl ProjectAudit for DirectStateMutationAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            risk: Default::default(),
                     });
                     break;
                 }

--- a/src/audits/framework/react_native/styling.rs
+++ b/src/audits/framework/react_native/styling.rs
@@ -52,6 +52,7 @@ impl ProjectAudit for RnInlineStyleAudit {
                         }],
                         workspace_package: None,
                         docs_url: Some("https://reactnative.dev/docs/stylesheet".to_string()),
+            risk: Default::default(),
                     });
                     break;
                 }
@@ -135,6 +136,7 @@ impl ProjectAudit for RnDeprecatedApiAudit {
                             docs_url: Some(
                                 "https://reactnative.dev/docs/out-of-tree-platforms".to_string(),
                             ),
+                            risk: Default::default(),
                         });
                         break;
                     }
@@ -200,6 +202,7 @@ impl ProjectAudit for RnFlatListMissingKeyAudit {
                             docs_url: Some(
                                 "https://reactnative.dev/docs/flatlist#keyextractor".to_string(),
                             ),
+                            risk: Default::default(),
                         });
                     }
                     i = window_end;

--- a/src/audits/framework/rn_dep_health.rs
+++ b/src/audits/framework/rn_dep_health.rs
@@ -42,6 +42,7 @@ impl ProjectAudit for RnDepHealthAudit {
                 }],
                 workspace_package: None,
                 docs_url: Some("https://react-native-async-storage.github.io/async-storage/docs/install".to_string()),
+            risk: Default::default(),
             });
         }
 
@@ -77,6 +78,7 @@ impl ProjectAudit for RnDepHealthAudit {
                     }],
                     workspace_package: None,
                     docs_url: Some("https://reactnavigation.org/docs/getting-started".to_string()),
+            risk: Default::default(),
                 });
             }
         }
@@ -114,6 +116,7 @@ impl ProjectAudit for RnDepHealthAudit {
                     }],
                     workspace_package: None,
                     docs_url: Some("https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation".to_string()),
+            risk: Default::default(),
                 });
             }
         }
@@ -150,6 +153,7 @@ impl ProjectAudit for RnDepHealthAudit {
                     }],
                     workspace_package: None,
                     docs_url: Some("https://docs.swmansion.com/react-native-gesture-handler/docs/installation".to_string()),
+            risk: Default::default(),
                 });
             }
         }
@@ -178,6 +182,7 @@ impl ProjectAudit for RnDepHealthAudit {
                         }],
                         workspace_package: None,
                         docs_url: Some("https://reactnative.dev/docs/new-architecture-intro".to_string()),
+            risk: Default::default(),
                     });
                 }
             }

--- a/src/audits/security/env_file_committed.rs
+++ b/src/audits/security/env_file_committed.rs
@@ -52,5 +52,6 @@ fn build_finding(path: &std::path::Path) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }

--- a/src/audits/security/private_key_candidate.rs
+++ b/src/audits/security/private_key_candidate.rs
@@ -89,5 +89,6 @@ fn build_finding(path: &std::path::Path, line_number: usize, header: &str) -> Fi
             "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html"
                 .to_string(),
         ),
+        risk: Default::default(),
     }
 }

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -241,6 +241,7 @@ fn build_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 

--- a/src/audits/testing/missing_test_folder.rs
+++ b/src/audits/testing/missing_test_folder.rs
@@ -40,6 +40,7 @@ impl ProjectAudit for MissingTestFolderAudit {
             }],
             workspace_package: None,
             docs_url: None,
+            risk: Default::default(),
         }]
     }
 }

--- a/src/audits/testing/source_without_test.rs
+++ b/src/audits/testing/source_without_test.rs
@@ -69,5 +69,6 @@ fn build_finding(source: &Path) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }

--- a/src/baseline/diff.rs
+++ b/src/baseline/diff.rs
@@ -1,6 +1,7 @@
 use crate::baseline::key::stable_finding_key;
 use crate::baseline::model::Baseline;
 use crate::findings::types::Finding;
+use crate::risk::apply_baseline_overlay;
 use crate::scan::types::ScanSummary;
 use serde::Serialize;
 use std::collections::HashSet;
@@ -70,7 +71,7 @@ impl BaselineScanReport {
 }
 
 pub fn diff_summary_against_baseline(
-    summary: ScanSummary,
+    mut summary: ScanSummary,
     baseline: &Baseline,
     baseline_path: PathBuf,
 ) -> BaselineScanReport {
@@ -80,7 +81,13 @@ pub fn diff_summary_against_baseline(
         .map(|finding| finding.key.clone())
         .collect::<HashSet<_>>();
 
-    let findings = status_findings(&summary, &baseline_keys);
+    let mut findings = status_findings(&summary, &baseline_keys);
+    apply_baseline_overlay(
+        &mut summary.findings,
+        &findings,
+        summary.root_path.as_path(),
+    );
+    sort_findings_with_status(&mut summary.findings, &mut findings);
 
     BaselineScanReport {
         summary,
@@ -89,8 +96,8 @@ pub fn diff_summary_against_baseline(
     }
 }
 
-pub fn all_findings_new(summary: ScanSummary) -> BaselineScanReport {
-    let findings = summary
+pub fn all_findings_new(mut summary: ScanSummary) -> BaselineScanReport {
+    let mut findings: Vec<FindingBaselineStatus> = summary
         .findings
         .iter()
         .map(|finding| FindingBaselineStatus {
@@ -98,6 +105,12 @@ pub fn all_findings_new(summary: ScanSummary) -> BaselineScanReport {
             status: BaselineStatus::New,
         })
         .collect();
+    apply_baseline_overlay(
+        &mut summary.findings,
+        &findings,
+        summary.root_path.as_path(),
+    );
+    sort_findings_with_status(&mut summary.findings, &mut findings);
 
     BaselineScanReport {
         summary,
@@ -126,6 +139,21 @@ fn status_findings(
             FindingBaselineStatus { key, status }
         })
         .collect()
+}
+
+fn sort_findings_with_status(
+    findings: &mut Vec<Finding>,
+    statuses: &mut Vec<FindingBaselineStatus>,
+) {
+    let mut paired = findings
+        .drain(..)
+        .zip(statuses.drain(..))
+        .collect::<Vec<_>>();
+    paired.sort_by(|(left, _), (right, _)| crate::risk::compare_findings(left, right));
+    for (finding, status) in paired {
+        findings.push(finding);
+        statuses.push(status);
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -14,6 +14,7 @@ use repopilot::findings::types::Finding;
 use repopilot::output::{render_baseline_scan_report, render_scan_summary};
 use repopilot::receipt::{build_audit_receipt, render_receipt_json};
 use repopilot::report::writer::write_report;
+use repopilot::risk::{apply_workspace_hotspot_overlay, sort_findings};
 use repopilot::scan::config::ScanConfig;
 use repopilot::scan::scanner::scan_path_with_config;
 use repopilot::scan::types::{LanguageSummary, ScanSummary};
@@ -185,6 +186,9 @@ fn scan_workspace(path: &Path, scan_config: &ScanConfig) -> Result<ScanSummary, 
     }
 
     deduplicate_workspace_findings(&mut merged.findings);
+    apply_workspace_hotspot_overlay(&mut merged.findings);
+    sort_findings(&mut merged.findings);
+    merged.health_score = ScanSummary::compute_health_score(&merged.findings, merged.lines_of_code);
     merged.scan_duration_us = wall_start.elapsed().as_micros() as u64;
     Ok(merged)
 }

--- a/src/findings/types.rs
+++ b/src/findings/types.rs
@@ -18,6 +18,8 @@ pub struct Finding {
     pub workspace_package: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub docs_url: Option<String>,
+    #[serde(default)]
+    pub risk: crate::risk::RiskAssessment,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,5 +27,6 @@ pub mod output;
 pub mod receipt;
 pub mod report;
 pub mod review;
+pub mod risk;
 pub mod rules;
 pub mod scan;

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -270,6 +270,16 @@ fn render_finding(output: &mut String, finding: &Finding, status: Option<&str>) 
     let severity = color::severity_label(finding.severity_label());
     writeln!(output, "      [{}] {}", severity, finding.title).unwrap();
     writeln!(output, "        Confidence: {}", finding.confidence_label()).unwrap();
+    writeln!(
+        output,
+        "        Priority: {} (risk {}/100)",
+        finding.risk.priority.label(),
+        finding.risk.score
+    )
+    .unwrap();
+    if let Some(reasons) = risk_reason_text(finding) {
+        writeln!(output, "        Risk signals: {reasons}").unwrap();
+    }
     if let Some(status) = status {
         writeln!(output, "        Baseline: {status}").unwrap();
     }
@@ -306,6 +316,19 @@ fn render_finding(output: &mut String, finding: &Finding, status: Option<&str>) 
     if let Some(url) = &finding.docs_url {
         writeln!(output, "        Docs: {url}").unwrap();
     }
+}
+
+fn risk_reason_text(finding: &Finding) -> Option<String> {
+    let reasons = finding
+        .risk
+        .signals
+        .iter()
+        .filter(|signal| !signal.id.starts_with("severity."))
+        .take(3)
+        .map(|signal| format!("{} ({:+})", signal.label, signal.weight))
+        .collect::<Vec<_>>();
+
+    (!reasons.is_empty()).then(|| reasons.join(", "))
 }
 
 fn workspace_risk_table(output: &mut String, findings: &[Finding]) {

--- a/src/output/finding_helpers.rs
+++ b/src/output/finding_helpers.rs
@@ -18,9 +18,7 @@ pub(crate) fn clusters_by_rule<'a>(findings: &'a [&'a Finding]) -> Vec<RuleClust
         .into_values()
         .filter_map(|mut group| {
             group.sort_by(|left, right| {
-                right
-                    .severity
-                    .cmp(&left.severity)
+                crate::risk::compare_findings(left, right)
                     .then_with(|| finding_location(left).cmp(&finding_location(right)))
             });
             let first = group.first().copied()?;

--- a/src/output/html/finding.rs
+++ b/src/output/html/finding.rs
@@ -95,6 +95,14 @@ fn render_finding_card(finding: &Finding, status: Option<&str>) -> String {
         r#"<p class="finding-meta"><strong>Recommendation:</strong> {}</p>"#,
         escape_html(finding.recommendation_or_default())
     );
+    let risk = format!(
+        r#"<p class="finding-meta"><strong>Priority:</strong> {} (risk {}/100){}</p>"#,
+        finding.risk.priority.label(),
+        finding.risk.score,
+        risk_reason_text(finding)
+            .map(|reasons| format!(" - {}", escape_html(&reasons)))
+            .unwrap_or_default()
+    );
     let docs = finding
         .docs_url
         .as_ref()
@@ -108,9 +116,10 @@ fn render_finding_card(finding: &Finding, status: Option<&str>) -> String {
         .unwrap_or_default();
 
     format!(
-        r#"<article class="finding-card" data-severity="{}" data-confidence="{}" data-category="{}" data-rule="{}">
-  <div class="finding-title"><span class="badge {}">{}</span><span class="badge confidence">confidence {}</span><strong>{}</strong>{}</div>
+        r#"<article class="finding-card" data-severity="{}" data-confidence="{}" data-priority="{}" data-category="{}" data-rule="{}">
+  <div class="finding-title"><span class="badge {}">{}</span><span class="badge confidence">confidence {}</span><span class="badge confidence">{}</span><strong>{}</strong>{}</div>
   <p class="finding-meta"><strong>Rule:</strong> <code>{}</code></p>
+  {}
   {}
   {}
   {}
@@ -119,11 +128,13 @@ fn render_finding_card(finding: &Finding, status: Option<&str>) -> String {
 </article>"#,
         finding.severity.lowercase_label(),
         finding.confidence.lowercase_label(),
+        finding.risk.priority.label(),
         finding.category.label(),
         escape_html(&finding.rule_id),
         finding.severity.lowercase_label(),
         finding.severity.label(),
         finding.confidence.label(),
+        finding.risk.priority.label(),
         escape_html(&finding.title),
         status,
         escape_html(&finding.rule_id),
@@ -131,8 +142,22 @@ fn render_finding_card(finding: &Finding, status: Option<&str>) -> String {
         evidence,
         context,
         recommendation,
+        risk,
         docs
     )
+}
+
+fn risk_reason_text(finding: &Finding) -> Option<String> {
+    let reasons = finding
+        .risk
+        .signals
+        .iter()
+        .filter(|signal| !signal.id.starts_with("severity."))
+        .take(3)
+        .map(|signal| format!("{} ({:+})", signal.label, signal.weight))
+        .collect::<Vec<_>>();
+
+    (!reasons.is_empty()).then(|| reasons.join(", "))
 }
 
 fn category_title(category: &FindingCategory) -> &'static str {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -5,7 +5,7 @@ use crate::scan::types::LanguageSummary;
 use crate::scan::types::ScanSummary;
 use serde::Serialize;
 
-pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.9";
+pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.10";
 pub const REPOPILOT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn render(summary: &ScanSummary) -> Result<String, serde_json::Error> {

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -302,6 +302,16 @@ fn render_finding_detail(output: &mut String, finding: &Finding, status: Option<
     )
     .unwrap();
     writeln!(output, "  - Confidence: {}", finding.confidence_label()).unwrap();
+    writeln!(
+        output,
+        "  - Priority: {} (risk {}/100)",
+        finding.risk.priority.label(),
+        finding.risk.score
+    )
+    .unwrap();
+    if let Some(reasons) = risk_reason_text(finding) {
+        writeln!(output, "  - Risk signals: {reasons}").unwrap();
+    }
     if let Some(status) = status {
         writeln!(output, "  - Baseline: {status}").unwrap();
     }
@@ -344,6 +354,19 @@ fn render_finding_detail(output: &mut String, finding: &Finding, status: Option<
         writeln!(output, "  - Docs: {url}").unwrap();
     }
     output.push('\n');
+}
+
+fn risk_reason_text(finding: &Finding) -> Option<String> {
+    let reasons = finding
+        .risk
+        .signals
+        .iter()
+        .filter(|signal| !signal.id.starts_with("severity."))
+        .take(3)
+        .map(|signal| format!("{} ({:+})", signal.label, signal.weight))
+        .collect::<Vec<_>>();
+
+    (!reasons.is_empty()).then(|| reasons.join(", "))
 }
 
 fn render_react_native_section(output: &mut String, rn: &ReactNativeArchitectureProfile) {

--- a/src/output/report_stats.rs
+++ b/src/output/report_stats.rs
@@ -128,14 +128,7 @@ pub(crate) fn category_order() -> [FindingCategory; 5] {
 
 pub(crate) fn sorted_findings(findings: &[Finding]) -> Vec<&Finding> {
     let mut sorted = findings.iter().collect::<Vec<_>>();
-    sorted.sort_by(|left, right| {
-        right
-            .severity
-            .cmp(&left.severity)
-            .then_with(|| category_rank(&left.category).cmp(&category_rank(&right.category)))
-            .then_with(|| left.rule_id.cmp(&right.rule_id))
-            .then_with(|| finding_location_key(left).cmp(&finding_location_key(right)))
-    });
+    sorted.sort_by(|left, right| crate::risk::compare_findings(left, right));
     sorted
 }
 
@@ -197,18 +190,4 @@ pub(crate) fn risk_label_for_counts(
     } else {
         "Clean"
     }
-}
-
-fn category_rank(category: &FindingCategory) -> usize {
-    match category {
-        FindingCategory::Security => 0,
-        FindingCategory::Architecture => 1,
-        FindingCategory::Framework => 2,
-        FindingCategory::CodeQuality => 3,
-        FindingCategory::Testing => 4,
-    }
-}
-
-fn finding_location_key(finding: &Finding) -> String {
-    first_location(finding).unwrap_or_default()
 }

--- a/src/output/vibe/tests.rs
+++ b/src/output/vibe/tests.rs
@@ -29,6 +29,7 @@ fn make_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -11,6 +11,7 @@ use crate::baseline::model::Baseline;
 use crate::findings::types::Finding;
 use crate::review::diff::{ChangedFile, DiffTarget, load_changed_files, resolve_git_root};
 use crate::review::model::{ReviewFindingStatus, ReviewReport};
+use crate::risk::apply_review_overlay;
 use crate::scan::types::ScanSummary;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -42,9 +43,9 @@ fn classify_findings(
     repo_root: PathBuf,
     changed_files: Vec<ChangedFile>,
 ) -> ReviewReport {
-    let summary = baseline_report.summary;
+    let mut summary = baseline_report.summary;
     let blast_radius = compute_blast_radius(&summary, &repo_root, &changed_files);
-    let findings = summary
+    let mut findings: Vec<ReviewFindingStatus> = summary
         .findings
         .iter()
         .enumerate()
@@ -60,6 +61,12 @@ fn classify_findings(
             ),
         })
         .collect();
+    let in_diff = findings
+        .iter()
+        .map(|status| status.in_diff)
+        .collect::<Vec<_>>();
+    apply_review_overlay(&mut summary.findings, &in_diff);
+    sort_findings_with_review_status(&mut summary.findings, &mut findings);
 
     ReviewReport {
         summary,
@@ -68,6 +75,21 @@ fn classify_findings(
         changed_files,
         blast_radius,
         findings,
+    }
+}
+
+fn sort_findings_with_review_status(
+    findings: &mut Vec<Finding>,
+    statuses: &mut Vec<ReviewFindingStatus>,
+) {
+    let mut paired = findings
+        .drain(..)
+        .zip(statuses.drain(..))
+        .collect::<Vec<_>>();
+    paired.sort_by(|(left, _), (right, _)| crate::risk::compare_findings(left, right));
+    for (finding, status) in paired {
+        findings.push(finding);
+        statuses.push(status);
     }
 }
 

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -1,0 +1,580 @@
+use crate::audits::context::{FileRole, classify_file};
+use crate::baseline::diff::{BaselineStatus, FindingBaselineStatus};
+use crate::findings::types::{Confidence, Finding, FindingCategory, Severity};
+use crate::scan::facts::{FileFacts, ScanFacts};
+use crate::scan::path_classification::is_low_signal_audit_path;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+pub const FORMULA_VERSION: &str = "risk-v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RiskAssessment {
+    pub score: u8,
+    pub priority: RiskPriority,
+    pub signals: Vec<RiskSignal>,
+    pub formula_version: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RiskPriority {
+    P0,
+    P1,
+    P2,
+    P3,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RiskSignal {
+    pub id: String,
+    pub label: String,
+    pub weight: i16,
+    pub reason: String,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RiskInputs {
+    pub baseline_status: Option<BaselineStatus>,
+    pub in_diff: bool,
+    pub workspace_hotspot: bool,
+}
+
+impl Default for RiskAssessment {
+    fn default() -> Self {
+        Self {
+            score: 0,
+            priority: RiskPriority::P3,
+            signals: Vec::new(),
+            formula_version: FORMULA_VERSION.to_string(),
+        }
+    }
+}
+
+impl RiskAssessment {
+    fn new(score: u8, signals: Vec<RiskSignal>) -> Self {
+        Self {
+            score,
+            priority: priority_for_score(score),
+            signals,
+            formula_version: FORMULA_VERSION.to_string(),
+        }
+    }
+}
+
+pub fn priority_for_score(score: u8) -> RiskPriority {
+    match score {
+        90..=100 => RiskPriority::P0,
+        70..=89 => RiskPriority::P1,
+        40..=69 => RiskPriority::P2,
+        _ => RiskPriority::P3,
+    }
+}
+
+impl RiskPriority {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::P0 => "P0",
+            Self::P1 => "P1",
+            Self::P2 => "P2",
+            Self::P3 => "P3",
+        }
+    }
+}
+
+pub fn assess_findings(findings: &mut [Finding], facts: &ScanFacts) {
+    let files = file_index(facts);
+    for finding in findings {
+        let file = finding_file(finding, facts.root_path.as_path(), &files);
+        finding.risk = assess_finding(finding, file, RiskInputs::default());
+    }
+}
+
+pub fn apply_baseline_overlay(
+    findings: &mut [Finding],
+    statuses: &[FindingBaselineStatus],
+    root: &Path,
+) {
+    let status_by_key = statuses
+        .iter()
+        .map(|status| (status.key.as_str(), status.status))
+        .collect::<HashMap<_, _>>();
+
+    for finding in findings {
+        let key = crate::baseline::key::stable_finding_key(finding, root);
+        if let Some(status) = status_by_key.get(key.as_str()).copied() {
+            apply_overlay_signal(
+                finding,
+                baseline_signal(status),
+                RiskInputs {
+                    baseline_status: Some(status),
+                    ..RiskInputs::default()
+                },
+            );
+        }
+    }
+}
+
+pub fn apply_review_overlay(findings: &mut [Finding], in_diff: &[bool]) {
+    for (finding, in_diff) in findings.iter_mut().zip(in_diff.iter().copied()) {
+        if in_diff {
+            apply_overlay_signal(
+                finding,
+                signal(
+                    "review.in-diff",
+                    "changed lines",
+                    12,
+                    "finding touches changed diff lines",
+                ),
+                RiskInputs {
+                    in_diff: true,
+                    ..RiskInputs::default()
+                },
+            );
+        }
+    }
+}
+
+pub fn apply_workspace_hotspot_overlay(findings: &mut [Finding]) {
+    let hotspot_packages = workspace_hotspots(findings);
+    if hotspot_packages.is_empty() {
+        return;
+    }
+
+    for finding in findings {
+        if finding
+            .workspace_package
+            .as_ref()
+            .is_some_and(|package| hotspot_packages.contains(package))
+        {
+            apply_overlay_signal(
+                finding,
+                signal(
+                    "workspace.hotspot",
+                    "workspace hotspot",
+                    5,
+                    "workspace package has multiple high-risk findings",
+                ),
+                RiskInputs {
+                    workspace_hotspot: true,
+                    ..RiskInputs::default()
+                },
+            );
+        }
+    }
+}
+
+pub fn sort_findings(findings: &mut [Finding]) {
+    findings.sort_by(compare_findings);
+}
+
+pub fn compare_findings(left: &Finding, right: &Finding) -> std::cmp::Ordering {
+    right
+        .risk
+        .score
+        .cmp(&left.risk.score)
+        .then_with(|| right.severity.cmp(&left.severity))
+        .then_with(|| category_rank(&left.category).cmp(&category_rank(&right.category)))
+        .then_with(|| left.rule_id.cmp(&right.rule_id))
+        .then_with(|| finding_location_key(left).cmp(&finding_location_key(right)))
+}
+
+pub fn assess_finding(
+    finding: &Finding,
+    file: Option<&FileFacts>,
+    inputs: RiskInputs,
+) -> RiskAssessment {
+    let base = severity_base_score(finding.severity);
+    let confidence_delta = confidence_delta(base, finding.confidence);
+    let mut score = base as i16 + confidence_delta;
+    let mut signals = vec![severity_signal(finding.severity, base)];
+
+    if confidence_delta != 0 {
+        signals.push(confidence_signal(finding.confidence, confidence_delta));
+    }
+
+    if finding.category == FindingCategory::Security {
+        push_adjustment(
+            &mut score,
+            &mut signals,
+            "category.security",
+            "security finding",
+            12,
+            "security findings usually have higher remediation priority",
+        );
+    }
+
+    if let Some(file) = file {
+        add_file_context_signals(file, &mut score, &mut signals);
+    }
+
+    if let Some(status) = inputs.baseline_status {
+        let signal = baseline_signal(status);
+        push_signal(&mut score, &mut signals, signal);
+    }
+
+    if inputs.in_diff {
+        push_adjustment(
+            &mut score,
+            &mut signals,
+            "review.in-diff",
+            "changed lines",
+            12,
+            "finding touches changed diff lines",
+        );
+    }
+
+    if inputs.workspace_hotspot {
+        push_adjustment(
+            &mut score,
+            &mut signals,
+            "workspace.hotspot",
+            "workspace hotspot",
+            5,
+            "workspace package has multiple high-risk findings",
+        );
+    }
+
+    RiskAssessment::new(clamp_score(score), signals)
+}
+
+fn add_file_context_signals(file: &FileFacts, score: &mut i16, signals: &mut Vec<RiskSignal>) {
+    let context = classify_file(file);
+    if context.is_production_code() {
+        push_adjustment(
+            score,
+            signals,
+            "role.production",
+            "production code",
+            10,
+            "production code findings are more likely to affect runtime behavior",
+        );
+    }
+
+    if context.has_role(FileRole::Test) || context.has_role(FileRole::RustTest) {
+        push_adjustment(
+            score,
+            signals,
+            "role.test",
+            "test code",
+            -20,
+            "test code often accepts patterns that would be risky in production",
+        );
+    }
+
+    if context.has_role(FileRole::Generated) {
+        push_adjustment(
+            score,
+            signals,
+            "role.generated",
+            "generated file",
+            -30,
+            "generated files should usually be fixed at the generator source",
+        );
+    }
+
+    if context.has_role(FileRole::Config) {
+        push_adjustment(
+            score,
+            signals,
+            "role.config",
+            "config file",
+            -18,
+            "configuration files often use declarative patterns that differ from application code",
+        );
+    }
+
+    if is_low_signal_audit_path(&file.path)
+        && !context.has_role(FileRole::Test)
+        && !context.has_role(FileRole::Generated)
+    {
+        push_adjustment(
+            score,
+            signals,
+            "role.low-signal-path",
+            "low-signal path",
+            -15,
+            "fixtures, examples, and benchmark paths are lower-priority by default",
+        );
+    }
+
+    if context.has_role(FileRole::AppEntrypoint) {
+        push_adjustment(
+            score,
+            signals,
+            "role.entrypoint",
+            "entrypoint",
+            10,
+            "entrypoints can affect application startup and process behavior",
+        );
+    }
+
+    if context.has_role(FileRole::FrameworkController)
+        || context.has_role(FileRole::DotNetController)
+    {
+        push_adjustment(
+            score,
+            signals,
+            "role.controller",
+            "controller/router",
+            12,
+            "controllers and routers sit on user-facing request boundaries",
+        );
+    }
+
+    if context.has_role(FileRole::FrameworkService) || context.has_role(FileRole::DotNetService) {
+        push_adjustment(
+            score,
+            signals,
+            "role.service",
+            "service layer",
+            10,
+            "service-layer findings can affect reusable production behavior",
+        );
+    }
+
+    if context.has_role(FileRole::Domain) {
+        push_adjustment(
+            score,
+            signals,
+            "role.domain",
+            "domain model",
+            8,
+            "domain code usually carries core business behavior",
+        );
+    }
+
+    if context.has_role(FileRole::ReactComponent) {
+        push_adjustment(
+            score,
+            signals,
+            "role.react-component",
+            "React component",
+            4,
+            "React component findings can affect user-visible behavior",
+        );
+    }
+}
+
+fn apply_overlay_signal(finding: &mut Finding, signal: RiskSignal, _inputs: RiskInputs) {
+    if finding
+        .risk
+        .signals
+        .iter()
+        .any(|existing| existing.id == signal.id)
+    {
+        return;
+    }
+
+    let score = finding.risk.score as i16 + signal.weight;
+    finding.risk.signals.push(signal);
+    finding.risk.score = clamp_score(score);
+    finding.risk.priority = priority_for_score(finding.risk.score);
+    finding.risk.formula_version = FORMULA_VERSION.to_string();
+}
+
+fn severity_base_score(severity: Severity) -> u8 {
+    match severity {
+        Severity::Critical => 95,
+        Severity::High => 75,
+        Severity::Medium => 45,
+        Severity::Low => 20,
+        Severity::Info => 5,
+    }
+}
+
+fn severity_signal(severity: Severity, score: u8) -> RiskSignal {
+    signal(
+        &format!("severity.{}", severity.lowercase_label()),
+        &format!("{} severity", severity.label()),
+        score as i16,
+        "base score from rule severity",
+    )
+}
+
+fn confidence_delta(base: u8, confidence: Confidence) -> i16 {
+    let multiplier = match confidence {
+        Confidence::High => 1.10,
+        Confidence::Medium => 1.00,
+        Confidence::Low => 0.80,
+    };
+    ((base as f64 * multiplier).round() as i16) - base as i16
+}
+
+fn confidence_signal(confidence: Confidence, weight: i16) -> RiskSignal {
+    signal(
+        &format!("confidence.{}", confidence.lowercase_label()),
+        &format!("{} confidence", confidence.label()),
+        weight,
+        "confidence adjusts certainty without changing rule severity",
+    )
+}
+
+fn baseline_signal(status: BaselineStatus) -> RiskSignal {
+    match status {
+        BaselineStatus::New => signal(
+            "baseline.new",
+            "new finding",
+            10,
+            "new findings should be prioritized over accepted existing debt",
+        ),
+        BaselineStatus::Existing => signal(
+            "baseline.existing",
+            "existing finding",
+            -8,
+            "existing baseline findings are already accepted technical debt",
+        ),
+    }
+}
+
+fn push_adjustment(
+    score: &mut i16,
+    signals: &mut Vec<RiskSignal>,
+    id: &str,
+    label: &str,
+    weight: i16,
+    reason: &str,
+) {
+    push_signal(score, signals, signal(id, label, weight, reason));
+}
+
+fn push_signal(score: &mut i16, signals: &mut Vec<RiskSignal>, signal: RiskSignal) {
+    *score += signal.weight;
+    signals.push(signal);
+}
+
+fn signal(id: &str, label: &str, weight: i16, reason: &str) -> RiskSignal {
+    RiskSignal {
+        id: id.to_string(),
+        label: label.to_string(),
+        weight,
+        reason: reason.to_string(),
+    }
+}
+
+fn clamp_score(score: i16) -> u8 {
+    score.clamp(0, 100) as u8
+}
+
+fn file_index(facts: &ScanFacts) -> HashMap<PathBuf, &FileFacts> {
+    let mut files = HashMap::new();
+    for file in &facts.files {
+        files.insert(file.path.clone(), file);
+        if let Ok(relative) = file.path.strip_prefix(&facts.root_path) {
+            files.insert(relative.to_path_buf(), file);
+        }
+    }
+    files
+}
+
+fn finding_file<'a>(
+    finding: &Finding,
+    root: &Path,
+    files: &'a HashMap<PathBuf, &'a FileFacts>,
+) -> Option<&'a FileFacts> {
+    let evidence = finding.evidence.first()?;
+    files.get(&evidence.path).copied().or_else(|| {
+        evidence
+            .path
+            .strip_prefix(root)
+            .ok()
+            .and_then(|relative| files.get(relative).copied())
+    })
+}
+
+fn workspace_hotspots(findings: &[Finding]) -> HashSet<String> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for finding in findings {
+        if finding.severity >= Severity::High
+            && let Some(package) = &finding.workspace_package
+        {
+            *counts.entry(package.clone()).or_default() += 1;
+        }
+    }
+    counts
+        .into_iter()
+        .filter_map(|(package, count)| (count > 1).then_some(package))
+        .collect()
+}
+
+fn category_rank(category: &FindingCategory) -> usize {
+    match category {
+        FindingCategory::Security => 0,
+        FindingCategory::Architecture => 1,
+        FindingCategory::Framework => 2,
+        FindingCategory::CodeQuality => 3,
+        FindingCategory::Testing => 4,
+    }
+}
+
+fn finding_location_key(finding: &Finding) -> String {
+    finding
+        .evidence
+        .first()
+        .map(|evidence| format!("{}:{}", evidence.path.display(), evidence.line_start))
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::findings::types::{Evidence, Finding};
+
+    #[test]
+    fn priority_thresholds_match_v1_plan() {
+        assert_eq!(priority_for_score(90), RiskPriority::P0);
+        assert_eq!(priority_for_score(70), RiskPriority::P1);
+        assert_eq!(priority_for_score(40), RiskPriority::P2);
+        assert_eq!(priority_for_score(39), RiskPriority::P3);
+    }
+
+    #[test]
+    fn high_confidence_critical_score_clamps_to_100() {
+        let finding = Finding {
+            severity: Severity::Critical,
+            confidence: Confidence::High,
+            ..Finding::default()
+        };
+
+        let assessment = assess_finding(&finding, None, RiskInputs::default());
+
+        assert_eq!(assessment.score, 100);
+        assert_eq!(assessment.priority, RiskPriority::P0);
+    }
+
+    #[test]
+    fn production_domain_file_scores_above_equivalent_test_file() {
+        let finding = Finding {
+            severity: Severity::Medium,
+            confidence: Confidence::Medium,
+            evidence: vec![Evidence {
+                path: PathBuf::from("src/domain/user.rs"),
+                line_start: 1,
+                line_end: None,
+                snippet: String::new(),
+            }],
+            ..Finding::default()
+        };
+        let production = file("src/domain/user.rs", Some("Rust"), false);
+        let test = file("tests/user.rs", Some("Rust"), false);
+
+        let prod_risk = assess_finding(&finding, Some(&production), RiskInputs::default());
+        let test_risk = assess_finding(&finding, Some(&test), RiskInputs::default());
+
+        assert!(prod_risk.score > test_risk.score);
+        assert!(prod_risk.signals.iter().any(|s| s.id == "role.domain"));
+        assert!(test_risk.signals.iter().any(|s| s.id == "role.test"));
+    }
+
+    fn file(path: &str, language: Option<&str>, has_inline_tests: bool) -> FileFacts {
+        FileFacts {
+            path: PathBuf::from(path),
+            language: language.map(str::to_string),
+            lines_of_code: 10,
+            branch_count: 0,
+            imports: Vec::new(),
+            content: None,
+            has_inline_tests,
+        }
+    }
+}

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -11,6 +11,7 @@ use crate::frameworks::{
     detect_react_native_architecture,
 };
 use crate::knowledge::decision::apply_project_decisions;
+use crate::risk::assess_findings;
 use crate::scan::config::ScanConfig;
 use crate::scan::types::{ScanSummary, ScanTimings};
 use std::io;
@@ -70,6 +71,7 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
         finding.populate_recommendation();
         finding.id = stable_finding_key(finding, path);
     }
+    assess_findings(&mut findings, &facts);
     summary::sort_findings(&mut findings);
 
     let scan_duration_us = start.elapsed().as_micros() as u64;

--- a/src/scan/scanner/summary.rs
+++ b/src/scan/scanner/summary.rs
@@ -3,21 +3,7 @@ use crate::scan::types::LanguageSummary;
 use std::collections::HashMap;
 
 pub(super) fn sort_findings(findings: &mut [Finding]) {
-    findings.sort_by(|a, b| {
-        b.severity
-            .cmp(&a.severity)
-            .then_with(|| a.rule_id.cmp(&b.rule_id))
-            .then_with(|| {
-                let pa = a.evidence.first().map(|e| e.path.as_path());
-                let pb = b.evidence.first().map(|e| e.path.as_path());
-                pa.cmp(&pb)
-            })
-            .then_with(|| {
-                let la = a.evidence.first().map(|e| e.line_start).unwrap_or(0);
-                let lb = b.evidence.first().map(|e| e.line_start).unwrap_or(0);
-                la.cmp(&lb)
-            })
-    });
+    crate::risk::sort_findings(findings);
 }
 
 pub(super) fn build_language_summary(languages: HashMap<String, usize>) -> Vec<LanguageSummary> {

--- a/tests/baseline_key.rs
+++ b/tests/baseline_key.rs
@@ -63,5 +63,6 @@ fn finding(rule_id: &str, path: &str, line: usize) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -105,5 +105,6 @@ fn finding(id: &str, rule_id: &str, path: &str, line: usize, severity: Severity)
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }

--- a/tests/finding_model.rs
+++ b/tests/finding_model.rs
@@ -20,6 +20,7 @@ fn finding_contains_evidence() {
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     };
 
     assert_eq!(finding.rule_id, "code-marker.todo");

--- a/tests/output_console.rs
+++ b/tests/output_console.rs
@@ -28,6 +28,7 @@ fn console_output_includes_versioned_summary_and_grouped_findings() {
             }],
             workspace_package: None,
             docs_url: None,
+            risk: Default::default(),
         }],
         health_score: 95,
         ..ScanSummary::default()

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -35,6 +35,7 @@ fn html_output_escapes_snippets_and_renders_summary() {
             }],
             workspace_package: None,
             docs_url: None,
+            risk: Default::default(),
         }],
         react_native: None,
         coupling_graph: None,

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -1,6 +1,7 @@
 use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use repopilot::frameworks::ReactNativeArchitectureProfile;
 use repopilot::output::{OutputFormat, render_scan_summary};
+use repopilot::risk::{RiskInputs, assess_finding};
 use repopilot::scan::types::{LanguageSummary, ScanSummary};
 use std::path::PathBuf;
 
@@ -50,26 +51,30 @@ fn renders_valid_json_scan_summary() {
 
 #[test]
 fn json_findings_include_confidence() {
+    let mut finding = Finding {
+        id: "code-quality.long-function:src/lib.rs:1".to_string(),
+        rule_id: "code-quality.long-function".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("code-quality.long-function"),
+        title: "Large Rust production function".to_string(),
+        description: "Function spans more lines than the configured threshold.".to_string(),
+        category: FindingCategory::CodeQuality,
+        severity: Severity::Medium,
+        confidence: Confidence::High,
+        evidence: vec![Evidence {
+            path: PathBuf::from("src/lib.rs"),
+            line_start: 1,
+            line_end: Some(80),
+            snippet: "function spans lines 1-80".to_string(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+        risk: Default::default(),
+    };
+    finding.risk = assess_finding(&finding, None, RiskInputs::default());
+
     let summary = ScanSummary {
         root_path: PathBuf::from("demo"),
-        findings: vec![Finding {
-            id: "code-quality.long-function:src/lib.rs:1".to_string(),
-            rule_id: "code-quality.long-function".to_string(),
-            recommendation: Finding::recommendation_for_rule_id("code-quality.long-function"),
-            title: "Large Rust production function".to_string(),
-            description: "Function spans more lines than the configured threshold.".to_string(),
-            category: FindingCategory::CodeQuality,
-            severity: Severity::Medium,
-            confidence: Confidence::High,
-            evidence: vec![Evidence {
-                path: PathBuf::from("src/lib.rs"),
-                line_start: 1,
-                line_end: Some(80),
-                snippet: "function spans lines 1-80".to_string(),
-            }],
-            workspace_package: None,
-            docs_url: None,
-        }],
+        findings: vec![finding],
         ..ScanSummary::default()
     };
 
@@ -79,6 +84,12 @@ fn json_findings_include_confidence() {
         serde_json::from_str(&output).expect("output should be valid json");
 
     assert_eq!(parsed["findings"][0]["confidence"], "HIGH");
+    assert_eq!(parsed["findings"][0]["risk"]["priority"], "P2");
+    assert_eq!(parsed["findings"][0]["risk"]["score"], 50);
+    assert_eq!(
+        parsed["findings"][0]["risk"]["signals"][0]["id"],
+        "severity.medium"
+    );
     assert_eq!(
         parsed["findings"][0]["recommendation"],
         Finding::recommendation_for_rule_id("code-quality.long-function")

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -44,6 +44,7 @@ fn renders_markdown_scan_summary() {
             }],
             workspace_package: None,
             docs_url: None,
+            risk: Default::default(),
         }],
         detected_frameworks: vec![],
         framework_projects: vec![],

--- a/tests/output_sarif.rs
+++ b/tests/output_sarif.rs
@@ -22,6 +22,7 @@ fn make_finding_with_package(rule_id: &str, pkg: Option<&str>) -> Finding {
         }],
         workspace_package: pkg.map(str::to_owned),
         docs_url: None,
+        risk: Default::default(),
     }
 }
 
@@ -77,6 +78,7 @@ fn sarif_rule_uses_title_and_full_description() {
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     };
 
     let root = PathBuf::from(".");
@@ -121,6 +123,7 @@ fn sarif_result_includes_partial_fingerprints() {
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     };
 
     let root = PathBuf::from(".");

--- a/tests/risk_engine.rs
+++ b/tests/risk_engine.rs
@@ -1,0 +1,214 @@
+use repopilot::baseline::diff::{BaselineStatus, FindingBaselineStatus};
+use repopilot::baseline::key::stable_finding_key;
+use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
+use repopilot::risk::{
+    RiskInputs, RiskPriority, apply_baseline_overlay, apply_review_overlay,
+    apply_workspace_hotspot_overlay, assess_finding,
+};
+use repopilot::scan::facts::FileFacts;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn file_role_context_changes_risk_without_changing_rule_severity() {
+    let finding = finding(
+        "code-quality.complex-file",
+        "src/domain/user.rs",
+        Severity::Medium,
+    );
+    let production = file("src/domain/user.rs", Some("Rust"));
+    let generated = file("src/generated/user.rs", Some("Rust"));
+    let config = file("Cargo.toml", Some("TOML"));
+
+    let production_risk = assess_finding(&finding, Some(&production), RiskInputs::default());
+    let generated_risk = assess_finding(&finding, Some(&generated), RiskInputs::default());
+    let config_risk = assess_finding(&finding, Some(&config), RiskInputs::default());
+
+    assert!(production_risk.score > generated_risk.score);
+    assert!(production_risk.score > config_risk.score);
+    assert_eq!(finding.severity, Severity::Medium);
+    assert!(
+        generated_risk
+            .signals
+            .iter()
+            .any(|signal| signal.id == "role.generated")
+    );
+    assert!(
+        config_risk
+            .signals
+            .iter()
+            .any(|signal| signal.id == "role.config")
+    );
+}
+
+#[test]
+fn baseline_overlay_boosts_new_findings_and_downweights_existing_findings() {
+    let root = Path::new("/repo");
+    let mut findings = vec![
+        assessed_finding("security.secret-candidate", "src/new.rs", Severity::High),
+        assessed_finding(
+            "security.secret-candidate",
+            "src/existing.rs",
+            Severity::High,
+        ),
+    ];
+    let statuses = vec![
+        FindingBaselineStatus {
+            key: stable_finding_key(&findings[0], root),
+            status: BaselineStatus::New,
+        },
+        FindingBaselineStatus {
+            key: stable_finding_key(&findings[1], root),
+            status: BaselineStatus::Existing,
+        },
+    ];
+
+    apply_baseline_overlay(&mut findings, &statuses, root);
+
+    assert!(findings[0].risk.score > findings[1].risk.score);
+    assert!(
+        findings[0]
+            .risk
+            .signals
+            .iter()
+            .any(|signal| signal.id == "baseline.new")
+    );
+    assert!(
+        findings[1]
+            .risk
+            .signals
+            .iter()
+            .any(|signal| signal.id == "baseline.existing")
+    );
+}
+
+#[test]
+fn review_overlay_boosts_in_diff_findings() {
+    let mut findings = vec![
+        assessed_finding(
+            "architecture.large-file",
+            "src/changed.rs",
+            Severity::Medium,
+        ),
+        assessed_finding(
+            "architecture.large-file",
+            "src/unchanged.rs",
+            Severity::Medium,
+        ),
+    ];
+
+    apply_review_overlay(&mut findings, &[true, false]);
+
+    assert!(findings[0].risk.score > findings[1].risk.score);
+    assert!(
+        findings[0]
+            .risk
+            .signals
+            .iter()
+            .any(|signal| signal.id == "review.in-diff")
+    );
+}
+
+#[test]
+fn workspace_hotspot_overlay_adds_stable_learning_signal() {
+    let mut findings = vec![
+        assessed_finding(
+            "security.secret-candidate",
+            "packages/web/a.rs",
+            Severity::High,
+        ),
+        assessed_finding(
+            "security.secret-candidate",
+            "packages/web/b.rs",
+            Severity::High,
+        ),
+        assessed_finding(
+            "security.secret-candidate",
+            "packages/api/a.rs",
+            Severity::High,
+        ),
+    ];
+    findings[0].workspace_package = Some("web".to_string());
+    findings[1].workspace_package = Some("web".to_string());
+    findings[2].workspace_package = Some("api".to_string());
+
+    apply_workspace_hotspot_overlay(&mut findings);
+
+    assert!(
+        findings[0]
+            .risk
+            .signals
+            .iter()
+            .any(|signal| signal.id == "workspace.hotspot")
+    );
+    assert!(
+        findings[1]
+            .risk
+            .signals
+            .iter()
+            .any(|signal| signal.id == "workspace.hotspot")
+    );
+    assert!(
+        findings[2]
+            .risk
+            .signals
+            .iter()
+            .all(|signal| signal.id != "workspace.hotspot")
+    );
+}
+
+#[test]
+fn priority_labels_follow_score_thresholds() {
+    let critical = assessed_finding(
+        "security.private-key-candidate",
+        "src/key.rs",
+        Severity::Critical,
+    );
+    let low = assessed_finding("code-marker.todo", "src/lib.rs", Severity::Low);
+
+    assert_eq!(critical.risk.priority, RiskPriority::P0);
+    assert_eq!(low.risk.priority, RiskPriority::P3);
+}
+
+fn assessed_finding(rule_id: &str, path: &str, severity: Severity) -> Finding {
+    let mut finding = finding(rule_id, path, severity);
+    finding.risk = assess_finding(&finding, None, RiskInputs::default());
+    finding
+}
+
+fn finding(rule_id: &str, path: &str, severity: Severity) -> Finding {
+    Finding {
+        id: String::new(),
+        rule_id: rule_id.to_string(),
+        title: "test finding".to_string(),
+        description: "test finding".to_string(),
+        recommendation: Finding::recommendation_for_rule_id(rule_id),
+        category: if rule_id.starts_with("security.") {
+            FindingCategory::Security
+        } else {
+            FindingCategory::CodeQuality
+        },
+        severity,
+        confidence: Confidence::Medium,
+        evidence: vec![Evidence {
+            path: PathBuf::from(path),
+            line_start: 1,
+            line_end: None,
+            snippet: String::new(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+        risk: Default::default(),
+    }
+}
+
+fn file(path: &str, language: Option<&str>) -> FileFacts {
+    FileFacts {
+        path: PathBuf::from(path),
+        language: language.map(str::to_string),
+        lines_of_code: 10,
+        branch_count: 0,
+        imports: Vec::new(),
+        content: None,
+        has_inline_tests: false,
+    }
+}

--- a/tests/rule_registry.rs
+++ b/tests/rule_registry.rs
@@ -97,6 +97,7 @@ fn make_finding(rule_id: &str) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }
 

--- a/tests/sarif_mapping.rs
+++ b/tests/sarif_mapping.rs
@@ -163,5 +163,6 @@ fn finding(rule_id: &str, severity: Severity, path: Option<&str>, line_start: us
             .unwrap_or_default(),
         workspace_package: None,
         docs_url: None,
+        risk: Default::default(),
     }
 }

--- a/tests/scan_summary.rs
+++ b/tests/scan_summary.rs
@@ -116,6 +116,7 @@ fn health_score_decreases_with_severity() {
             evidence: vec![],
             workspace_package: None,
             docs_url: None,
+            risk: Default::default(),
         }
     }
     let critical = ScanSummary::compute_health_score(&[finding(Severity::Critical)], 1000);
@@ -144,6 +145,7 @@ fn health_score_is_clamped_at_zero_for_catastrophic_repos() {
             evidence: vec![],
             workspace_package: None,
             docs_url: None,
+            risk: Default::default(),
         })
         .collect();
     assert_eq!(

--- a/tests/workspace_risk.rs
+++ b/tests/workspace_risk.rs
@@ -21,6 +21,7 @@ fn make_finding(pkg: Option<&str>, severity: Severity) -> Finding {
         }],
         workspace_package: pkg.map(str::to_owned),
         docs_url: None,
+        risk: Default::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds an explainable risk prioritization layer to RepoPilot findings.

Each finding now receives a `risk` assessment with a numeric score, priority label, formula version, and stable risk signals. The scan, baseline, review, workspace, and output layers now use this risk metadata to make reports easier to triage by actual remediation priority rather than severity alone.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation

## What changed

- Added a new `risk` module for explainable finding prioritization.
- Added `risk` metadata to the `Finding` model.
- Added risk scoring based on:
  - severity
  - confidence
  - security category
  - file role/context
  - baseline status
  - review diff status
  - workspace hotspot status
- Updated scan flow to assess risk before sorting findings.
- Updated workspace scan flow to apply workspace hotspot overlays.
- Updated baseline and review reports to apply risk overlays and keep finding/status ordering aligned.
- Updated console, Markdown, HTML, and JSON output to expose priority and risk signals.
- Updated finding sorting to use risk score first, then severity/category/rule/location.
- Bumped JSON scan report schema from `0.9` to `0.10`.
- Added tests for risk scoring, baseline overlays, review overlays, workspace hotspot overlays, output rendering, and schema behavior.

## Why

Severity alone is not enough for practical remediation.

A high-severity finding in generated/test code may be less urgent than a medium-severity finding in production domain or request-boundary code. This PR makes RepoPilot reports more useful by showing not only “how bad” a finding is, but also “what should be fixed first” and why.

This also improves AI-assisted remediation workflows because generated reports now contain stable, explainable prioritization signals that can be used by ChatGPT, Claude, Cursor, or other coding assistants.

## Architecture notes

- [x] Findings remain evidence-backed.
- [x] Risk assessment is centralized in a dedicated `risk` module.
- [x] Scanner, baseline, review, output, and workspace responsibilities remain separated.
- [x] Risk overlays are applied at the layer where extra context becomes available:
  - base scan risk during scanning
  - baseline overlay during baseline diff
  - review overlay during changed-code review
  - workspace hotspot overlay during workspace scan
- [x] Sorting is centralized through the risk comparator.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan . --format json
cargo run -- scan . --format markdown
cargo run -- scan . --format html --output /tmp/repopilot-risk.html