### PR TITLE
chore: prepare RepoPilot 0.11.0 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Kiev
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: deps
+      include: scope
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Europe/Kiev
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - npm
+    commit-message:
+      prefix: deps
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: Europe/Kiev
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: ci
+      include: scope

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -10,6 +10,21 @@
 - name: docs
   color: "0075ca"
   description: Documentation and examples
+- name: dependencies
+  color: "0366d6"
+  description: Dependency updates and supply chain maintenance
+- name: rust
+  color: "dea584"
+  description: Rust code, Cargo dependencies, or toolchain changes
+- name: npm
+  color: "cb3837"
+  description: npm package wrapper or JavaScript dependency changes
+- name: ci
+  color: "5319e7"
+  description: GitHub Actions, checks, and automation
+- name: security
+  color: "d73a4a"
+  description: Security hardening, vulnerability fixes, or security tooling
 - name: good-first-issue
   color: "7057ff"
   description: Small, well-scoped issue suitable for new contributors

--- a/.github/repository-topics.txt
+++ b/.github/repository-topics.txt
@@ -2,9 +2,13 @@ repopilot
 static-analysis
 code-review
 architecture
+security
+security-tools
 react-native
 expo
 sarif
+github-actions
+ai-tools
 cli
 rust
 npm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust 1.87
         uses: dtolnay/rust-toolchain@1.87
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -48,7 +48,7 @@ jobs:
       - name: CLI release smoke tests
         run: cargo test --test cli_release_smoke
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -106,9 +106,10 @@ jobs:
           shellcheck "${scripts[@]}"
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.x'
+          cache: false
 
       - name: Install actionlint
         run: |
@@ -134,7 +135,7 @@ jobs:
 
       - name: Install Node.js
         if: ${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json') != '' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: rust,javascript-typescript
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             archive: zip
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -107,7 +107,7 @@ jobs:
       - build
       - verify-crates-package
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download packaged artifacts
         uses: actions/download-artifact@v4
@@ -138,7 +138,7 @@ jobs:
         if: ${{ env.CARGO_REGISTRY_TOKEN == '' }}
         run: echo "CRATES_IO_TOKEN is not configured; skipping crates.io publish."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ env.CARGO_REGISTRY_TOKEN != '' }}
 
       - name: Install Rust toolchain
@@ -161,7 +161,7 @@ jobs:
         if: ${{ env.HOMEBREW_TAP_TOKEN == '' }}
         run: echo "HOMEBREW_TAP_TOKEN is not configured; skipping Homebrew tap update."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ env.HOMEBREW_TAP_TOKEN != '' }}
 
       - name: Download release artifacts
