### PR TITLE
feat(scan): add confidence filtering and shared finding filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
 /target
 .claude/
 dist/
+.DS_Store
+.idea/
+.vscode/
+*.log
+*.tmp
+*.bak
+*.swp
+*.swo
+*.class
+*.jar
+*.war
+*.ear

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,6 +84,8 @@ repopilot s <PATH> [OPTIONS]
 | `--changed` | flag | — | Scan only files changed against `HEAD`, including untracked files; repo-level rules are skipped |
 | `--since` | git ref | — | Scan only files changed between `BASE...HEAD`; repo-level rules are skipped |
 | `--min-severity` | `info\|low\|medium\|high\|critical` | — | Only show findings at or above this severity |
+| `--min-confidence` | `low\|medium\|high` | — | Only show findings at or above this confidence |
+| `--min-priority` | `p0\|p1\|p2\|p3` | — | Only show findings at or above this risk priority |
 | `--verbose` | flag | — | Print scan phase timing breakdown after the report |
 | `--preset` | `strict\|balanced\|lenient` | `balanced` | Apply a threshold preset without editing config |
 
@@ -205,6 +207,8 @@ repopilot r [PATH] [OPTIONS]
 | `--max-directory-modules` | integer | `20` | Maximum files per directory before flagging |
 | `--max-directory-depth` | integer | `5` | Maximum nesting depth before flagging |
 | `--min-severity` | `info\|low\|medium\|high\|critical` | — | Only show findings at or above this severity |
+| `--min-confidence` | `low\|medium\|high` | — | Only show findings at or above this confidence |
+| `--min-priority` | `p0\|p1\|p2\|p3` | — | Only show findings at or above this risk priority |
 
 ### Exit codes
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -109,13 +109,15 @@ Size values accept raw bytes plus `kb`, `mb`, and `gb` suffixes. By default, low
 
 JSON reports expose this accounting with `files_discovered`, `files_analyzed` (analyzed text files), `files_skipped_low_signal`, `binary_files_skipped`, `large_files_skipped`, and `skipped_bytes`.
 
-### Filtering by severity
+### Filtering by severity, confidence, and priority
 
-Use `--min-severity` to reduce local report noise while keeping the same rules enabled:
+Use `--min-severity` and `--min-confidence` to reduce local report noise while keeping the same rules enabled:
 
 ```bash
 repopilot scan . --min-severity high
 repopilot review . --min-severity high
+repopilot scan . --min-confidence high
+repopilot review . --base origin/main --min-confidence medium
 ```
 
 Use `--min-priority` when you want risk-ranked output instead of severity-only

--- a/src/baseline/diff.rs
+++ b/src/baseline/diff.rs
@@ -1,5 +1,6 @@
 use crate::baseline::key::stable_finding_key;
 use crate::baseline::model::Baseline;
+use crate::findings::filter::{FindingFilter, recompute_summary_metrics};
 use crate::findings::types::Finding;
 use crate::risk::apply_baseline_overlay;
 use crate::scan::types::ScanSummary;
@@ -67,6 +68,31 @@ impl BaselineScanReport {
                 (self.finding_status(index) == status).then_some(finding)
             })
             .collect()
+    }
+
+    pub fn apply_filter(&mut self, filter: &FindingFilter) {
+        self.retain_findings(|finding| filter.matches(finding));
+    }
+
+    pub fn retain_findings<F>(&mut self, mut keep: F)
+    where
+        F: FnMut(&Finding) -> bool,
+    {
+        let mut paired = self
+            .summary
+            .findings
+            .drain(..)
+            .zip(self.findings.drain(..))
+            .collect::<Vec<_>>();
+
+        paired.retain(|(finding, _)| keep(finding));
+
+        for (finding, status) in paired {
+            self.summary.findings.push(finding);
+            self.findings.push(status);
+        }
+
+        recompute_summary_metrics(&mut self.summary);
     }
 }
 

--- a/src/baseline/gate.rs
+++ b/src/baseline/gate.rs
@@ -83,20 +83,7 @@ fn finding_matches(
                 && finding.severity.is_at_least(&threshold)
         }
         FailOn::Any(threshold) => finding.severity.is_at_least(&threshold),
-        FailOn::Priority(threshold) => priority_is_at_least(finding.risk.priority, threshold),
-    }
-}
-
-fn priority_is_at_least(priority: RiskPriority, threshold: RiskPriority) -> bool {
-    priority_rank(priority) <= priority_rank(threshold)
-}
-
-fn priority_rank(priority: RiskPriority) -> u8 {
-    match priority {
-        RiskPriority::P0 => 0,
-        RiskPriority::P1 => 1,
-        RiskPriority::P2 => 2,
-        RiskPriority::P3 => 3,
+        FailOn::Priority(threshold) => finding.risk.priority.is_at_least(threshold),
     }
 }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,6 +1,6 @@
 use clap::ValueEnum;
 use repopilot::baseline::gate::FailOn;
-use repopilot::findings::types::Severity;
+use repopilot::findings::types::{Confidence, Severity};
 use repopilot::output::OutputFormat;
 use repopilot::risk::RiskPriority;
 
