### PR TITLE
feat(scan): add granular timing and review report envelope

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,7 +86,8 @@ repopilot s <PATH> [OPTIONS]
 | `--min-severity` | `info\|low\|medium\|high\|critical` | — | Only show findings at or above this severity |
 | `--min-confidence` | `low\|medium\|high` | — | Only show findings at or above this confidence |
 | `--min-priority` | `p0\|p1\|p2\|p3` | — | Only show findings at or above this risk priority |
-| `--verbose` | flag | — | Print scan phase timing breakdown after the report |
+| `--verbose` | flag | — | Print scan/render timing after the report |
+| `--timing` | flag | — | Print pipeline timing for discovery, file analysis, framework detection, audits, enrichment, risk scoring, and report finalization |
 | `--preset` | `strict\|balanced\|lenient` | `balanced` | Apply a threshold preset without editing config |
 
 `files_discovered` in JSON output means files found after gitignore, `.repopilotignore`, built-in ignores, and `--exclude` filters. `files_analyzed` means analyzed text files; skipped large files, low-signal paths, binary/unreadable files, and files beyond `--max-files` are not included. JSON also includes `files_skipped_low_signal` and `binary_files_skipped`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -135,6 +135,10 @@ Use `--verbose` when you need scan and render timing:
 repopilot scan . --verbose
 ```
 
+Use `--timing` when you need the engine pipeline breakdown. It reports
+discovery, file analysis, framework detection, project audits, enrichment, risk
+scoring, and report finalization separately.
+
 ---
 
 ## AI workflows

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -46,6 +46,7 @@ JSON scan reports include explicit schema metadata. The current schema is 0.13:
 | `report` | object | Versioned report envelope for consumers that prefer metadata under one stable object. |
 | `risk_summary` | object | Aggregate priority counts and average risk score derived from finding risk assessments. |
 | `cache_telemetry` | object | Optional changed-scan cache summary with hits, misses, changed-file reasons, per-file cache decisions, and cache timing impact. |
+| `scan_timings` | object | Optional engine timing metadata. `file_scan_us` remains the compatibility aggregate; newer fields break out `discovery_us`, `file_analysis_us`, `enrichment_us`, `risk_scoring_us`, and `report_finalization_us`. |
 | `diagnostics` | array | Optional structured warnings/errors captured during a scan, such as workspace partial failures. |
 
 Diagnostics use `{ code, severity, message, path? }`. Recoverable diagnostics
@@ -112,6 +113,14 @@ Example shape:
   "findings": []
 }
 ```