@@ -190,7 +190,7 @@ jobs:
 
       - name: Checkout homebrew tap
         if: ${{ env.HOMEBREW_TAP_TOKEN != '' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: MykytaStel/homebrew-repopilot
           path: tap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-17
+
+### Added
+
+- Added v0.11 release checklist focused on signal quality, GitHub Action parity, and release trust.
+- Added first-party GitHub Action support for `command: doctor`, `fail-on-priority`, `min-priority`, `rule`, and `timing`.
+- Added product smoke coverage for priority filtering, rule filtering, scan timing, and priority gates.
+
+### Changed
+
+- Reduced RepoPilot self-audit P2 noise by treating `write!`/`writeln!` result unwraps in report renderers as infallible string-rendering boilerplate while still reporting unwraps inside formatting arguments.
+- Documented the v0.11 adoption loop: doctor diagnostics, focused scan/review filters, AI context, and CI gates.
+
 ## [0.10.0] - 2026-05-16
 
 ### Added
@@ -201,7 +214,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added `compare` for diffing two JSON scan reports.
 - Added CI workflow, release workflow, distribution docs, release docs, and ruleset docs.
 
-[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/MykytaStel/repopilot/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/MykytaStel/repopilot/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/MykytaStel/repopilot/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/MykytaStel/repopilot/compare/v0.7.0...v0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repopilot"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repopilot"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Local-first CLI for repository audit, architecture risk detection, baseline tracking, and CI-friendly code review."

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ and framework health checks. It gives developers useful terminal reports, CI gat
 SARIF for GitHub Code Scanning, and Markdown briefs that can be pasted into Claude
 Code, ChatGPT, Cursor, or another coding assistant.
 
-Version `0.10.0` is an adoption and stability release: it focuses on cleaner
-rollout diagnostics, reproducible audit receipts, CI artifacts, and 0.x command
-compatibility while keeping all scans local.
+Version `0.11.0` is a signal quality and CI polish release: it reduces
+low-value self-audit findings, adds first-party Action parity for priority/rule
+filters, and tightens the `doctor -> scan/review -> ai context -> CI gate` loop
+while keeping all scans local.
 
 ## Why RepoPilot?
 
@@ -133,8 +134,10 @@ Once you want CI integration, baseline tracking, or tighter configuration:
 ```bash
 repopilot init                                              # generate repopilot.toml
 repopilot doctor .                                          # check CI / baseline readiness
+repopilot scan . --min-priority p2 --rule security.secret-candidate
+repopilot ai context . --focus security                     # prepare local AI context
 repopilot baseline create .                                 # accept existing findings as known debt
-repopilot review . --base origin/main --fail-on new-high    # CI gate on new findings only
+repopilot review . --base origin/main --fail-on-priority p1 # CI gate on high-priority risk
 ```
 
 Save a shareable report:
@@ -217,7 +220,7 @@ RepoPilot is a local-first safety layer for AI-assisted and vibe-coded changes. 
 repopilot ai context . --focus security    # get an LLM brief for Claude Code
 repopilot ai plan . --focus security       # get a prioritized hardening plan
 repopilot ai prompt . --budget 8k          # generate a paste-ready remediation prompt
-repopilot review . --base origin/main --baseline .repopilot/baseline.json --fail-on new-high
+repopilot review . --base origin/main --baseline .repopilot/baseline.json --fail-on-priority p1
 repopilot scan . --workspace --min-severity medium --format markdown --output repopilot-report.md
 ```
 
@@ -403,7 +406,7 @@ Use `--fail-on new-high` to fail CI only when new high or critical findings are 
 When `--fail-on new-*` is used without `--baseline`, RepoPilot treats all current findings as new. For baseline-based adoption, commit an accepted baseline and scan against it in CI.
 
 To upload RepoPilot findings to GitHub Code Scanning, generate SARIF and use `github/codeql-action/upload-sarif`. The workflow must include `security-events: write`.
-The first-party action can also run `command: ai-context`, `command: ai-plan`, or `command: ai-prompt`; those commands emit Markdown and do not produce SARIF. Prefer typed action inputs such as `path`, `config`, `baseline`, `fail-on`, `focus`, `budget`, `output`, and `receipt`; `args` remains available for advanced flags.
+The first-party action can also run `command: doctor`, `command: ai-context`, `command: ai-plan`, or `command: ai-prompt`; AI commands emit Markdown and do not produce SARIF. Prefer typed action inputs such as `path`, `config`, `baseline`, `fail-on`, `fail-on-priority`, `min-priority`, `rule`, `timing`, `focus`, `budget`, `output`, and `receipt`; `args` remains available for advanced flags.
 
 ```yaml
 name: RepoPilot
@@ -472,6 +475,7 @@ These are planned ideas, not current features:
 | [docs/react-native.md](docs/react-native.md) | React Native and Expo detection, findings, and limitations |
 | [docs/integrations/github-code-scanning.md](docs/integrations/github-code-scanning.md) | GitHub Code Scanning SARIF workflow |
 | [docs/release.md](docs/release.md) | Manual release process |
+| [docs/release-checklist-0.11.md](docs/release-checklist-0.11.md) | 0.11.0 release readiness checklist |
 | [docs/release-checklist-0.10.md](docs/release-checklist-0.10.md) | 0.10.0 release readiness checklist |
 | [docs/distribution.md](docs/distribution.md) | Distribution channels |
 | [docs/github-ruleset.md](docs/github-ruleset.md) | GitHub branch ruleset configuration |

--- a/action.yml
+++ b/action.yml
@@ -8,15 +8,15 @@ branding:
 
 inputs:
   command:
-    description: "Command to run: scan | review | compare | ai-context | ai-plan | ai-prompt"
+    description: "Command to run: scan | review | compare | doctor | ai-context | ai-plan | ai-prompt"
     required: false
     default: "scan"
   format:
-    description: "Output format: auto | console | json | markdown | sarif. auto uses sarif for scan and markdown for review/compare; AI commands emit Markdown."
+    description: "Output format: auto | console | json | markdown | sarif. auto uses sarif for scan and markdown for review/compare/doctor; AI commands emit Markdown."
     required: false
     default: "auto"
   path:
-    description: "Path passed to scan, review, or AI commands."
+    description: "Path passed to scan, review, doctor, or AI commands."
     required: false
     default: "."
   config:
@@ -31,10 +31,26 @@ inputs:
     description: "Optional scan/review failure threshold, e.g. new-high."
     required: false
     default: ""
+  fail-on-priority:
+    description: "Optional scan/review failure threshold by risk priority: p0 | p1 | p2 | p3."
+    required: false
+    default: ""
   min-severity:
     description: "Optional minimum rendered severity, e.g. high."
     required: false
     default: ""
+  min-priority:
+    description: "Optional minimum rendered risk priority: p0 | p1 | p2 | p3."
+    required: false
+    default: ""
+  rule:
+    description: "Optional scan rule filter. For multiple rules, provide a space-separated list of rule IDs."
+    required: false
+    default: ""
+  timing:
+    description: "Print per-phase scan timing breakdown for scan commands."
+    required: false
+    default: "false"
   base:
     description: "Optional Git base ref for review."
     required: false
@@ -64,7 +80,7 @@ inputs:
     required: false
     default: ""
   version:
-    description: "npm version tag to install (e.g. latest, 0.10.0)"
+    description: "npm version tag to install (e.g. latest, 0.11.0)"
     required: false
     default: "latest"
   upload-sarif:
@@ -98,7 +114,11 @@ runs:
         CONFIG="${{ inputs.config }}"
         BASELINE="${{ inputs.baseline }}"
         FAIL_ON="${{ inputs.fail-on }}"
+        FAIL_ON_PRIORITY="${{ inputs.fail-on-priority }}"
         MIN_SEVERITY="${{ inputs.min-severity }}"
+        MIN_PRIORITY="${{ inputs.min-priority }}"
+        RULE_INPUT="${{ inputs.rule }}"
+        TIMING="${{ inputs.timing }}"
         BASE="${{ inputs.base }}"
         HEAD="${{ inputs.head }}"
         FOCUS="${{ inputs.focus }}"
@@ -111,11 +131,12 @@ runs:
           scan) RUN_ARGS=(scan "$PATH_INPUT") ;;
           review) RUN_ARGS=(review "$PATH_INPUT") ;;
           compare) RUN_ARGS=(compare) ;;
