### PR TITLE
feat: add risk-priority CI gate

### DIFF
--- a/src/baseline/gate.rs
+++ b/src/baseline/gate.rs
@@ -1,11 +1,13 @@
 use crate::baseline::diff::{BaselineScanReport, BaselineStatus};
 use crate::findings::types::{Finding, Severity};
+use crate::risk::RiskPriority;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum FailOn {
     New(Severity),
     Any(Severity),
+    Priority(RiskPriority),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -23,6 +25,7 @@ impl CiGateResult {
         match self.fail_on {
             FailOn::New(severity) => format!("new-{}", severity.lowercase_label()),
             FailOn::Any(severity) => severity.lowercase_label().to_string(),
+            FailOn::Priority(priority) => format!("priority-{}", priority.label().to_lowercase()),
         }
     }
 
@@ -31,18 +34,25 @@ impl CiGateResult {
             return None;
         }
 
-        let scope = match self.fail_on {
-            FailOn::New(_) => "new findings",
-            FailOn::Any(_) => "findings",
-        };
-        let severity = match self.fail_on {
-            FailOn::New(severity) | FailOn::Any(severity) => severity.lowercase_label(),
-        };
-
-        Some(format!(
-            "RepoPilot CI Gate failed\n\nReason:\nFound {} {scope} at or above {severity} severity.\n\nUse `repopilot baseline create . --force` only if these findings are accepted technical debt.",
-            self.failed_findings
-        ))
+        match self.fail_on {
+            FailOn::New(severity) | FailOn::Any(severity) => {
+                let scope = match self.fail_on {
+                    FailOn::New(_) => "new findings",
+                    FailOn::Any(_) => "findings",
+                    FailOn::Priority(_) => unreachable!("handled by outer match"),
+                };
+                Some(format!(
+                    "RepoPilot CI Gate failed\n\nReason:\nFound {} {scope} at or above {} severity.\n\nUse `repopilot baseline create . --force` only if these findings are accepted technical debt.",
+                    self.failed_findings,
+                    severity.lowercase_label()
+                ))
+            }
+            FailOn::Priority(priority) => Some(format!(
+                "RepoPilot CI Gate failed\n\nReason:\nFound {} findings at or above {} risk priority.\n\nUse `--min-priority` to inspect the same prioritized scope locally, or lower the gate only if this risk is accepted.",
+                self.failed_findings,
+                priority.label()
+            )),
+        }
     }
 }
 
@@ -73,6 +83,20 @@ fn finding_matches(
                 && finding.severity.is_at_least(&threshold)
         }
         FailOn::Any(threshold) => finding.severity.is_at_least(&threshold),
+        FailOn::Priority(threshold) => priority_is_at_least(finding.risk.priority, threshold),
+    }
+}
+
+fn priority_is_at_least(priority: RiskPriority, threshold: RiskPriority) -> bool {
+    priority_rank(priority) <= priority_rank(threshold)
+}
+
+fn priority_rank(priority: RiskPriority) -> u8 {
+    match priority {
+        RiskPriority::P0 => 0,
+        RiskPriority::P1 => 1,
+        RiskPriority::P2 => 2,
+        RiskPriority::P3 => 3,
     }
 }
 
@@ -81,6 +105,7 @@ mod tests {
     use super::*;
     use crate::baseline::diff::{BaselineScanReport, BaselineStatus, FindingBaselineStatus};
     use crate::findings::types::{Evidence, Finding, Severity};
+    use crate::risk::RiskPriority;
     use crate::scan::types::ScanSummary;
     use std::path::PathBuf;
 
@@ -98,6 +123,13 @@ mod tests {
             }],
             ..Default::default()
         }
