### PR TITLE
feat(scan): add changed-scan cache telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,6 @@ Planned direction:
 - `repopilot eval` with golden fixtures
 - local feedback through `.repopilot/feedback.yml`
 - hidden suggestion trend tracking
-- deeper changed-scan cache telemetry
 - deeper dependency graph and impact analysis
 - AI task packs with context, constraints, and acceptance criteria
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -143,7 +143,9 @@ repopilot scan . --verbose
 
 Changed scans write local cache files under `.repopilot/cache/` and intentionally
 skip repo-level architecture, framework, testing, and coupling rules. Use a full
-scan for authoritative repository-wide risk.
+scan for authoritative repository-wide risk. Changed-scan summaries include
+`cache_telemetry` with cache hits, misses, skipped files, changed-file reasons,
+per-file cache decisions, and cache timing impact.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -40,6 +40,8 @@ repopilot scan src/payments/processor.rs
 Use changed scans when you want a fast file-level pass for the current diff.
 RepoPilot writes local cache files under `.repopilot/cache/` and skips
 repo-level architecture, framework, testing, and coupling rules in this mode.
+Changed-scan summaries include cache hits, misses, skipped changed files,
+changed-file reasons, cache decisions, and cache timing impact.
 
 ```bash
 repopilot scan . --changed

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -38,6 +38,7 @@ JSON scan reports include explicit schema metadata. The current schema is 0.10:
 | `schema_version` | string | RepoPilot JSON report schema version. |
 | `repopilot_version` | string | RepoPilot binary version that produced the report. |
 | `risk_summary` | object | Aggregate priority counts and average risk score derived from finding risk assessments. |
+| `cache_telemetry` | object | Optional changed-scan cache summary with hits, misses, changed-file reasons, per-file cache decisions, and cache timing impact. |
 
 `schema_version` is intentionally separate from the binary version. Patch releases
 may fix bugs without changing the report schema, while future minor releases can

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -244,6 +244,24 @@ fn print_timing_breakdown(summary: &ScanSummary) {
             total / 1000,
         );
     }
+
+    if let Some(cache) = &summary.cache_telemetry {
+        let estimated_saved = cache
+            .timings
+            .estimated_time_saved_us
+            .map(|value| format!("{}ms", value / 1000))
+            .unwrap_or_else(|| "n/a".to_string());
+        eprintln!(
+            "[timing] Cache: load {}ms · hash {}ms · lookup {}ms · hit reuse {}ms · miss scan {}ms · write {}ms · estimated saved {}",
+            cache.timings.load_us / 1000,
+            cache.timings.file_hash_us / 1000,
+            cache.timings.lookup_us / 1000,
+            cache.timings.hit_reuse_us / 1000,
+            cache.timings.miss_scan_us / 1000,
+            cache.timings.write_us / 1000,
+            estimated_saved,
+        );
+    }
 }
 
 fn write_scan_receipt_if_requested(

--- a/src/output/console/sections.rs
+++ b/src/output/console/sections.rs
@@ -52,6 +52,7 @@ pub(crate) fn render_header(output: &mut String, summary: &ScanSummary, stats: &
     )
     .unwrap();
     render_scan_input(output, summary);
+    render_cache_telemetry(output, summary);
     if summary.scan_duration_us > 0 {
         writeln!(
             output,
@@ -61,6 +62,70 @@ pub(crate) fn render_header(output: &mut String, summary: &ScanSummary, stats: &
         .unwrap();
     }
     output.push('\n');
+}
+
+fn render_cache_telemetry(output: &mut String, summary: &ScanSummary) {
+    let Some(cache) = &summary.cache_telemetry else {
+        return;
+    };
+
+    output.push_str("Cache telemetry:\n");
+    writeln!(
+        output,
+        " Cache hits: {:>7} | misses: {:>7} | skipped: {:>7} | hit rate: {}%",
+        cache.hits, cache.misses, cache.skipped, cache.hit_rate_percent
+    )
+    .unwrap();
+
+    if !cache.changed_file_reasons.is_empty() {
+        let reasons = cache
+            .changed_file_reasons
+            .iter()
+            .map(|item| format!("{} ({})", item.reason, item.count))
+            .collect::<Vec<_>>()
+            .join(", ");
+        writeln!(output, " Changed file reasons: {reasons}").unwrap();
+    }
+
+    writeln!(
+        output,
+        " Cache timing: load {}ms | hash {}ms | lookup {}ms | reuse {}ms | miss scan {}ms | write {}ms | est. saved {}",
+        cache.timings.load_us / 1000,
+        cache.timings.file_hash_us / 1000,
+        cache.timings.lookup_us / 1000,
+        cache.timings.hit_reuse_us / 1000,
+        cache.timings.miss_scan_us / 1000,
+        cache.timings.write_us / 1000,
+        format_optional_ms(cache.timings.estimated_time_saved_us)
+    )
+    .unwrap();
+
+    for file in cache.changed_files.iter().take(8) {
+        writeln!(
+            output,
+            "  {}: {} ({}, {})",
+            file.path.display(),
+            file.cache_status,
+            file.change_reason,
+            file.cache_reason
+        )
+        .unwrap();
+    }
+
+    if cache.changed_files.len() > 8 {
+        writeln!(
+            output,
+            "  ... {} more changed file(s)",
+            cache.changed_files.len() - 8
+        )
+        .unwrap();
+    }
+}
+
+fn format_optional_ms(value: Option<u64>) -> String {
+    value
+        .map(|value| format!("{}ms", value / 1000))
+        .unwrap_or_else(|| "n/a".to_string())
 }
 
 fn render_hidden_suggestions_breakdown(output: &mut String, summary: &ScanSummary) {

--- a/src/output/html/sections.rs
+++ b/src/output/html/sections.rs
@@ -14,10 +14,17 @@ pub(super) fn render_scan_meta(summary: &ScanSummary) -> String {
             .as_ref()
             .map(|base| format!(" since <code>{}</code>", escape_html(base)))
             .unwrap_or_else(|| " against <code>HEAD</code>".to_string());
-        return format!(
+        let mut output = format!(
             r#"<p class="meta">Scope: changed files{base}; {} changed file(s); repo-level rules skipped.</p>"#,
             summary.changed_files_count
         );
+        if let Some(cache) = &summary.cache_telemetry {
+            output.push_str(&format!(
+                r#"<p class="meta">Cache: {} hit(s), {} miss(es), {} skipped, {}% hit rate.</p>"#,
+                cache.hits, cache.misses, cache.skipped, cache.hit_rate_percent
+            ));
+        }
+        return output;
     }
 
     r#"<p class="meta">Scope: full scan; repo-level rules included.</p>"#.to_string()

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -2,7 +2,9 @@ use crate::baseline::diff::{BaselineScanReport, BaselineStatus};
 use crate::baseline::gate::CiGateResult;
 use crate::findings::types::Finding;
 use crate::risk::RiskSummary;
-use crate::scan::types::{HiddenSuggestionSummary, LanguageSummary, ScanMode, ScanSummary};
+use crate::scan::types::{
+    HiddenSuggestionSummary, LanguageSummary, ScanCacheTelemetry, ScanMode, ScanSummary,
+};
 use serde::Serialize;
 
 pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.10";
@@ -60,6 +62,7 @@ pub fn render_with_baseline(
         hidden_suggestions_count: report.summary.hidden_suggestions_count,
         hidden_suggestions: &report.summary.hidden_suggestions,
         visibility_profile: report.summary.visibility_profile.as_deref(),
+        cache_telemetry: report.summary.cache_telemetry.as_ref(),
         languages: &report.summary.languages,
         risk_summary: RiskSummary::from_findings(&report.summary.findings),
         baseline: BaselineJsonMetadata {
@@ -98,6 +101,8 @@ struct BaselineJsonReport<'a> {
     hidden_suggestions: &'a Vec<HiddenSuggestionSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
     visibility_profile: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_telemetry: Option<&'a ScanCacheTelemetry>,
     languages: &'a [LanguageSummary],
     risk_summary: RiskSummary,
     baseline: BaselineJsonMetadata,

--- a/src/output/markdown/sections.rs
+++ b/src/output/markdown/sections.rs
@@ -55,6 +55,7 @@ pub(crate) fn render_overview(output: &mut String, summary: &ScanSummary, stats:
         )
         .unwrap();
     }
+    render_cache_telemetry(output, summary);
     if summary.skipped_files_count > 0 {
         writeln!(
             output,
@@ -64,6 +65,74 @@ pub(crate) fn render_overview(output: &mut String, summary: &ScanSummary, stats:
         .unwrap();
     }
     output.push('\n');
+}
+
+fn render_cache_telemetry(output: &mut String, summary: &ScanSummary) {
+    let Some(cache) = &summary.cache_telemetry else {
+        return;
+    };
+
+    writeln!(
+        output,
+        "- **Cache:** {} hit(s), {} miss(es), {} skipped ({}% hit rate)",
+        cache.hits, cache.misses, cache.skipped, cache.hit_rate_percent
+    )
+    .unwrap();
+
+    if !cache.changed_file_reasons.is_empty() {
+        let reasons = cache
+            .changed_file_reasons
+            .iter()
+            .map(|item| format!("{} ({})", item.reason, item.count))
+            .collect::<Vec<_>>()
+            .join(", ");
+        writeln!(output, "- **Changed file reasons:** {reasons}").unwrap();
+    }
+
+    writeln!(
+        output,
+        "- **Cache timing:** load {}ms; hash {}ms; lookup {}ms; reuse {}ms; miss scan {}ms; write {}ms; est. saved {}",
+        cache.timings.load_us / 1000,
+        cache.timings.file_hash_us / 1000,
+        cache.timings.lookup_us / 1000,
+        cache.timings.hit_reuse_us / 1000,
+        cache.timings.miss_scan_us / 1000,
+        cache.timings.write_us / 1000,
+        format_optional_ms(cache.timings.estimated_time_saved_us)
+    )
+    .unwrap();
+
+    if cache.changed_files.is_empty() {
+        return;
+    }
+
+    output.push_str("- **Changed file cache decisions:**\n");
+    for file in cache.changed_files.iter().take(8) {
+        writeln!(
+            output,
+            "  - `{}`: {} ({}, {})",
+            file.path.display(),
+            file.cache_status,
+            file.change_reason,
+            file.cache_reason
+        )
+        .unwrap();
+    }
+
+    if cache.changed_files.len() > 8 {
+        writeln!(
+            output,
+            "  - ... {} more changed file(s)",
+            cache.changed_files.len() - 8
+        )
+        .unwrap();
+    }
+}
+
+fn format_optional_ms(value: Option<u64>) -> String {
+    value
+        .map(|value| format!("{}ms", value / 1000))
+        .unwrap_or_else(|| "n/a".to_string())
 }
 
 fn render_hidden_suggestions_breakdown(output: &mut String, summary: &ScanSummary) {

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -186,6 +186,7 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
             files_skipped_repopilotignore: report.summary.files_skipped_repopilotignore,
             repopilotignore_path: report.summary.repopilotignore_path.clone(),
             scan_timings: None,
+            cache_telemetry: report.summary.cache_telemetry.clone(),
         },
         baseline_path: report.baseline_path.clone(),
         findings,

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -8,13 +8,16 @@ use crate::review::diff::{
 };
 use crate::risk::{apply_cluster_overlay, assess_findings};
 use crate::scan::cache::{
-    FileRoleEntry, FindingsEntry, ScanCache, config_fingerprint, file_hash_entry,
+    CACHE_DIR, FileRoleEntry, FindingsEntry, ScanCache, config_fingerprint, file_hash_entry,
     relative_cache_path,
 };
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::{FileFacts, ScanFacts};
-use crate::scan::types::{ScanMode, ScanSummary, ScanTimings};
-use std::collections::{HashMap, HashSet};
+use crate::scan::types::{
+    ChangedFileCacheTelemetry, ChangedFileReasonSummary, ScanCacheTelemetry, ScanMode, ScanSummary,
+    ScanTimings,
+};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -31,12 +34,23 @@ pub fn scan_changed_with_config(
         Some(base) => DiffTarget::Refs { base, head: "HEAD" },
         None => DiffTarget::WorkingTree,
     };
-    let changed_files =
-        load_changed_files(&repo_root, target, pathspec.as_deref()).map_err(diff_error_to_io)?;
+    let changed_files = load_changed_files(&repo_root, target, pathspec.as_deref())
+        .map_err(diff_error_to_io)?
+        .into_iter()
+        .filter(|changed_file| !is_cache_path(&changed_file.path))
+        .collect::<Vec<_>>();
 
     let file_scan_start = Instant::now();
     let file_audits = build_file_audits(config);
+    let cache_load_start = Instant::now();
     let mut cache = ScanCache::load(&repo_root);
+    let mut cache_telemetry = ScanCacheTelemetry {
+        timings: crate::scan::types::ScanCacheTimings {
+            load_us: cache_load_start.elapsed().as_micros() as u64,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
     let fingerprint = config_fingerprint(config);
     let mut facts = ScanFacts {
         root_path: path.to_path_buf(),
@@ -46,14 +60,37 @@ pub fn scan_changed_with_config(
     let mut languages: HashMap<String, usize> = HashMap::new();
     let mut findings = Vec::new();
     let mut directories = HashSet::new();
+    let mut changed_file_reasons: BTreeMap<String, usize> = BTreeMap::new();
 
     for changed_file in &changed_files {
+        let change_reason = change_status_label(changed_file.status).to_string();
+        *changed_file_reasons
+            .entry(change_reason.clone())
+            .or_insert(0) += 1;
+
         if changed_file.status == ChangeStatus::Deleted {
+            record_skipped_cache_file(
+                &mut cache_telemetry,
+                &changed_file.path,
+                &change_reason,
+                "deleted",
+            );
             continue;
         }
 
         let absolute_path = repo_root.join(&changed_file.path);
         if !absolute_path.is_file() {
+            let reason = if absolute_path.exists() {
+                "not-regular-file"
+            } else {
+                "missing-file"
+            };
+            record_skipped_cache_file(
+                &mut cache_telemetry,
+                &changed_file.path,
+                &change_reason,
+                reason,
+            );
             continue;
         }
 
@@ -63,24 +100,56 @@ pub fn scan_changed_with_config(
             directories.insert(parent.to_path_buf());
         }
 
+        let hash_start = Instant::now();
         let hash_entry = file_hash_entry(&repo_root, &absolute_path)?;
+        cache_telemetry.timings.file_hash_us = cache_telemetry
+            .timings
+            .file_hash_us
+            .saturating_add(hash_start.elapsed().as_micros() as u64);
         let cache_path = hash_entry.path.clone();
         cache
             .file_hashes
             .insert(cache_path.clone(), hash_entry.clone());
 
-        if let (Some(role_entry), Some(findings_entry)) = (
+        let lookup_start = Instant::now();
+        let cache_decision = cache_decision(
             cache.file_roles.get(&cache_path),
             cache.findings.get(&cache_path),
-        ) && role_entry.hash == hash_entry.hash
-            && findings_entry.hash == hash_entry.hash
-            && findings_entry.config_fingerprint == fingerprint
-        {
-            record_cached_file(&mut facts, &mut languages, role_entry);
-            findings.extend(findings_entry.findings.clone());
-            continue;
-        }
+            &hash_entry.hash,
+            &fingerprint,
+        );
+        cache_telemetry.timings.lookup_us = cache_telemetry
+            .timings
+            .lookup_us
+            .saturating_add(lookup_start.elapsed().as_micros() as u64);
 
+        let mut reason = match cache_decision {
+            CacheDecision::Hit {
+                role_entry,
+                findings: cached_findings,
+            } => {
+                let reuse_start = Instant::now();
+                record_cached_file(&mut facts, &mut languages, &role_entry);
+                findings.extend(cached_findings);
+                cache_telemetry.timings.hit_reuse_us = cache_telemetry
+                    .timings
+                    .hit_reuse_us
+                    .saturating_add(reuse_start.elapsed().as_micros() as u64);
+                cache_telemetry.hits += 1;
+                cache_telemetry
+                    .changed_files
+                    .push(ChangedFileCacheTelemetry {
+                        path: changed_file.path.clone(),
+                        change_reason,
+                        cache_status: "hit".to_string(),
+                        cache_reason: "unchanged-content-and-config".to_string(),
+                    });
+                continue;
+            }
+            CacheDecision::Miss { reason } => reason,
+        };
+
+        let miss_start = Instant::now();
         let mut per_file = process_file_with_content(&absolute_path, &file_audits, config)?;
         normalize_per_file_paths(
             &mut per_file.file_facts.path,
@@ -127,17 +196,33 @@ pub fn scan_changed_with_config(
                 findings.extend(per_file.findings);
             }
             SkipReason::LargeFile => {
+                reason = "large-file";
                 facts.skipped_files_count += 1;
                 facts.skipped_bytes = facts.skipped_bytes.saturating_add(per_file.skipped_bytes);
             }
             SkipReason::Binary => {
+                reason = "binary-file";
                 facts.binary_files_skipped += 1;
                 facts.skipped_bytes = facts.skipped_bytes.saturating_add(per_file.skipped_bytes);
             }
             SkipReason::LowSignal => {
+                reason = "low-signal-file";
                 facts.files_skipped_low_signal += 1;
             }
         }
+        cache_telemetry.timings.miss_scan_us = cache_telemetry
+            .timings
+            .miss_scan_us
+            .saturating_add(miss_start.elapsed().as_micros() as u64);
+        cache_telemetry.misses += 1;
+        cache_telemetry
+            .changed_files
+            .push(ChangedFileCacheTelemetry {
+                path: changed_file.path.clone(),
+                change_reason,
+                cache_status: "miss".to_string(),
+                cache_reason: reason.to_string(),
+            });
     }
 
     facts.directories_count = directories.len();
@@ -152,7 +237,10 @@ pub fn scan_changed_with_config(
     apply_cluster_overlay(&mut findings);
     super::summary::sort_findings(&mut findings);
 
+    let cache_write_start = Instant::now();
     cache.write(&repo_root)?;
+    cache_telemetry.timings.write_us = cache_write_start.elapsed().as_micros() as u64;
+    finalize_cache_telemetry(&mut cache_telemetry, changed_file_reasons);
 
     let scan_duration_us = start.elapsed().as_micros() as u64;
     let health_score = ScanSummary::compute_health_score(&findings, facts.lines_of_code);
@@ -192,7 +280,123 @@ pub fn scan_changed_with_config(
             framework_detection_us: 0,
             post_scan_audits_us: 0,
         }),
+        cache_telemetry: Some(cache_telemetry),
     })
+}
+
+enum CacheDecision {
+    Hit {
+        role_entry: FileRoleEntry,
+        findings: Vec<Finding>,
+    },
+    Miss {
+        reason: &'static str,
+    },
+}
+
+fn cache_decision(
+    role_entry: Option<&FileRoleEntry>,
+    findings_entry: Option<&FindingsEntry>,
+    hash: &str,
+    fingerprint: &str,
+) -> CacheDecision {
+    match (role_entry, findings_entry) {
+        (Some(role_entry), Some(findings_entry))
+            if role_entry.hash == hash
+                && findings_entry.hash == hash
+                && findings_entry.config_fingerprint == fingerprint =>
+        {
+            CacheDecision::Hit {
+                role_entry: role_entry.clone(),
+                findings: findings_entry.findings.clone(),
+            }
+        }
+        (None, None) => CacheDecision::Miss {
+            reason: "missing-cache-entry",
+        },
+        (None, Some(_)) => CacheDecision::Miss {
+            reason: "missing-file-role-cache",
+        },
+        (Some(_), None) => CacheDecision::Miss {
+            reason: "missing-findings-cache",
+        },
+        (Some(role_entry), Some(findings_entry))
+            if role_entry.hash != hash || findings_entry.hash != hash =>
+        {
+            CacheDecision::Miss {
+                reason: "content-changed",
+            }
+        }
+        (Some(_), Some(findings_entry)) if findings_entry.config_fingerprint != fingerprint => {
+            CacheDecision::Miss {
+                reason: "config-changed",
+            }
+        }
+        (Some(_), Some(_)) => CacheDecision::Miss {
+            reason: "cache-mismatch",
+        },
+    }
+}
+
+fn record_skipped_cache_file(
+    telemetry: &mut ScanCacheTelemetry,
+    path: &Path,
+    change_reason: &str,
+    cache_reason: &str,
+) {
+    telemetry.skipped += 1;
+    telemetry.changed_files.push(ChangedFileCacheTelemetry {
+        path: path.to_path_buf(),
+        change_reason: change_reason.to_string(),
+        cache_status: "skipped".to_string(),
+        cache_reason: cache_reason.to_string(),
+    });
+}
+
+fn finalize_cache_telemetry(
+    telemetry: &mut ScanCacheTelemetry,
+    changed_file_reasons: BTreeMap<String, usize>,
+) {
+    let cached_total = telemetry.hits + telemetry.misses;
+    telemetry.hit_rate_percent = if cached_total == 0 {
+        0
+    } else {
+        ((telemetry.hits * 100) / cached_total) as u8
+    };
+    telemetry.changed_file_reasons = changed_file_reasons
+        .into_iter()
+        .map(|(reason, count)| ChangedFileReasonSummary { reason, count })
+        .collect();
+
+    telemetry.timings.estimated_time_saved_us = if telemetry.hits > 0 && telemetry.misses > 0 {
+        let average_miss_us = telemetry.timings.miss_scan_us / telemetry.misses as u64;
+        let average_hit_reuse_us = telemetry.timings.hit_reuse_us / telemetry.hits as u64;
+        Some(
+            average_miss_us
+                .saturating_sub(average_hit_reuse_us)
+                .saturating_mul(telemetry.hits as u64),
+        )
+    } else {
+        None
+    };
+}
+
+fn change_status_label(status: ChangeStatus) -> &'static str {
+    match status {
+        ChangeStatus::Added => "added",
+        ChangeStatus::Modified => "modified",
+        ChangeStatus::Deleted => "deleted",
+        ChangeStatus::Renamed => "renamed",
+        ChangeStatus::Untracked => "untracked",
+    }
+}
+
+fn is_cache_path(path: &Path) -> bool {
+    let path = path.to_string_lossy().replace('\\', "/");
+    path == CACHE_DIR
+        || path
+            .strip_prefix(CACHE_DIR)
+            .is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 fn record_cached_file(

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -357,28 +357,34 @@ fn finalize_cache_telemetry(
     telemetry: &mut ScanCacheTelemetry,
     changed_file_reasons: BTreeMap<String, usize>,
 ) {
-    let cached_total = telemetry.hits + telemetry.misses;
-    telemetry.hit_rate_percent = if cached_total == 0 {
-        0
-    } else {
-        ((telemetry.hits * 100) / cached_total) as u8
-    };
+    let cached_total = telemetry.hits.saturating_add(telemetry.misses);
+    let hit_rate = telemetry
+        .hits
+        .saturating_mul(100)
+        .checked_div(cached_total)
+        .unwrap_or(0);
+    telemetry.hit_rate_percent = hit_rate.min(100) as u8;
     telemetry.changed_file_reasons = changed_file_reasons
         .into_iter()
         .map(|(reason, count)| ChangedFileReasonSummary { reason, count })
         .collect();
 
-    telemetry.timings.estimated_time_saved_us = if telemetry.hits > 0 && telemetry.misses > 0 {
-        let average_miss_us = telemetry.timings.miss_scan_us / telemetry.misses as u64;
-        let average_hit_reuse_us = telemetry.timings.hit_reuse_us / telemetry.hits as u64;
-        Some(
-            average_miss_us
-                .saturating_sub(average_hit_reuse_us)
-                .saturating_mul(telemetry.hits as u64),
-        )
-    } else {
-        None
-    };
+    let average_miss_us = telemetry
+        .timings
+        .miss_scan_us
+        .checked_div(telemetry.misses as u64);
+    let average_hit_reuse_us = telemetry
+        .timings
+        .hit_reuse_us
+        .checked_div(telemetry.hits as u64);
+    telemetry.timings.estimated_time_saved_us =
+        average_miss_us
+            .zip(average_hit_reuse_us)
+            .map(|(average_miss_us, average_hit_reuse_us)| {
+                average_miss_us
+                    .saturating_sub(average_hit_reuse_us)
+                    .saturating_mul(telemetry.hits as u64)
+            });
 }
 
 fn change_status_label(status: ChangeStatus) -> &'static str {

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -116,5 +116,6 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
             framework_detection_us,
             post_scan_audits_us,
         }),
+        cache_telemetry: None,
     })
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -32,6 +32,45 @@ pub struct ScanTimings {
     pub post_scan_audits_us: u64,
 }
 
+/// Cache effectiveness and per-file cache decisions captured during changed scans.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScanCacheTelemetry {
+    pub hits: usize,
+    pub misses: usize,
+    pub skipped: usize,
+    pub hit_rate_percent: u8,
+    pub changed_file_reasons: Vec<ChangedFileReasonSummary>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_files: Vec<ChangedFileCacheTelemetry>,
+    pub timings: ScanCacheTimings,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChangedFileReasonSummary {
+    pub reason: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChangedFileCacheTelemetry {
+    pub path: PathBuf,
+    pub change_reason: String,
+    pub cache_status: String,
+    pub cache_reason: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScanCacheTimings {
+    pub load_us: u64,
+    pub file_hash_us: u64,
+    pub lookup_us: u64,
+    pub hit_reuse_us: u64,
+    pub miss_scan_us: u64,
+    pub write_us: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_time_saved_us: Option<u64>,
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct HiddenSuggestionSummary {
     pub intent: String,
@@ -120,6 +159,9 @@ pub struct ScanSummary {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scan_timings: Option<ScanTimings>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_telemetry: Option<ScanCacheTelemetry>,
 }
 
 fn default_repo_level_rules_included() -> bool {
@@ -158,6 +200,7 @@ impl Default for ScanSummary {
             files_skipped_repopilotignore: 0,
             repopilotignore_path: None,
             scan_timings: None,
+            cache_telemetry: None,
         }
     }
 }

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -93,6 +93,7 @@ fn summary(findings: Vec<Finding>) -> ScanSummary {
         files_skipped_repopilotignore: 0,
         repopilotignore_path: None,
         scan_timings: None,
+        cache_telemetry: None,
     }
 }
 

--- a/tests/output_console.rs
+++ b/tests/output_console.rs
@@ -1,6 +1,9 @@
 use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use repopilot::output::{OutputFormat, render_scan_summary};
-use repopilot::scan::types::{HiddenSuggestionSummary, ScanSummary};
+use repopilot::scan::types::{
+    ChangedFileCacheTelemetry, ChangedFileReasonSummary, HiddenSuggestionSummary,
+    ScanCacheTelemetry, ScanCacheTimings, ScanSummary,
+};
 use std::path::PathBuf;
 
 #[test]
@@ -89,4 +92,51 @@ fn console_output_includes_hidden_suggestion_breakdown() {
 
     assert!(output.contains("Hidden suggestions breakdown:"));
     assert!(output.contains("architecture / maintainability / architecture.large-file"));
+}
+
+#[test]
+fn console_output_includes_cache_telemetry_for_changed_scans() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("demo"),
+        cache_telemetry: Some(cache_telemetry()),
+        ..ScanSummary::default()
+    };
+
+    let output = render_scan_summary(&summary, OutputFormat::Console)
+        .expect("failed to render console report");
+
+    assert!(output.contains("Cache telemetry:"));
+    assert!(output.contains("Cache hits:"));
+    assert!(output.contains("misses:"));
+    assert!(output.contains("Changed file reasons: modified (2)"));
+    assert!(output.contains("Cache timing:"));
+    assert!(output.contains("src/lib.rs: hit (modified, unchanged-content-and-config)"));
+}
+
+fn cache_telemetry() -> ScanCacheTelemetry {
+    ScanCacheTelemetry {
+        hits: 1,
+        misses: 1,
+        skipped: 0,
+        hit_rate_percent: 50,
+        changed_file_reasons: vec![ChangedFileReasonSummary {
+            reason: "modified".to_string(),
+            count: 2,
+        }],
+        changed_files: vec![ChangedFileCacheTelemetry {
+            path: PathBuf::from("src/lib.rs"),
+            change_reason: "modified".to_string(),
+            cache_status: "hit".to_string(),
+            cache_reason: "unchanged-content-and-config".to_string(),
+        }],
+        timings: ScanCacheTimings {
+            load_us: 1_000,
+            file_hash_us: 2_000,
+            lookup_us: 3_000,
+            hit_reuse_us: 4_000,
+            miss_scan_us: 5_000,
+            write_us: 6_000,
+            estimated_time_saved_us: Some(7_000),
+        },
+    }
 }

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -53,6 +53,7 @@ fn html_output_escapes_snippets_and_renders_summary() {
         files_skipped_repopilotignore: 0,
         repopilotignore_path: None,
         scan_timings: None,
+        cache_telemetry: None,
     };
 
     let html = render_scan_summary(&summary, OutputFormat::Html).expect("failed to render html");

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -40,6 +40,7 @@ fn renders_valid_json_scan_summary() {
         files_skipped_repopilotignore: 0,
         repopilotignore_path: None,
         scan_timings: None,
+        cache_telemetry: None,
     };
 
     let output =

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -1,7 +1,10 @@
 use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use repopilot::frameworks::ReactNativeArchitectureProfile;
 use repopilot::output::{OutputFormat, render_scan_summary};
-use repopilot::scan::types::{HiddenSuggestionSummary, LanguageSummary, ScanSummary};
+use repopilot::scan::types::{
+    ChangedFileCacheTelemetry, ChangedFileReasonSummary, HiddenSuggestionSummary, LanguageSummary,
+    ScanCacheTelemetry, ScanCacheTimings, ScanSummary,
+};
 use std::path::PathBuf;
 
 #[test]
@@ -64,6 +67,7 @@ fn renders_markdown_scan_summary() {
         files_skipped_repopilotignore: 0,
         repopilotignore_path: None,
         scan_timings: None,
+        cache_telemetry: None,
     };
 
     let output = render_scan_summary(&summary, OutputFormat::Markdown)
@@ -127,6 +131,7 @@ fn renders_empty_markdown_sections() {
         files_skipped_repopilotignore: 0,
         repopilotignore_path: None,
         scan_timings: None,
+        cache_telemetry: None,
     };
 
     let output = render_scan_summary(&summary, OutputFormat::Markdown)
@@ -185,6 +190,7 @@ fn renders_react_native_architecture_section_when_profile_present() {
         files_skipped_repopilotignore: 0,
         repopilotignore_path: None,
         scan_timings: None,
+        cache_telemetry: None,
     };
 
     let output = render_scan_summary(&summary, OutputFormat::Markdown)
@@ -234,4 +240,49 @@ fn markdown_output_includes_hidden_suggestion_breakdown() {
 
     assert!(output.contains("- **Top hidden suggestions:**"));
     assert!(output.contains("`testing` / `testing-gap` / `testing.source-without-test`: 2"));
+}
+
+#[test]
+fn markdown_output_includes_cache_telemetry() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("demo"),
+        cache_telemetry: Some(cache_telemetry()),
+        ..ScanSummary::default()
+    };
+
+    let output = render_scan_summary(&summary, OutputFormat::Markdown)
+        .expect("failed to render markdown summary");
+
+    assert!(output.contains("- **Cache:** 1 hit(s), 1 miss(es), 0 skipped (50% hit rate)"));
+    assert!(output.contains("- **Changed file reasons:** modified (2)"));
+    assert!(output.contains("- **Cache timing:** load 1ms; hash 2ms; lookup 3ms; reuse 4ms; miss scan 5ms; write 6ms; est. saved 7ms"));
+    assert!(output.contains("`src/lib.rs`: hit (modified, unchanged-content-and-config)"));
+}
+
+fn cache_telemetry() -> ScanCacheTelemetry {
+    ScanCacheTelemetry {
+        hits: 1,
+        misses: 1,
+        skipped: 0,
+        hit_rate_percent: 50,
+        changed_file_reasons: vec![ChangedFileReasonSummary {
+            reason: "modified".to_string(),
+            count: 2,
+        }],
+        changed_files: vec![ChangedFileCacheTelemetry {
+            path: PathBuf::from("src/lib.rs"),
+            change_reason: "modified".to_string(),
+            cache_status: "hit".to_string(),
+            cache_reason: "unchanged-content-and-config".to_string(),
+        }],
+        timings: ScanCacheTimings {
+            load_us: 1_000,
+            file_hash_us: 2_000,
+            lookup_us: 3_000,
+            hit_reuse_us: 4_000,
+            miss_scan_us: 5_000,
+            write_us: 6_000,
+            estimated_time_saved_us: Some(7_000),
+        },
+    }
 }

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -24,6 +24,31 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
     assert_eq!(first["mode"], "changed");
     assert_eq!(first["repo_level_rules_included"], false);
     assert_eq!(first["changed_files_count"], 1);
+    assert_eq!(first["cache_telemetry"]["hits"], 0);
+    assert_eq!(first["cache_telemetry"]["misses"], 1);
+    assert_eq!(first["cache_telemetry"]["skipped"], 0);
+    assert_eq!(
+        first["cache_telemetry"]["changed_files"][0]["path"],
+        "src/lib.rs"
+    );
+    assert_eq!(
+        first["cache_telemetry"]["changed_files"][0]["change_reason"],
+        "modified"
+    );
+    assert_eq!(
+        first["cache_telemetry"]["changed_files"][0]["cache_status"],
+        "miss"
+    );
+    assert_eq!(
+        first["cache_telemetry"]["changed_files"][0]["cache_reason"],
+        "missing-cache-entry"
+    );
+    assert_changed_reason(&first, "modified", 1);
+    assert!(
+        first["cache_telemetry"]["timings"]["miss_scan_us"]
+            .as_u64()
+            .is_some()
+    );
     assert_rule_present(&first, "security.secret-candidate");
 
     let cache_dir = temp.path().join(".repopilot/cache");
@@ -33,6 +58,17 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
 
     rewrite_cached_finding_title(&cache_dir.join("findings.json"), "Cached secret title");
     let cached = scan_changed_json(temp.path(), &["--changed"]);
+    assert_eq!(cached["cache_telemetry"]["hits"], 1);
+    assert_eq!(cached["cache_telemetry"]["misses"], 0);
+    assert_eq!(cached["cache_telemetry"]["hit_rate_percent"], 100);
+    assert_eq!(
+        cached["cache_telemetry"]["changed_files"][0]["cache_status"],
+        "hit"
+    );
+    assert_eq!(
+        cached["cache_telemetry"]["changed_files"][0]["cache_reason"],
+        "unchanged-content-and-config"
+    );
     assert_eq!(first_finding_title(&cached), "Cached secret title");
 
     write(
@@ -40,6 +76,12 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
         "pub fn live() {}\nconst API_KEY: &str = \"xyz987abc123\";\n",
     );
     let invalidated = scan_changed_json(temp.path(), &["--changed"]);
+    assert_eq!(invalidated["cache_telemetry"]["hits"], 0);
+    assert_eq!(invalidated["cache_telemetry"]["misses"], 1);
+    assert_eq!(
+        invalidated["cache_telemetry"]["changed_files"][0]["cache_reason"],
+        "content-changed"
+    );
     assert_eq!(
         first_finding_title(&invalidated),
         "Possible secret detected"
@@ -164,6 +206,17 @@ fn assert_rule_present(json: &Value, rule_id: &str) {
             .flatten()
             .any(|finding| finding["rule_id"] == rule_id),
         "expected {rule_id} in findings: {json:#?}"
+    );
+}
+
+fn assert_changed_reason(json: &Value, reason: &str, count: u64) {
+    assert!(
+        json["cache_telemetry"]["changed_file_reasons"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .any(|item| item["reason"] == reason && item["count"] == count),
+        "expected changed file reason {reason} ({count}) in {json:#?}"
     );
 }
 


### PR DESCRIPTION
## Summary

This PR adds cache telemetry for changed-file scans.

Changed scans now report cache effectiveness, changed-file reasons, per-file cache decisions, and timing impact. This makes the local cache behavior transparent and helps users understand whether `scan --changed` is actually reusing previous work or falling back to fresh analysis.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] Output/reporting

## What changed

- Added `cache_telemetry` to changed-scan summaries.
- Added cache hit/miss/skipped counters.
- Added cache hit-rate calculation.
- Added changed-file reason summaries:
  - added;
  - modified;
  - deleted;
  - renamed;
  - untracked.
- Added per-file cache decisions with:
  - path;
  - change reason;
  - cache status;
  - cache reason.
- Added cache timing breakdown:
  - cache load time;
  - file hashing time;
  - lookup time;
  - hit reuse time;
  - miss scan time;
  - cache write time;
  - estimated time saved.
- Excluded `.repopilot/cache` paths from changed-file scans.
- Added cache telemetry output to:
  - console reports;
  - Markdown reports;
  - HTML reports;
  - JSON/baseline reports.
- Added cache timing details to `--verbose` scan output.
- Preserved `cache_telemetry: None` for normal full scans.
- Updated docs for changed-scan cache telemetry.
- Updated tests for output rendering and scan summary compatibility.

## Why

The previous changed-scan cache worked, but users could not easily tell whether the cache was helping.

This PR makes changed scans inspectable:

```text
changed scan -> cache hit/miss decision -> timing impact -> visible report metadata
```
That matters because changed scans are meant to be fast local feedback. If a scan is slow, noisy, or unexpectedly missing cache hits, the telemetry now gives enough information to debug why.

## Architecture notes

- No god files introduced.
- Cache telemetry is part of ScanSummary, so all output renderers can consume the same data.
- Changed-scan cache logic remains inside src/scan/scanner/changed.rs.
- Cache-specific data structures are kept in scan types.
- Full scans continue to report cache_telemetry: None.
- Output renderers display telemetry only when it exists.
- The implementation stays local-first:

  - no remote cache;
  - no telemetry upload;
  - no background service;
  - no hosted scanner.

## Compatibility

- Existing full scans are unchanged.
- Existing changed scans still work.
- Existing cache files remain local under .repopilot/cache/.
- JSON reports now include optional cache_telemetry for changed scans.
- Full-scan JSON output skips cache_telemetry.
- Changed scans still skip repo-level rules and clearly report that scope.


## Verification

Recommended checks:
```

cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```

Smoke checks:

```
cargo run -- cache clear .
cargo run -- scan . --changed --format markdown --output /tmp/repopilot-changed-first.md
cargo run -- scan . --changed --format markdown --output /tmp/repopilot-changed-second.md
cargo run -- scan . --changed --format json --output /tmp/repopilot-changed-cache.json
cargo run -- scan . --changed --verbose
cargo run -- scan . --format json --output /tmp/repopilot-full.json
```