### PR TITLE
feat(core): add diagnostics, report envelope, and stable API facade

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,9 +80,9 @@ inputs:
     required: false
     default: ""
   version:
-    description: "npm version tag to install (e.g. latest, 0.12.0)"
+    description: "npm version tag to install. Pin this for reproducible CI (e.g. 0.12.0)."
     required: false
-    default: "latest"
+    default: "0.12.0"
   upload-sarif:
     description: "Automatically upload SARIF output to GitHub Code Scanning"
     required: false
@@ -106,132 +106,27 @@ runs:
     - name: Run repopilot
       id: run
       shell: bash
+      env:
+        INPUT_COMMAND: ${{ inputs.command }}
+        INPUT_FORMAT: ${{ inputs.format }}
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_CONFIG: ${{ inputs.config }}
+        INPUT_BASELINE: ${{ inputs.baseline }}
+        INPUT_FAIL_ON: ${{ inputs.fail-on }}
+        INPUT_FAIL_ON_PRIORITY: ${{ inputs.fail-on-priority }}
+        INPUT_MIN_SEVERITY: ${{ inputs.min-severity }}
+        INPUT_MIN_PRIORITY: ${{ inputs.min-priority }}
+        INPUT_RULE: ${{ inputs.rule }}
+        INPUT_TIMING: ${{ inputs.timing }}
+        INPUT_BASE: ${{ inputs.base }}
+        INPUT_HEAD: ${{ inputs.head }}
+        INPUT_FOCUS: ${{ inputs.focus }}
+        INPUT_BUDGET: ${{ inputs.budget }}
+        INPUT_OUTPUT: ${{ inputs.output }}
+        INPUT_RECEIPT: ${{ inputs.receipt }}
+        INPUT_ARGS: ${{ inputs.args }}
       run: |
-        set -euo pipefail
-        COMMAND="${{ inputs.command }}"
-        FORMAT="${{ inputs.format }}"
-        PATH_INPUT="${{ inputs.path }}"
-        CONFIG="${{ inputs.config }}"
-        BASELINE="${{ inputs.baseline }}"
-        FAIL_ON="${{ inputs.fail-on }}"
-        FAIL_ON_PRIORITY="${{ inputs.fail-on-priority }}"
-        MIN_SEVERITY="${{ inputs.min-severity }}"
-        MIN_PRIORITY="${{ inputs.min-priority }}"
-        RULE_INPUT="${{ inputs.rule }}"
-        TIMING="${{ inputs.timing }}"
-        BASE="${{ inputs.base }}"
-        HEAD="${{ inputs.head }}"
-        FOCUS="${{ inputs.focus }}"
-        BUDGET="${{ inputs.budget }}"
-        OUTPUT="${{ inputs.output }}"
-        RECEIPT="${{ inputs.receipt }}"
-        ARGS="${{ inputs.args }}"
-
-        case "$COMMAND" in
-          scan) RUN_ARGS=(scan "$PATH_INPUT") ;;
-          review) RUN_ARGS=(review "$PATH_INPUT") ;;
-          compare) RUN_ARGS=(compare) ;;
-          doctor) RUN_ARGS=(doctor "$PATH_INPUT") ;;
-          ai-context|vibe) RUN_ARGS=(ai context "$PATH_INPUT") ;;
-          ai-plan|harden) RUN_ARGS=(ai plan "$PATH_INPUT") ;;
-          ai-prompt|prompt) RUN_ARGS=(ai prompt "$PATH_INPUT") ;;
-          *)
-          echo "::error::Unsupported command '$COMMAND'. Expected scan, review, compare, doctor, ai-context, ai-plan, or ai-prompt."
-          exit 1
-          ;;
-        esac
-
-        IS_AI="false"
-        if [[ "$COMMAND" == "ai-context" || "$COMMAND" == "ai-plan" || "$COMMAND" == "ai-prompt" || "$COMMAND" == "vibe" || "$COMMAND" == "harden" || "$COMMAND" == "prompt" ]]; then
-          IS_AI="true"
-        fi
-
-        if [[ "$FORMAT" == "auto" ]]; then
-          if [[ "$COMMAND" == "scan" ]]; then
-            FORMAT="sarif"
-          else
-            FORMAT="markdown"
-          fi
-        fi
-        if [[ "$FORMAT" == "sarif" && "$COMMAND" != "scan" ]]; then
-          echo "::error::SARIF output and upload are only supported by 'scan'. Use format=markdown for '$COMMAND'."
-          exit 1
-        fi
-        if [[ -n "$RECEIPT" && "$COMMAND" != "scan" ]]; then
-          echo "::error::Receipt output is only supported by 'scan'. Remove receipt or use command=scan."
-          exit 1
-        fi
-        if [[ -n "$FAIL_ON_PRIORITY" && "$COMMAND" != "scan" && "$COMMAND" != "review" ]]; then
-          echo "::error::fail-on-priority is only supported by 'scan' and 'review'."
-          exit 1
-        fi
-        if [[ -n "$MIN_PRIORITY" && "$COMMAND" != "scan" && "$COMMAND" != "review" ]]; then
-          echo "::error::min-priority is only supported by 'scan' and 'review'."
-          exit 1
-        fi
-        if [[ -n "$RULE_INPUT" && "$COMMAND" != "scan" ]]; then
-          echo "::error::rule filtering is only supported by 'scan'."
-          exit 1
-        fi
-        if [[ "$TIMING" == "true" && "$COMMAND" != "scan" ]]; then
-          echo "::error::timing is only supported by 'scan'."
-          exit 1
-        fi
-
-        if [[ -n "$CONFIG" && "$COMMAND" != "compare" ]]; then RUN_ARGS+=(--config "$CONFIG"); fi
-        if [[ "$COMMAND" == "scan" || "$COMMAND" == "review" ]]; then
-          if [[ -n "$BASELINE" ]]; then RUN_ARGS+=(--baseline "$BASELINE"); fi
-          if [[ -n "$FAIL_ON" ]]; then RUN_ARGS+=(--fail-on "$FAIL_ON"); fi
-          if [[ -n "$FAIL_ON_PRIORITY" ]]; then RUN_ARGS+=(--fail-on-priority "$FAIL_ON_PRIORITY"); fi
-          if [[ -n "$MIN_SEVERITY" ]]; then RUN_ARGS+=(--min-severity "$MIN_SEVERITY"); fi
-          if [[ -n "$MIN_PRIORITY" ]]; then RUN_ARGS+=(--min-priority "$MIN_PRIORITY"); fi
-        fi
-        if [[ "$COMMAND" == "scan" && -n "$RULE_INPUT" ]]; then
-          read -r -a RULES <<< "$RULE_INPUT"
-          for RULE in "${RULES[@]}"; do
-            RUN_ARGS+=(--rule "$RULE")
-          done
-        fi
-        if [[ "$COMMAND" == "scan" && "$TIMING" == "true" ]]; then RUN_ARGS+=(--timing); fi
-        if [[ "$COMMAND" == "review" && -n "$BASE" ]]; then RUN_ARGS+=(--base "$BASE"); fi
-        if [[ "$COMMAND" == "review" && -n "$HEAD" ]]; then RUN_ARGS+=(--head "$HEAD"); fi
-        if [[ "$IS_AI" == "true" && -n "$FOCUS" ]]; then RUN_ARGS+=(--focus "$FOCUS"); fi
-        if [[ "$IS_AI" == "true" && -n "$BUDGET" ]]; then RUN_ARGS+=(--budget "$BUDGET"); fi
-        if [[ -n "$OUTPUT" && "$FORMAT" != "sarif" ]]; then RUN_ARGS+=(--output "$OUTPUT"); fi
-        if [[ -n "$RECEIPT" ]]; then RUN_ARGS+=(--receipt "$RECEIPT"); fi
-
-        if [[ -n "$ARGS" ]]; then
-          read -r -a EXTRA_ARGS <<< "$ARGS"
-          RUN_ARGS+=("${EXTRA_ARGS[@]}")
-        fi
-
-        OUTFILE="${OUTPUT:-repopilot-results.sarif}"
-        RUN_STATUS=0
-        if [[ "$IS_AI" == "true" ]]; then
-          if [[ "$FORMAT" != "markdown" ]]; then
-            echo "::error::'$COMMAND' emits Markdown and does not accept --format. Use format=auto or format=markdown."
-            exit 1
-          fi
-          set +e
-          repopilot "${RUN_ARGS[@]}"
-          RUN_STATUS=$?
-          set -e
-        elif [[ "$FORMAT" == "sarif" ]]; then
-          set +e
-          repopilot "${RUN_ARGS[@]}" --format sarif --output "$OUTFILE"
-          RUN_STATUS=$?
-          set -e
-          echo "sarif_file=$OUTFILE" >> "$GITHUB_OUTPUT"
-        else
-          set +e
-          repopilot "${RUN_ARGS[@]}" --format "$FORMAT"
-          RUN_STATUS=$?
-          set -e
-        fi
-        if [[ -n "$RECEIPT" ]]; then
-          echo "receipt_file=$RECEIPT" >> "$GITHUB_OUTPUT"
-        fi
-        exit "$RUN_STATUS"
+        bash "$GITHUB_ACTION_PATH/scripts/repopilot-action.sh"
 
     - name: Upload SARIF to GitHub Code Scanning
       if: inputs.upload-sarif == 'true' && steps.run.outputs.sarif_file != ''

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -251,7 +251,7 @@ Scans the repository and formats findings as structured Markdown for pasting int
 The output includes a risk summary, tech stack signals, findings grouped by category, evidence snippets, finding recommendations, and an approximate token count.
 `ai context` emits Markdown only and does not accept `--format`.
 