+    }
+
+    fn make_priority_finding(priority: RiskPriority, score: u8) -> Finding {
+        let mut finding = make_finding(Severity::Low);
+        finding.risk.priority = priority;
+        finding.risk.score = score;
+        finding
     }
 
     fn make_report(findings: Vec<Finding>, statuses: Vec<BaselineStatus>) -> BaselineScanReport {
@@ -166,6 +198,32 @@ mod tests {
 
         assert!(!result.passed());
         assert_eq!(result.failed_findings, 1);
+    }
+
+    #[test]
+    fn priority_gate_fails_on_p1_or_higher_priority() {
+        let report = make_report(
+            vec![make_priority_finding(RiskPriority::P1, 70)],
+            vec![BaselineStatus::Existing],
+        );
+
+        let result = evaluate_ci_gate(&report, FailOn::Priority(RiskPriority::P1));
+
+        assert!(!result.passed());
+        assert_eq!(result.failed_findings, 1);
+        assert_eq!(result.label(), "priority-p1");
+    }
+
+    #[test]
+    fn priority_gate_passes_when_findings_are_below_threshold() {
+        let report = make_report(
+            vec![make_priority_finding(RiskPriority::P3, 20)],
+            vec![BaselineStatus::New],
+        );
+
+        let result = evaluate_ci_gate(&report, FailOn::Priority(RiskPriority::P1));
+
+        assert!(result.passed());
     }
 
     #[test]

--- a/src/cli/options/review.rs
+++ b/src/cli/options/review.rs
@@ -24,9 +24,13 @@ pub struct ReviewOptions {
     #[arg(long)]
     pub baseline: Option<PathBuf>,
 
-    /// Exit with code 1 when in-diff findings meet this threshold
+    /// Exit with code 1 when in-diff findings meet this severity threshold
     #[arg(long, value_enum)]
     pub fail_on: Option<FailOnArg>,
+
+    /// Exit with code 1 when in-diff findings meet this risk priority threshold
+    #[arg(long, value_enum)]
+    pub fail_on_priority: Option<PriorityArg>,
 
     /// Output format for the review report
     #[arg(long, value_enum, default_value = "console")]

--- a/src/cli/options/scan.rs
+++ b/src/cli/options/scan.rs
@@ -31,6 +31,10 @@ pub struct ScanOptions {
     #[arg(long, value_enum)]
     pub fail_on: Option<FailOnArg>,
 
+    /// Exit with code 1 when findings meet this risk priority threshold
+    #[arg(long, value_enum)]
+    pub fail_on_priority: Option<PriorityArg>,
+
     /// Override the large-file LOC threshold
     #[arg(long)]
     pub max_file_loc: Option<usize>,

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -5,7 +5,7 @@ use crate::commands::{
     build_scan_config, finding_meets_min_priority, review_options_min_priority,
     review_options_min_severity,
 };
-use repopilot::baseline::gate::evaluate_ci_gate;
+use repopilot::baseline::gate::{FailOn, evaluate_ci_gate};
 use repopilot::baseline::reader::read_baseline;
 use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::report::writer::write_report;
@@ -18,6 +18,14 @@ use repopilot::scan::scanner::scan_path_with_config;
 pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
     let min_severity = review_options_min_severity(&options);
     let min_priority = review_options_min_priority(&options);
+    let fail_on_priority = options.fail_on_priority.map(Into::into);
+
+    if options.fail_on.is_some() && fail_on_priority.is_some() {
+        return Err(Box::new(CliExit {
+            code: EXIT_USAGE,
+            message: "`--fail-on` and `--fail-on-priority` cannot be used together".to_string(),
+        }));
+    }
 
     if options.base.is_none() && options.head.is_some() {
         return Err(Box::new(CliExit {
@@ -70,7 +78,10 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
     let ci_gate = options
         .fail_on
         .map(Into::into)
-        .map(|fail_on| evaluate_ci_gate(&ci_report, fail_on));
+        .map(|fail_on| evaluate_ci_gate(&ci_report, fail_on))
+        .or_else(|| {
+            fail_on_priority.map(|priority| evaluate_ci_gate(&ci_report, FailOn::Priority(priority)))
+        });
     let rendered_report = render(&review_report, options.format.into(), ci_gate.as_ref())?;
 
     write_report(&rendered_report, options.output.as_deref())?;

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -80,7 +80,8 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
         .map(Into::into)
         .map(|fail_on| evaluate_ci_gate(&ci_report, fail_on))
         .or_else(|| {
-            fail_on_priority.map(|priority| evaluate_ci_gate(&ci_report, FailOn::Priority(priority)))
+            fail_on_priority
+                .map(|priority| evaluate_ci_gate(&ci_report, FailOn::Priority(priority)))
         });
     let rendered_report = render(&review_report, options.format.into(), ci_gate.as_ref())?;
 

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -9,7 +9,7 @@ use rayon::prelude::*;
 use repopilot::baseline::diff::{
     BaselineScanReport, all_findings_new, diff_summary_against_baseline,
 };
-use repopilot::baseline::gate::evaluate_ci_gate;
+use repopilot::baseline::gate::{FailOn, evaluate_ci_gate};
 use repopilot::baseline::reader::read_baseline;
 use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::config::presets::{Preset, apply_preset};
@@ -29,6 +29,14 @@ use std::time::Instant;
 pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     let min_severity = scan_options_min_severity(&options);
     let min_priority = scan_options_min_priority(&options);
+    let fail_on_priority = options.fail_on_priority.map(Into::into);
+
+    if options.fail_on.is_some() && fail_on_priority.is_some() {
+        return Err(Box::new(CliExit {
+            code: EXIT_USAGE,
+            message: "`--fail-on` and `--fail-on-priority` cannot be used together".to_string(),
+        }));
+    }
     let mut repo_config = match &options.config {
         Some(config_path) => load_optional_config(config_path)?,
         None => load_default_config()?,
@@ -85,7 +93,7 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
         apply_rule_filter(&mut summary, &options.rule);
     }
 
-    if options.baseline.is_some() || options.fail_on.is_some() {
+    if options.baseline.is_some() || options.fail_on.is_some() || fail_on_priority.is_some() {
         let mut baseline_report = match options.baseline.clone() {
             Some(baseline_path) => {
                 let baseline_file = read_baseline(&baseline_path)?;
@@ -100,7 +108,11 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
         let ci_gate = options
             .fail_on
             .map(Into::into)
-            .map(|fail_on| evaluate_ci_gate(&baseline_report, fail_on));
+            .map(|fail_on| evaluate_ci_gate(&baseline_report, fail_on))
+            .or_else(|| {
+                fail_on_priority
+                    .map(|priority| evaluate_ci_gate(&baseline_report, FailOn::Priority(priority)))
+            });
         let render_start = Instant::now();
         let rendered_report =
             render_baseline_scan_report(&baseline_report, output_format, ci_gate.as_ref())?;


### PR DESCRIPTION
## Summary

This PR adds a risk-priority CI gate for `scan` and `review`.

RepoPilot already supports risk priorities (`P0`, `P1`, `P2`, `P3`) and priority-based filtering. This change makes risk priority actionable in CI by adding `--fail-on-priority`.

## Type of change

- [x] Feature
- [x] Tests
- [x] Documentation

## What changed

- Added `FailOn::Priority(RiskPriority)` to the CI gate model.
- Added `--fail-on-priority p0|p1|p2|p3` to `repopilot scan`.
- Added `--fail-on-priority p0|p1|p2|p3` to `repopilot review`.
- Made priority gates fail when findings are at or above the selected priority.
- Kept `review` gate behavior scoped to in-diff findings.
- Added validation so `--fail-on` and `--fail-on-priority` cannot be used together.
- Updated CLI documentation.
- Added integration tests for:
  - priority gate failure
  - priority gate pass
  - invalid combined gate usage
  - help output

## Why

Severity-based gates are useful, but after introducing explainable risk scoring, users need a CI gate based on actual remediation priority.

For example:

```bash
repopilot scan . --fail-on-priority p1
repopilot review . --fail-on-priority p1
```

## Verification
```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo run -- scan . --fail-on-priority p1
cargo run -- review . --fail-on-priority p1
cargo run -- scan . --min-priority p1 --fail-on-priority p1
```