+
+## Review JSON reports
+
+`repopilot review --format json` uses the same envelope policy with
+`report.kind = "review"`. Review reports include scan scope, changed files,
+blast-radius files, `risk_summary`, structured diagnostics, baseline metadata,
+CI gate metadata when requested, and per-finding `in_diff` / `baseline_status`
+classification.
 
 ## Audit receipt JSON
 

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -202,14 +202,20 @@ fn scan_visibility_profile(options: &ScanOptions) -> FindingVisibilityProfile {
 
 fn print_timing_breakdown(summary: &ScanSummary) {
     if let Some(timings) = &summary.scan_timings {
-        let total =
-            timings.file_scan_us + timings.framework_detection_us + timings.post_scan_audits_us;
         eprintln!(
             "\n[timing] File scan: {}ms · Framework detection: {}ms · Post-scan audits: {}ms · Engine total: {}ms",
             timings.file_scan_us / 1000,
             timings.framework_detection_us / 1000,
             timings.post_scan_audits_us / 1000,
-            total / 1000,
+            timings.accounted_engine_us() / 1000,
+        );
+        eprintln!(
+            "[timing] Pipeline: discovery {}ms · file analysis {}ms · enrichment {}ms · risk scoring {}ms · report finalization {}ms",
+            timings.discovery_us / 1000,
+            timings.file_analysis_us / 1000,
+            timings.enrichment_us / 1000,
+            timings.risk_scoring_us / 1000,
+            timings.report_finalization_us / 1000,
         );
     }
 

--- a/src/report/schema.rs
+++ b/src/report/schema.rs
@@ -39,6 +39,10 @@ impl ReportEnvelope {
         Self::new("baseline-scan", SCAN_REPORT_SCHEMA_VERSION)
     }
 
+    pub fn review() -> Self {
+        Self::new("review", SCAN_REPORT_SCHEMA_VERSION)
+    }
+
     pub fn sarif() -> Self {
         Self::new("sarif", "2.1.0")
     }

--- a/src/review/render/json.rs
+++ b/src/review/render/json.rs
@@ -1,8 +1,11 @@
 use crate::baseline::diff::BaselineStatus;
 use crate::baseline::gate::CiGateResult;
 use crate::findings::types::Finding;
+use crate::report::schema::{REPOPILOT_VERSION, ReportEnvelope, SCAN_REPORT_SCHEMA_VERSION};
 use crate::review::diff::ChangedFile;
 use crate::review::model::{ReviewReport, SeverityCounts};
+use crate::risk::RiskSummary;
+use crate::scan::types::ScanDiagnostic;
 use serde::Serialize;
 
 pub fn render_json(
@@ -27,6 +30,9 @@ pub fn render_json(
         .collect::<Vec<_>>();
 
     let output = ReviewJsonReport {
+        schema_version: SCAN_REPORT_SCHEMA_VERSION,
+        repopilot_version: REPOPILOT_VERSION,
+        report: ReportEnvelope::review(),
         root_path: report.summary.root_path.to_string_lossy().to_string(),
         git_root: report.repo_root.to_string_lossy().to_string(),
         files_analyzed: report.summary.files_analyzed,
@@ -45,6 +51,7 @@ pub fn render_json(
             existing_in_diff_findings: report.existing_in_diff_count(),
             severity_counts: report.severity_counts(),
         },
+        risk_summary: RiskSummary::from_findings(&report.summary.findings),
         baseline: ReviewBaselineJsonMetadata {
             path: report
                 .baseline_path
@@ -52,6 +59,7 @@ pub fn render_json(
                 .map(|path| path.to_string_lossy().to_string()),
         },
         ci_gate: ci_gate.map(ReviewCiGateJsonMetadata::from),
+        diagnostics: &report.summary.diagnostics,
         findings,
     };
 
@@ -60,6 +68,9 @@ pub fn render_json(
 
 #[derive(Serialize)]
 struct ReviewJsonReport<'a> {
+    schema_version: &'static str,
+    repopilot_version: &'static str,
+    report: ReportEnvelope,
     root_path: String,
     git_root: String,
     files_analyzed: usize,
@@ -68,10 +79,17 @@ struct ReviewJsonReport<'a> {
     changed_files: &'a [ChangedFile],
     blast_radius: Vec<String>,
     review: ReviewJsonMetadata,
+    risk_summary: RiskSummary,
     baseline: ReviewBaselineJsonMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]
     ci_gate: Option<ReviewCiGateJsonMetadata>,
+    #[serde(skip_serializing_if = "diagnostics_empty")]
+    diagnostics: &'a [ScanDiagnostic],
     findings: Vec<ReviewJsonFinding<'a>>,
+}
+
+fn diagnostics_empty(value: &&[ScanDiagnostic]) -> bool {
+    value.is_empty()
 }
 
 #[derive(Serialize)]

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -1,10 +1,17 @@
+#[doc(hidden)]
 pub mod cache;
 pub mod config;
+#[doc(hidden)]
 pub mod facts;
+#[doc(hidden)]
 pub mod language;
+#[doc(hidden)]
 pub mod markers;
 pub(crate) mod path_classification;
+#[doc(hidden)]
 pub mod scanner;
 pub mod types;
+#[doc(hidden)]
 pub mod workspace;
+#[doc(hidden)]
 pub mod workspace_scan;

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -36,7 +36,9 @@ pub fn scan_changed_with_config(
     base_ref: Option<&str>,
 ) -> io::Result<ScanSummary> {
     let start = Instant::now();
+    let discovery_start = Instant::now();
     let changed_scope = collect_changed_scope(path, base_ref)?;
+    let discovery_us = discovery_start.elapsed().as_micros() as u64;
     let repo_root = changed_scope.repo_root;
     let changed_files = changed_scope.changed_files;
 
@@ -242,13 +244,18 @@ pub fn scan_changed_with_config(
     facts.react_native = repo_context.react_native.clone();
     let framework_detection_us = framework_start.elapsed().as_micros() as u64;
 
+    let enrichment_start = Instant::now();
     for finding in &mut findings {
         finding.populate_recommendation();
         finding.id = stable_finding_key(finding, &repo_root);
     }
+    let enrichment_us = enrichment_start.elapsed().as_micros() as u64;
+    let risk_scoring_start = Instant::now();
     assess_findings(&mut findings, &repo_context);
     apply_graph_overlay(&mut findings, &coupling_graph);
     apply_cluster_overlay(&mut findings);
+    let risk_scoring_us = risk_scoring_start.elapsed().as_micros() as u64;
+    let finalization_start = Instant::now();
     super::summary::sort_findings(&mut findings);
 
     let cache_write_start = Instant::now();
@@ -259,7 +266,7 @@ pub fn scan_changed_with_config(
     facts.root_path = path.to_path_buf();
     let scan_duration_us = start.elapsed().as_micros() as u64;
 
-    Ok(build_scan_summary(
+    let mut summary = build_scan_summary(
         facts,
         findings,
         ScanSummaryParts {
@@ -270,14 +277,23 @@ pub fn scan_changed_with_config(
             coupling_graph: None,
             scan_duration_us,
             scan_timings: Some(ScanTimings {
+                discovery_us,
+                file_analysis_us: file_scan_us,
                 file_scan_us,
                 framework_detection_us,
                 post_scan_audits_us: 0,
+                enrichment_us,
+                risk_scoring_us,
+                report_finalization_us: 0,
             }),
             cache_telemetry: Some(cache_telemetry),
             diagnostics: Vec::new(),
         },
-    ))
+    );
+    if let Some(timings) = &mut summary.scan_timings {
+        timings.report_finalization_us = finalization_start.elapsed().as_micros() as u64;
+    }
+    Ok(summary)
 }
 
 fn detect_react_native_profile(

--- a/src/scan/scanner/collection.rs
+++ b/src/scan/scanner/collection.rs
@@ -1,4 +1,4 @@
-use super::file::{SkipReason, audit_file_inline, collect_file_facts, process_file};
+use super::file::{SkipReason, collect_file_facts, process_file};
 use super::summary::build_language_summary;
 use super::walker::collect_paths;
 use crate::audits::traits::FileAudit;
@@ -8,13 +8,26 @@ use crate::scan::facts::ScanFacts;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+pub(super) struct DiscoveredScanPaths {
+    pub(super) facts: ScanFacts,
+    pub(super) file_paths: Vec<PathBuf>,
+}
 
 pub(super) fn collect_and_audit_inline(
     path: &Path,
     config: &ScanConfig,
     file_audits: &[Box<dyn FileAudit>],
 ) -> io::Result<(ScanFacts, Vec<Finding>)> {
+    let discovered = discover_scan_paths(path, config)?;
+    analyze_discovered_files(discovered, file_audits, config)
+}
+
+pub(super) fn discover_scan_paths(
+    path: &Path,
+    config: &ScanConfig,
+) -> io::Result<DiscoveredScanPaths> {
     ensure_path_exists(path)?;
 
     let mut facts = ScanFacts {
@@ -24,18 +37,10 @@ pub(super) fn collect_and_audit_inline(
 
     if path.is_file() {
         facts.files_discovered = 1;
-        let mut languages: HashMap<String, usize> = HashMap::new();
-        let mut findings: Vec<Finding> = Vec::new();
-        audit_file_inline(
-            path,
-            &mut facts,
-            &mut languages,
-            file_audits,
-            config,
-            &mut findings,
-        )?;
-        facts.languages = build_language_summary(languages);
-        return Ok((facts, findings));
+        return Ok(DiscoveredScanPaths {
+            facts,
+            file_paths: vec![path.to_path_buf()],
+        });
     }
 
     let collected = collect_paths(path, config)?;
@@ -47,6 +52,19 @@ pub(super) fn collect_and_audit_inline(
     facts.directories_count = collected.directories_count;
 
     apply_max_files_limit(&mut file_paths, &mut facts, config);
+
+    Ok(DiscoveredScanPaths { facts, file_paths })
+}
+
+pub(super) fn analyze_discovered_files(
+    discovered: DiscoveredScanPaths,
+    file_audits: &[Box<dyn FileAudit>],
+    config: &ScanConfig,
+) -> io::Result<(ScanFacts, Vec<Finding>)> {
+    let DiscoveredScanPaths {
+        mut facts,
+        file_paths,
+    } = discovered;
 
     let results: Vec<io::Result<_>> = file_paths
         .par_iter()

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -87,30 +87,6 @@ fn process_file_inner(
     })
 }
 
-pub(super) fn audit_file_inline(
-    path: &Path,
-    facts: &mut ScanFacts,
-    languages: &mut HashMap<String, usize>,
-    file_audits: &[Box<dyn FileAudit>],
-    config: &ScanConfig,
-    findings: &mut Vec<Finding>,
-) -> io::Result<()> {
-    let LoadedFile::Analyzable { full_facts, .. } = load_file_or_record_skip(path, facts, config)?
-    else {
-        return Ok(());
-    };
-
-    record_analyzed_file(facts, languages, &full_facts);
-
-    for audit in file_audits {
-        findings.extend(audit.audit(&full_facts, config));
-    }
-
-    facts.files.push(without_content(full_facts));
-
-    Ok(())
-}
-
 pub(super) fn collect_file_facts(
     path: &Path,
     facts: &mut ScanFacts,

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -45,6 +45,11 @@ struct FileAnalysisStage {
     elapsed_us: u64,
 }
 
+struct DiscoveryStage {
+    discovered: collection::DiscoveredScanPaths,
+    elapsed_us: u64,
+}
+
 struct FrameworkDetectionStage {
     facts: crate::scan::facts::ScanFacts,
     elapsed_us: u64,
@@ -64,19 +69,45 @@ impl<'a> ScanEngine<'a> {
 
     pub fn run(self) -> io::Result<ScanSummary> {
         let start = Instant::now();
-        let file_stage = self.run_file_analysis()?;
+        let discovery_stage = self.run_discovery()?;
+        let file_stage = self.run_file_analysis(discovery_stage.discovered)?;
         let framework_stage = self.run_framework_detection(file_stage.facts);
         let mut project_stage =
             self.run_project_analysis(framework_stage.facts, file_stage.findings);
 
-        self.enrich_findings(
+        let enrichment_us = self.enrich_findings(&mut project_stage.findings);
+        let risk_scoring_us = self.score_findings(
             &project_stage.facts,
             &project_stage.coupling_graph,
             &mut project_stage.findings,
         );
 
         let scan_duration_us = start.elapsed().as_micros() as u64;
-        Ok(build_scan_summary(
+        let timings = ScanTimings {
+            discovery_us: discovery_stage.elapsed_us,
+            file_analysis_us: file_stage.elapsed_us,
+            file_scan_us: discovery_stage
+                .elapsed_us
+                .saturating_add(file_stage.elapsed_us),
+            framework_detection_us: framework_stage.elapsed_us,
+            post_scan_audits_us: project_stage.elapsed_us,
+            enrichment_us,
+            risk_scoring_us,
+            report_finalization_us: 0,
+        };
+
+        Ok(self.finalize_report(project_stage, scan_duration_us, timings))
+    }
+
+    fn finalize_report(
+        &self,
+        mut project_stage: ProjectAnalysisStage,
+        scan_duration_us: u64,
+        timings: ScanTimings,
+    ) -> ScanSummary {
+        let finalization_start = Instant::now();
+        summary::sort_findings(&mut project_stage.findings);
+        let mut summary = build_scan_summary(
             project_stage.facts,
             project_stage.findings,
             ScanSummaryParts {
@@ -86,22 +117,34 @@ impl<'a> ScanEngine<'a> {
                 repo_level_rules_included: true,
                 coupling_graph: Some(project_stage.coupling_graph),
                 scan_duration_us,
-                scan_timings: Some(ScanTimings {
-                    file_scan_us: file_stage.elapsed_us,
-                    framework_detection_us: framework_stage.elapsed_us,
-                    post_scan_audits_us: project_stage.elapsed_us,
-                }),
+                scan_timings: Some(timings),
                 cache_telemetry: None,
                 diagnostics: Vec::new(),
             },
-        ))
+        );
+        if let Some(timings) = &mut summary.scan_timings {
+            timings.report_finalization_us = finalization_start.elapsed().as_micros() as u64;
+        }
+        summary
     }
 
-    fn run_file_analysis(&self) -> io::Result<FileAnalysisStage> {
+    fn run_discovery(&self) -> io::Result<DiscoveryStage> {
+        let start = Instant::now();
+        let discovered = collection::discover_scan_paths(self.path, self.config)?;
+        Ok(DiscoveryStage {
+            discovered,
+            elapsed_us: start.elapsed().as_micros() as u64,
+        })
+    }
+
+    fn run_file_analysis(
+        &self,
+        discovered: collection::DiscoveredScanPaths,
+    ) -> io::Result<FileAnalysisStage> {
         let start = Instant::now();
         let file_audits = build_file_audits(self.config);
         let (facts, findings) =
-            collection::collect_and_audit_inline(self.path, self.config, &file_audits)?;
+            collection::analyze_discovered_files(discovered, &file_audits, self.config)?;
         Ok(FileAnalysisStage {
             facts,
             findings,
@@ -167,21 +210,27 @@ impl<'a> ScanEngine<'a> {
         }
     }
 
-    fn enrich_findings(
-        &self,
-        facts: &crate::scan::facts::ScanFacts,
-        coupling_graph: &crate::graph::CouplingGraph,
-        findings: &mut [crate::findings::types::Finding],
-    ) {
+    fn enrich_findings(&self, findings: &mut [crate::findings::types::Finding]) -> u64 {
+        let start = Instant::now();
         for finding in findings.iter_mut() {
             finding.populate_recommendation();
             finding.id = stable_finding_key(finding, self.path);
         }
+        start.elapsed().as_micros() as u64
+    }
+
+    fn score_findings(
+        &self,
+        facts: &crate::scan::facts::ScanFacts,
+        coupling_graph: &crate::graph::CouplingGraph,
+        findings: &mut [crate::findings::types::Finding],
+    ) -> u64 {
+        let start = Instant::now();
         assess_findings(findings, facts);
         // Graph and cluster overlays are kept after the base scoring pass because
         // they depend on the complete cross-file project view.
         apply_graph_overlay(findings, coupling_graph);
         apply_cluster_overlay(findings);
-        summary::sort_findings(findings);
+        start.elapsed().as_micros() as u64
     }
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -24,12 +24,42 @@ pub struct Marker {
 /// Per-phase wall-clock timings captured during a scan.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ScanTimings {
+    /// Time spent discovering candidate files before analysis (microseconds).
+    #[serde(default)]
+    pub discovery_us: u64,
+    /// Time spent loading files and running per-file audits (microseconds).
+    #[serde(default)]
+    pub file_analysis_us: u64,
     /// Time spent walking the file tree and running per-file audits (microseconds).
     pub file_scan_us: u64,
     /// Time spent detecting frameworks (microseconds).
     pub framework_detection_us: u64,
     /// Time spent running project, framework, and coupling audits (microseconds).
     pub post_scan_audits_us: u64,
+    /// Time spent populating recommendations, IDs, and derived finding metadata.
+    #[serde(default)]
+    pub enrichment_us: u64,
+    /// Time spent applying risk scoring and risk overlays.
+    #[serde(default)]
+    pub risk_scoring_us: u64,
+    /// Time spent building the final report summary object.
+    #[serde(default)]
+    pub report_finalization_us: u64,
+}
+
+impl ScanTimings {
+    pub fn accounted_engine_us(&self) -> u64 {
+        let file_pipeline_us = self
+            .file_scan_us
+            .max(self.discovery_us.saturating_add(self.file_analysis_us));
+
+        file_pipeline_us
+            .saturating_add(self.framework_detection_us)
+            .saturating_add(self.post_scan_audits_us)
+            .saturating_add(self.enrichment_us)
+            .saturating_add(self.risk_scoring_us)
+            .saturating_add(self.report_finalization_us)
+    }
 }
 
 /// Cache effectiveness and per-file cache decisions captured during changed scans.

--- a/tests/parallel_scan.rs
+++ b/tests/parallel_scan.rs
@@ -58,6 +58,27 @@ fn scan_duration_is_recorded() {
     );
 }
 
+#[test]
+fn scan_timings_expose_pipeline_stage_breakdown() {
+    let temp = tempdir().unwrap();
+    fs::write(temp.path().join("file.rs"), "fn main() {}\n").unwrap();
+
+    let summary = scan_path_with_config(temp.path(), &ScanConfig::default()).unwrap();
+    let timings = summary
+        .scan_timings
+        .expect("full scan should expose engine timings");
+
+    assert_eq!(
+        timings.file_scan_us,
+        timings.discovery_us + timings.file_analysis_us,
+        "legacy file_scan_us should remain the discovery + file analysis aggregate"
+    );
+    assert!(
+        timings.accounted_engine_us() >= timings.file_scan_us,
+        "accounted timing should include file scan plus later pipeline stages"
+    );
+}
+
 /// Verifies that parallel scan handles an empty directory cleanly without panicking.
 #[test]
 fn parallel_scan_empty_directory() {

--- a/tests/review_command.rs
+++ b/tests/review_command.rs
@@ -23,6 +23,9 @@ fn review_reports_working_tree_findings_on_changed_lines() {
 
     let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
 
+    assert_eq!(json["schema_version"], "0.13");
+    assert_eq!(json["report"]["kind"], "review");
+    assert!(json["risk_summary"]["total"].as_u64().is_some());
     assert_eq!(json["review"]["in_diff_findings"], 1);
     assert_eq!(json["review"]["out_of_diff_findings"], 0);
     assert_eq!(json["changed_files"][0]["path"], "src/lib.rs");

--- a/tests/scan_summary.rs
+++ b/tests/scan_summary.rs
@@ -2,7 +2,7 @@ use repopilot::findings::types::{Finding, FindingCategory, Severity};
 use repopilot::scan::config::ScanConfig;
 use repopilot::scan::scanner::scan_path;
 use repopilot::scan::scanner::scan_path_with_config;
-use repopilot::scan::types::{ScanDiagnostic, ScanSummary};
+use repopilot::scan::types::{ScanDiagnostic, ScanSummary, ScanTimings};
 use std::fs;
 use tempfile::tempdir;
 
@@ -192,4 +192,20 @@ fn diagnostic_helpers_separate_warnings_from_errors() {
         error_summary.first_error_diagnostic().unwrap().code,
         "scanner.fatal-stage"
     );
+}
+
+#[test]
+fn timing_accounting_uses_granular_file_pipeline_when_available() {
+    let timings = ScanTimings {
+        discovery_us: 10,
+        file_analysis_us: 40,
+        file_scan_us: 40,
+        framework_detection_us: 5,
+        post_scan_audits_us: 7,
+        enrichment_us: 3,
+        risk_scoring_us: 2,
+        report_finalization_us: 1,
+    };
+
+    assert_eq!(timings.accounted_engine_us(), 68);
 }


### PR DESCRIPTION
## Summary

This PR improves RepoPilot's scan observability and machine-readable review reports.

It adds granular scan pipeline timings, including discovery, file analysis, enrichment, risk scoring, and report finalization. It also adds a proper review JSON report envelope so `repopilot review --format json` follows the same schema policy as scan, baseline, SARIF, and receipt outputs.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] Report/schema stabilization

## What changed

- Added granular `ScanTimings` fields:
  - `discovery_us`
  - `file_analysis_us`
  - `enrichment_us`
  - `risk_scoring_us`
  - `report_finalization_us`
- Kept `file_scan_us` as a compatibility aggregate.
- Added `ScanTimings::accounted_engine_us()`.
- Updated `--timing` output to show the full scan pipeline breakdown.
- Split full scan execution into clearer stages:
  - discovery
  - file analysis
  - framework detection
  - project audits
  - enrichment
  - risk scoring
  - report finalization
- Added `ReportEnvelope::review()`.
- Added schema metadata to review JSON output:
  - `schema_version`
  - `repopilot_version`
  - `report.kind = "review"`
- Added `risk_summary` and diagnostics to review JSON output.
- Updated report docs with review JSON schema notes.
- Updated scan timing docs for the new pipeline timing fields.
- Marked selected internal scan modules as `#[doc(hidden)]` to keep the public API surface cleaner.
- Added tests for:
  - scan timing breakdown;
  - timing accounting;
  - review JSON report envelope;
  - review JSON risk summary.

## Why

RepoPilot needs better observability as the scan engine becomes more structured.

A single `file_scan_us` number is not enough once the engine includes discovery, file analysis, repo context, enrichment, risk scoring, cache, diagnostics, and report finalization. Granular timing helps debug performance and makes future optimization easier.

Review JSON also needs the same report-envelope policy as other machine-readable outputs. This makes downstream CI integrations more predictable.

## Architecture notes

- No god files introduced.
- Full scan execution is now closer to a staged engine pipeline.
- `file_scan_us` remains available for compatibility.
- New timing fields are additive and default-safe.
- Review JSON now participates in the report envelope model.
- Machine-readable review output includes risk and diagnostics metadata.
- Internal scan modules are hidden from generated public docs where appropriate.

## Compatibility

- Existing `--verbose` remains available for high-level scan/render timing.
- `--timing` now gives deeper engine pipeline timing.
- `file_scan_us` remains present.
- New timing fields are additive.
- Review JSON now includes schema metadata and report envelope fields.
- Existing review JSON consumers may see additional fields but existing core fields remain available.

## Verification

Recommended checks:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```