@@ -27,6 +27,13 @@ pub enum SeverityArg {
     Medium,
     High,
     Critical,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum ConfidenceArg {
+    Low,
+    Medium,
+    High,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -83,6 +90,16 @@ impl From<OutputFormatArg> for OutputFormat {
             OutputFormatArg::Json => OutputFormat::Json,
             OutputFormatArg::Markdown => OutputFormat::Markdown,
             OutputFormatArg::Sarif => OutputFormat::Sarif,
+        }
+    }
+}
+
+impl From<ConfidenceArg> for Confidence {
+    fn from(value: ConfidenceArg) -> Self {
+        match value {
+            ConfidenceArg::Low => Confidence::Low,
+            ConfidenceArg::Medium => Confidence::Medium,
+            ConfidenceArg::High => Confidence::High,
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,8 +2,8 @@ mod args;
 mod options;
 
 pub use args::{
-    CompareOutputFormatArg, FailOnArg, KnowledgeSectionArg, OutputFormatArg, PriorityArg,
-    ScanProfileArg, SeverityArg, parse_byte_size, parse_vibe_budget,
+    CompareOutputFormatArg, ConfidenceArg, FailOnArg, KnowledgeSectionArg, OutputFormatArg,
+    PriorityArg, ScanProfileArg, SeverityArg, parse_byte_size, parse_vibe_budget,
 };
 pub use options::*;
 

--- a/src/cli/options/review.rs
+++ b/src/cli/options/review.rs
@@ -1,4 +1,4 @@
-use crate::cli::{CompareOutputFormatArg, FailOnArg, PriorityArg, SeverityArg};
+use crate::cli::{CompareOutputFormatArg, ConfidenceArg, FailOnArg, PriorityArg, SeverityArg};
 use clap::Args;
 use std::path::PathBuf;
 
@@ -55,6 +55,10 @@ pub struct ReviewOptions {
     /// Only render findings at or above this severity
     #[arg(long, value_enum)]
     pub min_severity: Option<SeverityArg>,
+
+    /// Only render findings at or above this confidence
+    #[arg(long, value_enum)]
+    pub min_confidence: Option<ConfidenceArg>,
 
     /// Only render findings at or above this risk priority
     #[arg(long, value_enum)]

--- a/src/cli/options/scan.rs
+++ b/src/cli/options/scan.rs
@@ -1,5 +1,6 @@
 use crate::cli::{
-    FailOnArg, OutputFormatArg, PriorityArg, ScanProfileArg, SeverityArg, parse_byte_size,
+    ConfidenceArg, FailOnArg, OutputFormatArg, PriorityArg, ScanProfileArg, SeverityArg,
+    parse_byte_size,
 };
 use clap::Args;
 use std::path::PathBuf;
@@ -80,6 +81,10 @@ pub struct ScanOptions {
     /// Only render findings at or above this severity
     #[arg(long, value_enum)]
     pub min_severity: Option<SeverityArg>,
+
+    /// Only render findings at or above this confidence
+    #[arg(long, value_enum)]
+    pub min_confidence: Option<ConfidenceArg>,
 
     /// Only render findings at or above this risk priority
     #[arg(long, value_enum)]

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,5 +1,5 @@
 use crate::cli::CompareOutputFormatArg;
-use crate::commands::{ScanConfigOverrides, build_scan_config};
+use crate::commands::scan_config::{ScanConfigOverrides, build_scan_config};
 use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::config::model::RepoPilotConfig;
 use repopilot::doctor::{build_doctor_report, render_doctor_report};

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -1,5 +1,5 @@
 use crate::cli::{CompareOutputFormatArg, SeverityArg};
-use crate::commands::severity_arg_into;
+use crate::commands::filters::severity_arg_into;
 use repopilot::explain::{build_explain_report, render_explain_report};
 use repopilot::output::OutputFormat;
 use repopilot::report::writer::write_report;

--- a/src/commands/filters.rs
+++ b/src/commands/filters.rs
@@ -1,0 +1,54 @@
+use crate::cli::{ConfidenceArg, PriorityArg, ReviewOptions, ScanOptions, SeverityArg};
+use repopilot::findings::filter::FindingFilter;
+use repopilot::findings::types::{Confidence, Severity};
+use repopilot::risk::RiskPriority;
+
+pub fn severity_arg_into(arg: SeverityArg) -> Severity {
+    match arg {
+        SeverityArg::Info => Severity::Info,
+        SeverityArg::Low => Severity::Low,
+        SeverityArg::Medium => Severity::Medium,
+        SeverityArg::High => Severity::High,
+        SeverityArg::Critical => Severity::Critical,
+    }
+}
+
+pub fn confidence_arg_into(arg: ConfidenceArg) -> Confidence {
+    arg.into()
+}
+
+pub fn priority_arg_into(arg: PriorityArg) -> RiskPriority {
+    arg.into()
+}
+
+pub fn scan_pre_visibility_filter(options: &ScanOptions) -> FindingFilter {
+    FindingFilter {
+        min_severity: options.min_severity.map(severity_arg_into),
+        min_confidence: options.min_confidence.map(confidence_arg_into),
+        min_priority: None,
+        rule_ids: options.rule.clone(),
+    }
+}
+
+pub fn scan_priority_filter(options: &ScanOptions) -> FindingFilter {
+    FindingFilter {
+        min_priority: options.min_priority.map(priority_arg_into),
+        ..FindingFilter::default()
+    }
+}
+
+pub fn review_pre_diff_filter(options: &ReviewOptions) -> FindingFilter {
+    FindingFilter {
+        min_severity: options.min_severity.map(severity_arg_into),
+        min_confidence: options.min_confidence.map(confidence_arg_into),
+        min_priority: None,
+        rule_ids: Vec::new(),
+    }
+}
+
+pub fn review_priority_filter(options: &ReviewOptions) -> FindingFilter {
+    FindingFilter {
+        min_priority: options.min_priority.map(priority_arg_into),
+        ..FindingFilter::default()
+    }
+}

--- a/src/commands/focus.rs
+++ b/src/commands/focus.rs
@@ -1,0 +1,18 @@
+use crate::commands::{CliExit, EXIT_USAGE};
+use repopilot::output::vibe::VibeCategory;
+
+pub const VALID_FOCUS_VALUES: &str = "security, arch, architecture, quality, framework, all";
+
+pub fn parse_focus_category(
+    focus: Option<&str>,
+) -> Result<Option<VibeCategory>, Box<dyn std::error::Error>> {
+    match focus {
+        Some(value) => Ok(Some(value.parse::<VibeCategory>().map_err(|_| {
+            CliExit {
+                code: EXIT_USAGE,
+                message: format!("Invalid focus '{value}'. Expected: {VALID_FOCUS_VALUES}"),
+            }
+        })?)),
+        None => Ok(None),
+    }
+}

--- a/src/commands/llm.rs
+++ b/src/commands/llm.rs
@@ -1,5 +1,6 @@
+use crate::commands::focus::parse_focus_category;
 use crate::commands::progress::{finish_spinner, make_spinner};
-use crate::commands::{ScanConfigOverrides, build_scan_config, parse_focus_category};
+use crate::commands::scan_config::{ScanConfigOverrides, build_scan_config};
 use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::output::vibe::{DEFAULT_TOKEN_BUDGET, VibeCategory};
 use repopilot::report::writer::write_report;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,8 @@ pub mod cache_inspect;
 pub mod compare;
 pub mod doctor;
 pub mod explain;
+pub(crate) mod filters;
+pub(crate) mod focus;
 pub mod harden;
 pub mod init;
 pub mod knowledge;
@@ -12,21 +14,12 @@ mod progress;
 pub mod prompt;
 pub mod review;
 pub mod scan;
+pub(crate) mod scan_config;
 pub mod vibe;
 
-use crate::cli::{
-    AiCommands, Cli, Commands, ConfidenceArg, InspectCommands, PriorityArg, ReviewOptions,
-    ScanOptions, SeverityArg,
-};
-use repopilot::config::model::RepoPilotConfig;
-use repopilot::findings::types::{Confidence, Finding, Severity};
-use repopilot::output::vibe::VibeCategory;
-use repopilot::risk::RiskPriority;
-use repopilot::scan::config::ScanConfig;
-use repopilot::scan::types::ScanSummary;
+use crate::cli::{AiCommands, Cli, Commands, InspectCommands};
 use std::fmt;
 
-pub const VALID_FOCUS_VALUES: &str = "security, arch, architecture, quality, framework, all";
 pub const EXIT_FINDINGS: i32 = 1;
 pub const EXIT_USAGE: i32 = 2;
 pub const EXIT_RUNTIME: i32 = 3;
@@ -135,140 +128,3 @@ impl fmt::Display for CliExit {
 }
 
 impl std::error::Error for CliExit {}
-
-pub fn severity_arg_into(arg: SeverityArg) -> Severity {
-    match arg {
-        SeverityArg::Info => Severity::Info,
-        SeverityArg::Low => Severity::Low,
-        SeverityArg::Medium => Severity::Medium,
-        SeverityArg::High => Severity::High,
-        SeverityArg::Critical => Severity::Critical,
-    }
-}
-
-pub fn confidence_arg_into(arg: ConfidenceArg) -> Confidence {
-    arg.into()
-}
-
-pub fn priority_arg_into(arg: PriorityArg) -> RiskPriority {
-    arg.into()
-}
-
-pub fn parse_focus_category(
-    focus: Option<&str>,
-) -> Result<Option<VibeCategory>, Box<dyn std::error::Error>> {
-    match focus {
-        Some(value) => Ok(Some(value.parse::<VibeCategory>().map_err(|_| {
-            CliExit {
-                code: EXIT_USAGE,
-                message: format!("Invalid focus '{value}'. Expected: {VALID_FOCUS_VALUES}"),
-            }
-        })?)),
-        None => Ok(None),
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct ScanConfigOverrides {
-    pub max_file_loc: Option<usize>,
-    pub max_directory_modules: Option<usize>,
-    pub max_directory_depth: Option<usize>,
-    pub exclude_patterns: Vec<String>,
-    pub include_low_signal: bool,
-    pub max_file_size: Option<u64>,
-    pub max_files: Option<usize>,
-}
-
-pub fn build_scan_config(
-    repo_config: &RepoPilotConfig,
-    overrides: ScanConfigOverrides,
-) -> ScanConfig {
-    let mut config = repo_config.to_scan_config();
-
-    if let Some(threshold) = overrides.max_file_loc {
-        config = config.with_large_file_loc_threshold(threshold);
-    }
-
-    if let Some(modules) = overrides.max_directory_modules {
-        config.max_directory_modules = modules;
-    }
-
-    if let Some(depth) = overrides.max_directory_depth {
-        config.max_directory_depth = depth;
-    }
-
-    config.exclude_patterns = overrides.exclude_patterns;
-    config.include_low_signal = overrides.include_low_signal;
-    if let Some(bytes) = overrides.max_file_size {
-        config.max_file_bytes = bytes;
-    }
-    config.max_files = overrides.max_files;
-
-    config
-}
-
-pub fn apply_min_severity_filter(summary: &mut ScanSummary, min: Severity) {
-    summary.findings.retain(|finding| finding.severity >= min);
-    summary.visible_findings_count = summary.findings.len();
-    summary.health_score =
-        ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
-}
-
-pub fn apply_min_confidence_filter(summary: &mut ScanSummary, min: Confidence) {
-    summary
-        .findings
-        .retain(|finding| finding_meets_min_confidence(finding, min));
-    summary.visible_findings_count = summary.findings.len();
-    summary.health_score =
-        ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
-}
-
-pub fn apply_min_priority_filter(summary: &mut ScanSummary, min: RiskPriority) {
-    summary
-        .findings
-        .retain(|finding| finding_meets_min_priority(finding, min));
-    summary.visible_findings_count = summary.findings.len();
-    summary.health_score =
-        ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
-}
-
-pub fn finding_meets_min_priority(finding: &Finding, min: RiskPriority) -> bool {
-    priority_rank(finding.risk.priority) <= priority_rank(min)
-}
-
-pub fn finding_meets_min_confidence(finding: &Finding, min: Confidence) -> bool {
-    finding.confidence >= min
-}
-
-fn priority_rank(priority: RiskPriority) -> u8 {
-    match priority {
-        RiskPriority::P0 => 0,
-        RiskPriority::P1 => 1,
-        RiskPriority::P2 => 2,
-        RiskPriority::P3 => 3,
-    }
-}
-
-pub fn scan_options_min_severity(options: &ScanOptions) -> Option<Severity> {
-    options.min_severity.map(severity_arg_into)
-}
-
-pub fn scan_options_min_confidence(options: &ScanOptions) -> Option<Confidence> {
-    options.min_confidence.map(confidence_arg_into)
-}
-
-pub fn scan_options_min_priority(options: &ScanOptions) -> Option<RiskPriority> {
-    options.min_priority.map(priority_arg_into)
-}
-
-pub fn review_options_min_severity(options: &ReviewOptions) -> Option<Severity> {
-    options.min_severity.map(severity_arg_into)
-}
-
-pub fn review_options_min_confidence(options: &ReviewOptions) -> Option<Confidence> {
-    options.min_confidence.map(confidence_arg_into)
-}
-
-pub fn review_options_min_priority(options: &ReviewOptions) -> Option<RiskPriority> {
-    options.min_priority.map(priority_arg_into)
-}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,11 +15,11 @@ pub mod scan;
 pub mod vibe;
 
 use crate::cli::{
-    AiCommands, Cli, Commands, InspectCommands, PriorityArg, ReviewOptions, ScanOptions,
-    SeverityArg,
+    AiCommands, Cli, Commands, ConfidenceArg, InspectCommands, PriorityArg, ReviewOptions,
+    ScanOptions, SeverityArg,
 };
 use repopilot::config::model::RepoPilotConfig;
-use repopilot::findings::types::{Finding, Severity};
+use repopilot::findings::types::{Confidence, Finding, Severity};
 use repopilot::output::vibe::VibeCategory;
 use repopilot::risk::RiskPriority;
 use repopilot::scan::config::ScanConfig;
@@ -146,6 +146,10 @@ pub fn severity_arg_into(arg: SeverityArg) -> Severity {
     }
 }
 
+pub fn confidence_arg_into(arg: ConfidenceArg) -> Confidence {
+    arg.into()
+}
+
 pub fn priority_arg_into(arg: PriorityArg) -> RiskPriority {
     arg.into()
 }
@@ -210,6 +214,15 @@ pub fn apply_min_severity_filter(summary: &mut ScanSummary, min: Severity) {
         ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
 }
 
+pub fn apply_min_confidence_filter(summary: &mut ScanSummary, min: Confidence) {
+    summary
+        .findings
+        .retain(|finding| finding_meets_min_confidence(finding, min));
+    summary.visible_findings_count = summary.findings.len();
+    summary.health_score =
+        ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
+}
+
 pub fn apply_min_priority_filter(summary: &mut ScanSummary, min: RiskPriority) {
     summary
         .findings
@@ -221,6 +234,10 @@ pub fn apply_min_priority_filter(summary: &mut ScanSummary, min: RiskPriority) {
 
 pub fn finding_meets_min_priority(finding: &Finding, min: RiskPriority) -> bool {
     priority_rank(finding.risk.priority) <= priority_rank(min)
+}
+
+pub fn finding_meets_min_confidence(finding: &Finding, min: Confidence) -> bool {
+    finding.confidence >= min
 }
 
 fn priority_rank(priority: RiskPriority) -> u8 {
@@ -236,12 +253,20 @@ pub fn scan_options_min_severity(options: &ScanOptions) -> Option<Severity> {
     options.min_severity.map(severity_arg_into)
 }
 
+pub fn scan_options_min_confidence(options: &ScanOptions) -> Option<Confidence> {
+    options.min_confidence.map(confidence_arg_into)
+}
+
 pub fn scan_options_min_priority(options: &ScanOptions) -> Option<RiskPriority> {
     options.min_priority.map(priority_arg_into)
 }
 
 pub fn review_options_min_severity(options: &ReviewOptions) -> Option<Severity> {
     options.min_severity.map(severity_arg_into)
+}
+
+pub fn review_options_min_confidence(options: &ReviewOptions) -> Option<Confidence> {
+    options.min_confidence.map(confidence_arg_into)
 }
 
 pub fn review_options_min_priority(options: &ReviewOptions) -> Option<RiskPriority> {

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -1,9 +1,9 @@
 use crate::cli::ReviewOptions;
 use crate::commands::progress::{finish_spinner, make_spinner};
 use crate::commands::{
-    CliExit, EXIT_FINDINGS, EXIT_USAGE, ScanConfigOverrides, apply_min_severity_filter,
-    build_scan_config, finding_meets_min_priority, review_options_min_priority,
-    review_options_min_severity,
+    CliExit, EXIT_FINDINGS, EXIT_USAGE, ScanConfigOverrides, apply_min_confidence_filter,
+    apply_min_severity_filter, build_scan_config, finding_meets_min_priority,
+    review_options_min_confidence, review_options_min_priority, review_options_min_severity,
 };
 use repopilot::baseline::gate::{FailOn, evaluate_ci_gate};
 use repopilot::baseline::reader::read_baseline;
@@ -17,6 +17,7 @@ use repopilot::scan::scanner::scan_path_with_config;
 
 pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
     let min_severity = review_options_min_severity(&options);
+    let min_confidence = review_options_min_confidence(&options);
     let min_priority = review_options_min_priority(&options);
     let fail_on_priority = options.fail_on_priority.map(Into::into);
 
@@ -54,6 +55,10 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
 
     if let Some(min) = min_severity {
         apply_min_severity_filter(&mut summary, min);
+    }
+
+    if let Some(min) = min_confidence {
+        apply_min_confidence_filter(&mut summary, min);
     }
 
     let baseline_file = match options.baseline {

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -1,24 +1,19 @@
 use crate::cli::ReviewOptions;
+use crate::commands::filters::{review_pre_diff_filter, review_priority_filter};
 use crate::commands::progress::{finish_spinner, make_spinner};
-use crate::commands::{
-    CliExit, EXIT_FINDINGS, EXIT_USAGE, ScanConfigOverrides, apply_min_confidence_filter,
-    apply_min_severity_filter, build_scan_config, finding_meets_min_priority,
-    review_options_min_confidence, review_options_min_priority, review_options_min_severity,
-};
+use crate::commands::scan_config::{ScanConfigOverrides, build_scan_config};
+use crate::commands::{CliExit, EXIT_FINDINGS, EXIT_USAGE};
 use repopilot::baseline::gate::{FailOn, evaluate_ci_gate};
 use repopilot::baseline::reader::read_baseline;
 use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::report::writer::write_report;
-use repopilot::review::model::ReviewReport;
 use repopilot::review::render::render;
 use repopilot::review::{build_review_report, review_report_for_ci};
-use repopilot::risk::RiskPriority;
 use repopilot::scan::scanner::scan_path_with_config;
 
 pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
-    let min_severity = review_options_min_severity(&options);
-    let min_confidence = review_options_min_confidence(&options);
-    let min_priority = review_options_min_priority(&options);
+    let pre_diff_filter = review_pre_diff_filter(&options);
+    let priority_filter = review_priority_filter(&options);
     let fail_on_priority = options.fail_on_priority.map(Into::into);
 
     if options.fail_on.is_some() && fail_on_priority.is_some() {
@@ -53,12 +48,8 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
     let mut summary = scan_path_with_config(&options.path, &scan_config)?;
     finish_spinner(pb);
 
-    if let Some(min) = min_severity {
-        apply_min_severity_filter(&mut summary, min);
-    }
-
-    if let Some(min) = min_confidence {
-        apply_min_confidence_filter(&mut summary, min);
+    if !pre_diff_filter.is_empty() {
+        pre_diff_filter.apply_to_summary(&mut summary);
     }
 
     let baseline_file = match options.baseline {
@@ -75,8 +66,8 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
         options.head.as_deref(),
         baseline_ref,
     )?;
-    if let Some(min) = min_priority {
-        apply_min_priority_filter_to_review_report(&mut review_report, min);
+    if !priority_filter.is_empty() {
+        review_report.apply_filter(&priority_filter);
     }
 
     let ci_report = review_report_for_ci(&review_report);
@@ -102,25 +93,4 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
-}
-
-fn apply_min_priority_filter_to_review_report(report: &mut ReviewReport, min: RiskPriority) {
-    let mut paired = report
-        .summary
-        .findings
-        .drain(..)
-        .zip(report.findings.drain(..))
-        .collect::<Vec<_>>();
-
-    paired.retain(|(finding, _)| finding_meets_min_priority(finding, min));
-
-    for (finding, status) in paired {
-        report.summary.findings.push(finding);
-        report.findings.push(status);
-    }
-
-    report.summary.health_score = repopilot::scan::types::ScanSummary::compute_health_score(
-        &report.summary.findings,
-        report.summary.non_empty_lines,
-    );
 }

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -1,14 +1,9 @@
 use crate::cli::ScanOptions;
+use crate::commands::filters::{scan_pre_visibility_filter, scan_priority_filter};
 use crate::commands::progress::{finish_spinner, make_spinner};
-use crate::commands::{
-    CliExit, EXIT_FINDINGS, EXIT_USAGE, ScanConfigOverrides, apply_min_confidence_filter,
-    apply_min_priority_filter, apply_min_severity_filter, build_scan_config,
-    finding_meets_min_priority, scan_options_min_confidence, scan_options_min_priority,
-    scan_options_min_severity,
-};
-use repopilot::baseline::diff::{
-    BaselineScanReport, all_findings_new, diff_summary_against_baseline,
-};
+use crate::commands::scan_config::{ScanConfigOverrides, build_scan_config};
+use crate::commands::{CliExit, EXIT_FINDINGS, EXIT_USAGE};
+use repopilot::baseline::diff::{all_findings_new, diff_summary_against_baseline};
 use repopilot::baseline::gate::{FailOn, evaluate_ci_gate};
 use repopilot::baseline::reader::read_baseline;
 use repopilot::config::loader::{load_default_config, load_optional_config};
@@ -18,7 +13,6 @@ use repopilot::findings::visibility::{FindingVisibilityProfile, apply_visibility
 use repopilot::output::{render_baseline_scan_report, render_scan_summary};
 use repopilot::receipt::{build_audit_receipt, render_receipt_json};
 use repopilot::report::writer::write_report;
-use repopilot::risk::RiskPriority;
 use repopilot::scan::scanner::{scan_changed_with_config, scan_path_with_config};
 use repopilot::scan::types::ScanSummary;
 use repopilot::scan::workspace_scan::scan_workspace_with_config;
@@ -26,9 +20,8 @@ use std::path::Path;
 use std::time::Instant;
 
 pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
-    let min_severity = scan_options_min_severity(&options);
-    let min_confidence = scan_options_min_confidence(&options);
-    let min_priority = scan_options_min_priority(&options);
+    let pre_visibility_filter = scan_pre_visibility_filter(&options);
+    let priority_filter = scan_priority_filter(&options);
     let fail_on_priority = options.fail_on_priority.map(Into::into);
 
     if options.fail_on.is_some() && fail_on_priority.is_some() {
@@ -103,16 +96,8 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
         apply_local_feedback(&mut summary, &options.path)?;
     }
 
-    if let Some(min) = min_severity {
-        apply_min_severity_filter(&mut summary, min);
-    }
-
-    if let Some(min) = min_confidence {
-        apply_min_confidence_filter(&mut summary, min);
-    }
-
-    if !options.rule.is_empty() {
-        apply_rule_filter(&mut summary, &options.rule);
+    if !pre_visibility_filter.is_empty() {
+        pre_visibility_filter.apply_to_summary(&mut summary);
     }
 
     let visibility_profile = scan_visibility_profile(&options);
@@ -126,8 +111,8 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
             }
             None => all_findings_new(summary),
         };
-        if let Some(min) = min_priority {
-            apply_min_priority_filter_to_baseline_report(&mut baseline_report, min);
+        if !priority_filter.is_empty() {
+            baseline_report.apply_filter(&priority_filter);
         }
 
         let ci_gate = options
@@ -172,8 +157,8 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    if let Some(min) = min_priority {
-        apply_min_priority_filter(&mut summary, min);
+    if !priority_filter.is_empty() {
+        priority_filter.apply_to_summary(&mut summary);
     }
 
     let render_start = Instant::now();
@@ -198,38 +183,6 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
-}
-
-fn apply_min_priority_filter_to_baseline_report(
-    report: &mut BaselineScanReport,
-    min: RiskPriority,
-) {
-    let mut paired = report
-        .summary
-        .findings
-        .drain(..)
-        .zip(report.findings.drain(..))
-        .collect::<Vec<_>>();
-
-    paired.retain(|(finding, _)| finding_meets_min_priority(finding, min));
-
-    for (finding, status) in paired {
-        report.summary.findings.push(finding);
-        report.findings.push(status);
-    }
-
-    report.summary.visible_findings_count = report.summary.findings.len();
-    report.summary.health_score =
-        ScanSummary::compute_health_score(&report.summary.findings, report.summary.non_empty_lines);
-}
-
-fn apply_rule_filter(summary: &mut ScanSummary, rules: &[String]) {
-    summary
-        .findings
-        .retain(|f| rules.iter().any(|r| r == &f.rule_id));
-    summary.visible_findings_count = summary.findings.len();
-    summary.health_score =
-        ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
 }
 
 fn scan_visibility_profile(options: &ScanOptions) -> FindingVisibilityProfile {

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -1,9 +1,10 @@
 use crate::cli::ScanOptions;
 use crate::commands::progress::{finish_spinner, make_spinner};
 use crate::commands::{
-    CliExit, EXIT_FINDINGS, EXIT_USAGE, ScanConfigOverrides, apply_min_priority_filter,
-    apply_min_severity_filter, build_scan_config, finding_meets_min_priority,
-    scan_options_min_priority, scan_options_min_severity,
+    CliExit, EXIT_FINDINGS, EXIT_USAGE, ScanConfigOverrides, apply_min_confidence_filter,
+    apply_min_priority_filter, apply_min_severity_filter, build_scan_config,
+    finding_meets_min_priority, scan_options_min_confidence, scan_options_min_priority,
+    scan_options_min_severity,
 };
 use repopilot::baseline::diff::{
     BaselineScanReport, all_findings_new, diff_summary_against_baseline,
@@ -26,6 +27,7 @@ use std::time::Instant;
 
 pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     let min_severity = scan_options_min_severity(&options);
+    let min_confidence = scan_options_min_confidence(&options);
     let min_priority = scan_options_min_priority(&options);
     let fail_on_priority = options.fail_on_priority.map(Into::into);
 
@@ -103,6 +105,10 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
 
     if let Some(min) = min_severity {
         apply_min_severity_filter(&mut summary, min);
+    }
+
+    if let Some(min) = min_confidence {
+        apply_min_confidence_filter(&mut summary, min);
     }
 
     if !options.rule.is_empty() {

--- a/src/commands/scan_config.rs
+++ b/src/commands/scan_config.rs
@@ -1,0 +1,41 @@
+use repopilot::config::model::RepoPilotConfig;
+use repopilot::scan::config::ScanConfig;
+
+#[derive(Debug, Default)]
+pub struct ScanConfigOverrides {
+    pub max_file_loc: Option<usize>,
+    pub max_directory_modules: Option<usize>,
+    pub max_directory_depth: Option<usize>,
+    pub exclude_patterns: Vec<String>,
+    pub include_low_signal: bool,
+    pub max_file_size: Option<u64>,
+    pub max_files: Option<usize>,
+}
+
+pub fn build_scan_config(
+    repo_config: &RepoPilotConfig,
+    overrides: ScanConfigOverrides,
+) -> ScanConfig {
+    let mut config = repo_config.to_scan_config();
+
+    if let Some(threshold) = overrides.max_file_loc {
+        config = config.with_large_file_loc_threshold(threshold);
+    }
+
+    if let Some(modules) = overrides.max_directory_modules {
+        config.max_directory_modules = modules;
+    }
+
+    if let Some(depth) = overrides.max_directory_depth {
+        config.max_directory_depth = depth;
+    }
+
+    config.exclude_patterns = overrides.exclude_patterns;
+    config.include_low_signal = overrides.include_low_signal;
+    if let Some(bytes) = overrides.max_file_size {
+        config.max_file_bytes = bytes;
+    }
+    config.max_files = overrides.max_files;
+
+    config
+}

--- a/src/findings/filter.rs
+++ b/src/findings/filter.rs
@@ -1,0 +1,235 @@
+use crate::findings::types::{Confidence, Finding, Severity};
+use crate::risk::RiskPriority;
+use crate::scan::types::ScanSummary;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct FindingFilter {
+    pub min_severity: Option<Severity>,
+    pub min_confidence: Option<Confidence>,
+    pub min_priority: Option<RiskPriority>,
+    pub rule_ids: Vec<String>,
+}
+
+impl FindingFilter {
+    pub fn is_empty(&self) -> bool {
+        self.min_severity.is_none()
+            && self.min_confidence.is_none()
+            && self.min_priority.is_none()
+            && self.rule_ids.is_empty()
+    }
+
+    pub fn matches(&self, finding: &Finding) -> bool {
+        if let Some(min) = self.min_severity
+            && !finding.severity.is_at_least(&min)
+        {
+            return false;
+        }
+
+        if let Some(min) = self.min_confidence
+            && finding.confidence < min
+        {
+            return false;
+        }
+
+        if let Some(min) = self.min_priority
+            && !finding.risk.priority.is_at_least(min)
+        {
+            return false;
+        }
+
+        if !self.rule_ids.is_empty()
+            && !self
+                .rule_ids
+                .iter()
+                .any(|rule_id| rule_id == &finding.rule_id)
+        {
+            return false;
+        }
+
+        true
+    }
+
+    pub fn apply_to_summary(&self, summary: &mut ScanSummary) {
+        if !self.is_empty() {
+            summary.findings.retain(|finding| self.matches(finding));
+        }
+        recompute_summary_metrics(summary);
+    }
+}
+
+pub fn recompute_summary_metrics(summary: &mut ScanSummary) {
+    summary.visible_findings_count = summary.findings.len();
+    summary.health_score =
+        ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::risk::RiskAssessment;
+    use std::path::PathBuf;
+
+    fn finding(
+        rule_id: &str,
+        severity: Severity,
+        confidence: Confidence,
+        priority: RiskPriority,
+    ) -> Finding {
+        Finding {
+            rule_id: rule_id.to_string(),
+            severity,
+            confidence,
+            risk: RiskAssessment {
+                priority,
+                ..RiskAssessment::default()
+            },
+            ..Finding::default()
+        }
+    }
+
+    #[test]
+    fn severity_threshold_matches_at_or_above_minimum() {
+        let filter = FindingFilter {
+            min_severity: Some(Severity::High),
+            ..FindingFilter::default()
+        };
+
+        assert!(filter.matches(&finding(
+            "rule.high",
+            Severity::High,
+            Confidence::Medium,
+            RiskPriority::P3
+        )));
+        assert!(!filter.matches(&finding(
+            "rule.medium",
+            Severity::Medium,
+            Confidence::Medium,
+            RiskPriority::P3
+        )));
+    }
+
+    #[test]
+    fn confidence_threshold_matches_at_or_above_minimum() {
+        let filter = FindingFilter {
+            min_confidence: Some(Confidence::Medium),
+            ..FindingFilter::default()
+        };
+
+        assert!(filter.matches(&finding(
+            "rule.medium",
+            Severity::Low,
+            Confidence::Medium,
+            RiskPriority::P3
+        )));
+        assert!(!filter.matches(&finding(
+            "rule.low",
+            Severity::Low,
+            Confidence::Low,
+            RiskPriority::P3
+        )));
+    }
+
+    #[test]
+    fn priority_threshold_matches_at_or_above_minimum() {
+        let filter = FindingFilter {
+            min_priority: Some(RiskPriority::P1),
+            ..FindingFilter::default()
+        };
+
+        assert!(filter.matches(&finding(
+            "rule.p1",
+            Severity::Low,
+            Confidence::Medium,
+            RiskPriority::P1
+        )));
+        assert!(!filter.matches(&finding(
+            "rule.p2",
+            Severity::Low,
+            Confidence::Medium,
+            RiskPriority::P2
+        )));
+    }
+
+    #[test]
+    fn repeated_rule_filter_matches_any_rule_id() {
+        let filter = FindingFilter {
+            rule_ids: vec!["rule.one".to_string(), "rule.two".to_string()],
+            ..FindingFilter::default()
+        };
+
+        assert!(filter.matches(&finding(
+            "rule.two",
+            Severity::Low,
+            Confidence::Medium,
+            RiskPriority::P3
+        )));
+        assert!(!filter.matches(&finding(
+            "rule.three",
+            Severity::Low,
+            Confidence::Medium,
+            RiskPriority::P3
+        )));
+    }
+
+    #[test]
+    fn combined_filter_requires_every_selected_threshold() {
+        let filter = FindingFilter {
+            min_severity: Some(Severity::Medium),
+            min_confidence: Some(Confidence::High),
+            min_priority: Some(RiskPriority::P2),
+            rule_ids: vec!["rule.keep".to_string()],
+        };
+
+        assert!(filter.matches(&finding(
+            "rule.keep",
+            Severity::High,
+            Confidence::High,
+            RiskPriority::P2
+        )));
+        assert!(!filter.matches(&finding(
+            "rule.keep",
+            Severity::High,
+            Confidence::Medium,
+            RiskPriority::P2
+        )));
+        assert!(!filter.matches(&finding(
+            "rule.drop",
+            Severity::High,
+            Confidence::High,
+            RiskPriority::P2
+        )));
+    }
+
+    #[test]
+    fn apply_to_summary_recomputes_visible_count_and_health_score() {
+        let filter = FindingFilter {
+            min_severity: Some(Severity::High),
+            ..FindingFilter::default()
+        };
+        let mut summary = ScanSummary {
+            root_path: PathBuf::from("."),
+            non_empty_lines: 1_000,
+            findings: vec![
+                finding(
+                    "rule.keep",
+                    Severity::High,
+                    Confidence::Medium,
+                    RiskPriority::P3,
+                ),
+                finding(
+                    "rule.drop",
+                    Severity::Low,
+                    Confidence::Medium,
+                    RiskPriority::P3,
+                ),
+            ],
+            ..ScanSummary::default()
+        };
+
+        filter.apply_to_summary(&mut summary);
+
+        assert_eq!(summary.findings.len(), 1);
+        assert_eq!(summary.visible_findings_count, 1);
+        assert_eq!(summary.health_score, 95);
+    }
+}

--- a/src/findings/mod.rs
+++ b/src/findings/mod.rs
@@ -1,3 +1,4 @@
 pub mod feedback;
+pub mod filter;
 pub mod types;
 pub mod visibility;

--- a/src/findings/types.rs
+++ b/src/findings/types.rs
@@ -44,7 +44,7 @@ pub enum Severity {
     Critical,
 }
 
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Confidence {
     Low,

--- a/src/output/console/sections.rs
+++ b/src/output/console/sections.rs
@@ -255,8 +255,9 @@ pub(crate) fn render_top_risk_clusters(output: &mut String, findings: &[Finding]
     let finding_refs = findings.iter().collect::<Vec<_>>();
     let mut clusters = clusters_by_rule_scope(&finding_refs);
     clusters.sort_by(|left, right| {
-        priority_rank(left.priority)
-            .cmp(&priority_rank(right.priority))
+        left.priority
+            .rank()
+            .cmp(&right.priority.rank())
             .then_with(|| right.max_score.cmp(&left.max_score))
             .then_with(|| right.findings.len().cmp(&left.findings.len()))
             .then_with(|| left.rule_id.cmp(right.rule_id))
@@ -388,15 +389,6 @@ fn render_scan_input(output: &mut String, summary: &ScanSummary) {
             summary.files_skipped_low_signal
         )
         .unwrap();
-    }
-}
-
-fn priority_rank(priority: RiskPriority) -> u8 {
-    match priority {
-        RiskPriority::P0 => 0,
-        RiskPriority::P1 => 1,
-        RiskPriority::P2 => 2,
-        RiskPriority::P3 => 3,
     }
 }
 

--- a/src/output/finding_helpers.rs
+++ b/src/output/finding_helpers.rs
@@ -98,7 +98,7 @@ fn build_cluster<'a>(
     let priority = group
         .iter()
         .map(|finding| finding.risk.priority)
-        .min_by_key(|priority| priority_rank(*priority))
+        .min_by_key(|priority| priority.rank())
         .unwrap_or(first.risk.priority);
     let title = cluster_title(first, group.len(), scope.as_deref());
 
@@ -150,14 +150,5 @@ fn cluster_scope_for_path(path: &std::path::Path) -> String {
         (Some(first), Some(second)) => format!("{first}/{second}"),
         (Some(first), None) => first.clone(),
         _ => ".".to_string(),
-    }
-}
-
-fn priority_rank(priority: RiskPriority) -> u8 {
-    match priority {
-        RiskPriority::P0 => 0,
-        RiskPriority::P1 => 1,
-        RiskPriority::P2 => 2,
-        RiskPriority::P3 => 3,
     }
 }

--- a/src/output/harden.rs
+++ b/src/output/harden.rs
@@ -189,12 +189,7 @@ fn cluster_priority(cluster: &RuleCluster<'_>) -> u8 {
 }
 
 fn priority_rank(cluster: &RuleCluster<'_>) -> u8 {
-    match cluster.priority {
-        crate::risk::RiskPriority::P0 => 0,
-        crate::risk::RiskPriority::P1 => 1,
-        crate::risk::RiskPriority::P2 => 2,
-        crate::risk::RiskPriority::P3 => 3,
-    }
+    cluster.priority.rank()
 }
 
 fn legacy_priority_rank(finding: &Finding) -> u8 {

--- a/src/output/markdown/sections.rs
+++ b/src/output/markdown/sections.rs
@@ -4,7 +4,6 @@ use crate::output::finding_helpers::{clusters_by_rule_scope, example_locations};
 use crate::output::render_helpers::escape_table_cell;
 use crate::output::report_stats::{ReportStats, TOOL_VERSION};
 use crate::output::report_text::{markdown_severity_counts_text, named_counts_text};
-use crate::risk::RiskPriority;
 use crate::scan::types::ScanSummary;
 use std::fmt::Write;
 
@@ -260,8 +259,9 @@ pub(crate) fn render_top_risk_clusters(output: &mut String, findings: &[Finding]
     let finding_refs = findings.iter().collect::<Vec<_>>();
     let mut clusters = clusters_by_rule_scope(&finding_refs);
     clusters.sort_by(|left, right| {
-        priority_rank(left.priority)
-            .cmp(&priority_rank(right.priority))
+        left.priority
+            .rank()
+            .cmp(&right.priority.rank())
             .then_with(|| right.max_score.cmp(&left.max_score))
             .then_with(|| right.findings.len().cmp(&left.findings.len()))
             .then_with(|| left.rule_id.cmp(right.rule_id))
@@ -347,13 +347,4 @@ pub(crate) fn render_framework_projects_section(
         .unwrap();
     }
     output.push('\n');
-}
-
-fn priority_rank(priority: RiskPriority) -> u8 {
-    match priority {
-        RiskPriority::P0 => 0,
-        RiskPriority::P1 => 1,
-        RiskPriority::P2 => 2,
-        RiskPriority::P3 => 3,
-    }
 }

--- a/src/output/vibe/recommendations.rs
+++ b/src/output/vibe/recommendations.rs
@@ -65,12 +65,7 @@ fn recommendation_clusters<'a>(
 }
 
 fn priority_rank(cluster: &RuleCluster<'_>) -> u8 {
-    match cluster.priority {
-        crate::risk::RiskPriority::P0 => 0,
-        crate::risk::RiskPriority::P1 => 1,
-        crate::risk::RiskPriority::P2 => 2,
-        crate::risk::RiskPriority::P3 => 3,
-    }
+    cluster.priority.rank()
 }
 
 pub(super) fn render_footer(

--- a/src/review/model.rs
+++ b/src/review/model.rs
@@ -1,4 +1,5 @@
 use crate::baseline::diff::BaselineStatus;
+use crate::findings::filter::{FindingFilter, recompute_summary_metrics};
 use crate::findings::types::{Finding, Severity};
 use crate::review::diff::{ChangeStatus, ChangedFile};
 use crate::scan::types::ScanSummary;
@@ -110,6 +111,31 @@ impl ReviewReport {
 
     pub fn finding_status(&self, index: usize) -> Option<&ReviewFindingStatus> {
         self.findings.get(index)
+    }
+
+    pub fn apply_filter(&mut self, filter: &FindingFilter) {
+        self.retain_findings(|finding| filter.matches(finding));
+    }
+
+    pub fn retain_findings<F>(&mut self, mut keep: F)
+    where
+        F: FnMut(&Finding) -> bool,
+    {
+        let mut paired = self
+            .summary
+            .findings
+            .drain(..)
+            .zip(self.findings.drain(..))
+            .collect::<Vec<_>>();
+
+        paired.retain(|(finding, _)| keep(finding));
+
+        for (finding, status) in paired {
+            self.summary.findings.push(finding);
+            self.findings.push(status);
+        }
+
+        recompute_summary_metrics(&mut self.summary);
     }
 }
 

--- a/src/risk/model.rs
+++ b/src/risk/model.rs
@@ -83,6 +83,19 @@ impl RiskPriority {
             Self::P3 => "P3",
         }
     }
+
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::P0 => 0,
+            Self::P1 => 1,
+            Self::P2 => 2,
+            Self::P3 => 3,
+        }
+    }
+
+    pub fn is_at_least(self, threshold: Self) -> bool {
+        self.rank() <= threshold.rank()
+    }
 }
 
 pub(super) fn push_adjustment(

--- a/src/risk/summary.rs
+++ b/src/risk/summary.rs
@@ -32,7 +32,7 @@ impl RiskSummary {
 
         for finding in findings {
             counts.increment(finding.risk.priority);
-            if priority_rank(finding.risk.priority) < priority_rank(highest_priority) {
+            if finding.risk.priority.rank() < highest_priority.rank() {
                 highest_priority = finding.risk.priority;
             }
             score_sum += finding.risk.score as usize;
@@ -70,14 +70,5 @@ impl RiskPriorityCounts {
             RiskPriority::P2 => self.p2 += 1,
             RiskPriority::P3 => self.p3 += 1,
         }
-    }
-}
-
-fn priority_rank(priority: RiskPriority) -> u8 {
-    match priority {
-        RiskPriority::P0 => 0,
-        RiskPriority::P1 => 1,
-        RiskPriority::P2 => 2,
-        RiskPriority::P3 => 3,
     }
 }

--- a/tests/config_scan_cli.rs
+++ b/tests/config_scan_cli.rs
@@ -271,3 +271,94 @@ fn scan_max_file_size_accepts_byte_units() {
         assert_eq!(json["large_files_skipped"], 0);
     }
 }
+
+#[test]
+fn scan_min_confidence_keeps_only_high_confidence_findings() {
+    let temp = tempdir().expect("failed to create temp dir");
+    fs::create_dir_all(temp.path().join("src")).expect("failed to create src dir");
+    fs::create_dir_all(temp.path().join("tests")).expect("failed to create tests dir");
+    fs::write(
+        temp.path().join("src/lib.rs"),
+        "pub fn live() {}\n// TODO: medium-confidence follow-up\nconst API_KEY: &str = \"abc12345\";\n",
+    )
+    .expect("failed to write source file");
+    fs::write(temp.path().join("tests/lib.rs"), "fn covers_lib() {}\n")
+        .expect("failed to write test file");
+
+    let output = repopilot()
+        .args([
+            "scan",
+            ".",
+            "--format",
+            "json",
+            "--profile",
+            "strict",
+            "--min-confidence",
+            "high",
+        ])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).expect("expected JSON output");
+    let findings = json["findings"]
+        .as_array()
+        .expect("findings should be an array");
+
+    assert!(
+        findings
+            .iter()
+            .all(|finding| finding["confidence"] == "HIGH")
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["rule_id"] == "security.secret-candidate")
+    );
+    assert!(
+        findings
+            .iter()
+            .all(|finding| finding["rule_id"] != "code-marker.todo")
+    );
+}
+
+#[test]
+fn scan_rule_with_min_priority_keeps_rule_filter_strict_visibility() {
+    let temp = tempdir().expect("failed to create temp dir");
+    let content = (0..20)
+        .map(|index| format!("pub fn function_{index}() {{}}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(temp.path().join("large.rs"), content).expect("failed to write source file");
+
+    let output = repopilot()
+        .args([
+            "scan",
+            ".",
+            "--format",
+            "json",
+            "--max-file-loc",
+            "10",
+            "--rule",
+            "architecture.large-file",
+            "--min-priority",
+            "p3",
+        ])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).expect("expected JSON output");
+    let findings = json["findings"]
+        .as_array()
+        .expect("findings should be an array");
+
+    assert_eq!(json["visibility_profile"], "strict");
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["rule_id"] == "architecture.large-file")
+    );
+}

--- a/tests/review_command.rs
+++ b/tests/review_command.rs
@@ -65,6 +65,85 @@ fn review_treats_untracked_files_as_fully_changed() {
 }
 
 #[test]
+fn review_min_confidence_keeps_only_high_confidence_findings() {
+    let temp = tempdir().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_covered_source(temp.path(), "lib", "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+
+    fs::write(
+        temp.path().join("src/lib.rs"),
+        "pub fn live() {}\n// TODO: medium-confidence review note\nconst API_KEY: &str = \"abc12345\";\n",
+    )
+    .expect("failed to modify source file");
+
+    let json = run_review_json(
+        temp.path(),
+        &[
+            "review",
+            ".",
+            "--format",
+            "json",
+            "--min-confidence",
+            "high",
+        ],
+    );
+    let findings = json["findings"].as_array().unwrap();
+
+    assert!(
+        findings
+            .iter()
+            .all(|finding| finding["confidence"] == "HIGH")
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["rule_id"] == "security.secret-candidate")
+    );
+    assert!(
+        findings
+            .iter()
+            .all(|finding| finding["rule_id"] != "code-marker.todo")
+    );
+}
+
+#[test]
+fn review_min_priority_preserves_in_diff_status_alignment() {
+    let temp = tempdir().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_covered_source(
+        temp.path(),
+        "config",
+        "const API_KEY: &str = \"abc12345\";\n",
+    );
+    write_covered_source(temp.path(), "lib", "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+
+    fs::write(
+        temp.path().join("src/lib.rs"),
+        "pub fn live() {}\n// TODO: changed low finding\n",
+    )
+    .expect("failed to modify source file");
+
+    let json = run_review_json(
+        temp.path(),
+        &["review", ".", "--format", "json", "--min-priority", "p3"],
+    );
+    let findings = json["findings"].as_array().unwrap();
+
+    assert!(findings.iter().any(|finding| {
+        finding["rule_id"] == "security.secret-candidate" && finding["in_diff"] == false
+    }));
+    assert!(
+        findings.iter().any(|finding| {
+            finding["rule_id"] == "code-marker.todo" && finding["in_diff"] == true
+        })
+    );
+    assert_eq!(json["review"]["in_diff_findings"], 1);
+    assert_eq!(json["review"]["out_of_diff_findings"], 1);
+}
+
+#[test]
 fn review_accepts_file_paths() {
     let temp = tempdir().expect("failed to create temp dir");
     init_repo(temp.path());

--- a/tests/scan_baseline_cli.rs
+++ b/tests/scan_baseline_cli.rs
@@ -182,6 +182,51 @@ fn scan_with_baseline_sarif_includes_baseline_properties() {
 }
 
 #[test]
+fn scan_min_priority_preserves_baseline_status_alignment() {
+    let temp = tempdir().expect("failed to create temp dir");
+    write_project_with_secret(temp.path(), "config");
+    create_baseline(temp.path());
+    write_project_with_secret(temp.path(), "creds");
+
+    let output = repopilot()
+        .args([
+            "scan",
+            ".",
+            "--baseline",
+            ".repopilot/baseline.json",
+            "--format",
+            "json",
+            "--min-priority",
+            "p3",
+        ])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run scan");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).expect("expected JSON output");
+    let findings = json["findings"]
+        .as_array()
+        .expect("findings should be an array");
+
+    assert_eq!(json["baseline"]["new_findings"], 1);
+    assert_eq!(json["baseline"]["existing_findings"], 1);
+    assert_eq!(findings.len(), 2);
+    assert!(findings.iter().any(|finding| {
+        finding["baseline_status"] == "existing"
+            && finding["evidence"][0]["path"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("src/config.rs"))
+    }));
+    assert!(findings.iter().any(|finding| {
+        finding["baseline_status"] == "new"
+            && finding["evidence"][0]["path"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("src/creds.rs"))
+    }));
+}
+
+#[test]
 fn fail_on_new_high_passes_when_no_new_high_findings_exist() {
     let temp = tempdir().expect("failed to create temp dir");
     write_project_with_secret(temp.path(), "config");


### PR DESCRIPTION
## Summary

This PR adds confidence-based filtering and centralizes finding filtering logic across scan, review, and baseline flows.

Users can now filter reports by minimum confidence in addition to severity, priority, and rule ID. The filtering logic is moved into a shared `FindingFilter` model so scan, review, and baseline reports apply filtering consistently.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] CLI / UX improvement

## What changed

- Added `--min-confidence` for `scan`.
- Added `--min-confidence` for `review`.
- Added `ConfidenceArg` CLI value enum:
  - `low`
  - `medium`
  - `high`
- Added shared `FindingFilter` model.
- Centralized filtering by:
  - minimum severity;
  - minimum confidence;
  - minimum risk priority;
  - rule ID.
- Added shared summary metric recomputation after filters are applied.
- Updated scan filtering flow to use shared filters before visibility profile logic.
- Updated review filtering flow to use shared filters before diff classification.
- Added baseline report filtering support through `BaselineScanReport::apply_filter`.
- Added review report filtering support.
- Reused `RiskPriority::is_at_least` instead of local duplicated priority ranking.
- Split command helpers into focused modules:
  - `commands/filters.rs`
  - `commands/focus.rs`
  - `commands/scan_config.rs`
- Updated CLI docs for `--min-confidence`.
- Updated `.gitignore` with common local/editor/build artifacts.
- Added/updated tests for scan, review, baseline, and filtering behavior.

## Why

RepoPilot already supports severity and priority filters, but confidence is just as important for controlling report noise.

A user may want to see only findings that are both important and reliable:

```bash
repopilot scan . --min-severity medium --min-confidence high
repopilot review . --base origin/main --min-confidence medium
```

This is especially useful after Trust Mode and visibility profiles because RepoPilot is moving toward a more explainable and signal-quality based workflow.

Centralizing the filtering logic also reduces duplicated behavior between scan, review, and baseline reports.

## Architecture notes

- No god files introduced.
- Filtering is centralized in src/findings/filter.rs.
- CLI argument conversion is centralized in src/commands/filters.rs.
- Scan config construction is moved into src/commands/scan_config.rs.
- Focus parsing is moved into src/commands/focus.rs.
- Scan and review commands now consume shared filter objects instead of each implementing filtering locally.
- Baseline and review reports expose filtering methods that keep finding/status pairs aligned.
- Summary metrics are recomputed after filtering so report counts and health score remain accurate.

## Compatibility
Existing --min-severity behavior remains available.
Existing --min-priority behavior remains available.
Existing --rule behavior remains available.
--min-confidence is additive.
Scan and review reports should keep the same output shape except for filtered result sets.
Filtering should preserve baseline/review finding-status alignment.

## Verification

Recommended checks:

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```

Smoke checks:

```
cargo run -- scan . --min-confidence high
cargo run -- scan . --min-severity medium --min-confidence high
cargo run -- scan . --min-priority p1 --min-confidence medium
cargo run -- review . --min-confidence high
cargo run -- review . --base origin/main --min-confidence medium
cargo run -- scan . --rule security.secret-candidate --min-confidence high
```