### PR TITLE
feat: introduce risk engine v2 with cluster-aware prioritization

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ If your installed RepoPilot version does not support `--output`, redirect stdout
 repopilot scan . --format sarif > repopilot.sarif
 ```
 
-Use JSON when custom scripts need to parse RepoPilot results. Console, Markdown, and HTML reports include the RepoPilot version, risk summary, top rules, and grouped findings for human review. Use SARIF for CI and code scanning integrations, including GitHub Code Scanning.
+Use JSON when custom scripts need to parse RepoPilot results. Console, Markdown, and HTML reports include the RepoPilot version, risk summary, top risk clusters, top rules, and grouped findings for human review. Use SARIF for CI and code scanning integrations, including GitHub Code Scanning.
 Use `--receipt <path>` with `scan` when CI or release processes need compact evidence of the exact RepoPilot version, git state, scan scope, finding counts, language counts, and health score.
 
 See [docs/integrations/github-code-scanning.md](docs/integrations/github-code-scanning.md) for a copy-paste GitHub Actions workflow, required permissions, and local validation commands.
@@ -465,6 +465,7 @@ These are planned ideas, not current features:
 | [docs/security.md](docs/security.md) | Local-first trust model, installer security, and vulnerability reporting |
 | [docs/configuration.md](docs/configuration.md) | `repopilot.toml`, presets, ignore files, and baseline adoption |
 | [docs/language-support.md](docs/language-support.md) | Supported language/framework tiers, rule families, and limitations |
+| [docs/risk-engine.md](docs/risk-engine.md) | Risk scoring, priority buckets, signals, and calibration policy |
 | [docs/cli.md](docs/cli.md) | Complete CLI reference — all commands, flags, and exit codes |
 | [docs/commands.md](docs/commands.md) | Task-oriented command guide and common patterns |
 | [docs/rulesets.md](docs/rulesets.md) | Implemented audit rules, categories, and severity levels |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -569,7 +569,7 @@ The `--min-severity` flag filters rendered findings before baseline or CI gate e
 
 | Format | Available in | Best for |
 |--------|-------------|----------|
-| `console` | `scan`, `review`, `compare` | Versioned terminal report with risk summary and grouped findings |
+| `console` | `scan`, `review`, `compare` | Versioned terminal report with risk summary, top risk clusters, and grouped findings |
 | `json` | `scan`, `review`, `compare` | Machine consumption, piping to scripts |
 | `markdown` | `scan`, `review`, `compare` | Versioned human-readable report with top rules and findings index |
 | `html` | `scan` | Standalone visual report with severity, category, and rule filters |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -125,7 +125,7 @@ The legacy `repopilot vibe` command still works in 0.x, but `repopilot ai contex
 
 ### Hardening plan
 
