### PR TITLE
feat(local): add cache diagnostics, feedback suppressions, and schema fixtures

### DIFF
--- a/docs/cache-diagnostics.md
+++ b/docs/cache-diagnostics.md
@@ -1,0 +1,13 @@
+# Cache Diagnostics
+
+Changed-file scans use a local cache under `.repopilot/cache`.
+
+```bash
+repopilot inspect cache .
+repopilot inspect cache . --format json
+repopilot cache clear .
+```
+
+`inspect cache` is read-only. It reports cache directory path, cache existence,
+schema version, cache entry counts, stale/unmatched cache entries, and approximate
+cache size.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -348,3 +348,37 @@ repopilot compare before.json after.json --format markdown
 ```bash
 repopilot scan src/payments/processor.rs
 ```
+
+---
+
+## `inspect cache`
+
+Inspect local changed-scan cache diagnostics.
+
+```bash
+repopilot inspect cache .
+repopilot inspect cache . --format json
+repopilot inspect cache . --format markdown --output cache.md
+```
+
+The command is read-only and reports cache entry counts, schema version,
+approximate cache size, and stale entry count.
+
+---
+
+## Local feedback suppressions
+
+RepoPilot reads `.repopilot/feedback.yml` by default:
+
+```yaml
+suppressions:
+  - rule_id: architecture.large-file
+    path: src/generated/schema.rs
+    reason: generated schema boundary
+```
+
+Use raw output without local suppressions:
+
+```bash
+repopilot scan . --ignore-feedback
+```

--- a/docs/local-feedback.md
+++ b/docs/local-feedback.md
@@ -1,0 +1,30 @@
+# Local Feedback
+
+RepoPilot can read local suppressions from:
+
+```text
+.repopilot/feedback.yml
+```
+
+Minimal example:
+
+```yaml
+suppressions:
+  - rule_id: architecture.large-file
+    path: src/generated/schema.rs
+    reason: generated schema boundary
+```
+
+Run normally:
+
+```bash
+repopilot scan .
+```
+
+Ignore local feedback when you want the raw report:
+
+```bash
+repopilot scan . --ignore-feedback
+```
+
+This is repository-local calibration, not remote learning.

--- a/docs/report-schema-migration.md
+++ b/docs/report-schema-migration.md
@@ -1,0 +1,39 @@
+# Report Schema Migration
+
+RepoPilot report schemas are intentionally versioned because JSON reports are
+useful in CI, dashboards, PR bots, and downstream tooling.
+
+## Current direction
+
+Schema `0.13` clarifies scan accounting names:
+
+| Old field | New field | Why |
+|---|---|---|
+| `files_count` | `files_analyzed` | The value counts analyzed text files, not all discovered files. |
+| `lines_of_code` | `non_empty_lines` | RepoPilot counts non-empty lines used by audit thresholds. |
+| `skipped_files_count` | `large_files_skipped` | The field describes large files skipped by size/limit rules. |
+
+## Consumer guidance
+
+Consumers should prefer:
+
+```json
+{
+  "files_analyzed": 42,
+  "non_empty_lines": 3200,
+  "large_files_skipped": 1
+}
+```
+
+For older reports, consumers can fall back to:
+
+```text
+files_analyzed <- files_count
+non_empty_lines <- lines_of_code
+large_files_skipped <- skipped_files_count
+```
+
+## Compatibility policy
+
+RepoPilot should keep reading older reports where practical, especially for
+`repopilot compare`, baseline workflows, and older CI artifacts.

--- a/src/cli/options/inspect.rs
+++ b/src/cli/options/inspect.rs
@@ -29,6 +29,16 @@ repopilot inspect knowledge --section languages\n  \
 repopilot inspect knowledge --section rules --format json"
     )]
     Knowledge(KnowledgeOptions),
+
+    /// Inspect local changed-scan cache diagnostics
+    #[command(
+        about = "Inspect RepoPilot local cache diagnostics",
+        after_help = "EXAMPLES:\n  \
+repopilot inspect cache\n  \
+repopilot inspect cache . --format json\n  \
+repopilot inspect cache . --format markdown --output cache.md"
+    )]
+    Cache(CacheInspectOptions),
 }
 
 #[derive(Args)]
