### PR TITLE
feat(knowledge): expand functional and infrastructure context classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- Expanded context classification for functional, declarative, and infrastructure-oriented files.
 - Added a pre-1.0 roadmap with the 0.12 through 0.20 release train, local-first learning policy, and v1 release gates.
 - Added Knowledge Engine documentation covering built-in rules, metadata, applicability, calibration, local overlays, and the rule lifecycle.
 - Added a 0.12 release checklist focused on core foundation work, rule lifecycle completeness, workspace scan behavior, and v1 readiness.
@@ -17,6 +18,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Improved Knowledge Engine taxonomy so future audits can distinguish application code from infrastructure and declarative files.
 - Hardened npm distribution by replacing the install-time binary downloader with platform-specific optional `@repopilot/*` native packages.
 - Moved workspace scan orchestration from the CLI command layer into the library scan core while preserving existing `--workspace` behavior.
 - Split Knowledge Catalog model construction from rendering while preserving the `inspect knowledge` JSON shape.

--- a/docs/knowledge-engine.md
+++ b/docs/knowledge-engine.md
@@ -26,6 +26,8 @@ not loaded by `scan`, `review`, `ai`, or CI.
 | Calibration | Deterministic severity, suppression, or risk adjustments based on local file/project context. |
 | Local overlay | A future local file that can tune known rules in an inspectable way. Not enabled in 0.12.0. |
 | Local learning | User-controlled local calibration or fixtures, not model training or remote telemetry. |
+| Declarative context | Infrastructure, config, markup, query, and data-description files that should not be judged like imperative application code. |
+| Infrastructure context | Terraform, Dockerfile, Nix, Kubernetes, Helm, CI workflow, and infra-directory files where orchestration is expected. |
 
 ## Rule Lifecycle
 
@@ -46,6 +48,17 @@ ship unless it produces evidence-backed findings, has a recommendation, and can
 be inspected through the existing diagnostic commands.
 
 ## Diagnostics
+## Context Taxonomy
+
+The context classifier separates language, framework, file role, paradigm, and runtime.
+This matters because the same surface pattern can mean different things in different
+contexts. A long declarative infrastructure file, a functional pipeline, and an
+object-oriented service should not receive the same generic interpretation.
+
+0.12.0 expands this taxonomy with explicit declarative and infrastructure context
+so future rules can narrow applicability instead of treating every file as normal
+application code.
+
 
 Use the inspection commands when debugging rule behavior:
 

--- a/src/audits/context/classify/mod.rs
+++ b/src/audits/context/classify/mod.rs
@@ -336,6 +336,42 @@ mod tests {
         assert!(!context.is_production_code());
     }
 