-The legacy `repopilot vibe` command still works in 0.x for compatibility, but `repopilot ai context` is the stable command shape.
+The removed 0.x `repopilot vibe` alias is no longer part of the executable command surface; use `repopilot ai context`.
 
 ### Synopsis
 
@@ -292,7 +292,7 @@ Scans the repository and formats findings as a Markdown hardening plan with P0/P
 
 `ai plan` emits Markdown only and does not accept `--format`.
 
-The legacy `repopilot harden` command still works in 0.x for compatibility, but `repopilot ai plan` is the stable command shape.
+The removed 0.x `repopilot harden` alias is no longer part of the executable command surface; use `repopilot ai plan`.
 
 ### Synopsis
 
@@ -325,7 +325,7 @@ Scans the repository and emits a Markdown prompt for a coding assistant, includi
 
 `ai prompt` emits Markdown only; it does not call an AI service or accept `--format`.
 
-The legacy `repopilot prompt` command still works in 0.x for compatibility, but `repopilot ai prompt` is the stable command shape.
+The removed 0.x `repopilot prompt` alias is no longer part of the executable command surface; use `repopilot ai prompt`.
 
 ### Synopsis
 
@@ -356,7 +356,7 @@ repopilot ai prompt . --output prompt.md
 
 Explains how RepoPilot classifies a single file before applying audits. This is an advanced diagnostic command for rule authors, false-positive debugging, and context-model development.
 
-The legacy `repopilot explain` command still works in 0.x for compatibility, but `repopilot inspect explain` is the stable command shape.
+The removed 0.x `repopilot explain` alias is no longer part of the executable command surface; use `repopilot inspect explain`.
 
 ### Synopsis
 
@@ -388,7 +388,7 @@ repopilot inspect explain src/App.tsx --format markdown --output explain.md
 
 Prints the bundled Knowledge Engine catalog: languages, frameworks, runtimes, paradigms, and rule applicability records. This is an advanced diagnostic command rather than a normal audit workflow.
 
-The legacy `repopilot knowledge` command still works in 0.x for compatibility, but `repopilot inspect knowledge` is the stable command shape.
+The removed 0.x `repopilot knowledge` alias is no longer part of the executable command surface; use `repopilot inspect knowledge`.
 
 ### Synopsis
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -149,7 +149,7 @@ repopilot ai context . --no-header | pbcopy
 ```
 
 Use `--focus security`, `--focus arch`, `--focus quality`, or `--focus framework` to narrow the context before pasting it into Claude Code, Cursor, ChatGPT, or another LLM assistant.
-The legacy `repopilot vibe` command still works in 0.x, but `repopilot ai context` is the stable command shape. The GitHub Action can run `command: ai-context`; it defaults the path to `.` and does not pass `--format` because AI commands are Markdown-only.
+The removed 0.x `repopilot vibe` alias is no longer part of the executable command surface. The GitHub Action can run `command: ai-context`; it defaults the path to `.` and does not pass `--format` because AI commands are Markdown-only.
 
 ### Hardening plan
 

--- a/docs/product-readiness.md
+++ b/docs/product-readiness.md
@@ -53,12 +53,6 @@ Keep generated smoke artifacts:
 ./scripts/smoke-product.sh --keep-tmp
 ```
 
-Skip legacy compatibility checks:
-
-```bash
-./scripts/smoke-product.sh --skip-legacy
-```
-
 The script checks the main product workflows:
 
 ```text
@@ -74,11 +68,6 @@ ai plan
 ai prompt
 inspect knowledge
 inspect explain
-legacy vibe
-legacy harden
-legacy prompt
-legacy knowledge
-legacy explain
 ```
 
 `review` is skipped when the target path is not inside a Git repository.
@@ -106,16 +95,6 @@ repopilot inspect knowledge
 repopilot inspect explain src/main.rs
 ```
 
-Legacy 0.x commands must continue to work until a documented breaking release:
-
-```bash
-repopilot vibe .
-repopilot harden .
-repopilot prompt .
-repopilot knowledge
-repopilot explain src/main.rs
-```
-
 The primary help surface should prefer the stable command shape:
 
 ```text
@@ -128,7 +107,9 @@ repopilot ai ...
 repopilot inspect ...
 ```
 
-Legacy commands may stay hidden from primary help while still being executable.
+The legacy 0.x aliases (`vibe`, `harden`, `prompt`, `knowledge`, and
+`explain`) have been removed from the executable CLI surface. Use `ai ...` and
+`inspect ...` commands.
 
 ---
 
@@ -217,13 +198,6 @@ with:
 ```yaml
 with:
   command: ai-context
-```
-
-Legacy action command names may remain available for compatibility:
-
-```yaml
-with:
-  command: vibe
 ```
 
 Receipt output is scan-only. The action should fail clearly when `receipt` is

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -17,6 +17,11 @@ JSON scan reports include explicit schema metadata. The current schema is 0.13:
 {
   "schema_version": "0.13",
   "repopilot_version": "0.12.0",
+  "report": {
+    "kind": "scan",
+    "schema_version": "0.13",
+    "repopilot_version": "0.12.0"
+  },
   "root_path": ".",
   "files_analyzed": 42,
   "directories_count": 12,
@@ -27,6 +32,7 @@ JSON scan reports include explicit schema metadata. The current schema is 0.13:
     "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 },
     "average_score": 0
   },
+  "diagnostics": [],
   "findings": []
 }
 ```
@@ -37,8 +43,10 @@ JSON scan reports include explicit schema metadata. The current schema is 0.13:
 |---|---|---|
 | `schema_version` | string | RepoPilot JSON report schema version. |
 | `repopilot_version` | string | RepoPilot binary version that produced the report. |
+| `report` | object | Versioned report envelope for consumers that prefer metadata under one stable object. |
 | `risk_summary` | object | Aggregate priority counts and average risk score derived from finding risk assessments. |
 | `cache_telemetry` | object | Optional changed-scan cache summary with hits, misses, changed-file reasons, per-file cache decisions, and cache timing impact. |
+| `diagnostics` | array | Optional structured warnings/errors captured during a scan, such as workspace partial failures. |
 
 `schema_version` is intentionally separate from the binary version. Patch releases
 may fix bugs without changing the report schema, while future minor releases can
@@ -54,6 +62,9 @@ Schema `0.13` intentionally renamed scope counters for accuracy:
 - `repopilot compare` continues to read older JSON reports that do not contain
   `schema_version`;
 - future tools can branch on `schema_version` when parsing reports.
+- consumers should prefer `report.schema_version` when they want a single
+  envelope object, while top-level `schema_version` remains present during the
+  migration window.
 
 ## Baseline JSON reports
 