@@ -64,6 +74,21 @@ pub struct KnowledgeOptions {
     pub section: KnowledgeSectionArg,
 
     /// Output format for the catalog
+    #[arg(long, value_enum, default_value = "console")]
+    pub format: CompareOutputFormatArg,
+
+    /// Write report to a file instead of stdout
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct CacheInspectOptions {
+    /// Repository or project path whose .repopilot/cache directory should be inspected
+    #[arg(default_value = ".")]
+    pub path: PathBuf,
+
+    /// Output format for cache diagnostics
     #[arg(long, value_enum, default_value = "console")]
     pub format: CompareOutputFormatArg,
 

--- a/src/cli/options/scan.rs
+++ b/src/cli/options/scan.rs
@@ -105,6 +105,10 @@ pub struct ScanOptions {
     #[arg(long, value_parser = ["strict", "balanced", "lenient"])]
     pub preset: Option<String>,
 
+    /// Ignore .repopilot/feedback.yml local suppressions
+    #[arg(long)]
+    pub ignore_feedback: bool,
+
     /// Only show findings for specific rule ID(s); repeatable
     #[arg(long, value_name = "RULE_ID")]
     pub rule: Vec<String>,

--- a/src/commands/cache_inspect.rs
+++ b/src/commands/cache_inspect.rs
@@ -1,0 +1,63 @@
+use crate::cli::CompareOutputFormatArg;
+use repopilot::output::OutputFormat;
+use repopilot::report::writer::write_report;
+use repopilot::scan::cache::{CacheDiagnostics, inspect_cache};
+use std::path::PathBuf;
+
+pub fn run(
+    path: PathBuf,
+    format: CompareOutputFormatArg,
+    output: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let diagnostics = inspect_cache(&path);
+    let rendered = render_cache_diagnostics(&diagnostics, OutputFormat::from(format))?;
+    write_report(&rendered, output.as_deref())?;
+    Ok(())
+}
+
+fn render_cache_diagnostics(
+    diagnostics: &CacheDiagnostics,
+    format: OutputFormat,
+) -> Result<String, serde_json::Error> {
+    match format {
+        OutputFormat::Console => Ok(render_console(diagnostics)),
+        OutputFormat::Markdown => Ok(render_markdown(diagnostics)),
+        OutputFormat::Json | OutputFormat::Html | OutputFormat::Sarif => {
+            serde_json::to_string_pretty(diagnostics)
+        }
+    }
+}
+
+fn render_console(diagnostics: &CacheDiagnostics) -> String {
+    format!(
+        "RepoPilot Cache Diagnostics\n\nCache dir: {}\nExists: {}\nSchema version: {}\nRepoPilot version: {}\nApprox size: {} bytes\nFile hashes: {}\nFile roles: {}\nFindings entries: {}\nStale entries: {}\n",
+        diagnostics.cache_dir.display(),
+        yes_no(diagnostics.exists),
+        diagnostics.schema_version,
+        diagnostics.repopilot_version,
+        diagnostics.approximate_size_bytes,
+        diagnostics.file_hashes_count,
+        diagnostics.file_roles_count,
+        diagnostics.findings_count,
+        diagnostics.stale_entries_count,
+    )
+}
+
+fn render_markdown(diagnostics: &CacheDiagnostics) -> String {
+    format!(
+        "# RepoPilot Cache Diagnostics\n\n- **Cache dir:** `{}`\n- **Exists:** {}\n- **Schema version:** `{}`\n- **RepoPilot version:** `{}`\n- **Approx size:** {} bytes\n- **File hashes:** {}\n- **File roles:** {}\n- **Findings entries:** {}\n- **Stale entries:** {}\n",
+        diagnostics.cache_dir.display(),
+        yes_no(diagnostics.exists),
+        diagnostics.schema_version,
+        diagnostics.repopilot_version,
+        diagnostics.approximate_size_bytes,
+        diagnostics.file_hashes_count,
+        diagnostics.file_roles_count,
+        diagnostics.findings_count,
+        diagnostics.stale_entries_count,
+    )
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod baseline;
 pub mod cache;
+pub mod cache_inspect;
 pub mod compare;
 pub mod doctor;
 pub mod explain;
@@ -114,6 +115,9 @@ fn run_inspect(command: InspectCommands) -> Result<(), Box<dyn std::error::Error
         ),
         InspectCommands::Knowledge(options) => {
             knowledge::run(options.section, options.format, options.output)
+        }
+        InspectCommands::Cache(options) => {
+            cache_inspect::run(options.path, options.format, options.output)
         }
     }
 }

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -12,6 +12,7 @@ use repopilot::baseline::gate::{FailOn, evaluate_ci_gate};
 use repopilot::baseline::reader::read_baseline;
 use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::config::presets::{Preset, apply_preset};
+use repopilot::findings::feedback::apply_local_feedback;
 use repopilot::findings::visibility::{FindingVisibilityProfile, apply_visibility_profile};
 use repopilot::output::{render_baseline_scan_report, render_scan_summary};
 use repopilot::receipt::{build_audit_receipt, render_receipt_json};
@@ -95,6 +96,10 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
 
     let scan_elapsed = scan_start.elapsed();
     finish_spinner(pb);
+
+    if !options.ignore_feedback {
+        apply_local_feedback(&mut summary, &options.path)?;
+    }
 
     if let Some(min) = min_severity {
         apply_min_severity_filter(&mut summary, min);

--- a/src/explain/builder.rs
+++ b/src/explain/builder.rs
@@ -1,11 +1,14 @@
 use crate::audits::context::classify_file;
 use crate::explain::model::{
     ExplainContext, ExplainDecision, ExplainReport, ExplainRiskSignal, ExplainSource,
+    ExplainVisibility,
 };
-use crate::findings::types::Severity;
+use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
+use crate::findings::visibility::classify_visibility;
 use crate::knowledge::decision::decide_for_file;
 use crate::knowledge::language::{detect_language_for_path, profile_by_id};
 use crate::knowledge::model::{RuleDecisionAction, SupportLevel};
+use crate::rules::registry::lookup_rule_metadata;
 use crate::scan::facts::FileFacts;
 use std::fs;
 use std::io;
@@ -80,6 +83,7 @@ pub fn build_explain_report(
                 weight: signal.weight,
                 reason: signal.reason,
             }),
+            visibility: Some(explain_visibility(path, rule_id, decision.severity)),
         }
     });
 
