### PR TITLE
feat(release): prepare 0.12 launch with feedback diagnostics and CI gates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,10 @@ jobs:
 
       - name: Test
         run: cargo test --all
+
+      - name: RepoPilot CI gate
+        run: cargo run -- scan . --baseline .repopilot/baseline.json --fail-on new-high --format markdown --output /tmp/repopilot-ci.md
+
       - name: CLI release smoke tests
         run: cargo test --test cli_release_smoke
       - name: Install Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   build:
@@ -77,6 +79,13 @@ jobs:
           Get-FileHash "dist/${AssetName}.zip" -Algorithm SHA256 | ForEach-Object { "$($_.Hash.ToLower())  ${AssetName}.zip" } | Out-File -Encoding ascii "dist/${AssetName}.zip.sha256"
           echo "ASSET=dist/${AssetName}.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "CHECKSUM=dist/${AssetName}.zip.sha256" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Generate artifact attestations
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            ${{ env.ASSET }}
+            ${{ env.CHECKSUM }}
 
       - name: Upload packaged artifact
         uses: actions/upload-artifact@v7

--- a/.repopilot/baseline.json
+++ b/.repopilot/baseline.json
@@ -1,0 +1,890 @@
+{
+  "schema_version": 1,
+  "tool": "repopilot",
+  "created_at": "2026-05-19T23:08:59Z",
+  "root": ".",
+  "findings": [
+    {
+      "key": "architecture.large-file:src/audits/security/secret_candidate.rs:1",
+      "rule_id": "architecture.large-file",
+      "severity": "medium",
+      "path": "src/audits/security/secret_candidate.rs",
+      "message": "Large file detected"
+    },
+    {
+      "key": "architecture.large-file:src/output/console/sections.rs:1",
+      "rule_id": "architecture.large-file",
+      "severity": "medium",
+      "path": "src/output/console/sections.rs",
+      "message": "Large file detected"
+    },
+    {
+      "key": "architecture.large-file:src/output/markdown/sections.rs:1",
+      "rule_id": "architecture.large-file",
+      "severity": "medium",
+      "path": "src/output/markdown/sections.rs",
+      "message": "Large file detected"
+    },
+    {
+      "key": "architecture.large-file:src/report/schema.rs:1",
+      "rule_id": "architecture.large-file",
+      "severity": "medium",
+      "path": "src/report/schema.rs",
+      "message": "Large file detected"
+    },
+    {
+      "key": "architecture.large-file:src/scan/cache.rs:1",
+      "rule_id": "architecture.large-file",
+      "severity": "medium",
+      "path": "src/scan/cache.rs",
+      "message": "Large file detected"
+    },
+    {
+      "key": "architecture.large-file:src/scan/scanner/changed.rs:1",
+      "rule_id": "architecture.large-file",
+      "severity": "medium",
+      "path": "src/scan/scanner/changed.rs",
+      "message": "Large file detected"
+    },
+    {
+      "key": "architecture.too-many-modules:docs:1",
+      "rule_id": "architecture.too-many-modules",
+      "severity": "medium",
+      "path": "docs",
+      "message": "Directory contains too many modules"
+    },
+    {
+      "key": "code-quality.complex-file:src/audits/code_quality/complexity.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/audits/code_quality/complexity.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/audits/code_quality/long_function/brace.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/audits/code_quality/long_function/brace.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/audits/code_quality/long_function/python.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/audits/code_quality/long_function/python.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/audits/code_quality/sanitize.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/audits/code_quality/sanitize.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/audits/context/classify/frameworks.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/audits/context/classify/frameworks.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/audits/context/classify/paradigms.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/audits/context/classify/paradigms.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/audits/context/classify/runtimes.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/audits/context/classify/runtimes.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/audits/framework/react_native/async_storage.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/audits/framework/react_native/async_storage.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/audits/security/secret_candidate.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/audits/security/secret_candidate.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/audits/testing/source_without_test/classification.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/audits/testing/source_without_test/classification.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/baseline/key.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/baseline/key.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/cli/mod.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/cli/mod.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/doctor/checks/helpers.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "low",
+      "path": "src/doctor/checks/helpers.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/frameworks/detector/go.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/frameworks/detector/go.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/frameworks/detector/js.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/frameworks/detector/js.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/frameworks/react_native/detector/config.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/frameworks/react_native/detector/config.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/graph/imports/common.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/graph/imports/common.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/graph/imports/go.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/graph/imports/go.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/graph/imports/jvm.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/graph/imports/jvm.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/graph/imports/rust.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/graph/imports/rust.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/output/console/baseline.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/output/console/baseline.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/output/console/react_native.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/output/console/react_native.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/scan/markers.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/scan/markers.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.complex-file:src/scan/workspace.rs:1",
+      "rule_id": "code-quality.complex-file",
+      "severity": "medium",
+      "path": "src/scan/workspace.rs",
+      "message": "High complexity density"
+    },
+    {
+      "key": "code-quality.long-function:scripts/build-npm-platform-packages.js:191-244",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "scripts/build-npm-platform-packages.js",
+      "message": "Large generic production code function: `buildPlatformPackage`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/architecture/barrel_file_risk.rs:97-290",
+      "rule_id": "code-quality.long-function",
+      "severity": "low",
+      "path": "src/audits/architecture/barrel_file_risk.rs",
+      "message": "Large test code function: `is_re_export_line`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/code_quality/complexity.rs:14-72",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/code_quality/complexity.rs",
+      "message": "Large Rust production code function: `audit`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/code_quality/long_function/brace.rs:120-246",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/code_quality/long_function/brace.rs",
+      "message": "Large Rust production code function: `is_function_start`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/code_quality/long_function/brace.rs:4-88",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/code_quality/long_function/brace.rs",
+      "message": "Large Rust production code function: `detect_brace_based`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/code_quality/long_function/python.rs:4-65",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/code_quality/long_function/python.rs",
+      "message": "Large Rust production code function: `detect_python`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/code_quality/sanitize.rs:12-84",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/code_quality/sanitize.rs",
+      "message": "Large Rust production code function: `sanitize_c_style`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/framework/react_native/async_storage.rs:10-60",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/framework/react_native/async_storage.rs",
+      "message": "Large Rust production code function: `audit`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/framework/react_native/navigation.rs:10-68",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/framework/react_native/navigation.rs",
+      "message": "Large Rust production code function: `audit`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/framework/react_native/navigation.rs:74-126",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/framework/react_native/navigation.rs",
+      "message": "Large Rust production code function: `audit`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/framework/react_native/styling.rs:10-214",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/framework/react_native/styling.rs",
+      "message": "Large Rust production code function: `audit`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/framework/rn_dep_health.rs:9-192",
+      "rule_id": "code-quality.long-function",
+      "severity": "low",
+      "path": "src/audits/framework/rn_dep_health.rs",
+      "message": "Large test code function: `audit`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/pipeline/file_audits.rs:16-91",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/pipeline/file_audits.rs",
+      "message": "Large Rust production code function: `registered_file_audits`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/pipeline/framework_audits.rs:19-177",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/pipeline/framework_audits.rs",
+      "message": "Large Rust production code function: `registered_framework_audits`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/pipeline/framework_audits.rs:196-253",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/pipeline/framework_audits.rs",
+      "message": "Large Rust production code function: `detect_framework_scope`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/pipeline/project_audits.rs:14-84",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/pipeline/project_audits.rs",
+      "message": "Large Rust production code function: `registered_project_audits`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/security/secret_candidate.rs:145-407",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/security/secret_candidate.rs",
+      "message": "Large Rust production code function: `is_secret_literal`"
+    },
+    {
+      "key": "code-quality.long-function:src/audits/testing/source_without_test/classification.rs:25-93",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/audits/testing/source_without_test/classification.rs",
+      "message": "Large Rust production code function: `is_low_signal_wrapper`"
+    },
+    {
+      "key": "code-quality.long-function:src/commands/review.rs:15-101",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/commands/review.rs",
+      "message": "Large Rust production code function: `run`"
+    },
+    {
+      "key": "code-quality.long-function:src/commands/scan.rs:22-190",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/commands/scan.rs",
+      "message": "Large Rust production code function: `run`"
+    },
+    {
+      "key": "code-quality.long-function:src/compare/diff.rs:18-68",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/compare/diff.rs",
+      "message": "Large Rust production code function: `diff_summaries`"
+    },
+    {
+      "key": "code-quality.long-function:src/compare/render.rs:80-134",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/compare/render.rs",
+      "message": "Large Rust production code function: `render_markdown`"
+    },
+    {
+      "key": "code-quality.long-function:src/compare/render.rs:9-78",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/compare/render.rs",
+      "message": "Large Rust production code function: `render_console`"
+    },
+    {
+      "key": "code-quality.long-function:src/doctor/checks/mod.rs:113-225",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/doctor/checks/mod.rs",
+      "message": "Large Rust production code function: `build_doctor_report`"
+    },
+    {
+      "key": "code-quality.long-function:src/doctor/checks/mod.rs:42-111",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/doctor/checks/mod.rs",
+      "message": "Large Rust production code function: `build_recommendations`"
+    },
+    {
+      "key": "code-quality.long-function:src/doctor/render.rs:17-95",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/doctor/render.rs",
+      "message": "Large Rust production code function: `render_console`"
+    },
+    {
+      "key": "code-quality.long-function:src/doctor/render.rs:97-182",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/doctor/render.rs",
+      "message": "Large Rust production code function: `render_markdown`"
+    },
+    {
+      "key": "code-quality.long-function:src/explain/render.rs:119-218",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/explain/render.rs",
+      "message": "Large Rust production code function: `render_markdown`"
+    },
+    {
+      "key": "code-quality.long-function:src/explain/render.rs:17-74",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/explain/render.rs",
+      "message": "Large Rust production code function: `render_console`"
+    },
+    {
+      "key": "code-quality.long-function:src/frameworks/detector/js.rs:5-80",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/frameworks/detector/js.rs",
+      "message": "Large Rust production code function: `detect_js_frameworks`"
+    },
+    {
+      "key": "code-quality.long-function:src/frameworks/react_native/detector/mod.rs:13-130",
+      "rule_id": "code-quality.long-function",
+      "severity": "low",
+      "path": "src/frameworks/react_native/detector/mod.rs",
+      "message": "Large test code function: `detect_react_native_architecture`"
+    },
+    {
+      "key": "code-quality.long-function:src/graph/imports/rust.rs:45-162",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/graph/imports/rust.rs",
+      "message": "Large Rust production code function: `rust_mod_import`"
+    },
+    {
+      "key": "code-quality.long-function:src/knowledge/catalog/mod.rs:13-128",
+      "rule_id": "code-quality.long-function",
+      "severity": "low",
+      "path": "src/knowledge/catalog/mod.rs",
+      "message": "Large test code function: `build_knowledge_catalog_report`"
+    },
+    {
+      "key": "code-quality.long-function:src/knowledge/catalog/render.rs:17-96",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/knowledge/catalog/render.rs",
+      "message": "Large Rust production code function: `render_console`"
+    },
+    {
+      "key": "code-quality.long-function:src/knowledge/catalog/render.rs:98-183",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/knowledge/catalog/render.rs",
+      "message": "Large Rust production code function: `render_markdown`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/console/findings.rs:43-93",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/console/findings.rs",
+      "message": "Large Rust production code function: `render_finding`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/console/sections.rs:11-67",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/console/sections.rs",
+      "message": "Large Rust production code function: `render_header`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/console/sections.rs:136-192",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/console/sections.rs",
+      "message": "Large Rust production code function: `render_cache_telemetry`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/console/sections.rs:407-462",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/console/sections.rs",
+      "message": "Large Rust production code function: `render_scan_input`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/console/workspace.rs:5-56",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/console/workspace.rs",
+      "message": "Large Rust production code function: `workspace_risk_table`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/html/document.rs:18-73",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/html/document.rs",
+      "message": "Large Rust production code function: `render_document`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/html/finding.rs:54-148",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/html/finding.rs",
+      "message": "Large Rust production code function: `render_finding_card`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/html/sections.rs:105-159",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/html/sections.rs",
+      "message": "Large Rust production code function: `render_risk_section`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/markdown/findings.rs:96-157",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/markdown/findings.rs",
+      "message": "Large Rust production code function: `render_finding_detail`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/markdown/react_native.rs:5-75",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/markdown/react_native.rs",
+      "message": "Large Rust production code function: `render_react_native_section`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/markdown/sections.rs:10-69",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/markdown/sections.rs",
+      "message": "Large Rust production code function: `render_overview`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/markdown/sections.rs:138-198",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/markdown/sections.rs",
+      "message": "Large Rust production code function: `render_cache_telemetry`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/report_stats.rs:44-101",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/report_stats.rs",
+      "message": "Large Rust production code function: `build_report_stats`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/vibe.rs:95-200",
+      "rule_id": "code-quality.long-function",
+      "severity": "low",
+      "path": "src/output/vibe.rs",
+      "message": "Large test code function: `render_internal`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/vibe/findings.rs:78-153",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/vibe/findings.rs",
+      "message": "Large Rust production code function: `render_category`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/vibe/header.rs:7-76",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/vibe/header.rs",
+      "message": "Large Rust production code function: `render_header`"
+    },
+    {
+      "key": "code-quality.long-function:src/output/vibe/header.rs:80-161",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/output/vibe/header.rs",
+      "message": "Large Rust production code function: `render_task_instruction`"
+    },
+    {
+      "key": "code-quality.long-function:src/report/schema.rs:259-309",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/report/schema.rs",
+      "message": "Large Rust production code function: `from_report`"
+    },
+    {
+      "key": "code-quality.long-function:src/review/diff.rs:137-203",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/review/diff.rs",
+      "message": "Large Rust production code function: `parse_diff`"
+    },
+    {
+      "key": "code-quality.long-function:src/review/mod.rs:139-196",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/review/mod.rs",
+      "message": "Large Rust production code function: `review_report_for_ci`"
+    },
+    {
+      "key": "code-quality.long-function:src/review/render/console.rs:6-67",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/review/render/console.rs",
+      "message": "Large Rust production code function: `render_console`"
+    },
+    {
+      "key": "code-quality.long-function:src/review/render/markdown.rs:8-88",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/review/render/markdown.rs",
+      "message": "Large Rust production code function: `render_markdown`"
+    },
+    {
+      "key": "code-quality.long-function:src/risk/context.rs:7-127",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/risk/context.rs",
+      "message": "Large Rust production code function: `add_file_context_signals`"
+    },
+    {
+      "key": "code-quality.long-function:src/risk/scoring.rs:22-107",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/risk/scoring.rs",
+      "message": "Large Rust production code function: `assess_finding`"
+    },
+    {
+      "key": "code-quality.long-function:src/scan/scanner/changed.rs:106-160",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/scan/scanner/changed.rs",
+      "message": "Large Rust production code function: `run_file_analysis`"
+    },
+    {
+      "key": "code-quality.long-function:src/scan/scanner/changed.rs:163-330",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/scan/scanner/changed.rs",
+      "message": "Large Rust production code function: `process_changed_file`"
+    },
+    {
+      "key": "code-quality.long-function:src/scan/scanner/changed.rs:410-467",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/scan/scanner/changed.rs",
+      "message": "Large Rust production code function: `finalize_report`"
+    },
+    {
+      "key": "code-quality.long-function:src/scan/workspace.rs:52-104",
+      "rule_id": "code-quality.long-function",
+      "severity": "medium",
+      "path": "src/scan/workspace.rs",
+      "message": "Large Rust production code function: `from_cargo_workspace`"
+    },
+    {
+      "key": "language.javascript.runtime-exit-risk:bin/repopilot.js:133",
+      "rule_id": "language.javascript.runtime-exit-risk",
+      "severity": "low",
+      "path": "bin/repopilot.js",
+      "message": "JavaScript process.exit usage"
+    },
+    {
+      "key": "language.javascript.runtime-exit-risk:bin/repopilot.js:144",
+      "rule_id": "language.javascript.runtime-exit-risk",
+      "severity": "low",
+      "path": "bin/repopilot.js",
+      "message": "JavaScript process.exit usage"
+    },
+    {
+      "key": "language.javascript.runtime-exit-risk:bin/repopilot.js:154",
+      "rule_id": "language.javascript.runtime-exit-risk",
+      "severity": "low",
+      "path": "bin/repopilot.js",
+      "message": "JavaScript process.exit usage"
+    },
+    {
+      "key": "language.javascript.runtime-exit-risk:bin/repopilot.js:161",
+      "rule_id": "language.javascript.runtime-exit-risk",
+      "severity": "low",
+      "path": "bin/repopilot.js",
+      "message": "JavaScript process.exit usage"
+    },
+    {
+      "key": "language.javascript.runtime-exit-risk:scripts/build-npm-platform-packages.js:267",
+      "rule_id": "language.javascript.runtime-exit-risk",
+      "severity": "low",
+      "path": "scripts/build-npm-platform-packages.js",
+      "message": "JavaScript process.exit usage"
+    },
+    {
+      "key": "language.rust.panic-risk:src/audits/pipeline/mod.rs:121",
+      "rule_id": "language.rust.panic-risk",
+      "severity": "low",
+      "path": "src/audits/pipeline/mod.rs",
+      "message": "Risky Rust panic! usage in Rust test code"
+    },
+    {
+      "key": "language.rust.panic-risk:src/knowledge/loader.rs:35",
+      "rule_id": "language.rust.panic-risk",
+      "severity": "low",
+      "path": "src/knowledge/loader.rs",
+      "message": "Risky Rust panic! usage in Rust test code"
+    },
+    {
+      "key": "language.rust.panic-risk:src/output/console/baseline.rs:11",
+      "rule_id": "language.rust.panic-risk",
+      "severity": "medium",
+      "path": "src/output/console/baseline.rs",
+      "message": "Risky Rust unwrap() usage in Rust library code"
+    },
+    {
+      "key": "language.rust.panic-risk:src/output/markdown/baseline.rs:12",
+      "rule_id": "language.rust.panic-risk",
+      "severity": "medium",
+      "path": "src/output/markdown/baseline.rs",
+      "message": "Risky Rust unwrap() usage in Rust library code"
+    },
+    {
+      "key": "language.rust.panic-risk:src/scan/scanner/file/read.rs:162",
+      "rule_id": "language.rust.panic-risk",
+      "severity": "low",
+      "path": "src/scan/scanner/file/read.rs",
+      "message": "Risky Rust panic! usage in Rust test code"
+    },
+    {
+      "key": "testing.source-without-test:src/api.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/api.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/audits/code_quality/sanitize.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/audits/code_quality/sanitize.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/audits/context/classify/frameworks.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/audits/context/classify/frameworks.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/audits/context/classify/helpers.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/audits/context/classify/helpers.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/audits/context/classify/paradigms.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/audits/context/classify/paradigms.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/audits/context/classify/roles.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/audits/context/classify/roles.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/audits/context/classify/runtimes.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/audits/context/classify/runtimes.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/audits/traits.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/audits/traits.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/cli/args.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/cli/args.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/cli/options/ai.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/cli/options/ai.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/cli/options/inspect.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/cli/options/inspect.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/commands/feedback.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/commands/feedback.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/commands/filters.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/commands/filters.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/commands/focus.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/commands/focus.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/commands/llm.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/commands/llm.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/commands/progress.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/commands/progress.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/frameworks/detector/go.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/frameworks/detector/go.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/frameworks/detector/js.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/frameworks/detector/js.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/frameworks/detector/python.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/frameworks/detector/python.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/frameworks/react_native/detector/project.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/frameworks/react_native/detector/project.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/frameworks/react_native/profile.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/frameworks/react_native/profile.rs",
+      "message": "Source file has no corresponding test"
+    },
+    {
+      "key": "testing.source-without-test:src/frameworks/types.rs:1",
+      "rule_id": "testing.source-without-test",
+      "severity": "low",
+      "path": "src/frameworks/types.rs",
+      "message": "Source file has no corresponding test"
+    }
+  ]
+}