-Use `ai plan` when you want a deterministic remediation plan before editing code. It groups findings into P0/P1/P2/P3 priorities and includes verification commands.
+Use `ai plan` when you want a deterministic remediation plan before editing code. It groups findings into P0/P1/P2/P3 priorities, clusters repeated rule patterns by repository area, and includes verification commands.
 
 ```bash
 repopilot ai plan .

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -158,6 +158,39 @@ Every finding includes stable fields documented in [rulesets.md](rulesets.md):
 | `workspace_package` | string? | Optional monorepo package name. |
 | `evidence` | array | One or more evidence locations. |
 
+### Risk object
+
+RepoPilot 0.10 uses `risk-v2` for deterministic, explainable prioritization:
+
+```json
+{
+  "score": 67,
+  "priority": "P2",
+  "formula_version": "risk-v2",
+  "signals": [
+    {
+      "id": "severity.medium",
+      "label": "MEDIUM severity",
+      "weight": 45,
+      "reason": "base score from rule severity"
+    },
+    {
+      "id": "cluster.repeated",
+      "label": "repeated pattern",
+      "weight": 7,
+      "reason": "same rule appears repeatedly in the same repository area"
+    }
+  ]
+}
+```
+
+Markdown and console reports include a Top Risk Clusters section that groups
+repeated findings by rule and repository area. JSON keeps individual findings so
+baselines, SARIF, and scripts can continue to address exact evidence locations.
+
+See [Risk Engine](risk-engine.md) for priority buckets, signal families, and
+calibration policy.
+
 SARIF output carries the same category, recommendation, confidence, baseline
 status, and workspace package metadata in result properties when available.
 

--- a/docs/risk-engine.md
+++ b/docs/risk-engine.md
@@ -1,0 +1,70 @@
+# Risk Engine
+
+RepoPilot risk scoring is local, deterministic, and explainable. It does not use
+telemetry, hosted analysis, or machine learning. The goal is to rank review work
+better than severity alone while keeping every score auditable.
+
+## Formula v2
+
+`risk-v2` scores each finding on a 0-100 scale:
+
+```text
+base impact
+→ confidence adjustment
+→ Knowledge Engine rule calibration
+→ file and role context
+→ baseline, review, workspace, graph, and cluster overlays
+→ priority bucket
+```
+
+Priority buckets are stable:
+
+| Priority | Score | Meaning |
+|---|---:|---|
+| P0 | 90-100 | Immediate risk; fix or explicitly accept before release. |
+| P1 | 70-89 | High-impact hardening; should be reviewed soon. |
+| P2 | 40-69 | Maintainability, architecture, or moderate runtime risk. |
+| P3 | 0-39 | Backlog cleanup or low-urgency review signal. |
+
+## Signals
+
+Each finding includes `risk.signals[]` with a stable `id`, label, signed weight,
+and reason. Common signal families:
+
+- `severity.*` and `confidence.*` define the starting point.
+- `knowledge.*` applies rule-specific calibration from the bundled Knowledge Engine.
+- `role.*` adjusts for production, test, generated, config, domain, service, and controller files.
+- `baseline.*` prioritizes new findings over accepted existing debt.
+- `review.in-diff` and `review.blast-radius` prioritize changed lines and impacted import dependents.
+- `workspace.hotspot` marks packages with repeated high-risk findings.
+- `graph.*` marks dependency hubs and shared dependencies.
+- `cluster.repeated` marks repeated rule patterns in the same repository area.
+
+Signals are additive but clamped to the 0-100 score range. They are meant to
+explain ranking, not prove that a finding is always a defect.
+
+## Cluster-Aware Reports
+
+Reports and AI plans group repeated findings by rule and repository area. This
+keeps patterns such as many `unwrap()` calls in one renderer module from hiding
+other risk clusters.
+
+Raw JSON still includes each finding individually so downstream tools can keep
+stable finding IDs, evidence, SARIF mapping, and baseline matching.
+
+## Calibration Policy
+
+Risk changes should include focused tests or fixtures that show the intended
+ordering. RepoPilot keeps self-audit as a regression target: the repository
+should not produce P0/P1 findings by default, and repeated medium findings should
+surface as clusters rather than a long undifferentiated list.
+
+## Limitations
+
+RepoPilot uses static, heuristic signals. It is not a compiler, type checker, or
+security proof. Treat findings as review evidence:
+
+- confirm the cited code path before changing behavior;
+- prefer focused suppressions or Knowledge Engine calibration over broad rule removal;
+- add regression tests when a finding is a false positive in a supported context;
+- use language-native tools such as `cargo clippy`, ESLint, Ruff, Pyright, `go vet`, and test suites alongside RepoPilot.

--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -27,6 +27,15 @@ recommendation, and evidence metadata.
 `severity` is the expected impact if the finding is true. `confidence` is how
 certain RepoPilot is that the finding is a real problem in this context.
 
+## Risk Prioritization
+
+Severity is not the final sort key. RepoPilot also assigns each finding an
+explainable `risk-v2` score and P0/P1/P2/P3 priority from severity, confidence,
+Knowledge Engine rule calibration, file role, baseline status, review diff,
+dependency graph impact, workspace hotspots, and repeated-pattern clusters.
+
+See [Risk Engine](risk-engine.md) for the priority contract and signal families.
+
 ## Architecture Rules
 
 | Rule ID | Default severity | What it detects |
@@ -175,3 +184,10 @@ Each entry in the `evidence` array contains:
 | `line_start` | usize | First relevant line, 1-based. |
 | `line_end` | usize? | Last relevant line, when available. |
 | `snippet` | string | Source text or computed evidence at that location. |
+
+## False-Positive Policy
+
+Rules should be tuned with context before they are broadened. If a finding is a
+false positive, prefer adding a narrow regression test, Knowledge Engine
+override, or documented limitation over lowering the rule globally. RepoPilot
+findings are review signals and should be used alongside language-native tools.

--- a/examples/polyglot-report.md
+++ b/examples/polyglot-report.md
@@ -1,0 +1,70 @@
+# RepoPilot Scan Report
+
+## Overview
+
+- **RepoPilot version:** 0.10.0
+- **Path:** `polyglot-api`
+- **Risk:** Moderate
+- **Health score:** 88/100
+- **Findings:** 5 (1.6/kloc)
+- **Files analyzed:** 18
+- **Directories analyzed:** 6
+- **Lines of code:** 3,120
+
+## Risk Summary
+
+- **Severity:** 1 high, 3 medium, 1 low
+- **Categories:** security 1, architecture 1, code-quality 2, testing 1
+- **Top paths:** `src/config.py` 1, `server/main.go` 1, `web/api/client.ts` 1
+
+## Top Risk Clusters
+
+| Priority | Area | Rule | Count | Max severity | Max risk | Examples |
+| --- | --- | --- | ---: | --- | ---: | --- |
+| P1 | `src` | `security.secret-candidate` | 1 | HIGH | 97 | `src/config.py:1` |
+| P2 | `server` | `language.go.panic-exit-risk` | 1 | MEDIUM | 60 | `server/main.go:18` |
+| P2 | `web/api` | `architecture.deep-relative-imports` | 1 | MEDIUM | 50 | `web/api/client.ts:4` |
+| P3 | `server` | `code-marker.todo` | 1 | LOW | 26 | `server/main.go:3` |
+
+## Findings
+
+### Security
+
+#### `security.secret-candidate` (1)
+
+- **[HIGH] Possible secret detected**
+  - Confidence: MEDIUM
+  - Priority: P1 (risk 97/100)
+  - Risk signals: security finding (+12), production code (+10)
+  - Location: `src/config.py:1`
+  - Evidence: `src/config.py:1` - API_KEY = "sk_live_..."
+  - Recommendation: Move the value to an environment variable or secrets manager and rotate the exposed credential.
+
+### Code Quality
+
+#### `language.go.panic-exit-risk` (1)
+
+- **[MEDIUM] Risky Go log.Fatal usage**
+  - Confidence: MEDIUM
+  - Priority: P2 (risk 60/100)
+  - Location: `server/main.go:18`
+  - Recommendation: Return errors from reusable code and centralize process exits at the CLI boundary.
+
+#### `code-marker.todo` (1)
+
+- **[LOW] TODO marker found**
+  - Confidence: MEDIUM
+  - Priority: P3 (risk 26/100)
+  - Risk signals: backlog marker (-4)
+  - Location: `server/main.go:3`
+  - Recommendation: Convert the TODO into a tracked issue or resolve it.
+
+### Architecture
+
+#### `architecture.deep-relative-imports` (1)
+
+- **[MEDIUM] Deep relative import**
+  - Confidence: MEDIUM
+  - Priority: P2 (risk 50/100)
+  - Location: `web/api/client.ts:4`
+  - Recommendation: Introduce a stable module boundary or path alias before the import chain spreads.

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -17,7 +17,9 @@ use repopilot::findings::types::Finding;
 use repopilot::output::{render_baseline_scan_report, render_scan_summary};
 use repopilot::receipt::{build_audit_receipt, render_receipt_json};
 use repopilot::report::writer::write_report;
-use repopilot::risk::{RiskPriority, apply_workspace_hotspot_overlay, sort_findings};
+use repopilot::risk::{
+    RiskPriority, apply_cluster_overlay, apply_workspace_hotspot_overlay, sort_findings,
+};
 use repopilot::scan::config::ScanConfig;
 use repopilot::scan::scanner::scan_path_with_config;
 use repopilot::scan::types::{LanguageSummary, ScanSummary};
@@ -232,6 +234,7 @@ fn scan_workspace(path: &Path, scan_config: &ScanConfig) -> Result<ScanSummary, 
 
     deduplicate_workspace_findings(&mut merged.findings);
     apply_workspace_hotspot_overlay(&mut merged.findings);
+    apply_cluster_overlay(&mut merged.findings);
     sort_findings(&mut merged.findings);
     merged.health_score = ScanSummary::compute_health_score(&merged.findings, merged.lines_of_code);
     merged.scan_duration_us = wall_start.elapsed().as_micros() as u64;

--- a/src/explain/builder.rs
+++ b/src/explain/builder.rs
@@ -1,5 +1,7 @@
 use crate::audits::context::classify_file;
-use crate::explain::model::{ExplainContext, ExplainDecision, ExplainReport, ExplainSource};
+use crate::explain::model::{
+    ExplainContext, ExplainDecision, ExplainReport, ExplainRiskSignal, ExplainSource,
+};
 use crate::findings::types::Severity;
 use crate::knowledge::decision::decide_for_file;
 use crate::knowledge::language::{detect_language_for_path, profile_by_id};
@@ -72,6 +74,12 @@ pub fn build_explain_report(
             action: decision_action_label(decision.action).to_string(),
             final_severity: decision.severity,
             reason: decision.reason,
+            risk_signal: decision.risk_signal.map(|signal| ExplainRiskSignal {
+                id: signal.id,
+                label: signal.label,
+                weight: signal.weight,
+                reason: signal.reason,
+            }),
         }
     });
 

--- a/src/explain/model.rs
+++ b/src/explain/model.rs
@@ -40,4 +40,14 @@ pub struct ExplainDecision {
     pub final_severity: Severity,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk_signal: Option<ExplainRiskSignal>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExplainRiskSignal {
+    pub id: String,
+    pub label: String,
+    pub weight: i16,
+    pub reason: String,
 }

--- a/src/explain/render.rs
+++ b/src/explain/render.rs
@@ -90,6 +90,12 @@ fn render_console_decision(decision: &ExplainDecision) -> String {
     if let Some(reason) = &decision.reason {
         output.push_str(&format!(" Reason: {reason}\n"));
     }
+    if let Some(signal) = &decision.risk_signal {
+        output.push_str(&format!(
+            " Risk signal: {} ({:+}) - {}\n",
+            signal.label, signal.weight, signal.reason
+        ));
+    }
 
     output
 }
@@ -166,6 +172,12 @@ fn render_markdown(report: &ExplainReport) -> String {
             ));
             if let Some(reason) = &decision.reason {
                 output.push_str(&format!("- **Reason:** {reason}\n"));
+            }
+            if let Some(signal) = &decision.risk_signal {
+                output.push_str(&format!(
+                    "- **Risk signal:** {} ({:+}) — {}\n",
+                    signal.label, signal.weight, signal.reason
+                ));
             }
         }
         None => {

--- a/src/knowledge/decision.rs
+++ b/src/knowledge/decision.rs
@@ -99,14 +99,15 @@ pub fn decide(context: &RuleMatchContext<'_>) -> RuleDecision {
         return RuleDecision::suppress(SuppressReason::GeneratedFile);
     }
 
-    let mut decision = RuleDecision::apply(context.base_severity);
+    let mut decision =
+        RuleDecision::apply(context.base_severity).with_risk_signal(rule.risk.clone());
 
     for override_rule in &rule.overrides {
         if context.is_test && !is_test_override(override_rule) {
             continue;
         }
         if override_matches(override_rule, context) {
-            decision = apply_override(override_rule, decision.severity);
+            decision = apply_override(override_rule, decision.severity, rule.risk.clone());
             if decision.is_suppressed() {
                 return decision;
             }
@@ -288,17 +289,24 @@ fn is_test_override(override_rule: &RuleOverride) -> bool {
     matches!(override_rule.role.as_deref(), Some("test" | "rust-test"))
 }
 
-fn apply_override(override_rule: &RuleOverride, current: Severity) -> RuleDecision {
+fn apply_override(
+    override_rule: &RuleOverride,
+    current: Severity,
+    fallback_risk: Option<crate::knowledge::model::RuleRiskAdjustment>,
+) -> RuleDecision {
+    let risk_signal = override_rule.risk.clone().or(fallback_risk);
     match override_rule.action {
         RuleDecisionAction::Apply => RuleDecision {
             action: RuleDecisionAction::Apply,
             severity: override_rule.severity.unwrap_or(current),
             reason: override_rule.reason.clone(),
+            risk_signal,
         },
         RuleDecisionAction::Suppress => RuleDecision {
             action: RuleDecisionAction::Suppress,
             severity: Severity::Info,
             reason: override_rule.reason.clone(),
+            risk_signal: None,
         },
         RuleDecisionAction::Downgrade => {
             let severity = override_rule
@@ -309,6 +317,7 @@ fn apply_override(override_rule: &RuleOverride, current: Severity) -> RuleDecisi
                 action: RuleDecisionAction::Downgrade,
                 severity,
                 reason: override_rule.reason.clone(),
+                risk_signal,
             }
         }
         RuleDecisionAction::Upgrade => {
@@ -320,6 +329,7 @@ fn apply_override(override_rule: &RuleOverride, current: Severity) -> RuleDecisi
                 action: RuleDecisionAction::Upgrade,
                 severity,
                 reason: override_rule.reason.clone(),
+                risk_signal,
             }
         }
     }

--- a/src/knowledge/model.rs
+++ b/src/knowledge/model.rs
@@ -1,5 +1,5 @@
 use crate::findings::types::Severity;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
@@ -62,6 +62,8 @@ pub struct RuleApplicability {
     #[serde(default)]
     pub suppress_config: bool,
     #[serde(default)]
+    pub risk: Option<RuleRiskAdjustment>,
+    #[serde(default)]
     pub overrides: Vec<RuleOverride>,
 }
 
@@ -84,6 +86,16 @@ pub struct RuleOverride {
     pub severity: Option<Severity>,
     #[serde(default)]
     pub reason: Option<String>,
+    #[serde(default)]
+    pub risk: Option<RuleRiskAdjustment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct RuleRiskAdjustment {
+    pub id: String,
+    pub label: String,
+    pub weight: i16,
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -151,6 +163,7 @@ pub struct RuleDecision {
     pub action: RuleDecisionAction,
     pub severity: Severity,
     pub reason: Option<String>,
+    pub risk_signal: Option<RuleRiskAdjustment>,
 }
 
 impl RuleDecision {
@@ -159,6 +172,7 @@ impl RuleDecision {
             action: RuleDecisionAction::Apply,
             severity,
             reason: None,
+            risk_signal: None,
         }
     }
 
@@ -167,11 +181,17 @@ impl RuleDecision {
             action: RuleDecisionAction::Suppress,
             severity: Severity::Info,
             reason: Some(reason.into()),
+            risk_signal: None,
         }
     }
 
     pub fn is_suppressed(&self) -> bool {
         self.action == RuleDecisionAction::Suppress
+    }
+
+    pub fn with_risk_signal(mut self, risk_signal: Option<RuleRiskAdjustment>) -> Self {
+        self.risk_signal = risk_signal;
+        self
     }
 }
 

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -703,6 +703,7 @@ minimum_support = "rule-aware"
 languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin"]
 suppress_low_signal = true
 suppress_generated = true
+risk = { id = "knowledge.circular-dependency", label = "cycle risk", weight = 6, reason = "dependency cycles make local changes harder to isolate and review" }
 
 [[rules]]
 rule_id = "architecture.excessive-fan-out"
@@ -710,6 +711,7 @@ minimum_support = "rule-aware"
 languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin"]
 suppress_low_signal = true
 suppress_generated = true
+risk = { id = "knowledge.excessive-fan-out", label = "wide dependency fan-out", weight = 4, reason = "files that depend on many internal modules are harder to change safely" }
 
 [[rules]]
 rule_id = "architecture.high-instability-hub"
@@ -717,11 +719,13 @@ minimum_support = "rule-aware"
 languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin"]
 suppress_low_signal = true
 suppress_generated = true
+risk = { id = "knowledge.instability-hub", label = "unstable hub", weight = 8, reason = "high fan-in and fan-out indicates a file where changes can ripple broadly" }
 
 [[rules]]
 rule_id = "code-marker.todo"
 suppress_low_signal = true
 suppress_generated = true
+risk = { id = "knowledge.todo-backlog", label = "backlog marker", weight = -4, reason = "TODO markers are useful review signals but usually lower urgency than runtime or security findings" }
 
 [[rules.overrides]]
 role = "test"
@@ -764,6 +768,7 @@ suppress_generated = true
 rule_id = "testing.missing-test-folder"
 minimum_support = "context-aware"
 languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin", "swift", "csharp", "c", "cpp", "php", "ruby", "dart", "scala"]
+risk = { id = "knowledge.testing-adoption", label = "testing adoption signal", weight = -3, reason = "project-level testing gaps guide adoption but often need human prioritization" }
 
 [[rules]]
 rule_id = "testing.source-without-test"
@@ -771,6 +776,7 @@ minimum_support = "context-aware"
 languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin", "swift", "csharp", "c", "cpp", "php", "ruby", "dart", "scala"]
 suppress_low_signal = true
 suppress_generated = true
+risk = { id = "knowledge.coverage-gap", label = "coverage gap", weight = -4, reason = "missing counterpart tests are lower urgency unless they overlap changed or high-risk code" }
 
 [[rules]]
 rule_id = "framework.react-native.inline-style"

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -5,6 +5,7 @@ use crate::frameworks::DetectedFramework;
 use crate::frameworks::FrameworkProject;
 use crate::frameworks::ReactNativeArchitectureProfile;
 use crate::output::color;
+use crate::output::finding_helpers::{clusters_by_rule_scope, example_locations};
 use crate::output::render_helpers::workspace_package_counts;
 use crate::output::report_stats::{
     ReportStats, TOOL_VERSION, build_report_stats, category_order, findings_for_category,
@@ -22,6 +23,7 @@ pub fn render(summary: &ScanSummary) -> String {
 
     render_header(&mut output, summary, &stats);
     render_risk_summary(&mut output, &stats);
+    render_top_risk_clusters(&mut output, &summary.findings);
     render_top_rules(&mut output, &stats);
     render_languages_section(&mut output, summary);
     render_frameworks_section(&mut output, &summary.detected_frameworks);
@@ -54,6 +56,7 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
     output.push('\n');
 
     render_risk_summary(&mut output, &stats);
+    render_top_risk_clusters(&mut output, &summary.findings);
     render_top_rules(&mut output, &stats);
     render_languages_section(&mut output, summary);
     render_frameworks_section(&mut output, &summary.detected_frameworks);
@@ -228,6 +231,52 @@ fn render_top_rules(output: &mut String, stats: &ReportStats) {
         writeln!(output, "  {:>4}  [{}] {}", rule.count, severity, rule.label).unwrap();
     }
     output.push('\n');
+}
+
+fn render_top_risk_clusters(output: &mut String, findings: &[Finding]) {
+    output.push_str("Top Risk Clusters:\n");
+
+    if findings.is_empty() {
+        output.push_str("  none\n\n");
+        return;
+    }
+
+    let finding_refs = findings.iter().collect::<Vec<_>>();
+    let mut clusters = clusters_by_rule_scope(&finding_refs);
+    clusters.sort_by(|left, right| {
+        priority_rank(left.priority)
+            .cmp(&priority_rank(right.priority))
+            .then_with(|| right.max_score.cmp(&left.max_score))
+            .then_with(|| right.findings.len().cmp(&left.findings.len()))
+            .then_with(|| left.rule_id.cmp(right.rule_id))
+            .then_with(|| left.scope.cmp(&right.scope))
+    });
+
+    for cluster in clusters.into_iter().take(5) {
+        let area = cluster.scope.as_deref().unwrap_or(".");
+        let examples = example_locations(&cluster.findings, 2).join(", ");
+        writeln!(
+            output,
+            "  {} risk {:>3}  {:>3} finding(s)  {} in {}  {}",
+            cluster.priority.label(),
+            cluster.max_score,
+            cluster.findings.len(),
+            cluster.rule_id,
+            area,
+            examples
+        )
+        .unwrap();
+    }
+    output.push('\n');
+}
+
+fn priority_rank(priority: crate::risk::RiskPriority) -> u8 {
+    match priority {
+        crate::risk::RiskPriority::P0 => 0,
+        crate::risk::RiskPriority::P1 => 1,
+        crate::risk::RiskPriority::P2 => 2,
+        crate::risk::RiskPriority::P3 => 3,
+    }
 }
 
 fn render_languages_section(output: &mut String, summary: &ScanSummary) {

--- a/src/output/finding_helpers.rs
+++ b/src/output/finding_helpers.rs
@@ -1,37 +1,39 @@
 use crate::findings::types::{Finding, FindingCategory, Severity};
+use crate::risk::RiskPriority;
 use std::collections::BTreeMap;
+use std::path::Component;
 
 pub(crate) struct RuleCluster<'a> {
-    pub(crate) title: &'a str,
+    pub(crate) title: String,
     pub(crate) rule_id: &'a str,
     pub(crate) severity: Severity,
+    pub(crate) priority: RiskPriority,
+    pub(crate) max_score: u8,
+    pub(crate) scope: Option<String>,
     pub(crate) findings: Vec<&'a Finding>,
 }
 
-pub(crate) fn clusters_by_rule<'a>(findings: &'a [&'a Finding]) -> Vec<RuleCluster<'a>> {
-    let mut by_rule: BTreeMap<&str, Vec<&Finding>> = BTreeMap::new();
+pub(crate) fn clusters_by_rule_scope<'a>(findings: &'a [&'a Finding]) -> Vec<RuleCluster<'a>> {
+    let mut by_scope: BTreeMap<(String, String), Vec<&Finding>> = BTreeMap::new();
     for finding in findings.iter().copied() {
-        by_rule.entry(&finding.rule_id).or_default().push(finding);
+        by_scope
+            .entry((
+                finding.rule_id.clone(),
+                cluster_scope_for_finding(finding).unwrap_or_else(|| ".".to_string()),
+            ))
+            .or_default()
+            .push(finding);
     }
 
-    by_rule
-        .into_values()
-        .filter_map(|mut group| {
+    by_scope
+        .into_iter()
+        .filter_map(|((_, scope), mut group)| {
             group.sort_by(|left, right| {
                 crate::risk::compare_findings(left, right)
                     .then_with(|| finding_location(left).cmp(&finding_location(right)))
             });
             let first = group.first().copied()?;
-            Some(RuleCluster {
-                title: cluster_title(first, group.len()),
-                rule_id: first.rule_id.as_str(),
-                severity: group
-                    .iter()
-                    .map(|finding| finding.severity)
-                    .max()
-                    .unwrap_or(first.severity),
-                findings: group,
-            })
+            Some(build_cluster(first, group, Some(scope)))
         })
         .collect()
 }
@@ -78,12 +80,84 @@ pub(crate) fn example_locations(findings: &[&Finding], limit: usize) -> Vec<Stri
         .collect()
 }
 
-fn cluster_title(finding: &Finding, count: usize) -> &str {
-    if count > 1 {
+fn build_cluster<'a>(
+    first: &'a Finding,
+    group: Vec<&'a Finding>,
+    scope: Option<String>,
+) -> RuleCluster<'a> {
+    let severity = group
+        .iter()
+        .map(|finding| finding.severity)
+        .max()
+        .unwrap_or(first.severity);
+    let max_score = group
+        .iter()
+        .map(|finding| finding.risk.score)
+        .max()
+        .unwrap_or(first.risk.score);
+    let priority = group
+        .iter()
+        .map(|finding| finding.risk.priority)
+        .min_by_key(|priority| priority_rank(*priority))
+        .unwrap_or(first.risk.priority);
+    let title = cluster_title(first, group.len(), scope.as_deref());
+
+    RuleCluster {
+        title,
+        rule_id: first.rule_id.as_str(),
+        severity,
+        priority,
+        max_score,
+        scope,
+        findings: group,
+    }
+}
+
+fn cluster_title(finding: &Finding, count: usize, scope: Option<&str>) -> String {
+    let base = if count > 1 {
         crate::rules::lookup_rule_metadata(&finding.rule_id)
             .map(|metadata| metadata.title)
             .unwrap_or(finding.rule_id.as_str())
     } else {
         finding.title.as_str()
+    };
+
+    match scope {
+        Some(scope) if count > 1 && scope != "." => format!("{base} in {scope}"),
+        _ => base.to_string(),
+    }
+}
+
+fn cluster_scope_for_finding(finding: &Finding) -> Option<String> {
+    finding
+        .evidence
+        .first()
+        .map(|evidence| cluster_scope_for_path(&evidence.path))
+}
+
+fn cluster_scope_for_path(path: &std::path::Path) -> String {
+    let parts = path
+        .components()
+        .filter_map(|component| match component {
+            Component::CurDir => None,
+            Component::Normal(value) => Some(value.to_string_lossy().to_string()),
+            Component::RootDir | Component::Prefix(_) | Component::ParentDir => None,
+        })
+        .collect::<Vec<_>>();
+
+    match (parts.first(), parts.get(1)) {
+        (Some(first), Some(second)) if second.contains('.') => first.clone(),
+        (Some(first), Some(second)) => format!("{first}/{second}"),
+        (Some(first), None) => first.clone(),
+        _ => ".".to_string(),
+    }
+}
+
+fn priority_rank(priority: RiskPriority) -> u8 {
+    match priority {
+        RiskPriority::P0 => 0,
+        RiskPriority::P1 => 1,
+        RiskPriority::P2 => 2,
+        RiskPriority::P3 => 3,
     }
 }

--- a/src/output/harden.rs
+++ b/src/output/harden.rs
@@ -1,6 +1,6 @@
 use crate::findings::types::{Finding, FindingCategory, Severity};
 use crate::output::finding_helpers::{
-    RuleCluster, category_rank, clusters_by_rule, example_locations, finding_recommendation,
+    RuleCluster, category_rank, clusters_by_rule_scope, example_locations, finding_recommendation,
 };
 use crate::output::vibe::{DEFAULT_TOKEN_BUDGET, VibeCategory, project_name};
 use crate::scan::types::ScanSummary;
@@ -33,7 +33,7 @@ pub fn render(summary: &ScanSummary, opts: &HardenOptions) -> String {
                 .is_none_or(|focus| focus.matches(&finding.category))
         })
         .collect();
-    let mut clusters = clusters_by_rule(&findings);
+    let mut clusters = clusters_by_rule_scope(&findings);
     sort_harden_clusters(&mut clusters);
 
     let mut out = String::new();
@@ -120,6 +120,17 @@ fn render_cluster_plan(out: &mut String, cluster: &RuleCluster<'_>, index: usize
         count_note
     );
     let _ = writeln!(out, "- Rule: `{}`", cluster.rule_id);
+    if let Some(scope) = &cluster.scope
+        && scope != "."
+    {
+        let _ = writeln!(out, "- Area: `{scope}`");
+    }
+    let _ = writeln!(
+        out,
+        "- Priority: {} (max risk {}/100)",
+        cluster.priority.label(),
+        cluster.max_score
+    );
 
     let examples = example_locations(&cluster.findings, 3);
     if !examples.is_empty() {
@@ -155,24 +166,12 @@ fn priority_label(priority: u8) -> &'static str {
     }
 }
 
-fn priority_rank(finding: &Finding) -> u8 {
-    if finding.severity == Severity::Critical
-        || (finding.severity == Severity::High && finding.category == FindingCategory::Security)
-    {
-        0
-    } else if finding.severity == Severity::High {
-        1
-    } else if finding.severity == Severity::Medium {
-        2
-    } else {
-        3
-    }
-}
-
 fn sort_harden_clusters(clusters: &mut [RuleCluster<'_>]) {
     clusters.sort_by(|left, right| {
-        cluster_priority(left)
-            .cmp(&cluster_priority(right))
+        priority_rank(left)
+            .cmp(&priority_rank(right))
+            .then_with(|| right.max_score.cmp(&left.max_score))
+            .then_with(|| cluster_priority(left).cmp(&cluster_priority(right)))
             .then_with(|| right.severity.cmp(&left.severity))
             .then_with(|| cluster_category_rank(left).cmp(&cluster_category_rank(right)))
             .then_with(|| right.findings.len().cmp(&left.findings.len()))
@@ -184,9 +183,32 @@ fn cluster_priority(cluster: &RuleCluster<'_>) -> u8 {
     cluster
         .findings
         .iter()
-        .map(|finding| priority_rank(finding))
+        .map(|finding| legacy_priority_rank(finding))
         .min()
         .unwrap_or(3)
+}
+
+fn priority_rank(cluster: &RuleCluster<'_>) -> u8 {
+    match cluster.priority {
+        crate::risk::RiskPriority::P0 => 0,
+        crate::risk::RiskPriority::P1 => 1,
+        crate::risk::RiskPriority::P2 => 2,
+        crate::risk::RiskPriority::P3 => 3,
+    }
+}
+
+fn legacy_priority_rank(finding: &Finding) -> u8 {
+    if finding.severity == Severity::Critical
+        || (finding.severity == Severity::High && finding.category == FindingCategory::Security)
+    {
+        0
+    } else if finding.severity == Severity::High {
+        1
+    } else if finding.severity == Severity::Medium {
+        2
+    } else {
+        3
+    }
 }
 
 fn cluster_category_rank(cluster: &RuleCluster<'_>) -> u8 {

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -4,6 +4,7 @@ use crate::findings::types::{Finding, Severity};
 use crate::frameworks::DetectedFramework;
 use crate::frameworks::FrameworkProject;
 use crate::frameworks::ReactNativeArchitectureProfile;
+use crate::output::finding_helpers::{clusters_by_rule_scope, example_locations};
 use crate::output::render_helpers::{escape_table_cell, workspace_package_counts};
 use crate::output::report_stats::{
     ReportStats, TOOL_VERSION, build_report_stats, category_order, findings_for_category,
@@ -24,6 +25,7 @@ pub fn render(summary: &ScanSummary) -> String {
     output.push_str("# RepoPilot Scan Report\n\n");
     render_overview(&mut output, summary, &stats);
     render_risk_summary(&mut output, summary, &stats);
+    render_top_risk_clusters(&mut output, &summary.findings);
     render_top_rules(&mut output, &stats);
     render_languages_section(&mut output, summary);
     render_frameworks_section(&mut output, &summary.detected_frameworks);
@@ -65,6 +67,7 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
     output.push('\n');
 
     render_risk_summary(&mut output, summary, &stats);
+    render_top_risk_clusters(&mut output, &summary.findings);
     render_top_rules(&mut output, &stats);
     render_languages_section(&mut output, summary);
     render_frameworks_section(&mut output, &summary.detected_frameworks);
@@ -184,6 +187,56 @@ fn render_top_rules(output: &mut String, stats: &ReportStats) {
         .unwrap();
     }
     output.push('\n');
+}
+
+fn render_top_risk_clusters(output: &mut String, findings: &[Finding]) {
+    output.push_str("## Top Risk Clusters\n\n");
+
+    if findings.is_empty() {
+        output.push_str("No risk clusters found.\n\n");
+        return;
+    }
+
+    let finding_refs = findings.iter().collect::<Vec<_>>();
+    let mut clusters = clusters_by_rule_scope(&finding_refs);
+    clusters.sort_by(|left, right| {
+        priority_rank(left.priority)
+            .cmp(&priority_rank(right.priority))
+            .then_with(|| right.max_score.cmp(&left.max_score))
+            .then_with(|| right.findings.len().cmp(&left.findings.len()))
+            .then_with(|| left.rule_id.cmp(right.rule_id))
+            .then_with(|| left.scope.cmp(&right.scope))
+    });
+    clusters.truncate(8);
+
+    output.push_str("| Priority | Area | Rule | Count | Max severity | Max risk | Examples |\n");
+    output.push_str("| --- | --- | --- | ---: | --- | ---: | --- |\n");
+    for cluster in clusters {
+        let area = cluster.scope.as_deref().unwrap_or(".");
+        let examples = example_locations(&cluster.findings, 2).join(", ");
+        writeln!(
+            output,
+            "| {} | `{}` | `{}` | {} | {} | {} | {} |",
+            cluster.priority.label(),
+            escape_table_cell(area),
+            escape_table_cell(cluster.rule_id),
+            cluster.findings.len(),
+            cluster.severity.label(),
+            cluster.max_score,
+            escape_table_cell(&examples)
+        )
+        .unwrap();
+    }
+    output.push('\n');
+}
+
+fn priority_rank(priority: crate::risk::RiskPriority) -> u8 {
+    match priority {
+        crate::risk::RiskPriority::P0 => 0,
+        crate::risk::RiskPriority::P1 => 1,
+        crate::risk::RiskPriority::P2 => 2,
+        crate::risk::RiskPriority::P3 => 3,
+    }
 }
 
 fn render_languages_section(output: &mut String, summary: &ScanSummary) {

--- a/src/output/vibe/recommendations.rs
+++ b/src/output/vibe/recommendations.rs
@@ -1,6 +1,6 @@
 use crate::findings::types::{Finding, Severity};
 use crate::output::finding_helpers::{
-    RuleCluster, clusters_by_rule, example_locations, finding_recommendation,
+    RuleCluster, clusters_by_rule_scope, example_locations, finding_recommendation,
 };
 use std::fmt::Write as FmtWrite;
 
@@ -48,19 +48,29 @@ fn recommendation_clusters<'a>(
     findings: &'a [&'a Finding],
     min_severity: Severity,
 ) -> Vec<RuleCluster<'a>> {
-    let mut clusters = clusters_by_rule(findings)
+    let mut clusters = clusters_by_rule_scope(findings)
         .into_iter()
         .filter(|cluster| cluster.severity >= min_severity && !cluster.findings.is_empty())
         .collect::<Vec<_>>();
 
     clusters.sort_by(|left, right| {
-        right
-            .severity
-            .cmp(&left.severity)
+        priority_rank(left)
+            .cmp(&priority_rank(right))
+            .then_with(|| right.max_score.cmp(&left.max_score))
+            .then_with(|| right.severity.cmp(&left.severity))
             .then_with(|| right.findings.len().cmp(&left.findings.len()))
-            .then_with(|| left.title.cmp(right.title))
+            .then_with(|| left.title.cmp(&right.title))
     });
     clusters
+}
+
+fn priority_rank(cluster: &RuleCluster<'_>) -> u8 {
+    match cluster.priority {
+        crate::risk::RiskPriority::P0 => 0,
+        crate::risk::RiskPriority::P1 => 1,
+        crate::risk::RiskPriority::P2 => 2,
+        crate::risk::RiskPriority::P3 => 3,
+    }
 }
 
 pub(super) fn render_footer(

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -11,7 +11,7 @@ use crate::baseline::model::Baseline;
 use crate::findings::types::Finding;
 use crate::review::diff::{ChangedFile, DiffTarget, load_changed_files, resolve_git_root};
 use crate::review::model::{ReviewFindingStatus, ReviewReport};
-use crate::risk::apply_review_overlay;
+use crate::risk::{apply_blast_radius_overlay, apply_review_overlay};
 use crate::scan::types::ScanSummary;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -66,6 +66,7 @@ fn classify_findings(
         .map(|status| status.in_diff)
         .collect::<Vec<_>>();
     apply_review_overlay(&mut summary.findings, &in_diff);
+    apply_blast_radius_overlay(&mut summary.findings, &repo_root, &blast_radius);
     sort_findings_with_review_status(&mut summary.findings, &mut findings);
 
     ReviewReport {

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -9,9 +9,13 @@ mod summary;
 mod tests;
 
 pub use model::{
-    FORMULA_VERSION, RiskAssessment, RiskInputs, RiskPriority, RiskSignal, priority_for_score,
+    FORMULA_VERSION, GraphImpact, RiskAssessment, RiskInputs, RiskPriority, RiskSignal,
+    priority_for_score,
 };
-pub use overlays::{apply_baseline_overlay, apply_review_overlay, apply_workspace_hotspot_overlay};
+pub use overlays::{
+    apply_baseline_overlay, apply_blast_radius_overlay, apply_cluster_overlay, apply_graph_overlay,
+    apply_review_overlay, apply_workspace_hotspot_overlay,
+};
 pub use scoring::{assess_finding, assess_findings};
 pub use sorting::{compare_findings, sort_findings};
 pub use summary::{RiskPriorityCounts, RiskSummary};

--- a/src/risk/model.rs
+++ b/src/risk/model.rs
@@ -1,7 +1,7 @@
 use crate::baseline::diff::BaselineStatus;
 use serde::{Deserialize, Serialize};
 
-pub const FORMULA_VERSION: &str = "risk-v1";
+pub const FORMULA_VERSION: &str = "risk-v2";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RiskAssessment {
@@ -32,6 +32,15 @@ pub struct RiskInputs {
     pub baseline_status: Option<BaselineStatus>,
     pub in_diff: bool,
     pub workspace_hotspot: bool,
+    pub graph_impact: Option<GraphImpact>,
+    pub blast_radius: bool,
+    pub cluster_size: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphImpact {
+    Hub,
+    Dependency,
 }
 
 impl Default for RiskAssessment {

--- a/src/risk/overlays.rs
+++ b/src/risk/overlays.rs
@@ -1,10 +1,12 @@
 use crate::baseline::diff::{BaselineStatus, FindingBaselineStatus};
+use crate::baseline::key::normalized_relative_path;
 use crate::findings::types::{Finding, Severity};
+use crate::graph::{CouplingGraph, compute_metrics};
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use super::model::{
-    FORMULA_VERSION, RiskInputs, RiskSignal, clamp_score, priority_for_score, signal,
+    FORMULA_VERSION, GraphImpact, RiskInputs, RiskSignal, clamp_score, priority_for_score, signal,
 };
 
 pub fn apply_baseline_overlay(
@@ -81,6 +83,110 @@ pub fn apply_workspace_hotspot_overlay(findings: &mut [Finding]) {
     }
 }
 
+pub fn apply_graph_overlay(findings: &mut [Finding], graph: &CouplingGraph) {
+    let impacts = graph_impacts(graph);
+    if impacts.is_empty() {
+        return;
+    }
+
+    for finding in findings {
+        let Some(path) = finding_path_key(finding) else {
+            continue;
+        };
+        let Some(impact) = impacts.get(path.as_str()).copied() else {
+            continue;
+        };
+        let signal = match impact {
+            GraphImpact::Hub => signal(
+                "graph.hub",
+                "dependency hub",
+                8,
+                "file has high fan-in or fan-out, so changes can ripple through the codebase",
+            ),
+            GraphImpact::Dependency => signal(
+                "graph.dependency",
+                "shared dependency",
+                5,
+                "file is imported by multiple other files",
+            ),
+        };
+        apply_overlay_signal(
+            finding,
+            signal,
+            RiskInputs {
+                graph_impact: Some(impact),
+                ..RiskInputs::default()
+            },
+        );
+    }
+}
+
+pub fn apply_blast_radius_overlay(
+    findings: &mut [Finding],
+    repo_root: &Path,
+    blast_radius: &[PathBuf],
+) {
+    let impacted = blast_radius
+        .iter()
+        .map(|path| path_key(path))
+        .collect::<HashSet<_>>();
+    if impacted.is_empty() {
+        return;
+    }
+
+    for finding in findings {
+        if finding
+            .evidence
+            .first()
+            .map(|evidence| normalized_relative_path(&evidence.path, repo_root))
+            .is_some_and(|path| impacted.contains(&path))
+        {
+            apply_overlay_signal(
+                finding,
+                signal(
+                    "review.blast-radius",
+                    "blast radius",
+                    6,
+                    "finding is in a file impacted by changed import dependencies",
+                ),
+                RiskInputs {
+                    blast_radius: true,
+                    ..RiskInputs::default()
+                },
+            );
+        }
+    }
+}
+
+pub fn apply_cluster_overlay(findings: &mut [Finding]) {
+    let cluster_sizes = repeated_cluster_sizes(findings);
+    if cluster_sizes.is_empty() {
+        return;
+    }
+
+    for finding in findings {
+        let Some(key) = finding_cluster_key(finding) else {
+            continue;
+        };
+        let Some(size) = cluster_sizes.get(&key).copied().filter(|size| *size >= 3) else {
+            continue;
+        };
+        apply_overlay_signal(
+            finding,
+            signal(
+                "cluster.repeated",
+                "repeated pattern",
+                cluster_weight(size),
+                "same rule appears repeatedly in the same repository area",
+            ),
+            RiskInputs {
+                cluster_size: size,
+                ..RiskInputs::default()
+            },
+        );
+    }
+}
+
 pub(super) fn baseline_signal(status: BaselineStatus) -> RiskSignal {
     match status {
         BaselineStatus::New => signal(
@@ -128,4 +234,78 @@ fn workspace_hotspots(findings: &[Finding]) -> HashSet<String> {
         .into_iter()
         .filter_map(|(package, count)| (count > 1).then_some(package))
         .collect()
+}
+
+fn graph_impacts(graph: &CouplingGraph) -> HashMap<String, GraphImpact> {
+    compute_metrics(graph)
+        .into_iter()
+        .filter_map(|metric| {
+            let impact = if metric.fan_in >= 3 || metric.fan_out >= 8 {
+                GraphImpact::Hub
+            } else if metric.fan_in >= 2 {
+                GraphImpact::Dependency
+            } else {
+                return None;
+            };
+            Some((path_key(&metric.path), impact))
+        })
+        .collect()
+}
+
+fn repeated_cluster_sizes(findings: &[Finding]) -> HashMap<String, usize> {
+    let mut counts = HashMap::new();
+    for finding in findings {
+        if let Some(key) = finding_cluster_key(finding) {
+            *counts.entry(key).or_default() += 1;
+        }
+    }
+    counts.retain(|_, count| *count >= 3);
+    counts
+}
+
+fn finding_cluster_key(finding: &Finding) -> Option<String> {
+    let path = finding
+        .evidence
+        .first()
+        .map(|evidence| path_key(&evidence.path))?;
+    Some(format!("{}:{}", finding.rule_id, cluster_scope(&path)))
+}
+
+fn finding_path_key(finding: &Finding) -> Option<String> {
+    finding
+        .evidence
+        .first()
+        .map(|evidence| path_key(&evidence.path))
+}
+
+fn cluster_scope(path: &str) -> String {
+    let mut parts = path.split('/').filter(|part| !part.is_empty());
+    match (parts.next(), parts.next()) {
+        (Some(first), Some(second)) if second.contains('.') => first.to_string(),
+        (Some(first), Some(second)) => format!("{first}/{second}"),
+        (Some(first), None) => first.to_string(),
+        _ => ".".to_string(),
+    }
+}
+
+fn path_key(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::CurDir => None,
+            Component::Normal(value) => Some(value.to_string_lossy().to_string()),
+            Component::RootDir | Component::Prefix(_) | Component::ParentDir => {
+                Some(component.as_os_str().to_string_lossy().to_string())
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn cluster_weight(size: usize) -> i16 {
+    match size {
+        0..=2 => 0,
+        3..=5 => 3,
+        6..=15 => 5,
+        _ => 7,
+    }
 }

--- a/src/risk/scoring.rs
+++ b/src/risk/scoring.rs
@@ -1,10 +1,13 @@
 use crate::findings::types::{Confidence, Finding, FindingCategory, Severity};
+use crate::knowledge::decision::decide_for_file;
 use crate::scan::facts::{FileFacts, ScanFacts};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use super::context::add_file_context_signals;
-use super::model::{RiskAssessment, RiskInputs, RiskSignal, clamp_score, push_adjustment, signal};
+use super::model::{
+    GraphImpact, RiskAssessment, RiskInputs, RiskSignal, clamp_score, push_adjustment, signal,
+};
 use super::overlays::baseline_signal;
 
 pub fn assess_findings(findings: &mut [Finding], facts: &ScanFacts) {
@@ -41,6 +44,7 @@ pub fn assess_finding(
     }
 
     if let Some(file) = file {
+        add_knowledge_rule_signal(finding, file, &mut score, &mut signals);
         add_file_context_signals(file, &mut score, &mut signals);
     }
 
@@ -71,7 +75,85 @@ pub fn assess_finding(
         );
     }
 
+    if let Some(impact) = inputs.graph_impact {
+        add_graph_signal(impact, &mut score, &mut signals);
+    }
+
+    if inputs.blast_radius {
+        push_adjustment(
+            &mut score,
+            &mut signals,
+            "review.blast-radius",
+            "blast radius",
+            6,
+            "finding is in a file impacted by changed import dependencies",
+        );
+    }
+
+    if inputs.cluster_size >= 3 {
+        let weight = cluster_weight(inputs.cluster_size);
+        push_adjustment(
+            &mut score,
+            &mut signals,
+            "cluster.repeated",
+            "repeated pattern",
+            weight,
+            "same rule appears repeatedly in the same repository area",
+        );
+    }
+
     RiskAssessment::new(clamp_score(score), signals)
+}
+
+fn add_knowledge_rule_signal(
+    finding: &Finding,
+    file: &FileFacts,
+    score: &mut i16,
+    signals: &mut Vec<RiskSignal>,
+) {
+    let decision = decide_for_file(&finding.rule_id, file, finding.severity, None);
+    let Some(rule_signal) = decision.risk_signal else {
+        return;
+    };
+
+    push_adjustment(
+        score,
+        signals,
+        rule_signal.id.as_str(),
+        rule_signal.label.as_str(),
+        rule_signal.weight,
+        rule_signal.reason.as_str(),
+    );
+}
+
+fn add_graph_signal(impact: GraphImpact, score: &mut i16, signals: &mut Vec<RiskSignal>) {
+    match impact {
+        GraphImpact::Hub => push_adjustment(
+            score,
+            signals,
+            "graph.hub",
+            "dependency hub",
+            8,
+            "file has high fan-in or fan-out, so changes can ripple through the codebase",
+        ),
+        GraphImpact::Dependency => push_adjustment(
+            score,
+            signals,
+            "graph.dependency",
+            "shared dependency",
+            5,
+            "file is imported by multiple other files",
+        ),
+    }
+}
+
+fn cluster_weight(size: usize) -> i16 {
+    match size {
+        0..=2 => 0,
+        3..=5 => 3,
+        6..=15 => 5,
+        _ => 7,
+    }
 }
 
 fn severity_base_score(severity: Severity) -> u8 {

--- a/src/risk/tests.rs
+++ b/src/risk/tests.rs
@@ -4,7 +4,8 @@ use crate::scan::facts::FileFacts;
 use std::path::PathBuf;
 
 #[test]
-fn priority_thresholds_match_v1_plan() {
+fn priority_thresholds_match_v2_plan() {
+    assert_eq!(FORMULA_VERSION, "risk-v2");
     assert_eq!(priority_for_score(90), RiskPriority::P0);
     assert_eq!(priority_for_score(70), RiskPriority::P1);
     assert_eq!(priority_for_score(40), RiskPriority::P2);

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -11,7 +11,7 @@ use crate::frameworks::{
     detect_react_native_architecture,
 };
 use crate::knowledge::decision::apply_project_decisions;
-use crate::risk::assess_findings;
+use crate::risk::{apply_cluster_overlay, apply_graph_overlay, assess_findings};
 use crate::scan::config::ScanConfig;
 use crate::scan::types::{ScanSummary, ScanTimings};
 use std::io;
@@ -72,6 +72,8 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
         finding.id = stable_finding_key(finding, path);
     }
     assess_findings(&mut findings, &facts);
+    apply_graph_overlay(&mut findings, &coupling_graph);
+    apply_cluster_overlay(&mut findings);
     summary::sort_findings(&mut findings);
 
     let scan_duration_us = start.elapsed().as_micros() as u64;

--- a/tests/cli_stabilization.rs
+++ b/tests/cli_stabilization.rs
@@ -204,19 +204,25 @@ fn exit_codes_distinguish_findings_usage_and_runtime_errors() {
 #[test]
 fn self_audit_stays_clean_at_high_severity() {
     let repo = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let output = run_ok(
-        &["scan", ".", "--min-severity", "high", "--format", "json"],
-        repo,
-    );
+    let output = run_ok(&["scan", ".", "--format", "json"], repo);
     let json: Value = serde_json::from_slice(&output.stdout).expect("json output from self-audit");
-    let finding_count = json["findings"]
+    let high_or_higher = json["findings"]
         .as_array()
-        .map(|a| a.len())
+        .map(|findings| {
+            findings
+                .iter()
+                .filter(|finding| matches!(finding["severity"].as_str(), Some("HIGH" | "CRITICAL")))
+                .count()
+        })
         .unwrap_or(usize::MAX);
+    let p0 = json["risk_summary"]["counts"]["p0"].as_u64().unwrap_or(1);
+    let p1 = json["risk_summary"]["counts"]["p1"].as_u64().unwrap_or(1);
     assert_eq!(
-        finding_count,
+        high_or_higher,
         0,
         "self-audit high severity should stay clean\n{}",
         serde_json::to_string_pretty(&json).unwrap_or_default()
     );
+    assert_eq!(p0, 0, "self-audit should not produce P0 findings");
+    assert_eq!(p1, 0, "self-audit should not produce P1 findings");
 }

--- a/tests/harden_prompt_command.rs
+++ b/tests/harden_prompt_command.rs
@@ -88,8 +88,9 @@ fn harden_groups_repeated_medium_findings_by_rule() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
-    assert!(stdout.contains("File exceeds recommended size (2 findings)"));
+    assert!(stdout.contains("File exceeds recommended size in src (2 findings)"));
     assert!(stdout.contains("Rule: `architecture.large-file`"));
+    assert!(stdout.contains("Area: `src`"));
     assert!(stdout.contains("`./src/large_a.rs:1`"));
     assert!(stdout.contains("`./src/large_b.rs:1`"));
 }

--- a/tests/output_console.rs
+++ b/tests/output_console.rs
@@ -40,6 +40,7 @@ fn console_output_includes_versioned_summary_and_grouped_findings() {
     assert!(output.contains("RepoPilot Scan"));
     assert!(output.contains(&format!("Version: {}", env!("CARGO_PKG_VERSION"))));
     assert!(output.contains("Risk Summary:"));
+    assert!(output.contains("Top Risk Clusters:"));
     assert!(output.contains("Top Rules:"));
     assert!(output.contains("Findings:"));
     assert!(output.contains("Security:"));

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -68,6 +68,7 @@ fn renders_markdown_scan_summary() {
     )));
     assert!(output.contains("## Overview"));
     assert!(output.contains("## Risk Summary"));
+    assert!(output.contains("## Top Risk Clusters"));
     assert!(output.contains("## Top Rules"));
     assert!(output.contains("## Languages"));
     assert!(output.contains("## Findings Index"));
@@ -75,6 +76,7 @@ fn renders_markdown_scan_summary() {
     assert!(output.contains("### Code Quality"));
     assert!(output.contains("#### `code-marker.todo` (1)"));
     assert!(output.contains("| `code-marker.todo` | 1 | LOW |"));
+    assert!(output.contains("| P3 | `src` | `code-marker.todo` | 1 | LOW | 0 |"));
     assert!(output.contains("`src/main.rs:7`"));
     assert!(output.contains("- **Path:** `demo-project`"));
     assert!(output.contains("- **Files analyzed:** 2"));

--- a/tests/risk_calibration.rs
+++ b/tests/risk_calibration.rs
@@ -1,0 +1,153 @@
+use repopilot::findings::types::Finding;
+use repopilot::risk::{RiskPriority, RiskSummary};
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::scanner::scan_path_with_config;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+#[test]
+fn clean_small_rust_cli_has_no_high_priority_risk() {
+    let temp = tempdir().expect("temp dir");
+    write_file(
+        temp.path(),
+        "src/main.rs",
+        r#"
+fn main() {
+    println!("hello");
+}
+"#,
+    );
+    let config = ScanConfig {
+        detect_missing_tests: false,
+        ..ScanConfig::default()
+    };
+
+    let summary = scan_path_with_config(temp.path(), &config).expect("scan");
+    let risk = RiskSummary::from_findings(&summary.findings);
+
+    assert_eq!(risk.counts.p0, 0);
+    assert_eq!(risk.counts.p1, 0);
+}
+
+#[test]
+fn repeated_render_module_patterns_are_clustered() {
+    let temp = tempdir().expect("temp dir");
+    for file in ["a.rs", "b.rs", "c.rs"] {
+        write_file(
+            temp.path(),
+            &format!("src/output/{file}"),
+            r#"
+pub fn render(value: Option<&str>) -> String {
+    value.unwrap().to_string()
+}
+"#,
+        );
+    }
+    let config = ScanConfig {
+        detect_missing_tests: false,
+        ..ScanConfig::default()
+    };
+
+    let summary = scan_path_with_config(temp.path(), &config).expect("scan");
+    let render_findings = findings_for_rule(&summary.findings, "language.rust.panic-risk");
+
+    assert_eq!(render_findings.len(), 3);
+    assert!(render_findings.iter().all(|finding| {
+        finding
+            .risk
+            .signals
+            .iter()
+            .any(|signal| signal.id == "cluster.repeated")
+    }));
+}
+
+#[test]
+fn polyglot_backend_prioritizes_secret_over_backlog_marker() {
+    let temp = tempdir().expect("temp dir");
+    write_file(
+        temp.path(),
+        "src/config.py",
+        r#"API_KEY = "sk_live_123456789abcdef"
+"#,
+    );
+    write_file(
+        temp.path(),
+        "server/main.go",
+        r#"
+package main
+
+// TODO: replace demo handler
+func main() {}
+"#,
+    );
+    let config = ScanConfig {
+        detect_missing_tests: false,
+        ..ScanConfig::default()
+    };
+
+    let summary = scan_path_with_config(temp.path(), &config).expect("scan");
+    let secret = first_rule(&summary.findings, "security.secret-candidate");
+    let todo = first_rule(&summary.findings, "code-marker.todo");
+
+    assert!(secret.risk.score > todo.risk.score);
+    assert!(matches!(
+        secret.risk.priority,
+        RiskPriority::P0 | RiskPriority::P1
+    ));
+    assert_eq!(todo.risk.priority, RiskPriority::P3);
+}
+
+#[test]
+fn react_native_fixture_keeps_framework_findings_explainable_not_critical() {
+    let temp = tempdir().expect("temp dir");
+    write_file(
+        temp.path(),
+        "package.json",
+        r#"{"dependencies":{"react":"18.2.0","react-native":"0.73.0"}}"#,
+    );
+    write_file(
+        temp.path(),
+        "src/App.tsx",
+        r#"
+import React from "react";
+import { Text } from "react-native";
+
+export function App() {
+  return <Text style={{ color: "red" }}>Hi</Text>;
+}
+"#,
+    );
+    let config = ScanConfig {
+        detect_missing_tests: false,
+        ..ScanConfig::default()
+    };
+
+    let summary = scan_path_with_config(temp.path(), &config).expect("scan");
+    let inline_style = first_rule(&summary.findings, "framework.react-native.inline-style");
+
+    assert_eq!(inline_style.risk.formula_version, "risk-v2");
+    assert_ne!(inline_style.risk.priority, RiskPriority::P0);
+}
+
+fn write_file(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent");
+    }
+    fs::write(path, content).expect("write file");
+}
+
+fn first_rule<'a>(findings: &'a [Finding], rule_id: &str) -> &'a Finding {
+    findings
+        .iter()
+        .find(|finding| finding.rule_id == rule_id)
+        .unwrap_or_else(|| panic!("missing finding for {rule_id}"))
+}
+
+fn findings_for_rule<'a>(findings: &'a [Finding], rule_id: &str) -> Vec<&'a Finding> {
+    findings
+        .iter()
+        .filter(|finding| finding.rule_id == rule_id)
+        .collect()
+}

--- a/tests/risk_engine.rs
+++ b/tests/risk_engine.rs
@@ -1,11 +1,14 @@
 use repopilot::baseline::diff::{BaselineStatus, FindingBaselineStatus};
 use repopilot::baseline::key::stable_finding_key;
 use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
+use repopilot::graph::CouplingGraph;
 use repopilot::risk::{
-    RiskInputs, RiskPriority, apply_baseline_overlay, apply_review_overlay,
+    FORMULA_VERSION, RiskInputs, RiskPriority, apply_baseline_overlay, apply_blast_radius_overlay,
+    apply_cluster_overlay, apply_graph_overlay, apply_review_overlay,
     apply_workspace_hotspot_overlay, assess_finding,
 };
 use repopilot::scan::facts::FileFacts;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 #[test]
@@ -167,6 +170,116 @@ fn priority_labels_follow_score_thresholds() {
 
     assert_eq!(critical.risk.priority, RiskPriority::P0);
     assert_eq!(low.risk.priority, RiskPriority::P3);
+    assert_eq!(critical.risk.formula_version, FORMULA_VERSION);
+}
+
+#[test]
+fn graph_overlay_boosts_hub_findings_above_leaf_findings() {
+    let mut findings = vec![
+        assessed_finding("code-quality.complex-file", "src/core.rs", Severity::Medium),
+        assessed_finding("code-quality.complex-file", "src/leaf.rs", Severity::Medium),
+    ];
+    let graph = graph(&[
+        ("src/a.rs", "src/core.rs"),
+        ("src/b.rs", "src/core.rs"),
+        ("src/c.rs", "src/core.rs"),
+        ("src/core.rs", "src/leaf.rs"),
+    ]);
+
+    apply_graph_overlay(&mut findings, &graph);
+
+    assert!(findings[0].risk.score > findings[1].risk.score);
+    assert!(
+        findings[0]
+            .risk
+            .signals
+            .iter()
+            .any(|signal| signal.id == "graph.hub")
+    );
+}
+
+#[test]
+fn blast_radius_overlay_boosts_impacted_files() {
+    let mut findings = vec![
+        assessed_finding(
+            "architecture.large-file",
+            "src/impacted.rs",
+            Severity::Medium,
+        ),
+        assessed_finding("architecture.large-file", "src/other.rs", Severity::Medium),
+    ];
+
+    apply_blast_radius_overlay(
+        &mut findings,
+        Path::new("/repo"),
+        &[PathBuf::from("src/impacted.rs")],
+    );
+
+    assert!(findings[0].risk.score > findings[1].risk.score);
+    assert!(
+        findings[0]
+            .risk
+            .signals
+            .iter()
+            .any(|signal| signal.id == "review.blast-radius")
+    );
+}
+
+#[test]
+fn cluster_overlay_marks_repeated_rule_scope_patterns() {
+    let mut findings = vec![
+        assessed_finding(
+            "language.rust.panic-risk",
+            "src/output/a.rs",
+            Severity::Medium,
+        ),
+        assessed_finding(
+            "language.rust.panic-risk",
+            "src/output/b.rs",
+            Severity::Medium,
+        ),
+        assessed_finding(
+            "language.rust.panic-risk",
+            "src/output/c.rs",
+            Severity::Medium,
+        ),
+        assessed_finding(
+            "language.rust.panic-risk",
+            "src/core/d.rs",
+            Severity::Medium,
+        ),
+    ];
+
+    apply_cluster_overlay(&mut findings);
+
+    assert!(
+        findings[0]
+            .risk
+            .signals
+            .iter()
+            .any(|signal| signal.id == "cluster.repeated")
+    );
+    assert!(
+        findings[3]
+            .risk
+            .signals
+            .iter()
+            .all(|signal| signal.id != "cluster.repeated")
+    );
+}
+
+#[test]
+fn knowledge_rule_adjustment_participates_in_risk_scoring() {
+    let finding = finding("code-marker.todo", "src/lib.rs", Severity::Low);
+    let file = file("src/lib.rs", Some("Rust"));
+
+    let risk = assess_finding(&finding, Some(&file), RiskInputs::default());
+
+    assert!(
+        risk.signals
+            .iter()
+            .any(|signal| signal.id == "knowledge.todo-backlog")
+    );
 }
 
 fn assessed_finding(rule_id: &str, path: &str, severity: Severity) -> Finding {
@@ -210,5 +323,23 @@ fn file(path: &str, language: Option<&str>) -> FileFacts {
         imports: Vec::new(),
         content: None,
         has_inline_tests: false,
+    }
+}
+
+fn graph(edges: &[(&str, &str)]) -> CouplingGraph {
+    let mut edge_map: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
+    let mut nodes = BTreeSet::new();
+
+    for (source, target) in edges {
+        let source = PathBuf::from(source);
+        let target = PathBuf::from(target);
+        nodes.insert(source.clone());
+        nodes.insert(target.clone());
+        edge_map.entry(source).or_default().insert(target);
+    }
+
+    CouplingGraph {
+        edges: edge_map,
+        nodes,
     }
 }


### PR DESCRIPTION
## Summary

This PR upgrades RepoPilot’s risk prioritization model to `risk-v2`.

The new version improves finding ranking with Knowledge Engine calibration, dependency graph context, repeated-pattern clustering, and clearer report output. Reports now surface Top Risk Clusters so users can identify repeated high-impact patterns by rule and repository area instead of reading a flat list of findings.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation

## What changed

- Updated the risk formula from `risk-v1` to `risk-v2`.
- Added Knowledge Engine risk calibration through rule-level risk adjustments.
- Added risk signal support to rule decisions and `inspect explain`.
- Added graph-aware risk overlays for dependency hubs and shared dependencies.
- Added repeated-pattern cluster overlays.
- Added Top Risk Clusters to console and Markdown reports.
- Updated AI/hardening output to better group repeated risk patterns.
- Added/updated risk engine documentation:
  - `docs/risk-engine.md`
  - `docs/reports.md`
  - `docs/rulesets.md`
  - README/CLI/command docs
- Added an example polyglot report showing the new cluster-aware output.
- Added tests for risk calibration, cluster overlays, report rendering, CLI behavior, and AI prompt/plan output.

## Why

Severity alone is not enough to decide what should be fixed first.

A medium-severity finding repeated across the same repository area can be more important than a single isolated finding. Similarly, findings in dependency hubs, shared modules, or changed blast-radius paths deserve stronger prioritization.

`risk-v2` makes RepoPilot’s remediation order more useful by combining:

- rule severity
- confidence
- Knowledge Engine calibration
- file role/context
- baseline and review context
- dependency graph impact
- workspace hotspots
- repeated-pattern clusters

This makes reports better for human triage, CI review, and AI-assisted remediation workflows.

## Architecture notes

- [x] Risk scoring remains centralized in the `risk` module.
- [x] Knowledge Engine owns rule-specific calibration metadata.
- [x] Output layers render risk clusters but do not own scoring logic.
- [x] Explain output can show why a rule contributes a risk signal.
- [x] Scan/review flows apply overlays where the required context exists.
- [x] Findings remain evidence-backed and individually addressable.
- [x] JSON/SARIF-compatible finding-level data remains available for downstream tooling.

## User-facing behavior

Users now get clearer prioritization in reports:

- individual findings include `risk-v2` scores and signals;
- console and Markdown reports include Top Risk Clusters;
- repeated findings are grouped by rule and repository area;
- AI plan/context output can focus on repeated remediation patterns;
- `inspect explain` can show Knowledge Engine risk signal reasoning.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo run -- scan . --format console
cargo run -- scan . --format markdown --output /tmp/repopilot-risk-v2.md
cargo run -- scan . --format json --output /tmp/repopilot-risk-v2.json
cargo run -- ai plan . --budget 4k
cargo run -- inspect explain . --rule code-marker.todo