@@ -73,6 +84,11 @@ Example shape:
 {
   "schema_version": "0.13",
   "repopilot_version": "0.12.0",
+  "report": {
+    "kind": "baseline-scan",
+    "schema_version": "0.13",
+    "repopilot_version": "0.12.0"
+  },
   "root_path": ".",
   "files_analyzed": 42,
   "risk_summary": {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,7 +19,7 @@ discipline, and distribution trust before adding broad custom execution surfaces
 
 | Version | Theme | Main outcome |
 |---|---|---|
-| 0.12 | Core foundation | Document the rule lifecycle, v1 gates, and local-first learning policy; refactor core scan and Knowledge Engine boundaries without public schema changes. |
+| 0.12 | Core foundation | Document the rule lifecycle, v1 gates, and local-first learning policy; start the API facade, ScanEngine pipeline, report envelope, diagnostics, and legacy alias cleanup. |
 | 0.13 | Local overlays MVP | Prototype local project/user knowledge overlays for calibration only, behind an explicit unstable surface. |
 | 0.14 | Rule-author workflow | Add validation and inspection workflows for rule authors, false-positive fixtures, and clearer decision debugging. |
 | 0.15 | Adoption hardening | Improve workspace noise, baseline ergonomics, and performance budgets for larger repositories. |
@@ -55,8 +55,8 @@ Not allowed for the 0.x line:
 RepoPilot can move to 1.0.0 only after the 0.20 review confirms:
 
 - stable primary command surface: `scan`, `review`, `baseline`, `compare`, `doctor`, `ai`, and `inspect`;
-- documented policy for legacy 0.x aliases;
-- stable JSON, SARIF, baseline, and receipt schema compatibility rules;
+- removed legacy 0.x aliases with documented replacements under `ai` and `inspect`;
+- stable JSON, SARIF, baseline, receipt, report-envelope, and diagnostics schema compatibility rules;
 - documented Knowledge Engine lifecycle from audit registration to risk calibration;
 - local-first trust model with no telemetry, source upload, hosted scanner, or LLM API calls;
 - release verification and product smoke suites pass from a clean release branch;

--- a/scripts/repopilot-action.sh
+++ b/scripts/repopilot-action.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMAND="${INPUT_COMMAND:-scan}"
+FORMAT="${INPUT_FORMAT:-auto}"
+PATH_INPUT="${INPUT_PATH:-.}"
+CONFIG="${INPUT_CONFIG:-}"
+BASELINE="${INPUT_BASELINE:-}"
+FAIL_ON="${INPUT_FAIL_ON:-}"
+FAIL_ON_PRIORITY="${INPUT_FAIL_ON_PRIORITY:-}"
+MIN_SEVERITY="${INPUT_MIN_SEVERITY:-}"
+MIN_PRIORITY="${INPUT_MIN_PRIORITY:-}"
+RULE_INPUT="${INPUT_RULE:-}"
+TIMING="${INPUT_TIMING:-false}"
+BASE="${INPUT_BASE:-}"
+HEAD="${INPUT_HEAD:-}"
+FOCUS="${INPUT_FOCUS:-}"
+BUDGET="${INPUT_BUDGET:-}"
+OUTPUT="${INPUT_OUTPUT:-}"
+RECEIPT="${INPUT_RECEIPT:-}"
+ARGS="${INPUT_ARGS:-}"
+
+RUN_ARGS=()
+case "$COMMAND" in
+  scan) RUN_ARGS=(scan "$PATH_INPUT") ;;
+  review) RUN_ARGS=(review "$PATH_INPUT") ;;
+  compare) RUN_ARGS=(compare) ;;
+  doctor) RUN_ARGS=(doctor "$PATH_INPUT") ;;
+  ai-context) RUN_ARGS=(ai context "$PATH_INPUT") ;;
+  ai-plan) RUN_ARGS=(ai plan "$PATH_INPUT") ;;
+  ai-prompt) RUN_ARGS=(ai prompt "$PATH_INPUT") ;;
+  *)
+    echo "::error::Unsupported command '$COMMAND'. Expected scan, review, compare, doctor, ai-context, ai-plan, or ai-prompt."
+    exit 2
+    ;;
+esac
+
+IS_AI=false
+case "$COMMAND" in
+  ai-context|ai-plan|ai-prompt) IS_AI=true ;;
+esac
+
+if [[ "$FORMAT" == "auto" ]]; then
+  if [[ "$COMMAND" == "scan" ]]; then
+    FORMAT="sarif"
+  else
+    FORMAT="markdown"
+  fi
+fi
+
+if [[ "$FORMAT" == "sarif" && "$COMMAND" != "scan" ]]; then
+  echo "::error::SARIF output and upload are only supported by 'scan'. Use format=markdown for '$COMMAND'."
+  exit 2
+fi
+if [[ -n "$RECEIPT" && "$COMMAND" != "scan" ]]; then
+  echo "::error::Receipt output is only supported by 'scan'. Remove receipt or use command=scan."
+  exit 2
+fi
+if [[ -n "$FAIL_ON_PRIORITY" && "$COMMAND" != "scan" && "$COMMAND" != "review" ]]; then
+  echo "::error::fail-on-priority is only supported by 'scan' and 'review'."
+  exit 2
+fi
+if [[ -n "$MIN_PRIORITY" && "$COMMAND" != "scan" && "$COMMAND" != "review" ]]; then
+  echo "::error::min-priority is only supported by 'scan' and 'review'."
+  exit 2
+fi
+if [[ -n "$RULE_INPUT" && "$COMMAND" != "scan" ]]; then
+  echo "::error::rule filtering is only supported by 'scan'."
+  exit 2
+fi
+if [[ "$TIMING" == "true" && "$COMMAND" != "scan" ]]; then
+  echo "::error::timing is only supported by 'scan'."
+  exit 2
+fi
+
+if [[ -n "$CONFIG" && "$COMMAND" != "compare" ]]; then RUN_ARGS+=(--config "$CONFIG"); fi
+if [[ "$COMMAND" == "scan" || "$COMMAND" == "review" ]]; then
+  if [[ -n "$BASELINE" ]]; then RUN_ARGS+=(--baseline "$BASELINE"); fi
+  if [[ -n "$FAIL_ON" ]]; then RUN_ARGS+=(--fail-on "$FAIL_ON"); fi
+  if [[ -n "$FAIL_ON_PRIORITY" ]]; then RUN_ARGS+=(--fail-on-priority "$FAIL_ON_PRIORITY"); fi
+  if [[ -n "$MIN_SEVERITY" ]]; then RUN_ARGS+=(--min-severity "$MIN_SEVERITY"); fi
+  if [[ -n "$MIN_PRIORITY" ]]; then RUN_ARGS+=(--min-priority "$MIN_PRIORITY"); fi
+fi
+if [[ "$COMMAND" == "scan" && -n "$RULE_INPUT" ]]; then
+  read -r -a RULES <<< "$RULE_INPUT"
+  for RULE in "${RULES[@]}"; do
+    RUN_ARGS+=(--rule "$RULE")
+  done
+fi
+if [[ "$COMMAND" == "scan" && "$TIMING" == "true" ]]; then RUN_ARGS+=(--timing); fi
+if [[ "$COMMAND" == "review" && -n "$BASE" ]]; then RUN_ARGS+=(--base "$BASE"); fi
+if [[ "$COMMAND" == "review" && -n "$HEAD" ]]; then RUN_ARGS+=(--head "$HEAD"); fi
+if [[ "$IS_AI" == "true" && -n "$FOCUS" ]]; then RUN_ARGS+=(--focus "$FOCUS"); fi
+if [[ "$IS_AI" == "true" && -n "$BUDGET" ]]; then RUN_ARGS+=(--budget "$BUDGET"); fi
+if [[ -n "$OUTPUT" && "$FORMAT" != "sarif" ]]; then RUN_ARGS+=(--output "$OUTPUT"); fi
+if [[ -n "$RECEIPT" ]]; then RUN_ARGS+=(--receipt "$RECEIPT"); fi
+
+if [[ -n "$ARGS" ]]; then
+  read -r -a EXTRA_ARGS <<< "$ARGS"
+  RUN_ARGS+=("${EXTRA_ARGS[@]}")
+fi
+
+OUTFILE="${OUTPUT:-repopilot-results.sarif}"
+RUN_STATUS=0
+if [[ "$IS_AI" == "true" ]]; then
+  if [[ "$FORMAT" != "markdown" ]]; then
+    echo "::error::'$COMMAND' emits Markdown and does not accept --format. Use format=auto or format=markdown."
+    exit 2
+  fi
+  set +e
+  repopilot "${RUN_ARGS[@]}"
+  RUN_STATUS=$?
+  set -e
+elif [[ "$FORMAT" == "sarif" ]]; then
+  set +e
+  repopilot "${RUN_ARGS[@]}" --format sarif --output "$OUTFILE"
+  RUN_STATUS=$?
+  set -e
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "sarif_file=$OUTFILE" >> "$GITHUB_OUTPUT"
+  fi
+else
+  set +e
+  repopilot "${RUN_ARGS[@]}" --format "$FORMAT"
+  RUN_STATUS=$?
+  set -e
+fi
+
+if [[ -n "$RECEIPT" && -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "receipt_file=$RECEIPT" >> "$GITHUB_OUTPUT"
+fi
+
+exit "$RUN_STATUS"

--- a/scripts/smoke-product.sh
+++ b/scripts/smoke-product.sh
@@ -8,7 +8,6 @@ REPO_PATH="$ROOT_DIR"
 TMP_DIR=""
 TMP_CREATED=0
 KEEP_TMP=0
-RUN_LEGACY=1
 
 usage() {
   cat <<'EOF'
@@ -21,7 +20,6 @@ Options:
   --repo PATH        Repository or project path to smoke test. Defaults to this repo.
   --tmp-dir PATH     Directory for generated smoke artifacts. Defaults to mktemp.
   --keep-tmp         Keep generated smoke artifacts when using a temporary directory.
-  --skip-legacy      Skip hidden 0.x compatibility command checks.
   -h, --help         Show this help message.
 
 Examples:
@@ -47,10 +45,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --keep-tmp)
       KEEP_TMP=1
-      shift
-      ;;
-    --skip-legacy)
-      RUN_LEGACY=0
       shift
       ;;
     -h|--help)
@@ -263,25 +257,6 @@ assert_non_empty "$TMP_DIR/inspect-knowledge-rules.md"
 run_repopilot inspect explain "$EXPLAIN_FILE" --format json --output "$TMP_DIR/inspect-explain.json"
 assert_non_empty "$TMP_DIR/inspect-explain.json"
 validate_json_if_possible "$TMP_DIR/inspect-explain.json"