--- a/.repopilotignore
+++ b/.repopilotignore
@@ -1,0 +1,11 @@
+# RepoPilot local/cache artifacts
+.repopilot/cache
+
+# Build and release outputs
+target
+dist
+
+# Editor/system files
+.DS_Store
+.idea
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "serde_norway",
  "sha2",
  "tempfile",
  "toml",
@@ -666,6 +667,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -724,6 +731,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
 ]
 
 [[package]]
@@ -922,6 +942,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ indicatif = "0.18.4"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_norway = "0.9.42"
 sha2 = "0.10"
 tree-sitter = "0.26.8"
 tree-sitter-javascript = "0.25.0"

--- a/README.md
+++ b/README.md
@@ -285,6 +285,13 @@ Fail CI only on new high-risk findings:
 repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
 ```
 
+Validate or bypass local feedback suppressions:
+
+```bash
+repopilot inspect feedback .
+repopilot scan . --ignore-feedback
+```
+
 Review a pull request or branch diff:
 
 ```bash
@@ -369,6 +376,7 @@ repopilot scan . --profile strict
 | [Language support](docs/language-support.md) | Supported language/framework tiers and limitations |
 | [Knowledge Engine](docs/knowledge-engine.md) | Rule applicability and local-first learning policy |
 | [Risk Engine](docs/risk-engine.md) | Risk scoring, priorities, and calibration policy |
+| [Local Feedback](docs/local-feedback.md) | Repository-local suppressions and validation |
 | [Trust Mode](docs/trust-mode.md) | Default vs strict visibility and hidden suggestions |
 | [Core Visibility Engine](docs/core-visibility-engine.md) | Finding intent model and visibility decisions |
 | [CLI reference](docs/cli.md) | Commands, flags, and exit codes |
@@ -377,6 +385,7 @@ repopilot scan . --profile strict
 | [React Native](docs/react-native.md) | React Native and Expo detection |
 | [GitHub Code Scanning](docs/integrations/github-code-scanning.md) | SARIF workflow and CI setup |
 | [Roadmap](docs/roadmap.md) | Pre-1.0 roadmap and v1 gates |
+| [0.12 GTM plan](docs/gtm-0.12.md) | Launch audiences, messaging, and proof points |
 | [Release process](docs/release.md) | Manual release process |
 | [Changelog](CHANGELOG.md) | Version history |
 
@@ -388,7 +397,7 @@ Planned direction:
 
 - stronger Trust Mode calibration
 - `repopilot eval` with golden fixtures