@@ -148,5 +152,34 @@ fn decision_action_label(action: RuleDecisionAction) -> &'static str {
         RuleDecisionAction::Suppress => "suppress",
         RuleDecisionAction::Downgrade => "downgrade",
         RuleDecisionAction::Upgrade => "upgrade",
+    }
+}
+
+fn explain_visibility(path: &Path, rule_id: &str, severity: Severity) -> ExplainVisibility {
+    let category = lookup_rule_metadata(rule_id)
+        .map(|metadata| metadata.category.clone())
+        .unwrap_or(FindingCategory::CodeQuality);
+
+    let finding = Finding {
+        rule_id: rule_id.to_string(),
+        category,
+        severity,
+        confidence: Confidence::High,
+        evidence: vec![Evidence {
+            path: path.to_path_buf(),
+            line_start: 1,
+            line_end: None,
+            snippet: "synthetic finding for visibility explanation".to_string(),
+        }],
+        ..Default::default()
+    };
+
+    let decision = classify_visibility(&finding);
+
+    ExplainVisibility {
+        profile: "default".to_string(),
+        intent: decision.intent.label().to_string(),
+        visible_by_default: decision.visible_by_default,
+        reason: decision.reason.to_string(),
     }
 }

--- a/src/explain/model.rs
+++ b/src/explain/model.rs
@@ -42,6 +42,8 @@ pub struct ExplainDecision {
     pub reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub risk_signal: Option<ExplainRiskSignal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<ExplainVisibility>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -49,5 +51,13 @@ pub struct ExplainRiskSignal {
     pub id: String,
     pub label: String,
     pub weight: i16,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExplainVisibility {
+    pub profile: String,
+    pub intent: String,
+    pub visible_by_default: bool,
     pub reason: String,
 }

--- a/src/explain/render.rs
+++ b/src/explain/render.rs
@@ -99,6 +99,19 @@ fn render_console_decision(decision: &ExplainDecision) -> String {
             signal.label, signal.weight, signal.reason
         ));
     }
+    if let Some(visibility) = &decision.visibility {
+        output.push_str(&format!(
+            " Visibility: {} in {} profile ({})\n",
+            if visibility.visible_by_default {
+                "visible"
+            } else {
+                "hidden"
+            },
+            visibility.profile,
+            visibility.reason
+        ));
+        output.push_str(&format!(" Intent: {}\n", visibility.intent));
+    }
 
     output
 }
@@ -181,6 +194,19 @@ fn render_markdown(report: &ExplainReport) -> String {
                     "- **Risk signal:** {} ({:+}) — {}\n",
                     signal.label, signal.weight, signal.reason
                 ));
