### PR TITLE
feat: add risk summary metadata

### DIFF
--- a/docs/reports.md
+++ b/docs/reports.md
@@ -22,6 +22,11 @@ JSON scan reports include explicit schema metadata. The current schema is 0.10:
   "directories_count": 12,
   "lines_of_code": 3200,
   "languages": [],
+  "risk_summary": {
+    "total": 0,
+    "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 },
+    "average_score": 0
+  },
   "findings": []
 }
 ```
@@ -32,6 +37,7 @@ JSON scan reports include explicit schema metadata. The current schema is 0.10:
 |---|---|---|
 | `schema_version` | string | RepoPilot JSON report schema version. |
 | `repopilot_version` | string | RepoPilot binary version that produced the report. |
+| `risk_summary` | object | Aggregate priority counts and average risk score derived from finding risk assessments. |
 
 `schema_version` is intentionally separate from the binary version. Patch releases
 may fix bugs without changing the report schema, while future minor releases can
@@ -68,6 +74,12 @@ Example shape:
   "repopilot_version": "0.10.0",
   "root_path": ".",
   "files_count": 42,
+  "risk_summary": {
+    "total": 12,
+    "counts": { "p0": 0, "p1": 2, "p2": 5, "p3": 5 },
+    "highest_priority": "P1",
+    "average_score": 46
+  },
   "baseline": {
     "path": ".repopilot/baseline.json",
     "new_findings": 2,

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -172,6 +172,23 @@ fn render_risk_summary(output: &mut String, stats: &ReportStats) {
     .unwrap();
     writeln!(
         output,
+        "  Priority: P0 {}, P1 {}, P2 {}, P3 {}{}",
+        stats.priority_count(crate::risk::RiskPriority::P0),
+        stats.priority_count(crate::risk::RiskPriority::P1),
+        stats.priority_count(crate::risk::RiskPriority::P2),
+        stats.priority_count(crate::risk::RiskPriority::P3),
+        stats
+            .highest_priority
+            .map(|priority| format!(
+                " | highest {} | avg score {}",
+                priority.label(),
+                stats.average_risk_score
+            ))
+            .unwrap_or_default()
+    )
+    .unwrap();
+    writeln!(
+        output,
         "  Categories: {}",
         named_counts_text(&stats.category_counts)
     )

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -1,6 +1,7 @@
 use crate::baseline::diff::{BaselineScanReport, BaselineStatus};
 use crate::baseline::gate::CiGateResult;
 use crate::findings::types::Finding;
+use crate::risk::RiskSummary;
 use crate::scan::types::LanguageSummary;
 use crate::scan::types::ScanSummary;
 use serde::Serialize;
@@ -12,6 +13,7 @@ pub fn render(summary: &ScanSummary) -> Result<String, serde_json::Error> {
     let output = JsonScanReport {
         schema_version: SCAN_REPORT_SCHEMA_VERSION,
         repopilot_version: REPOPILOT_VERSION,
+        risk_summary: RiskSummary::from_findings(&summary.findings),
         summary,
     };
 
@@ -22,6 +24,7 @@ pub fn render(summary: &ScanSummary) -> Result<String, serde_json::Error> {
 struct JsonScanReport<'a> {
     schema_version: &'static str,
     repopilot_version: &'static str,
+    risk_summary: RiskSummary,
     #[serde(flatten)]
     summary: &'a ScanSummary,
 }
@@ -51,6 +54,7 @@ pub fn render_with_baseline(
         skipped_files_count: report.summary.skipped_files_count,
         skipped_bytes: report.summary.skipped_bytes,
         languages: &report.summary.languages,
+        risk_summary: RiskSummary::from_findings(&report.summary.findings),
         baseline: BaselineJsonMetadata {
             path: report
                 .baseline_path
@@ -77,6 +81,7 @@ struct BaselineJsonReport<'a> {
     skipped_files_count: usize,
     skipped_bytes: u64,
     languages: &'a [LanguageSummary],
+    risk_summary: RiskSummary,
     baseline: BaselineJsonMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]
     ci_gate: Option<CiGateJsonMetadata>,

--- a/src/output/report_stats.rs
+++ b/src/output/report_stats.rs
@@ -1,4 +1,5 @@
 use crate::findings::types::{Finding, FindingCategory, Severity};
+use crate::risk::{RiskPriority, RiskPriorityCounts, RiskSummary};
 use crate::scan::types::ScanSummary;
 use counts::{CountWithSeverity, category_counts_from_map, increment, top_counts_from_map};
 use std::collections::BTreeMap;
@@ -11,6 +12,9 @@ mod counts;
 pub(crate) struct ReportStats {
     pub total_findings: usize,
     pub severity_counts: [usize; 5],
+    pub priority_counts: RiskPriorityCounts,
+    pub highest_priority: Option<RiskPriority>,
+    pub average_risk_score: u8,
     pub category_counts: Vec<NamedCount>,
     pub top_rules: Vec<NamedCount>,
     pub top_paths: Vec<NamedCount>,
@@ -30,6 +34,10 @@ pub(crate) struct NamedCount {
 impl ReportStats {
     pub fn severity_count(&self, severity: Severity) -> usize {
         self.severity_counts[severity_index(severity)]
+    }
+
+    pub fn priority_count(&self, priority: RiskPriority) -> usize {
+        self.priority_counts.count(priority)
     }
 }
 
@@ -69,6 +77,7 @@ pub(crate) fn build_report_stats(summary: &ScanSummary) -> ReportStats {
     }
 
     let total_findings = summary.findings.len();
+    let risk_summary = RiskSummary::from_findings(&summary.findings);
     let finding_density = if summary.lines_of_code > 0 {
         total_findings as f64 * 1000.0 / summary.lines_of_code as f64
     } else {
@@ -78,6 +87,9 @@ pub(crate) fn build_report_stats(summary: &ScanSummary) -> ReportStats {
     ReportStats {
         total_findings,
         severity_counts,
+        priority_counts: risk_summary.counts,
+        highest_priority: risk_summary.highest_priority,
+        average_risk_score: risk_summary.average_score,
         category_counts: category_counts_from_map(category_counts),
         top_rules: top_counts_from_map(rule_counts, 10),
         top_paths: top_counts_from_map(path_counts, 10),

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -3,6 +3,7 @@ mod model;
 mod overlays;
 mod scoring;
 mod sorting;
+mod summary;
 
 #[cfg(test)]
 mod tests;
@@ -13,3 +14,4 @@ pub use model::{
 pub use overlays::{apply_baseline_overlay, apply_review_overlay, apply_workspace_hotspot_overlay};
 pub use scoring::{assess_finding, assess_findings};
 pub use sorting::{compare_findings, sort_findings};
+pub use summary::{RiskPriorityCounts, RiskSummary};

--- a/src/risk/summary.rs
+++ b/src/risk/summary.rs
@@ -1,0 +1,83 @@
+use crate::findings::types::Finding;
+use serde::{Deserialize, Serialize};
+
+use super::model::RiskPriority;
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RiskPriorityCounts {
+    pub p0: usize,
+    pub p1: usize,
+    pub p2: usize,
+    pub p3: usize,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RiskSummary {
+    pub total: usize,
+    pub counts: RiskPriorityCounts,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub highest_priority: Option<RiskPriority>,
+    pub average_score: u8,
+}
+
+impl RiskSummary {
+    pub fn from_findings(findings: &[Finding]) -> Self {
+        if findings.is_empty() {
+            return Self::default();
+        }
+
+        let mut counts = RiskPriorityCounts::default();
+        let mut highest_priority = RiskPriority::P3;
+        let mut score_sum = 0usize;
+
+        for finding in findings {
+            counts.increment(finding.risk.priority);
+            if priority_rank(finding.risk.priority) < priority_rank(highest_priority) {
+                highest_priority = finding.risk.priority;
+            }
+            score_sum += finding.risk.score as usize;
+        }
+
+        let average_score = ((score_sum as f64) / (findings.len() as f64)).round() as u8;
+
+        Self {
+            total: findings.len(),
+            counts,
+            highest_priority: Some(highest_priority),
+            average_score,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total == 0
+    }
+}
+
+impl RiskPriorityCounts {
+    pub fn count(&self, priority: RiskPriority) -> usize {
+        match priority {
+            RiskPriority::P0 => self.p0,
+            RiskPriority::P1 => self.p1,
+            RiskPriority::P2 => self.p2,
+            RiskPriority::P3 => self.p3,
+        }
+    }
+
+    fn increment(&mut self, priority: RiskPriority) {
+        match priority {
+            RiskPriority::P0 => self.p0 += 1,
+            RiskPriority::P1 => self.p1 += 1,
+            RiskPriority::P2 => self.p2 += 1,
+            RiskPriority::P3 => self.p3 += 1,
+        }
+    }
+}
+
+fn priority_rank(priority: RiskPriority) -> u8 {
+    match priority {
+        RiskPriority::P0 => 0,
+        RiskPriority::P1 => 1,
+        RiskPriority::P2 => 2,
+        RiskPriority::P3 => 3,
+    }
+}

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -1,7 +1,7 @@
 use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use repopilot::frameworks::ReactNativeArchitectureProfile;
 use repopilot::output::{OutputFormat, render_scan_summary};
-use repopilot::risk::{RiskInputs, assess_finding};
+use repopilot::risk::{RiskInputs, RiskSummary, assess_finding};
 use repopilot::scan::types::{LanguageSummary, ScanSummary};
 use std::path::PathBuf;
 
@@ -45,6 +45,8 @@ fn renders_valid_json_scan_summary() {
     assert_eq!(parsed["directories_count"], 0);
     assert_eq!(parsed["lines_of_code"], 3);
     assert_eq!(parsed["languages"][0]["name"], "Rust");
+    assert_eq!(parsed["risk_summary"]["total"], 0);
+    assert_eq!(parsed["risk_summary"]["average_score"], 0);
     // react_native must be absent when None
     assert!(parsed.get("react_native").is_none());
 }
@@ -77,6 +79,9 @@ fn json_findings_include_confidence() {
         findings: vec![finding],
         ..ScanSummary::default()
     };
+    let risk_summary = RiskSummary::from_findings(&summary.findings);
+    assert_eq!(risk_summary.total, 1);
+    assert_eq!(risk_summary.counts.p2, 1);
 
     let output =
         render_scan_summary(&summary, OutputFormat::Json).expect("failed to render json summary");
@@ -84,6 +89,10 @@ fn json_findings_include_confidence() {
         serde_json::from_str(&output).expect("output should be valid json");
 
     assert_eq!(parsed["findings"][0]["confidence"], "HIGH");
+    assert_eq!(parsed["risk_summary"]["total"], 1);
+    assert_eq!(parsed["risk_summary"]["counts"]["p2"], 1);
+    assert_eq!(parsed["risk_summary"]["highest_priority"], "P2");
+    assert_eq!(parsed["risk_summary"]["average_score"], 50);
     assert_eq!(parsed["findings"][0]["risk"]["priority"], "P2");
     assert_eq!(parsed["findings"][0]["risk"]["score"], 50);
     assert_eq!(

--- a/tests/risk_summary.rs
+++ b/tests/risk_summary.rs
@@ -1,0 +1,39 @@
+use repopilot::findings::types::Finding;
+use repopilot::risk::{RiskPriority, RiskSummary};
+
+fn finding(priority: RiskPriority, score: u8) -> Finding {
+    let mut finding = Finding::default();
+    finding.risk.priority = priority;
+    finding.risk.score = score;
+    finding
+}
+
+#[test]
+fn risk_summary_counts_priorities_and_average_score() {
+    let findings = vec![
+        finding(RiskPriority::P1, 70),
+        finding(RiskPriority::P2, 50),
+        finding(RiskPriority::P2, 40),
+        finding(RiskPriority::P3, 10),
+    ];
+
+    let summary = RiskSummary::from_findings(&findings);
+
+    assert_eq!(summary.total, 4);
+    assert_eq!(summary.counts.p0, 0);
+    assert_eq!(summary.counts.p1, 1);
+    assert_eq!(summary.counts.p2, 2);
+    assert_eq!(summary.counts.p3, 1);
+    assert_eq!(summary.highest_priority, Some(RiskPriority::P1));
+    assert_eq!(summary.average_score, 43);
+}
+
+#[test]
+fn risk_summary_is_empty_for_no_findings() {
+    let summary = RiskSummary::from_findings(&[]);
+
+    assert!(summary.is_empty());
+    assert_eq!(summary.total, 0);
+    assert_eq!(summary.highest_priority, None);
+    assert_eq!(summary.average_score, 0);
+}


### PR DESCRIPTION
## Summary

This PR adds first-class risk summary metadata derived from finding risk priorities.

RepoPilot findings already contain explainable risk assessments with score and priority. This change adds an aggregate `RiskSummary` model so reports and downstream tooling can consume priority counts without recalculating them from raw findings.

## Type of change

- [x] Feature
- [x] Tests
- [x] Documentation

## What changed

- Added `risk::RiskSummary`.
- Added `risk::RiskPriorityCounts`.
- Added risk summary calculation from findings:
  - total findings
  - P0/P1/P2/P3 counts
  - highest priority
  - average risk score
- Exposed `risk_summary` in JSON scan reports.
- Exposed `risk_summary` in baseline JSON reports.
- Added priority counts to console report stats.
- Updated console Risk Summary output to include priority distribution.
- Updated report documentation.
- Added focused tests for risk summary aggregation.
- Strengthened JSON output tests to verify `risk_summary`.

## Why

Risk priority is now part of RepoPilot’s core remediation model, but consumers still need an aggregate view.

This PR makes risk priority usable as report metadata, which helps with:

- CI summaries
- dashboards
- release checks
- AI remediation planning
- future compare reports
- future quality/risk budgeting

Instead of every consumer recalculating priority counts from `findings`, RepoPilot now provides a stable summary object.

## Architecture notes

- [x] Risk aggregation lives in the `risk` module.
- [x] Finding-level risk scoring remains unchanged.
- [x] No risk weights changed.
- [x] No signal IDs changed.
- [x] JSON change is additive.
- [x] `ScanSummary` is not expanded directly, avoiding unnecessary churn in existing Rust struct literals.
- [x] Report layers consume the new core `RiskSummary` model.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo run -- scan . --format json
cargo run -- scan . --format markdown
cargo run -- scan . --format json --min-priority p1