-- local feedback through `.repopilot/feedback.yml`
+- local feedback validation and report transparency
 - hidden suggestion trend tracking
 - deeper dependency graph and impact analysis
 - AI task packs with context, constraints, and acceptance criteria

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,6 +23,7 @@ Use `-h` for a short summary or `--help` for the full description and examples.
 | [`ai prompt`](#ai-prompt) | — | Generate an AI-ready remediation prompt |
 | [`inspect explain`](#inspect-explain) | — | Explain file classification and rule decisions |
 | [`inspect knowledge`](#inspect-knowledge) | — | Inspect bundled Knowledge Engine data |
+| [`inspect feedback`](#inspect-feedback) | — | Validate local feedback suppressions |
 | [`compare`](#compare) | `cmp` | Compare two JSON scan reports and show what changed |
 | [`cache`](#cache) | — | Manage local changed-scan cache files |
 | [`baseline`](#baseline) | `bl` | Manage accepted baseline findings |
@@ -73,6 +74,7 @@ repopilot s <PATH> [OPTIONS]
 | `--config` | path | auto-detected | Path to a `repopilot.toml` config file |
 | `--baseline` | path | — | Path to a baseline file; marks findings as new or existing |
 | `--fail-on` | threshold | — | Exit code 1 when findings meet this threshold (see [Thresholds](#thresholds)) |
+| `--ignore-feedback` | flag | — | Ignore `.repopilot/feedback.yml` local suppressions |
 | `--max-file-loc` | integer | `300` | Maximum non-empty LOC before a file is flagged as large |
 | `--max-directory-modules` | integer | `20` | Maximum files per directory before flagging |
 | `--max-directory-depth` | integer | `5` | Maximum nesting depth before flagging |
@@ -123,6 +125,10 @@ repopilot scan . --baseline .repopilot/baseline.json
 
 # Fail CI on new high or critical findings
 repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
+
+# Inspect or bypass local feedback suppressions
+repopilot inspect feedback .
+repopilot scan . --ignore-feedback
 
 # Override thresholds at the command line
 repopilot scan . --max-file-loc 500 --max-directory-modules 30 --max-directory-depth 8
@@ -204,6 +210,7 @@ repopilot r [PATH] [OPTIONS]
 | `--config` | path | auto-detected | Path to a `repopilot.toml` config file |
 | `--baseline` | path | — | Path to a baseline file |
 | `--fail-on` | threshold | — | Exit code 1 when **in-diff** findings meet this threshold |
+| `--ignore-feedback` | flag | — | Ignore `.repopilot/feedback.yml` local suppressions |
 | `--max-file-loc` | integer | `300` | Maximum non-empty LOC before a file is flagged as large |
 | `--max-directory-modules` | integer | `20` | Maximum files per directory before flagging |
 | `--max-directory-depth` | integer | `5` | Maximum nesting depth before flagging |
@@ -235,6 +242,9 @@ repopilot review . --base origin/main --format markdown --output review.md
 
 # Baseline-aware CI gate on in-diff findings only
 repopilot review . --baseline .repopilot/baseline.json --fail-on new-high
+
+# Review without local feedback suppressions
+repopilot review . --ignore-feedback
 
 # JSON output for downstream tooling
 repopilot review . --format json --output review.json
@@ -411,6 +421,35 @@ repopilot inspect knowledge [OPTIONS]
 repopilot inspect knowledge
 repopilot inspect knowledge --section languages
 repopilot inspect knowledge --section rules --format json
+```
+
+---
+
+## `inspect feedback`
+
+Validates `.repopilot/feedback.yml`, reports malformed or unmatched
+suppressions, and shows how many findings the local feedback file suppresses.
+This command is local-only and does not upload source code.
+
+### Synopsis
+
+```
+repopilot inspect feedback [PATH] [OPTIONS]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `console\|json\|markdown` | `console` | Output format |
+| `-o, --output` | path | stdout | Write report to a file instead of stdout |
+
+### Examples
+
+```bash
+repopilot inspect feedback .
+repopilot inspect feedback . --format json
+repopilot inspect feedback . --format markdown --output feedback.md
 ```
 
 ---

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -372,6 +372,22 @@ approximate cache size, and stale entry count.
 
 ---
 
+## `inspect feedback`
+
+Validate local feedback suppressions and show which ones were applied.
+
+```bash
+repopilot inspect feedback .
+repopilot inspect feedback . --format json
+repopilot inspect feedback . --format markdown --output feedback.md
+```
+
+The command parses `.repopilot/feedback.yml` with a YAML parser, reports
+malformed entries, warns about suppressions that do not match current findings,
+and includes the same `local_feedback` summary that scan/review reports expose.
+
+---
+
 ## Local feedback suppressions
 
 RepoPilot reads `.repopilot/feedback.yml` by default:
@@ -379,7 +395,7 @@ RepoPilot reads `.repopilot/feedback.yml` by default:
 ```yaml
 suppressions:
   - rule_id: architecture.large-file
-    path: src/generated/schema.rs
+    path: "src/generated/schema.rs"
     reason: generated schema boundary
 ```
 
@@ -387,4 +403,9 @@ Use raw output without local suppressions:
 
 ```bash
 repopilot scan . --ignore-feedback
+repopilot review . --ignore-feedback
 ```
+
+When suppressions are applied, console, Markdown, JSON, and receipt output show
+the local feedback counts so findings are visibly suppressed rather than
+silently disappearing.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -78,7 +78,9 @@ The release workflow builds binaries for the following targets on every `v*` tag
 | `aarch64-apple-darwin` | macOS Apple Silicon |
 | `x86_64-pc-windows-msvc` | Windows x86-64 |
 
-Binaries and `.sha256` checksum files are attached to GitHub Releases.
+Binaries and `.sha256` checksum files are attached to GitHub Releases. The
+release workflow also requests GitHub artifact attestations for each release
+archive and checksum file when the tag workflow runs with OIDC permissions.
 
 ## Runtime and Artifact Security Model
 
@@ -88,9 +90,9 @@ Binaries and `.sha256` checksum files are attached to GitHub Releases.
 - The curl installer downloads a GitHub Release artifact and its `.sha256` checksum, then fails closed if the checksum file cannot be downloaded, no SHA256 tool is available, or verification fails.
 - npm installation uses platform-specific optional packages and does not run a downloader script.
 - Platform npm packages are generated from GitHub Release archives only after their SHA256 checksum files are verified.
+- GitHub Release artifacts are checksummed and attested by the release workflow;
+  npm packages publish through Trusted Publishing / GitHub OIDC when configured.
 - `REPOPILOT_BINARY_PATH` can point the npm wrapper at a user-managed binary when optional dependencies are omitted or unsupported.
-
-Before v1, the preferred hardening path is GitHub artifact attestations for release assets in addition to npm Trusted Publishing provenance.
 
 ## Publishing Policy
 

--- a/docs/gtm-0.12.md
+++ b/docs/gtm-0.12.md
@@ -1,0 +1,86 @@
+# RepoPilot 0.12 GTM Plan
+
+RepoPilot's launch order for 0.12.0:
+
+1. Publish `0.12.0` across GitHub Releases, crates.io, npm, and Homebrew tap.
+2. Publish or update GitHub Marketplace/action docs.
+3. Post the AI workflow story.
+4. Post the CI/baseline story.
+5. Post the React Native/Expo proof story.
+
+## AI Developers
+
+Message:
+
+```text
+Scan repo locally, paste AI-ready context into Claude Code, ChatGPT, or Cursor,
+then fix with less surprise.
+```
+
+Primary commands:
+
+```bash
+repopilot ai context .
+repopilot ai plan .
+repopilot ai prompt .
+```
+
+Proof points:
+
+- no telemetry, no source upload, no automatic LLM API calls;
+- risk-ranked findings with evidence and recommendations;
+- focused context budgets for security, architecture, quality, or framework work.
+
+## CI Teams
+
+Message:
+
+```text
+Adopt gradually with baseline-aware gates, SARIF, receipts, and no source upload.
+```
+
+Primary commands:
+
+```bash
+repopilot baseline create .
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
+repopilot review . --base origin/main --baseline .repopilot/baseline.json --fail-on-priority p1
+```
+
+Proof points:
+
+- GitHub Action job summaries for PR readability;
+- SARIF upload for Code Scanning;
+- receipts for release evidence;
+- local feedback metadata so suppressions are auditable.
+
+## React Native And Expo
+
+Message:
+
+```text
+Catch React Native architecture health issues locally before a release.
+```
+
+Primary commands:
+
+```bash
+repopilot scan . --format markdown --output rn-architecture-health.md
+repopilot ai context . --focus framework --budget 4k
+```
+
+Proof points:
+
+- Hermes and New Architecture signal checks;
+- deprecated React Native APIs;
+- async storage/core import and direct state mutation checks;
+- normal repository risks like large files, testing gaps, and secret candidates.
+
+## Trust Angle
+
+Use these claims only after the matching release workflows have completed:
+
+- GitHub Release archives include checksums and artifact attestations;
+- npm packages publish through Trusted Publishing / GitHub OIDC;
+- npm install uses platform optional packages and no postinstall downloader;
+- runtime commands stay local-first.

--- a/docs/integrations/github-code-scanning.md
+++ b/docs/integrations/github-code-scanning.md
@@ -73,6 +73,8 @@ Keep the SARIF file name consistent between the scan step and the upload step. T
 
 The first-party action can generate SARIF and a compact audit receipt from the
 same scan. `receipt` is only valid with `command: scan`.
+For Markdown, console, review, doctor, compare, and AI command output, the
+action also writes a short GitHub job summary through `GITHUB_STEP_SUMMARY`.
 
 ```yaml
 name: RepoPilot

--- a/docs/knowledge-engine.md
+++ b/docs/knowledge-engine.md
@@ -107,10 +107,12 @@ path/language/content
 Future rules should prefer the shared context signals instead of adding another
 local copy of the same path or language checks inside an individual audit.
 
-## Future Local Overlays
+## Local Feedback And Future Overlays
 
-The intended 0.13 direction is inspectable local calibration, not a plugin
-runtime. Local overlays should be normal files that users can review, commit,
-diff, or delete. They may tune known rule severity, confidence, or suppression
-decisions, but they must not execute arbitrary code, load remote packs, or change
-scan behavior silently.
+RepoPilot's first local calibration surface is `.repopilot/feedback.yml` for
+explicit suppressions plus `repopilot inspect feedback` for validation. Future
+overlays should remain inspectable local calibration, not a plugin runtime.
+Local overlays should be normal files that users can review, commit, diff, or
+delete. They may tune known rule severity, confidence, or suppression decisions,
+but they must not execute arbitrary code, load remote packs, or change scan
+behavior silently.

--- a/docs/local-feedback.md
+++ b/docs/local-feedback.md
@@ -11,20 +11,49 @@ Minimal example:
 ```yaml
 suppressions:
   - rule_id: architecture.large-file
-    path: src/generated/schema.rs
+    path: "src/generated/schema.rs"
     reason: generated schema boundary
 ```
 
-Run normally:
+Run normally. RepoPilot applies matching suppressions before rendering console,
+Markdown, JSON, review, and receipt output:
 
 ```bash
 repopilot scan .
+repopilot review .
+```
+
+Inspect local feedback before committing it:
+
+```bash
+repopilot inspect feedback .
+repopilot inspect feedback . --format json
 ```
 
 Ignore local feedback when you want the raw report:
 
 ```bash
 repopilot scan . --ignore-feedback
+repopilot review . --ignore-feedback
 ```
 
-This is repository-local calibration, not remote learning.
+RepoPilot validates feedback as structured YAML. Malformed YAML, entries without
+`rule_id` or `path`, and suppressions that do not match current findings are
+reported as diagnostics. Matching suppressions are counted in `local_feedback`:
+
+```json
+{
+  "local_feedback": {
+    "feedback_path": ".repopilot/feedback.yml",
+    "suppressions_loaded": 1,
+    "suppressed_findings_count": 1,
+    "unmatched_suppressions_count": 0,
+    "invalid_suppressions_count": 0,
+    "unmatched_suppressions": [],
+    "parse_error": null
+  }
+}
+```
+
+This is repository-local calibration, not remote learning. RepoPilot does not
+upload feedback files, source code, or suppression history.

--- a/docs/product-readiness.md
+++ b/docs/product-readiness.md
@@ -68,6 +68,7 @@ ai plan
 ai prompt
 inspect knowledge
 inspect explain
+inspect feedback
 ```
 
 `review` is skipped when the target path is not inside a Git repository.
@@ -93,6 +94,7 @@ repopilot ai plan .
 repopilot ai prompt .
 repopilot inspect knowledge
 repopilot inspect explain src/main.rs
+repopilot inspect feedback .
 ```
 
 The primary help surface should prefer the stable command shape:
@@ -148,6 +150,8 @@ RepoPilot runtime commands must stay local-first:
 - scans read files from disk;
 - reports write to stdout or explicit output paths;
 - scan receipts write only to explicit local paths;
+- local feedback is read from `.repopilot/feedback.yml`, validated locally, and
+  reported in `local_feedback` metadata when applied;
 - no source code is uploaded;
 - no telemetry is sent;
 - AI commands do not call AI providers;
@@ -180,6 +184,9 @@ Before release, verify:
 - `npm run test:npm` passes;
 - `npm pack --dry-run` looks correct;
 - platform npm packages can be generated from release archives and packed with no lifecycle scripts;
+- RepoPilot's own repository has `.repopilotignore`, `.repopilot/baseline.json`,
+  and a CI gate using `--baseline .repopilot/baseline.json --fail-on new-high`;
+- `repopilot doctor .` reports no adoption warnings for the repository;
 - `scripts/smoke-product.sh` passes against the release binary.
 
 The GitHub Action should support:
@@ -202,6 +209,10 @@ with:
 
 Receipt output is scan-only. The action should fail clearly when `receipt` is
 provided with `review`, `compare`, or AI commands.
+
+The action should also write a concise `$GITHUB_STEP_SUMMARY` entry for `scan`,
+`review`, `doctor`, `compare`, and AI commands so pull request reviewers can see
+the RepoPilot result without opening artifacts first.
 
 ---
 

--- a/docs/react-native.md
+++ b/docs/react-native.md
@@ -38,6 +38,26 @@ repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
 repopilot scan . --format sarif --output repopilot.sarif
 ```
 
+## Report Example
+
+Use RepoPilot as a local architecture health pass before a React Native release:
+
+```bash
+repopilot scan . --format markdown --output rn-architecture-health.md
+repopilot ai context . --focus framework --budget 4k --output rn-ai-context.md
+```
+
+The report highlights Hermes/New Architecture mismatches, deprecated core APIs,
+direct state mutation, missing Codegen config, dependency signals, and normal
+repository risks such as large files or hardcoded secret candidates. Commit a
+baseline for accepted migration debt, then gate pull requests on new high-risk
+findings:
+
+```bash
+repopilot baseline create .
+repopilot review . --base origin/main --baseline .repopilot/baseline.json --fail-on new-high
+```
+
 ## Known Limitations
 
 - JavaScript and TypeScript config files are detected with conservative heuristics, not executed.

--- a/docs/release-announcement-0.12.md
+++ b/docs/release-announcement-0.12.md
@@ -1,0 +1,58 @@
+# RepoPilot 0.12.0 Release Announcement
+
+RepoPilot 0.12.0 is the trust release: local-first scans, AI-ready context,
+baseline adoption, receipts, SARIF, and a first-party GitHub Action that can gate
+pull requests without uploading source code.
+
+## Suggested Post
+
+RepoPilot 0.12.0 is ready.
+
+This release is for teams that want a fast repository safety layer before code
+goes into CI or an AI coding session:
+
+- scan locally with no telemetry, no hosted scanner, and no source upload;
+- paste `ai context`, `ai plan`, or `ai prompt` into Claude Code, ChatGPT, Cursor,
+  or another coding assistant;
+- adopt gradually with `.repopilot/baseline.json` and fail CI only on new risk;
+- publish SARIF, receipts, and GitHub Action job summaries for pull requests;
+- keep local suppressions visible through `local_feedback` metadata.
+
+Try it:
+
+```bash
+repopilot doctor .
+repopilot baseline create .
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
+repopilot ai context . --budget 4k
+```
+
+GitHub Actions:
+
+```yaml
+- uses: MykytaStel/repopilot@v0.12.0
+  with:
+    command: scan
+    baseline: .repopilot/baseline.json
+    fail-on: new-high
+    receipt: repopilot-receipt.json
+```
+
+Best first audiences:
+
+- AI developers who want safer local context before asking an assistant to edit;
+- CI teams that need baseline-aware gates, SARIF, receipts, and no source upload;
+- React Native and Expo teams checking New Architecture, Hermes, deprecated APIs,
+  and architecture health before releases.
+
+## Post-Publish Checks
+
+Run after publishing completes:
+
+```bash
+npm view repopilot version
+cargo search repopilot
+gh release list --repo MykytaStel/repopilot --limit 5
+```
+
+Expected public version: `0.12.0`.

--- a/docs/release-checklist-0.12.md
+++ b/docs/release-checklist-0.12.md
@@ -1,11 +1,12 @@
 # RepoPilot 0.12.0 Release Checklist
 
-RepoPilot 0.12.0 is the core foundation and roadmap release.
+RepoPilot 0.12.0 is the core foundation, local feedback, and release trust
+sync release.
 
 Main release promise:
 
 ```text
-core foundation -> rule lifecycle -> v1 gates
+core foundation -> local feedback transparency -> release trust sync
 ```
 
 ## Release Scope
@@ -16,6 +17,9 @@ core foundation -> rule lifecycle -> v1 gates
 - Document the Knowledge Engine lifecycle and local-first learning policy.
 - Move workspace scan orchestration out of the CLI command layer without changing behavior.
 - Keep `bundled_knowledge()` as the only runtime Knowledge Engine source.
+- Add validated local feedback suppressions without hosted scanner, telemetry, or
+  arbitrary plugin runtime.
+- Keep public distribution channels synchronized at `0.12.0` after publishing.
 
 ## Knowledge Engine Gates
 
@@ -74,6 +78,39 @@ cargo run -- scan . --min-severity medium --format json \
   | jq '.findings | group_by(.rule_id)[] | {rule: .[0].rule_id, count: length}'
 ```
 
+## Adoption And Feedback Gates
+
+Verify RepoPilot's own repository is adopted:
+
+```bash
+repopilot doctor .
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
+```
+
+Expected:
+
+- `.repopilotignore` exists;
+- `.repopilot/baseline.json` exists and parses;
+- CI contains a RepoPilot gate with `--baseline .repopilot/baseline.json --fail-on new-high`;
+- default self-scan has no P0/P1/high/critical findings;
+- `repopilot doctor .` reports no adoption warnings.
+
+Verify local feedback:
+
+```bash
+repopilot inspect feedback .
+repopilot scan . --format json --output /tmp/repopilot-feedback.json
+repopilot scan . --ignore-feedback --format json --output /tmp/repopilot-raw.json
+```
+
+Expected:
+
+- malformed feedback emits `feedback.parse-failed`;
+- invalid entries emit `feedback.invalid-suppression`;
+- unmatched suppressions emit `feedback.unmatched-suppressions`;
+- scan, review, JSON, Markdown, console, and receipt output expose
+  `local_feedback` when feedback is applied.
+
 ## Required Local Checks
 
 Run from the repository root:
@@ -110,3 +147,16 @@ rg '0\.[[]11[]]\.0|release-checklist-0\.[[]11[]]' Cargo.toml package.json action
 The final search should only report historical changelog entries, old release
 checklists, old release announcements, and examples intentionally pinned to old
 versions.
+
+## Post-Publish Public Channel Checks
+
+After the tag/release workflows complete, verify the public state:
+
+```bash
+npm view repopilot version
+cargo search repopilot --limit 5
+gh release list --repo MykytaStel/repopilot --limit 5
+```
+
+All three should show `0.12.0` as the latest public version before promotion
+posts go out.

--- a/docs/release.md
+++ b/docs/release.md
@@ -90,7 +90,15 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-The tag workflow builds GitHub Release artifacts, creates or updates the GitHub Release once, runs `cargo publish --dry-run`, publishes crates.io with `CRATES_IO_TOKEN`, and updates the Homebrew tap with `HOMEBREW_TAP_TOKEN`. The separate `publish-npm.yml` workflow downloads the GitHub Release artifacts, generates checksum-verified `@repopilot/*` platform packages, publishes those packages first, then publishes the root `repopilot` package through npm Trusted Publishing / GitHub OIDC. Optional secret-backed channels are skipped when their secret is absent.
+The tag workflow builds GitHub Release artifacts, creates or updates the GitHub
+Release once, generates artifact attestations for release archives and checksum
+files, runs `cargo publish --dry-run`, publishes crates.io with
+`CRATES_IO_TOKEN`, and updates the Homebrew tap with `HOMEBREW_TAP_TOKEN`. The
+separate `publish-npm.yml` workflow downloads the GitHub Release artifacts,
+generates checksum-verified `@repopilot/*` platform packages, publishes those
+packages first, then publishes the root `repopilot` package through npm Trusted
+Publishing / GitHub OIDC. Optional secret-backed channels are skipped when their
+secret is absent.
 
 ## 7. Verify publishing
 
@@ -122,6 +130,7 @@ done
 npm install -g repopilot@0.12.0
 repopilot --version
 repopilot scan . --format json --output /tmp/repopilot-0.12-smoke.json
+gh attestation verify path/to/repopilot-*.tar.gz --owner MykytaStel
 ```
 
 If a publishing secret is intentionally absent, publish that channel manually from the exact tagged commit and a clean worktree.

--- a/docs/report-schema-migration.md
+++ b/docs/report-schema-migration.md
@@ -5,6 +5,17 @@ useful in CI, dashboards, PR bots, and downstream tooling.
 
 ## Current direction
 
+Schema `0.14` adds optional local feedback transparency:
+
+| Field | Where | Why |
+|---|---|---|
+| `local_feedback` | scan, baseline-scan, review, receipt | Shows how many `.repopilot/feedback.yml` suppressions were loaded, matched, unmatched, invalid, or blocked by parse errors. |
+
+The field is omitted when no local feedback file was applied or when the command
+uses `--ignore-feedback`.
+
+## 0.13 accounting migration
+
 Schema `0.13` clarifies scan accounting names:
 
 | Old field | New field | Why |
@@ -36,4 +47,5 @@ large_files_skipped <- skipped_files_count
 ## Compatibility policy
 
 RepoPilot should keep reading older reports where practical, especially for
-`repopilot compare`, baseline workflows, and older CI artifacts.
+`repopilot compare`, baseline workflows, and older CI artifacts. Current readers
+accept the legacy `0.10` accounting names and the `0.13` report-envelope shape.

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -11,15 +11,15 @@ repopilot scan . --format json --output repopilot-report.json
 
 ## JSON report schema
 
-JSON scan reports include explicit schema metadata. The current schema is 0.13:
+JSON scan reports include explicit schema metadata. The current schema is 0.14:
 
 ```json
 {
-  "schema_version": "0.13",
+  "schema_version": "0.14",
   "repopilot_version": "0.12.0",
   "report": {
     "kind": "scan",
-    "schema_version": "0.13",
+    "schema_version": "0.14",
     "repopilot_version": "0.12.0"
   },
   "root_path": ".",
@@ -31,6 +31,15 @@ JSON scan reports include explicit schema metadata. The current schema is 0.13:
     "total": 0,
     "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 },
     "average_score": 0
+  },
+  "local_feedback": {
+    "feedback_path": ".repopilot/feedback.yml",
+    "suppressions_loaded": 1,
+    "suppressed_findings_count": 1,
+    "unmatched_suppressions_count": 0,
+    "invalid_suppressions_count": 0,
+    "unmatched_suppressions": [],
+    "parse_error": null
   },
   "diagnostics": [],
   "findings": []
@@ -47,6 +56,7 @@ JSON scan reports include explicit schema metadata. The current schema is 0.13:
 | `risk_summary` | object | Aggregate priority counts and average risk score derived from finding risk assessments. |
 | `cache_telemetry` | object | Optional changed-scan cache summary with hits, misses, changed-file reasons, per-file cache decisions, and cache timing impact. |
 | `scan_timings` | object | Optional engine timing metadata. `file_scan_us` remains the compatibility aggregate; newer fields break out `discovery_us`, `file_analysis_us`, `enrichment_us`, `risk_scoring_us`, and `report_finalization_us`. |
+| `local_feedback` | object | Optional summary of `.repopilot/feedback.yml` suppressions applied during this scan or review. |
 | `diagnostics` | array | Optional structured warnings/errors captured during a scan, such as workspace partial failures. |
 
 Diagnostics use `{ code, severity, message, path? }`. Recoverable diagnostics
@@ -73,6 +83,10 @@ for accuracy:
   envelope object, while top-level `schema_version` remains present during the
   migration window.
 
+Schema `0.14` adds optional `local_feedback` metadata to scan, baseline-scan,
+review, and receipt output. Older `0.10` and `0.13` reports still parse through
+the compatibility reader used by `repopilot compare`.
+
 ## Baseline JSON reports
 
 When a scan is rendered with a baseline, the JSON report also includes the same
@@ -89,11 +103,11 @@ Example shape:
 
 ```json
 {
-  "schema_version": "0.13",
+  "schema_version": "0.14",
   "repopilot_version": "0.12.0",
   "report": {
     "kind": "baseline-scan",
-    "schema_version": "0.13",
+    "schema_version": "0.14",
     "repopilot_version": "0.12.0"
   },
   "root_path": ".",
@@ -119,8 +133,8 @@ Example shape:
 `repopilot review --format json` uses the same envelope policy with
 `report.kind = "review"`. Review reports include scan scope, changed files,
 blast-radius files, `risk_summary`, structured diagnostics, baseline metadata,
-CI gate metadata when requested, and per-finding `in_diff` / `baseline_status`
-classification.
+optional `local_feedback`, CI gate metadata when requested, and per-finding
+`in_diff` / `baseline_status` classification.
 
 ## Audit receipt JSON
 
@@ -138,10 +152,10 @@ Receipt JSON is intentionally smaller than a scan report and has its own schema:
 
 ```json
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "report": {
     "kind": "receipt",
-    "schema_version": "4",
+    "schema_version": "5",
     "repopilot_version": "0.12.0"
   },
   "tool": "repopilot",
@@ -170,6 +184,7 @@ Receipt JSON is intentionally smaller than a scan report and has its own schema:
   },
   "languages": [],
   "diagnostics": [],
+  "local_feedback": null,
   "health_score": 91
 }
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,7 +20,7 @@ discipline, and distribution trust before adding broad custom execution surfaces
 | Version | Theme | Main outcome |
 |---|---|---|
 | 0.12 | Core foundation | Document the rule lifecycle, v1 gates, and local-first learning policy; start the API facade, ScanEngine pipeline, report envelope, diagnostics, and legacy alias cleanup. |
-| 0.13 | Local overlays MVP | Prototype local project/user knowledge overlays for calibration only, behind an explicit unstable surface. |
+| 0.13 | Local feedback MVP | Validate `.repopilot/feedback.yml`, expose applied suppression metadata in reports/receipts, and add `inspect feedback` before broader overlay work. |
 | 0.14 | Rule-author workflow | Add validation and inspection workflows for rule authors, false-positive fixtures, and clearer decision debugging. |
 | 0.15 | Adoption hardening | Improve workspace noise, baseline ergonomics, and performance budgets for larger repositories. |
 | 0.16 | Distribution trust | Add release artifact attestations and tighten npm, crates.io, Homebrew, and installer verification. |
@@ -57,6 +57,7 @@ RepoPilot can move to 1.0.0 only after the 0.20 review confirms:
 - stable primary command surface: `scan`, `review`, `baseline`, `compare`, `doctor`, `ai`, and `inspect`;
 - removed legacy 0.x aliases with documented replacements under `ai` and `inspect`;
 - stable JSON, SARIF, baseline, receipt, report-envelope, and diagnostics schema compatibility rules;
+- visible local feedback metadata for suppressions so findings never disappear silently;
 - documented Knowledge Engine lifecycle from audit registration to risk calibration;
 - local-first trust model with no telemetry, source upload, hosted scanner, or LLM API calls;
 - release verification and product smoke suites pass from a clean release branch;

--- a/docs/trust-mode.md
+++ b/docs/trust-mode.md
@@ -136,6 +136,6 @@ centralized and semantic. The next improvements should be:
 
 - persisted hidden summaries in SARIF properties
 - `repopilot eval` fixtures for visibility behavior
-- local feedback through `.repopilot/feedback.yml`
+- validated local feedback with visible `local_feedback` metadata
 - confidence calibration per rule
 - project profile specific visibility defaults

--- a/scripts/repopilot-action.sh
+++ b/scripts/repopilot-action.sh
@@ -100,6 +100,50 @@ if [[ -n "$ARGS" ]]; then
   RUN_ARGS+=("${EXTRA_ARGS[@]}")
 fi
 
+SUMMARY_SOURCE=""
+TMP_SUMMARY_OUTPUT=""
+
+append_job_summary() {
+  local status="$1"
+  local source_file="${2:-}"
+
+  if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    return 0
+  fi
+
+  {
+    echo "## RepoPilot"
+    echo
+    printf -- "- **Command:** \`repopilot"
+    printf ' %q' "${RUN_ARGS[@]}"
+    printf '\`\n'
+    echo "- **Exit status:** ${status}"
+    if [[ "$FORMAT" == "sarif" ]]; then
+      echo "- **SARIF file:** \`${OUTFILE}\`"
+    fi
+    if [[ -n "$RECEIPT" ]]; then
+      echo "- **Receipt:** \`${RECEIPT}\`"
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+
+  if [[ -z "$source_file" || ! -f "$source_file" ]]; then
+    return 0
+  fi
+
+  {
+    echo
+    if [[ "$FORMAT" == "console" ]]; then
+      echo '```text'
+      sed -n '1,200p' "$source_file"
+      echo '```'
+    else
+      sed -n '1,200p' "$source_file"
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+}
+
+trap 'if [[ -n "$TMP_SUMMARY_OUTPUT" && -f "$TMP_SUMMARY_OUTPUT" ]]; then rm -f "$TMP_SUMMARY_OUTPUT"; fi' EXIT
+
 OUTFILE="${OUTPUT:-repopilot-results.sarif}"
 RUN_STATUS=0
 if [[ "$IS_AI" == "true" ]]; then
@@ -107,9 +151,19 @@ if [[ "$IS_AI" == "true" ]]; then
     echo "::error::'$COMMAND' emits Markdown and does not accept --format. Use format=auto or format=markdown."
     exit 2
   fi
+  if [[ -z "$OUTPUT" && -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    TMP_SUMMARY_OUTPUT="$(mktemp)"
+  fi
   set +e
-  repopilot "${RUN_ARGS[@]}"
-  RUN_STATUS=$?
+  if [[ -n "$TMP_SUMMARY_OUTPUT" ]]; then
+    repopilot "${RUN_ARGS[@]}" | tee "$TMP_SUMMARY_OUTPUT"
+    RUN_STATUS=${PIPESTATUS[0]}
+    SUMMARY_SOURCE="$TMP_SUMMARY_OUTPUT"
+  else
+    repopilot "${RUN_ARGS[@]}"
+    RUN_STATUS=$?
+    SUMMARY_SOURCE="$OUTPUT"
+  fi
   set -e
 elif [[ "$FORMAT" == "sarif" ]]; then
   set +e
@@ -120,14 +174,30 @@ elif [[ "$FORMAT" == "sarif" ]]; then
     echo "sarif_file=$OUTFILE" >> "$GITHUB_OUTPUT"
   fi
 else
+  if [[ -z "$OUTPUT" && -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    TMP_SUMMARY_OUTPUT="$(mktemp)"
+  fi
   set +e
-  repopilot "${RUN_ARGS[@]}" --format "$FORMAT"
-  RUN_STATUS=$?
+  if [[ -n "$TMP_SUMMARY_OUTPUT" ]]; then
+    repopilot "${RUN_ARGS[@]}" --format "$FORMAT" | tee "$TMP_SUMMARY_OUTPUT"
+    RUN_STATUS=${PIPESTATUS[0]}
+    SUMMARY_SOURCE="$TMP_SUMMARY_OUTPUT"
+  else
+    repopilot "${RUN_ARGS[@]}" --format "$FORMAT"
+    RUN_STATUS=$?
+    SUMMARY_SOURCE="$OUTPUT"
+  fi
   set -e
 fi
 
 if [[ -n "$RECEIPT" && -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "receipt_file=$RECEIPT" >> "$GITHUB_OUTPUT"
+fi
+
+if [[ "$RUN_STATUS" -eq 0 ]]; then
+  append_job_summary "passed" "$SUMMARY_SOURCE"
+else
+  append_job_summary "failed (exit ${RUN_STATUS})" "$SUMMARY_SOURCE"
 fi
 
 exit "$RUN_STATUS"

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,6 +10,10 @@ pub mod config {
 }
 
 pub mod findings {
+    pub use crate::findings::feedback::{
+        LocalFeedbackReport, LocalFeedbackValidation, LocalSuppression, apply_local_feedback,
+        validate_local_feedback,
+    };
     pub use crate::findings::filter::{FindingFilter, recompute_summary_metrics};
     pub use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
     pub use crate::findings::visibility::{FindingVisibilityProfile, apply_visibility_profile};

--- a/src/cli/options/inspect.rs
+++ b/src/cli/options/inspect.rs
@@ -39,6 +39,16 @@ repopilot inspect cache . --format json\n  \
 repopilot inspect cache . --format markdown --output cache.md"
     )]
     Cache(CacheInspectOptions),
+
+    /// Inspect local feedback suppressions and validation diagnostics
+    #[command(
+        about = "Inspect RepoPilot local feedback suppressions",
+        after_help = "EXAMPLES:\n  \
+repopilot inspect feedback\n  \
+repopilot inspect feedback . --format json\n  \
+repopilot inspect feedback . --format markdown --output feedback.md"
+    )]
+    Feedback(FeedbackInspectOptions),
 }
 
 #[derive(Args)]
@@ -89,6 +99,21 @@ pub struct CacheInspectOptions {
     pub path: PathBuf,
 
     /// Output format for cache diagnostics
+    #[arg(long, value_enum, default_value = "console")]
+    pub format: CompareOutputFormatArg,
+
+    /// Write report to a file instead of stdout
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct FeedbackInspectOptions {
+    /// Repository or project path whose .repopilot/feedback.yml should be inspected
+    #[arg(default_value = ".")]
+    pub path: PathBuf,
+
+    /// Output format for feedback diagnostics
     #[arg(long, value_enum, default_value = "console")]
     pub format: CompareOutputFormatArg,
 

--- a/src/cli/options/mod.rs
+++ b/src/cli/options/mod.rs
@@ -136,11 +136,13 @@ repopilot ai prompt . --output prompt.md"
         about = "Inspect RepoPilot classification and bundled knowledge",
         long_about = "Advanced diagnostics for rule authors and power users.\n\n\
 Use `inspect explain` to understand file context classification and rule decisions.\n\
-Use `inspect knowledge` to inspect the bundled Knowledge Engine catalog.",
+Use `inspect knowledge` to inspect the bundled Knowledge Engine catalog.\n\
+Use `inspect feedback` to validate local .repopilot/feedback.yml suppressions.",
         after_help = "EXAMPLES:\n  \
 repopilot inspect explain src/main.rs\n  \
 repopilot inspect explain src/main.rs --rule language.rust.panic-risk --signal rust.unwrap\n  \
-repopilot inspect knowledge --section rules --format json"
+repopilot inspect knowledge --section rules --format json\n  \
+repopilot inspect feedback . --format markdown"
     )]
     Inspect(InspectOptions),
 

--- a/src/cli/options/review.rs
+++ b/src/cli/options/review.rs
@@ -63,4 +63,8 @@ pub struct ReviewOptions {
     /// Only render findings at or above this risk priority
     #[arg(long, value_enum)]
     pub min_priority: Option<PriorityArg>,
+
+    /// Ignore .repopilot/feedback.yml local suppressions
+    #[arg(long)]
+    pub ignore_feedback: bool,
 }

--- a/src/commands/feedback.rs
+++ b/src/commands/feedback.rs
@@ -1,0 +1,169 @@
+use crate::cli::CompareOutputFormatArg;
+use repopilot::config::loader::load_default_config;
+use repopilot::findings::feedback::{
+    LocalFeedbackReport, apply_local_feedback, validate_local_feedback,
+};
+use repopilot::output::OutputFormat;
+use repopilot::report::writer::write_report;
+use repopilot::scan::scanner::scan_path_with_config;
+use repopilot::scan::types::ScanDiagnostic;
+use serde::Serialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize)]
+struct FeedbackInspection {
+    feedback_path: PathBuf,
+    exists: bool,
+    findings_after_feedback: usize,
+    local_feedback: Option<LocalFeedbackReport>,
+    diagnostics: Vec<ScanDiagnostic>,
+}
+
+pub fn run(
+    path: PathBuf,
+    format: CompareOutputFormatArg,
+    output: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let validation = validate_local_feedback(&path)?;
+    let inspection = if validation.exists {
+        let repo_config = load_default_config()?;
+        let scan_config = repo_config.to_scan_config();
+        let mut summary = scan_path_with_config(&path, &scan_config)?;
+        apply_local_feedback(&mut summary, &path)?;
+
+        FeedbackInspection {
+            feedback_path: validation.feedback_path,
+            exists: true,
+            findings_after_feedback: summary.findings.len(),
+            local_feedback: summary.local_feedback,
+            diagnostics: summary.diagnostics,
+        }
+    } else {
+        FeedbackInspection {
+            feedback_path: validation.feedback_path,
+            exists: false,
+            findings_after_feedback: 0,
+            local_feedback: None,
+            diagnostics: validation.diagnostics,
+        }
+    };
+
+    let rendered = render_feedback_inspection(&inspection, OutputFormat::from(format))?;
+    write_report(&rendered, output.as_deref())?;
+    Ok(())
+}
+
+fn render_feedback_inspection(
+    inspection: &FeedbackInspection,
+    format: OutputFormat,
+) -> Result<String, serde_json::Error> {
+    match format {
+        OutputFormat::Console => Ok(render_console(inspection)),
+        OutputFormat::Markdown => Ok(render_markdown(inspection)),
+        OutputFormat::Json | OutputFormat::Html | OutputFormat::Sarif => {
+            serde_json::to_string_pretty(inspection)
+        }
+    }
+}
+
+fn render_console(inspection: &FeedbackInspection) -> String {
+    let mut output = String::new();
+    output.push_str("RepoPilot Feedback Diagnostics\n\n");
+    output.push_str(&format!(
+        "Feedback file: {}\n",
+        inspection.feedback_path.display()
+    ));
+    output.push_str(&format!("Exists: {}\n", yes_no(inspection.exists)));
+
+    match &inspection.local_feedback {
+        Some(feedback) => {
+            output.push_str(&format!(
+                "Suppressions loaded: {}\nSuppressed findings: {}\nUnmatched suppressions: {}\nInvalid suppressions: {}\nFindings after feedback: {}\n",
+                feedback.suppressions_loaded,
+                feedback.suppressed_findings_count,
+                feedback.unmatched_suppressions_count,
+                feedback.invalid_suppressions_count,
+                inspection.findings_after_feedback
+            ));
+            if let Some(error) = &feedback.parse_error {
+                output.push_str(&format!("Parse error: {error}\n"));
+            }
+        }
+        None => output.push_str("Suppressions loaded: 0\n"),
+    }
+
+    render_diagnostics_console(&mut output, &inspection.diagnostics);
+    output
+}
+
+fn render_markdown(inspection: &FeedbackInspection) -> String {
+    let mut output = String::new();
+    output.push_str("# RepoPilot Feedback Diagnostics\n\n");
+    output.push_str(&format!(
+        "- **Feedback file:** `{}`\n",
+        inspection.feedback_path.display()
+    ));
+    output.push_str(&format!("- **Exists:** {}\n", yes_no(inspection.exists)));
+
+    match &inspection.local_feedback {
+        Some(feedback) => {
+            output.push_str(&format!(
+                "- **Suppressions loaded:** {}\n- **Suppressed findings:** {}\n- **Unmatched suppressions:** {}\n- **Invalid suppressions:** {}\n- **Findings after feedback:** {}\n",
+                feedback.suppressions_loaded,
+                feedback.suppressed_findings_count,
+                feedback.unmatched_suppressions_count,
+                feedback.invalid_suppressions_count,
+                inspection.findings_after_feedback
+            ));
+            if let Some(error) = &feedback.parse_error {
+                output.push_str(&format!("- **Parse error:** `{error}`\n"));
+            }
+        }
+        None => output.push_str("- **Suppressions loaded:** 0\n"),
+    }
+
+    render_diagnostics_markdown(&mut output, &inspection.diagnostics);
+    output
+}
+
+fn render_diagnostics_console(output: &mut String, diagnostics: &[ScanDiagnostic]) {
+    if diagnostics.is_empty() {
+        return;
+    }
+
+    output.push_str("\nDiagnostics:\n");
+    for diagnostic in diagnostics {
+        let path = diagnostic
+            .path
+            .as_ref()
+            .map(|path| format!(" ({})", path.display()))
+            .unwrap_or_default();
+        output.push_str(&format!(
+            "  [{:?}] {}{}: {}\n",
+            diagnostic.severity, diagnostic.code, path, diagnostic.message
+        ));
+    }
+}
+
+fn render_diagnostics_markdown(output: &mut String, diagnostics: &[ScanDiagnostic]) {
+    if diagnostics.is_empty() {
+        return;
+    }
+
+    output.push_str("\n## Diagnostics\n\n");
+    for diagnostic in diagnostics {
+        let path = diagnostic
+            .path
+            .as_ref()
+            .map(|path| format!(" `{}`", path.display()))
+            .unwrap_or_default();
+        output.push_str(&format!(
+            "- `{:?}` `{}`{}: {}\n",
+            diagnostic.severity, diagnostic.code, path, diagnostic.message
+        ));
+    }
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod cache_inspect;
 pub mod compare;
 pub mod doctor;
 pub mod explain;
+pub mod feedback;
 pub(crate) mod filters;
 pub(crate) mod focus;
 pub mod harden;
@@ -85,6 +86,9 @@ fn run_inspect(command: InspectCommands) -> Result<(), Box<dyn std::error::Error
         }
         InspectCommands::Cache(options) => {
             cache_inspect::run(options.path, options.format, options.output)
+        }
+        InspectCommands::Feedback(options) => {
+            feedback::run(options.path, options.format, options.output)
         }
     }
 }

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -6,6 +6,7 @@ use crate::commands::{CliExit, EXIT_FINDINGS, EXIT_USAGE};
 use repopilot::baseline::gate::{FailOn, evaluate_ci_gate};
 use repopilot::baseline::reader::read_baseline;
 use repopilot::config::loader::{load_default_config, load_optional_config};
+use repopilot::findings::feedback::apply_local_feedback;
 use repopilot::report::writer::write_report;
 use repopilot::review::render::render;
 use repopilot::review::{build_review_report, review_report_for_ci};
@@ -47,6 +48,10 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
     let pb = make_spinner("Scanning...");
     let mut summary = scan_path_with_config(&options.path, &scan_config)?;
     finish_spinner(pb);
+
+    if !options.ignore_feedback {
+        apply_local_feedback(&mut summary, &options.path)?;
+    }
 
     if !pre_diff_filter.is_empty() {
         pre_diff_filter.apply_to_summary(&mut summary);

--- a/src/findings/feedback.rs
+++ b/src/findings/feedback.rs
@@ -1,149 +1,234 @@
 use crate::findings::types::Finding;
-use crate::scan::types::ScanSummary;
-use serde::Serialize;
+use crate::scan::types::{ScanDiagnostic, ScanSummary};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
 const FEEDBACK_PATH: &str = ".repopilot/feedback.yml";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LocalSuppression {
+    pub index: usize,
     pub rule_id: String,
     pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LocalFeedbackReport {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub feedback_path: Option<PathBuf>,
     pub suppressions_loaded: usize,
     pub suppressed_findings_count: usize,
+    pub unmatched_suppressions_count: usize,
+    pub invalid_suppressions_count: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unmatched_suppressions: Vec<LocalSuppression>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parse_error: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LocalFeedbackValidation {
+    pub feedback_path: PathBuf,
+    pub exists: bool,
+    pub suppressions: Vec<LocalSuppression>,
+    pub invalid_suppressions_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parse_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<ScanDiagnostic>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawFeedbackFile {
+    #[serde(default)]
+    suppressions: Vec<RawSuppression>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawSuppression {
+    rule_id: Option<String>,
+    path: Option<String>,
+    reason: Option<String>,
 }
 
 pub fn apply_local_feedback(
     summary: &mut ScanSummary,
     root: &Path,
 ) -> io::Result<LocalFeedbackReport> {
-    let feedback_path = root.join(FEEDBACK_PATH);
+    let validation = validate_local_feedback(root)?;
 
-    if !feedback_path.is_file() {
+    if !validation.exists {
         return Ok(LocalFeedbackReport::default());
     }
 
-    let content = fs::read_to_string(&feedback_path)?;
-    let suppressions = parse_suppressions(&content);
+    summary.diagnostics.extend(validation.diagnostics.clone());
 
-    if suppressions.is_empty() {
-        return Ok(LocalFeedbackReport {
-            feedback_path: Some(feedback_path),
-            suppressions_loaded: 0,
-            suppressed_findings_count: 0,
-        });
+    let mut report = LocalFeedbackReport {
+        feedback_path: Some(validation.feedback_path.clone()),
+        suppressions_loaded: validation.suppressions.len(),
+        invalid_suppressions_count: validation.invalid_suppressions_count,
+        parse_error: validation.parse_error.clone(),
+        ..LocalFeedbackReport::default()
+    };
+
+    if validation.parse_error.is_some() || validation.suppressions.is_empty() {
+        summary.local_feedback = Some(report.clone());
+        return Ok(report);
     }
 
     let original_count = summary.findings.len();
-    summary
-        .findings
-        .retain(|finding| !is_suppressed(finding, &suppressions));
+    let mut matched_suppression_indices = BTreeSet::new();
 
-    let suppressed_findings_count = original_count.saturating_sub(summary.findings.len());
+    summary.findings.retain(|finding| {
+        let matched = matching_suppression_index(finding, &validation.suppressions);
+        if let Some(index) = matched {
+            matched_suppression_indices.insert(index);
+            false
+        } else {
+            true
+        }
+    });
+
+    report.suppressed_findings_count = original_count.saturating_sub(summary.findings.len());
+    report.unmatched_suppressions = validation
+        .suppressions
+        .iter()
+        .filter(|suppression| !matched_suppression_indices.contains(&suppression.index))
+        .cloned()
+        .collect();
+    report.unmatched_suppressions_count = report.unmatched_suppressions.len();
+
+    if report.unmatched_suppressions_count > 0 {
+        summary.diagnostics.push(
+            ScanDiagnostic::warning(
+                "feedback.unmatched-suppressions",
+                format!(
+                    "{} local feedback suppression(s) did not match current findings.",
+                    report.unmatched_suppressions_count
+                ),
+            )
+            .with_path(validation.feedback_path),
+        );
+    }
+
     summary.visible_findings_count = summary.findings.len();
     summary.health_score =
         ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
+    summary.local_feedback = Some(report.clone());
 
-    Ok(LocalFeedbackReport {
-        feedback_path: Some(feedback_path),
-        suppressions_loaded: suppressions.len(),
-        suppressed_findings_count,
-    })
+    Ok(report)
 }
 
-pub fn parse_suppressions(content: &str) -> Vec<LocalSuppression> {
+pub fn validate_local_feedback(root: &Path) -> io::Result<LocalFeedbackValidation> {
+    let feedback_path = root.join(FEEDBACK_PATH);
+
+    if !feedback_path.is_file() {
+        return Ok(LocalFeedbackValidation {
+            feedback_path,
+            exists: false,
+            ..LocalFeedbackValidation::default()
+        });
+    }
+
+    let content = fs::read_to_string(&feedback_path)?;
+    Ok(validate_feedback_content(content.as_str(), feedback_path))
+}
+
+pub fn validate_feedback_content(content: &str, feedback_path: PathBuf) -> LocalFeedbackValidation {
+    let parsed = match serde_norway::from_str::<RawFeedbackFile>(content) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            let message = error.to_string();
+            return LocalFeedbackValidation {
+                feedback_path: feedback_path.clone(),
+                exists: true,
+                parse_error: Some(message.clone()),
+                diagnostics: vec![
+                    ScanDiagnostic::warning(
+                        "feedback.parse-failed",
+                        format!("Could not parse local feedback YAML: {message}"),
+                    )
+                    .with_path(feedback_path),
+                ],
+                ..LocalFeedbackValidation::default()
+            };
+        }
+    };
+
     let mut suppressions = Vec::new();
-    let mut current_rule_id: Option<String> = None;
-    let mut current_path: Option<String> = None;
-    let mut current_reason: Option<String> = None;
+    let mut diagnostics = Vec::new();
+    let mut invalid_suppressions_count = 0;
 
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed == "suppressions:" {
-            continue;
-        }
+    for (offset, raw) in parsed.suppressions.into_iter().enumerate() {
+        let index = offset + 1;
+        let rule_id = clean_optional_value(raw.rule_id);
+        let path = clean_optional_value(raw.path);
+        let reason = clean_optional_value(raw.reason);
 
-        if let Some(value) = trimmed.strip_prefix("- rule_id:") {
-            push_current(
-                &mut suppressions,
-                &mut current_rule_id,
-                &mut current_path,
-                &mut current_reason,
-            );
-            current_rule_id = Some(clean_yaml_value(value));
-            continue;
-        }
-
-        if let Some(value) = trimmed.strip_prefix("rule_id:") {
-            current_rule_id = Some(clean_yaml_value(value));
-            continue;
-        }
-
-        if let Some(value) = trimmed.strip_prefix("path:") {
-            current_path = Some(clean_yaml_value(value));
-            continue;
-        }
-
-        if let Some(value) = trimmed.strip_prefix("reason:") {
-            current_reason = Some(clean_yaml_value(value));
+        match (rule_id, path) {
+            (Some(rule_id), Some(path)) => suppressions.push(LocalSuppression {
+                index,
+                rule_id,
+                path: normalize_path_text(&path),
+                reason,
+            }),
+            (rule_id, path) => {
+                invalid_suppressions_count += 1;
+                let missing = match (rule_id.is_none(), path.is_none()) {
+                    (true, true) => "rule_id and path",
+                    (true, false) => "rule_id",
+                    (false, true) => "path",
+                    (false, false) => "required field",
+                };
+                diagnostics.push(
+                    ScanDiagnostic::warning(
+                        "feedback.invalid-suppression",
+                        format!("Suppression #{index} is missing {missing}."),
+                    )
+                    .with_path(feedback_path.clone()),
+                );
+            }
         }
     }
 
-    push_current(
-        &mut suppressions,
-        &mut current_rule_id,
-        &mut current_path,
-        &mut current_reason,
-    );
-    suppressions
+    LocalFeedbackValidation {
+        feedback_path,
+        exists: true,
+        suppressions,
+        invalid_suppressions_count,
+        parse_error: None,
+        diagnostics,
+    }
 }
 
-fn push_current(
-    suppressions: &mut Vec<LocalSuppression>,
-    rule_id: &mut Option<String>,
-    path: &mut Option<String>,
-    reason: &mut Option<String>,
-) {
-    let Some(rule_id_value) = rule_id.take() else {
-        *path = None;
-        *reason = None;
-        return;
-    };
-    let Some(path_value) = path.take() else {
-        *reason = None;
-        return;
-    };
-
-    suppressions.push(LocalSuppression {
-        rule_id: rule_id_value,
-        path: normalize_path_text(&path_value),
-        reason: reason.take(),
-    });
+pub fn parse_suppressions(content: &str) -> Vec<LocalSuppression> {
+    validate_feedback_content(content, PathBuf::from(FEEDBACK_PATH)).suppressions
 }
 
-fn clean_yaml_value(value: &str) -> String {
+fn clean_optional_value(value: Option<String>) -> Option<String> {
     value
-        .trim()
-        .trim_matches('"')
-        .trim_matches('\'')
-        .to_string()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
-fn is_suppressed(finding: &Finding, suppressions: &[LocalSuppression]) -> bool {
-    suppressions.iter().any(|suppression| {
-        finding.rule_id == suppression.rule_id
-            && finding.evidence.first().is_some_and(|evidence| {
-                normalize_path_text(&evidence.path.to_string_lossy()) == suppression.path
-            })
-    })
+fn matching_suppression_index(
+    finding: &Finding,
+    suppressions: &[LocalSuppression],
+) -> Option<usize> {
+    suppressions
+        .iter()
+        .find(|suppression| {
+            finding.rule_id == suppression.rule_id
+                && finding.evidence.iter().any(|evidence| {
+                    normalize_path_text(&evidence.path.to_string_lossy()) == suppression.path
+                })
+        })
+        .map(|suppression| suppression.index)
 }
 
 fn normalize_path_text(path: &str) -> String {
@@ -166,11 +251,40 @@ suppressions:
         );
 
         assert_eq!(suppressions.len(), 1);
+        assert_eq!(suppressions[0].index, 1);
         assert_eq!(suppressions[0].rule_id, "architecture.large-file");
         assert_eq!(suppressions[0].path, "src/generated/schema.rs");
         assert_eq!(
             suppressions[0].reason.as_deref(),
             Some("generated schema boundary")
         );
+    }
+
+    #[test]
+    fn reports_malformed_yaml_as_warning() {
+        let validation = validate_feedback_content(
+            "suppressions:\n  - rule_id: [\n",
+            PathBuf::from(".repopilot/feedback.yml"),
+        );
+
+        assert!(validation.parse_error.is_some());
+        assert_eq!(validation.diagnostics.len(), 1);
+        assert_eq!(validation.diagnostics[0].code, "feedback.parse-failed");
+    }
+
+    #[test]
+    fn rejects_incomplete_suppressions() {
+        let validation = validate_feedback_content(
+            r#"
+suppressions:
+  - rule_id: security.secret-candidate
+  - path: src/main.rs
+"#,
+            PathBuf::from(".repopilot/feedback.yml"),
+        );
+
+        assert_eq!(validation.suppressions.len(), 0);
+        assert_eq!(validation.invalid_suppressions_count, 2);
+        assert_eq!(validation.diagnostics.len(), 2);
     }
 }

--- a/src/output/console/sections.rs
+++ b/src/output/console/sections.rs
@@ -45,6 +45,7 @@ pub(crate) fn render_header(output: &mut String, summary: &ScanSummary, stats: &
         .unwrap();
     }
     render_hidden_suggestions_breakdown(output, summary);
+    render_local_feedback(output, summary);
     render_diagnostics(output, summary);
     writeln!(
         output,
@@ -63,6 +64,41 @@ pub(crate) fn render_header(output: &mut String, summary: &ScanSummary, stats: &
         .unwrap();
     }
     output.push('\n');
+}
+
+fn render_local_feedback(output: &mut String, summary: &ScanSummary) {
+    let Some(feedback) = &summary.local_feedback else {
+        return;
+    };
+
+    let path = feedback
+        .feedback_path
+        .as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| ".repopilot/feedback.yml".to_string());
+    writeln!(
+        output,
+        "Local feedback: {} suppression(s) loaded, {} finding(s) suppressed ({})",
+        feedback.suppressions_loaded, feedback.suppressed_findings_count, path
+    )
+    .unwrap();
+
+    if feedback.unmatched_suppressions_count > 0 {
+        writeln!(
+            output,
+            "Local feedback unmatched: {} suppression(s)",
+            feedback.unmatched_suppressions_count
+        )
+        .unwrap();
+    }
+    if feedback.invalid_suppressions_count > 0 {
+        writeln!(
+            output,
+            "Local feedback invalid: {} suppression(s)",
+            feedback.invalid_suppressions_count
+        )
+        .unwrap();
+    }
 }
 
 fn render_diagnostics(output: &mut String, summary: &ScanSummary) {

--- a/src/output/markdown/sections.rs
+++ b/src/output/markdown/sections.rs
@@ -38,6 +38,7 @@ pub(crate) fn render_overview(output: &mut String, summary: &ScanSummary, stats:
         .unwrap();
     }
     render_hidden_suggestions_breakdown(output, summary);
+    render_local_feedback(output, summary);
     render_diagnostics(output, summary);
     writeln!(output, "- **Files analyzed:** {}", summary.files_analyzed).unwrap();
     writeln!(
@@ -65,6 +66,41 @@ pub(crate) fn render_overview(output: &mut String, summary: &ScanSummary, stats:
         .unwrap();
     }
     output.push('\n');
+}
+
+fn render_local_feedback(output: &mut String, summary: &ScanSummary) {
+    let Some(feedback) = &summary.local_feedback else {
+        return;
+    };
+
+    let path = feedback
+        .feedback_path
+        .as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| ".repopilot/feedback.yml".to_string());
+    writeln!(
+        output,
+        "- **Local feedback:** {} suppression(s) loaded, {} finding(s) suppressed (`{}`)",
+        feedback.suppressions_loaded, feedback.suppressed_findings_count, path
+    )
+    .unwrap();
+
+    if feedback.unmatched_suppressions_count > 0 {
+        writeln!(
+            output,
+            "- **Local feedback unmatched:** {} suppression(s)",
+            feedback.unmatched_suppressions_count
+        )
+        .unwrap();
+    }
+    if feedback.invalid_suppressions_count > 0 {
+        writeln!(
+            output,
+            "- **Local feedback invalid:** {} suppression(s)",
+            feedback.invalid_suppressions_count
+        )
+        .unwrap();
+    }
 }
 
 fn render_diagnostics(output: &mut String, summary: &ScanSummary) {

--- a/src/receipt/builder.rs
+++ b/src/receipt/builder.rs
@@ -2,7 +2,7 @@ use crate::findings::types::Severity;
 use crate::receipt::git::collect_git_receipt;
 use crate::receipt::model::{
     AUDIT_RECEIPT_SCHEMA_VERSION, AuditReceipt, ReceiptDiagnostic, ReceiptFindings,
-    ReceiptHiddenSuggestion, ReceiptLanguage, ReceiptScope,
+    ReceiptHiddenSuggestion, ReceiptLanguage, ReceiptLocalFeedback, ReceiptScope,
 };
 use crate::report::schema::ReportEnvelope;
 use crate::scan::types::ScanSummary;
@@ -19,6 +19,7 @@ pub fn build_audit_receipt(summary: &ScanSummary) -> AuditReceipt {
         git: collect_git_receipt(&summary.root_path),
         scope: build_scope(summary),
         findings: build_findings(summary),
+        local_feedback: build_local_feedback(summary),
         languages: build_languages(summary),
         diagnostics: build_diagnostics(summary),
         health_score: summary.health_score,
@@ -81,6 +82,24 @@ fn build_findings(summary: &ScanSummary) -> ReceiptFindings {
     }
 
     findings
+}
+
+fn build_local_feedback(summary: &ScanSummary) -> Option<ReceiptLocalFeedback> {
+    summary
+        .local_feedback
+        .as_ref()
+        .map(|feedback| ReceiptLocalFeedback {
+            feedback_path: feedback
+                .feedback_path
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            suppressions_loaded: feedback.suppressions_loaded,
+            suppressed_findings_count: feedback.suppressed_findings_count,
+            unmatched_suppressions_count: feedback.unmatched_suppressions_count,
+            invalid_suppressions_count: feedback.invalid_suppressions_count,
+            unmatched_suppressions: feedback.unmatched_suppressions.clone(),
+            parse_error: feedback.parse_error.clone(),
+        })
 }
 
 fn build_languages(summary: &ScanSummary) -> Vec<ReceiptLanguage> {

--- a/src/receipt/model.rs
+++ b/src/receipt/model.rs
@@ -1,8 +1,9 @@
+use crate::findings::feedback::LocalSuppression;
 use crate::report::schema::ReportEnvelope;
 use crate::scan::types::DiagnosticSeverity;
 use serde::Serialize;
 
-pub const AUDIT_RECEIPT_SCHEMA_VERSION: u32 = 4;
+pub const AUDIT_RECEIPT_SCHEMA_VERSION: u32 = 5;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AuditReceipt {
@@ -15,6 +16,7 @@ pub struct AuditReceipt {
     pub git: ReceiptGit,
     pub scope: ReceiptScope,
     pub findings: ReceiptFindings,
+    pub local_feedback: Option<ReceiptLocalFeedback>,
     pub languages: Vec<ReceiptLanguage>,
     pub diagnostics: Vec<ReceiptDiagnostic>,
     pub health_score: u8,
@@ -66,6 +68,17 @@ pub struct ReceiptHiddenSuggestion {
     pub category: String,
     pub reason: String,
     pub count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReceiptLocalFeedback {
+    pub feedback_path: Option<String>,
+    pub suppressions_loaded: usize,
+    pub suppressed_findings_count: usize,
+    pub unmatched_suppressions_count: usize,
+    pub invalid_suppressions_count: usize,
+    pub unmatched_suppressions: Vec<LocalSuppression>,
+    pub parse_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/report/schema.rs
+++ b/src/report/schema.rs
@@ -1,5 +1,6 @@
 use crate::baseline::diff::{BaselineScanReport, BaselineStatus};
 use crate::baseline::gate::CiGateResult;
+use crate::findings::feedback::LocalFeedbackReport;
 use crate::findings::types::Finding;
 use crate::frameworks::{DetectedFramework, FrameworkProject, ReactNativeArchitectureProfile};
 use crate::graph::CouplingGraph;
@@ -14,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::path::PathBuf;
 
-pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.13";
+pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.14";
 pub const REPOPILOT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -96,6 +97,8 @@ pub struct ScanJsonReport<'a> {
     pub scan_timings: Option<&'a ScanTimings>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_telemetry: Option<&'a ScanCacheTelemetry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_feedback: Option<&'a LocalFeedbackReport>,
     #[serde(skip_serializing_if = "diagnostics_empty")]
     pub diagnostics: &'a [ScanDiagnostic],
     pub risk_summary: RiskSummary,
@@ -137,6 +140,7 @@ impl<'a> ScanJsonReport<'a> {
             repopilotignore_path: summary.repopilotignore_path.as_ref(),
             scan_timings: summary.scan_timings.as_ref(),
             cache_telemetry: summary.cache_telemetry.as_ref(),
+            local_feedback: summary.local_feedback.as_ref(),
             diagnostics: &summary.diagnostics,
             risk_summary: RiskSummary::from_findings(&summary.findings),
         }
@@ -167,6 +171,8 @@ pub struct BaselineJsonReport<'a> {
     pub visibility_profile: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_telemetry: Option<&'a ScanCacheTelemetry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_feedback: Option<&'a LocalFeedbackReport>,
     #[serde(skip_serializing_if = "diagnostics_empty")]
     pub diagnostics: &'a [ScanDiagnostic],
     pub languages: &'a [LanguageSummary],
@@ -198,6 +204,7 @@ impl<'a> BaselineJsonReport<'a> {
             hidden_suggestions: &report.summary.hidden_suggestions,
             visibility_profile: report.summary.visibility_profile.as_deref(),
             cache_telemetry: report.summary.cache_telemetry.as_ref(),
+            local_feedback: report.summary.local_feedback.as_ref(),
             diagnostics: &report.summary.diagnostics,
             languages: &report.summary.languages,
             risk_summary: RiskSummary::from_findings(&report.summary.findings),
@@ -241,6 +248,8 @@ pub struct ReviewJsonReport<'a> {
     pub baseline: ReviewBaselineJsonMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ci_gate: Option<CiGateJsonMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_feedback: Option<&'a LocalFeedbackReport>,
     #[serde(skip_serializing_if = "diagnostics_empty")]
     pub diagnostics: &'a [ScanDiagnostic],
     pub findings: Vec<ReviewJsonFinding<'a>>,
@@ -278,6 +287,7 @@ impl<'a> ReviewJsonReport<'a> {
                     .map(|path| path.to_string_lossy().to_string()),
             },
             ci_gate: ci_gate.map(CiGateJsonMetadata::from),
+            local_feedback: report.summary.local_feedback.as_ref(),
             diagnostics: &report.summary.diagnostics,
             findings: report
                 .summary

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -187,6 +187,7 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
             repopilotignore_path: report.summary.repopilotignore_path.clone(),
             scan_timings: None,
             cache_telemetry: report.summary.cache_telemetry.clone(),
+            local_feedback: report.summary.local_feedback.clone(),
             diagnostics: report.summary.diagnostics.clone(),
         },
         baseline_path: report.baseline_path.clone(),

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -13,6 +13,12 @@ pub fn render_console(report: &ReviewReport, ci_gate: Option<&CiGateResult>) -> 
         Some(path) => output.push_str(&format!("Baseline: {}\n", path.display())),
         None => output.push_str("Baseline: none (all findings treated as new)\n"),
     }
+    if let Some(feedback) = &report.summary.local_feedback {
+        output.push_str(&format!(
+            "Local feedback: {} suppression(s) loaded, {} finding(s) suppressed\n",
+            feedback.suppressions_loaded, feedback.suppressed_findings_count
+        ));
+    }
     output.push('\n');
 
     output.push_str(&format!("Changed files: {}\n", report.changed_files.len()));

--- a/src/review/render/markdown.rs
+++ b/src/review/render/markdown.rs
@@ -30,6 +30,12 @@ pub fn render_markdown(report: &ReviewReport, ci_gate: Option<&CiGateResult>) ->
         "- **Out-of-diff findings:** {}\n",
         report.out_of_diff_count()
     ));
+    if let Some(feedback) = &report.summary.local_feedback {
+        output.push_str(&format!(
+            "- **Local feedback:** {} suppression(s) loaded, {} finding(s) suppressed\n",
+            feedback.suppressions_loaded, feedback.suppressed_findings_count
+        ));
+    }
 
     if let Some(ci_gate) = ci_gate {
         let status = if ci_gate.passed() { "passed" } else { "failed" };

--- a/src/scan/scanner/summary.rs
+++ b/src/scan/scanner/summary.rs
@@ -79,6 +79,7 @@ pub(super) fn build_scan_summary(
         repopilotignore_path: facts.repopilotignore_path,
         scan_timings: parts.scan_timings,
         cache_telemetry: parts.cache_telemetry,
+        local_feedback: None,
         diagnostics: parts.diagnostics,
     }
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -1,3 +1,4 @@
+use crate::findings::feedback::LocalFeedbackReport;
 use crate::findings::types::Finding;
 use crate::frameworks::DetectedFramework;
 use crate::frameworks::FrameworkProject;
@@ -236,6 +237,9 @@ pub struct ScanSummary {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_telemetry: Option<ScanCacheTelemetry>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_feedback: Option<LocalFeedbackReport>,
+
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<ScanDiagnostic>,
 }
@@ -277,6 +281,7 @@ impl Default for ScanSummary {
             repopilotignore_path: None,
             scan_timings: None,
             cache_telemetry: None,
+            local_feedback: None,
             diagnostics: Vec::new(),
         }
     }

--- a/tests/action_yml.rs
+++ b/tests/action_yml.rs
@@ -58,6 +58,7 @@ fn action_supports_doctor_as_markdown_auto_command() {
     let helper = fs::read_to_string(helper_path).expect("read action helper");
     assert!(helper.contains("doctor) RUN_ARGS=(doctor \"$PATH_INPUT\") ;;"));
     assert!(helper.contains("SARIF output and upload are only supported by 'scan'"));
+    assert!(helper.contains("GITHUB_STEP_SUMMARY"));
     assert!(!helper.contains("ai-context|vibe"));
 }
 
@@ -155,4 +156,50 @@ printf '%s\n' "$@" > "$CAPTURE_ARGS"
         !capture.exists(),
         "validation should fail before invoking repopilot"
     );
+}
+
+#[test]
+#[cfg(unix)]
+fn action_helper_writes_markdown_job_summary() {
+    let temp = tempdir().expect("tempdir");
+    let capture = temp.path().join("args.txt");
+    let step_summary = temp.path().join("summary.md");
+    let fake_bin = temp.path().join("bin");
+    fs::create_dir(&fake_bin).expect("create fake bin");
+    let fake_repopilot = fake_bin.join("repopilot");
+    fs::write(
+        &fake_repopilot,
+        r#"#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CAPTURE_ARGS"
+printf '# Fake RepoPilot Report\n\n- ok\n'
+"#,
+    )
+    .expect("write fake repopilot");
+    let mut permissions = fs::metadata(&fake_repopilot).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_repopilot, permissions).expect("chmod fake repopilot");
+
+    let helper = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/repopilot-action.sh");
+    let output = Command::new("bash")
+        .arg(helper)
+        .env("PATH", format!("{}:{}", fake_bin.display(), env!("PATH")))
+        .env("CAPTURE_ARGS", &capture)
+        .env("GITHUB_STEP_SUMMARY", &step_summary)
+        .env("INPUT_COMMAND", "doctor")
+        .env("INPUT_FORMAT", "auto")
+        .env("INPUT_PATH", ".")
+        .output()
+        .expect("run helper");
+
+    assert!(
+        output.status.success(),
+        "helper failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("Fake RepoPilot Report"));
+
+    let summary = fs::read_to_string(step_summary).expect("read step summary");
+    assert!(summary.contains("## RepoPilot"));
+    assert!(summary.contains("Exit status:** passed"));
+    assert!(summary.contains("# Fake RepoPilot Report"));
 }

--- a/tests/changed_scan_fixture_coverage.rs
+++ b/tests/changed_scan_fixture_coverage.rs
@@ -68,7 +68,7 @@ fn live_smoke() { assert!(true); }
         r#"
 suppressions:
   - rule_id: security.secret-candidate
-    path: src/live.rs
+    path: "src/live.rs"
     reason: fixture value accepted for this test
 "#,
     );
@@ -79,12 +79,105 @@ suppressions:
         !has_rule(&suppressed, "security.secret-candidate"),
         "feedback should suppress matching security finding: {suppressed:#?}"
     );
+    assert_eq!(suppressed["local_feedback"]["suppressions_loaded"], 1);
+    assert_eq!(suppressed["local_feedback"]["suppressed_findings_count"], 1);
+    assert_eq!(
+        suppressed["local_feedback"]["unmatched_suppressions_count"],
+        0
+    );
 
     let raw = scan_json(temp.path(), &["--ignore-feedback"]);
     assert!(
         has_rule(&raw, "security.secret-candidate"),
         "ignore feedback should reveal the finding: {raw:#?}"
     );
+    assert!(raw.get("local_feedback").is_none());
+}
+
+#[test]
+fn malformed_feedback_file_reports_warning_and_keeps_findings() {
+    let temp = tempdir().expect("temp dir");
+
+    write(
+        temp.path().join("src/live.rs"),
+        "const API_KEY: &str = \"abc123xyz987\";\n",
+    );
+    write(
+        temp.path().join(".repopilot/feedback.yml"),
+        "suppressions:\n  - rule_id: [\n",
+    );
+
+    let json = scan_json(temp.path(), &[]);
+
+    assert!(
+        has_rule(&json, "security.secret-candidate"),
+        "malformed feedback should not suppress findings: {json:#?}"
+    );
+    assert_eq!(json["local_feedback"]["suppressions_loaded"], 0);
+    assert!(json["local_feedback"]["parse_error"].as_str().is_some());
+    assert!(diagnostics_include(&json, "feedback.parse-failed"));
+}
+
+#[test]
+fn unmatched_feedback_suppression_reports_warning() {
+    let temp = tempdir().expect("temp dir");
+
+    write(temp.path().join("src/live.rs"), "pub fn live() {}\n");
+    write(
+        temp.path().join(".repopilot/feedback.yml"),
+        r#"
+suppressions:
+  - rule_id: security.secret-candidate
+    path: src/live.rs
+    reason: stale suppression
+"#,
+    );
+
+    let json = scan_json(temp.path(), &[]);
+
+    assert_eq!(json["local_feedback"]["suppressions_loaded"], 1);
+    assert_eq!(json["local_feedback"]["suppressed_findings_count"], 0);
+    assert_eq!(json["local_feedback"]["unmatched_suppressions_count"], 1);
+    assert!(diagnostics_include(
+        &json,
+        "feedback.unmatched-suppressions"
+    ));
+}
+
+#[test]
+fn inspect_feedback_reports_loaded_suppressions() {
+    let temp = tempdir().expect("temp dir");
+
+    write(
+        temp.path().join("src/live.rs"),
+        "const API_KEY: &str = \"abc123xyz987\";\n",
+    );
+    write(
+        temp.path().join(".repopilot/feedback.yml"),
+        r#"
+suppressions:
+  - rule_id: security.secret-candidate
+    path: src/live.rs
+"#,
+    );
+
+    let output = repopilot()
+        .args(["inspect", "feedback", ".", "--format", "json"])
+        .current_dir(temp.path())
+        .output()
+        .expect("run inspect feedback");
+
+    assert!(
+        output.status.success(),
+        "inspect feedback failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("json");
+    assert_eq!(json["exists"], true);
+    assert_eq!(json["local_feedback"]["suppressions_loaded"], 1);
+    assert_eq!(json["local_feedback"]["suppressed_findings_count"], 1);
 }
 
 fn scan_json(root: &Path, extra: &[&str]) -> Value {
@@ -129,6 +222,14 @@ fn has_rule(json: &Value, rule_id: &str) -> bool {
         .into_iter()
         .flatten()
         .any(|finding| finding["rule_id"] == rule_id)
+}
+
+fn diagnostics_include(json: &Value, code: &str) -> bool {
+    json["diagnostics"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .any(|diagnostic| diagnostic["code"] == code)
 }
 
 fn assert_changed_reason(json: &Value, reason: &str, count: u64) {

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -94,6 +94,7 @@ fn summary(findings: Vec<Finding>) -> ScanSummary {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        local_feedback: None,
         diagnostics: Vec::new(),
     }
 }

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -54,6 +54,7 @@ fn html_output_escapes_snippets_and_renders_summary() {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        local_feedback: None,
         diagnostics: Vec::new(),
     };
 

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -43,6 +43,7 @@ fn renders_valid_json_scan_summary() {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        local_feedback: None,
         diagnostics: Vec::new(),
     };
 

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -68,6 +68,7 @@ fn renders_markdown_scan_summary() {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        local_feedback: None,
         diagnostics: Vec::new(),
     };
 
@@ -133,6 +134,7 @@ fn renders_empty_markdown_sections() {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        local_feedback: None,
         diagnostics: Vec::new(),
     };
 
@@ -193,6 +195,7 @@ fn renders_react_native_architecture_section_when_profile_present() {
         repopilotignore_path: None,
         scan_timings: None,
         cache_telemetry: None,
+        local_feedback: None,
         diagnostics: Vec::new(),
     };
 

--- a/tests/receipt_cli.rs
+++ b/tests/receipt_cli.rs
@@ -43,9 +43,9 @@ fn scan_writes_audit_receipt_json() {
     let receipt: Value = serde_json::from_slice(&fs::read(receipt_path).expect("read receipt"))
         .expect("valid receipt json");
 
-    assert_eq!(receipt["schema_version"], 4);
+    assert_eq!(receipt["schema_version"], 5);
     assert_eq!(receipt["report"]["kind"], "receipt");
-    assert_eq!(receipt["report"]["schema_version"], "4");
+    assert_eq!(receipt["report"]["schema_version"], "5");
     assert_eq!(receipt["tool"], "repopilot");
     assert!(receipt["version"].as_str().is_some());
     assert!(receipt["generated_at"].as_str().is_some());
@@ -69,6 +69,58 @@ fn scan_writes_audit_receipt_json() {
     );
     assert!(receipt["diagnostics"].as_array().is_some());
     assert!(receipt["health_score"].as_u64().is_some());
+}
+
+#[test]
+fn scan_receipt_includes_local_feedback_metadata() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+
+    fs::create_dir_all(root.join(".repopilot")).expect("create repopilot dir");
+    fs::create_dir_all(root.join("src")).expect("create src dir");
+    fs::write(
+        root.join("src/live.rs"),
+        "const API_KEY: &str = \"abc123xyz987\";\n",
+    )
+    .expect("write source");
+    fs::write(
+        root.join(".repopilot/feedback.yml"),
+        r#"
+suppressions:
+  - rule_id: security.secret-candidate
+    path: src/live.rs
+    reason: accepted fixture
+"#,
+    )
+    .expect("write feedback");
+
+    let output = repopilot()
+        .args([
+            "scan",
+            ".",
+            "--format",
+            "json",
+            "--output",
+            "report.json",
+            "--receipt",
+            "receipt.json",
+        ])
+        .current_dir(root)
+        .output()
+        .expect("run scan");
+
+    assert!(
+        output.status.success(),
+        "scan should pass, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let receipt: Value =
+        serde_json::from_slice(&fs::read(root.join("receipt.json")).expect("read receipt"))
+            .expect("valid receipt json");
+
+    assert_eq!(receipt["local_feedback"]["suppressions_loaded"], 1);
+    assert_eq!(receipt["local_feedback"]["suppressed_findings_count"], 1);
 }
 
 #[test]

--- a/tests/report_schema_compat.rs
+++ b/tests/report_schema_compat.rs
@@ -1,25 +1,26 @@
-use repopilot::report::schema::parse_scan_summary_json;
+use repopilot::report::schema::{SCAN_REPORT_SCHEMA_VERSION, parse_scan_summary_json};
 use serde_json::Value;
 
 #[test]
-fn schema_fixtures_document_legacy_and_current_metric_names() {
+fn schema_fixtures_document_legacy_and_013_metric_names() {
     let legacy: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v010.json"))
         .expect("legacy report fixture should be valid JSON");
-    let current: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v013.json"))
-        .expect("current report fixture should be valid JSON");
+    let v013: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v013.json"))
+        .expect("0.13 report fixture should be valid JSON");
 
     assert_eq!(legacy["schema_version"], "0.10");
     assert_eq!(legacy["files_count"], 2);
     assert_eq!(legacy["lines_of_code"], 12);
 
-    assert_eq!(current["schema_version"], "0.13");
-    assert_eq!(current["report"]["kind"], "scan");
-    assert_eq!(current["report"]["schema_version"], "0.13");
-    assert_eq!(current["files_analyzed"], 2);
-    assert_eq!(current["non_empty_lines"], 12);
-    assert_eq!(current["large_files_skipped"], 0);
+    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.14");
+    assert_eq!(v013["schema_version"], "0.13");
+    assert_eq!(v013["report"]["kind"], "scan");
+    assert_eq!(v013["report"]["schema_version"], "0.13");
+    assert_eq!(v013["files_analyzed"], 2);
+    assert_eq!(v013["non_empty_lines"], 12);
+    assert_eq!(v013["large_files_skipped"], 0);
     assert_eq!(
-        current["diagnostics"][0]["code"],
+        v013["diagnostics"][0]["code"],
         "workspace.package-scan-failed"
     );
 }

--- a/tests/review_command.rs
+++ b/tests/review_command.rs
@@ -23,7 +23,7 @@ fn review_reports_working_tree_findings_on_changed_lines() {
 
     let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
 
-    assert_eq!(json["schema_version"], "0.13");
+    assert_eq!(json["schema_version"], "0.14");
     assert_eq!(json["report"]["kind"], "review");
     assert!(json["risk_summary"]["total"].as_u64().is_some());
     assert_eq!(json["review"]["in_diff_findings"], 1);
@@ -62,6 +62,77 @@ fn review_treats_untracked_files_as_fully_changed() {
             .iter()
             .any(|file| file["path"] == "src/creds.rs" && file["status"] == "untracked")
     );
+    assert!(json["findings"].as_array().unwrap().iter().any(|finding| {
+        finding["rule_id"] == "security.secret-candidate" && finding["in_diff"] == true
+    }));
+}
+
+#[test]
+fn review_json_includes_local_feedback_metadata() {
+    let temp = tempdir().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_covered_source(temp.path(), "lib", "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+
+    write_covered_source(
+        temp.path(),
+        "creds",
+        "const API_KEY: &str = \"abc12345\";\n",
+    );
+    fs::create_dir_all(temp.path().join(".repopilot")).expect("create repopilot dir");
+    fs::write(
+        temp.path().join(".repopilot/feedback.yml"),
+        r#"
+suppressions:
+  - rule_id: security.secret-candidate
+    path: src/creds.rs
+    reason: accepted fixture
+"#,
+    )
+    .expect("write feedback");
+
+    let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
+
+    assert_eq!(json["local_feedback"]["suppressions_loaded"], 1);
+    assert_eq!(json["local_feedback"]["suppressed_findings_count"], 1);
+    assert!(
+        json["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|finding| finding["rule_id"] != "security.secret-candidate")
+    );
+}
+
+#[test]
+fn review_ignore_feedback_reveals_suppressed_findings() {
+    let temp = tempdir().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_covered_source(temp.path(), "lib", "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+
+    write_covered_source(
+        temp.path(),
+        "creds",
+        "const API_KEY: &str = \"abc12345\";\n",
+    );
+    fs::create_dir_all(temp.path().join(".repopilot")).expect("create repopilot dir");
+    fs::write(
+        temp.path().join(".repopilot/feedback.yml"),
+        r#"
+suppressions:
+  - rule_id: security.secret-candidate
+    path: src/creds.rs
+"#,
+    )
+    .expect("write feedback");
+
+    let json = run_review_json(
+        temp.path(),
+        &["review", ".", "--format", "json", "--ignore-feedback"],
+    );
+
+    assert!(json.get("local_feedback").is_none());
     assert!(json["findings"].as_array().unwrap().iter().any(|finding| {
         finding["rule_id"] == "security.secret-candidate" && finding["in_diff"] == true
     }));


### PR DESCRIPTION
## Summary

This PR prepares RepoPilot 0.12.0 for a stronger public release by adding release-readiness docs, CI self-gating, supply-chain attestation support, local feedback diagnostics, and launch/go-to-market materials.

It also dogfoods RepoPilot inside its own CI using a checked-in baseline, adds `.repopilotignore` for local/build artifacts, and documents the 0.12 positioning around local-first scans, AI-ready context, CI adoption, and React Native/Expo proof points.

## Type of change

- [x] Feature
- [x] Tests
- [x] Documentation
- [x] CI / repository maintenance
- [x] Release preparation
- [x] Product / GTM readiness

## What changed

- Added `.repopilotignore` to exclude local/cache/build/editor artifacts from scans.
- Added `.repopilot/baseline.json` as the current accepted baseline for RepoPilot's own repository.
- Added a RepoPilot CI gate:

```bash
cargo run -- scan . --baseline .repopilot/baseline.json --fail-on new-high --format markdown --output /tmp/repopilot-ci.md
```

- Added artifact attestation permissions and provenance generation to the release workflow.
- Added inspect feedback command support for local feedback diagnostics.
- Added local feedback validation and reporting logic.
- Added diagnostics for:

  - malformed feedback YAML;
  - invalid suppressions;
  - unmatched suppressions.
  - Added release and GTM docs for 0.12.0:
  - GTM plan;
  - release announcement;
  - release checklist;
  - product readiness;
  - distribution docs;
  - report/schema migration docs;
  - local feedback docs;
  - trust mode docs;
  - GitHub Code Scanning integration docs.
- Updated README and command docs around the 0.12 workflow.
- Updated tests for reports, output formats, receipt behavior, review command behavior, changed scan fixtures, and schema compatibility.

## Why

RepoPilot 0.12.0 should feel like a real product release, not just another CLI iteration.

This PR improves three important areas:

```
trust        -> baseline gate, attestations, local-first docs
adoption     -> GTM/release docs, GitHub Action, CI guidance
control      -> local feedback diagnostics and auditable suppressions
```

It also makes RepoPilot dogfood its own scanning workflow. The repository now has a baseline-aware CI gate so new high-severity findings can be caught before merging.

## Architecture notes

- No god files introduced.
- Local feedback domain logic lives in src/findings/feedback.rs.
- CLI inspection logic lives in src/commands/feedback.rs.
- inspect feedback is added under the existing inspect command family.
- Scan summaries carry local feedback metadata and diagnostics.
- Output layers render feedback/report metadata instead of owning suppression logic.
- CI/release hardening remains in workflow files and release docs.
- GTM/release content stays in docs/, separate from scanner internals.

## Compatibility

- Existing scan/review/report behavior remains available.
- .repopilot/baseline.json establishes current accepted repository debt for CI gating.
- .repopilotignore prevents RepoPilot from scanning its own cache/build/editor artifacts.
- Local feedback remains local-first and file-based.
- Warnings from local feedback validation are diagnostic/report metadata; they do not become remote telemetry.

## Verification

Recommended checks:

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```

Smoke checks:

```
cargo run -- scan . --baseline .repopilot/baseline.json --fail-on new-high --format markdown --output /tmp/repopilot-ci.md
cargo run -- inspect feedback .
cargo run -- inspect feedback . --format json
cargo run -- scan . --format json --output /tmp/repopilot-scan.json
cargo run -- review . --format json --output /tmp/repopilot-review.json
```