+          doctor) RUN_ARGS=(doctor "$PATH_INPUT") ;;
           ai-context|vibe) RUN_ARGS=(ai context "$PATH_INPUT") ;;
           ai-plan|harden) RUN_ARGS=(ai plan "$PATH_INPUT") ;;
           ai-prompt|prompt) RUN_ARGS=(ai prompt "$PATH_INPUT") ;;
           *)
-          echo "::error::Unsupported command '$COMMAND'. Expected scan, review, compare, ai-context, ai-plan, or ai-prompt."
+          echo "::error::Unsupported command '$COMMAND'. Expected scan, review, compare, doctor, ai-context, ai-plan, or ai-prompt."
           exit 1
           ;;
         esac
@@ -140,13 +161,38 @@ runs:
           echo "::error::Receipt output is only supported by 'scan'. Remove receipt or use command=scan."
           exit 1
         fi
+        if [[ -n "$FAIL_ON_PRIORITY" && "$COMMAND" != "scan" && "$COMMAND" != "review" ]]; then
+          echo "::error::fail-on-priority is only supported by 'scan' and 'review'."
+          exit 1
+        fi
+        if [[ -n "$MIN_PRIORITY" && "$COMMAND" != "scan" && "$COMMAND" != "review" ]]; then
+          echo "::error::min-priority is only supported by 'scan' and 'review'."
+          exit 1
+        fi
+        if [[ -n "$RULE_INPUT" && "$COMMAND" != "scan" ]]; then
+          echo "::error::rule filtering is only supported by 'scan'."
+          exit 1
+        fi
+        if [[ "$TIMING" == "true" && "$COMMAND" != "scan" ]]; then
+          echo "::error::timing is only supported by 'scan'."
+          exit 1
+        fi
 
         if [[ -n "$CONFIG" && "$COMMAND" != "compare" ]]; then RUN_ARGS+=(--config "$CONFIG"); fi
         if [[ "$COMMAND" == "scan" || "$COMMAND" == "review" ]]; then
           if [[ -n "$BASELINE" ]]; then RUN_ARGS+=(--baseline "$BASELINE"); fi
           if [[ -n "$FAIL_ON" ]]; then RUN_ARGS+=(--fail-on "$FAIL_ON"); fi
+          if [[ -n "$FAIL_ON_PRIORITY" ]]; then RUN_ARGS+=(--fail-on-priority "$FAIL_ON_PRIORITY"); fi
           if [[ -n "$MIN_SEVERITY" ]]; then RUN_ARGS+=(--min-severity "$MIN_SEVERITY"); fi
+          if [[ -n "$MIN_PRIORITY" ]]; then RUN_ARGS+=(--min-priority "$MIN_PRIORITY"); fi
         fi
+        if [[ "$COMMAND" == "scan" && -n "$RULE_INPUT" ]]; then
+          read -r -a RULES <<< "$RULE_INPUT"
+          for RULE in "${RULES[@]}"; do
+            RUN_ARGS+=(--rule "$RULE")
+          done
+        fi
+        if [[ "$COMMAND" == "scan" && "$TIMING" == "true" ]]; then RUN_ARGS+=(--timing); fi
         if [[ "$COMMAND" == "review" && -n "$BASE" ]]; then RUN_ARGS+=(--base "$BASE"); fi
         if [[ "$COMMAND" == "review" && -n "$HEAD" ]]; then RUN_ARGS+=(--head "$HEAD"); fi
         if [[ "$IS_AI" == "true" && -n "$FOCUS" ]]; then RUN_ARGS+=(--focus "$FOCUS"); fi

--- a/docs/ai-workflows.md
+++ b/docs/ai-workflows.md
@@ -6,6 +6,7 @@ development without uploading source code.
 ## Core workflow
 
 ```bash
+repopilot doctor .
 repopilot scan .
 repopilot ai context .
 repopilot ai plan .
@@ -15,7 +16,7 @@ repopilot ai prompt .
 Use this loop:
 
 ```text
-scan -> understand -> plan -> prompt -> change -> review
+doctor -> scan -> understand -> plan -> prompt -> change -> review
 ```
 
 ## Generate context
@@ -71,7 +72,7 @@ Run cargo fmt, clippy, and tests.
 repopilot ai prompt . --focus security --output prompt.md
 # paste prompt into your coding assistant
 cargo test --all
-repopilot review . --base origin/main --fail-on new-high
+repopilot review . --base origin/main --fail-on-priority p1
 ```
 
 ## Good focus values