+            }
+            if let Some(visibility) = &decision.visibility {
+                output.push_str(&format!(
+                    "- **Visibility:** `{}` in `{}` profile\n",
+                    if visibility.visible_by_default {
+                        "visible"
+                    } else {
+                        "hidden"
+                    },
+                    visibility.profile
+                ));
+                output.push_str(&format!("- **Intent:** `{}`\n", visibility.intent));
+                output.push_str(&format!("- **Visibility reason:** {}\n", visibility.reason));
             }
         }
         None => {

--- a/src/findings/feedback.rs
+++ b/src/findings/feedback.rs
@@ -1,0 +1,176 @@
+use crate::findings::types::Finding;
+use crate::scan::types::ScanSummary;
+use serde::Serialize;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+const FEEDBACK_PATH: &str = ".repopilot/feedback.yml";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalSuppression {
+    pub rule_id: String,
+    pub path: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+pub struct LocalFeedbackReport {
+    pub feedback_path: Option<PathBuf>,
+    pub suppressions_loaded: usize,
+    pub suppressed_findings_count: usize,
+}
+
+pub fn apply_local_feedback(
+    summary: &mut ScanSummary,
+    root: &Path,
+) -> io::Result<LocalFeedbackReport> {
+    let feedback_path = root.join(FEEDBACK_PATH);
+
+    if !feedback_path.is_file() {
+        return Ok(LocalFeedbackReport::default());
+    }
+
+    let content = fs::read_to_string(&feedback_path)?;
+    let suppressions = parse_suppressions(&content);
+
+    if suppressions.is_empty() {
+        return Ok(LocalFeedbackReport {
+            feedback_path: Some(feedback_path),
+            suppressions_loaded: 0,
+            suppressed_findings_count: 0,
+        });
+    }
+
+    let original_count = summary.findings.len();
+    summary
+        .findings
+        .retain(|finding| !is_suppressed(finding, &suppressions));
+
+    let suppressed_findings_count = original_count.saturating_sub(summary.findings.len());
+    summary.visible_findings_count = summary.findings.len();
+    summary.health_score =
+        ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
+
+    Ok(LocalFeedbackReport {
+        feedback_path: Some(feedback_path),
+        suppressions_loaded: suppressions.len(),
+        suppressed_findings_count,
+    })
+}
+
+pub fn parse_suppressions(content: &str) -> Vec<LocalSuppression> {
+    let mut suppressions = Vec::new();
+    let mut current_rule_id: Option<String> = None;
+    let mut current_path: Option<String> = None;
+    let mut current_reason: Option<String> = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed == "suppressions:" {
+            continue;
+        }
+
+        if let Some(value) = trimmed.strip_prefix("- rule_id:") {
+            push_current(
+                &mut suppressions,
+                &mut current_rule_id,
+                &mut current_path,
+                &mut current_reason,
+            );
+            current_rule_id = Some(clean_yaml_value(value));
+            continue;
+        }
+
+        if let Some(value) = trimmed.strip_prefix("rule_id:") {
+            current_rule_id = Some(clean_yaml_value(value));
+            continue;
+        }
+
+        if let Some(value) = trimmed.strip_prefix("path:") {
+            current_path = Some(clean_yaml_value(value));
+            continue;
+        }
+
+        if let Some(value) = trimmed.strip_prefix("reason:") {
+            current_reason = Some(clean_yaml_value(value));
+        }
+    }
+
+    push_current(
+        &mut suppressions,
+        &mut current_rule_id,
+        &mut current_path,
+        &mut current_reason,
+    );
+    suppressions
+}
+
+fn push_current(
+    suppressions: &mut Vec<LocalSuppression>,
+    rule_id: &mut Option<String>,
+    path: &mut Option<String>,
+    reason: &mut Option<String>,
+) {
+    let Some(rule_id_value) = rule_id.take() else {
+        *path = None;
+        *reason = None;
+        return;
+    };
+    let Some(path_value) = path.take() else {
+        *reason = None;
+        return;
+    };
+
+    suppressions.push(LocalSuppression {
+        rule_id: rule_id_value,
+        path: normalize_path_text(&path_value),
+        reason: reason.take(),
+    });
+}
+
+fn clean_yaml_value(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_string()
+}
+
+fn is_suppressed(finding: &Finding, suppressions: &[LocalSuppression]) -> bool {
+    suppressions.iter().any(|suppression| {
+        finding.rule_id == suppression.rule_id
+            && finding.evidence.first().is_some_and(|evidence| {
+                normalize_path_text(&evidence.path.to_string_lossy()) == suppression.path
+            })
+    })
+}
+
+fn normalize_path_text(path: &str) -> String {
+    path.replace('\\', "/").trim_start_matches("./").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_feedback_suppressions() {
+        let suppressions = parse_suppressions(
+            r#"
+suppressions:
+  - rule_id: architecture.large-file
+    path: src/generated/schema.rs
+    reason: generated schema boundary
+"#,
+        );
+
+        assert_eq!(suppressions.len(), 1);
+        assert_eq!(suppressions[0].rule_id, "architecture.large-file");
+        assert_eq!(suppressions[0].path, "src/generated/schema.rs");
+        assert_eq!(
+            suppressions[0].reason.as_deref(),
+            Some("generated schema boundary")
+        );
+    }
+}

--- a/src/findings/mod.rs
+++ b/src/findings/mod.rs
@@ -1,2 +1,3 @@
+pub mod feedback;
 pub mod types;
 pub mod visibility;

--- a/src/scan/cache.rs
+++ b/src/scan/cache.rs
@@ -309,3 +309,76 @@ fn valid_findings_cache(cache: &FindingsCache) -> bool {
     cache.schema_version == CACHE_SCHEMA_VERSION
         && cache.repopilot_version == env!("CARGO_PKG_VERSION")
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CacheDiagnostics {
+    pub cache_dir: PathBuf,
+    pub exists: bool,
+    pub schema_version: u32,
+    pub repopilot_version: String,
+    pub approximate_size_bytes: u64,
+    pub file_hashes_count: usize,
+    pub file_roles_count: usize,
+    pub findings_count: usize,
+    pub stale_entries_count: usize,
+}
+
+pub fn inspect_cache(root: &Path) -> CacheDiagnostics {
+    let cache_root = cache_dir(root);
+    let exists = cache_root.is_dir();
+    let cache = ScanCache::load(root);
+
+    CacheDiagnostics {
+        cache_dir: cache_root.clone(),
+        exists,
+        schema_version: CACHE_SCHEMA_VERSION,
+        repopilot_version: env!("CARGO_PKG_VERSION").to_string(),
+        approximate_size_bytes: directory_size_bytes(&cache_root),
+        file_hashes_count: cache.file_hashes.len(),
+        file_roles_count: cache.file_roles.len(),
+        findings_count: cache.findings.len(),
+        stale_entries_count: stale_cache_entries_count(&cache),
+    }
+}
+
+fn stale_cache_entries_count(cache: &ScanCache) -> usize {
+    let mut count = 0;
+
+    for key in cache.file_hashes.keys() {
+        if !cache.file_roles.contains_key(key) || !cache.findings.contains_key(key) {
+            count += 1;
+        }
+    }
+
+    for key in cache.file_roles.keys() {
+        if !cache.file_hashes.contains_key(key) {
+            count += 1;
+        }
+    }
+
+    for key in cache.findings.keys() {
+        if !cache.file_hashes.contains_key(key) {
+            count += 1;
+        }
+    }
+
+    count
+}
+
+fn directory_size_bytes(path: &Path) -> u64 {
+    let Ok(entries) = fs::read_dir(path) else {
+        return 0;
+    };
+
+    entries
+        .filter_map(Result::ok)
+        .map(|entry| {
+            let entry_path = entry.path();
+            match entry.metadata() {
+                Ok(metadata) if metadata.is_file() => metadata.len(),
+                Ok(metadata) if metadata.is_dir() => directory_size_bytes(&entry_path),
+                _ => 0,
+            }
+        })
+        .sum()
+}

--- a/tests/changed_scan_fixture_coverage.rs
+++ b/tests/changed_scan_fixture_coverage.rs
@@ -1,0 +1,178 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+#[test]
+fn changed_scan_tracks_untracked_deleted_and_cache_paths() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+
+    write(temp.path().join("src/live.rs"), "pub fn live() {}\n");
+    write(temp.path().join("src/delete_me.rs"), "pub fn gone() {}\n");
+    commit_all(temp.path(), "initial");
+
+    fs::remove_file(temp.path().join("src/delete_me.rs")).expect("delete file");
+    write(
+        temp.path().join("src/untracked.rs"),
+        "const API_KEY: &str = \"abc123xyz987\";\n",
+    );
+    write(
+        temp.path().join(".repopilot/cache/noise.json"),
+        "{\"should\":\"not be scanned\"}\n",
+    );
+
+    let json = scan_changed_json(temp.path(), &["--changed"]);
+
+    assert_eq!(json["mode"], "changed");
+    assert_eq!(json["repo_level_rules_included"], false);
+    assert_changed_reason(&json, "deleted", 1);
+    assert_changed_reason(&json, "untracked", 1);
+
+    let changed_files = json["cache_telemetry"]["changed_files"]
+        .as_array()
+        .expect("changed files telemetry");
+
+    assert!(
+        changed_files.iter().all(|file| !file["path"]
+            .as_str()
+            .unwrap_or_default()
+            .starts_with(".repopilot/cache")),
+        "cache paths should not be included in changed scan telemetry: {changed_files:#?}"
+    );
+}
+
+#[test]
+fn local_feedback_file_suppresses_matching_finding_unless_ignored() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+
+    write(
+        temp.path().join("src/live.rs"),
+        "const API_KEY: &str = \"abc123xyz987\";
+",
+    );
+    write(
+        temp.path().join("tests/live_test.rs"),
+        "#[test]
+fn live_smoke() { assert!(true); }
+",
+    );
+    write(
+        temp.path().join(".repopilot/feedback.yml"),
+        r#"
+suppressions:
+  - rule_id: security.secret-candidate
+    path: src/live.rs
+    reason: fixture value accepted for this test
+"#,
+    );
+    commit_all(temp.path(), "initial");
+
+    let suppressed = scan_json(temp.path(), &[]);
+    assert!(
+        !has_rule(&suppressed, "security.secret-candidate"),
+        "feedback should suppress matching security finding: {suppressed:#?}"
+    );
+
+    let raw = scan_json(temp.path(), &["--ignore-feedback"]);
+    assert!(
+        has_rule(&raw, "security.secret-candidate"),
+        "ignore feedback should reveal the finding: {raw:#?}"
+    );
+}
+
+fn scan_json(root: &Path, extra: &[&str]) -> Value {
+    let output = repopilot()
+        .args(["scan", ".", "--format", "json", "--profile", "strict"])
+        .args(extra)
+        .current_dir(root)
+        .output()
+        .expect("run scan");
+
+    assert!(
+        output.status.success(),
+        "scan failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    serde_json::from_slice(&output.stdout).expect("json")
+}
+
+fn scan_changed_json(root: &Path, extra: &[&str]) -> Value {
+    let output = repopilot()
+        .args(["scan", ".", "--format", "json"])
+        .args(extra)
+        .current_dir(root)
+        .output()
+        .expect("run changed scan");
+
+    assert!(
+        output.status.success(),
+        "changed scan failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    serde_json::from_slice(&output.stdout).expect("json")
+}
+
+fn has_rule(json: &Value, rule_id: &str) -> bool {
+    json["findings"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .any(|finding| finding["rule_id"] == rule_id)
+}
+
+fn assert_changed_reason(json: &Value, reason: &str, count: u64) {
+    assert!(
+        json["cache_telemetry"]["changed_file_reasons"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .any(|item| item["reason"] == reason && item["count"] == count),
+        "expected changed reason {reason} ({count}) in {json:#?}"
+    );
+}
+
+fn init_repo(root: &Path) {
+    git(root, &["init"]);
+    git(root, &["checkout", "-B", "main"]);
+    git(root, &["config", "user.email", "repopilot@example.com"]);
+    git(root, &["config", "user.name", "RepoPilot Test"]);
+}
+
+fn commit_all(root: &Path, message: &str) {
+    git(root, &["add", "."]);
+    git(root, &["commit", "-m", message]);
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run git");
+
+    assert!(
+        output.status.success(),
+        "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write(path: std::path::PathBuf, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent");
+    }
+    fs::write(path, content).expect("write file");
+}

--- a/tests/fixtures/reports/scan-v010.json
+++ b/tests/fixtures/reports/scan-v010.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "0.10",
+  "repopilot_version": "0.10.0",
+  "root_path": ".",
+  "files_count": 2,
+  "directories_count": 1,
+  "lines_of_code": 12,
+  "findings": [],
+  "languages": [],
+  "risk_summary": {
+    "total": 0,
+    "average_score": 0,
+    "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 }
+  }
+}

--- a/tests/fixtures/reports/scan-v013.json
+++ b/tests/fixtures/reports/scan-v013.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "0.13",
+  "repopilot_version": "0.12.0",
+  "root_path": ".",
+  "files_analyzed": 2,
+  "directories_count": 1,
+  "non_empty_lines": 12,
+  "large_files_skipped": 0,
+  "findings": [],
+  "languages": [],
+  "risk_summary": {
+    "total": 0,
+    "average_score": 0,
+    "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 }
+  }
+}

--- a/tests/report_schema_compat.rs
+++ b/tests/report_schema_compat.rs
@@ -1,0 +1,39 @@
+use serde_json::Value;
+
+#[test]
+fn schema_fixtures_document_legacy_and_current_metric_names() {
+    let legacy: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v010.json"))
+        .expect("legacy report fixture should be valid JSON");
+    let current: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v013.json"))
+        .expect("current report fixture should be valid JSON");
+
+    assert_eq!(legacy["schema_version"], "0.10");
+    assert_eq!(legacy["files_count"], 2);
+    assert_eq!(legacy["lines_of_code"], 12);
+
+    assert_eq!(current["schema_version"], "0.13");
+    assert_eq!(current["files_analyzed"], 2);
+    assert_eq!(current["non_empty_lines"], 12);
+    assert_eq!(current["large_files_skipped"], 0);
+}
+
+#[test]
+fn legacy_metric_fallbacks_are_unambiguous_for_consumers() {
+    let legacy: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v010.json"))
+        .expect("legacy report fixture should be valid JSON");
+
+    let files_analyzed = legacy
+        .get("files_analyzed")
+        .or_else(|| legacy.get("files_count"))
+        .and_then(Value::as_u64)
+        .expect("files analyzed fallback");
+
+    let non_empty_lines = legacy
+        .get("non_empty_lines")
+        .or_else(|| legacy.get("lines_of_code"))
+        .and_then(Value::as_u64)
+        .expect("non-empty lines fallback");
+
+    assert_eq!(files_analyzed, 2);
+    assert_eq!(non_empty_lines, 12);
+}


### PR DESCRIPTION
## Summary

This PR continues the RepoPilot 0.12 foundation work by adding local diagnostics, schema compatibility fixtures, visibility explanations, and repository-local feedback suppressions.

It focuses on making RepoPilot more trustable and easier to debug after the changed-scan/cache/schema refactors.

## Type of change

- [x] Feature
- [x] Tests
- [x] Documentation
- [x] Refactor
- [x] Local-first workflow

## What changed

- Added report schema migration documentation.
- Added JSON schema compatibility fixtures for older and current report fields.
- Added tests documenting legacy/current scan metric compatibility.
- Added `repopilot inspect cache`.
- Added cache diagnostics for:
  - cache directory;
  - schema version;
  - RepoPilot version;
  - cache entry counts;
  - stale entry count;
  - approximate cache size.
- Added local feedback suppressions via `.repopilot/feedback.yml`.
- Added `--ignore-feedback` for raw scan output.
- Added visibility decision output to `inspect explain`.
- Added changed-scan fixture coverage for:
  - untracked files;
  - deleted files;
  - ignored `.repopilot/cache` paths.
- Added docs for:
  - cache diagnostics;
  - local feedback;
  - report schema migration.

## Why

RepoPilot is moving from a scanner into a local-first repository review engine.

After adding changed scans, local cache, cache telemetry, trust mode, and clearer report schemas, the next step is making those systems inspectable and controllable.

This PR improves that trust layer:

```text
cache exists -> inspect it
report schema changed -> document and fixture it
finding hidden -> explain why
false positive accepted locally -> suppress it in repo-local feedback
```

## Architecture notes

- No remote services.
- No telemetry upload.
- No hosted scanner.
- No plugin execution.
- Cache diagnostics are read-only.
- Feedback suppressions are local and inspectable.
- Scan behavior can bypass feedback with --ignore-feedback.
- Visibility explanation reuses the existing visibility engine instead of duplicating policy.

## Verification

```
cargo fmt --all -- --check
cargo test --all
cargo clippy --all-targets --all-features -- -D warnings
```
Smoke checks:

```
cargo run -- inspect cache .
cargo run -- inspect cache . --format json
cargo run -- inspect explain src/main.rs --rule language.rust.panic-risk
cargo run -- scan .
cargo run -- scan . --ignore-feedback
cargo run -- scan . --changed --format json
```