### PR TITLE
refactor(reports): centralize schema handling and diagnostics

### DIFF
--- a/docs/reports.md
+++ b/docs/reports.md
@@ -48,20 +48,26 @@ JSON scan reports include explicit schema metadata. The current schema is 0.13:
 | `cache_telemetry` | object | Optional changed-scan cache summary with hits, misses, changed-file reasons, per-file cache decisions, and cache timing impact. |
 | `diagnostics` | array | Optional structured warnings/errors captured during a scan, such as workspace partial failures. |
 
+Diagnostics use `{ code, severity, message, path? }`. Recoverable diagnostics
+with `warning` severity are report-only and keep the scan exit code at `0`
+unless a finding gate fails. A reportable `error` diagnostic is written into the
+requested report/receipt and then exits with RepoPilot runtime code `3`.
+
 `schema_version` is intentionally separate from the binary version. Patch releases
 may fix bugs without changing the report schema, while future minor releases can
 evolve the schema in a documented way.
 
 ### Compatibility
 
-RepoPilot keeps the scan summary fields at the top level of the JSON document.
-Schema `0.13` intentionally renamed scope counters for accuracy:
+RepoPilot renders JSON through explicit report DTOs instead of serializing the
+internal scan model directly. Schema `0.13` intentionally renamed scope counters
+for accuracy:
 
 - consumers should read `files_analyzed`, `non_empty_lines`, and
   `large_files_skipped`;
 - `repopilot compare` continues to read older JSON reports that do not contain
-  `schema_version`;
-- future tools can branch on `schema_version` when parsing reports.
+  `schema_version` or that use the old `files_count` and `lines_of_code` names;
+- future tools can branch on `schema_version` when parsing reports;
 - consumers should prefer `report.schema_version` when they want a single
   envelope object, while top-level `schema_version` remains present during the
   migration window.
@@ -102,6 +108,7 @@ Example shape:
     "new_findings": 2,
     "existing_findings": 10
   },
+  "diagnostics": [],
   "findings": []
 }
 ```
@@ -122,7 +129,12 @@ Receipt JSON is intentionally smaller than a scan report and has its own schema:
 
 ```json
 {
-  "schema_version": 3,
+  "schema_version": 4,
+  "report": {
+    "kind": "receipt",
+    "schema_version": "4",
+    "repopilot_version": "0.12.0"
+  },
   "tool": "repopilot",
   "version": "0.12.0",
   "generated_at": "2026-05-16T00:00:00Z",
@@ -148,6 +160,7 @@ Receipt JSON is intentionally smaller than a scan report and has its own schema:
     "info": 0
   },
   "languages": [],
