### PR TITLE
docs: prepare v0.11 release promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ These are planned ideas, not current features:
 | [docs/react-native.md](docs/react-native.md) | React Native and Expo detection, findings, and limitations |
 | [docs/integrations/github-code-scanning.md](docs/integrations/github-code-scanning.md) | GitHub Code Scanning SARIF workflow |
 | [docs/release.md](docs/release.md) | Manual release process |
+| [docs/release-announcement-0.11.md](docs/release-announcement-0.11.md) | 0.11.0 launch post and post-publish checks |
 | [docs/release-checklist-0.11.md](docs/release-checklist-0.11.md) | 0.11.0 release readiness checklist |
 | [docs/release-checklist-0.10.md](docs/release-checklist-0.10.md) | 0.10.0 release readiness checklist |
 | [docs/distribution.md](docs/distribution.md) | Distribution channels |

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -113,6 +113,26 @@ Before publishing:
 
 See [docs/release.md](release.md) for the full release process.
 
+For RepoPilot 0.11.0, publish the GitHub Release assets first, then the platform
+npm packages, then the root npm package. The root `repopilot` package declares
+optional dependencies on the platform packages at the same version, so publishing
+the root package before the platform packages can create a broken install window.
+
+After publishing, verify:
+
+```bash
+npm view repopilot version
+for pkg in \
+  @repopilot/darwin-arm64 \
+  @repopilot/darwin-x64 \
+  @repopilot/linux-arm64-gnu \
+  @repopilot/linux-x64-gnu \
+  @repopilot/win32-x64-msvc; do
+  npm view "$pkg" version
+done
+git ls-remote --tags origin v0.11.0
+```
+
 ## Homebrew (via tap)
 
 A formula template lives at [`Formula/repopilot.rb`](../Formula/repopilot.rb) in the repo.

--- a/docs/release-announcement-0.11.md
+++ b/docs/release-announcement-0.11.md
@@ -1,0 +1,90 @@
+# RepoPilot 0.11.0 Release Announcement
+
+RepoPilot 0.11.0 is the signal quality and CI trust release. It keeps the
+local-first model intact while making scan output easier to act on in pull
+requests and GitHub Actions.
+
+## Suggested Post
+
+RepoPilot 0.11.0 is ready.
+
+This release focuses on signal quality, CI parity, and release trust:
+
+- lower self-audit noise while keeping P0/P1 risk visible;
+- first-party GitHub Action support for `doctor`, priority filters, focused rule
+  scans, receipt output, and review gates;
+- stable local workflows from `doctor` to `scan` or `review`, then AI-ready
+  context and CI gating;
+- no telemetry, no source upload, and no hosted scanner dependency.
+
+Local release verification passed end-to-end with:
+
+```bash
+./scripts/verify-release.sh
+```
+
+Current self-audit proof for the 0.11.0 release candidate:
+
+```text
+p0=0
+p1=0
+p2=85
+p3=31
+scan engine timing: about 32-51ms on the RepoPilot repository
+```
+
+Try it locally:
+
+```bash
+repopilot doctor .
+repopilot scan . --min-priority p2
+repopilot review . --base origin/main --fail-on-priority p1
+repopilot ai context .
+```
+
+GitHub Actions users can pin the release after publishing:
+
+```yaml
+- uses: MykytaStel/repopilot@v0.11.0
+  with:
+    command: scan
+    min-priority: p2
+    upload-sarif: "true"
+```
+
+Recommended first adopters:
+
+- Rust CLI maintainers who want local, fast repository risk checks;
+- React Native and Expo teams that need architecture and platform health signals;
+- polyglot repositories that want one CI-friendly report across languages.
+
+See the changelog for the full list of changes:
+<https://github.com/MykytaStel/repopilot/blob/main/CHANGELOG.md>
+
+## Release Proof
+
+- `./scripts/verify-release.sh` passed end-to-end locally.
+- `cargo publish --dry-run` packaged and verified `repopilot v0.11.0`.
+- `npm pack --dry-run` produced `repopilot-0.11.0.tgz`.
+- Product smoke tests passed against `target/release/repopilot`.
+- Self-audit stayed below the release gate of `p2 <= 135`.
+
+## Post-Publish Checks
+
+Run these after the GitHub Release and npm publish workflows complete:
+
+```bash
+git ls-remote --tags origin v0.11.0
+npm view repopilot version
+for pkg in \
+  @repopilot/darwin-arm64 \
+  @repopilot/darwin-x64 \
+  @repopilot/linux-arm64-gnu \
+  @repopilot/linux-x64-gnu \
+  @repopilot/win32-x64-msvc; do
+  npm view "$pkg" version
+done
+npm install -g repopilot@0.11.0
+repopilot --version
+repopilot scan . --format json --output /tmp/repopilot-smoke.json
+```

--- a/docs/release.md
+++ b/docs/release.md
@@ -105,6 +105,25 @@ repopilot --version
 brew test repopilot
 ```
 
+For the 0.11.0 release, also verify that the public package and tag state moved
+to 0.11.0:
+
+```bash
+git ls-remote --tags origin v0.11.0
+npm view repopilot version
+for pkg in \
+  @repopilot/darwin-arm64 \
+  @repopilot/darwin-x64 \
+  @repopilot/linux-arm64-gnu \
+  @repopilot/linux-x64-gnu \
+  @repopilot/win32-x64-msvc; do
+  npm view "$pkg" version
+done
+npm install -g repopilot@0.11.0
+repopilot --version
+repopilot scan . --format json --output /tmp/repopilot-0.11-smoke.json
+```
+
 If a publishing secret is intentionally absent, publish that channel manually from the exact tagged commit and a clean worktree.
 
 For Homebrew failures, check the custom tap first: `MykytaStel/homebrew-repopilot` must exist, contain a `Formula/` directory, and be writable by `HOMEBREW_TAP_TOKEN`.

--- a/examples/polyglot-report.md
+++ b/examples/polyglot-report.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-- **RepoPilot version:** 0.10.0
+- **RepoPilot version:** 0.11.0
 - **Path:** `polyglot-api`
 - **Risk:** Moderate
 - **Health score:** 88/100


### PR DESCRIPTION
## Summary
- update the polyglot example report to show RepoPilot 0.11.0
- add a 0.11.0 release announcement draft with launch copy and post-publish verification commands
- document 0.11.0 publish ordering and verification for npm platform packages, root npm package, and Git tag

## Verification
- ./scripts/verify-release.sh