### PR TITLE
feat(scan): add changed-file scans with local cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ See [AI workflows](docs/ai-workflows.md).
 | Command | Alias | Description |
 |---|---:|---|
 | `repopilot scan <path>` | `s` | Scan a project, folder, or file |
+| `repopilot scan <path> --changed` | — | Scan changed files with local cache |
+| `repopilot cache clear [path]` | — | Remove `.repopilot/cache` |
 | `repopilot review [path]` | `r` | Review findings that touch changed Git diff lines |
 | `repopilot ai context <path>` | — | Generate LLM-ready repository context |
 | `repopilot ai plan <path>` | — | Generate a prioritized remediation plan |
@@ -388,7 +390,7 @@ Planned direction:
 - `repopilot eval` with golden fixtures
 - local feedback through `.repopilot/feedback.yml`
 - hidden suggestion trend tracking
-- changed-file cache and incremental scans
+- deeper changed-scan cache telemetry
 - deeper dependency graph and impact analysis
 - AI task packs with context, constraints, and acceptance criteria
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,7 @@ Use `-h` for a short summary or `--help` for the full description and examples.
 | [`inspect explain`](#inspect-explain) | — | Explain file classification and rule decisions |
 | [`inspect knowledge`](#inspect-knowledge) | — | Inspect bundled Knowledge Engine data |
 | [`compare`](#compare) | `cmp` | Compare two JSON scan reports and show what changed |
+| [`cache`](#cache) | — | Manage local changed-scan cache files |
 | [`baseline`](#baseline) | `bl` | Manage accepted baseline findings |
 | [`baseline create`](#baseline-create) | — | Scan a path and store current findings as accepted debt |
 | [`doctor`](#doctor) | `d` | Diagnose audit readiness |
@@ -80,6 +81,8 @@ repopilot s <PATH> [OPTIONS]
 | `--max-file-size` | size | `2097152` | Skip files larger than this size; accepts bytes, `kb`, `mb`, or `gb`; `0` disables the guard |
 | `--max-files` | integer | — | Analyze at most this many discovered files after ignore and exclude filters |
 | `-w, --workspace` | flag | — | Scan each detected workspace package separately and group findings by package |
+| `--changed` | flag | — | Scan only files changed against `HEAD`, including untracked files; repo-level rules are skipped |
+| `--since` | git ref | — | Scan only files changed between `BASE...HEAD`; repo-level rules are skipped |
 | `--min-severity` | `info\|low\|medium\|high\|critical` | — | Only show findings at or above this severity |
 | `--verbose` | flag | — | Print scan phase timing breakdown after the report |
 | `--preset` | `strict\|balanced\|lenient` | `balanced` | Apply a threshold preset without editing config |
@@ -129,10 +132,33 @@ repopilot scan . --include-low-signal
 # Monorepo scan with less noise
 repopilot scan . --workspace --min-severity medium
 
+# Focus on changed files
+repopilot scan . --changed
+repopilot scan . --since main
+
 # One-shot threshold presets and timing
 repopilot scan . --preset strict
 repopilot scan . --verbose
 ```
+
+Changed scans write local cache files under `.repopilot/cache/` and intentionally
+skip repo-level architecture, framework, testing, and coupling rules. Use a full
+scan for authoritative repository-wide risk.
+
+---
+
+## `cache`
+
+Manage RepoPilot's local scan cache.
+
+### Synopsis
+
+```bash
+repopilot cache clear [PATH]
+```
+
+`cache clear` removes only `.repopilot/cache` for the selected path and succeeds
+when the cache directory does not exist.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -35,6 +35,20 @@ repopilot scan src/payments/
 repopilot scan src/payments/processor.rs
 ```
 
+### Scanning changed files
+
+Use changed scans when you want a fast file-level pass for the current diff.
+RepoPilot writes local cache files under `.repopilot/cache/` and skips
+repo-level architecture, framework, testing, and coupling rules in this mode.
+
+```bash
+repopilot scan . --changed
+repopilot scan . --since main
+repopilot cache clear .
+```
+
+Use a regular full scan when you need authoritative repository-wide risk.
+
 ### Scanning workspaces
 
 Use `--workspace` in npm, Yarn, pnpm, or Cargo monorepos to scan each package root separately and group findings by package. Console and Markdown output include a compact workspace risk summary.

--- a/src/cli/options/cache.rs
+++ b/src/cli/options/cache.rs
@@ -1,0 +1,29 @@
+use clap::{Args, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Args)]
+pub struct CacheOptions {
+    #[command(subcommand)]
+    pub command: CacheCommands,
+}
+
+#[derive(Subcommand)]
+pub enum CacheCommands {
+    /// Clear RepoPilot's local scan cache
+    #[command(
+        about = "Clear RepoPilot's local scan cache",
+        long_about = "Removes only the .repopilot/cache directory for the selected path.\n\n\
+The command succeeds when the cache directory does not exist.",
+        after_help = "EXAMPLES:\n  \
+repopilot cache clear\n  \
+repopilot cache clear ."
+    )]
+    Clear(CacheClearOptions),
+}
+
+#[derive(Args)]
+pub struct CacheClearOptions {
+    /// Repository or project path whose .repopilot/cache directory should be removed
+    #[arg(default_value = ".")]
+    pub path: PathBuf,
+}

--- a/src/cli/options/mod.rs
+++ b/src/cli/options/mod.rs
@@ -1,5 +1,6 @@
 pub mod ai;
 pub mod baseline;
+pub mod cache;
 pub mod compare;
 pub mod doctor;
 pub mod inspect;
@@ -8,6 +9,7 @@ pub mod scan;
 
 pub use ai::{AiCommands, AiContextOptions, AiOptions, AiPlanOptions, AiPromptOptions};
 pub use baseline::{BaselineCommands, BaselineOptions};
+pub use cache::{CacheCommands, CacheOptions};
 pub use compare::CompareOptions;
 pub use doctor::{DoctorOptions, InitOptions};
 pub use inspect::{ExplainOptions, InspectCommands, InspectOptions, KnowledgeOptions};
@@ -18,6 +20,17 @@ use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Manage RepoPilot's local scan cache
+    #[command(
+        about = "Manage RepoPilot's local scan cache",
+        long_about = "Manage RepoPilot's local cache files under .repopilot/cache.\n\n\
+Cache data is local to the repository and is used by changed scans.",
+        after_help = "EXAMPLES:\n  \
+repopilot cache clear\n  \
+repopilot cache clear ."
+    )]
+    Cache(CacheOptions),
+
     /// Manage accepted baseline findings (alias: bl)
     #[command(
         alias = "bl",

--- a/src/cli/options/scan.rs
+++ b/src/cli/options/scan.rs
@@ -69,6 +69,14 @@ pub struct ScanOptions {
     #[arg(long, short = 'w')]
     pub workspace: bool,
 
+    /// Scan only files changed against HEAD, including untracked files
+    #[arg(long)]
+    pub changed: bool,
+
+    /// Scan only files changed since BASE ref, compared with HEAD
+    #[arg(long, value_name = "BASE")]
+    pub since: Option<String>,
+
     /// Only render findings at or above this severity
     #[arg(long, value_enum)]
     pub min_severity: Option<SeverityArg>,

--- a/src/commands/cache.rs
+++ b/src/commands/cache.rs
@@ -1,0 +1,13 @@
+use crate::cli::CacheCommands;
+use repopilot::scan::cache::{cache_dir, clear_cache};
+
+pub fn run(command: CacheCommands) -> Result<(), Box<dyn std::error::Error>> {
+    match command {
+        CacheCommands::Clear(options) => {
+            let cache_path = cache_dir(&options.path);
+            clear_cache(&options.path)?;
+            println!("Cache cleared: {}", cache_path.display());
+            Ok(())
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod baseline;
+pub mod cache;
 pub mod compare;
 pub mod doctor;
 pub mod explain;
@@ -31,6 +32,7 @@ pub const EXIT_RUNTIME: i32 = 3;
 
 pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
+        Commands::Cache(options) => cache::run(options.command),
         Commands::Scan(options) => scan::run(options),
         Commands::Review(options) => review::run(options),
         Commands::Baseline(options) => baseline::run(options.command),

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -17,7 +17,7 @@ use repopilot::output::{render_baseline_scan_report, render_scan_summary};
 use repopilot::receipt::{build_audit_receipt, render_receipt_json};
 use repopilot::report::writer::write_report;
 use repopilot::risk::RiskPriority;
-use repopilot::scan::scanner::scan_path_with_config;
+use repopilot::scan::scanner::{scan_changed_with_config, scan_path_with_config};
 use repopilot::scan::types::ScanSummary;
 use repopilot::scan::workspace_scan::scan_workspace_with_config;
 use std::path::Path;
@@ -32,6 +32,18 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
         return Err(Box::new(CliExit {
             code: EXIT_USAGE,
             message: "`--fail-on` and `--fail-on-priority` cannot be used together".to_string(),
+        }));
+    }
+    if options.changed && options.since.is_some() {
+        return Err(Box::new(CliExit {
+            code: EXIT_USAGE,
+            message: "`--changed` and `--since` cannot be used together".to_string(),
+        }));
+    }
+    if options.workspace && (options.changed || options.since.is_some()) {
+        return Err(Box::new(CliExit {
+            code: EXIT_USAGE,
+            message: "`--workspace` cannot be used with changed scans".to_string(),
         }));
     }
     let mut repo_config = match &options.config {
@@ -73,7 +85,9 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     let pb = make_spinner("Scanning...");
     let scan_start = Instant::now();
 
-    let mut summary = if options.workspace {
+    let mut summary = if options.changed || options.since.is_some() {
+        scan_changed_with_config(&options.path, &scan_config, options.since.as_deref())?
+    } else if options.workspace {
         scan_workspace_with_config(&options.path, &scan_config)?
     } else {
         scan_path_with_config(&options.path, &scan_config)?
@@ -208,7 +222,7 @@ fn apply_rule_filter(summary: &mut ScanSummary, rules: &[String]) {
 }
 
 fn scan_visibility_profile(options: &ScanOptions) -> FindingVisibilityProfile {
-    if options.include_maintainability || options.verbose || !options.rule.is_empty() {
+    if options.include_maintainability || !options.rule.is_empty() {
         return FindingVisibilityProfile::Strict;
     }
 

--- a/src/output/console/sections.rs
+++ b/src/output/console/sections.rs
@@ -15,6 +15,7 @@ pub(crate) fn render_header(output: &mut String, summary: &ScanSummary, stats: &
     if let Some(profile) = &summary.visibility_profile {
         writeln!(output, "Profile: {profile}").unwrap();
     }
+    render_scope(output, summary);
     writeln!(
         output,
         "Risk: {} | Health score: {}/100 {}",
@@ -75,8 +76,8 @@ fn render_hidden_suggestions_breakdown(output: &mut String, summary: &ScanSummar
     for item in summary.hidden_suggestions.iter().take(8) {
         writeln!(
             output,
-            "  {:>4}  {} / {} ({})",
-            item.count, item.intent, item.rule_id, item.reason
+            "  {:>4}  {} / {} / {} ({})",
+            item.count, item.category, item.intent, item.rule_id, item.reason
         )
         .unwrap();
     }
@@ -89,6 +90,25 @@ fn render_hidden_suggestions_breakdown(output: &mut String, summary: &ScanSummar
         )
         .unwrap();
     }
+}
+
+fn render_scope(output: &mut String, summary: &ScanSummary) {
+    if summary.mode == crate::scan::types::ScanMode::Changed {
+        let base = summary
+            .base_ref
+            .as_ref()
+            .map(|base| format!(" since {base}"))
+            .unwrap_or_else(|| " against HEAD".to_string());
+        writeln!(
+            output,
+            "Scope: changed files{base} | changed files: {} | repo-level rules: skipped",
+            summary.changed_files_count
+        )
+        .unwrap();
+        return;
+    }
+
+    writeln!(output, "Scope: full scan | repo-level rules: included").unwrap();
 }
 
 pub(crate) fn render_risk_summary(output: &mut String, stats: &ReportStats) {

--- a/src/output/html/document.rs
+++ b/src/output/html/document.rs
@@ -4,6 +4,7 @@ use crate::output::report_stats::TOOL_VERSION;
 
 pub(super) struct DocumentParts<'a> {
     pub(super) path: &'a str,
+    pub(super) scan_meta: &'a str,
     pub(super) baseline_meta: &'a str,
     pub(super) cards: &'a str,
     pub(super) risk_section: &'a str,
@@ -17,6 +18,7 @@ pub(super) struct DocumentParts<'a> {
 pub(super) fn render_document(p: DocumentParts<'_>) -> String {
     let DocumentParts {
         path,
+        scan_meta,
         baseline_meta,
         cards,
         risk_section,
@@ -42,6 +44,7 @@ pub(super) fn render_document(p: DocumentParts<'_>) -> String {
   <h1>RepoPilot Scan Report</h1>
   <p class="meta">RepoPilot version: <strong>{version}</strong></p>
   <p class="meta">Path: <code>{path}</code></p>
+  {scan_meta}
   {baseline_meta}
 </header>
 

--- a/src/output/html/mod.rs
+++ b/src/output/html/mod.rs
@@ -18,10 +18,12 @@ pub fn render(summary: &ScanSummary) -> String {
     let frameworks_section = sections::render_frameworks_section(summary);
     let filter_bar = sections::render_filter_bar(&stats);
     let findings_section = finding::render_findings_section(summary, |_| None);
+    let scan_meta = sections::render_scan_meta(summary);
     let path = summary.root_path.to_string_lossy();
 
     document::render_document(document::DocumentParts {
         path: &path,
+        scan_meta: &scan_meta,
         baseline_meta: "",
         cards: &cards,
         risk_section: &risk_section,
@@ -44,11 +46,13 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
     let findings_section = finding::render_findings_section(&report.summary, |index| {
         Some(report.finding_status(index).lowercase_label())
     });
+    let scan_meta = sections::render_scan_meta(&report.summary);
     let baseline_meta = sections::render_baseline_meta(report, ci_gate);
     let path = report.summary.root_path.to_string_lossy();
 
     document::render_document(document::DocumentParts {
         path: &path,
+        scan_meta: &scan_meta,
         baseline_meta: &baseline_meta,
         cards: &cards,
         risk_section: &risk_section,

--- a/src/output/html/sections.rs
+++ b/src/output/html/sections.rs
@@ -7,6 +7,22 @@ use crate::scan::types::ScanSummary;
 
 mod frameworks;
 
+pub(super) fn render_scan_meta(summary: &ScanSummary) -> String {
+    if summary.mode == crate::scan::types::ScanMode::Changed {
+        let base = summary
+            .base_ref
+            .as_ref()
+            .map(|base| format!(" since <code>{}</code>", escape_html(base)))
+            .unwrap_or_else(|| " against <code>HEAD</code>".to_string());
+        return format!(
+            r#"<p class="meta">Scope: changed files{base}; {} changed file(s); repo-level rules skipped.</p>"#,
+            summary.changed_files_count
+        );
+    }
+
+    r#"<p class="meta">Scope: full scan; repo-level rules included.</p>"#.to_string()
+}
+
 pub(super) fn render_summary_cards(summary: &ScanSummary, stats: &ReportStats) -> String {
     let mut cards = vec![
         summary_card(stats.risk_label, "Risk"),
@@ -125,10 +141,7 @@ pub(super) fn render_risk_section(summary: &ScanSummary, stats: &ReportStats) ->
     };
 
     let hidden_note = if summary.hidden_suggestions_count > 0 {
-        format!(
-            r#"<p class="meta">{} maintainability/testing suggestions hidden. Run with <code>--profile strict</code> to view.</p>"#,
-            summary.hidden_suggestions_count
-        )
+        render_hidden_suggestions(summary)
     } else {
         String::new()
     };
@@ -136,6 +149,46 @@ pub(super) fn render_risk_section(summary: &ScanSummary, stats: &ReportStats) ->
     format!(
         r#"<section class="panel"><h2>Risk Summary</h2>{hidden_note}<h3>Severity</h3>{severity}{categories}</section>"#
     )
+}
+
+fn render_hidden_suggestions(summary: &ScanSummary) -> String {
+    let mut output = format!(
+        r#"<p class="meta">{} strict-only suggestions hidden. Run with <code>--profile strict</code> or <code>--include-maintainability</code> to view.</p>"#,
+        summary.hidden_suggestions_count
+    );
+
+    if summary.hidden_suggestions.is_empty() {
+        return output;
+    }
+
+    let rows = summary
+        .hidden_suggestions
+        .iter()
+        .take(8)
+        .map(|item| {
+            format!(
+                "<tr><td><code>{}</code></td><td><code>{}</code></td><td><code>{}</code></td><td class=\"num-cell\">{}</td><td>{}</td></tr>",
+                escape_html(&item.category),
+                escape_html(&item.intent),
+                escape_html(&item.rule_id),
+                item.count,
+                escape_html(&item.reason)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    output.push_str(&format!(
+        "<h3>Top Hidden Suggestions</h3><table><thead><tr><th>Category</th><th>Intent</th><th>Rule</th><th class=\"num-cell\">Count</th><th>Reason</th></tr></thead><tbody>{rows}</tbody></table>"
+    ));
+
+    if summary.hidden_suggestions.len() > 8 {
+        output.push_str(&format!(
+            r#"<p class="meta">{} more hidden group(s).</p>"#,
+            summary.hidden_suggestions.len() - 8
+        ));
+    }
+
+    output
 }
 
 pub(super) fn render_top_rules_section(stats: &ReportStats) -> String {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -2,8 +2,7 @@ use crate::baseline::diff::{BaselineScanReport, BaselineStatus};
 use crate::baseline::gate::CiGateResult;
 use crate::findings::types::Finding;
 use crate::risk::RiskSummary;
-use crate::scan::types::LanguageSummary;
-use crate::scan::types::ScanSummary;
+use crate::scan::types::{HiddenSuggestionSummary, LanguageSummary, ScanMode, ScanSummary};
 use serde::Serialize;
 
 pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.10";
@@ -53,8 +52,13 @@ pub fn render_with_baseline(
         lines_of_code: report.summary.lines_of_code,
         skipped_files_count: report.summary.skipped_files_count,
         skipped_bytes: report.summary.skipped_bytes,
+        mode: report.summary.mode,
+        base_ref: report.summary.base_ref.as_deref(),
+        changed_files_count: report.summary.changed_files_count,
+        repo_level_rules_included: report.summary.repo_level_rules_included,
         visible_findings_count: report.summary.findings.len(),
         hidden_suggestions_count: report.summary.hidden_suggestions_count,
+        hidden_suggestions: &report.summary.hidden_suggestions,
         visibility_profile: report.summary.visibility_profile.as_deref(),
         languages: &report.summary.languages,
         risk_summary: RiskSummary::from_findings(&report.summary.findings),
@@ -83,8 +87,15 @@ struct BaselineJsonReport<'a> {
     lines_of_code: usize,
     skipped_files_count: usize,
     skipped_bytes: u64,
+    mode: ScanMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_ref: Option<&'a str>,
+    changed_files_count: usize,
+    repo_level_rules_included: bool,
     visible_findings_count: usize,
     hidden_suggestions_count: usize,
+    #[serde(skip_serializing_if = "hidden_suggestions_empty")]
+    hidden_suggestions: &'a Vec<HiddenSuggestionSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
     visibility_profile: Option<&'a str>,
     languages: &'a [LanguageSummary],
@@ -93,6 +104,10 @@ struct BaselineJsonReport<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     ci_gate: Option<CiGateJsonMetadata>,
     findings: Vec<FindingWithBaselineStatus<'a>>,
+}
+
+fn hidden_suggestions_empty(value: &&Vec<HiddenSuggestionSummary>) -> bool {
+    value.is_empty()
 }
 
 #[derive(Serialize)]
@@ -154,7 +169,14 @@ mod tests {
     #[test]
     fn baseline_json_report_includes_schema_and_tool_versions() {
         let summary = ScanSummary {
-            hidden_suggestions: Vec::new(),
+            hidden_suggestions_count: 5,
+            hidden_suggestions: vec![HiddenSuggestionSummary {
+                intent: "testing-gap".to_string(),
+                rule_id: "testing.source-without-test".to_string(),
+                category: "testing".to_string(),
+                reason: "testing gaps are hidden in the default profile".to_string(),
+                count: 5,
+            }],
             root_path: PathBuf::from("."),
             files_count: 2,
             ..ScanSummary::default()
@@ -172,6 +194,11 @@ mod tests {
         assert_eq!(value["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
         assert_eq!(value["repopilot_version"], REPOPILOT_VERSION);
         assert_eq!(value["files_count"], 2);
+        assert_eq!(value["hidden_suggestions_count"], 5);
+        assert_eq!(
+            value["hidden_suggestions"][0]["rule_id"],
+            "testing.source-without-test"
+        );
         assert!(value.get("baseline").is_some());
     }
 }

--- a/src/output/markdown/sections.rs
+++ b/src/output/markdown/sections.rs
@@ -15,6 +15,7 @@ pub(crate) fn render_overview(output: &mut String, summary: &ScanSummary, stats:
     if let Some(profile) = &summary.visibility_profile {
         writeln!(output, "- **Profile:** `{profile}`").unwrap();
     }
+    render_scope(output, summary);
     writeln!(output, "- **Risk:** {}", stats.risk_label).unwrap();
     writeln!(output, "- **Health score:** {}/100", stats.health_score).unwrap();
     writeln!(
@@ -78,8 +79,8 @@ fn render_hidden_suggestions_breakdown(output: &mut String, summary: &ScanSummar
     for item in summary.hidden_suggestions.iter().take(8) {
         writeln!(
             output,
-            "  - `{}` / `{}`: {} — {}",
-            item.intent, item.rule_id, item.count, item.reason
+            "  - `{}` / `{}` / `{}`: {} - {}",
+            item.category, item.intent, item.rule_id, item.count, item.reason
         )
         .unwrap();
     }
@@ -92,6 +93,25 @@ fn render_hidden_suggestions_breakdown(output: &mut String, summary: &ScanSummar
         )
         .unwrap();
     }
+}
+
+fn render_scope(output: &mut String, summary: &ScanSummary) {
+    if summary.mode == crate::scan::types::ScanMode::Changed {
+        let base = summary
+            .base_ref
+            .as_ref()
+            .map(|base| format!(" since `{base}`"))
+            .unwrap_or_else(|| " against `HEAD`".to_string());
+        writeln!(
+            output,
+            "- **Scope:** changed files{base}; {} changed file(s); repo-level rules skipped",
+            summary.changed_files_count
+        )
+        .unwrap();
+        return;
+    }
+
+    writeln!(output, "- **Scope:** full scan; repo-level rules included").unwrap();
 }
 
 pub(crate) fn render_risk_summary(output: &mut String, summary: &ScanSummary, stats: &ReportStats) {

--- a/src/receipt/builder.rs
+++ b/src/receipt/builder.rs
@@ -1,7 +1,8 @@
 use crate::findings::types::Severity;
 use crate::receipt::git::collect_git_receipt;
 use crate::receipt::model::{
-    AUDIT_RECEIPT_SCHEMA_VERSION, AuditReceipt, ReceiptFindings, ReceiptLanguage, ReceiptScope,
+    AUDIT_RECEIPT_SCHEMA_VERSION, AuditReceipt, ReceiptFindings, ReceiptHiddenSuggestion,
+    ReceiptLanguage, ReceiptScope,
 };
 use crate::scan::types::ScanSummary;
 use chrono::Utc;
@@ -23,6 +24,10 @@ pub fn build_audit_receipt(summary: &ScanSummary) -> AuditReceipt {
 
 fn build_scope(summary: &ScanSummary) -> ReceiptScope {
     ReceiptScope {
+        mode: summary.mode.label().to_string(),
+        base_ref: summary.base_ref.clone(),
+        changed_files_count: summary.changed_files_count,
+        repo_level_rules_included: summary.repo_level_rules_included,
         files_discovered: summary.files_discovered,
         files_analyzed: summary.files_count,
         directories_count: summary.directories_count,
@@ -43,6 +48,18 @@ fn build_scope(summary: &ScanSummary) -> ReceiptScope {
 fn build_findings(summary: &ScanSummary) -> ReceiptFindings {
     let mut findings = ReceiptFindings {
         total: summary.findings.len(),
+        hidden_suggestions_count: summary.hidden_suggestions_count,
+        hidden_suggestions: summary
+            .hidden_suggestions
+            .iter()
+            .map(|item| ReceiptHiddenSuggestion {
+                intent: item.intent.clone(),
+                rule_id: item.rule_id.clone(),
+                category: item.category.clone(),
+                reason: item.reason.clone(),
+                count: item.count,
+            })
+            .collect(),
         critical: 0,
         high: 0,
         medium: 0,

--- a/src/receipt/model.rs
+++ b/src/receipt/model.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-pub const AUDIT_RECEIPT_SCHEMA_VERSION: u32 = 1;
+pub const AUDIT_RECEIPT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AuditReceipt {
@@ -26,6 +26,10 @@ pub struct ReceiptGit {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ReceiptScope {
+    pub mode: String,
+    pub base_ref: Option<String>,
+    pub changed_files_count: usize,
+    pub repo_level_rules_included: bool,
     pub files_discovered: usize,
     pub files_analyzed: usize,
     pub directories_count: usize,
@@ -42,11 +46,22 @@ pub struct ReceiptScope {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ReceiptFindings {
     pub total: usize,
+    pub hidden_suggestions_count: usize,
+    pub hidden_suggestions: Vec<ReceiptHiddenSuggestion>,
     pub critical: usize,
     pub high: usize,
     pub medium: usize,
     pub low: usize,
     pub info: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReceiptHiddenSuggestion {
+    pub intent: String,
+    pub rule_id: String,
+    pub category: String,
+    pub reason: String,
+    pub count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -158,6 +158,10 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
     BaselineScanReport {
         summary: ScanSummary {
             root_path: report.summary.root_path.clone(),
+            mode: report.summary.mode,
+            base_ref: report.summary.base_ref.clone(),
+            changed_files_count: report.summary.changed_files_count,
+            repo_level_rules_included: report.summary.repo_level_rules_included,
             files_discovered: report.summary.files_discovered,
             files_count: report.summary.files_count,
             directories_count: report.summary.directories_count,

--- a/src/scan/cache.rs
+++ b/src/scan/cache.rs
@@ -1,0 +1,244 @@
+use crate::findings::types::Finding;
+use crate::scan::config::ScanConfig;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+pub const CACHE_SCHEMA_VERSION: u32 = 1;
+pub const CACHE_DIR: &str = ".repopilot/cache";
+const FILE_HASHES_NAME: &str = "file_hashes.json";
+const FILE_ROLES_NAME: &str = "file_roles.json";
+const FINDINGS_NAME: &str = "findings.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileHashEntry {
+    pub path: String,
+    pub hash: String,
+    pub size: u64,
+    pub modified_unix_seconds: u64,
+    pub cache_key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileRoleEntry {
+    pub path: String,
+    pub hash: String,
+    pub language: Option<String>,
+    pub lines_of_code: usize,
+    pub roles: Vec<String>,
+    pub frameworks: Vec<String>,
+    pub runtimes: Vec<String>,
+    pub paradigms: Vec<String>,
+    pub is_test: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FindingsEntry {
+    pub path: String,
+    pub hash: String,
+    pub config_fingerprint: String,
+    pub findings: Vec<Finding>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileHashesCache {
+    pub schema_version: u32,
+    pub repopilot_version: String,
+    pub entries: Vec<FileHashEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileRolesCache {
+    pub schema_version: u32,
+    pub repopilot_version: String,
+    pub entries: Vec<FileRoleEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FindingsCache {
+    pub schema_version: u32,
+    pub repopilot_version: String,
+    pub entries: Vec<FindingsEntry>,
+}
+
+#[derive(Debug, Default)]
+pub struct ScanCache {
+    pub file_hashes: BTreeMap<String, FileHashEntry>,
+    pub file_roles: BTreeMap<String, FileRoleEntry>,
+    pub findings: BTreeMap<String, FindingsEntry>,
+}
+
+impl ScanCache {
+    pub fn load(root: &Path) -> Self {
+        let cache_root = cache_dir(root);
+        Self {
+            file_hashes: read_cache::<FileHashesCache>(&cache_root.join(FILE_HASHES_NAME))
+                .filter(valid_file_hashes_cache)
+                .map(|cache| entries_by_path(cache.entries))
+                .unwrap_or_default(),
+            file_roles: read_cache::<FileRolesCache>(&cache_root.join(FILE_ROLES_NAME))
+                .filter(valid_file_roles_cache)
+                .map(|cache| entries_by_path(cache.entries))
+                .unwrap_or_default(),
+            findings: read_cache::<FindingsCache>(&cache_root.join(FINDINGS_NAME))
+                .filter(valid_findings_cache)
+                .map(|cache| entries_by_path(cache.entries))
+                .unwrap_or_default(),
+        }
+    }
+
+    pub fn write(&self, root: &Path) -> io::Result<()> {
+        let cache_root = cache_dir(root);
+        fs::create_dir_all(&cache_root)?;
+
+        write_cache(
+            &cache_root.join(FILE_HASHES_NAME),
+            &FileHashesCache {
+                schema_version: CACHE_SCHEMA_VERSION,
+                repopilot_version: env!("CARGO_PKG_VERSION").to_string(),
+                entries: self.file_hashes.values().cloned().collect(),
+            },
+        )?;
+        write_cache(
+            &cache_root.join(FILE_ROLES_NAME),
+            &FileRolesCache {
+                schema_version: CACHE_SCHEMA_VERSION,
+                repopilot_version: env!("CARGO_PKG_VERSION").to_string(),
+                entries: self.file_roles.values().cloned().collect(),
+            },
+        )?;
+        write_cache(
+            &cache_root.join(FINDINGS_NAME),
+            &FindingsCache {
+                schema_version: CACHE_SCHEMA_VERSION,
+                repopilot_version: env!("CARGO_PKG_VERSION").to_string(),
+                entries: self.findings.values().cloned().collect(),
+            },
+        )?;
+
+        Ok(())
+    }
+}
+
+pub fn clear_cache(root: &Path) -> io::Result<()> {
+    let cache_root = cache_dir(root);
+    match fs::remove_dir_all(cache_root) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+pub fn cache_dir(root: &Path) -> PathBuf {
+    root.join(CACHE_DIR)
+}
+
+pub fn file_hash_entry(root: &Path, path: &Path) -> io::Result<FileHashEntry> {
+    let bytes = fs::read(path)?;
+    let metadata = fs::metadata(path)?;
+    let relative = relative_cache_path(root, path);
+    let hash = stable_hash_hex(&bytes);
+    let modified_unix_seconds = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    let cache_key = stable_hash_hex(format!("{relative}:{hash}:{}", metadata.len()).as_bytes());
+
+    Ok(FileHashEntry {
+        path: relative,
+        hash,
+        size: metadata.len(),
+        modified_unix_seconds,
+        cache_key,
+    })
+}
+
+pub fn config_fingerprint(config: &ScanConfig) -> String {
+    stable_hash_hex(format!("{config:?}").as_bytes())
+}
+
+pub fn stable_hash_hex(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+pub fn relative_cache_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .to_string()
+}
+
+fn read_cache<T>(path: &Path) -> Option<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn write_cache<T>(path: &Path, value: &T) -> io::Result<()>
+where
+    T: Serialize,
+{
+    let rendered = serde_json::to_string_pretty(value).map_err(io::Error::other)?;
+    fs::write(path, rendered)
+}
+
+fn entries_by_path<T>(entries: Vec<T>) -> BTreeMap<String, T>
+where
+    T: CachePath,
+{
+    entries
+        .into_iter()
+        .map(|entry| (entry.cache_path().to_string(), entry))
+        .collect()
+}
+
+trait CachePath {
+    fn cache_path(&self) -> &str;
+}
+
+impl CachePath for FileHashEntry {
+    fn cache_path(&self) -> &str {
+        &self.path
+    }
+}
+
+impl CachePath for FileRoleEntry {
+    fn cache_path(&self) -> &str {
+        &self.path
+    }
+}
+
+impl CachePath for FindingsEntry {
+    fn cache_path(&self) -> &str {
+        &self.path
+    }
+}
+
+fn valid_file_hashes_cache(cache: &FileHashesCache) -> bool {
+    cache.schema_version == CACHE_SCHEMA_VERSION
+        && cache.repopilot_version == env!("CARGO_PKG_VERSION")
+}
+
+fn valid_file_roles_cache(cache: &FileRolesCache) -> bool {
+    cache.schema_version == CACHE_SCHEMA_VERSION
+        && cache.repopilot_version == env!("CARGO_PKG_VERSION")
+}
+
+fn valid_findings_cache(cache: &FindingsCache) -> bool {
+    cache.schema_version == CACHE_SCHEMA_VERSION
+        && cache.repopilot_version == env!("CARGO_PKG_VERSION")
+}

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod config;
 pub mod facts;
 pub mod language;

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -1,0 +1,245 @@
+use super::file::{SkipReason, process_file_with_content};
+use super::summary::build_language_summary;
+use crate::audits::pipeline::build_file_audits;
+use crate::baseline::key::stable_finding_key;
+use crate::findings::types::Finding;
+use crate::review::diff::{
+    ChangeStatus, DiffTarget, GitDiffError, load_changed_files, resolve_git_root,
+};
+use crate::risk::{apply_cluster_overlay, assess_findings};
+use crate::scan::cache::{
+    FileRoleEntry, FindingsEntry, ScanCache, config_fingerprint, file_hash_entry,
+    relative_cache_path,
+};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::{FileFacts, ScanFacts};
+use crate::scan::types::{ScanMode, ScanSummary, ScanTimings};
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+pub fn scan_changed_with_config(
+    path: &Path,
+    config: &ScanConfig,
+    base_ref: Option<&str>,
+) -> io::Result<ScanSummary> {
+    let start = Instant::now();
+    let repo_root = resolve_git_root(path).map_err(diff_error_to_io)?;
+    let pathspec = pathspec_for_scan_path(path, &repo_root);
+    let target = match base_ref {
+        Some(base) => DiffTarget::Refs { base, head: "HEAD" },
+        None => DiffTarget::WorkingTree,
+    };
+    let changed_files =
+        load_changed_files(&repo_root, target, pathspec.as_deref()).map_err(diff_error_to_io)?;
+
+    let file_scan_start = Instant::now();
+    let file_audits = build_file_audits(config);
+    let mut cache = ScanCache::load(&repo_root);
+    let fingerprint = config_fingerprint(config);
+    let mut facts = ScanFacts {
+        root_path: path.to_path_buf(),
+        files_discovered: changed_files.len(),
+        ..ScanFacts::default()
+    };
+    let mut languages: HashMap<String, usize> = HashMap::new();
+    let mut findings = Vec::new();
+    let mut directories = HashSet::new();
+
+    for changed_file in &changed_files {
+        if changed_file.status == ChangeStatus::Deleted {
+            continue;
+        }
+
+        let absolute_path = repo_root.join(&changed_file.path);
+        if !absolute_path.is_file() {
+            continue;
+        }
+
+        if let Some(parent) = changed_file.path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            directories.insert(parent.to_path_buf());
+        }
+
+        let hash_entry = file_hash_entry(&repo_root, &absolute_path)?;
+        let cache_path = hash_entry.path.clone();
+        cache
+            .file_hashes
+            .insert(cache_path.clone(), hash_entry.clone());
+
+        if let (Some(role_entry), Some(findings_entry)) = (
+            cache.file_roles.get(&cache_path),
+            cache.findings.get(&cache_path),
+        ) && role_entry.hash == hash_entry.hash
+            && findings_entry.hash == hash_entry.hash
+            && findings_entry.config_fingerprint == fingerprint
+        {
+            record_cached_file(&mut facts, &mut languages, role_entry);
+            findings.extend(findings_entry.findings.clone());
+            continue;
+        }
+
+        let mut per_file = process_file_with_content(&absolute_path, &file_audits, config)?;
+        normalize_per_file_paths(
+            &mut per_file.file_facts.path,
+            &mut per_file.findings,
+            &repo_root,
+        );
+
+        match per_file.skip_reason {
+            SkipReason::None => {
+                facts.files_count += 1;
+                facts.lines_of_code += per_file.file_facts.lines_of_code;
+                if let Some(language) = &per_file.language {
+                    *languages.entry(language.clone()).or_insert(0) += 1;
+                }
+
+                if let Some(context) = per_file.context {
+                    cache.file_roles.insert(
+                        cache_path.clone(),
+                        FileRoleEntry {
+                            path: cache_path.clone(),
+                            hash: hash_entry.hash.clone(),
+                            language: per_file.language.clone(),
+                            lines_of_code: per_file.file_facts.lines_of_code,
+                            roles: context.roles,
+                            frameworks: context.frameworks,
+                            runtimes: context.runtimes,
+                            paradigms: context.paradigms,
+                            is_test: context.is_test,
+                        },
+                    );
+                }
+
+                cache.findings.insert(
+                    cache_path,
+                    FindingsEntry {
+                        path: hash_entry.path,
+                        hash: hash_entry.hash,
+                        config_fingerprint: fingerprint.clone(),
+                        findings: per_file.findings.clone(),
+                    },
+                );
+
+                facts.files.push(per_file.file_facts);
+                findings.extend(per_file.findings);
+            }
+            SkipReason::LargeFile => {
+                facts.skipped_files_count += 1;
+                facts.skipped_bytes = facts.skipped_bytes.saturating_add(per_file.skipped_bytes);
+            }
+            SkipReason::Binary => {
+                facts.binary_files_skipped += 1;
+                facts.skipped_bytes = facts.skipped_bytes.saturating_add(per_file.skipped_bytes);
+            }
+            SkipReason::LowSignal => {
+                facts.files_skipped_low_signal += 1;
+            }
+        }
+    }
+
+    facts.directories_count = directories.len();
+    facts.languages = build_language_summary(languages);
+    let file_scan_us = file_scan_start.elapsed().as_micros() as u64;
+
+    for finding in &mut findings {
+        finding.populate_recommendation();
+        finding.id = stable_finding_key(finding, &repo_root);
+    }
+    assess_findings(&mut findings, &facts);
+    apply_cluster_overlay(&mut findings);
+    super::summary::sort_findings(&mut findings);
+
+    cache.write(&repo_root)?;
+
+    let scan_duration_us = start.elapsed().as_micros() as u64;
+    let health_score = ScanSummary::compute_health_score(&findings, facts.lines_of_code);
+    let visible_findings_count = findings.len();
+
+    Ok(ScanSummary {
+        root_path: path.to_path_buf(),
+        mode: ScanMode::Changed,
+        base_ref: base_ref.map(str::to_string),
+        changed_files_count: changed_files.len(),
+        repo_level_rules_included: false,
+        files_discovered: facts.files_discovered,
+        files_count: facts.files_count,
+        directories_count: facts.directories_count,
+        lines_of_code: facts.lines_of_code,
+        skipped_files_count: facts.skipped_files_count,
+        files_skipped_low_signal: facts.files_skipped_low_signal,
+        binary_files_skipped: facts.binary_files_skipped,
+        skipped_bytes: facts.skipped_bytes,
+        languages: facts.languages,
+        detected_frameworks: Vec::new(),
+        framework_projects: Vec::new(),
+        react_native: None,
+        findings,
+        coupling_graph: None,
+        scan_duration_us,
+        health_score,
+        visible_findings_count,
+        hidden_suggestions_count: 0,
+        hidden_suggestions: Vec::new(),
+        visibility_profile: None,
+        files_skipped_by_limit: 0,
+        files_skipped_repopilotignore: 0,
+        repopilotignore_path: None,
+        scan_timings: Some(ScanTimings {
+            file_scan_us,
+            framework_detection_us: 0,
+            post_scan_audits_us: 0,
+        }),
+    })
+}
+
+fn record_cached_file(
+    facts: &mut ScanFacts,
+    languages: &mut HashMap<String, usize>,
+    entry: &FileRoleEntry,
+) {
+    facts.files_count += 1;
+    facts.lines_of_code += entry.lines_of_code;
+    if let Some(language) = &entry.language {
+        *languages.entry(language.clone()).or_insert(0) += 1;
+    }
+    facts.files.push(FileFacts {
+        path: PathBuf::from(&entry.path),
+        language: entry.language.clone(),
+        lines_of_code: entry.lines_of_code,
+        branch_count: 0,
+        imports: Vec::new(),
+        content: None,
+        has_inline_tests: entry.is_test,
+    });
+}
+
+fn normalize_per_file_paths(path: &mut PathBuf, findings: &mut [Finding], repo_root: &Path) {
+    *path = PathBuf::from(relative_cache_path(repo_root, path));
+    for finding in findings {
+        for evidence in &mut finding.evidence {
+            evidence.path = PathBuf::from(relative_cache_path(repo_root, &evidence.path));
+        }
+    }
+}
+
+fn pathspec_for_scan_path(scan_path: &Path, repo_root: &Path) -> Option<String> {
+    let absolute = if scan_path.is_absolute() {
+        scan_path.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(scan_path)
+    };
+    let absolute = absolute.canonicalize().unwrap_or(absolute);
+    let relative = absolute.strip_prefix(repo_root).ok()?;
+    if relative.as_os_str().is_empty() {
+        None
+    } else {
+        Some(relative.to_string_lossy().replace('\\', "/"))
+    }
+}
+
+fn diff_error_to_io(error: GitDiffError) -> io::Error {
+    io::Error::other(error)
+}

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -1,5 +1,6 @@
 mod read;
 
+use crate::audits::context::classify_file;
 use crate::audits::traits::FileAudit;
 use crate::findings::types::Finding;
 use crate::scan::config::ScanConfig;
@@ -13,8 +14,18 @@ pub(super) struct PerFileResult {
     pub(super) file_facts: FileFacts,
     pub(super) findings: Vec<Finding>,
     pub(super) language: Option<String>,
+    pub(super) context: Option<PerFileContext>,
     pub(super) skip_reason: SkipReason,
     pub(super) skipped_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PerFileContext {
+    pub(super) roles: Vec<String>,
+    pub(super) frameworks: Vec<String>,
+    pub(super) runtimes: Vec<String>,
+    pub(super) paradigms: Vec<String>,
+    pub(super) is_test: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,6 +41,23 @@ pub(super) fn process_file(
     file_audits: &[Box<dyn FileAudit>],
     config: &ScanConfig,
 ) -> io::Result<PerFileResult> {
+    process_file_inner(path, file_audits, config, false)
+}
+
+pub(super) fn process_file_with_content(
+    path: &Path,
+    file_audits: &[Box<dyn FileAudit>],
+    config: &ScanConfig,
+) -> io::Result<PerFileResult> {
+    process_file_inner(path, file_audits, config, true)
+}
+
+fn process_file_inner(
+    path: &Path,
+    file_audits: &[Box<dyn FileAudit>],
+    config: &ScanConfig,
+    retain_content: bool,
+) -> io::Result<PerFileResult> {
     let loaded = load_file(path, config)?;
     let LoadedFile::Analyzable {
         full_facts,
@@ -39,15 +67,21 @@ pub(super) fn process_file(
         return Ok(skipped_result_from_loaded(path, loaded));
     };
 
+    let context = PerFileContext::from_file(&full_facts);
     let mut findings = Vec::new();
     for audit in file_audits {
         findings.extend(audit.audit(&full_facts, config));
     }
 
     Ok(PerFileResult {
-        file_facts: without_content(full_facts),
+        file_facts: if retain_content {
+            full_facts
+        } else {
+            without_content(full_facts)
+        },
         findings,
         language,
+        context: Some(context),
         skip_reason: SkipReason::None,
         skipped_bytes: 0,
     })
@@ -160,8 +194,34 @@ fn skipped_result(
         file_facts: empty_file_facts(path, language.clone()),
         findings: Vec::new(),
         language,
+        context: None,
         skip_reason,
         skipped_bytes,
+    }
+}
+
+impl PerFileContext {
+    fn from_file(file: &FileFacts) -> Self {
+        let context = classify_file(file);
+        Self {
+            roles: context.role_ids().into_iter().map(str::to_string).collect(),
+            frameworks: context
+                .framework_ids()
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            runtimes: context
+                .runtime_ids()
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            paradigms: context
+                .paradigm_ids()
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            is_test: context.is_test,
+        }
     }
 }
 

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -1,3 +1,4 @@
+mod changed;
 mod collection;
 mod file;
 mod summary;
@@ -13,11 +14,12 @@ use crate::frameworks::{
 use crate::knowledge::decision::apply_project_decisions;
 use crate::risk::{apply_cluster_overlay, apply_graph_overlay, assess_findings};
 use crate::scan::config::ScanConfig;
-use crate::scan::types::{ScanSummary, ScanTimings};
+use crate::scan::types::{ScanMode, ScanSummary, ScanTimings};
 use std::io;
 use std::path::Path;
 use std::time::Instant;
 
+pub use changed::scan_changed_with_config;
 pub use collection::{collect_scan_facts, collect_scan_facts_with_config};
 
 pub fn scan_path(path: &Path) -> io::Result<ScanSummary> {
@@ -82,6 +84,10 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
 
     Ok(ScanSummary {
         root_path: facts.root_path,
+        mode: ScanMode::Full,
+        base_ref: None,
+        changed_files_count: 0,
+        repo_level_rules_included: true,
         files_discovered: facts.files_discovered,
         files_count: facts.files_count,
         directories_count: facts.directories_count,

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -41,9 +41,34 @@ pub struct HiddenSuggestionSummary {
     pub count: usize,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ScanMode {
+    #[default]
+    Full,
+    Changed,
+}
+
+impl ScanMode {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Changed => "changed",
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ScanSummary {
     pub root_path: PathBuf,
+    #[serde(default)]
+    pub mode: ScanMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_ref: Option<String>,
+    #[serde(default)]
+    pub changed_files_count: usize,
+    #[serde(default = "default_repo_level_rules_included")]
+    pub repo_level_rules_included: bool,
     /// Files found after gitignore, `.repopilotignore`, built-in ignores, and
     /// `--exclude` path/name filters are applied.
     #[serde(default)]
@@ -95,6 +120,46 @@ pub struct ScanSummary {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scan_timings: Option<ScanTimings>,
+}
+
+fn default_repo_level_rules_included() -> bool {
+    true
+}
+
+impl Default for ScanSummary {
+    fn default() -> Self {
+        Self {
+            root_path: PathBuf::new(),
+            mode: ScanMode::Full,
+            base_ref: None,
+            changed_files_count: 0,
+            repo_level_rules_included: true,
+            files_discovered: 0,
+            files_count: 0,
+            directories_count: 0,
+            lines_of_code: 0,
+            skipped_files_count: 0,
+            files_skipped_low_signal: 0,
+            binary_files_skipped: 0,
+            skipped_bytes: 0,
+            languages: Vec::new(),
+            findings: Vec::new(),
+            detected_frameworks: Vec::new(),
+            framework_projects: Vec::new(),
+            react_native: None,
+            coupling_graph: None,
+            scan_duration_us: 0,
+            health_score: 0,
+            visible_findings_count: 0,
+            hidden_suggestions_count: 0,
+            hidden_suggestions: Vec::new(),
+            visibility_profile: None,
+            files_skipped_by_limit: 0,
+            files_skipped_repopilotignore: 0,
+            repopilotignore_path: None,
+            scan_timings: None,
+        }
+    }
 }
 
 impl ScanSummary {

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -65,6 +65,10 @@ fn summary(findings: Vec<Finding>) -> ScanSummary {
     let visible_findings_count = findings.len();
     ScanSummary {
         root_path: PathBuf::from("demo"),
+        mode: Default::default(),
+        base_ref: None,
+        changed_files_count: 0,
+        repo_level_rules_included: true,
         files_discovered: 0,
         files_count: 1,
         directories_count: 0,

--- a/tests/output_console.rs
+++ b/tests/output_console.rs
@@ -1,6 +1,6 @@
 use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use repopilot::output::{OutputFormat, render_scan_summary};
-use repopilot::scan::types::ScanSummary;
+use repopilot::scan::types::{HiddenSuggestionSummary, ScanSummary};
 use std::path::PathBuf;
 
 #[test]
@@ -67,4 +67,26 @@ fn console_output_labels_max_files_remainder_as_limit_skipped() {
 
     assert!(output.contains("Files skipped (limit):"));
     assert!(!output.contains("Files skipped (ignore):"));
+}
+
+#[test]
+fn console_output_includes_hidden_suggestion_breakdown() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("demo"),
+        hidden_suggestions_count: 3,
+        hidden_suggestions: vec![HiddenSuggestionSummary {
+            intent: "maintainability".to_string(),
+            rule_id: "architecture.large-file".to_string(),
+            category: "architecture".to_string(),
+            reason: "maintainability signals are hidden in the default profile".to_string(),
+            count: 3,
+        }],
+        ..ScanSummary::default()
+    };
+
+    let output = render_scan_summary(&summary, OutputFormat::Console)
+        .expect("failed to render console report");
+
+    assert!(output.contains("Hidden suggestions breakdown:"));
+    assert!(output.contains("architecture / maintainability / architecture.large-file"));
 }

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -1,12 +1,16 @@
 use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use repopilot::output::{OutputFormat, render_scan_summary};
-use repopilot::scan::types::ScanSummary;
+use repopilot::scan::types::{HiddenSuggestionSummary, ScanSummary};
 use std::path::PathBuf;
 
 #[test]
 fn html_output_escapes_snippets_and_renders_summary() {
     let summary = ScanSummary {
         root_path: PathBuf::from("demo"),
+        mode: Default::default(),
+        base_ref: None,
+        changed_files_count: 0,
+        repo_level_rules_included: true,
         files_discovered: 0,
         files_count: 1,
         directories_count: 1,
@@ -71,4 +75,27 @@ fn html_output_escapes_snippets_and_renders_summary() {
     assert!(html.contains("<strong>Recommendation:</strong>"));
     assert!(html.contains("API_KEY = &quot;abc&lt;123&gt;&quot;"));
     assert!(!html.contains("API_KEY = \"abc<123>\""));
+}
+
+#[test]
+fn html_output_includes_hidden_suggestion_breakdown() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("demo"),
+        hidden_suggestions_count: 1,
+        hidden_suggestions: vec![HiddenSuggestionSummary {
+            intent: "runtime-risk".to_string(),
+            rule_id: "language.javascript.runtime-exit-risk".to_string(),
+            category: "code-quality".to_string(),
+            reason: "process exit in script/tooling boundary is a strict-mode suggestion"
+                .to_string(),
+            count: 1,
+        }],
+        ..ScanSummary::default()
+    };
+
+    let html = render_scan_summary(&summary, OutputFormat::Html).expect("failed to render html");
+
+    assert!(html.contains("Top Hidden Suggestions"));
+    assert!(html.contains("language.javascript.runtime-exit-risk"));
+    assert!(html.contains("code-quality"));
 }

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -2,13 +2,17 @@ use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory,
 use repopilot::frameworks::ReactNativeArchitectureProfile;
 use repopilot::output::{OutputFormat, render_scan_summary};
 use repopilot::risk::{RiskInputs, RiskSummary, assess_finding};
-use repopilot::scan::types::{LanguageSummary, ScanSummary};
+use repopilot::scan::types::{HiddenSuggestionSummary, LanguageSummary, ScanSummary};
 use std::path::PathBuf;
 
 #[test]
 fn renders_valid_json_scan_summary() {
     let summary = ScanSummary {
         root_path: PathBuf::from("demo"),
+        mode: Default::default(),
+        base_ref: None,
+        changed_files_count: 0,
+        repo_level_rules_included: true,
         files_discovered: 0,
         files_count: 1,
         directories_count: 0,
@@ -152,4 +156,33 @@ fn react_native_profile_appears_in_json_when_present() {
     assert_eq!(rn["hermes_enabled"], true);
     assert_eq!(rn["package_manager"], "npm");
     assert_eq!(rn["has_codegen_config"], true);
+}
+
+#[test]
+fn json_scan_report_includes_hidden_suggestion_breakdown() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("demo"),
+        hidden_suggestions_count: 4,
+        hidden_suggestions: vec![HiddenSuggestionSummary {
+            intent: "maintainability".to_string(),
+            rule_id: "code-quality.long-function".to_string(),
+            category: "code-quality".to_string(),
+            reason: "maintainability signals are hidden in the default profile".to_string(),
+            count: 4,
+        }],
+        ..ScanSummary::default()
+    };
+
+    let output =
+        render_scan_summary(&summary, OutputFormat::Json).expect("failed to render json summary");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("output should be valid json");
+
+    assert_eq!(parsed["hidden_suggestions_count"], 4);
+    assert_eq!(
+        parsed["hidden_suggestions"][0]["rule_id"],
+        "code-quality.long-function"
+    );
+    assert_eq!(parsed["mode"], "full");
+    assert_eq!(parsed["repo_level_rules_included"], true);
 }

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -1,13 +1,17 @@
 use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use repopilot::frameworks::ReactNativeArchitectureProfile;
 use repopilot::output::{OutputFormat, render_scan_summary};
-use repopilot::scan::types::{LanguageSummary, ScanSummary};
+use repopilot::scan::types::{HiddenSuggestionSummary, LanguageSummary, ScanSummary};
 use std::path::PathBuf;
 
 #[test]
 fn renders_markdown_scan_summary() {
     let summary = ScanSummary {
         root_path: PathBuf::from("demo-project"),
+        mode: Default::default(),
+        base_ref: None,
+        changed_files_count: 0,
+        repo_level_rules_included: true,
         files_discovered: 0,
         files_count: 2,
         directories_count: 1,
@@ -95,6 +99,10 @@ fn renders_markdown_scan_summary() {
 fn renders_empty_markdown_sections() {
     let summary = ScanSummary {
         root_path: PathBuf::from("empty-project"),
+        mode: Default::default(),
+        base_ref: None,
+        changed_files_count: 0,
+        repo_level_rules_included: true,
         files_discovered: 0,
         files_count: 0,
         directories_count: 0,
@@ -135,6 +143,10 @@ fn renders_empty_markdown_sections() {
 fn renders_react_native_architecture_section_when_profile_present() {
     let summary = ScanSummary {
         root_path: PathBuf::from("rn-project"),
+        mode: Default::default(),
+        base_ref: None,
+        changed_files_count: 0,
+        repo_level_rules_included: true,
         files_discovered: 0,
         files_count: 5,
         directories_count: 2,
@@ -200,4 +212,26 @@ fn react_native_section_absent_when_profile_is_none() {
         .expect("failed to render markdown summary");
 
     assert!(!output.contains("### React Native"));
+}
+
+#[test]
+fn markdown_output_includes_hidden_suggestion_breakdown() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("demo"),
+        hidden_suggestions_count: 2,
+        hidden_suggestions: vec![HiddenSuggestionSummary {
+            intent: "testing-gap".to_string(),
+            rule_id: "testing.source-without-test".to_string(),
+            category: "testing".to_string(),
+            reason: "testing gaps are hidden in the default profile".to_string(),
+            count: 2,
+        }],
+        ..ScanSummary::default()
+    };
+
+    let output = render_scan_summary(&summary, OutputFormat::Markdown)
+        .expect("failed to render markdown summary");
+
+    assert!(output.contains("- **Top hidden suggestions:**"));
+    assert!(output.contains("`testing` / `testing-gap` / `testing.source-without-test`: 2"));
 }

--- a/tests/receipt_cli.rs
+++ b/tests/receipt_cli.rs
@@ -43,16 +43,28 @@ fn scan_writes_audit_receipt_json() {
     let receipt: Value = serde_json::from_slice(&fs::read(receipt_path).expect("read receipt"))
         .expect("valid receipt json");
 
-    assert_eq!(receipt["schema_version"], 1);
+    assert_eq!(receipt["schema_version"], 2);
     assert_eq!(receipt["tool"], "repopilot");
     assert!(receipt["version"].as_str().is_some());
     assert!(receipt["generated_at"].as_str().is_some());
 
     assert_eq!(receipt["scope"]["files_discovered"], 1);
+    assert_eq!(receipt["scope"]["mode"], "full");
+    assert_eq!(receipt["scope"]["repo_level_rules_included"], true);
     assert_eq!(receipt["scope"]["files_analyzed"], 1);
     assert_eq!(receipt["scope"]["files_skipped_repopilotignore"], 1);
 
     assert!(receipt["findings"]["total"].as_u64().is_some());
+    assert!(
+        receipt["findings"]["hidden_suggestions_count"]
+            .as_u64()
+            .is_some()
+    );
+    assert!(
+        receipt["findings"]["hidden_suggestions"]
+            .as_array()
+            .is_some()
+    );
     assert!(receipt["health_score"].as_u64().is_some());
 }
 

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -1,0 +1,202 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+#[test]
+fn changed_scan_writes_cache_and_reuses_matching_findings() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(temp.path().join("src/lib.rs"), "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+
+    write(
+        temp.path().join("src/lib.rs"),
+        "pub fn live() {}\nconst API_KEY: &str = \"abc123xyz987\";\n",
+    );
+
+    let first = scan_changed_json(temp.path(), &["--changed"]);
+    assert_eq!(first["mode"], "changed");
+    assert_eq!(first["repo_level_rules_included"], false);
+    assert_eq!(first["changed_files_count"], 1);
+    assert_rule_present(&first, "security.secret-candidate");
+
+    let cache_dir = temp.path().join(".repopilot/cache");
+    assert!(cache_dir.join("file_hashes.json").is_file());
+    assert!(cache_dir.join("file_roles.json").is_file());
+    assert!(cache_dir.join("findings.json").is_file());
+
+    rewrite_cached_finding_title(&cache_dir.join("findings.json"), "Cached secret title");
+    let cached = scan_changed_json(temp.path(), &["--changed"]);
+    assert_eq!(first_finding_title(&cached), "Cached secret title");
+
+    write(
+        temp.path().join("src/lib.rs"),
+        "pub fn live() {}\nconst API_KEY: &str = \"xyz987abc123\";\n",
+    );
+    let invalidated = scan_changed_json(temp.path(), &["--changed"]);
+    assert_eq!(
+        first_finding_title(&invalidated),
+        "Possible secret detected"
+    );
+}
+
+#[test]
+fn since_scan_uses_base_ref_scope() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(temp.path().join("src/lib.rs"), "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+    git(temp.path(), &["checkout", "-b", "feature"]);
+    write(
+        temp.path().join("src/lib.rs"),
+        "pub fn live() {}\nconst API_KEY: &str = \"abc123xyz987\";\n",
+    );
+    commit_all(temp.path(), "feature secret");
+
+    let json = scan_changed_json(temp.path(), &["--since", "main"]);
+
+    assert_eq!(json["mode"], "changed");
+    assert_eq!(json["base_ref"], "main");
+    assert_eq!(json["changed_files_count"], 1);
+    assert_rule_present(&json, "security.secret-candidate");
+}
+
+#[test]
+fn cache_clear_removes_cache_and_is_idempotent() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(temp.path().join("src/lib.rs"), "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+    write(
+        temp.path().join("src/lib.rs"),
+        "pub fn live() {}\nconst API_KEY: &str = \"abc123xyz987\";\n",
+    );
+    scan_changed_json(temp.path(), &["--changed"]);
+
+    let cache_dir = temp.path().join(".repopilot/cache");
+    assert!(cache_dir.is_dir());
+
+    clear_cache(temp.path());
+    assert!(!cache_dir.exists());
+    clear_cache(temp.path());
+    assert!(!cache_dir.exists());
+}
+
+#[test]
+fn changed_scan_rejects_invalid_flag_combinations() {
+    let temp = tempdir().expect("temp dir");
+
+    let both = repopilot()
+        .args(["scan", ".", "--changed", "--since", "main"])
+        .current_dir(temp.path())
+        .output()
+        .expect("run scan");
+    assert_eq!(both.status.code(), Some(2));
+
+    let workspace = repopilot()
+        .args(["scan", ".", "--workspace", "--changed"])
+        .current_dir(temp.path())
+        .output()
+        .expect("run scan");
+    assert_eq!(workspace.status.code(), Some(2));
+}
+
+fn scan_changed_json(root: &Path, args: &[&str]) -> Value {
+    let output = repopilot()
+        .args(["scan", ".", "--format", "json"])
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run repopilot scan");
+
+    assert!(
+        output.status.success(),
+        "scan failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    serde_json::from_slice(&output.stdout).expect("json output")
+}
+
+fn clear_cache(root: &Path) {
+    let output = repopilot()
+        .args(["cache", "clear", "."])
+        .current_dir(root)
+        .output()
+        .expect("run cache clear");
+
+    assert!(
+        output.status.success(),
+        "cache clear failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn rewrite_cached_finding_title(path: &Path, title: &str) {
+    let mut value: Value =
+        serde_json::from_slice(&fs::read(path).expect("read findings cache")).expect("json");
+    value["entries"][0]["findings"][0]["title"] = Value::String(title.to_string());
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&value).expect("render findings cache"),
+    )
+    .expect("write findings cache");
+}
+
+fn first_finding_title(json: &Value) -> &str {
+    json["findings"][0]["title"]
+        .as_str()
+        .expect("finding title")
+}
+
+fn assert_rule_present(json: &Value, rule_id: &str) {
+    assert!(
+        json["findings"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .any(|finding| finding["rule_id"] == rule_id),
+        "expected {rule_id} in findings: {json:#?}"
+    );
+}
+
+fn init_repo(root: &Path) {
+    git(root, &["init"]);
+    git(root, &["checkout", "-B", "main"]);
+    git(root, &["config", "user.email", "repopilot@example.com"]);
+    git(root, &["config", "user.name", "RepoPilot Test"]);
+}
+
+fn commit_all(root: &Path, message: &str) {
+    git(root, &["add", "."]);
+    git(root, &["commit", "-m", message]);
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write(path: std::path::PathBuf, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent");
+    }
+    fs::write(path, content).expect("write file");
+}

--- a/tests/scan_visibility_cli.rs
+++ b/tests/scan_visibility_cli.rs
@@ -25,6 +25,7 @@ fn default_scan_hides_source_without_test_but_strict_includes_it() {
 
     let strict = scan_json(root, &["--profile", "strict"]);
     assert_rule_present(&strict, "testing.source-without-test");
+    assert_rule_present(&strict, "testing.missing-test-folder");
 }
 
 #[test]
@@ -50,6 +51,13 @@ fn default_scan_hides_script_process_exit_but_reports_library_process_exit() {
         first_path(runtime_findings[0]).ends_with("src/lib/runtime.js"),
         "reported process.exit should be in reusable library code"
     );
+
+    let strict = scan_json(root, &["--profile", "strict"]);
+    assert_eq!(
+        findings_for_rule(&strict, "language.javascript.runtime-exit-risk").count(),
+        2,
+        "strict report should include script and library process.exit findings: {strict:#?}"
+    );
 }
 
 #[test]
@@ -70,6 +78,70 @@ fn default_scan_reports_unwrap_on_external_parse_path() {
         "external parse unwrap should remain visible in default report: {json:#?}"
     );
     assert_eq!(rust_findings[0]["severity"], "HIGH");
+}
+
+#[test]
+fn default_scan_keeps_real_secret_and_private_key_candidates() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    write(
+        root.join("src/config.rs"),
+        "const API_KEY: &str = \"abc123xyz987\";\n",
+    );
+    write(
+        root.join("src/key.pem"),
+        "-----BEGIN RSA PRIVATE KEY-----\nvery-secret-key-bytes\n-----END RSA PRIVATE KEY-----\n",
+    );
+
+    let json = scan_json(root, &[]);
+
+    assert_rule_present(&json, "security.secret-candidate");
+    assert_rule_present(&json, "security.private-key-candidate");
+}
+
+#[test]
+fn default_scan_hides_large_file_and_long_function_threshold_findings() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    write(
+        root.join("repopilot.toml"),
+        "[architecture]\nmax_file_lines = 3\nhuge_file_lines = 20\nmax_function_lines = 2\n",
+    );
+    write(
+        root.join("src/lib.rs"),
+        "pub fn large() {\nlet a = 1;\nlet b = 2;\nlet c = 3;\nprintln!(\"{}{}{}\", a, b, c);\n}\n",
+    );
+
+    let default = scan_json(root, &[]);
+    assert_rule_absent(&default, "architecture.large-file");
+    assert_rule_absent(&default, "code-quality.long-function");
+    assert!(
+        default["hidden_suggestions_count"].as_u64().unwrap_or(0) >= 2,
+        "default report should count hidden maintainability suggestions: {default:#?}"
+    );
+
+    let strict = scan_json(root, &["--profile", "strict"]);
+    assert_rule_present(&strict, "architecture.large-file");
+    assert_rule_present(&strict, "code-quality.long-function");
+}
+
+#[test]
+fn verbose_does_not_change_default_visibility() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    write(
+        root.join("src/payment.rs"),
+        "pub fn charge() -> bool { true }\n",
+    );
+
+    let default = scan_json(root, &[]);
+    let verbose = scan_json(root, &["--verbose"]);
+
+    assert_eq!(rule_ids(&default), rule_ids(&verbose));
+    assert_eq!(
+        default["hidden_suggestions_count"],
+        verbose["hidden_suggestions_count"]
+    );
 }
 
 fn scan_json(root: &std::path::Path, extra_args: &[&str]) -> Value {
@@ -118,6 +190,17 @@ fn first_path(finding: &Value) -> &str {
     finding["evidence"][0]["path"]
         .as_str()
         .expect("finding path")
+}
+
+fn rule_ids(json: &Value) -> Vec<String> {
+    let mut ids = json["findings"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|finding| finding["rule_id"].as_str().map(str::to_string))
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids
 }
 
 fn write(path: std::path::PathBuf, content: &str) {


### PR DESCRIPTION
## Summary

This PR adds changed-file scanning with a local RepoPilot cache.

Users can now run a faster scan focused only on files changed against `HEAD` or a selected base ref. Changed scans use local cache data under `.repopilot/cache/` and intentionally skip repository-level rules that require a full-project view.

The PR also adds a `cache clear` command, scan scope metadata, and output/report updates so users can clearly see whether a report came from a full scan or a changed-file scan.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] Output/reporting

## What changed

- Added changed-file scan mode:

```bash
repopilot scan . --changed
repopilot scan . --since main
``` 
- Added local scan cache support under:

`.repopilot/cache/`

- Added cache management command:

```
repopilot cache clear
repopilot cache clear .
```
- Added cache storage for changed-scan reuse.
- Added changed scan implementation under scanner modules.
- Added scan mode metadata to ScanSummary:

  - scan mode;
  - base ref;
  - changed files count;
  - whether repo-level rules were included.

-Updated console output to show scan scope:

  - full scan;
  - changed-files scan;
  - repo-level rules included/skipped.

- Updated Markdown output with scan scope metadata.
- Updated HTML output with scan scope metadata.
- Updated JSON/baseline output with scan mode fields.
- Updated receipt schema to version 2.
- Added receipt metadata for:

  - mode;
  - base ref;
  - changed files count;
  - repo-level rules included;
  - hidden suggestions.

- Updated review report conversion to preserve scan scope metadata.
- Added docs for:
```
  scan --changed;
  scan --since;
  cache clear;
  changed-scan limitations.
```
-Added tests for:
changed scan cache CLI behavior;

  - JSON output metadata;
  - console output metadata;
  - Markdown output metadata;
  - HTML output metadata;
  - receipt output schema;
  - scan visibility behavior;
  - compare/report compatibility.

## Why

Full repository scans are useful, but they are not always the right default for local iteration.

When a developer is working on a branch, they often need a quick answer to:

What did I just change, and did those changes introduce obvious risks?

Changed-file scans make that workflow faster and more focused.

At the same time, RepoPilot should be honest about scope. Changed scans skip repo-level architecture, framework, testing, and coupling rules because those checks require a full-project view. The report now makes that explicit instead of pretending a changed scan is equivalent to a full scan.

## Architecture notes

- No god files introduced.
- Cache logic is isolated in src/scan/cache.rs.
- Changed scan logic is isolated under src/scan/scanner/changed.rs.
- Normal file scanning remains in the scanner/file path.
- CLI cache command is isolated under src/commands/cache.rs.
- Scan command remains responsible for option validation and orchestration.
- Output renderers consume scan summary metadata instead of duplicating scan-mode logic.
- Changed scans are local-first:

  - no telemetry;
  - no remote cache;
  - no hosted scanner;
  - no background service.

- Changed scans intentionally skip repo-level rules where full-repository context is required.

## Compatibility
Existing repopilot scan . behavior remains available as the authoritative full scan.
--workspace cannot be combined with --changed or --since.
--changed and --since cannot be used together.
cache clear only removes .repopilot/cache.
Existing output formats remain supported.
Receipt schema is bumped to version 2 because scope and hidden-suggestion metadata were added.

## Verification

Recommended checks:

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```

Smoke checks:

```
cargo run -- scan . --changed --format markdown --output /tmp/repopilot-changed.md
cargo run -- scan . --since main --format json --output /tmp/repopilot-since-main.json
cargo run -- cache clear .
cargo run -- scan . --format markdown --output /tmp/repopilot-full.md
cargo run -- scan . --workspace --format markdown --output /tmp/repopilot-workspace.md
```