+  "diagnostics": [],
   "health_score": 91
 }
 ```

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,9 +16,12 @@ pub mod findings {
 }
 
 pub mod report {
-    pub use crate::output::json::{REPOPILOT_VERSION, SCAN_REPORT_SCHEMA_VERSION};
     pub use crate::output::{OutputFormat, render_baseline_scan_report, render_scan_summary};
     pub use crate::receipt::{build_audit_receipt, render_receipt_json};
+    pub use crate::report::schema::{
+        BaselineJsonReport, REPOPILOT_VERSION, ReportEnvelope, SCAN_REPORT_SCHEMA_VERSION,
+        ScanJsonReport, parse_scan_summary_json, parse_scan_summary_value,
+    };
     pub use crate::report::writer::write_report;
 }
 

--- a/src/commands/compare.rs
+++ b/src/commands/compare.rs
@@ -1,6 +1,7 @@
 use crate::cli::CompareOutputFormatArg;
 use repopilot::compare::diff::diff_summaries;
 use repopilot::compare::render::render;
+use repopilot::report::schema::parse_scan_summary_json;
 use repopilot::report::writer::write_report;
 use repopilot::scan::types::ScanSummary;
 use std::error::Error;
@@ -31,7 +32,7 @@ fn read_summary(path: &Path) -> Result<ScanSummary, CompareInputError> {
         source,
     })?;
 
-    serde_json::from_str(&content).map_err(|source| CompareInputError::Parse {
+    parse_scan_summary_json(&content).map_err(|source| CompareInputError::Parse {
         path: path.to_path_buf(),
         source,
     })

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -2,7 +2,7 @@ use crate::cli::ScanOptions;
 use crate::commands::filters::{scan_pre_visibility_filter, scan_priority_filter};
 use crate::commands::progress::{finish_spinner, make_spinner};
 use crate::commands::scan_config::{ScanConfigOverrides, build_scan_config};
-use crate::commands::{CliExit, EXIT_FINDINGS, EXIT_USAGE};
+use crate::commands::{CliExit, EXIT_FINDINGS, EXIT_RUNTIME, EXIT_USAGE};
 use repopilot::baseline::diff::{all_findings_new, diff_summary_against_baseline};
 use repopilot::baseline::gate::{FailOn, evaluate_ci_gate};
 use repopilot::baseline::reader::read_baseline;
@@ -145,6 +145,8 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
             print_timing_breakdown(&baseline_report.summary);
         }
 
+        enforce_diagnostics_exit_policy(&baseline_report.summary)?;
+
         if let Some(ci_gate) = ci_gate
             && let Some(message) = ci_gate.failure_message()
         {
@@ -181,6 +183,8 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     if options.timing {
         print_timing_breakdown(&summary);
     }
+
+    enforce_diagnostics_exit_policy(&summary)?;
 
     Ok(())
 }
@@ -242,4 +246,20 @@ fn write_scan_receipt_if_requested(
     write_report(&rendered, Some(receipt_path))?;
 
     Ok(())
+}
+
+fn enforce_diagnostics_exit_policy(
+    summary: &ScanSummary,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(diagnostic) = summary.first_error_diagnostic() else {
+        return Ok(());
+    };
+
+    Err(Box::new(CliExit {
+        code: EXIT_RUNTIME,
+        message: format!(
+            "RepoPilot scan completed with reportable error diagnostic `{}`: {}",
+            diagnostic.code, diagnostic.message
+        ),
+    }))
 }

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -1,174 +1,26 @@
-use crate::baseline::diff::{BaselineScanReport, BaselineStatus};
+use crate::baseline::diff::BaselineScanReport;
 use crate::baseline::gate::CiGateResult;
-use crate::findings::types::Finding;
-use crate::risk::RiskSummary;
-use crate::scan::types::{
-    HiddenSuggestionSummary, LanguageSummary, ScanCacheTelemetry, ScanMode, ScanSummary,
-};
-use serde::Serialize;
+use crate::report::schema::{BaselineJsonReport, ScanJsonReport};
+use crate::scan::types::ScanSummary;
 
-pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.13";
-pub const REPOPILOT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub use crate::report::schema::{REPOPILOT_VERSION, SCAN_REPORT_SCHEMA_VERSION};
 
 pub fn render(summary: &ScanSummary) -> Result<String, serde_json::Error> {
-    let output = JsonScanReport {
-        schema_version: SCAN_REPORT_SCHEMA_VERSION,
-        repopilot_version: REPOPILOT_VERSION,
-        report: ReportEnvelope {
-            kind: "scan",
-            schema_version: SCAN_REPORT_SCHEMA_VERSION,
-            repopilot_version: REPOPILOT_VERSION,
-        },
-        risk_summary: RiskSummary::from_findings(&summary.findings),
-        summary,
-    };
-
-    serde_json::to_string_pretty(&output)
-}
-
-#[derive(Serialize)]
-struct JsonScanReport<'a> {
-    schema_version: &'static str,
-    repopilot_version: &'static str,
-    report: ReportEnvelope,
-    risk_summary: RiskSummary,
-    #[serde(flatten)]
-    summary: &'a ScanSummary,
+    serde_json::to_string_pretty(&ScanJsonReport::from_summary(summary))
 }
 
 pub fn render_with_baseline(
     report: &BaselineScanReport,
     ci_gate: Option<&CiGateResult>,
 ) -> Result<String, serde_json::Error> {
-    let findings = report
-        .summary
-        .findings
-        .iter()
-        .enumerate()
-        .map(|(index, finding)| FindingWithBaselineStatus {
-            finding,
-            baseline_status: report.finding_status(index),
-        })
-        .collect::<Vec<_>>();
-
-    let output = BaselineJsonReport {
-        schema_version: SCAN_REPORT_SCHEMA_VERSION,
-        repopilot_version: REPOPILOT_VERSION,
-        report: ReportEnvelope {
-            kind: "baseline-scan",
-            schema_version: SCAN_REPORT_SCHEMA_VERSION,
-            repopilot_version: REPOPILOT_VERSION,
-        },
-        root_path: report.summary.root_path.to_string_lossy().to_string(),
-        files_analyzed: report.summary.files_analyzed,
-        directories_count: report.summary.directories_count,
-        non_empty_lines: report.summary.non_empty_lines,
-        large_files_skipped: report.summary.large_files_skipped,
-        skipped_bytes: report.summary.skipped_bytes,
-        mode: report.summary.mode,
-        base_ref: report.summary.base_ref.as_deref(),
-        changed_files_count: report.summary.changed_files_count,
-        repo_level_rules_included: report.summary.repo_level_rules_included,
-        visible_findings_count: report.summary.findings.len(),
-        hidden_suggestions_count: report.summary.hidden_suggestions_count,
-        hidden_suggestions: &report.summary.hidden_suggestions,
-        visibility_profile: report.summary.visibility_profile.as_deref(),
-        cache_telemetry: report.summary.cache_telemetry.as_ref(),
-        languages: &report.summary.languages,
-        risk_summary: RiskSummary::from_findings(&report.summary.findings),
-        baseline: BaselineJsonMetadata {
-            path: report
-                .baseline_path
-                .as_ref()
-                .map(|path| path.to_string_lossy().to_string()),
-            new_findings: report.new_count(),
-            existing_findings: report.existing_count(),
-        },
-        ci_gate: ci_gate.map(CiGateJsonMetadata::from),
-        findings,
-    };
-
-    serde_json::to_string_pretty(&output)
-}
-
-#[derive(Serialize)]
-struct ReportEnvelope {
-    kind: &'static str,
-    schema_version: &'static str,
-    repopilot_version: &'static str,
-}
-
-#[derive(Serialize)]
-struct BaselineJsonReport<'a> {
-    schema_version: &'static str,
-    repopilot_version: &'static str,
-    report: ReportEnvelope,
-    root_path: String,
-    files_analyzed: usize,
-    directories_count: usize,
-    non_empty_lines: usize,
-    large_files_skipped: usize,
-    skipped_bytes: u64,
-    mode: ScanMode,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    base_ref: Option<&'a str>,
-    changed_files_count: usize,
-    repo_level_rules_included: bool,
-    visible_findings_count: usize,
-    hidden_suggestions_count: usize,
-    #[serde(skip_serializing_if = "hidden_suggestions_empty")]
-    hidden_suggestions: &'a Vec<HiddenSuggestionSummary>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    visibility_profile: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    cache_telemetry: Option<&'a ScanCacheTelemetry>,
-    languages: &'a [LanguageSummary],
-    risk_summary: RiskSummary,
-    baseline: BaselineJsonMetadata,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    ci_gate: Option<CiGateJsonMetadata>,
-    findings: Vec<FindingWithBaselineStatus<'a>>,
-}
-
-fn hidden_suggestions_empty(value: &&Vec<HiddenSuggestionSummary>) -> bool {
-    value.is_empty()
-}
-
-#[derive(Serialize)]
-struct BaselineJsonMetadata {
-    path: Option<String>,
-    new_findings: usize,
-    existing_findings: usize,
-}
-
-#[derive(Serialize)]
-struct CiGateJsonMetadata {
-    fail_on: String,
-    status: &'static str,
-    failed_findings: usize,
-}
-
-impl From<&CiGateResult> for CiGateJsonMetadata {
-    fn from(result: &CiGateResult) -> Self {
-        Self {
-            fail_on: result.label(),
-            status: if result.passed() { "passed" } else { "failed" },
-            failed_findings: result.failed_findings,
-        }
-    }
-}
-
-#[derive(Serialize)]
-struct FindingWithBaselineStatus<'a> {
-    #[serde(flatten)]
-    finding: &'a Finding,
-    baseline_status: BaselineStatus,
+    serde_json::to_string_pretty(&BaselineJsonReport::from_report(report, ci_gate))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::baseline::diff::{BaselineScanReport, FindingBaselineStatus};
+    use crate::scan::types::HiddenSuggestionSummary;
     use serde_json::Value;
     use std::path::PathBuf;
 
@@ -187,6 +39,10 @@ mod tests {
         assert_eq!(value["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
         assert_eq!(value["repopilot_version"], REPOPILOT_VERSION);
         assert_eq!(value["report"]["kind"], "scan");
+        assert_eq!(
+            value["report"]["schema_version"],
+            SCAN_REPORT_SCHEMA_VERSION
+        );
         assert_eq!(value["files_analyzed"], 1);
         assert!(value.get("findings").is_some());
     }

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -1,5 +1,6 @@
 use crate::baseline::diff::BaselineScanReport;
 use crate::findings::types::{Finding, Severity};
+use crate::report::schema::ReportEnvelope;
 use crate::scan::types::ScanSummary;
 use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
@@ -86,6 +87,9 @@ fn findings_to_sarif_with_properties(
                     information_uri: TOOL_INFORMATION_URI.to_string(),
                     rules: sarif_rules(findings),
                 },
+            },
+            properties: SarifRunProperties {
+                report: ReportEnvelope::sarif(),
             },
             results: findings
                 .iter()

--- a/src/output/sarif/model.rs
+++ b/src/output/sarif/model.rs
@@ -1,3 +1,4 @@
+use crate::report::schema::ReportEnvelope;
 use serde::Serialize;
 use std::collections::BTreeMap;
 
@@ -12,7 +13,13 @@ pub struct SarifLog {
 #[derive(Debug, Clone, Serialize)]
 pub struct SarifRun {
     pub tool: SarifTool,
+    pub properties: SarifRunProperties,
     pub results: Vec<SarifResult>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SarifRunProperties {
+    pub report: ReportEnvelope,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/receipt/builder.rs
+++ b/src/receipt/builder.rs
@@ -1,15 +1,17 @@
 use crate::findings::types::Severity;
 use crate::receipt::git::collect_git_receipt;
 use crate::receipt::model::{
-    AUDIT_RECEIPT_SCHEMA_VERSION, AuditReceipt, ReceiptFindings, ReceiptHiddenSuggestion,
-    ReceiptLanguage, ReceiptScope,
+    AUDIT_RECEIPT_SCHEMA_VERSION, AuditReceipt, ReceiptDiagnostic, ReceiptFindings,
+    ReceiptHiddenSuggestion, ReceiptLanguage, ReceiptScope,
 };
+use crate::report::schema::ReportEnvelope;
 use crate::scan::types::ScanSummary;
 use chrono::Utc;
 
 pub fn build_audit_receipt(summary: &ScanSummary) -> AuditReceipt {
     AuditReceipt {
         schema_version: AUDIT_RECEIPT_SCHEMA_VERSION,
+        report: ReportEnvelope::receipt(AUDIT_RECEIPT_SCHEMA_VERSION),
         tool: "repopilot".to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
         generated_at: Utc::now().to_rfc3339(),
@@ -18,6 +20,7 @@ pub fn build_audit_receipt(summary: &ScanSummary) -> AuditReceipt {
         scope: build_scope(summary),
         findings: build_findings(summary),
         languages: build_languages(summary),
+        diagnostics: build_diagnostics(summary),
         health_score: summary.health_score,
     }
 }
@@ -87,6 +90,22 @@ fn build_languages(summary: &ScanSummary) -> Vec<ReceiptLanguage> {
         .map(|language| ReceiptLanguage {
             name: language.name.clone(),
             files_analyzed: language.files_analyzed,
+        })
+        .collect()
+}
+
+fn build_diagnostics(summary: &ScanSummary) -> Vec<ReceiptDiagnostic> {
+    summary
+        .diagnostics
+        .iter()
+        .map(|diagnostic| ReceiptDiagnostic {
+            code: diagnostic.code.clone(),
+            severity: diagnostic.severity,
+            message: diagnostic.message.clone(),
+            path: diagnostic
+                .path
+                .as_ref()
+                .map(|path| path.display().to_string()),
         })
         .collect()
 }

--- a/src/receipt/model.rs
+++ b/src/receipt/model.rs
@@ -1,10 +1,13 @@
+use crate::report::schema::ReportEnvelope;
+use crate::scan::types::DiagnosticSeverity;
 use serde::Serialize;
 
-pub const AUDIT_RECEIPT_SCHEMA_VERSION: u32 = 3;
+pub const AUDIT_RECEIPT_SCHEMA_VERSION: u32 = 4;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AuditReceipt {
     pub schema_version: u32,
+    pub report: ReportEnvelope,
     pub tool: String,
     pub version: String,
     pub generated_at: String,
@@ -13,6 +16,7 @@ pub struct AuditReceipt {
     pub scope: ReceiptScope,
     pub findings: ReceiptFindings,
     pub languages: Vec<ReceiptLanguage>,
+    pub diagnostics: Vec<ReceiptDiagnostic>,
     pub health_score: u8,
 }
 
@@ -68,4 +72,12 @@ pub struct ReceiptHiddenSuggestion {
 pub struct ReceiptLanguage {
     pub name: String,
     pub files_analyzed: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReceiptDiagnostic {
+    pub code: String,
+    pub severity: DiagnosticSeverity,
+    pub message: String,
+    pub path: Option<String>,
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,1 +1,2 @@
+pub mod schema;
 pub mod writer;

--- a/src/report/schema.rs
+++ b/src/report/schema.rs
@@ -1,0 +1,287 @@
+use crate::baseline::diff::{BaselineScanReport, BaselineStatus};
+use crate::baseline::gate::CiGateResult;
+use crate::findings::types::Finding;
+use crate::frameworks::{DetectedFramework, FrameworkProject, ReactNativeArchitectureProfile};
+use crate::graph::CouplingGraph;
+use crate::risk::RiskSummary;
+use crate::scan::types::{
+    HiddenSuggestionSummary, LanguageSummary, ScanCacheTelemetry, ScanDiagnostic, ScanMode,
+    ScanSummary, ScanTimings,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::path::PathBuf;
+
+pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.13";
+pub const REPOPILOT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReportEnvelope {
+    pub kind: String,
+    pub schema_version: String,
+    pub repopilot_version: String,
+}
+
+impl ReportEnvelope {
+    pub fn new(kind: impl Into<String>, schema_version: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            schema_version: schema_version.into(),
+            repopilot_version: REPOPILOT_VERSION.to_string(),
+        }
+    }
+
+    pub fn scan() -> Self {
+        Self::new("scan", SCAN_REPORT_SCHEMA_VERSION)
+    }
+
+    pub fn baseline_scan() -> Self {
+        Self::new("baseline-scan", SCAN_REPORT_SCHEMA_VERSION)
+    }
+
+    pub fn sarif() -> Self {
+        Self::new("sarif", "2.1.0")
+    }
+
+    pub fn receipt(schema_version: u32) -> Self {
+        Self::new("receipt", schema_version.to_string())
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ScanJsonReport<'a> {
+    pub schema_version: &'static str,
+    pub repopilot_version: &'static str,
+    pub report: ReportEnvelope,
+    pub root_path: String,
+    pub mode: ScanMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_ref: Option<&'a str>,
+    pub changed_files_count: usize,
+    pub repo_level_rules_included: bool,
+    pub files_discovered: usize,
+    pub files_analyzed: usize,
+    pub directories_count: usize,
+    pub non_empty_lines: usize,
+    pub large_files_skipped: usize,
+    pub files_skipped_low_signal: usize,
+    pub binary_files_skipped: usize,
+    pub skipped_bytes: u64,
+    pub languages: &'a [LanguageSummary],
+    pub findings: &'a [Finding],
+    pub detected_frameworks: &'a [DetectedFramework],
+    pub framework_projects: &'a [FrameworkProject],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub react_native: Option<&'a ReactNativeArchitectureProfile>,
+    pub coupling_graph: Option<&'a CouplingGraph>,
+    pub scan_duration_us: u64,
+    pub health_score: u8,
+    pub visible_findings_count: usize,
+    pub hidden_suggestions_count: usize,
+    #[serde(skip_serializing_if = "hidden_suggestions_empty")]
+    pub hidden_suggestions: &'a [HiddenSuggestionSummary],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility_profile: Option<&'a str>,
+    pub files_skipped_by_limit: usize,
+    pub files_skipped_repopilotignore: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repopilotignore_path: Option<&'a PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scan_timings: Option<&'a ScanTimings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_telemetry: Option<&'a ScanCacheTelemetry>,
+    #[serde(skip_serializing_if = "diagnostics_empty")]
+    pub diagnostics: &'a [ScanDiagnostic],
+    pub risk_summary: RiskSummary,
+}
+
+impl<'a> ScanJsonReport<'a> {
+    pub fn from_summary(summary: &'a ScanSummary) -> Self {
+        Self {
+            schema_version: SCAN_REPORT_SCHEMA_VERSION,
+            repopilot_version: REPOPILOT_VERSION,
+            report: ReportEnvelope::scan(),
+            root_path: summary.root_path.to_string_lossy().to_string(),
+            mode: summary.mode,
+            base_ref: summary.base_ref.as_deref(),
+            changed_files_count: summary.changed_files_count,
+            repo_level_rules_included: summary.repo_level_rules_included,
+            files_discovered: summary.files_discovered,
+            files_analyzed: summary.files_analyzed,
+            directories_count: summary.directories_count,
+            non_empty_lines: summary.non_empty_lines,
+            large_files_skipped: summary.large_files_skipped,
+            files_skipped_low_signal: summary.files_skipped_low_signal,
+            binary_files_skipped: summary.binary_files_skipped,
+            skipped_bytes: summary.skipped_bytes,
+            languages: &summary.languages,
+            findings: &summary.findings,
+            detected_frameworks: &summary.detected_frameworks,
+            framework_projects: &summary.framework_projects,
+            react_native: summary.react_native.as_ref(),
+            coupling_graph: summary.coupling_graph.as_ref(),
+            scan_duration_us: summary.scan_duration_us,
+            health_score: summary.health_score,
+            visible_findings_count: summary.visible_findings_count,
+            hidden_suggestions_count: summary.hidden_suggestions_count,
+            hidden_suggestions: &summary.hidden_suggestions,
+            visibility_profile: summary.visibility_profile.as_deref(),
+            files_skipped_by_limit: summary.files_skipped_by_limit,
+            files_skipped_repopilotignore: summary.files_skipped_repopilotignore,
+            repopilotignore_path: summary.repopilotignore_path.as_ref(),
+            scan_timings: summary.scan_timings.as_ref(),
+            cache_telemetry: summary.cache_telemetry.as_ref(),
+            diagnostics: &summary.diagnostics,
+            risk_summary: RiskSummary::from_findings(&summary.findings),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct BaselineJsonReport<'a> {
+    pub schema_version: &'static str,
+    pub repopilot_version: &'static str,
+    pub report: ReportEnvelope,
+    pub root_path: String,
+    pub files_analyzed: usize,
+    pub directories_count: usize,
+    pub non_empty_lines: usize,
+    pub large_files_skipped: usize,
+    pub skipped_bytes: u64,
+    pub mode: ScanMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_ref: Option<&'a str>,
+    pub changed_files_count: usize,
+    pub repo_level_rules_included: bool,
+    pub visible_findings_count: usize,
+    pub hidden_suggestions_count: usize,
+    #[serde(skip_serializing_if = "hidden_suggestions_empty")]
+    pub hidden_suggestions: &'a [HiddenSuggestionSummary],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility_profile: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_telemetry: Option<&'a ScanCacheTelemetry>,
+    #[serde(skip_serializing_if = "diagnostics_empty")]
+    pub diagnostics: &'a [ScanDiagnostic],
+    pub languages: &'a [LanguageSummary],
+    pub risk_summary: RiskSummary,
+    pub baseline: BaselineJsonMetadata,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_gate: Option<CiGateJsonMetadata>,
+    pub findings: Vec<FindingWithBaselineStatus<'a>>,
+}
+
+impl<'a> BaselineJsonReport<'a> {
+    pub fn from_report(report: &'a BaselineScanReport, ci_gate: Option<&CiGateResult>) -> Self {
+        Self {
+            schema_version: SCAN_REPORT_SCHEMA_VERSION,
+            repopilot_version: REPOPILOT_VERSION,
+            report: ReportEnvelope::baseline_scan(),
+            root_path: report.summary.root_path.to_string_lossy().to_string(),
+            files_analyzed: report.summary.files_analyzed,
+            directories_count: report.summary.directories_count,
+            non_empty_lines: report.summary.non_empty_lines,
+            large_files_skipped: report.summary.large_files_skipped,
+            skipped_bytes: report.summary.skipped_bytes,
+            mode: report.summary.mode,
+            base_ref: report.summary.base_ref.as_deref(),
+            changed_files_count: report.summary.changed_files_count,
+            repo_level_rules_included: report.summary.repo_level_rules_included,
+            visible_findings_count: report.summary.findings.len(),
+            hidden_suggestions_count: report.summary.hidden_suggestions_count,
+            hidden_suggestions: &report.summary.hidden_suggestions,
+            visibility_profile: report.summary.visibility_profile.as_deref(),
+            cache_telemetry: report.summary.cache_telemetry.as_ref(),
+            diagnostics: &report.summary.diagnostics,
+            languages: &report.summary.languages,
+            risk_summary: RiskSummary::from_findings(&report.summary.findings),
+            baseline: BaselineJsonMetadata {
+                path: report
+                    .baseline_path
+                    .as_ref()
+                    .map(|path| path.to_string_lossy().to_string()),
+                new_findings: report.new_count(),
+                existing_findings: report.existing_count(),
+            },
+            ci_gate: ci_gate.map(CiGateJsonMetadata::from),
+            findings: report
+                .summary
+                .findings
+                .iter()
+                .enumerate()
+                .map(|(index, finding)| FindingWithBaselineStatus {
+                    finding,
+                    baseline_status: report.finding_status(index),
+                })
+                .collect(),
+        }
+    }
+}
+
+fn hidden_suggestions_empty(value: &&[HiddenSuggestionSummary]) -> bool {
+    value.is_empty()
+}
+
+fn diagnostics_empty(value: &&[ScanDiagnostic]) -> bool {
+    value.is_empty()
+}
+
+#[derive(Debug, Serialize)]
+pub struct BaselineJsonMetadata {
+    pub path: Option<String>,
+    pub new_findings: usize,
+    pub existing_findings: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CiGateJsonMetadata {
+    pub fail_on: String,
+    pub status: &'static str,
+    pub failed_findings: usize,
+}
+
+impl From<&CiGateResult> for CiGateJsonMetadata {
+    fn from(result: &CiGateResult) -> Self {
+        Self {
+            fail_on: result.label(),
+            status: if result.passed() { "passed" } else { "failed" },
+            failed_findings: result.failed_findings,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct FindingWithBaselineStatus<'a> {
+    #[serde(flatten)]
+    pub finding: &'a Finding,
+    pub baseline_status: BaselineStatus,
+}
+
+pub fn parse_scan_summary_json(content: &str) -> Result<ScanSummary, serde_json::Error> {
+    let value: Value = serde_json::from_str(content)?;
+    parse_scan_summary_value(value)
+}
+
+pub fn parse_scan_summary_value(mut value: Value) -> Result<ScanSummary, serde_json::Error> {
+    migrate_scan_summary_value(&mut value);
+    serde_json::from_value(value)
+}
+
+fn migrate_scan_summary_value(value: &mut Value) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    copy_legacy_metric(object, "files_count", "files_analyzed");
+    copy_legacy_metric(object, "lines_of_code", "non_empty_lines");
+}
+
+fn copy_legacy_metric(object: &mut Map<String, Value>, legacy: &str, current: &str) {
+    if object.contains_key(current) {
+        return;
+    }
+    let Some(value) = object.get(legacy).cloned() else {
+        return;
+    };
+    object.insert(current.to_string(), value);
+}

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -99,6 +99,15 @@ pub struct ScanDiagnostic {
 }
 
 impl ScanDiagnostic {
+    pub fn error(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            severity: DiagnosticSeverity::Error,
+            message: message.into(),
+            path: None,
+        }
+    }
+
     pub fn warning(code: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             code: code.into(),
@@ -244,6 +253,18 @@ impl Default for ScanSummary {
 }
 
 impl ScanSummary {
+    pub fn has_error_diagnostics(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.severity == DiagnosticSeverity::Error)
+    }
+
+    pub fn first_error_diagnostic(&self) -> Option<&ScanDiagnostic> {
+        self.diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.severity == DiagnosticSeverity::Error)
+    }
+
     /// Computes the health score from findings and non-empty source lines.
     /// Penalty per finding type is normalized by project size (kloc) so large repos
     /// aren't unfairly penalized for having proportionally the same issue density.

--- a/tests/action_yml.rs
+++ b/tests/action_yml.rs
@@ -1,5 +1,11 @@
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+#[cfg(unix)]
+use std::process::Command;
+#[cfg(unix)]
+use tempfile::tempdir;
 
 #[test]
 fn action_exposes_typed_receipt_input_and_output() {
@@ -53,4 +59,100 @@ fn action_supports_doctor_as_markdown_auto_command() {
     assert!(helper.contains("doctor) RUN_ARGS=(doctor \"$PATH_INPUT\") ;;"));
     assert!(helper.contains("SARIF output and upload are only supported by 'scan'"));
     assert!(!helper.contains("ai-context|vibe"));
+}
+
+#[test]
+#[cfg(unix)]
+fn action_helper_routes_auto_scan_to_sarif_output() {
+    let temp = tempdir().expect("tempdir");
+    let capture = temp.path().join("args.txt");
+    let github_output = temp.path().join("github-output.txt");
+    let fake_bin = temp.path().join("bin");
+    fs::create_dir(&fake_bin).expect("create fake bin");
+    let fake_repopilot = fake_bin.join("repopilot");
+    fs::write(
+        &fake_repopilot,
+        r#"#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CAPTURE_ARGS"
+"#,
+    )
+    .expect("write fake repopilot");
+    let mut permissions = fs::metadata(&fake_repopilot).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_repopilot, permissions).expect("chmod fake repopilot");
+
+    let helper = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/repopilot-action.sh");
+    let output = Command::new("bash")
+        .arg(helper)
+        .env("PATH", format!("{}:{}", fake_bin.display(), env!("PATH")))
+        .env("CAPTURE_ARGS", &capture)
+        .env("GITHUB_OUTPUT", &github_output)
+        .env("INPUT_COMMAND", "scan")
+        .env("INPUT_FORMAT", "auto")
+        .env("INPUT_PATH", "src")
+        .output()
+        .expect("run helper");
+
+    assert!(
+        output.status.success(),
+        "helper failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let args = fs::read_to_string(capture).expect("read captured args");
+    assert_eq!(
+        args.lines().collect::<Vec<_>>(),
+        vec![
+            "scan",
+            "src",
+            "--format",
+            "sarif",
+            "--output",
+            "repopilot-results.sarif"
+        ]
+    );
+    assert!(
+        fs::read_to_string(github_output)
+            .expect("read github output")
+            .contains("sarif_file=repopilot-results.sarif")
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn action_helper_rejects_receipt_for_non_scan_before_running_repopilot() {
+    let temp = tempdir().expect("tempdir");
+    let capture = temp.path().join("args.txt");
+    let fake_bin = temp.path().join("bin");
+    fs::create_dir(&fake_bin).expect("create fake bin");
+    let fake_repopilot = fake_bin.join("repopilot");
+    fs::write(
+        &fake_repopilot,
+        r#"#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CAPTURE_ARGS"
+"#,
+    )
+    .expect("write fake repopilot");
+    let mut permissions = fs::metadata(&fake_repopilot).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_repopilot, permissions).expect("chmod fake repopilot");
+
+    let helper = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/repopilot-action.sh");
+    let output = Command::new("bash")
+        .arg(helper)
+        .env("PATH", format!("{}:{}", fake_bin.display(), env!("PATH")))
+        .env("CAPTURE_ARGS", &capture)
+        .env("INPUT_COMMAND", "review")
+        .env("INPUT_RECEIPT", "receipt.json")
+        .output()
+        .expect("run helper");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stdout)
+            .contains("Receipt output is only supported by 'scan'")
+    );
+    assert!(
+        !capture.exists(),
+        "validation should fail before invoking repopilot"
+    );
 }

--- a/tests/fixtures/reports/scan-v013.json
+++ b/tests/fixtures/reports/scan-v013.json
@@ -1,11 +1,24 @@
 {
   "schema_version": "0.13",
   "repopilot_version": "0.12.0",
+  "report": {
+    "kind": "scan",
+    "schema_version": "0.13",
+    "repopilot_version": "0.12.0"
+  },
   "root_path": ".",
   "files_analyzed": 2,
   "directories_count": 1,
   "non_empty_lines": 12,
   "large_files_skipped": 0,
+  "diagnostics": [
+    {
+      "code": "workspace.package-scan-failed",
+      "severity": "warning",
+      "message": "Package scan failed; results are partial.",
+      "path": "packages/api"
+    }
+  ],
   "findings": [],
   "languages": [],
   "risk_summary": {

--- a/tests/fixtures/risk/risk-v2-calibration.json
+++ b/tests/fixtures/risk/risk-v2-calibration.json
@@ -1,0 +1,125 @@
+{
+  "formula_version": "risk-v2",
+  "cases": [
+    {
+      "name": "p3_info_floor",
+      "rule_id": "code-marker.todo",
+      "category": "CODE_QUALITY",
+      "severity": "INFO",
+      "confidence": "MEDIUM",
+      "expected_score": 5,
+      "expected_priority": "P3",
+      "expected_signals": ["severity.info"]
+    },
+    {
+      "name": "p3_low_default",
+      "rule_id": "code-marker.todo",
+      "category": "CODE_QUALITY",
+      "severity": "LOW",
+      "confidence": "MEDIUM",
+      "expected_score": 20,
+      "expected_priority": "P3",
+      "expected_signals": ["severity.low"]
+    },
+    {
+      "name": "p2_medium_default",
+      "rule_id": "code-quality.long-function",
+      "category": "CODE_QUALITY",
+      "severity": "MEDIUM",
+      "confidence": "MEDIUM",
+      "expected_score": 45,
+      "expected_priority": "P2",
+      "expected_signals": ["severity.medium"]
+    },
+    {
+      "name": "p1_high_default",
+      "rule_id": "architecture.large-file",
+      "category": "ARCHITECTURE",
+      "severity": "HIGH",
+      "confidence": "MEDIUM",
+      "expected_score": 75,
+      "expected_priority": "P1",
+      "expected_signals": ["severity.high"]
+    },
+    {
+      "name": "p0_critical_default",
+      "rule_id": "security.private-key-candidate",
+      "category": "SECURITY",
+      "severity": "CRITICAL",
+      "confidence": "MEDIUM",
+      "expected_score": 100,
+      "expected_priority": "P0",
+      "expected_signals": ["severity.critical", "category.security"]
+    },
+    {
+      "name": "low_confidence_can_demote_high_severity",
+      "rule_id": "architecture.large-file",
+      "category": "ARCHITECTURE",
+      "severity": "HIGH",
+      "confidence": "LOW",
+      "expected_score": 60,
+      "expected_priority": "P2",
+      "expected_signals": ["severity.high", "confidence.low"]
+    },
+    {
+      "name": "security_high_boost_stays_p1",
+      "rule_id": "security.secret-candidate",
+      "category": "SECURITY",
+      "severity": "HIGH",
+      "confidence": "MEDIUM",
+      "expected_score": 87,
+      "expected_priority": "P1",
+      "expected_signals": ["severity.high", "category.security"]
+    },
+    {
+      "name": "review_diff_medium_boost",
+      "rule_id": "architecture.large-file",
+      "category": "ARCHITECTURE",
+      "severity": "MEDIUM",
+      "confidence": "MEDIUM",
+      "in_diff": true,
+      "expected_score": 57,
+      "expected_priority": "P2",
+      "expected_signals": ["severity.medium", "review.in-diff"]
+    },
+    {
+      "name": "graph_hub_medium_boost",
+      "rule_id": "code-quality.complex-file",
+      "category": "CODE_QUALITY",
+      "severity": "MEDIUM",
+      "confidence": "MEDIUM",
+      "graph_impact": "hub",
+      "expected_score": 53,
+      "expected_priority": "P2",
+      "expected_signals": ["severity.medium", "graph.hub"]
+    },
+    {
+      "name": "large_cluster_medium_boost",
+      "rule_id": "language.rust.panic-risk",
+      "category": "CODE_QUALITY",
+      "severity": "MEDIUM",
+      "confidence": "MEDIUM",
+      "cluster_size": 16,
+      "expected_score": 52,
+      "expected_priority": "P2",
+      "expected_signals": ["severity.medium", "cluster.repeated"]
+    },
+    {
+      "name": "stacked_security_diff_blast_radius_clamps_to_p0",
+      "rule_id": "security.secret-candidate",
+      "category": "SECURITY",
+      "severity": "HIGH",
+      "confidence": "MEDIUM",
+      "in_diff": true,
+      "blast_radius": true,
+      "expected_score": 100,
+      "expected_priority": "P0",
+      "expected_signals": [
+        "severity.high",
+        "category.security",
+        "review.in-diff",
+        "review.blast-radius"
+      ]
+    }
+  ]
+}

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -2,7 +2,9 @@ use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory,
 use repopilot::frameworks::ReactNativeArchitectureProfile;
 use repopilot::output::{OutputFormat, render_scan_summary};
 use repopilot::risk::{RiskInputs, RiskSummary, assess_finding};
-use repopilot::scan::types::{HiddenSuggestionSummary, LanguageSummary, ScanSummary};
+use repopilot::scan::types::{
+    DiagnosticSeverity, HiddenSuggestionSummary, LanguageSummary, ScanDiagnostic, ScanSummary,
+};
 use std::path::PathBuf;
 
 #[test]
@@ -187,4 +189,30 @@ fn json_scan_report_includes_hidden_suggestion_breakdown() {
     );
     assert_eq!(parsed["mode"], "full");
     assert_eq!(parsed["repo_level_rules_included"], true);
+}
+
+#[test]
+fn json_scan_report_includes_structured_diagnostics() {
+    let summary = ScanSummary {
+        root_path: PathBuf::from("demo"),
+        diagnostics: vec![ScanDiagnostic {
+            code: "workspace.package-scan-failed".to_string(),
+            severity: DiagnosticSeverity::Warning,
+            message: "Package scan failed; results are partial.".to_string(),
+            path: Some(PathBuf::from("packages/api")),
+        }],
+        ..ScanSummary::default()
+    };
+
+    let output =
+        render_scan_summary(&summary, OutputFormat::Json).expect("failed to render json summary");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("output should be valid json");
+
+    assert_eq!(
+        parsed["diagnostics"][0]["code"],
+        "workspace.package-scan-failed"
+    );
+    assert_eq!(parsed["diagnostics"][0]["severity"], "warning");
+    assert_eq!(parsed["diagnostics"][0]["path"], "packages/api");
 }

--- a/tests/output_sarif.rs
+++ b/tests/output_sarif.rs
@@ -41,6 +41,11 @@ fn renders_valid_sarif_scan_summary() {
 
     assert_eq!(parsed["version"], "2.1.0");
     assert!(parsed["runs"].is_array());
+    assert_eq!(parsed["runs"][0]["properties"]["report"]["kind"], "sarif");
+    assert_eq!(
+        parsed["runs"][0]["properties"]["report"]["schema_version"],
+        "2.1.0"
+    );
 }
 
 #[test]

--- a/tests/receipt_cli.rs
+++ b/tests/receipt_cli.rs
@@ -43,7 +43,9 @@ fn scan_writes_audit_receipt_json() {
     let receipt: Value = serde_json::from_slice(&fs::read(receipt_path).expect("read receipt"))
         .expect("valid receipt json");
 
-    assert_eq!(receipt["schema_version"], 3);
+    assert_eq!(receipt["schema_version"], 4);
+    assert_eq!(receipt["report"]["kind"], "receipt");
+    assert_eq!(receipt["report"]["schema_version"], "4");
     assert_eq!(receipt["tool"], "repopilot");
     assert!(receipt["version"].as_str().is_some());
     assert!(receipt["generated_at"].as_str().is_some());
@@ -65,6 +67,7 @@ fn scan_writes_audit_receipt_json() {
             .as_array()
             .is_some()
     );
+    assert!(receipt["diagnostics"].as_array().is_some());
     assert!(receipt["health_score"].as_u64().is_some());
 }
 

--- a/tests/report_schema_compat.rs
+++ b/tests/report_schema_compat.rs
@@ -1,3 +1,4 @@
+use repopilot::report::schema::parse_scan_summary_json;
 use serde_json::Value;
 
 #[test]
@@ -12,9 +13,15 @@ fn schema_fixtures_document_legacy_and_current_metric_names() {
     assert_eq!(legacy["lines_of_code"], 12);
 
     assert_eq!(current["schema_version"], "0.13");
+    assert_eq!(current["report"]["kind"], "scan");
+    assert_eq!(current["report"]["schema_version"], "0.13");
     assert_eq!(current["files_analyzed"], 2);
     assert_eq!(current["non_empty_lines"], 12);
     assert_eq!(current["large_files_skipped"], 0);
+    assert_eq!(
+        current["diagnostics"][0]["code"],
+        "workspace.package-scan-failed"
+    );
 }
 
 #[test]
@@ -36,4 +43,19 @@ fn legacy_metric_fallbacks_are_unambiguous_for_consumers() {
 
     assert_eq!(files_analyzed, 2);
     assert_eq!(non_empty_lines, 12);
+}
+
+#[test]
+fn migration_reader_accepts_legacy_and_current_report_shapes() {
+    let legacy = parse_scan_summary_json(include_str!("fixtures/reports/scan-v010.json"))
+        .expect("legacy report should migrate into ScanSummary");
+    let current = parse_scan_summary_json(include_str!("fixtures/reports/scan-v013.json"))
+        .expect("current report should parse into ScanSummary");
+
+    assert_eq!(legacy.files_analyzed, 2);
+    assert_eq!(legacy.non_empty_lines, 12);
+    assert_eq!(current.files_analyzed, 2);
+    assert_eq!(current.non_empty_lines, 12);
+    assert_eq!(current.diagnostics.len(), 1);
+    assert_eq!(current.diagnostics[0].code, "workspace.package-scan-failed");
 }

--- a/tests/risk_calibration.rs
+++ b/tests/risk_calibration.rs
@@ -1,9 +1,12 @@
-use repopilot::findings::types::Finding;
+use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
+use repopilot::risk::{GraphImpact, RiskInputs, assess_finding};
 use repopilot::risk::{RiskPriority, RiskSummary};
 use repopilot::scan::config::ScanConfig;
 use repopilot::scan::scanner::scan_path_with_config;
+use serde::Deserialize;
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 use tempfile::tempdir;
 
 #[test]
@@ -130,6 +133,45 @@ export function App() {
     assert_ne!(inline_style.risk.priority, RiskPriority::P0);
 }
 
+#[test]
+fn risk_v2_calibration_fixture_matches_snapshot_expectations() {
+    let fixture: RiskCalibrationFixture =
+        serde_json::from_str(include_str!("fixtures/risk/risk-v2-calibration.json"))
+            .expect("risk calibration fixture should parse");
+
+    assert_eq!(fixture.formula_version, "risk-v2");
+
+    for case in fixture.cases {
+        let finding = calibration_finding(&case);
+        let risk = assess_finding(&finding, None, case.inputs());
+        let signal_ids = risk
+            .signals
+            .iter()
+            .map(|signal| signal.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            risk.score, case.expected_score,
+            "unexpected score for {} with signals {:?}",
+            case.name, signal_ids
+        );
+        assert_eq!(
+            risk.priority, case.expected_priority,
+            "unexpected priority for {} with signals {:?}",
+            case.name, signal_ids
+        );
+        for expected_signal in &case.expected_signals {
+            assert!(
+                signal_ids.contains(&expected_signal.as_str()),
+                "{} missing expected risk signal `{}` in {:?}",
+                case.name,
+                expected_signal,
+                signal_ids
+            );
+        }
+    }
+}
+
 fn write_file(root: &Path, relative: &str, content: &str) {
     let path = root.join(relative);
     if let Some(parent) = path.parent() {
@@ -150,4 +192,67 @@ fn findings_for_rule<'a>(findings: &'a [Finding], rule_id: &str) -> Vec<&'a Find
         .iter()
         .filter(|finding| finding.rule_id == rule_id)
         .collect()
+}
+
+#[derive(Debug, Deserialize)]
+struct RiskCalibrationFixture {
+    formula_version: String,
+    cases: Vec<RiskCalibrationCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RiskCalibrationCase {
+    name: String,
+    rule_id: String,
+    category: FindingCategory,
+    severity: Severity,
+    confidence: Confidence,
+    #[serde(default)]
+    in_diff: bool,
+    #[serde(default)]
+    blast_radius: bool,
+    #[serde(default)]
+    cluster_size: usize,
+    graph_impact: Option<String>,
+    expected_score: u8,
+    expected_priority: RiskPriority,
+    expected_signals: Vec<String>,
+}
+
+impl RiskCalibrationCase {
+    fn inputs(&self) -> RiskInputs {
+        RiskInputs {
+            in_diff: self.in_diff,
+            blast_radius: self.blast_radius,
+            cluster_size: self.cluster_size,
+            graph_impact: self.graph_impact.as_deref().map(|value| match value {
+                "hub" => GraphImpact::Hub,
+                "dependency" => GraphImpact::Dependency,
+                other => panic!("unknown graph impact `{other}`"),
+            }),
+            ..RiskInputs::default()
+        }
+    }
+}
+
+fn calibration_finding(case: &RiskCalibrationCase) -> Finding {
+    Finding {
+        id: String::new(),
+        rule_id: case.rule_id.clone(),
+        title: case.name.clone(),
+        description: case.name.clone(),
+        recommendation: Finding::recommendation_for_rule_id(&case.rule_id),
+        category: case.category.clone(),
+        severity: case.severity,
+        confidence: case.confidence,
+        evidence: vec![Evidence {
+            path: PathBuf::from("src/main.rs"),
+            line_start: 1,
+            line_end: None,
+            snippet: String::new(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+        risk: Default::default(),
+    }
 }

--- a/tests/scan_summary.rs
+++ b/tests/scan_summary.rs
@@ -2,7 +2,7 @@ use repopilot::findings::types::{Finding, FindingCategory, Severity};
 use repopilot::scan::config::ScanConfig;
 use repopilot::scan::scanner::scan_path;
 use repopilot::scan::scanner::scan_path_with_config;
-use repopilot::scan::types::ScanSummary;
+use repopilot::scan::types::{ScanDiagnostic, ScanSummary};
 use std::fs;
 use tempfile::tempdir;
 
@@ -165,5 +165,31 @@ fn scan_result_includes_health_score() {
     assert!(
         summary.health_score > 0,
         "clean project should have positive health score"
+    );
+}
+
+#[test]
+fn diagnostic_helpers_separate_warnings_from_errors() {
+    let warning_summary = ScanSummary {
+        diagnostics: vec![ScanDiagnostic::warning(
+            "workspace.package-scan-failed",
+            "Package scan failed; results are partial.",
+        )],
+        ..ScanSummary::default()
+    };
+    let error_summary = ScanSummary {
+        diagnostics: vec![ScanDiagnostic::error(
+            "scanner.fatal-stage",
+            "A reportable scan stage failed.",
+        )],
+        ..ScanSummary::default()
+    };
+
+    assert!(!warning_summary.has_error_diagnostics());
+    assert!(warning_summary.first_error_diagnostic().is_none());
+    assert!(error_summary.has_error_diagnostics());
+    assert_eq!(
+        error_summary.first_error_diagnostic().unwrap().code,
+        "scanner.fatal-stage"
     );
 }


### PR DESCRIPTION
## Summary

This PR centralizes RepoPilot report schema handling and strengthens structured diagnostics across JSON, SARIF, receipts, scan output, and compare workflows.

It moves report DTO construction into a dedicated `report::schema` module, adds reusable report envelopes, improves diagnostics serialization, updates receipt schema to version 4, and ensures `compare` can parse both current and older scan report shapes.

## Type of change

- [x] Refactor
- [x] Feature
- [x] Tests
- [x] Documentation
- [x] Report/schema stabilization

## What changed

- Added dedicated `report::schema` module.
- Introduced reusable `ReportEnvelope`.
- Moved JSON scan report DTOs out of `output/json.rs`.
- Added structured report envelopes for:
  - scan reports;
  - baseline scan reports;
  - SARIF reports;
  - audit receipts.
- Updated JSON rendering to use:
  - `ScanJsonReport`
  - `BaselineJsonReport`
- Added report schema parsing helpers:
  - `parse_scan_summary_json`
  - `parse_scan_summary_value`
- Updated `compare` to parse reports through the schema layer instead of directly deserializing into internal `ScanSummary`.
- Improved compatibility with older JSON reports that used:
  - `files_count`
  - `lines_of_code`
  - missing `schema_version`
- Added diagnostics to receipt output.
- Updated audit receipt schema version to `4`.
- Added report envelope to receipts.
- Added diagnostics exit policy:
  - warning diagnostics stay report-only;
  - error diagnostics are written to report/receipt and then exit with runtime code `3`.
- Added SARIF run properties with report envelope metadata.
- Updated report documentation for diagnostics and receipt schema v4.
- Updated public API facade to export report schema helpers and DTOs.
- Added/updated tests for:
  - JSON report structure;
  - baseline report structure;
  - compare compatibility;
  - SARIF report envelope;
  - receipt diagnostics;
  - risk calibration fixtures.

## Why

RepoPilot reports are becoming a public integration surface.

As soon as users consume JSON/SARIF/receipt output in CI, dashboards, scripts, or GitHub Actions, report structure needs to be explicit and stable. Serializing internal scan models directly makes schema evolution risky.

This PR separates internal scan data from public report DTOs:

```text
ScanSummary
-> report::schema DTO
-> JSON / SARIF / receipt output
```

- That gives RepoPilot a cleaner path for future schema changes while keeping compatibility with older reports.

- Diagnostics also become more trustworthy: they are not just printed messages, but structured report data with a clear exit policy.

## Architecture notes

  - No god files introduced.
  - Report schema logic is centralized in src/report/schema.rs.
  - output/json.rs becomes a thin renderer over schema DTOs.
  - compare reads scan reports through schema parsing helpers.
  - SARIF report metadata is attached through ReportEnvelope.
  - Receipt schema is versioned independently and now includes diagnostics.
  - Scan command enforces diagnostic exit behavior after reports/receipts are written.
  - Public API facade now exposes the stable report schema layer.
  - Internal scan models can keep evolving without forcing downstream tools to depend on internal structure.

## Compatibility

- JSON scan schema remains 0.13.
- Receipt schema is updated to 4.
- Top-level schema_version and repopilot_version remain available.
- Consumers can prefer report.schema_version and report.repopilot_version.
- compare should continue to read older scan reports without schema_version.
- compare should continue to read older metric names:

  - files_count
  - lines_of_code
  - Diagnostics are optional and skipped when empty.

## Verification

Recommended checks:

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all

Smoke checks:

- cargo run -- scan . --format json --output /tmp/repopilot-scan.json
- cargo run -- scan . --format sarif --output /tmp/repopilot.sarif
- cargo run -- scan . --receipt /tmp/repopilot-receipt.json --format json --output /tmp/repopilot-scan-with-receipt.json
- cargo run -- scan . --baseline .repopilot/baseline.json --format json --output /tmp/repopilot-baseline.json
- cargo run -- compare /tmp/repopilot-scan.json /tmp/repopilot-scan.json