+    #[test]
+    fn classifies_functional_language_context() {
+        let file = facts(
+            "src/Pipeline.hs",
+            Some("Haskell"),
+            "module Pipeline where\nrun xs = map (+1) xs\n",
+            false,
+        );
+
+        let context = classify_file(&file);
+
+        assert_eq!(context.language, LanguageKind::Haskell);
+        assert!(context.has_paradigm(ProgrammingParadigm::Functional));
+        assert!(context.is_functional_code());
+    }
+
+    #[test]
+    fn classifies_infrastructure_files_as_declarative_context() {
+        let file = facts(
+            "infra/terraform/main.tf",
+            Some("Terraform"),
+            "resource \"aws_s3_bucket\" \"assets\" {}\n",
+            false,
+        );
+
+        let context = classify_file(&file);
+
+        assert_eq!(context.language, LanguageKind::Terraform);
+        assert!(context.has_role(FileRole::Infrastructure));
+        assert!(context.has_runtime(RuntimeKind::Infrastructure));
+        assert!(context.has_paradigm(ProgrammingParadigm::Declarative));
+        assert!(context.is_declarative_code());
+        assert!(context.is_infrastructure_code());
+        assert!(!context.is_production_code());
+    }
+
     fn facts(
         path: &str,
         language: Option<&str>,

--- a/src/audits/context/classify/paradigms.rs
+++ b/src/audits/context/classify/paradigms.rs
@@ -95,6 +95,34 @@ pub fn classify_paradigms(
         push_unique(paradigms, ProgrammingParadigm::ObjectOriented);
     }
 
+    if matches!(
+        language,
+        LanguageKind::Elixir
+            | LanguageKind::Erlang
+            | LanguageKind::Haskell
+            | LanguageKind::OCaml
+            | LanguageKind::FSharp
+            | LanguageKind::Scala
+    ) {
+        push_unique(paradigms, ProgrammingParadigm::Functional);
+    }
+
+    if matches!(
+        language,
+        LanguageKind::Terraform
+            | LanguageKind::Dockerfile
+            | LanguageKind::Nix
+            | LanguageKind::Yaml
+            | LanguageKind::Toml
+            | LanguageKind::Json
+            | LanguageKind::Sql
+            | LanguageKind::Html
+            | LanguageKind::Css
+            | LanguageKind::Scss
+    ) {
+        push_unique(paradigms, ProgrammingParadigm::Declarative);
+    }
+
     if paradigms.len() > 1 {
         push_unique(paradigms, ProgrammingParadigm::Mixed);
     }

--- a/src/audits/context/classify/roles.rs
+++ b/src/audits/context/classify/roles.rs
@@ -2,8 +2,8 @@ use super::frameworks::{
     is_dotnet_controller, is_dotnet_service, is_react_component_file, is_react_hook_file,
 };
 use super::helpers::{
-    is_app_entrypoint, is_config_file, is_generated_file, is_js_or_ts, path_contains_component,
-    push_unique,
+    is_app_entrypoint, is_config_file, is_generated_file, is_js_or_ts, normalize,
+    path_contains_component, push_unique,
 };
 use crate::audits::context::model::{FileRole, FrameworkKind, LanguageKind};
 use std::path::Path;
@@ -18,6 +18,10 @@ pub fn classify_roles(
 ) {
     if is_config_file(path) {
         push_unique(roles, FileRole::Config);
+    }
+
+    if is_infrastructure_file(path, language) {
+        push_unique(roles, FileRole::Infrastructure);
     }
 
     if is_generated_file(path, content) {
@@ -80,4 +84,47 @@ pub fn classify_roles(
     if path_contains_component(path, &["script", "scripts", "bin", "tools"]) {
         push_unique(roles, FileRole::Script);
     }
+}
+
+fn is_infrastructure_file(path: &Path, language: LanguageKind) -> bool {
+    if matches!(
+        language,
+        LanguageKind::Terraform
+            | LanguageKind::Dockerfile
+            | LanguageKind::Nix
+            | LanguageKind::Yaml
+            | LanguageKind::Toml
+    ) {
+        return true;
+    }
+
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(normalize)
+        .unwrap_or_default();
+
+    matches!(
+        file_name.as_str(),
+        "docker-compose.yml"
+            | "docker-compose.yaml"
+            | "compose.yml"
+            | "compose.yaml"
+            | "kustomization.yml"
+            | "kustomization.yaml"
+            | "helmfile.yml"
+            | "helmfile.yaml"
+    ) || path_contains_component(
+        path,
+        &[
+            "infra",
+            "infrastructure",
+            "terraform",
+            "k8s",
+            "kubernetes",
+            "helm",
+            ".github",
+            "workflows",
+        ],
+    )
 }

--- a/src/audits/context/classify/runtimes.rs
+++ b/src/audits/context/classify/runtimes.rs
@@ -1,4 +1,4 @@
-use super::helpers::push_unique;
+use super::helpers::{path_contains_component, push_unique};
 use crate::audits::context::model::{FrameworkKind, LanguageKind, RuntimeKind};
 use std::path::Path;
 
@@ -75,6 +75,25 @@ pub fn classify_runtimes(
         LanguageKind::C | LanguageKind::Cpp | LanguageKind::CHeader | LanguageKind::Swift
     ) {
         push_unique(runtimes, RuntimeKind::Native);
+    }
+
+    if matches!(
+        language,
+        LanguageKind::Terraform | LanguageKind::Dockerfile | LanguageKind::Nix
+    ) || path_contains_component(
+        path,
+        &[
+            "infra",
+            "infrastructure",
+            "terraform",
+            "k8s",
+            "kubernetes",
+            "helm",
+            ".github",
+            "workflows",
+        ],
+    ) {
+        push_unique(runtimes, RuntimeKind::Infrastructure);
     }
 
     if frameworks.contains(&FrameworkKind::Android) {

--- a/src/audits/context/model.rs
+++ b/src/audits/context/model.rs
@@ -87,6 +87,7 @@ pub enum FileRole {
     Generated,
     Domain,
     Script,
+    Infrastructure,
     Unknown,
 }
 
@@ -95,6 +96,7 @@ pub enum ProgrammingParadigm {
     Functional,
     ObjectOriented,
     Procedural,
+    Declarative,
     DeclarativeUi,
     Reactive,
     DataOriented,
@@ -118,6 +120,7 @@ pub enum RuntimeKind {
     Ios,
     Shell,
     Native,
+    Infrastructure,
     Unknown,
 }
 
@@ -176,8 +179,19 @@ impl AuditContext {
         self.has_paradigm(ProgrammingParadigm::DeclarativeUi)
     }
 
+    pub fn is_declarative_code(&self) -> bool {
+        self.has_paradigm(ProgrammingParadigm::Declarative)
+    }
+
+    pub fn is_infrastructure_code(&self) -> bool {
+        self.has_role(FileRole::Infrastructure) || self.has_runtime(RuntimeKind::Infrastructure)
+    }
+
     pub fn is_production_code(&self) -> bool {
-        !self.is_test && !self.has_role(FileRole::Config) && !self.has_role(FileRole::Generated)
+        !self.is_test
+            && !self.has_role(FileRole::Config)
+            && !self.has_role(FileRole::Generated)
+            && !self.has_role(FileRole::Infrastructure)
     }
 
     pub fn language_id(&self) -> &'static str {
@@ -306,6 +320,7 @@ impl FileRole {
             FileRole::Generated => "generated",
             FileRole::Domain => "domain",
             FileRole::Script => "script",
+            FileRole::Infrastructure => "infrastructure",
             FileRole::Unknown => "unknown",
         }
     }
@@ -317,6 +332,7 @@ impl ProgrammingParadigm {
             ProgrammingParadigm::Functional => "functional",
             ProgrammingParadigm::ObjectOriented => "object-oriented",
             ProgrammingParadigm::Procedural => "procedural",
+            ProgrammingParadigm::Declarative => "declarative",
             ProgrammingParadigm::DeclarativeUi => "declarative-ui",
             ProgrammingParadigm::Reactive => "reactive",
             ProgrammingParadigm::DataOriented => "data-oriented",
@@ -343,6 +359,7 @@ impl RuntimeKind {
             RuntimeKind::Ios => "ios",
             RuntimeKind::Shell => "shell",
             RuntimeKind::Native => "native",
+            RuntimeKind::Infrastructure => "infrastructure",
             RuntimeKind::Unknown => "unknown",
         }
     }

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -154,32 +154,32 @@ support = "context-aware"
 id = "elixir"
 name = "Elixir"
 extensions = ["ex", "exs"]
-support = "detect-only"
+support = "context-aware"
 
 [[languages]]
 id = "erlang"
 name = "Erlang"
 extensions = ["erl", "hrl"]
-support = "detect-only"
+support = "context-aware"
 
 [[languages]]
 id = "haskell"
 name = "Haskell"
 extensions = ["hs", "lhs"]
-support = "detect-only"
+support = "context-aware"
 
 [[languages]]
 id = "ocaml"
 name = "OCaml"
 extensions = ["ml", "mli"]
-support = "detect-only"
+support = "context-aware"
 
 [[languages]]
 id = "fsharp"
 name = "F#"
 aliases = ["fsharp"]
 extensions = ["fs", "fsx"]
-support = "detect-only"
+support = "context-aware"
 
 [[languages]]
 id = "r"
@@ -229,19 +229,19 @@ id = "terraform"
 name = "Terraform"
 aliases = ["hcl"]
 extensions = ["tf", "hcl"]
-support = "detect-only"
+support = "context-aware"
 
 [[languages]]
 id = "dockerfile"
 name = "Dockerfile"
 filenames = ["Dockerfile", "Containerfile"]
-support = "detect-only"
+support = "context-aware"
 
 [[languages]]
 id = "nix"
 name = "Nix"
 extensions = ["nix"]
-support = "detect-only"
+support = "context-aware"
 
 [[languages]]
 id = "yaml"
@@ -408,6 +408,10 @@ name = "Shell"
 id = "native"
 name = "Native"
 
+[[runtimes]]
+id = "infrastructure"
+name = "Infrastructure"
+
 [[paradigms]]
 id = "functional"
 name = "Functional"
@@ -419,6 +423,10 @@ name = "Object-oriented"
 [[paradigms]]
 id = "procedural"
 name = "Procedural"
+
+[[paradigms]]
+id = "declarative"
+name = "Declarative"
 
 [[paradigms]]
 id = "declarative-ui"
@@ -569,6 +577,12 @@ action = "downgrade"
 severity = "LOW"
 
 [[rules.overrides]]
+role = "infrastructure"
+action = "downgrade"
+severity = "LOW"
+reason = "Infrastructure files can be structurally dense without representing application-level complexity."
+
+[[rules.overrides]]
 role = "script"
 signal = "python.assert"
 action = "downgrade"
@@ -658,6 +672,12 @@ severity = "LOW"
 role = "react-hook"
 action = "downgrade"
 severity = "LOW"
+
+[[rules.overrides]]
+role = "infrastructure"
+action = "downgrade"
+severity = "LOW"
+reason = "Infrastructure-oriented code often contains orchestration or declarative setup around external systems."
 
 [[rules]]
 rule_id = "architecture.large-file"


### PR DESCRIPTION
## Summary

This PR expands RepoPilot's Knowledge Engine taxonomy so context classification can better distinguish functional, declarative, and infrastructure-oriented files from regular application code.

It adds explicit infrastructure role/runtime support, declarative paradigm support, functional-first language classification, and context-aware support levels for several languages and file types. This gives future audits a stronger foundation for reducing false positives and applying rules only where they make sense.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] Knowledge / rules

## What changed

- Added `Infrastructure` as a file role.
- Added `Infrastructure` as a runtime context.
- Added `Declarative` as a programming paradigm.
- Added helper methods on `AuditContext`:
  - `is_declarative_code()`
  - `is_infrastructure_code()`
- Updated `is_production_code()` so infrastructure files are not treated as normal production application code.
- Added functional-first classification for:
  - Elixir
  - Erlang
  - Haskell
  - OCaml
  - F#
  - Scala
- Added declarative classification for:
  - Terraform
  - Dockerfile
  - Nix
  - YAML
  - TOML
  - JSON
  - SQL
  - HTML
  - CSS
  - SCSS
- Added infrastructure detection for:
  - Terraform
  - Dockerfile
  - Nix
  - YAML/TOML infra files
  - `infra/`
  - `infrastructure/`
  - `terraform/`
  - `k8s/`
  - `kubernetes/`
  - `helm/`
  - `.github/workflows/`
- Promoted selected languages from `detect-only` to `context-aware` in the bundled knowledge pack.
- Added Knowledge Engine docs for declarative and infrastructure context.
- Added tests for functional and infrastructure/declarative classification.

## Why

RepoPilot should not judge every file as if it were regular imperative application code.

A functional pipeline, a Terraform file, a Docker Compose file, a CI workflow, and an object-oriented service can all be valid while looking very different structurally. Without this context, future audits risk producing noisy or misleading findings.

This PR improves the foundation for 0.12.0 by making the Knowledge Engine more aware of:

- programming paradigm;
- file role;
- runtime context;
- infrastructure-heavy paths;
- declarative configuration and orchestration files.

## Architecture notes

- No god files introduced.
- Context taxonomy remains centralized in `src/audits/context/model.rs`.
- Classification logic remains split by responsibility:
  - `roles.rs`
  - `paradigms.rs`
  - `runtimes.rs`
- Knowledge applicability remains data-driven through `src/knowledge/packs/core.toml`.
- Rule behavior stays deterministic and local-first.
- No telemetry, remote learning, hosted scanning, plugin execution, or LLM calls were added.

## Changelog

- [x] `CHANGELOG.md` updated

## Verification

Recommended checks:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- inspect knowledge --section rules --format markdown --output /tmp/repopilot-knowledge-rules.md
cargo run -- scan . --format markdown --output /tmp/repopilot-context-scan.md