-
-if [[ "$RUN_LEGACY" -eq 1 ]]; then
-  run_repopilot vibe . --focus security --budget 2k --output "$TMP_DIR/legacy-vibe.md"
-  assert_non_empty "$TMP_DIR/legacy-vibe.md"
-
-  run_repopilot harden . --focus all --budget 2k --output "$TMP_DIR/legacy-harden.md"
-  assert_non_empty "$TMP_DIR/legacy-harden.md"
-
-  run_repopilot prompt . --focus quality --budget 2k --output "$TMP_DIR/legacy-prompt.md"
-  assert_non_empty "$TMP_DIR/legacy-prompt.md"
-
-  run_repopilot knowledge --format json --output "$TMP_DIR/legacy-knowledge.json"
-  assert_non_empty "$TMP_DIR/legacy-knowledge.json"
-  validate_json_if_possible "$TMP_DIR/legacy-knowledge.json"
-
-  run_repopilot explain "$EXPLAIN_FILE" --format json --output "$TMP_DIR/legacy-explain.json"
-  assert_non_empty "$TMP_DIR/legacy-explain.json"
-  validate_json_if_possible "$TMP_DIR/legacy-explain.json"
-fi
 
 echo
 echo "==> Product smoke suite passed"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,48 @@
+//! Stable crate facade for consumers embedding RepoPilot.
+//!
+//! The CLI uses more internal modules while the library API intentionally keeps a
+//! small surface around scan, review, configuration, reporting, and risk models.
+
+pub mod config {
+    pub use crate::config::loader::{load_default_config, load_optional_config};
+    pub use crate::config::model::RepoPilotConfig;
+    pub use crate::config::presets::{Preset, apply_preset};
+}
+
+pub mod findings {
+    pub use crate::findings::filter::{FindingFilter, recompute_summary_metrics};
+    pub use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
+    pub use crate::findings::visibility::{FindingVisibilityProfile, apply_visibility_profile};
+}
+
+pub mod report {
+    pub use crate::output::json::{REPOPILOT_VERSION, SCAN_REPORT_SCHEMA_VERSION};
+    pub use crate::output::{OutputFormat, render_baseline_scan_report, render_scan_summary};
+    pub use crate::receipt::{build_audit_receipt, render_receipt_json};
+    pub use crate::report::writer::write_report;
+}
+
+pub mod review {
+    pub use crate::review::diff::{ChangeStatus, ChangedFile};
+    pub use crate::review::model::{ReviewFindingStatus, ReviewReport};
+    pub use crate::review::{build_review_report, review_report_for_ci};
+}
+
+pub mod risk {
+    pub use crate::risk::{
+        FORMULA_VERSION, RiskAssessment, RiskFormula, RiskInputs, RiskPriority, RiskSignal,
+        RiskSummary, assess_finding, assess_findings, priority_for_score,
+    };
+}
+
+pub mod scan {
+    pub use crate::scan::config::ScanConfig;
+    pub use crate::scan::scanner::{
+        ScanEngine, collect_scan_facts, collect_scan_facts_with_config, scan_changed_with_config,
+        scan_path, scan_path_with_config,
+    };
+    pub use crate::scan::types::{
+        DiagnosticSeverity, LanguageSummary, ScanDiagnostic, ScanMode, ScanSummary, ScanTimings,
+    };
+    pub use crate::scan::workspace_scan::scan_workspace_with_config;
+}

--- a/src/cli/options/mod.rs
+++ b/src/cli/options/mod.rs
@@ -7,12 +7,12 @@ pub mod inspect;
 pub mod review;
 pub mod scan;
 
-pub use ai::{AiCommands, AiContextOptions, AiOptions, AiPlanOptions, AiPromptOptions};
+pub use ai::{AiCommands, AiOptions};
 pub use baseline::{BaselineCommands, BaselineOptions};
 pub use cache::{CacheCommands, CacheOptions};
 pub use compare::CompareOptions;
 pub use doctor::{DoctorOptions, InitOptions};
-pub use inspect::{ExplainOptions, InspectCommands, InspectOptions, KnowledgeOptions};
+pub use inspect::{InspectCommands, InspectOptions};
 pub use review::ReviewOptions;
 pub use scan::ScanOptions;
 
@@ -172,24 +172,4 @@ repopilot doctor . --format json\n  \
 repopilot doctor . --format markdown --output doctor.md"
     )]
     Doctor(DoctorOptions),
-
-    /// Hidden 0.x compatibility alias for `ai context`
-    #[command(hide = true)]
-    Vibe(AiContextOptions),
-
-    /// Hidden 0.x compatibility alias for `ai plan`
-    #[command(hide = true)]
-    Harden(AiPlanOptions),
-
-    /// Hidden 0.x compatibility alias for `ai prompt`
-    #[command(hide = true)]
-    Prompt(AiPromptOptions),
-
-    /// Hidden 0.x compatibility alias for `inspect explain`
-    #[command(hide = true)]
-    Explain(ExplainOptions),
-
-    /// Hidden 0.x compatibility alias for `inspect knowledge`
-    #[command(hide = true)]
-    Knowledge(KnowledgeOptions),
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -47,32 +47,6 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             options.include_low_signal,
             options.max_files,
         ),