@@ -108,7 +109,8 @@ repopilot ai prompt . --focus architecture --budget 4k
 Use `review` after AI-generated or AI-assisted edits:
 
 ```bash
-repopilot review . --base origin/main --baseline .repopilot/baseline.json --fail-on new-high
+repopilot review . --base origin/main --baseline .repopilot/baseline.json --fail-on-priority p1
+repopilot scan . --min-priority p2 --rule language.rust.panic-risk
 ```
 
 This helps catch new high-risk findings introduced by the change rather than

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,6 +10,7 @@ Task-oriented guide to RepoPilot commands. For a complete flag reference see [do
 repopilot init          # generate repopilot.toml
 repopilot doctor .      # check adoption readiness
 repopilot scan .        # scan the current directory
+repopilot ai context .  # prepare local AI remediation context
 ```
 
 For React Native or Expo projects:
@@ -101,6 +102,15 @@ repopilot scan . --min-severity high
 repopilot review . --min-severity high
 ```
 
+Use `--min-priority` when you want risk-ranked output instead of severity-only
+filtering, and `--rule` when investigating one detector:
+
+```bash
+repopilot scan . --min-priority p2
+repopilot review . --base origin/main --min-priority p1
+repopilot scan . --rule language.rust.panic-risk --timing
+```
+
 Use `--verbose` when you need scan and render timing:
 
 ```bash
@@ -176,9 +186,11 @@ Covers staged, unstaged, and untracked files.
 ```bash
 repopilot review . --base origin/main
 repopilot review . --base origin/main --head HEAD
+repopilot review . --base origin/main --fail-on-priority p1
 ```
 
 When `--fail-on` is used with `review`, only **in-diff findings** trigger a failure — unrelated pre-existing issues do not block CI.
+`--fail-on-priority` works the same way, but evaluates P0/P1/P2/P3 risk priority instead of severity.
 
 ### Blast radius
 

--- a/docs/github-ruleset.md
+++ b/docs/github-ruleset.md
@@ -2,6 +2,44 @@
 
 This document describes the GitHub repository ruleset that protects the `main` branch.
 
+## Repository metadata
+
+Set these repository fields in **Settings -> General**:
+
+| Setting | Value |
+|---|---|
+| Description | `Local-first CLI for repository audits, architecture risk detection, SARIF, CI gates, and AI-ready remediation context.` |
+| Website | `https://github.com/MykytaStel/repopilot#readme` |
+| Topics | `rust`, `cli`, `static-analysis`, `code-review`, `security`, `security-tools`, `architecture`, `sarif`, `github-actions`, `ai-tools`, `react-native`, `expo`, `npm` |
+
+Recommended feature toggles:
+
+| Setting | Value |
+|---|---|
+| Issues | Enabled |
+| Projects | Disabled unless actively used |
+| Wiki | Disabled unless actively used |
+| Automatically delete head branches | Enabled |
+
+## Repository security settings
+
+Set these in **Settings -> Code security and analysis**:
+
+| Setting | Value |
+|---|---|
+| Dependency graph | Enabled |
+| Dependabot alerts | Enabled |
+| Dependabot security updates | Enabled |
+| Secret scanning | Enabled |
+| Push protection | Enabled |
+| Non-provider secret scanning patterns | Enabled if available |
+| Secret validity checks | Enabled if available |
+
+The repository also contains:
+
+- `.github/dependabot.yml` for Cargo, npm, and GitHub Actions updates.
+- `.github/workflows/codeql.yml` for CodeQL Rust and JavaScript/TypeScript scanning.
+
 ## Why rulesets instead of branch protection rules
 
 GitHub Rulesets (available on all plans) supersede the legacy branch protection UI. Advantages:
@@ -33,7 +71,10 @@ Go to **Settings → Rules → Rulesets → New ruleset** and configure the foll
 | — Dismiss stale approvals when new commits are pushed | Enabled |
 | — Require review from Code Owners | Disabled (no `CODEOWNERS` file yet) |
 | Require status checks to pass | Enabled |
-| — Required status check | `Rust checks` (job name in `ci.yaml`) |
+| — Required status check | `Rust MSRV 1.87` |
+| — Required status check | `Rust checks` |
+| — Required status check | `Security and maintenance checks` |
+| — Required status check | `CodeQL` |
 | — Require branches to be up to date before merging | Enabled |
 | Block force pushes | Enabled |
 

--- a/docs/integrations/github-code-scanning.md
+++ b/docs/integrations/github-code-scanning.md
@@ -93,11 +93,12 @@ jobs:
 
       - name: Run RepoPilot
         id: repopilot
-        uses: MykytaStel/repopilot@v0.10.0
+        uses: MykytaStel/repopilot@v0.11.0
         with:
           command: scan
           baseline: .repopilot/baseline.json
           fail-on: new-high
+          min-priority: p2
           receipt: repopilot-receipt.json
 
       - name: Upload audit receipt
@@ -112,12 +113,34 @@ For review-only gates, use `command: review` without `receipt`:
 
 ```yaml
       - name: RepoPilot review gate
-        uses: MykytaStel/repopilot@v0.10.0
+        uses: MykytaStel/repopilot@v0.11.0
         with:
           command: review
           base: origin/main
           baseline: .repopilot/baseline.json
-          fail-on: new-high
+          fail-on-priority: p1
+          upload-sarif: "false"
+```
+
+For adoption diagnostics or focused rule investigations, use the same first-party
+action without SARIF upload:
+
+```yaml
+      - name: RepoPilot doctor
+        uses: MykytaStel/repopilot@v0.11.0
+        with:
+          command: doctor
+          format: markdown
+          output: repopilot-doctor.md
+          upload-sarif: "false"
+
+      - name: RepoPilot focused scan
+        uses: MykytaStel/repopilot@v0.11.0
+        with:
+          command: scan
+          rule: language.rust.panic-risk
+          min-priority: p2
+          timing: "true"
           upload-sarif: "false"
 ```
 

--- a/docs/release-checklist-0.11.md
+++ b/docs/release-checklist-0.11.md
@@ -1,0 +1,127 @@
+# RepoPilot 0.11.0 Release Checklist
+
+RepoPilot 0.11.0 is the signal quality and CI polish release.
+
+Main release promise:
+
+```text
+signal quality -> action parity -> release trust
+```
+
+## Release Scope
+
+- Keep the stable command surface compatible with 0.10.
+- Reduce self-audit P2 noise without hiding P0/P1 risk.
+- Keep JSON, SARIF, baseline, and receipt schemas backward-compatible.
+- Bring the first-party GitHub Action closer to the CLI flags used in CI.
+- Keep runtime commands local-first: no telemetry, source upload, hosted scanner, or LLM API calls.
+
+## Signal Quality Gates
+
+Run the self-audit from the repository root:
+
+```bash
+cargo run -- scan . --format json --output /tmp/repopilot-self-audit.json
+```
+
+Verify:
+
+- `risk_summary.counts.p0 == 0`
+- `risk_summary.counts.p1 == 0`
+- `risk_summary.counts.p2 <= 135`
+- high/critical findings remain at `0`
+
+Spot-check the medium-or-higher clusters:
+
+```bash
+cargo run -- scan . --min-severity medium --format json \
+  | jq '.findings | group_by(.rule_id)[] | {rule: .[0].rule_id, count: length}'
+```
+
+Expected dominant clusters should stay explainable: long functions, complex files,
+large files, and only actionable Rust panic-risk findings.
+
+## Follow-Up Refactor Candidates
+
+Do not block the 0.11.0 release on broad large-file refactors. Track these
+hotspots after release unless they become scan stability issues:
+
+- `src/output/markdown.rs`
+- `src/output/console.rs`
+- `src/commands/scan.rs`
+- `src/knowledge/catalog.rs`
+- `src/audits/context/model.rs`
+
+## GitHub Action Parity
+
+Validate the first-party action supports:
+
+- `command: doctor`
+- `fail-on-priority`
+- `min-priority`
+- `rule`
+- `timing`
+- `receipt` only with `command: scan`
+- SARIF upload only with `command: scan`
+
+Smoke examples:
+
+```yaml
+- uses: MykytaStel/repopilot@v0.11.0
+  with:
+    command: doctor
+    format: markdown
+    output: repopilot-doctor.md
+
+- uses: MykytaStel/repopilot@v0.11.0
+  with:
+    command: scan
+    min-priority: p2
+    rule: language.rust.panic-risk
+    timing: "true"
+    upload-sarif: "false"
+
+- uses: MykytaStel/repopilot@v0.11.0
+  with:
+    command: review
+    base: origin/main
+    baseline: .repopilot/baseline.json
+    fail-on-priority: p1
+    upload-sarif: "false"
+```
+
+## Required Local Checks
+
+Run from the repository root:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+npm test
+npm pack --dry-run
+cargo package --list
+cargo publish --dry-run
+./scripts/verify-release.sh
+```
+
+Run the product smoke suite against the release binary:
+
+```bash
+cargo build --release
+./scripts/smoke-product.sh --binary ./target/release/repopilot --repo .
+```
+
+## Version Consistency
+
+Before tagging, update and verify:
+
+```bash
+grep '^version = "0.11.0"' Cargo.toml
+grep '"version": "0.11.0"' package.json
+grep '## \[0.11.0\]' CHANGELOG.md
+rg '0\.[[]10[]]\.0|release-checklist-0\.[[]10[]]' Cargo.toml package.json action.yml README.md docs .github scripts install.sh Formula
+```
+
+The final search should only report historical changelog entries, old release
+checklists, and examples intentionally pinned to old versions.

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -16,7 +16,7 @@ JSON scan reports include explicit schema metadata. The current schema is 0.10:
 ```json
 {
   "schema_version": "0.10",
-  "repopilot_version": "0.10.0",
+  "repopilot_version": "0.11.0",
   "root_path": ".",
   "files_count": 42,
   "directories_count": 12,
@@ -71,7 +71,7 @@ Example shape:
 ```json
 {
   "schema_version": "0.10",
-  "repopilot_version": "0.10.0",
+  "repopilot_version": "0.11.0",
   "root_path": ".",
   "files_count": 42,
   "risk_summary": {
@@ -107,7 +107,7 @@ Receipt JSON is intentionally smaller than a scan report and has its own schema:
 {
   "schema_version": 1,
   "tool": "repopilot",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "generated_at": "2026-05-16T00:00:00Z",
   "root_path": ".",
   "git": {
@@ -160,7 +160,7 @@ Every finding includes stable fields documented in [rulesets.md](rulesets.md):
 
 ### Risk object
 
-RepoPilot 0.10 uses `risk-v2` for deterministic, explainable prioritization:
+RepoPilot 0.11 uses `risk-v2` for deterministic, explainable prioritization:
 
 ```json
 {

--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -1,6 +1,6 @@
 # Audit Rulesets
 
-RepoPilot findings are identified by a stable `rule_id`. RepoPilot 0.10.0 ships
+RepoPilot findings are identified by a stable `rule_id`. RepoPilot 0.11.0 ships
 46 built-in rules. Each finding carries category, severity, confidence,
 recommendation, and evidence metadata.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -57,11 +57,17 @@ For RepoPilot itself and projects using RepoPilot in CI, prefer:
 
 - protected `main` branch;
 - required CI checks;
+- CodeQL code scanning;
 - no force-push to protected branches;
 - minimal GitHub Actions permissions;
-- dependency scanning;
+- dependency graph, Dependabot alerts, and Dependabot security updates;
 - secret scanning;
+- secret scanning push protection;
 - release tags created from reviewed commits.
+
+RepoPilot keeps `.github/dependabot.yml` for Cargo, npm, and GitHub Actions
+updates. Security updates still require Dependabot security updates to be enabled
+in the repository settings.
 
 ## GitHub Actions permissions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repopilot",
-	"version": "0.10.0",
+	"version": "0.11.0",
 	"description": "Local-first CLI for repository audit, architecture risk detection, baseline tracking, and CI-friendly code review.",
 	"license": "MIT OR Apache-2.0",
 	"repository": {

--- a/scripts/smoke-product.sh
+++ b/scripts/smoke-product.sh
@@ -116,6 +116,16 @@ run_repopilot() {
   )
 }
 
+run_repopilot_in() {
+  local cwd="$1"
+  shift
+  echo "==> repopilot $* (cwd: $cwd)" >&2
+  (
+    cd "$cwd"
+    "$BINARY" "$@"
+  )
+}
+
 assert_non_empty() {
   local file="$1"
   if [[ ! -s "$file" ]]; then
@@ -211,6 +221,18 @@ assert_non_empty "$TMP_DIR/scan.json"
 validate_json_if_possible "$TMP_DIR/scan.json"
 assert_non_empty "$TMP_DIR/receipt.json"
 validate_json_if_possible "$TMP_DIR/receipt.json"
+
+run_repopilot scan . --format json --min-priority p2 --rule language.rust.panic-risk --timing --output "$TMP_DIR/scan-rule-priority-timing.json"
+assert_non_empty "$TMP_DIR/scan-rule-priority-timing.json"
+validate_json_if_possible "$TMP_DIR/scan-rule-priority-timing.json"
+
+PRIORITY_GATE_PROJECT="$TMP_DIR/priority-gate-project"
+mkdir -p "$PRIORITY_GATE_PROJECT/src" "$PRIORITY_GATE_PROJECT/tests"
+printf 'pub fn ok() -> bool { true }\n' > "$PRIORITY_GATE_PROJECT/src/lib.rs"
+printf '#[test]\nfn ok() { assert!(priority_gate_project::ok()); }\n' > "$PRIORITY_GATE_PROJECT/tests/lib_test.rs"
+run_repopilot_in "$PRIORITY_GATE_PROJECT" scan . --format json --fail-on-priority p0 --output "$TMP_DIR/scan-priority-gate.json"
+assert_non_empty "$TMP_DIR/scan-priority-gate.json"
+validate_json_if_possible "$TMP_DIR/scan-priority-gate.json"
 
 run_repopilot scan . --format markdown --output "$TMP_DIR/scan.md"
 assert_non_empty "$TMP_DIR/scan.md"

--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -29,6 +29,7 @@ impl FileAudit for RustPanicRiskAudit {
 
         let mut findings = Vec::new();
         let mut in_block_comment = false;
+        let mut pending_render_write = false;
 
         for (index, line) in content.lines().enumerate() {
             let line_number = index + 1;
@@ -39,9 +40,25 @@ impl FileAudit for RustPanicRiskAudit {
             }
 
             let sanitized = sanitize_c_style(line, &mut in_block_comment);
-            let Some(pattern) = detect_pattern(sanitized.trim()) else {
+            let sanitized = sanitized.trim();
+            if is_infallible_render_write_start(&file.path, sanitized) {
+                pending_render_write = true;
+            }
+
+            let Some(pattern) = detect_pattern(sanitized) else {
+                if sanitized.ends_with(';') {
+                    pending_render_write = false;
+                }
                 continue;
             };
+
+            if pending_render_write && is_infallible_render_write_result_unwrap(pattern, sanitized)
+            {
+                if sanitized.ends_with(';') {
+                    pending_render_write = false;
+                }
+                continue;
+            }
 
             let decision = decide_for_audit_context(
                 RULE_ID,
@@ -62,6 +79,10 @@ impl FileAudit for RustPanicRiskAudit {
                 &context,
                 decision.severity,
             ));
+
+            if sanitized.ends_with(';') {
+                pending_render_write = false;
+            }
         }
 
         findings
@@ -130,6 +151,43 @@ fn detect_pattern(trimmed: &str) -> Option<RustPanicPattern> {
     }
 
     None
+}
+
+fn is_infallible_render_write_start(path: &std::path::Path, trimmed: &str) -> bool {
+    is_report_renderer_path(path)
+        && (trimmed.starts_with("writeln!(") || trimmed.starts_with("write!("))
+}
+
+fn is_report_renderer_path(path: &std::path::Path) -> bool {
+    let mut previous = None;
+    for component in path
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+    {
+        if previous == Some("src") && component == "output" {
+            return true;
+        }
+        previous = Some(component);
+    }
+    false
+}
+
+fn is_infallible_render_write_result_unwrap(pattern: RustPanicPattern, trimmed: &str) -> bool {
+    match pattern {
+        RustPanicPattern::Unwrap => {
+            trimmed == ".unwrap();"
+                || (is_infallible_render_write_line(trimmed) && trimmed.ends_with(".unwrap();"))
+        }
+        RustPanicPattern::Expect => {
+            trimmed.starts_with(".expect(")
+                || (is_infallible_render_write_line(trimmed) && trimmed.contains(").expect("))
+        }
+        RustPanicPattern::Panic | RustPanicPattern::Todo | RustPanicPattern::Unimplemented => false,
+    }
+}
+
+fn is_infallible_render_write_line(trimmed: &str) -> bool {
+    trimmed.starts_with("writeln!(") || trimmed.starts_with("write!(")
 }
 
 fn build_finding(
@@ -407,6 +465,60 @@ mod tests {
         let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
 
         assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn ignores_string_write_unwraps_in_report_renderers() {
+        let file = facts(
+            "src/output/markdown.rs",
+            "pub fn render(output: &mut String) {\n    writeln!(output, \"# Report\").unwrap();\n}\n",
+            false,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn ignores_multiline_string_write_unwraps_in_report_renderers() {
+        let file = facts(
+            "src/output/console.rs",
+            "pub fn render(output: &mut String) {\n    writeln!(\n        output,\n        \"Findings: {}\",\n        3\n    )\n    .unwrap();\n}\n",
+            false,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn still_reports_non_renderer_unwraps_in_output_modules() {
+        let file = facts(
+            "src/output/markdown.rs",
+            "pub fn render(value: Option<&str>) -> &str {\n    value.unwrap()\n}\n",
+            false,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, RULE_ID);
+    }
+
+    #[test]
+    fn still_reports_unwraps_inside_renderer_format_arguments() {
+        let file = facts(
+            "src/output/console.rs",
+            "pub fn render(output: &mut String, value: Option<&str>) {\n    writeln!(output, \"{}\", value.unwrap());\n}\n",
+            false,
+        );
+
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, RULE_ID);
     }
 
     #[test]

--- a/src/scan/scanner/file/read.rs
+++ b/src/scan/scanner/file/read.rs
@@ -25,13 +25,24 @@ pub(super) fn load_file(path: &Path, config: &ScanConfig) -> io::Result<LoadedFi
     let language = detect_language(path).map(str::to_string);
 
     if config.max_file_bytes > 0 {
-        let file_size = fs::metadata(path)?.len();
-        if file_size > config.max_file_bytes {
-            return Ok(LoadedFile::Skipped {
-                language,
-                reason: SkipReason::LargeFile,
-                skipped_bytes: file_size,
-            });
+        match fs::metadata(path) {
+            Ok(metadata) => {
+                let file_size = metadata.len();
+                if file_size > config.max_file_bytes {
+                    return Ok(LoadedFile::Skipped {
+                        language,
+                        reason: SkipReason::LargeFile,
+                        skipped_bytes: file_size,
+                    });
+                }
+            }
+            Err(_) => {
+                return Ok(LoadedFile::Skipped {
+                    language,
+                    reason: SkipReason::Binary,
+                    skipped_bytes: 0,
+                });
+            }
         }
     }
 
@@ -100,4 +111,28 @@ fn count_lines_of_code(content: &str) -> usize {
         .lines()
         .filter(|line| !line.trim().is_empty())
         .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_is_skipped_instead_of_aborting_scan() {
+        let loaded = load_file(Path::new("missing-after-walk.rs"), &ScanConfig::default())
+            .expect("missing file should be classified as skipped");
+
+        let LoadedFile::Skipped {
+            language,
+            reason,
+            skipped_bytes,
+        } = loaded
+        else {
+            panic!("missing file should not be analyzable");
+        };
+
+        assert_eq!(language.as_deref(), Some("Rust"));
+        assert_eq!(reason, SkipReason::Binary);
+        assert_eq!(skipped_bytes, 0);
+    }
 }

--- a/tests/action_yml.rs
+++ b/tests/action_yml.rs
@@ -13,3 +13,33 @@ fn action_exposes_typed_receipt_input_and_output() {
     assert!(action.contains("RUN_ARGS+=(--receipt \"$RECEIPT\")"));
     assert!(action.contains("receipt_file=$RECEIPT"));
 }
+
+#[test]
+fn action_exposes_v011_cli_parity_inputs() {
+    let action_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("action.yml");
+    let action = fs::read_to_string(action_path).expect("read action.yml");
+
+    for input in ["fail-on-priority:", "min-priority:", "rule:", "timing:"] {
+        assert!(action.contains(input), "missing action input {input}");
+    }
+
+    assert!(action.contains("FAIL_ON_PRIORITY=\"${{ inputs.fail-on-priority }}\""));
+    assert!(action.contains("MIN_PRIORITY=\"${{ inputs.min-priority }}\""));
+    assert!(action.contains("RULE_INPUT=\"${{ inputs.rule }}\""));
+    assert!(action.contains("TIMING=\"${{ inputs.timing }}\""));
+    assert!(action.contains("RUN_ARGS+=(--fail-on-priority \"$FAIL_ON_PRIORITY\")"));
+    assert!(action.contains("RUN_ARGS+=(--min-priority \"$MIN_PRIORITY\")"));
+    assert!(action.contains("RUN_ARGS+=(--rule \"$RULE\")"));
+    assert!(action.contains("RUN_ARGS+=(--timing)"));
+}
+
+#[test]
+fn action_supports_doctor_as_markdown_auto_command() {
+    let action_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("action.yml");
+    let action = fs::read_to_string(action_path).expect("read action.yml");
+
+    assert!(action.contains("doctor) RUN_ARGS=(doctor \"$PATH_INPUT\") ;;"));
+    assert!(action.contains("scan | review | compare | doctor | ai-context"));
+    assert!(action.contains("review/compare/doctor"));
+    assert!(action.contains("SARIF output and upload are only supported by 'scan'"));
+}

--- a/tests/cli_stabilization.rs
+++ b/tests/cli_stabilization.rs
@@ -217,6 +217,9 @@ fn self_audit_stays_clean_at_high_severity() {
         .unwrap_or(usize::MAX);
     let p0 = json["risk_summary"]["counts"]["p0"].as_u64().unwrap_or(1);
     let p1 = json["risk_summary"]["counts"]["p1"].as_u64().unwrap_or(1);
+    let p2 = json["risk_summary"]["counts"]["p2"]
+        .as_u64()
+        .unwrap_or(u64::MAX);
     assert_eq!(
         high_or_higher,
         0,
@@ -225,4 +228,9 @@ fn self_audit_stays_clean_at_high_severity() {
     );
     assert_eq!(p0, 0, "self-audit should not produce P0 findings");
     assert_eq!(p1, 0, "self-audit should not produce P1 findings");
+    assert!(
+        p2 <= 135,
+        "self-audit P2 noise should stay within the v0.11 signal-quality budget, got {p2}\n{}",
+        serde_json::to_string_pretty(&json).unwrap_or_default()
+    );
 }


### PR DESCRIPTION
## Summary

This PR prepares RepoPilot `0.11.0` as a signal quality and CI polish release.

The release builds on the new risk-prioritization work by improving GitHub Action parity, documenting the `0.11.0` adoption loop, adding product smoke coverage, and reducing low-value self-audit noise without hiding high-priority findings.

## Type of change

- [x] Feature
- [x] Bug fix
- [x] Tests
- [x] Documentation
- [x] CI / repository maintenance
- [x] Release preparation

## What changed

- Bumped RepoPilot from `0.10.0` to `0.11.0`.
- Added the `0.11.0` changelog entry.
- Added `docs/release-checklist-0.11.md`.
- Updated README and docs for the `0.11.0` workflow:
  - `doctor`
  - focused `scan`
  - `ai context`
  - `review`
  - priority-based CI gates
- Updated first-party GitHub Action support for:
  - `command: doctor`
  - `fail-on-priority`
  - `min-priority`
  - `rule`
  - `timing`
- Added validation around Action inputs so unsupported combinations fail clearly.
- Updated GitHub Action examples from `v0.10.0` to `v0.11.0`.
- Added product smoke coverage for:
  - priority filtering
  - rule filtering
  - scan timing
  - priority gates
- Reduced RepoPilot self-audit P2 noise by treating `write!`/`writeln!` result unwraps in report renderers as low-value boilerplate while still detecting unwraps inside formatting arguments.
- Updated report/ruleset docs to describe `risk-v2`.

## Why

`0.10.0` focused on adoption and stability.

`0.11.0` focuses on making the new risk model easier to trust and use in real workflows:

- fewer low-value self-audit findings;
- better GitHub Action support for the same flags users run locally;
- clearer release checklist;
- better smoke coverage before publishing;
- stronger path from local diagnostics to CI enforcement.

This helps keep RepoPilot useful for both local review and CI adoption.

## Architecture notes

- [x] No god files introduced
- [x] Risk scoring remains in the risk engine
- [x] GitHub Action input handling stays in `action.yml`
- [x] Product smoke checks stay in scripts
- [x] Docs and release checklist are separated from runtime logic
- [x] Rust panic-risk signal tuning is scoped to report renderer string-writing patterns
- [x] High-priority risk detection remains enabled

## Release notes

RepoPilot `0.11.0` is the signal quality and CI polish release.

Main release promise:

```text
signal quality -> action parity -> release trust
```

## Highlights:

- first-party GitHub Action support for doctor, fail-on-priority, min-priority, rule, and timing;
- clearer doctor -> scan/review -> ai context -> CI gate adoption loop;
- product smoke coverage for priority and rule-based workflows;
- reduced self-audit noise for infallible report-rendering unwraps;
- updated release checklist for validating signal quality before publishing.

## Verification
```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm test
npm pack --dry-run
cargo package --list
cargo publish --dry-run
./scripts/verify-release.sh
```
