### PR TITLE
docs: finalize v0.12.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
-## [0.12.0] - 2026-05-17
+## [0.12.0] - 2026-05-20
 
 ### Added
 

--- a/docs/release-checklist-0.12.md
+++ b/docs/release-checklist-0.12.md
@@ -153,7 +153,7 @@ Before tagging, update and verify:
 grep '^version = "0.12.0"' Cargo.toml
 grep '"version": "0.12.0"' package.json
 grep '## \[0.12.0\]' CHANGELOG.md
-rg '0\.[[]11[]]\.0|release-checklist-0\.[[]11[]]' Cargo.toml package.json action.yml README.md docs .github scripts install.sh Formula examples
+rg -n '0\.11\.0|release-checklist-0\.11' Cargo.toml package.json action.yml README.md docs .github scripts install.sh Formula examples
 ```
 
 The final search should only report historical changelog entries, old release


### PR DESCRIPTION
## Summary
- update the 0.12.0 changelog date to 2026-05-20
- fix the 0.12 release checklist version-consistency `rg` command so it runs correctly

## Verification
- `./scripts/verify-release.sh` passed end-to-end on commit `d0caf85`
- release binary smoke reported `repopilot 0.12.0`
- product smoke suite passed against `target/release/repopilot`

## Release follow-up after merge
- tag `main` with `v0.12.0`
- push the tag to trigger the release workflow
- verify npm, crates.io, and GitHub Releases all show `0.12.0`