-        Commands::Vibe(options) => vibe::run(options),
-        Commands::Harden(options) => harden::run(
-            options.path,
-            options.config,
-            options.focus,
-            options.budget,
-            options.output,
-        ),
-        Commands::Prompt(options) => prompt::run(
-            options.path,
-            options.config,
-            options.focus,
-            options.budget,
-            options.output,
-        ),
-        Commands::Explain(options) => explain::run(
-            options.path,
-            options.rule,
-            options.signal,
-            options.severity,
-            options.format,
-            options.output,
-        ),
-        Commands::Knowledge(options) => {
-            knowledge::run(options.section, options.format, options.output)
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,20 +13,32 @@
 //! repopilot baseline create .
 //! ```
 
+pub mod api;
+
+#[doc(hidden)]
 pub mod audits;
+#[doc(hidden)]
 pub mod baseline;
+#[doc(hidden)]
 pub mod compare;
 pub mod config;
+#[doc(hidden)]
 pub mod doctor;
+#[doc(hidden)]
 pub mod explain;
 pub mod findings;
+#[doc(hidden)]
 pub mod frameworks;
+#[doc(hidden)]
 pub mod graph;
+#[doc(hidden)]
 pub mod knowledge;
 pub mod output;
+#[doc(hidden)]
 pub mod receipt;
 pub mod report;
 pub mod review;
 pub mod risk;
+#[doc(hidden)]
 pub mod rules;
 pub mod scan;

--- a/src/output/console/sections.rs
+++ b/src/output/console/sections.rs
@@ -5,7 +5,7 @@ use crate::output::finding_helpers::{clusters_by_rule_scope, example_locations};
 use crate::output::report_stats::{ReportStats, TOOL_VERSION};
 use crate::output::report_text::{console_severity_counts_text, named_counts_text};
 use crate::risk::RiskPriority;
-use crate::scan::types::ScanSummary;
+use crate::scan::types::{DiagnosticSeverity, ScanSummary};
 use std::fmt::Write;
 
 pub(crate) fn render_header(output: &mut String, summary: &ScanSummary, stats: &ReportStats) {
@@ -45,6 +45,7 @@ pub(crate) fn render_header(output: &mut String, summary: &ScanSummary, stats: &
         .unwrap();
     }
     render_hidden_suggestions_breakdown(output, summary);
+    render_diagnostics(output, summary);
     writeln!(
         output,
         "Directories analyzed: {} | Non-empty lines: {}",
@@ -62,6 +63,38 @@ pub(crate) fn render_header(output: &mut String, summary: &ScanSummary, stats: &
         .unwrap();
     }
     output.push('\n');
+}
+
+fn render_diagnostics(output: &mut String, summary: &ScanSummary) {
+    if summary.diagnostics.is_empty() {
+        return;
+    }
+
+    output.push_str("Diagnostics:\n");
+    for diagnostic in &summary.diagnostics {
+        let path = diagnostic
+            .path
+            .as_ref()
+            .map(|path| format!(" ({})", path.display()))
+            .unwrap_or_default();
+        writeln!(
+            output,
+            "  [{}] {}{}: {}",
+            diagnostic_severity_label(diagnostic.severity),
+            diagnostic.code,
+            path,
+            diagnostic.message
+        )
+        .unwrap();
+    }
+}
+
+fn diagnostic_severity_label(severity: DiagnosticSeverity) -> &'static str {
+    match severity {
+        DiagnosticSeverity::Info => "info",
+        DiagnosticSeverity::Warning => "warning",
+        DiagnosticSeverity::Error => "error",
+    }
 }
 
 fn render_cache_telemetry(output: &mut String, summary: &ScanSummary) {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -14,6 +14,11 @@ pub fn render(summary: &ScanSummary) -> Result<String, serde_json::Error> {
     let output = JsonScanReport {
         schema_version: SCAN_REPORT_SCHEMA_VERSION,
         repopilot_version: REPOPILOT_VERSION,
+        report: ReportEnvelope {
+            kind: "scan",
+            schema_version: SCAN_REPORT_SCHEMA_VERSION,
+            repopilot_version: REPOPILOT_VERSION,
+        },
         risk_summary: RiskSummary::from_findings(&summary.findings),
         summary,
     };
@@ -25,6 +30,7 @@ pub fn render(summary: &ScanSummary) -> Result<String, serde_json::Error> {
 struct JsonScanReport<'a> {
     schema_version: &'static str,
     repopilot_version: &'static str,
+    report: ReportEnvelope,
     risk_summary: RiskSummary,
     #[serde(flatten)]
     summary: &'a ScanSummary,
@@ -48,6 +54,11 @@ pub fn render_with_baseline(
     let output = BaselineJsonReport {
         schema_version: SCAN_REPORT_SCHEMA_VERSION,
         repopilot_version: REPOPILOT_VERSION,
+        report: ReportEnvelope {
+            kind: "baseline-scan",
+            schema_version: SCAN_REPORT_SCHEMA_VERSION,
+            repopilot_version: REPOPILOT_VERSION,
+        },
         root_path: report.summary.root_path.to_string_lossy().to_string(),
         files_analyzed: report.summary.files_analyzed,
         directories_count: report.summary.directories_count,
@@ -81,9 +92,17 @@ pub fn render_with_baseline(
 }
 
 #[derive(Serialize)]
+struct ReportEnvelope {
+    kind: &'static str,
+    schema_version: &'static str,
+    repopilot_version: &'static str,
+}
+
+#[derive(Serialize)]
 struct BaselineJsonReport<'a> {
     schema_version: &'static str,
     repopilot_version: &'static str,
+    report: ReportEnvelope,
     root_path: String,
     files_analyzed: usize,
     directories_count: usize,
@@ -167,6 +186,7 @@ mod tests {
 
         assert_eq!(value["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
         assert_eq!(value["repopilot_version"], REPOPILOT_VERSION);
+        assert_eq!(value["report"]["kind"], "scan");
         assert_eq!(value["files_analyzed"], 1);
         assert!(value.get("findings").is_some());
     }
@@ -198,6 +218,7 @@ mod tests {
 
         assert_eq!(value["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
         assert_eq!(value["repopilot_version"], REPOPILOT_VERSION);
+        assert_eq!(value["report"]["kind"], "baseline-scan");
         assert_eq!(value["files_analyzed"], 2);
         assert_eq!(value["hidden_suggestions_count"], 5);
         assert_eq!(

--- a/src/output/markdown/sections.rs
+++ b/src/output/markdown/sections.rs
@@ -4,7 +4,7 @@ use crate::output::finding_helpers::{clusters_by_rule_scope, example_locations};
 use crate::output::render_helpers::escape_table_cell;
 use crate::output::report_stats::{ReportStats, TOOL_VERSION};
 use crate::output::report_text::{markdown_severity_counts_text, named_counts_text};
-use crate::scan::types::ScanSummary;
+use crate::scan::types::{DiagnosticSeverity, ScanSummary};
 use std::fmt::Write;
 
 pub(crate) fn render_overview(output: &mut String, summary: &ScanSummary, stats: &ReportStats) {
@@ -38,6 +38,7 @@ pub(crate) fn render_overview(output: &mut String, summary: &ScanSummary, stats:
         .unwrap();
     }
     render_hidden_suggestions_breakdown(output, summary);
+    render_diagnostics(output, summary);
     writeln!(output, "- **Files analyzed:** {}", summary.files_analyzed).unwrap();
     writeln!(
         output,
@@ -64,6 +65,38 @@ pub(crate) fn render_overview(output: &mut String, summary: &ScanSummary, stats:
         .unwrap();
     }
     output.push('\n');
+}
+
+fn render_diagnostics(output: &mut String, summary: &ScanSummary) {
+    if summary.diagnostics.is_empty() {
+        return;
+    }
+
+    output.push_str("- **Diagnostics:**\n");
+    for diagnostic in &summary.diagnostics {
+        let path = diagnostic
+            .path
+            .as_ref()
+            .map(|path| format!(" `{}`", path.display()))
+            .unwrap_or_default();
+        writeln!(
+            output,
+            "  - `{}` `{}`{}: {}",
+            diagnostic_severity_label(diagnostic.severity),
+            diagnostic.code,
+            path,
+            diagnostic.message
+        )
+        .unwrap();
+    }
+}
+
+fn diagnostic_severity_label(severity: DiagnosticSeverity) -> &'static str {
+    match severity {
+        DiagnosticSeverity::Info => "info",
+        DiagnosticSeverity::Warning => "warning",
+        DiagnosticSeverity::Error => "error",
+    }
 }
 
 fn render_cache_telemetry(output: &mut String, summary: &ScanSummary) {

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -187,6 +187,7 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
             repopilotignore_path: report.summary.repopilotignore_path.clone(),
             scan_timings: None,
             cache_telemetry: report.summary.cache_telemetry.clone(),
+            diagnostics: report.summary.diagnostics.clone(),
         },
         baseline_path: report.baseline_path.clone(),
         findings,

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -9,8 +9,8 @@ mod summary;
 mod tests;
 
 pub use model::{
-    FORMULA_VERSION, GraphImpact, RiskAssessment, RiskInputs, RiskPriority, RiskSignal,
-    priority_for_score,
+    FORMULA_VERSION, GraphImpact, RiskAssessment, RiskFormula, RiskInputs, RiskPriority,
+    RiskSignal, priority_for_score,
 };
 pub use overlays::{
     apply_baseline_overlay, apply_blast_radius_overlay, apply_cluster_overlay, apply_graph_overlay,

--- a/src/risk/model.rs
+++ b/src/risk/model.rs
@@ -3,6 +3,51 @@ use serde::{Deserialize, Serialize};
 
 pub const FORMULA_VERSION: &str = "risk-v2";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RiskFormula {
+    pub version: &'static str,
+    pub severity_critical: u8,
+    pub severity_high: u8,
+    pub severity_medium: u8,
+    pub severity_low: u8,
+    pub severity_info: u8,
+    pub confidence_high_percent: u16,
+    pub confidence_medium_percent: u16,
+    pub confidence_low_percent: u16,
+    pub security_category_weight: i16,
+    pub review_in_diff_weight: i16,
+    pub workspace_hotspot_weight: i16,
+    pub graph_hub_weight: i16,
+    pub graph_dependency_weight: i16,
+    pub blast_radius_weight: i16,
+    pub cluster_small_weight: i16,
+    pub cluster_medium_weight: i16,
+    pub cluster_large_weight: i16,
+}
+
+impl RiskFormula {
+    pub const CURRENT: Self = Self {
+        version: FORMULA_VERSION,
+        severity_critical: 95,
+        severity_high: 75,
+        severity_medium: 45,
+        severity_low: 20,
+        severity_info: 5,
+        confidence_high_percent: 110,
+        confidence_medium_percent: 100,
+        confidence_low_percent: 80,
+        security_category_weight: 12,
+        review_in_diff_weight: 12,
+        workspace_hotspot_weight: 5,
+        graph_hub_weight: 8,
+        graph_dependency_weight: 5,
+        blast_radius_weight: 6,
+        cluster_small_weight: 3,
+        cluster_medium_weight: 5,
+        cluster_large_weight: 7,
+    };
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RiskAssessment {
     pub score: u8,

--- a/src/risk/scoring.rs
+++ b/src/risk/scoring.rs
@@ -6,7 +6,8 @@ use std::path::{Path, PathBuf};
 
 use super::context::add_file_context_signals;
 use super::model::{
-    GraphImpact, RiskAssessment, RiskInputs, RiskSignal, clamp_score, push_adjustment, signal,
+    GraphImpact, RiskAssessment, RiskFormula, RiskInputs, RiskSignal, clamp_score, push_adjustment,
+    signal,
 };
 use super::overlays::baseline_signal;
 
@@ -38,7 +39,7 @@ pub fn assess_finding(
             &mut signals,
             "category.security",
             "security finding",
-            12,
+            RiskFormula::CURRENT.security_category_weight,
             "security findings usually have higher remediation priority",
         );
     }
@@ -59,7 +60,7 @@ pub fn assess_finding(
             &mut signals,
             "review.in-diff",
             "changed lines",
-            12,
+            RiskFormula::CURRENT.review_in_diff_weight,
             "finding touches changed diff lines",
         );
     }
@@ -70,7 +71,7 @@ pub fn assess_finding(
             &mut signals,
             "workspace.hotspot",
             "workspace hotspot",
-            5,
+            RiskFormula::CURRENT.workspace_hotspot_weight,
             "workspace package has multiple high-risk findings",
         );
     }
@@ -85,7 +86,7 @@ pub fn assess_finding(
             &mut signals,
             "review.blast-radius",
             "blast radius",
-            6,
+            RiskFormula::CURRENT.blast_radius_weight,
             "finding is in a file impacted by changed import dependencies",
         );
     }
@@ -133,7 +134,7 @@ fn add_graph_signal(impact: GraphImpact, score: &mut i16, signals: &mut Vec<Risk
             signals,
             "graph.hub",
             "dependency hub",
-            8,
+            RiskFormula::CURRENT.graph_hub_weight,
             "file has high fan-in or fan-out, so changes can ripple through the codebase",
         ),
         GraphImpact::Dependency => push_adjustment(
@@ -141,7 +142,7 @@ fn add_graph_signal(impact: GraphImpact, score: &mut i16, signals: &mut Vec<Risk
             signals,
             "graph.dependency",
             "shared dependency",
-            5,
+            RiskFormula::CURRENT.graph_dependency_weight,
             "file is imported by multiple other files",
         ),
     }
@@ -150,19 +151,19 @@ fn add_graph_signal(impact: GraphImpact, score: &mut i16, signals: &mut Vec<Risk
 fn cluster_weight(size: usize) -> i16 {
     match size {
         0..=2 => 0,
-        3..=5 => 3,
-        6..=15 => 5,
-        _ => 7,
+        3..=5 => RiskFormula::CURRENT.cluster_small_weight,
+        6..=15 => RiskFormula::CURRENT.cluster_medium_weight,
+        _ => RiskFormula::CURRENT.cluster_large_weight,
     }
 }
 
 fn severity_base_score(severity: Severity) -> u8 {
     match severity {
-        Severity::Critical => 95,
-        Severity::High => 75,
-        Severity::Medium => 45,
-        Severity::Low => 20,
-        Severity::Info => 5,
+        Severity::Critical => RiskFormula::CURRENT.severity_critical,
+        Severity::High => RiskFormula::CURRENT.severity_high,
+        Severity::Medium => RiskFormula::CURRENT.severity_medium,
+        Severity::Low => RiskFormula::CURRENT.severity_low,
+        Severity::Info => RiskFormula::CURRENT.severity_info,
     }
 }
 
@@ -176,12 +177,12 @@ fn severity_signal(severity: Severity, score: u8) -> RiskSignal {
 }
 
 fn confidence_delta(base: u8, confidence: Confidence) -> i16 {
-    let multiplier = match confidence {
-        Confidence::High => 1.10,
-        Confidence::Medium => 1.00,
-        Confidence::Low => 0.80,
+    let percent = match confidence {
+        Confidence::High => RiskFormula::CURRENT.confidence_high_percent,
+        Confidence::Medium => RiskFormula::CURRENT.confidence_medium_percent,
+        Confidence::Low => RiskFormula::CURRENT.confidence_low_percent,
     };
-    ((base as f64 * multiplier).round() as i16) - base as i16
+    (((base as u32 * percent as u32) + 50) / 100) as i16 - base as i16
 }
 
 fn confidence_signal(confidence: Confidence, weight: i16) -> RiskSignal {

--- a/src/risk/tests.rs
+++ b/src/risk/tests.rs
@@ -6,6 +6,9 @@ use std::path::PathBuf;
 #[test]
 fn priority_thresholds_match_v2_plan() {
     assert_eq!(FORMULA_VERSION, "risk-v2");
+    assert_eq!(RiskFormula::CURRENT.version, FORMULA_VERSION);
+    assert_eq!(RiskFormula::CURRENT.severity_critical, 95);
+    assert_eq!(RiskFormula::CURRENT.review_in_diff_weight, 12);
     assert_eq!(priority_for_score(90), RiskPriority::P0);
     assert_eq!(priority_for_score(70), RiskPriority::P1);
     assert_eq!(priority_for_score(40), RiskPriority::P2);

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -275,6 +275,7 @@ pub fn scan_changed_with_config(
                 post_scan_audits_us: 0,
             }),
             cache_telemetry: Some(cache_telemetry),
+            diagnostics: Vec::new(),
         },
     ))
 }

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -31,74 +31,157 @@ pub fn scan_path(path: &Path) -> io::Result<ScanSummary> {
 }
 
 pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<ScanSummary> {
-    let start = Instant::now();
-    let file_audits = build_file_audits(config);
-    let (mut facts, mut findings) =
-        collection::collect_and_audit_inline(path, config, &file_audits)?;
-    let file_scan_us = start.elapsed().as_micros() as u64;
+    ScanEngine::new(path, config).run()
+}
 
-    let framework_start = Instant::now();
-    facts.detected_frameworks = detect_frameworks(&facts.root_path);
-    facts.framework_projects = detect_framework_projects(&facts.root_path);
+pub struct ScanEngine<'a> {
+    path: &'a Path,
+    config: &'a ScanConfig,
+}
 
-    let react_native_profile = if facts
-        .detected_frameworks
-        .iter()
-        .any(|f| matches!(f, DetectedFramework::ReactNative { .. }))
-    {
-        let profile = detect_react_native_architecture(&facts.root_path);
-        if profile.detected {
-            Some(profile)
+struct FileAnalysisStage {
+    facts: crate::scan::facts::ScanFacts,
+    findings: Vec<crate::findings::types::Finding>,
+    elapsed_us: u64,
+}
+
+struct FrameworkDetectionStage {
+    facts: crate::scan::facts::ScanFacts,
+    elapsed_us: u64,
+}
+
+struct ProjectAnalysisStage {
+    facts: crate::scan::facts::ScanFacts,
+    findings: Vec<crate::findings::types::Finding>,
+    coupling_graph: crate::graph::CouplingGraph,
+    elapsed_us: u64,
+}
+
+impl<'a> ScanEngine<'a> {
+    pub fn new(path: &'a Path, config: &'a ScanConfig) -> Self {
+        Self { path, config }
+    }
+
+    pub fn run(self) -> io::Result<ScanSummary> {
+        let start = Instant::now();
+        let file_stage = self.run_file_analysis()?;
+        let framework_stage = self.run_framework_detection(file_stage.facts);
+        let mut project_stage =
+            self.run_project_analysis(framework_stage.facts, file_stage.findings);
+
+        self.enrich_findings(
+            &project_stage.facts,
+            &project_stage.coupling_graph,
+            &mut project_stage.findings,
+        );
+
+        let scan_duration_us = start.elapsed().as_micros() as u64;
+        Ok(build_scan_summary(
+            project_stage.facts,
+            project_stage.findings,
+            ScanSummaryParts {
+                mode: ScanMode::Full,
+                base_ref: None,
+                changed_files_count: 0,
+                repo_level_rules_included: true,
+                coupling_graph: Some(project_stage.coupling_graph),
+                scan_duration_us,
+                scan_timings: Some(ScanTimings {
+                    file_scan_us: file_stage.elapsed_us,
+                    framework_detection_us: framework_stage.elapsed_us,
+                    post_scan_audits_us: project_stage.elapsed_us,
+                }),
+                cache_telemetry: None,
+                diagnostics: Vec::new(),
+            },
+        ))
+    }
+
+    fn run_file_analysis(&self) -> io::Result<FileAnalysisStage> {
+        let start = Instant::now();
+        let file_audits = build_file_audits(self.config);
+        let (facts, findings) =
+            collection::collect_and_audit_inline(self.path, self.config, &file_audits)?;
+        Ok(FileAnalysisStage {
+            facts,
+            findings,
+            elapsed_us: start.elapsed().as_micros() as u64,
+        })
+    }
+
+    fn run_framework_detection(
+        &self,
+        mut facts: crate::scan::facts::ScanFacts,
+    ) -> FrameworkDetectionStage {
+        let start = Instant::now();
+        facts.detected_frameworks = detect_frameworks(&facts.root_path);
+        facts.framework_projects = detect_framework_projects(&facts.root_path);
+
+        let react_native_profile = if facts
+            .detected_frameworks
+            .iter()
+            .any(|f| matches!(f, DetectedFramework::ReactNative { .. }))
+        {
+            let profile = detect_react_native_architecture(&facts.root_path);
+            if profile.detected {
+                Some(profile)
+            } else {
+                None
+            }
         } else {
             None
+        };
+        facts.react_native = react_native_profile;
+
+        FrameworkDetectionStage {
+            facts,
+            elapsed_us: start.elapsed().as_micros() as u64,
         }
-    } else {
-        None
-    };
-    facts.react_native = react_native_profile;
-    let framework_detection_us = framework_start.elapsed().as_micros() as u64;
-
-    let post_scan_start = Instant::now();
-    let ((project_findings, framework_findings), (coupling_findings, coupling_graph)) = rayon::join(
-        || {
-            rayon::join(
-                || run_project_audits(&facts, config),
-                || run_framework_audits(&facts, config),
-            )
-        },
-        || ImportCouplingAudit.audit_with_graph(&facts, config, path),
-    );
-    findings.extend(project_findings);
-    findings.extend(framework_findings);
-    findings.extend(apply_project_decisions(&facts, coupling_findings));
-    let post_scan_audits_us = post_scan_start.elapsed().as_micros() as u64;
-
-    for finding in &mut findings {
-        finding.populate_recommendation();
-        finding.id = stable_finding_key(finding, path);
     }
-    assess_findings(&mut findings, &facts);
-    apply_graph_overlay(&mut findings, &coupling_graph);
-    apply_cluster_overlay(&mut findings);
-    summary::sort_findings(&mut findings);
 
-    let scan_duration_us = start.elapsed().as_micros() as u64;
-    Ok(build_scan_summary(
-        facts,
-        findings,
-        ScanSummaryParts {
-            mode: ScanMode::Full,
-            base_ref: None,
-            changed_files_count: 0,
-            repo_level_rules_included: true,
-            coupling_graph: Some(coupling_graph),
-            scan_duration_us,
-            scan_timings: Some(ScanTimings {
-                file_scan_us,
-                framework_detection_us,
-                post_scan_audits_us,
-            }),
-            cache_telemetry: None,
-        },
-    ))
+    fn run_project_analysis(
+        &self,
+        facts: crate::scan::facts::ScanFacts,
+        mut findings: Vec<crate::findings::types::Finding>,
+    ) -> ProjectAnalysisStage {
+        let start = Instant::now();
+        let ((project_findings, framework_findings), (coupling_findings, coupling_graph)) =
+            rayon::join(
+                || {
+                    rayon::join(
+                        || run_project_audits(&facts, self.config),
+                        || run_framework_audits(&facts, self.config),
+                    )
+                },
+                || ImportCouplingAudit.audit_with_graph(&facts, self.config, self.path),
+            );
+        findings.extend(project_findings);
+        findings.extend(framework_findings);
+        findings.extend(apply_project_decisions(&facts, coupling_findings));
+
+        ProjectAnalysisStage {
+            facts,
+            findings,
+            coupling_graph,
+            elapsed_us: start.elapsed().as_micros() as u64,
+        }
+    }
+
+    fn enrich_findings(
+        &self,
+        facts: &crate::scan::facts::ScanFacts,
+        coupling_graph: &crate::graph::CouplingGraph,
+        findings: &mut [crate::findings::types::Finding],
+    ) {
+        for finding in findings.iter_mut() {
+            finding.populate_recommendation();
+            finding.id = stable_finding_key(finding, self.path);
+        }
+        assess_findings(findings, facts);
+        // Graph and cluster overlays are kept after the base scoring pass because
+        // they depend on the complete cross-file project view.
+        apply_graph_overlay(findings, coupling_graph);
+        apply_cluster_overlay(findings);
+        summary::sort_findings(findings);
+    }
 }

--- a/src/scan/scanner/summary.rs
+++ b/src/scan/scanner/summary.rs
@@ -2,7 +2,7 @@ use crate::findings::types::Finding;
 use crate::graph::CouplingGraph;
 use crate::scan::facts::ScanFacts;
 use crate::scan::types::LanguageSummary;
-use crate::scan::types::{ScanCacheTelemetry, ScanMode, ScanSummary, ScanTimings};
+use crate::scan::types::{ScanCacheTelemetry, ScanDiagnostic, ScanMode, ScanSummary, ScanTimings};
 use std::collections::HashMap;
 
 pub(super) fn sort_findings(findings: &mut [Finding]) {
@@ -37,6 +37,7 @@ pub(super) struct ScanSummaryParts {
     pub(super) scan_timings: Option<ScanTimings>,
     pub(super) cache_telemetry: Option<ScanCacheTelemetry>,
     pub(super) coupling_graph: Option<CouplingGraph>,
+    pub(super) diagnostics: Vec<ScanDiagnostic>,
 }
 
 pub(super) fn build_scan_summary(
@@ -78,5 +79,6 @@ pub(super) fn build_scan_summary(
         repopilotignore_path: facts.repopilotignore_path,
         scan_timings: parts.scan_timings,
         cache_telemetry: parts.cache_telemetry,
+        diagnostics: parts.diagnostics,
     }
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -82,6 +82,40 @@ pub struct HiddenSuggestionSummary {
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+pub enum DiagnosticSeverity {
+    #[default]
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScanDiagnostic {
+    pub code: String,
+    pub severity: DiagnosticSeverity,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+}
+
+impl ScanDiagnostic {
+    pub fn warning(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            severity: DiagnosticSeverity::Warning,
+            message: message.into(),
+            path: None,
+        }
+    }
+
+    pub fn with_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
 pub enum ScanMode {
     #[default]
     Full,
@@ -162,6 +196,9 @@ pub struct ScanSummary {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_telemetry: Option<ScanCacheTelemetry>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<ScanDiagnostic>,
 }
 
 fn default_repo_level_rules_included() -> bool {
@@ -201,6 +238,7 @@ impl Default for ScanSummary {
             repopilotignore_path: None,
             scan_timings: None,
             cache_telemetry: None,
+            diagnostics: Vec::new(),
         }
     }
 }

--- a/src/scan/workspace_scan.rs
+++ b/src/scan/workspace_scan.rs
@@ -2,7 +2,7 @@ use crate::findings::types::Finding;
 use crate::risk::{apply_cluster_overlay, apply_workspace_hotspot_overlay, sort_findings};
 use crate::scan::config::ScanConfig;
 use crate::scan::scanner::scan_path_with_config;
-use crate::scan::types::{LanguageSummary, ScanSummary};
+use crate::scan::types::{LanguageSummary, ScanDiagnostic, ScanSummary};
 use crate::scan::workspace::{WorkspacePackage, detect_workspace_packages};
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
@@ -16,12 +16,15 @@ pub fn scan_workspace_with_config(
 ) -> io::Result<ScanSummary> {
     let plan = WorkspaceScanPlan::detect(path, scan_config);
     if plan.packages.is_empty() {
-        eprintln!(
-            "Warning: --workspace specified but no workspace packages found under {}. \
-             Falling back to single-package scan.",
-            path.display()
+        let mut summary = scan_path_with_config(path, scan_config)?;
+        summary.diagnostics.push(
+            ScanDiagnostic::warning(
+                "workspace.no-packages",
+                "--workspace was requested but no workspace packages were found; scanned as a single package",
+            )
+            .with_path(path),
         );
-        return scan_path_with_config(path, scan_config);
+        return Ok(summary);
     }
 
     plan.execute()
@@ -54,10 +57,10 @@ impl<'a> WorkspaceScanPlan<'a> {
         for package in self.scan_packages() {
             match package.result {
                 Ok(pkg_summary) => merge_package_summary(&mut merged, pkg_summary, &package.name),
-                Err(err) => eprintln!(
-                    "Warning: failed to scan workspace package '{}': {err}",
-                    package.name
-                ),
+                Err(err) => merged.diagnostics.push(ScanDiagnostic::warning(
+                    "workspace.package-scan-failed",
+                    format!("failed to scan workspace package '{}': {err}", package.name),
+                )),
             }
         }
 
@@ -137,6 +140,7 @@ fn merge_package_summary(merged: &mut ScanSummary, mut package: ScanSummary, pac
     merged.hidden_suggestions_count = merged
         .hidden_suggestions_count
         .saturating_add(package.hidden_suggestions_count);
+    merged.diagnostics.extend(package.diagnostics);
     merge_language_summaries(&mut merged.languages, package.languages);
     merged.findings.extend(package.findings);
 }

--- a/tests/action_yml.rs
+++ b/tests/action_yml.rs
@@ -8,10 +8,14 @@ fn action_exposes_typed_receipt_input_and_output() {
 
     assert!(action.contains("receipt:"));
     assert!(action.contains("receipt-file:"));
-    assert!(action.contains("RECEIPT=\"${{ inputs.receipt }}\""));
-    assert!(action.contains("Receipt output is only supported by 'scan'"));
-    assert!(action.contains("RUN_ARGS+=(--receipt \"$RECEIPT\")"));
-    assert!(action.contains("receipt_file=$RECEIPT"));
+    assert!(action.contains("INPUT_RECEIPT: ${{ inputs.receipt }}"));
+    assert!(action.contains("scripts/repopilot-action.sh"));
+
+    let helper_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/repopilot-action.sh");
+    let helper = fs::read_to_string(helper_path).expect("read action helper");
+    assert!(helper.contains("Receipt output is only supported by 'scan'"));
+    assert!(helper.contains("RUN_ARGS+=(--receipt \"$RECEIPT\")"));
+    assert!(helper.contains("receipt_file=$RECEIPT"));
 }
 
 #[test]
@@ -23,14 +27,17 @@ fn action_exposes_priority_and_rule_parity_inputs() {
         assert!(action.contains(input), "missing action input {input}");
     }
 
-    assert!(action.contains("FAIL_ON_PRIORITY=\"${{ inputs.fail-on-priority }}\""));
-    assert!(action.contains("MIN_PRIORITY=\"${{ inputs.min-priority }}\""));
-    assert!(action.contains("RULE_INPUT=\"${{ inputs.rule }}\""));
-    assert!(action.contains("TIMING=\"${{ inputs.timing }}\""));
-    assert!(action.contains("RUN_ARGS+=(--fail-on-priority \"$FAIL_ON_PRIORITY\")"));
-    assert!(action.contains("RUN_ARGS+=(--min-priority \"$MIN_PRIORITY\")"));
-    assert!(action.contains("RUN_ARGS+=(--rule \"$RULE\")"));
-    assert!(action.contains("RUN_ARGS+=(--timing)"));
+    assert!(action.contains("INPUT_FAIL_ON_PRIORITY: ${{ inputs.fail-on-priority }}"));
+    assert!(action.contains("INPUT_MIN_PRIORITY: ${{ inputs.min-priority }}"));
+    assert!(action.contains("INPUT_RULE: ${{ inputs.rule }}"));
+    assert!(action.contains("INPUT_TIMING: ${{ inputs.timing }}"));
+
+    let helper_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/repopilot-action.sh");
+    let helper = fs::read_to_string(helper_path).expect("read action helper");
+    assert!(helper.contains("RUN_ARGS+=(--fail-on-priority \"$FAIL_ON_PRIORITY\")"));
+    assert!(helper.contains("RUN_ARGS+=(--min-priority \"$MIN_PRIORITY\")"));
+    assert!(helper.contains("RUN_ARGS+=(--rule \"$RULE\")"));
+    assert!(helper.contains("RUN_ARGS+=(--timing)"));
 }
 
 #[test]
@@ -38,8 +45,12 @@ fn action_supports_doctor_as_markdown_auto_command() {
     let action_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("action.yml");
     let action = fs::read_to_string(action_path).expect("read action.yml");
 
-    assert!(action.contains("doctor) RUN_ARGS=(doctor \"$PATH_INPUT\") ;;"));
     assert!(action.contains("scan | review | compare | doctor | ai-context"));
     assert!(action.contains("review/compare/doctor"));
-    assert!(action.contains("SARIF output and upload are only supported by 'scan'"));
+
+    let helper_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/repopilot-action.sh");
+    let helper = fs::read_to_string(helper_path).expect("read action helper");
+    assert!(helper.contains("doctor) RUN_ARGS=(doctor \"$PATH_INPUT\") ;;"));
+    assert!(helper.contains("SARIF output and upload are only supported by 'scan'"));
+    assert!(!helper.contains("ai-context|vibe"));
 }

--- a/tests/cli_stabilization.rs
+++ b/tests/cli_stabilization.rs
@@ -144,44 +144,19 @@ fn inspect_commands_work() {
 }
 
 #[test]
-fn hidden_legacy_commands_remain_executable() {
+fn legacy_commands_are_removed_from_executable_surface() {
     let project = create_project();
 
-    let vibe = run_ok(
-        &["vibe", ".", "--focus", "security", "--budget", "2k"],
-        project.path(),
-    );
-    assert!(stdout(&vibe).contains("RepoPilot Vibe Check"));
-
-    let harden = run_ok(&["harden", ".", "--budget", "2k"], project.path());
-    assert!(stdout(&harden).contains("RepoPilot Harden Plan"));
-
-    let prompt = run_ok(&["prompt", ".", "--budget", "2k"], project.path());
-    assert!(stdout(&prompt).contains("RepoPilot Remediation Prompt"));
-
-    let explain = run_ok(
-        &[
-            "explain",
-            "src/lib.rs",
-            "--format",
-            "json",
-            "--rule",
-            "language.rust.panic-risk",
-            "--signal",
-            "rust.unwrap",
-        ],
-        project.path(),
-    );
-    let explain_json: Value = serde_json::from_slice(&explain.stdout).expect("legacy explain json");
-    assert!(explain_json["context"].is_object());
-
-    let knowledge = run_ok(
-        &["knowledge", "--section", "rules", "--format", "json"],
-        project.path(),
-    );
-    let knowledge_json: Value =
-        serde_json::from_slice::<Value>(&knowledge.stdout).expect("legacy knowledge json");
-    assert!(knowledge_json["summary"].is_object());
+    for command in ["vibe", "harden", "prompt", "explain", "knowledge"] {
+        let output = run(&[command, "."], project.path());
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "legacy command {command} should be rejected\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }
 
 #[test]

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -94,6 +94,7 @@ fn summary(findings: Vec<Finding>) -> ScanSummary {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        diagnostics: Vec::new(),
     }
 }
 

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -54,6 +54,7 @@ fn html_output_escapes_snippets_and_renders_summary() {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        diagnostics: Vec::new(),
     };
 
     let html = render_scan_summary(&summary, OutputFormat::Html).expect("failed to render html");

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -41,6 +41,7 @@ fn renders_valid_json_scan_summary() {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        diagnostics: Vec::new(),
     };
 
     let output =

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -68,6 +68,7 @@ fn renders_markdown_scan_summary() {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        diagnostics: Vec::new(),
     };
 
     let output = render_scan_summary(&summary, OutputFormat::Markdown)
@@ -132,6 +133,7 @@ fn renders_empty_markdown_sections() {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        diagnostics: Vec::new(),
     };
 
     let output = render_scan_summary(&summary, OutputFormat::Markdown)
@@ -191,6 +193,7 @@ fn renders_react_native_architecture_section_when_profile_present() {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        diagnostics: Vec::new(),
     };
 
     let output = render_scan_summary(&summary, OutputFormat::Markdown)


### PR DESCRIPTION
## Summary

This PR improves RepoPilot's core product foundation by adding structured scan diagnostics, a versioned report envelope, a stable library API facade, and a cleaner GitHub Action runner.

It also removes the old 0.x legacy CLI aliases from the executable command surface and updates docs/smoke checks to point users toward the stable command shape:

```text
ai context / ai plan / ai prompt
inspect explain / inspect knowledge
```

## Type of change

- [x]  Feature
- [x]  Refactor
- [x]  Tests
- [x]  Documentation
- [x]  GitHub Action / CI maintenance
- [x]  Product stabilization

## What changed
- Added structured scan diagnostics to scan summaries.
- Added ScanDiagnostic support for scan/report warnings and errors.
- Added diagnostics rendering to:

  - console output;
  - Markdown output;
  - JSON output.

- Added a versioned report envelope:
```
  {
    "report": {
      "kind": "scan",
      "schema_version": "0.13",
      "repopilot_version": "0.12.0"
    }
  }
```
- Added report envelope support for baseline scan reports.
- Added diagnostics documentation to report schema docs.
- Added src/api.rs as a stable crate-facing API facade.
- Exposed focused public API groups for:

  - config;
  - findings;
  - reports;
  - review;
  - risk;
  - scan.

- Refactored the GitHub Action runner into scripts/repopilot-action.sh.
- Changed the GitHub Action default npm version from latest to 0.12.0 for more reproducible CI.
- Removed legacy 0.x executable aliases:

  - vibe
  - harden
  - prompt
  - knowledge
  - explain

- Updated docs to use stable command shapes only.
- Updated product smoke script to remove legacy alias checks.
- Updated product readiness and roadmap docs.
- Added/updated tests for:

  - action metadata;
  - CLI stabilization;
  - JSON output;
  - Markdown output;
  - HTML output;
  - compare compatibility;
  - risk model changes.

## Why

RepoPilot is getting closer to a stable product shape.

At this point, the project needs stronger foundations around:

- stable commands
- stable report metadata
- structured diagnostics
- stable library-facing API
- reproducible GitHub Action behavior

Diagnostics make scans more transparent when something is partially skipped or degraded.

The report envelope gives downstream consumers a cleaner and more stable place to read report metadata.

The API facade makes the crate easier to embed without exposing every internal module as the public integration surface.

The GitHub Action refactor makes the action easier to maintain and test instead of keeping a large shell script directly inside action.yml.

## Architecture notes

- No god files introduced.
- GitHub Action command-building logic is moved into scripts/repopilot-action.sh.
- Report metadata is centralized through a report envelope.
- Diagnostics are part of scan summary data and rendered by output layers.
- The crate API facade is exposed through src/api.rs.
- Internal modules can continue evolving while consumers get a smaller stable API surface.
- Legacy alias cleanup reduces long-term CLI maintenance cost.
- Stable command surface is now clearer:

  - scan
  - review
  - baseline
  - compare
  - doctor
  - ai
  - inspect

## Compatibility
- This intentionally removes legacy 0.x aliases from the executable command surface.
- Users should migrate:

  - repopilot vibe → repopilot ai context
  - repopilot harden → repopilot ai plan
  - repopilot prompt → repopilot ai prompt
  - repopilot explain → repopilot inspect explain
  - repopilot knowledge → repopilot inspect knowledge
  - JSON reports keep top-level schema_version and repopilot_version.
  - JSON reports now also include report envelope metadata.
  - JSON reports may now include diagnostics.
  - GitHub Action users should pin the version input for reproducible CI.

## Verification

Recommended checks:

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```

Smoke checks:

```
cargo run -- scan . --format json --output /tmp/repopilot-scan.json
cargo run -- scan . --format markdown --output /tmp/repopilot-scan.md
cargo run -- review . --format json --output /tmp/repopilot-review.json
cargo run -- ai context . --output /tmp/repopilot-context.md
cargo run -- ai plan . --output /tmp/repopilot-plan.md
cargo run -- ai prompt . --output /tmp/repopilot-prompt.md
cargo run -- inspect knowledge --format json --output /tmp/repopilot-knowledge.json
cargo run -- inspect explain src/main.rs --format json --output /tmp/repopilot-explain.json
./scripts/smoke-product.sh
```

GitHub Action smoke check:

`bash scripts/repopilot-action.sh`
