### PR TITLE
feat(core): harden finding contract, rule lifecycle, and signal quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,26 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Added
 
 - Added a 0.13 release checklist for the breaking cleanup release.
-- Added a current `0.14` scan report fixture that documents the supported compare input schema.
-- Added a shared product scan pipeline for scan, review, and AI Markdown commands, including engine-contract diagnostics and shared runtime diagnostic handling.
+- Added a current `0.15` scan report fixture that documents the supported compare input schema.
+- Added finding contract validation with diagnostics, release-test coverage, and contract timing.
+- Added finding provenance with detector, rule lifecycle, signal source, and analysis scope.
+- Added rule lifecycle, signal source, default confidence, false-positive notes, and tags to rule metadata.
+- Added `repopilot inspect rules`, `repopilot inspect rule <rule_id>`, and `repopilot inspect eval-rules`.
+- Added signal quality summaries to JSON, console, and Markdown reports.
+- Added a shared product scan pipeline for scan, review, baseline creation, and AI Markdown commands, including shared runtime diagnostic handling.
+- Added local rule evaluation fixtures for `security.secret-candidate` and `language.rust.panic-risk`.
 
 ### Changed
 
 - Bumped the crate, npm wrapper, optional platform package pins, and GitHub Action default version to `0.13.0`.
+- Bumped scan report schema to `0.15` for provenance, signal quality, finding contract diagnostics, and `risk-v3`.
+- Updated risk scoring metadata to `risk-v3` with typed risk signal sources and clearer signal reasons.
 - Renamed internal AI modules from legacy context/plan names to `ai_context` and `ai_plan` while keeping the public CLI as `repopilot ai context|plan|prompt`.
 - Updated AI context and AI plan headings to use the stable product names.
 - AI context, AI plan, and AI prompt now use the same default visibility and local feedback behavior as product scans.
 - `repopilot review` now uses the shared default product visibility path before diff classification.
 - `repopilot compare` now requires current scan reports with matching top-level and envelope schema metadata instead of migrating older scan report shapes.
+- `repopilot baseline create` now uses the shared product scan path and supports `--config` and `--ignore-feedback`.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ See [AI workflows](docs/ai-workflows.md).
 | `repopilot compare <before> <after>` | `cmp` | Compare two JSON scan reports |
 | `repopilot baseline create <path>` | `bl` | Store current findings as accepted debt |
 | `repopilot doctor [path]` | `d` | Diagnose audit readiness |
+| `repopilot inspect rules` | — | Inspect rule lifecycle and signal-source metadata |
+| `repopilot inspect eval-rules` | — | Run local rule fixture evaluation |
 | `repopilot init` | — | Generate `repopilot.toml` |
 
 Get command help:
@@ -319,6 +321,29 @@ See:
 - [CLI reference](docs/cli.md)
 - [Commands guide](docs/commands.md)
 - [GitHub Code Scanning integration](docs/integrations/github-code-scanning.md)
+
+---
+
+## Finding Trust
+
+RepoPilot 0.13.0 is a breaking cleanup release focused on trustable findings,
+a stronger local scan engine, rule lifecycle discipline, signal quality metrics,
+and pre-v1 product contract hardening.
+
+Every rendered finding is enriched and validated before reporting. JSON reports
+include finding provenance, `risk-v3` signals, and a compact `signal_quality`
+summary. Rule metadata is inspectable locally:
+
+```bash
+repopilot inspect rules
+repopilot inspect rules --lifecycle preview
+repopilot inspect rules --source text-heuristic
+repopilot inspect rule security.secret-candidate
+repopilot inspect eval-rules --rule security.secret-candidate
+```
+
+RepoPilot remains local-first: no telemetry, no source upload, no hosted scanner,
+no arbitrary plugin execution, and no LLM API calls.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -137,7 +137,7 @@ repopilot scan . --verbose
 
 Use `--timing` when you need the engine pipeline breakdown. It reports
 discovery, file analysis, framework detection, project audits, enrichment, risk
-scoring, and report finalization separately.
+scoring, finding-contract validation, and report finalization separately.
 
 ---
 
@@ -188,6 +188,27 @@ Before v1, new user-facing behavior should fit the existing command families:
 - New debugging and rule-author tools become `inspect` subcommands.
 
 Top-level commands should stay focused on stable workflows: audit, review, baseline, compare, AI assistance, inspection, initialization, and readiness diagnostics.
+
+### Rule inspection and local evaluation
+
+Rule catalog inspection is local and read-only:
+
+```bash
+repopilot inspect rules
+repopilot inspect rules --format json
+repopilot inspect rules --lifecycle preview
+repopilot inspect rules --source text-heuristic
+repopilot inspect rule security.secret-candidate
+```
+
+Local rule evaluation runs bundled fixture projects without telemetry, upload, or
+remote training:
+
+```bash
+repopilot inspect eval-rules
+repopilot inspect eval-rules --rule security.secret-candidate
+repopilot inspect eval-rules --format json
+```
 
 ---
 

--- a/docs/finding-contract.md
+++ b/docs/finding-contract.md
@@ -1,0 +1,22 @@
+# Finding Contract
+
+RepoPilot 0.13.0 validates every rendered finding against an internal contract.
+Validation runs locally after enrichment and risk scoring. Normal scans report
+contract problems as diagnostics; tests and release checks should fail on them.
+
+A valid finding has:
+
+- non-empty `id`, `rule_id`, `title`, `description`, and `recommendation`;
+- at least one evidence item;
+- non-empty evidence path and a `line_start` greater than zero;
+- `line_end` greater than or equal to `line_start` when present;
+- non-empty `risk.formula_version`;
+- at least one risk signal;
+- docs for high and critical findings.
+
+The contract is intentionally strict because findings are used by baselines,
+SARIF, JSON reports, AI context, and CI gates. RepoPilot should not silently
+render incomplete findings or hide contract warnings through visibility filters.
+
+The validation model is exposed through `repopilot::api::findings` for embedded
+tests and release validation.

--- a/docs/release-checklist-0.13.md
+++ b/docs/release-checklist-0.13.md
@@ -5,7 +5,7 @@ RepoPilot 0.13.0 is the breaking cleanup release for the pre-1.0 line.
 Main release promise:
 
 ```text
-engine contract -> stable product commands -> current schema reads -> local-first audit evidence
+finding contract -> rule lifecycle -> signal quality -> risk-v3 -> local-first audit evidence
 ```
 
 ## Release Scope
@@ -15,6 +15,7 @@ engine contract -> stable product commands -> current schema reads -> local-firs
 - Use `repopilot::api::*` as the supported Rust embedding facade; treat direct internal modules as unsupported implementation detail.
 - Require current scan report schema metadata when reading reports for `repopilot compare`.
 - Keep rule growth limited to regression fixes only.
+- Keep finding validation, rule evaluation, and signal quality local-only: no telemetry, source upload, hosted scanner, plugin execution, or LLM API calls.
 
 ## Engine Contract Gates
 
@@ -22,10 +23,19 @@ Verify every rendered finding has:
 
 - stable `id`;
 - non-empty `rule_id`;
+- non-empty title and description;
 - non-empty recommendation;
 - at least one evidence item;
 - risk score, priority, formula version, and risk signals;
+- provenance with detector, lifecycle, signal source, and scope;
 - schema-safe serialization in JSON and SARIF.
+
+Rule metadata gates:
+
+- every registered rule has non-empty title, description, recommendation;
+- every registered rule has lifecycle, signal source, and default confidence;
+- high/critical findings have docs URLs after enrichment;
+- `repopilot inspect rules`, `inspect rule`, and `inspect eval-rules` pass locally.
 
 Smoke commands:
 
@@ -34,14 +44,17 @@ cargo run -- scan . --format json --output /tmp/repopilot-013-scan.json --receip
 cargo run -- scan . --format sarif --output /tmp/repopilot-013.sarif
 cargo run -- review . --format json --output /tmp/repopilot-013-review.json
 cargo run -- ai context . --budget 2k --output /tmp/repopilot-013-ai-context.md
+cargo run -- inspect rules --format json --output /tmp/repopilot-013-rules.json
+cargo run -- inspect eval-rules --format json --output /tmp/repopilot-013-rule-eval.json
 ```
 
 ## Breaking-Change Gates
 
 Verify:
 
-- `repopilot compare` accepts current `0.14` scan reports;
+- `repopilot compare` accepts current `0.15` scan reports;
 - `repopilot compare` rejects pre-current scan report shapes clearly;
+- JSON reports include `signal_quality`, finding `provenance`, `risk.signals[].source`, and `risk-v3`;
 - active docs describe the current command surface, not removed 0.x aliases;
 - schema migration docs state that historical report compatibility belongs in downstream consumers when needed.
 

--- a/docs/report-schema-migration.md
+++ b/docs/report-schema-migration.md
@@ -5,7 +5,18 @@ useful in CI, dashboards, PR bots, and downstream tooling.
 
 ## Current direction
 
-Schema `0.14` adds optional local feedback transparency:
+Schema `0.15` is the current scan report schema for RepoPilot 0.13.0. It adds
+finding provenance, typed risk signal sources, `risk-v3`, signal quality
+metrics, and finding-contract diagnostics.
+
+| Field | Where | Why |
+|---|---|---|
+| `provenance` | finding | Explains detector, lifecycle, signal source, and analysis scope. |
+| `risk.signals[].source` | finding risk signal | Gives machine-readable source families for risk explanations. |
+| `signal_quality` | scan, baseline-scan, review | Summarizes confidence, lifecycle, source, evidence, recommendation, docs, and contract warning coverage. |
+| `scan_timings.contract_validation_us` | scan timings | Exposes finding-contract validation timing separately. |
+
+Schema `0.14` added optional local feedback transparency:
 
 | Field | Where | Why |
 |---|---|---|

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -11,15 +11,15 @@ repopilot scan . --format json --output repopilot-report.json
 
 ## JSON report schema
 
-JSON scan reports include explicit schema metadata. The current schema is 0.14:
+JSON scan reports include explicit schema metadata. The current schema is 0.15:
 
 ```json
 {
-  "schema_version": "0.14",
+  "schema_version": "0.15",
   "repopilot_version": "0.13.0",
   "report": {
     "kind": "scan",
-    "schema_version": "0.14",
+    "schema_version": "0.15",
     "repopilot_version": "0.13.0"
   },
   "root_path": ".",
@@ -31,6 +31,13 @@ JSON scan reports include explicit schema metadata. The current schema is 0.14:
     "total": 0,
     "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 },
     "average_score": 0
+  },
+  "signal_quality": {
+    "findings_total": 0,
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
   },
   "local_feedback": {
     "feedback_path": ".repopilot/feedback.yml",
@@ -54,8 +61,9 @@ JSON scan reports include explicit schema metadata. The current schema is 0.14:
 | `repopilot_version` | string | RepoPilot binary version that produced the report. |
 | `report` | object | Versioned report envelope for consumers that prefer metadata under one stable object. |
 | `risk_summary` | object | Aggregate priority counts and average risk score derived from finding risk assessments. |
+| `signal_quality` | object | Aggregate confidence, lifecycle, source, coverage, and finding-contract warning metrics. |
 | `cache_telemetry` | object | Optional changed-scan cache summary with hits, misses, changed-file reasons, per-file cache decisions, and cache timing impact. |
-| `scan_timings` | object | Optional engine timing metadata. `file_scan_us` remains the compatibility aggregate; newer fields break out `discovery_us`, `file_analysis_us`, `enrichment_us`, `risk_scoring_us`, and `report_finalization_us`. |
+| `scan_timings` | object | Optional engine timing metadata. `file_scan_us` remains the compatibility aggregate; newer fields break out `discovery_us`, `file_analysis_us`, `enrichment_us`, `risk_scoring_us`, `contract_validation_us`, and `report_finalization_us`. |
 | `local_feedback` | object | Optional summary of `.repopilot/feedback.yml` suppressions applied during this scan or review. |
 | `diagnostics` | array | Optional structured warnings/errors captured during a scan, such as workspace partial failures. |
 
@@ -86,6 +94,10 @@ review, and receipt output. Starting with RepoPilot `0.13.0`, `repopilot compare
 requires current scan reports with `schema_version` and `report.schema_version`
 matching the current schema.
 
+Schema `0.15` adds finding provenance, typed risk signal sources, `risk-v3`,
+finding-contract diagnostics, and `signal_quality` metrics. This is part of the
+0.13.0 breaking cleanup release.
+
 ## Baseline JSON reports
 
 When a scan is rendered with a baseline, the JSON report also includes the same
@@ -102,11 +114,11 @@ Example shape:
 
 ```json
 {
-  "schema_version": "0.14",
+  "schema_version": "0.15",
   "repopilot_version": "0.13.0",
   "report": {
     "kind": "baseline-scan",
-    "schema_version": "0.14",
+    "schema_version": "0.15",
     "repopilot_version": "0.13.0"
   },
   "root_path": ".",
@@ -207,31 +219,34 @@ Every finding includes stable fields documented in [rulesets.md](rulesets.md):
 | `severity` | string | One of `INFO`, `LOW`, `MEDIUM`, `HIGH`, or `CRITICAL`. |
 | `confidence` | string | One of `LOW`, `MEDIUM`, or `HIGH`; used to separate impact from certainty. |
 | `risk` | object | Explainable prioritization assessment with `score`, `priority`, stable `signals`, and `formula_version`. |
+| `provenance` | object | Detector, rule lifecycle, signal source, and analysis scope for explaining where the finding came from. |
 | `docs_url` | string? | Optional documentation link for the rule. |
 | `workspace_package` | string? | Optional monorepo package name. |
 | `evidence` | array | One or more evidence locations. |
 
 ### Risk object
 
-RepoPilot uses `risk-v2` for deterministic, explainable prioritization:
+RepoPilot uses `risk-v3` for deterministic, explainable prioritization:
 
 ```json
 {
   "score": 67,
   "priority": "P2",
-  "formula_version": "risk-v2",
+  "formula_version": "risk-v3",
   "signals": [
     {
       "id": "severity.medium",
-      "label": "MEDIUM severity",
+      "label": "severity",
       "weight": 45,
-      "reason": "base score from rule severity"
+      "reason": "medium severity finding",
+      "source": "severity"
     },
     {
       "id": "cluster.repeated",
-      "label": "repeated pattern",
+      "label": "cluster",
       "weight": 7,
-      "reason": "same rule appears repeatedly in the same repository area"
+      "reason": "same rule appears repeatedly in the same repository area",
+      "source": "cluster"
     }
   ]
 }

--- a/docs/risk-engine.md
+++ b/docs/risk-engine.md
@@ -4,9 +4,9 @@ RepoPilot risk scoring is local, deterministic, and explainable. It does not use
 telemetry, hosted analysis, or machine learning. The goal is to rank review work
 better than severity alone while keeping every score auditable.
 
-## Formula v2
+## Formula v3
 
-`risk-v2` scores each finding on a 0-100 scale:
+`risk-v3` scores each finding on a 0-100 scale:
 
 ```text
 base impact
@@ -29,7 +29,7 @@ Priority buckets are stable:
 ## Signals
 
 Each finding includes `risk.signals[]` with a stable `id`, label, signed weight,
-and reason. Common signal families:
+reason, and `source`. Common signal families:
 
 - `severity.*` and `confidence.*` define the starting point.
 - `knowledge.*` applies rule-specific calibration from the bundled Knowledge Engine.
@@ -42,6 +42,15 @@ and reason. Common signal families:
 
 Signals are additive but clamped to the 0-100 score range. They are meant to
 explain ranking, not prove that a finding is always a defect.
+
+Example signal text in human reports:
+
+```text
++75 severity: high severity finding
++12 security: security findings are prioritized
++8 graph: file is an import hub
+-10 confidence: low confidence heuristic signal
+```
 
 ## Cluster-Aware Reports
 

--- a/docs/risk-model.md
+++ b/docs/risk-model.md
@@ -1,0 +1,27 @@
+# Risk Model
+
+RepoPilot uses `risk-v3` in 0.13.0.
+
+`risk-v3` is deterministic and local. It combines severity, confidence, category,
+Knowledge Engine calibration, file role, baseline status, review diff context,
+workspace hotspots, import graph impact, and repeated-rule clusters.
+
+Scores stay on a 0-100 scale:
+
+| Priority | Score | Meaning |
+|---|---:|---|
+| P0 | 90-100 | Immediate risk; fix or explicitly accept before release. |
+| P1 | 70-89 | High-impact hardening; should be reviewed soon. |
+| P2 | 40-69 | Maintainability, architecture, or moderate runtime risk. |
+| P3 | 0-39 | Backlog cleanup or low-urgency review signal. |
+
+Each risk signal has `id`, `label`, `weight`, `reason`, and `source`. Example:
+
+```text
++75 severity: high severity finding
++12 security: security findings are prioritized
++8 graph: file is an import hub
+-10 confidence: low confidence heuristic signal
+```
+
+See [Risk Engine](risk-engine.md) for the full scoring and calibration policy.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,8 +20,8 @@ discipline, and distribution trust before adding broad custom execution surfaces
 | Version | Theme | Main outcome |
 |---|---|---|
 | 0.12 | Core foundation | Document the rule lifecycle, v1 gates, and local-first learning policy; start the API facade, ScanEngine pipeline, report envelope, diagnostics, and legacy alias cleanup. |
-| 0.13 | Breaking cleanup | Centralize the product scan pipeline, tighten schema reads, make `api` the supported Rust facade, and keep local feedback transparency visible in reports/receipts. |
-| 0.14 | Rule-author workflow | Add validation and inspection workflows for rule authors, false-positive fixtures, and clearer decision debugging. |
+| 0.13 | Breaking cleanup | Harden the finding contract, rule lifecycle metadata, signal quality summary, risk-v3, inspectable rule catalog, local rule evaluation, current schema reads, and shared product scan behavior. |
+| 0.14 | Rule-author workflow | Broaden rule fixture coverage, false-positive suites, and clearer decision debugging on top of the 0.13 local evaluation foundation. |
 | 0.15 | Adoption hardening | Improve workspace noise, baseline ergonomics, and performance budgets for larger repositories. |
 | 0.16 | Distribution trust | Add release artifact attestations and tighten npm, crates.io, Homebrew, and installer verification. |
 | 0.17 | Curated packs | Introduce curated first-party knowledge/rule pack structure if the 0.13 overlay model is stable. |
@@ -54,7 +54,7 @@ Not allowed for the 0.x line:
 
 RepoPilot can move to 1.0.0 only after the 0.20 review confirms:
 
-- stable primary command surface: `scan`, `review`, `baseline`, `compare`, `doctor`, `ai`, and `inspect`;
+- stable primary command surface: `scan`, `review`, `baseline`, `compare`, `doctor`, `ai`, `inspect`, `init`, and `cache`;
 - removed legacy 0.x aliases with documented replacements under `ai` and `inspect`;
 - stable JSON, SARIF, baseline, receipt, report-envelope, and diagnostics schema compatibility rules;
 - visible local feedback metadata for suppressions so findings never disappear silently;

--- a/docs/rule-lifecycle.md
+++ b/docs/rule-lifecycle.md
@@ -1,0 +1,39 @@
+# Rule Lifecycle
+
+Every registered rule has lifecycle and signal-source metadata.
+
+Lifecycle values:
+
+| Lifecycle | Meaning |
+|---|---|
+| `experimental` | Broad or noisy heuristic. Useful signal, but not a stable product contract. |
+| `preview` | Supported rule that is still being calibrated through fixtures and feedback. |
+| `stable` | High-confidence rule with clear evidence, recommendation, and regression coverage. |
+| `deprecated` | Rule kept temporarily for compatibility while a replacement exists or behavior is removed. |
+
+Signal source values:
+
+| Source | Meaning |
+|---|---|
+| `text-heuristic` | Text or token heuristic. Usually preview or experimental. |
+| `ast` | Tree-sitter or parser-backed code structure signal. |
+| `config-file` | Project configuration file signal. |
+| `dependency-manifest` | Package/dependency manifest signal. |
+| `import-graph` | Repository graph or dependency edge signal. |
+| `framework-detector` | Framework/profile detector signal. |
+| `git-diff` | Changed-code review signal. |
+| `mixed` | Rule combines multiple sources. |
+
+Inspect the catalog locally:
+
+```bash
+repopilot inspect rules
+repopilot inspect rules --format json
+repopilot inspect rules --lifecycle preview
+repopilot inspect rules --source text-heuristic
+repopilot inspect rule security.secret-candidate
+```
+
+Rule lifecycle does not enable telemetry, hosted scanning, remote model calls, or
+arbitrary plugin execution. It is local metadata used for reports, provenance,
+quality summaries, and rule-author discipline.

--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -2,7 +2,7 @@
 
 RepoPilot findings are identified by a stable `rule_id`. RepoPilot 0.13.0 ships
 46 built-in rules. Each finding carries category, severity, confidence,
-recommendation, and evidence metadata.
+recommendation, evidence, provenance, lifecycle, and signal-source metadata.
 
 ## Categories
 
@@ -30,7 +30,7 @@ certain RepoPilot is that the finding is a real problem in this context.
 ## Risk Prioritization
 
 Severity is not the final sort key. RepoPilot also assigns each finding an
-explainable `risk-v2` score and P0/P1/P2/P3 priority from severity, confidence,
+explainable `risk-v3` score and P0/P1/P2/P3 priority from severity, confidence,
 Knowledge Engine rule calibration, file role, baseline status, review diff,
 dependency graph impact, workspace hotspots, and repeated-pattern clusters.
 

--- a/docs/signal-quality.md
+++ b/docs/signal-quality.md
@@ -1,0 +1,32 @@
+# Signal Quality
+
+RepoPilot 0.13.0 adds a report-level `signal_quality` summary derived from the
+visible findings and the finding contract.
+
+JSON reports include:
+
+- total findings;
+- counts by confidence;
+- counts by rule lifecycle;
+- counts by signal source;
+- evidence coverage percentage;
+- recommendation coverage percentage;
+- docs coverage for high/critical findings;
+- contract violation count.
+
+Console and Markdown reports show a compact summary:
+
+```text
+Signal quality:
+- High confidence: 12
+- Medium confidence: 8
+- Low confidence: 2
+- Evidence coverage: 100%
+- Recommendation coverage: 100%
+- Contract warnings: 0
+```
+
+The summary is meant to help users decide how much trust to place in the current
+report. A report with many experimental or low-confidence findings should be
+treated as review guidance, while stable high-confidence findings should receive
+faster attention.

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,11 +10,20 @@ pub mod config {
 }
 
 pub mod findings {
+    pub use crate::findings::contract::{
+        FindingContractReport, FindingContractViolation, FindingContractViolationKind,
+        validate_finding_contract, validate_findings_contract,
+    };
     pub use crate::findings::feedback::{
         LocalFeedbackReport, LocalFeedbackValidation, LocalSuppression, apply_local_feedback,
         validate_local_feedback,
     };
     pub use crate::findings::filter::{FindingFilter, recompute_summary_metrics};
+    pub use crate::findings::provenance::{AnalysisScope, FindingProvenance};
+    pub use crate::findings::quality::{
+        ConfidenceCounts, RuleLifecycleCounts, SignalQualitySummary, SignalSourceCounts,
+        summarize_signal_quality,
+    };
     pub use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
     pub use crate::findings::visibility::{FindingVisibilityProfile, apply_visibility_profile};
 }
@@ -39,7 +48,13 @@ pub mod review {
 pub mod risk {
     pub use crate::risk::{
         FORMULA_VERSION, RiskAssessment, RiskFormula, RiskInputs, RiskPriority, RiskSignal,
-        RiskSummary, assess_finding, assess_findings, priority_for_score,
+        RiskSignalSource, RiskSummary, assess_finding, assess_findings, priority_for_score,
+    };
+}
+
+pub mod rules {
+    pub use crate::rules::{
+        RuleLifecycle, RuleMetadata, SignalSource, all_rule_metadata, lookup_rule_metadata,
     };
 }
 

--- a/src/audits/architecture/barrel_file_risk.rs
+++ b/src/audits/architecture/barrel_file_risk.rs
@@ -131,6 +131,7 @@ fn build_finding(file: &FileFacts, stats: BarrelStats) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/architecture/deep_nesting.rs
+++ b/src/audits/architecture/deep_nesting.rs
@@ -50,6 +50,7 @@ fn build_finding(deepest_path: PathBuf, depth: usize, threshold: usize) -> Findi
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/architecture/deep_relative_imports.rs
+++ b/src/audits/architecture/deep_relative_imports.rs
@@ -127,6 +127,7 @@ fn build_finding(file: &FileFacts, line_number: usize, snippet: &str, depth: usi
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/architecture/import_coupling.rs
+++ b/src/audits/architecture/import_coupling.rs
@@ -79,6 +79,7 @@ fn excessive_fan_out_finding(metric: &FileMetrics, root: &Path, threshold: usize
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }
@@ -118,6 +119,7 @@ fn high_instability_hub_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }
@@ -154,6 +156,7 @@ fn circular_dependency_finding(cycle: &[PathBuf], root: &Path) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/architecture/large_file.rs
+++ b/src/audits/architecture/large_file.rs
@@ -48,6 +48,7 @@ pub fn detect_large_file_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     })
 }

--- a/src/audits/architecture/too_many_modules.rs
+++ b/src/audits/architecture/too_many_modules.rs
@@ -49,6 +49,7 @@ fn build_finding(dir: PathBuf, file_count: usize, threshold: usize) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/code_quality/code_markers.rs
+++ b/src/audits/code_quality/code_markers.rs
@@ -63,6 +63,7 @@ fn build_marker_finding(marker: &Marker) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/code_quality/complexity.rs
+++ b/src/audits/code_quality/complexity.rs
@@ -67,6 +67,7 @@ impl FileAudit for ComplexityAudit {
             }],
             workspace_package: None,
             docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
         }]
     }

--- a/src/audits/code_quality/language_risk.rs
+++ b/src/audits/code_quality/language_risk.rs
@@ -483,6 +483,7 @@ fn build_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/code_quality/long_function/mod.rs
+++ b/src/audits/code_quality/long_function/mod.rs
@@ -213,6 +213,7 @@ fn build_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -300,6 +300,7 @@ fn build_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/framework/django.rs
+++ b/src/audits/framework/django.rs
@@ -50,6 +50,7 @@ impl ProjectAudit for DjangoDebugTrueAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
                     });
                     break;
@@ -108,6 +109,7 @@ impl ProjectAudit for DjangoEmptyAllowedHostsAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
                     });
                     break;
@@ -172,6 +174,7 @@ impl ProjectAudit for DjangoRawSqlAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
                     });
                 }

--- a/src/audits/framework/js_common.rs
+++ b/src/audits/framework/js_common.rs
@@ -62,6 +62,7 @@ impl ProjectAudit for VarDeclarationAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
                     };
                     if let Some(finding) =
@@ -125,6 +126,7 @@ impl ProjectAudit for ConsoleLogAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
                     };
                     if let Some(finding) =

--- a/src/audits/framework/react.rs
+++ b/src/audits/framework/react.rs
@@ -53,6 +53,7 @@ impl ProjectAudit for ReactClassComponentAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
                     });
                     break; // one finding per file
@@ -115,6 +116,7 @@ impl ProjectAudit for ReactPropTypesAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
                     });
                     break; // one finding per file

--- a/src/audits/framework/react_native/architecture.rs
+++ b/src/audits/framework/react_native/architecture.rs
@@ -41,6 +41,7 @@ impl ProjectAudit for ReactNativeOldArchAudit {
             }],
             workspace_package: None,
             docs_url: Some("https://reactnative.dev/docs/new-architecture-intro".to_string()),
+            provenance: Default::default(),
             risk: Default::default(),
         }]
     }
@@ -83,6 +84,7 @@ impl ProjectAudit for ReactNativeArchitectureMismatchAudit {
             }],
             workspace_package: None,
             docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
         }]
     }
@@ -124,6 +126,7 @@ impl ProjectAudit for HermesMismatchAudit {
             }],
             workspace_package: None,
             docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
         }]
     }

--- a/src/audits/framework/react_native/async_storage.rs
+++ b/src/audits/framework/react_native/async_storage.rs
@@ -51,6 +51,7 @@ impl ProjectAudit for AsyncStorageFromCoreAudit {
                         "https://react-native-async-storage.github.io/async-storage/docs/install"
                             .to_string(),
                     ),
+                    provenance: Default::default(),
                     risk: Default::default(),
                 });
             }

--- a/src/audits/framework/react_native/hermes.rs
+++ b/src/audits/framework/react_native/hermes.rs
@@ -73,6 +73,7 @@ impl ProjectAudit for ReactNativeCodegenMissingAudit {
             }],
             workspace_package: None,
             docs_url: Some("https://reactnative.dev/docs/the-new-architecture/codegen".to_string()),
+            provenance: Default::default(),
             risk: Default::default(),
         }]
     }
@@ -125,6 +126,7 @@ fn hermes_finding(path: PathBuf, snippet: &str) -> Finding {
         }],
         workspace_package: None,
         docs_url: Some("https://reactnative.dev/docs/hermes".to_string()),
+            provenance: Default::default(),
             risk: Default::default(),
     }
 }

--- a/src/audits/framework/react_native/navigation.rs
+++ b/src/audits/framework/react_native/navigation.rs
@@ -57,6 +57,7 @@ impl ProjectAudit for ReactNavigationV4Audit {
                         docs_url: Some(
                             "https://reactnavigation.org/docs/getting-started".to_string(),
                         ),
+                        provenance: Default::default(),
                         risk: Default::default(),
                     });
                     break;
@@ -115,6 +116,7 @@ impl ProjectAudit for DirectStateMutationAudit {
                         }],
                         workspace_package: None,
                         docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
                     });
                     break;

--- a/src/audits/framework/react_native/styling.rs
+++ b/src/audits/framework/react_native/styling.rs
@@ -51,6 +51,7 @@ impl ProjectAudit for RnInlineStyleAudit {
                         }],
                         workspace_package: None,
                         docs_url: Some("https://reactnative.dev/docs/stylesheet".to_string()),
+            provenance: Default::default(),
             risk: Default::default(),
                     });
                     break;
@@ -134,6 +135,7 @@ impl ProjectAudit for RnDeprecatedApiAudit {
                             docs_url: Some(
                                 "https://reactnative.dev/docs/out-of-tree-platforms".to_string(),
                             ),
+                            provenance: Default::default(),
                             risk: Default::default(),
                         });
                         break;
@@ -199,6 +201,7 @@ impl ProjectAudit for RnFlatListMissingKeyAudit {
                             docs_url: Some(
                                 "https://reactnative.dev/docs/flatlist#keyextractor".to_string(),
                             ),
+                            provenance: Default::default(),
                             risk: Default::default(),
                         });
                     }

--- a/src/audits/framework/rn_dep_health.rs
+++ b/src/audits/framework/rn_dep_health.rs
@@ -42,6 +42,7 @@ impl ProjectAudit for RnDepHealthAudit {
                 }],
                 workspace_package: None,
                 docs_url: Some("https://react-native-async-storage.github.io/async-storage/docs/install".to_string()),
+            provenance: Default::default(),
             risk: Default::default(),
             });
         }
@@ -78,6 +79,7 @@ impl ProjectAudit for RnDepHealthAudit {
                     }],
                     workspace_package: None,
                     docs_url: Some("https://reactnavigation.org/docs/getting-started".to_string()),
+            provenance: Default::default(),
             risk: Default::default(),
                 });
             }
@@ -116,6 +118,7 @@ impl ProjectAudit for RnDepHealthAudit {
                     }],
                     workspace_package: None,
                     docs_url: Some("https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation".to_string()),
+            provenance: Default::default(),
             risk: Default::default(),
                 });
             }
@@ -153,6 +156,7 @@ impl ProjectAudit for RnDepHealthAudit {
                     }],
                     workspace_package: None,
                     docs_url: Some("https://docs.swmansion.com/react-native-gesture-handler/docs/installation".to_string()),
+            provenance: Default::default(),
             risk: Default::default(),
                 });
             }
@@ -182,6 +186,7 @@ impl ProjectAudit for RnDepHealthAudit {
                         }],
                         workspace_package: None,
                         docs_url: Some("https://reactnative.dev/docs/new-architecture-intro".to_string()),
+            provenance: Default::default(),
             risk: Default::default(),
                     });
                 }

--- a/src/audits/security/env_file_committed.rs
+++ b/src/audits/security/env_file_committed.rs
@@ -52,6 +52,7 @@ fn build_finding(path: &std::path::Path) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/security/private_key_candidate.rs
+++ b/src/audits/security/private_key_candidate.rs
@@ -89,6 +89,7 @@ fn build_finding(path: &std::path::Path, line_number: usize, header: &str) -> Fi
             "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html"
                 .to_string(),
         ),
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -364,6 +364,7 @@ fn build_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/audits/testing/missing_test_folder.rs
+++ b/src/audits/testing/missing_test_folder.rs
@@ -40,6 +40,7 @@ impl ProjectAudit for MissingTestFolderAudit {
             }],
             workspace_package: None,
             docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
         }]
     }

--- a/src/audits/testing/source_without_test.rs
+++ b/src/audits/testing/source_without_test.rs
@@ -69,6 +69,7 @@ fn build_finding(source: &Path) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3,6 +3,7 @@ use repopilot::baseline::gate::FailOn;
 use repopilot::findings::types::{Confidence, Severity};
 use repopilot::output::OutputFormat;
 use repopilot::risk::RiskPriority;
+use repopilot::rules::{RuleLifecycle, SignalSource};
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 pub enum OutputFormatArg {
@@ -58,6 +59,26 @@ pub enum KnowledgeSectionArg {
     Runtimes,
     Paradigms,
     Rules,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum RuleLifecycleArg {
+    Experimental,
+    Preview,
+    Stable,
+    Deprecated,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum SignalSourceArg {
+    TextHeuristic,
+    Ast,
+    ConfigFile,
+    DependencyManifest,
+    ImportGraph,
+    FrameworkDetector,
+    GitDiff,
+    Mixed,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -126,6 +147,32 @@ impl From<FailOnArg> for FailOn {
             FailOnArg::Medium => FailOn::Any(Severity::Medium),
             FailOnArg::High => FailOn::Any(Severity::High),
             FailOnArg::Critical => FailOn::Any(Severity::Critical),
+        }
+    }
+}
+
+impl From<RuleLifecycleArg> for RuleLifecycle {
+    fn from(value: RuleLifecycleArg) -> Self {
+        match value {
+            RuleLifecycleArg::Experimental => RuleLifecycle::Experimental,
+            RuleLifecycleArg::Preview => RuleLifecycle::Preview,
+            RuleLifecycleArg::Stable => RuleLifecycle::Stable,
+            RuleLifecycleArg::Deprecated => RuleLifecycle::Deprecated,
+        }
+    }
+}
+
+impl From<SignalSourceArg> for SignalSource {
+    fn from(value: SignalSourceArg) -> Self {
+        match value {
+            SignalSourceArg::TextHeuristic => SignalSource::TextHeuristic,
+            SignalSourceArg::Ast => SignalSource::Ast,
+            SignalSourceArg::ConfigFile => SignalSource::ConfigFile,
+            SignalSourceArg::DependencyManifest => SignalSource::DependencyManifest,
+            SignalSourceArg::ImportGraph => SignalSource::ImportGraph,
+            SignalSourceArg::FrameworkDetector => SignalSource::FrameworkDetector,
+            SignalSourceArg::GitDiff => SignalSource::GitDiff,
+            SignalSourceArg::Mixed => SignalSource::Mixed,
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,7 +3,8 @@ mod options;
 
 pub use args::{
     CompareOutputFormatArg, ConfidenceArg, FailOnArg, KnowledgeSectionArg, OutputFormatArg,
-    PriorityArg, ScanProfileArg, SeverityArg, parse_byte_size, parse_token_budget,
+    PriorityArg, RuleLifecycleArg, ScanProfileArg, SeverityArg, SignalSourceArg, parse_byte_size,
+    parse_token_budget,
 };
 pub use options::*;
 

--- a/src/cli/options/baseline.rs
+++ b/src/cli/options/baseline.rs
@@ -23,6 +23,8 @@ as technical debt — not as a way to silence CI.",
         after_help = "EXAMPLES:\n  \
 repopilot baseline create .\n  \
 repopilot baseline create . --output ./baseline.json\n  \
+repopilot baseline create . --config repopilot.toml\n  \
+repopilot baseline create . --ignore-feedback\n  \
 repopilot baseline create . --force"
     )]
     Create(BaselineCreateOptions),
@@ -36,6 +38,14 @@ pub struct BaselineCreateOptions {
     /// Baseline output path; defaults to .repopilot/baseline.json
     #[arg(short, long)]
     pub output: Option<PathBuf>,
+
+    /// Path to repopilot.toml config
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+
+    /// Do not apply local .repopilot/feedback.yml suppressions
+    #[arg(long)]
+    pub ignore_feedback: bool,
 
     /// Overwrite an existing baseline file
     #[arg(long)]

--- a/src/cli/options/inspect.rs
+++ b/src/cli/options/inspect.rs
@@ -1,4 +1,6 @@
-use crate::cli::{CompareOutputFormatArg, KnowledgeSectionArg, SeverityArg};
+use crate::cli::{
+    CompareOutputFormatArg, KnowledgeSectionArg, RuleLifecycleArg, SeverityArg, SignalSourceArg,
+};
 use clap::{Args, Subcommand};
 use std::path::PathBuf;
 
@@ -50,6 +52,37 @@ repopilot inspect feedback . --evaluate --format json\n  \
 repopilot inspect feedback . --format markdown --output feedback.md"
     )]
     Feedback(FeedbackInspectOptions),
+
+    /// List registered rules with lifecycle and signal metadata
+    #[command(
+        about = "List registered RepoPilot rules",
+        after_help = "EXAMPLES:\n  \
+repopilot inspect rules\n  \
+repopilot inspect rules --format json\n  \
+repopilot inspect rules --lifecycle preview\n  \
+repopilot inspect rules --source text-heuristic"
+    )]
+    Rules(RuleListOptions),
+
+    /// Inspect one registered rule by rule id
+    #[command(
+        about = "Inspect one RepoPilot rule",
+        after_help = "EXAMPLES:\n  \
+repopilot inspect rule security.secret-candidate\n  \
+repopilot inspect rule architecture.circular-dependency --format json"
+    )]
+    Rule(RuleInspectOptions),
+
+    /// Evaluate registered rules against local fixture projects
+    #[command(
+        name = "eval-rules",
+        about = "Evaluate rules against local fixture projects",
+        after_help = "EXAMPLES:\n  \
+repopilot inspect eval-rules\n  \
+repopilot inspect eval-rules --rule security.secret-candidate\n  \
+repopilot inspect eval-rules --format json"
+    )]
+    EvalRules(RuleEvalOptions),
 }
 
 #[derive(Args)]
@@ -121,6 +154,58 @@ pub struct FeedbackInspectOptions {
     /// Run a repository scan and evaluate suppressions against current findings
     #[arg(long)]
     pub evaluate: bool,
+
+    /// Write report to a file instead of stdout
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct RuleListOptions {
+    /// Output format for rule catalog
+    #[arg(long, value_enum, default_value = "console")]
+    pub format: CompareOutputFormatArg,
+
+    /// Filter by lifecycle
+    #[arg(long, value_enum)]
+    pub lifecycle: Option<RuleLifecycleArg>,
+
+    /// Filter by signal source
+    #[arg(long, value_enum)]
+    pub source: Option<SignalSourceArg>,
+
+    /// Write report to a file instead of stdout
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct RuleInspectOptions {
+    /// Rule ID to inspect
+    pub rule_id: String,
+
+    /// Output format for rule details
+    #[arg(long, value_enum, default_value = "console")]
+    pub format: CompareOutputFormatArg,
+
+    /// Write report to a file instead of stdout
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct RuleEvalOptions {
+    /// Evaluate only one rule ID
+    #[arg(long)]
+    pub rule: Option<String>,
+
+    /// Fixture root, defaults to tests/fixtures/rules
+    #[arg(long)]
+    pub fixtures: Option<PathBuf>,
+
+    /// Output format for evaluation report
+    #[arg(long, value_enum, default_value = "console")]
+    pub format: CompareOutputFormatArg,
 
     /// Write report to a file instead of stdout
     #[arg(short, long)]

--- a/src/commands/baseline.rs
+++ b/src/commands/baseline.rs
@@ -1,11 +1,13 @@
 use crate::cli::BaselineCommands;
+use crate::commands::product_scan::{ProductScanMode, ProductScanRequest, run_product_scan};
+use crate::commands::scan_config::ScanConfigOverrides;
 use chrono::{SecondsFormat, Utc};
 use repopilot::baseline::key::normalized_relative_path;
 use repopilot::baseline::model::Baseline;
 use repopilot::baseline::writer::{BaselineWriteError, write_baseline};
-use repopilot::config::loader::load_default_config;
+use repopilot::findings::filter::FindingFilter;
 use repopilot::findings::types::Severity;
-use repopilot::scan::scanner::scan_path_with_config;
+use repopilot::findings::visibility::FindingVisibilityProfile;
 use repopilot::scan::types::ScanSummary;
 use std::path::{Path, PathBuf};
 
@@ -15,11 +17,21 @@ pub fn run(command: BaselineCommands) -> Result<(), Box<dyn std::error::Error>> 
             let path = options.path;
             let output = options.output;
             let force = options.force;
+            let config = options.config;
+            let ignore_feedback = options.ignore_feedback;
             let output_path = output.unwrap_or_else(|| default_baseline_path(&path));
 
-            let repo_config = load_default_config()?;
-            let scan_config = repo_config.to_scan_config();
-            let summary = scan_path_with_config(&path, &scan_config)?;
+            let scan_result = run_product_scan(ProductScanRequest {
+                path: path.clone(),
+                config_path: config,
+                overrides: ScanConfigOverrides::default(),
+                preset: None,
+                mode: ProductScanMode::Full,
+                ignore_feedback,
+                visibility_profile: FindingVisibilityProfile::Default,
+                pre_visibility_filter: FindingFilter::default(),
+            })?;
+            let summary = scan_result.summary;
             let baseline = Baseline::from_scan_summary(
                 &summary,
                 &summary.root_path,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod product_scan;
 mod progress;
 pub mod prompt;
 pub mod review;
+pub mod rules;
 pub mod scan;
 pub(crate) mod scan_config;
 
@@ -93,6 +94,21 @@ fn run_inspect(command: InspectCommands) -> Result<(), Box<dyn std::error::Error
             options.format,
             options.output,
             options.evaluate,
+        ),
+        InspectCommands::Rules(options) => rules::list_rules(
+            options.format,
+            options.lifecycle,
+            options.source,
+            options.output,
+        ),
+        InspectCommands::Rule(options) => {
+            rules::inspect_rule(options.rule_id, options.format, options.output)
+        }
+        InspectCommands::EvalRules(options) => rules::eval_rules(
+            options.rule,
+            options.fixtures,
+            options.format,
+            options.output,
         ),
     }
 }

--- a/src/commands/product_scan.rs
+++ b/src/commands/product_scan.rs
@@ -66,7 +66,6 @@ pub fn run_product_scan(
     finish_spinner(pb);
 
     let mut summary = scan_result?;
-    validate_engine_contract(&mut summary);
 
     if !request.ignore_feedback {
         apply_local_feedback(&mut summary, &request.path)?;
@@ -108,63 +107,4 @@ pub fn emit_report_only_diagnostics(summary: &ScanSummary) {
             diagnostic.severity, diagnostic.code, diagnostic.message
         );
     }
-}
-
-fn validate_engine_contract(summary: &mut ScanSummary) {
-    let mut invalid = Vec::new();
-
-    for finding in &summary.findings {
-        let mut missing = Vec::new();
-        if finding.id.trim().is_empty() {
-            missing.push("id");
-        }
-        if finding.rule_id.trim().is_empty() {
-            missing.push("rule_id");
-        }
-        if finding.recommendation.trim().is_empty() {
-            missing.push("recommendation");
-        }
-        if finding.evidence.is_empty() {
-            missing.push("evidence");
-        }
-        if finding.risk.formula_version.trim().is_empty() {
-            missing.push("risk.formula_version");
-        }
-        if finding.risk.signals.is_empty() {
-            missing.push("risk.signals");
-        }
-
-        if !missing.is_empty() {
-            invalid.push(format!(
-                "{} missing {}",
-                if finding.rule_id.trim().is_empty() {
-                    "<unknown-rule>"
-                } else {
-                    finding.rule_id.as_str()
-                },
-                missing.join(", ")
-            ));
-        }
-    }
-
-    if invalid.is_empty() {
-        return;
-    }
-
-    let sample = invalid
-        .iter()
-        .take(5)
-        .cloned()
-        .collect::<Vec<_>>()
-        .join("; ");
-    summary
-        .diagnostics
-        .push(repopilot::scan::types::ScanDiagnostic::error(
-            "engine.contract-invalid",
-            format!(
-                "{} finding(s) violated the RepoPilot engine contract: {}",
-                invalid.len(),
-                sample
-            ),
-        ));
 }

--- a/src/commands/rules.rs
+++ b/src/commands/rules.rs
@@ -1,0 +1,450 @@
+use crate::cli::{CompareOutputFormatArg, RuleLifecycleArg, SignalSourceArg};
+use crate::commands::{CliExit, EXIT_RUNTIME, EXIT_USAGE};
+use repopilot::findings::contract::validate_findings_contract;
+use repopilot::output::OutputFormat;
+use repopilot::report::writer::write_report;
+use repopilot::rules::{RuleLifecycle, RuleMetadata, SignalSource, all_rule_metadata};
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::scanner::scan_path_with_config;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Serialize)]
+struct RuleCatalogReport {
+    rules: Vec<RuleCatalogItem>,
+}
+
+#[derive(Debug, Serialize)]
+struct RuleCatalogItem {
+    rule_id: &'static str,
+    title: &'static str,
+    category: String,
+    severity: String,
+    confidence: String,
+    lifecycle: RuleLifecycle,
+    signal_source: SignalSource,
+    docs_url: Option<&'static str>,
+    tags: &'static [&'static str],
+    description: &'static str,
+    recommendation: Option<&'static str>,
+    false_positive_notes: Option<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RuleEvaluationReport {
+    pub rules_evaluated: usize,
+    pub fixtures_total: usize,
+    pub expected_findings: usize,
+    pub actual_findings: usize,
+    pub missing_findings: usize,
+    pub unexpected_findings: usize,
+    pub contract_violations: usize,
+    pub stable_id_failures: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureExpectations {
+    fixtures: Vec<FixtureCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureCase {
+    path: PathBuf,
+    expected_rule_ids: Vec<String>,
+}
+
+pub fn list_rules(
+    format: CompareOutputFormatArg,
+    lifecycle: Option<RuleLifecycleArg>,
+    source: Option<SignalSourceArg>,
+    output: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let lifecycle = lifecycle.map(RuleLifecycle::from);
+    let source = source.map(SignalSource::from);
+    let rules = all_rule_metadata()
+        .filter(|rule| lifecycle.is_none_or(|value| rule.lifecycle == value))
+        .filter(|rule| source.is_none_or(|value| rule.signal_source == value))
+        .map(RuleCatalogItem::from)
+        .collect::<Vec<_>>();
+    let report = RuleCatalogReport { rules };
+    let rendered = render_catalog(&report, OutputFormat::from(format))?;
+    write_report(&rendered, output.as_deref())?;
+    Ok(())
+}
+
+pub fn inspect_rule(
+    rule_id: String,
+    format: CompareOutputFormatArg,
+    output: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(rule) = repopilot::rules::lookup_rule_metadata(&rule_id) else {
+        return Err(Box::new(CliExit {
+            code: EXIT_USAGE,
+            message: format!("Unknown RepoPilot rule `{rule_id}`"),
+        }));
+    };
+
+    let report = RuleCatalogItem::from(rule);
+    let rendered = render_rule(&report, OutputFormat::from(format))?;
+    write_report(&rendered, output.as_deref())?;
+    Ok(())
+}
+
+pub fn eval_rules(
+    rule: Option<String>,
+    fixtures: Option<PathBuf>,
+    format: CompareOutputFormatArg,
+    output: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(rule_id) = &rule
+        && repopilot::rules::lookup_rule_metadata(rule_id).is_none()
+    {
+        return Err(Box::new(CliExit {
+            code: EXIT_USAGE,
+            message: format!("Unknown RepoPilot rule `{rule_id}`"),
+        }));
+    }
+
+    let report = evaluate_rule_fixtures(rule.as_deref(), fixtures.as_deref())?;
+    let rendered = render_eval_report(&report, OutputFormat::from(format))?;
+    write_report(&rendered, output.as_deref())?;
+    Ok(())
+}
+
+fn render_catalog(
+    report: &RuleCatalogReport,
+    format: OutputFormat,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match validate_output_format(format)? {
+        OutputFormat::Console => Ok(render_catalog_console(report)),
+        OutputFormat::Markdown => Ok(render_catalog_markdown(report)),
+        OutputFormat::Json => Ok(serde_json::to_string_pretty(report)?),
+        OutputFormat::Html | OutputFormat::Sarif => unreachable!("validated output format"),
+    }
+}
+
+fn render_rule(
+    rule: &RuleCatalogItem,
+    format: OutputFormat,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match validate_output_format(format)? {
+        OutputFormat::Console => Ok(render_rule_console(rule)),
+        OutputFormat::Markdown => Ok(render_rule_markdown(rule)),
+        OutputFormat::Json => Ok(serde_json::to_string_pretty(rule)?),
+        OutputFormat::Html | OutputFormat::Sarif => unreachable!("validated output format"),
+    }
+}
+
+fn render_eval_report(
+    report: &RuleEvaluationReport,
+    format: OutputFormat,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match validate_output_format(format)? {
+        OutputFormat::Console => Ok(format!(
+            "RepoPilot Rule Evaluation\n\nRules evaluated: {}\nFixtures: {}\nExpected findings: {}\nActual findings: {}\nMissing findings: {}\nUnexpected findings: {}\nContract violations: {}\nStable ID failures: {}\n",
+            report.rules_evaluated,
+            report.fixtures_total,
+            report.expected_findings,
+            report.actual_findings,
+            report.missing_findings,
+            report.unexpected_findings,
+            report.contract_violations,
+            report.stable_id_failures,
+        )),
+        OutputFormat::Markdown => Ok(format!(
+            "# RepoPilot Rule Evaluation\n\n- **Rules evaluated:** {}\n- **Fixtures:** {}\n- **Expected findings:** {}\n- **Actual findings:** {}\n- **Missing findings:** {}\n- **Unexpected findings:** {}\n- **Contract violations:** {}\n- **Stable ID failures:** {}\n",
+            report.rules_evaluated,
+            report.fixtures_total,
+            report.expected_findings,
+            report.actual_findings,
+            report.missing_findings,
+            report.unexpected_findings,
+            report.contract_violations,
+            report.stable_id_failures,
+        )),
+        OutputFormat::Json => Ok(serde_json::to_string_pretty(report)?),
+        OutputFormat::Html | OutputFormat::Sarif => unreachable!("validated output format"),
+    }
+}
+
+fn render_catalog_console(report: &RuleCatalogReport) -> String {
+    let mut output = String::new();
+    output.push_str("RepoPilot Rules\n\n");
+    for rule in &report.rules {
+        output.push_str(&format!(
+            "{} [{} {} {}]\n  {}\n",
+            rule.rule_id,
+            rule.severity,
+            rule.lifecycle.label(),
+            rule.signal_source.label(),
+            rule.title
+        ));
+    }
+    output
+}
+
+fn render_catalog_markdown(report: &RuleCatalogReport) -> String {
+    let mut output = String::new();
+    output.push_str("# RepoPilot Rules\n\n");
+    output.push_str("| Rule | Title | Category | Severity | Confidence | Lifecycle | Source |\n");
+    output.push_str("| --- | --- | --- | --- | --- | --- | --- |\n");
+    for rule in &report.rules {
+        output.push_str(&format!(
+            "| `{}` | {} | {} | {} | {} | {} | {} |\n",
+            rule.rule_id,
+            escape_table_cell(rule.title),
+            rule.category,
+            rule.severity,
+            rule.confidence,
+            rule.lifecycle.label(),
+            rule.signal_source.label()
+        ));
+    }
+    output
+}
+
+fn render_rule_console(rule: &RuleCatalogItem) -> String {
+    format!(
+        "RepoPilot Rule\n\nRule: {}\nTitle: {}\nCategory: {}\nSeverity: {}\nConfidence: {}\nLifecycle: {}\nSignal source: {}\nDocs: {}\nTags: {}\nDescription: {}\nRecommendation: {}\nFalse positives: {}\n",
+        rule.rule_id,
+        rule.title,
+        rule.category,
+        rule.severity,
+        rule.confidence,
+        rule.lifecycle.label(),
+        rule.signal_source.label(),
+        rule.docs_url.unwrap_or("none"),
+        if rule.tags.is_empty() {
+            "none".to_string()
+        } else {
+            rule.tags.join(", ")
+        },
+        rule.description,
+        rule.recommendation.unwrap_or("none"),
+        rule.false_positive_notes.unwrap_or("none"),
+    )
+}
+
+fn render_rule_markdown(rule: &RuleCatalogItem) -> String {
+    format!(
+        "# `{}`\n\n- **Title:** {}\n- **Category:** {}\n- **Severity:** {}\n- **Confidence:** {}\n- **Lifecycle:** {}\n- **Signal source:** {}\n- **Docs:** {}\n- **Tags:** {}\n\n{}\n\n**Recommendation:** {}\n\n**False-positive notes:** {}\n",
+        rule.rule_id,
+        rule.title,
+        rule.category,
+        rule.severity,
+        rule.confidence,
+        rule.lifecycle.label(),
+        rule.signal_source.label(),
+        rule.docs_url.unwrap_or("none"),
+        if rule.tags.is_empty() {
+            "none".to_string()
+        } else {
+            rule.tags.join(", ")
+        },
+        rule.description,
+        rule.recommendation.unwrap_or("none"),
+        rule.false_positive_notes.unwrap_or("none"),
+    )
+}
+
+fn evaluate_rule_fixtures(
+    only_rule: Option<&str>,
+    fixture_root: Option<&Path>,
+) -> Result<RuleEvaluationReport, Box<dyn std::error::Error>> {
+    let fixture_root = fixture_root
+        .map(Path::to_path_buf)
+        .unwrap_or_else(default_fixture_root);
+
+    if !fixture_root.exists() {
+        return Err(Box::new(CliExit {
+            code: EXIT_RUNTIME,
+            message: format!(
+                "Rule fixture root does not exist: {}",
+                fixture_root.display()
+            ),
+        }));
+    }
+
+    let mut rules_evaluated = BTreeSet::new();
+    let mut report = RuleEvaluationReport {
+        rules_evaluated: 0,
+        fixtures_total: 0,
+        expected_findings: 0,
+        actual_findings: 0,
+        missing_findings: 0,
+        unexpected_findings: 0,
+        contract_violations: 0,
+        stable_id_failures: 0,
+    };
+
+    for entry in fs::read_dir(&fixture_root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let rule_id = entry.file_name().to_string_lossy().to_string();
+        if only_rule.is_some_and(|only_rule| only_rule != rule_id) {
+            continue;
+        }
+        rules_evaluated.insert(rule_id.clone());
+        evaluate_one_rule_fixture(&entry.path(), &rule_id, &mut report)?;
+    }
+
+    report.rules_evaluated = rules_evaluated.len();
+    Ok(report)
+}
+
+fn evaluate_one_rule_fixture(
+    rule_root: &Path,
+    rule_id: &str,
+    report: &mut RuleEvaluationReport,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let expected_path = rule_root.join("expected.json");
+    let expectations: FixtureExpectations =
+        serde_json::from_str(&fs::read_to_string(expected_path)?)?;
+    let config = ScanConfig {
+        detect_missing_tests: false,
+        include_low_signal: true,
+        ..ScanConfig::default()
+    };
+
+    for fixture in expectations.fixtures {
+        let path = rule_root.join(&fixture.path);
+        let scan_path = materialize_fixture_for_scan(&path)?;
+        let summary = scan_path_with_config(&scan_path, &config)?;
+        cleanup_materialized_fixture(&scan_path, &path);
+        let actual_rule_ids = summary
+            .findings
+            .iter()
+            .filter(|finding| finding.rule_id == rule_id)
+            .map(|finding| finding.rule_id.clone())
+            .collect::<Vec<_>>();
+        let expected = fixture
+            .expected_rule_ids
+            .iter()
+            .filter(|expected_rule| expected_rule.as_str() == rule_id)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        report.fixtures_total += 1;
+        report.expected_findings += expected.len();
+        report.actual_findings += actual_rule_ids.len();
+        report.missing_findings += missing_count(&expected, &actual_rule_ids);
+        report.unexpected_findings += missing_count(&actual_rule_ids, &expected);
+        report.contract_violations += validate_findings_contract(&summary.findings)
+            .violations
+            .len();
+
+        if has_stable_id_failure(&summary.findings) {
+            report.stable_id_failures += 1;
+        }
+    }
+
+    Ok(())
+}
+
+fn materialize_fixture_for_scan(path: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let path_text = path.to_string_lossy().to_lowercase();
+    if !path_text.contains("fixture") {
+        return Ok(path.to_path_buf());
+    }
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let target = std::env::temp_dir().join(format!(
+        "repopilot-rule-eval-{}-{nanos}",
+        std::process::id()
+    ));
+    copy_dir_all(path, &target)?;
+    Ok(target)
+}
+
+fn cleanup_materialized_fixture(scan_path: &Path, original_path: &Path) {
+    if scan_path != original_path {
+        let _ = fs::remove_dir_all(scan_path);
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let target = to.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_all(&entry.path(), &target)?;
+        } else if file_type.is_file() {
+            fs::copy(entry.path(), target)?;
+        }
+    }
+    Ok(())
+}
+
+fn missing_count(expected: &[String], actual: &[String]) -> usize {
+    let mut counts = BTreeMap::<&str, usize>::new();
+    for item in actual {
+        *counts.entry(item.as_str()).or_default() += 1;
+    }
+
+    expected
+        .iter()
+        .filter(|item| {
+            let count = counts.entry(item.as_str()).or_default();
+            if *count == 0 {
+                true
+            } else {
+                *count -= 1;
+                false
+            }
+        })
+        .count()
+}
+
+fn has_stable_id_failure(findings: &[repopilot::findings::types::Finding]) -> bool {
+    let mut seen = BTreeSet::new();
+    findings
+        .iter()
+        .any(|finding| finding.id.trim().is_empty() || !seen.insert(finding.id.as_str()))
+}
+
+fn default_fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rules")
+}
+
+fn validate_output_format(format: OutputFormat) -> Result<OutputFormat, CliExit> {
+    match format {
+        OutputFormat::Console | OutputFormat::Json | OutputFormat::Markdown => Ok(format),
+        OutputFormat::Html | OutputFormat::Sarif => Err(CliExit {
+            code: EXIT_USAGE,
+            message: "`inspect rules` supports only console, markdown, and json output".to_string(),
+        }),
+    }
+}
+
+fn escape_table_cell(value: &str) -> String {
+    value.replace('|', "\\|").replace('\n', " ")
+}
+
+impl From<&'static RuleMetadata> for RuleCatalogItem {
+    fn from(rule: &'static RuleMetadata) -> Self {
+        Self {
+            rule_id: rule.rule_id,
+            title: rule.title,
+            category: rule.category.label().to_string(),
+            severity: rule.default_severity.label().to_string(),
+            confidence: rule.default_confidence.label().to_string(),
+            lifecycle: rule.lifecycle,
+            signal_source: rule.signal_source,
+            docs_url: rule.docs_url,
+            tags: rule.tags,
+            description: rule.description,
+            recommendation: rule.recommendation,
+            false_positive_notes: rule.false_positive_notes,
+        }
+    }
+}

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -181,11 +181,12 @@ fn print_timing_breakdown(summary: &ScanSummary) {
             timings.accounted_engine_us() / 1000,
         );
         eprintln!(
-            "[timing] Pipeline: discovery {}ms · file analysis {}ms · enrichment {}ms · risk scoring {}ms · report finalization {}ms",
+            "[timing] Pipeline: discovery {}ms · file analysis {}ms · enrichment {}ms · risk scoring {}ms · contract validation {}ms · report finalization {}ms",
             timings.discovery_us / 1000,
             timings.file_analysis_us / 1000,
             timings.enrichment_us / 1000,
             timings.risk_scoring_us / 1000,
+            timings.contract_validation_us / 1000,
             timings.report_finalization_us / 1000,
         );
     }

--- a/src/engine/diagnostics.rs
+++ b/src/engine/diagnostics.rs
@@ -1,0 +1,64 @@
+use crate::findings::contract::{
+    FindingContractReport, FindingContractViolation, FindingContractViolationKind,
+};
+use crate::scan::types::ScanDiagnostic;
+
+pub fn finding_contract_diagnostics(report: &FindingContractReport) -> Vec<ScanDiagnostic> {
+    if report.violations.is_empty() {
+        return Vec::new();
+    }
+
+    let sample = report
+        .violations
+        .iter()
+        .take(5)
+        .map(describe_violation)
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    vec![ScanDiagnostic::warning(
+        "finding.contract-violation",
+        format!(
+            "{} finding contract violation(s) across {} invalid finding(s): {}",
+            report.violations.len(),
+            report.invalid_findings,
+            sample
+        ),
+    )]
+}
+
+fn describe_violation(violation: &FindingContractViolation) -> String {
+    let rule_id = if violation.rule_id.trim().is_empty() {
+        "<empty-rule>"
+    } else {
+        violation.rule_id.as_str()
+    };
+    let finding_id = if violation.finding_id.trim().is_empty() {
+        "<empty-finding>"
+    } else {
+        violation.finding_id.as_str()
+    };
+
+    format!(
+        "{rule_id}/{finding_id}: {}",
+        violation_label(violation.violation)
+    )
+}
+
+fn violation_label(kind: FindingContractViolationKind) -> &'static str {
+    match kind {
+        FindingContractViolationKind::EmptyId => "empty id",
+        FindingContractViolationKind::EmptyRuleId => "empty rule id",
+        FindingContractViolationKind::EmptyTitle => "empty title",
+        FindingContractViolationKind::EmptyDescription => "empty description",
+        FindingContractViolationKind::EmptyRecommendation => "empty recommendation",
+        FindingContractViolationKind::MissingEvidence => "missing evidence",
+        FindingContractViolationKind::InvalidEvidencePath => "invalid evidence path",
+        FindingContractViolationKind::InvalidEvidenceLineRange => "invalid evidence line range",
+        FindingContractViolationKind::MissingRiskFormulaVersion => "missing risk formula version",
+        FindingContractViolationKind::MissingRiskSignals => "missing risk signals",
+        FindingContractViolationKind::MissingDocsForHighSeverity => {
+            "missing docs for high severity"
+        }
+    }
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,0 +1,2 @@
+pub mod diagnostics;
+pub mod pipeline;

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -1,0 +1,15 @@
+use crate::engine::diagnostics::finding_contract_diagnostics;
+use crate::findings::contract::validate_findings_contract;
+use crate::findings::types::Finding;
+use crate::scan::types::ScanDiagnostic;
+use std::time::Instant;
+
+pub fn validate_finding_contract_stage(
+    findings: &[Finding],
+    diagnostics: &mut Vec<ScanDiagnostic>,
+) -> u64 {
+    let start = Instant::now();
+    let report = validate_findings_contract(findings);
+    diagnostics.extend(finding_contract_diagnostics(&report));
+    start.elapsed().as_micros() as u64
+}

--- a/src/findings/contract.rs
+++ b/src/findings/contract.rs
@@ -1,0 +1,168 @@
+use crate::findings::types::{Finding, Severity};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FindingContractViolation {
+    pub rule_id: String,
+    pub finding_id: String,
+    pub violation: FindingContractViolationKind,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum FindingContractViolationKind {
+    EmptyId,
+    EmptyRuleId,
+    EmptyTitle,
+    EmptyDescription,
+    EmptyRecommendation,
+    MissingEvidence,
+    InvalidEvidencePath,
+    InvalidEvidenceLineRange,
+    MissingRiskFormulaVersion,
+    MissingRiskSignals,
+    MissingDocsForHighSeverity,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FindingContractReport {
+    pub violations: Vec<FindingContractViolation>,
+    pub findings_checked: usize,
+    pub valid_findings: usize,
+    pub invalid_findings: usize,
+}
+
+pub fn validate_finding_contract(finding: &Finding) -> Vec<FindingContractViolation> {
+    let mut violations = Vec::new();
+
+    push_if(
+        &mut violations,
+        finding,
+        finding.id.trim().is_empty(),
+        FindingContractViolationKind::EmptyId,
+    );
+    push_if(
+        &mut violations,
+        finding,
+        finding.rule_id.trim().is_empty(),
+        FindingContractViolationKind::EmptyRuleId,
+    );
+    push_if(
+        &mut violations,
+        finding,
+        finding.title.trim().is_empty(),
+        FindingContractViolationKind::EmptyTitle,
+    );
+    push_if(
+        &mut violations,
+        finding,
+        finding.description.trim().is_empty(),
+        FindingContractViolationKind::EmptyDescription,
+    );
+    push_if(
+        &mut violations,
+        finding,
+        finding.recommendation.trim().is_empty(),
+        FindingContractViolationKind::EmptyRecommendation,
+    );
+
+    if finding.evidence.is_empty() {
+        push_violation(
+            &mut violations,
+            finding,
+            FindingContractViolationKind::MissingEvidence,
+        );
+    } else {
+        for evidence in &finding.evidence {
+            if evidence.path.as_os_str().is_empty() {
+                push_violation(
+                    &mut violations,
+                    finding,
+                    FindingContractViolationKind::InvalidEvidencePath,
+                );
+            }
+            if evidence.line_start == 0
+                || evidence
+                    .line_end
+                    .is_some_and(|line_end| line_end < evidence.line_start)
+            {
+                push_violation(
+                    &mut violations,
+                    finding,
+                    FindingContractViolationKind::InvalidEvidenceLineRange,
+                );
+            }
+        }
+    }
+
+    push_if(
+        &mut violations,
+        finding,
+        finding.risk.formula_version.trim().is_empty(),
+        FindingContractViolationKind::MissingRiskFormulaVersion,
+    );
+    push_if(
+        &mut violations,
+        finding,
+        finding.risk.signals.is_empty(),
+        FindingContractViolationKind::MissingRiskSignals,
+    );
+
+    if matches!(finding.severity, Severity::High | Severity::Critical)
+        && finding
+            .docs_url
+            .as_deref()
+            .is_none_or(|docs_url| docs_url.trim().is_empty())
+    {
+        push_violation(
+            &mut violations,
+            finding,
+            FindingContractViolationKind::MissingDocsForHighSeverity,
+        );
+    }
+
+    violations
+}
+
+pub fn validate_findings_contract(findings: &[Finding]) -> FindingContractReport {
+    let mut violations = Vec::new();
+    let mut invalid_findings = 0;
+
+    for finding in findings {
+        let finding_violations = validate_finding_contract(finding);
+        if !finding_violations.is_empty() {
+            invalid_findings += 1;
+        }
+        violations.extend(finding_violations);
+    }
+
+    FindingContractReport {
+        violations,
+        findings_checked: findings.len(),
+        valid_findings: findings.len().saturating_sub(invalid_findings),
+        invalid_findings,
+    }
+}
+
+fn push_if(
+    violations: &mut Vec<FindingContractViolation>,
+    finding: &Finding,
+    condition: bool,
+    kind: FindingContractViolationKind,
+) {
+    if condition {
+        push_violation(violations, finding, kind);
+    }
+}
+
+fn push_violation(
+    violations: &mut Vec<FindingContractViolation>,
+    finding: &Finding,
+    kind: FindingContractViolationKind,
+) {
+    violations.push(FindingContractViolation {
+        rule_id: finding.rule_id.clone(),
+        finding_id: finding.id.clone(),
+        violation: kind,
+    });
+}

--- a/src/findings/filter.rs
+++ b/src/findings/filter.rs
@@ -79,6 +79,7 @@ mod tests {
             rule_id: rule_id.to_string(),
             severity,
             confidence,
+            provenance: Default::default(),
             risk: RiskAssessment {
                 priority,
                 ..RiskAssessment::default()

--- a/src/findings/mod.rs
+++ b/src/findings/mod.rs
@@ -1,4 +1,7 @@
+pub mod contract;
 pub mod feedback;
 pub mod filter;
+pub mod provenance;
+pub mod quality;
 pub mod types;
 pub mod visibility;

--- a/src/findings/provenance.rs
+++ b/src/findings/provenance.rs
@@ -1,0 +1,45 @@
+use crate::rules::{RuleLifecycle, SignalSource};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FindingProvenance {
+    pub detector: String,
+    pub signal_source: SignalSource,
+    pub rule_lifecycle: RuleLifecycle,
+    pub analysis_scope: AnalysisScope,
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum AnalysisScope {
+    #[default]
+    File,
+    Repository,
+    Workspace,
+    GitDiff,
+    FrameworkProject,
+}
+
+impl Default for FindingProvenance {
+    fn default() -> Self {
+        Self {
+            detector: "unknown".to_string(),
+            signal_source: SignalSource::Mixed,
+            rule_lifecycle: RuleLifecycle::Preview,
+            analysis_scope: AnalysisScope::File,
+        }
+    }
+}
+
+impl AnalysisScope {
+    pub fn for_signal_source(signal_source: SignalSource) -> Self {
+        match signal_source {
+            SignalSource::ConfigFile
+            | SignalSource::DependencyManifest
+            | SignalSource::ImportGraph => Self::Repository,
+            SignalSource::FrameworkDetector => Self::FrameworkProject,
+            SignalSource::GitDiff => Self::GitDiff,
+            SignalSource::TextHeuristic | SignalSource::Ast | SignalSource::Mixed => Self::File,
+        }
+    }
+}

--- a/src/findings/quality.rs
+++ b/src/findings/quality.rs
@@ -1,0 +1,123 @@
+use crate::findings::contract::validate_findings_contract;
+use crate::findings::types::{Confidence, Finding, Severity};
+use crate::rules::{RuleLifecycle, SignalSource};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SignalQualitySummary {
+    pub findings_total: usize,
+    pub by_confidence: ConfidenceCounts,
+    pub by_lifecycle: RuleLifecycleCounts,
+    pub by_signal_source: SignalSourceCounts,
+    pub evidence_coverage_percent: u8,
+    pub recommendation_coverage_percent: u8,
+    pub docs_coverage_for_high_risk_percent: u8,
+    pub contract_violations: usize,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConfidenceCounts {
+    pub low: usize,
+    pub medium: usize,
+    pub high: usize,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuleLifecycleCounts {
+    pub experimental: usize,
+    pub preview: usize,
+    pub stable: usize,
+    pub deprecated: usize,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SignalSourceCounts {
+    pub text_heuristic: usize,
+    pub ast: usize,
+    pub config_file: usize,
+    pub dependency_manifest: usize,
+    pub import_graph: usize,
+    pub framework_detector: usize,
+    pub git_diff: usize,
+    pub mixed: usize,
+}
+
+pub fn summarize_signal_quality(findings: &[Finding]) -> SignalQualitySummary {
+    let findings_total = findings.len();
+    let mut by_confidence = ConfidenceCounts::default();
+    let mut by_lifecycle = RuleLifecycleCounts::default();
+    let mut by_signal_source = SignalSourceCounts::default();
+    let mut evidence_present = 0usize;
+    let mut recommendation_present = 0usize;
+    let mut high_risk_total = 0usize;
+    let mut high_risk_docs_present = 0usize;
+
+    for finding in findings {
+        match finding.confidence {
+            Confidence::Low => by_confidence.low += 1,
+            Confidence::Medium => by_confidence.medium += 1,
+            Confidence::High => by_confidence.high += 1,
+        }
+        match finding.provenance.rule_lifecycle {
+            RuleLifecycle::Experimental => by_lifecycle.experimental += 1,
+            RuleLifecycle::Preview => by_lifecycle.preview += 1,
+            RuleLifecycle::Stable => by_lifecycle.stable += 1,
+            RuleLifecycle::Deprecated => by_lifecycle.deprecated += 1,
+        }
+        match finding.provenance.signal_source {
+            SignalSource::TextHeuristic => by_signal_source.text_heuristic += 1,
+            SignalSource::Ast => by_signal_source.ast += 1,
+            SignalSource::ConfigFile => by_signal_source.config_file += 1,
+            SignalSource::DependencyManifest => by_signal_source.dependency_manifest += 1,
+            SignalSource::ImportGraph => by_signal_source.import_graph += 1,
+            SignalSource::FrameworkDetector => by_signal_source.framework_detector += 1,
+            SignalSource::GitDiff => by_signal_source.git_diff += 1,
+            SignalSource::Mixed => by_signal_source.mixed += 1,
+        }
+        if !finding.evidence.is_empty() {
+            evidence_present += 1;
+        }
+        if !finding.recommendation.trim().is_empty() {
+            recommendation_present += 1;
+        }
+        if matches!(finding.severity, Severity::High | Severity::Critical) {
+            high_risk_total += 1;
+            if finding
+                .docs_url
+                .as_deref()
+                .is_some_and(|docs_url| !docs_url.trim().is_empty())
+            {
+                high_risk_docs_present += 1;
+            }
+        }
+    }
+
+    SignalQualitySummary {
+        findings_total,
+        by_confidence,
+        by_lifecycle,
+        by_signal_source,
+        evidence_coverage_percent: coverage_percent(evidence_present, findings_total),
+        recommendation_coverage_percent: coverage_percent(recommendation_present, findings_total),
+        docs_coverage_for_high_risk_percent: coverage_percent_or_full(
+            high_risk_docs_present,
+            high_risk_total,
+        ),
+        contract_violations: validate_findings_contract(findings).violations.len(),
+    }
+}
+
+fn coverage_percent(numerator: usize, denominator: usize) -> u8 {
+    if denominator == 0 {
+        return 100;
+    }
+
+    ((numerator * 100 + denominator / 2) / denominator).min(100) as u8
+}
+
+fn coverage_percent_or_full(numerator: usize, denominator: usize) -> u8 {
+    if denominator == 0 {
+        return 100;
+    }
+    coverage_percent(numerator, denominator)
+}

--- a/src/findings/types.rs
+++ b/src/findings/types.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+use crate::findings::provenance::{AnalysisScope, FindingProvenance};
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Finding {
     pub id: String,
@@ -18,6 +20,8 @@ pub struct Finding {
     pub workspace_package: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub docs_url: Option<String>,
+    #[serde(default)]
+    pub provenance: FindingProvenance,
     #[serde(default)]
     pub risk: crate::risk::RiskAssessment,
 }
@@ -85,8 +89,39 @@ impl Finding {
     }
 
     pub fn populate_recommendation(&mut self) {
+        self.populate_rule_metadata();
+    }
+
+    pub fn populate_rule_metadata(&mut self) {
+        let Some(metadata) = crate::rules::lookup_rule_metadata(&self.rule_id) else {
+            if self.recommendation.trim().is_empty() {
+                self.recommendation = Self::GENERIC_RECOMMENDATION.to_string();
+            }
+            return;
+        };
+
+        if self.title.trim().is_empty() {
+            self.title = metadata.title.to_string();
+        }
+        if self.description.trim().is_empty() {
+            self.description = metadata.description.to_string();
+        }
         if self.recommendation.trim().is_empty() {
-            self.recommendation = Self::recommendation_for_rule_id(&self.rule_id);
+            self.recommendation = metadata
+                .recommendation
+                .unwrap_or(Self::GENERIC_RECOMMENDATION)
+                .to_string();
+        }
+        if self.docs_url.as_deref().is_none_or(str::is_empty) {
+            self.docs_url = metadata.docs_url.map(str::to_string);
+        }
+        if self.provenance == FindingProvenance::default() {
+            self.provenance = FindingProvenance {
+                detector: metadata.rule_id.to_string(),
+                signal_source: metadata.signal_source,
+                rule_lifecycle: metadata.lifecycle,
+                analysis_scope: AnalysisScope::for_signal_source(metadata.signal_source),
+            };
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ pub mod config;
 #[doc(hidden)]
 pub mod doctor;
 #[doc(hidden)]
+pub mod engine;
+#[doc(hidden)]
 pub mod explain;
 #[doc(hidden)]
 pub mod findings;

--- a/src/output/ai_context/tests.rs
+++ b/src/output/ai_context/tests.rs
@@ -29,6 +29,7 @@ fn make_finding(
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -11,7 +11,8 @@ use crate::output::console::findings::render_grouped_findings;
 use crate::output::console::react_native::render_react_native_section;
 use crate::output::console::sections::{
     render_framework_projects_section, render_frameworks_section, render_header,
-    render_languages_section, render_risk_summary, render_top_risk_clusters, render_top_rules,
+    render_languages_section, render_risk_summary, render_signal_quality, render_top_risk_clusters,
+    render_top_rules,
 };
 use crate::output::console::workspace::workspace_risk_table;
 use crate::output::report_stats::build_report_stats;
@@ -23,6 +24,7 @@ pub fn render(summary: &ScanSummary) -> String {
 
     render_header(&mut output, summary, &stats);
     render_risk_summary(&mut output, &stats);
+    render_signal_quality(&mut output, summary);
     render_top_risk_clusters(&mut output, &summary.findings);
     render_top_rules(&mut output, &stats);
     render_languages_section(&mut output, summary);
@@ -45,6 +47,7 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
     render_header(&mut output, summary, &stats);
     render_baseline_block(&mut output, report, ci_gate);
     render_risk_summary(&mut output, &stats);
+    render_signal_quality(&mut output, summary);
     render_top_risk_clusters(&mut output, &summary.findings);
     render_top_rules(&mut output, &stats);
     render_languages_section(&mut output, summary);

--- a/src/output/console/findings.rs
+++ b/src/output/console/findings.rs
@@ -97,9 +97,8 @@ fn risk_reason_text(finding: &Finding) -> Option<String> {
         .risk
         .signals
         .iter()
-        .filter(|signal| !signal.id.starts_with("severity."))
-        .take(3)
-        .map(|signal| format!("{} ({:+})", signal.label, signal.weight))
+        .take(4)
+        .map(|signal| format!("{:+} {}: {}", signal.weight, signal.label, signal.reason))
         .collect::<Vec<_>>();
 
     (!reasons.is_empty()).then(|| reasons.join(", "))

--- a/src/output/console/sections.rs
+++ b/src/output/console/sections.rs
@@ -4,6 +4,7 @@ use crate::output::color;
 use crate::output::finding_helpers::{clusters_by_rule_scope, example_locations};
 use crate::output::report_stats::{ReportStats, TOOL_VERSION};
 use crate::output::report_text::{console_severity_counts_text, named_counts_text};
+use crate::report::quality::build_signal_quality_summary;
 use crate::risk::RiskPriority;
 use crate::scan::types::{DiagnosticSeverity, ScanSummary};
 use std::fmt::Write;
@@ -292,6 +293,38 @@ pub(crate) fn render_risk_summary(output: &mut String, stats: &ReportStats) {
         )
         .unwrap();
     }
+    output.push('\n');
+}
+
+pub(crate) fn render_signal_quality(output: &mut String, summary: &ScanSummary) {
+    let quality = build_signal_quality_summary(&summary.findings);
+    output.push_str("Signal quality:\n");
+    writeln!(output, "  High confidence: {}", quality.by_confidence.high).unwrap();
+    writeln!(
+        output,
+        "  Medium confidence: {}",
+        quality.by_confidence.medium
+    )
+    .unwrap();
+    writeln!(output, "  Low confidence: {}", quality.by_confidence.low).unwrap();
+    writeln!(
+        output,
+        "  Evidence coverage: {}%",
+        quality.evidence_coverage_percent
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  Recommendation coverage: {}%",
+        quality.recommendation_coverage_percent
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  Contract warnings: {}",
+        quality.contract_violations
+    )
+    .unwrap();
     output.push('\n');
 }
 

--- a/src/output/html/finding.rs
+++ b/src/output/html/finding.rs
@@ -152,9 +152,8 @@ fn risk_reason_text(finding: &Finding) -> Option<String> {
         .risk
         .signals
         .iter()
-        .filter(|signal| !signal.id.starts_with("severity."))
-        .take(3)
-        .map(|signal| format!("{} ({:+})", signal.label, signal.weight))
+        .take(4)
+        .map(|signal| format!("{:+} {}: {}", signal.weight, signal.label, signal.reason))
         .collect::<Vec<_>>();
 
     (!reasons.is_empty()).then(|| reasons.join(", "))

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -11,7 +11,8 @@ use crate::output::markdown::findings::{render_findings_index, render_grouped_fi
 use crate::output::markdown::react_native::render_react_native_section;
 use crate::output::markdown::sections::{
     render_framework_projects_section, render_frameworks_section, render_languages_section,
-    render_overview, render_risk_summary, render_top_risk_clusters, render_top_rules,
+    render_overview, render_risk_summary, render_signal_quality, render_top_risk_clusters,
+    render_top_rules,
 };
 use crate::output::markdown::workspace::render_workspace_risk_table;
 use crate::output::report_stats::build_report_stats;
@@ -24,6 +25,7 @@ pub fn render(summary: &ScanSummary) -> String {
     output.push_str("# RepoPilot Scan Report\n\n");
     render_overview(&mut output, summary, &stats);
     render_risk_summary(&mut output, summary, &stats);
+    render_signal_quality(&mut output, summary);
     render_top_risk_clusters(&mut output, &summary.findings);
     render_top_rules(&mut output, &stats);
     render_languages_section(&mut output, summary);
@@ -48,6 +50,7 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
     render_overview(&mut output, summary, &stats);
     render_baseline_section(&mut output, report, ci_gate);
     render_risk_summary(&mut output, summary, &stats);
+    render_signal_quality(&mut output, summary);
     render_top_risk_clusters(&mut output, &summary.findings);
     render_top_rules(&mut output, &stats);
     render_languages_section(&mut output, summary);

--- a/src/output/markdown/findings.rs
+++ b/src/output/markdown/findings.rs
@@ -161,9 +161,8 @@ fn risk_reason_text(finding: &Finding) -> Option<String> {
         .risk
         .signals
         .iter()
-        .filter(|signal| !signal.id.starts_with("severity."))
-        .take(3)
-        .map(|signal| format!("{} ({:+})", signal.label, signal.weight))
+        .take(4)
+        .map(|signal| format!("{:+} {}: {}", signal.weight, signal.label, signal.reason))
         .collect::<Vec<_>>();
 
     (!reasons.is_empty()).then(|| reasons.join(", "))

--- a/src/output/markdown/sections.rs
+++ b/src/output/markdown/sections.rs
@@ -4,6 +4,7 @@ use crate::output::finding_helpers::{clusters_by_rule_scope, example_locations};
 use crate::output::render_helpers::escape_table_cell;
 use crate::output::report_stats::{ReportStats, TOOL_VERSION};
 use crate::output::report_text::{markdown_severity_counts_text, named_counts_text};
+use crate::report::quality::build_signal_quality_summary;
 use crate::scan::types::{DiagnosticSeverity, ScanSummary};
 use std::fmt::Write;
 
@@ -287,6 +288,48 @@ pub(crate) fn render_risk_summary(output: &mut String, summary: &ScanSummary, st
         )
         .unwrap();
     }
+    output.push('\n');
+}
+
+pub(crate) fn render_signal_quality(output: &mut String, summary: &ScanSummary) {
+    let quality = build_signal_quality_summary(&summary.findings);
+    output.push_str("## Signal Quality\n\n");
+    writeln!(
+        output,
+        "- **High confidence:** {}",
+        quality.by_confidence.high
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "- **Medium confidence:** {}",
+        quality.by_confidence.medium
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "- **Low confidence:** {}",
+        quality.by_confidence.low
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "- **Evidence coverage:** {}%",
+        quality.evidence_coverage_percent
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "- **Recommendation coverage:** {}%",
+        quality.recommendation_coverage_percent
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "- **Contract warnings:** {}",
+        quality.contract_violations
+    )
+    .unwrap();
     output.push('\n');
 }
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,2 +1,3 @@
+pub mod quality;
 pub mod schema;
 pub mod writer;

--- a/src/report/quality.rs
+++ b/src/report/quality.rs
@@ -1,0 +1,6 @@
+use crate::findings::quality::{SignalQualitySummary, summarize_signal_quality};
+use crate::findings::types::Finding;
+
+pub fn build_signal_quality_summary(findings: &[Finding]) -> SignalQualitySummary {
+    summarize_signal_quality(findings)
+}

--- a/src/report/schema.rs
+++ b/src/report/schema.rs
@@ -4,6 +4,7 @@ use crate::findings::feedback::LocalFeedbackReport;
 use crate::findings::types::Finding;
 use crate::frameworks::{DetectedFramework, FrameworkProject, ReactNativeArchitectureProfile};
 use crate::graph::CouplingGraph;
+use crate::report::quality::build_signal_quality_summary;
 use crate::review::diff::ChangedFile;
 use crate::review::model::{ReviewReport, SeverityCounts};
 use crate::risk::RiskSummary;
@@ -16,7 +17,7 @@ use serde_json::Value;
 use std::io;
 use std::path::PathBuf;
 
-pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.14";
+pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.15";
 pub const REPOPILOT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -103,6 +104,7 @@ pub struct ScanJsonReport<'a> {
     #[serde(skip_serializing_if = "diagnostics_empty")]
     pub diagnostics: &'a [ScanDiagnostic],
     pub risk_summary: RiskSummary,
+    pub signal_quality: crate::findings::quality::SignalQualitySummary,
 }
 
 impl<'a> ScanJsonReport<'a> {
@@ -144,6 +146,7 @@ impl<'a> ScanJsonReport<'a> {
             local_feedback: summary.local_feedback.as_ref(),
             diagnostics: &summary.diagnostics,
             risk_summary: RiskSummary::from_findings(&summary.findings),
+            signal_quality: build_signal_quality_summary(&summary.findings),
         }
     }
 }
@@ -178,6 +181,7 @@ pub struct BaselineJsonReport<'a> {
     pub diagnostics: &'a [ScanDiagnostic],
     pub languages: &'a [LanguageSummary],
     pub risk_summary: RiskSummary,
+    pub signal_quality: crate::findings::quality::SignalQualitySummary,
     pub baseline: BaselineJsonMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ci_gate: Option<CiGateJsonMetadata>,
@@ -209,6 +213,7 @@ impl<'a> BaselineJsonReport<'a> {
             diagnostics: &report.summary.diagnostics,
             languages: &report.summary.languages,
             risk_summary: RiskSummary::from_findings(&report.summary.findings),
+            signal_quality: build_signal_quality_summary(&report.summary.findings),
             baseline: BaselineJsonMetadata {
                 path: report
                     .baseline_path
@@ -246,6 +251,7 @@ pub struct ReviewJsonReport<'a> {
     pub blast_radius: Vec<String>,
     pub review: ReviewJsonMetadata,
     pub risk_summary: RiskSummary,
+    pub signal_quality: crate::findings::quality::SignalQualitySummary,
     pub baseline: ReviewBaselineJsonMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ci_gate: Option<CiGateJsonMetadata>,
@@ -281,6 +287,7 @@ impl<'a> ReviewJsonReport<'a> {
                 severity_counts: report.severity_counts(),
             },
             risk_summary: RiskSummary::from_findings(&report.summary.findings),
+            signal_quality: build_signal_quality_summary(&report.summary.findings),
             baseline: ReviewBaselineJsonMetadata {
                 path: report
                     .baseline_path

--- a/src/risk/context.rs
+++ b/src/risk/context.rs
@@ -15,7 +15,7 @@ pub(super) fn add_file_context_signals(
             score,
             signals,
             "role.production",
-            "production code",
+            "visibility",
             10,
             "production code findings are more likely to affect runtime behavior",
         );
@@ -26,7 +26,7 @@ pub(super) fn add_file_context_signals(
             score,
             signals,
             "role.test",
-            "test code",
+            "visibility",
             -20,
             "test code often accepts patterns that would be risky in production",
         );
@@ -37,7 +37,7 @@ pub(super) fn add_file_context_signals(
             score,
             signals,
             "role.generated",
-            "generated file",
+            "visibility",
             -30,
             "generated files should usually be fixed at the generator source",
         );
@@ -48,7 +48,7 @@ pub(super) fn add_file_context_signals(
             score,
             signals,
             "role.config",
-            "config file",
+            "visibility",
             -18,
             "configuration files often use declarative patterns that differ from application code",
         );
@@ -62,7 +62,7 @@ pub(super) fn add_file_context_signals(
             score,
             signals,
             "role.low-signal-path",
-            "low-signal path",
+            "visibility",
             -15,
             "fixtures, examples, and benchmark paths are lower-priority by default",
         );
@@ -73,7 +73,7 @@ pub(super) fn add_file_context_signals(
             score,
             signals,
             "role.entrypoint",
-            "entrypoint",
+            "visibility",
             10,
             "entrypoints can affect application startup and process behavior",
         );
@@ -86,7 +86,7 @@ pub(super) fn add_file_context_signals(
             score,
             signals,
             "role.controller",
-            "controller/router",
+            "visibility",
             12,
             "controllers and routers sit on user-facing request boundaries",
         );
@@ -97,7 +97,7 @@ pub(super) fn add_file_context_signals(
             score,
             signals,
             "role.service",
-            "service layer",
+            "visibility",
             10,
             "service-layer findings can affect reusable production behavior",
         );
@@ -108,7 +108,7 @@ pub(super) fn add_file_context_signals(
             score,
             signals,
             "role.domain",
-            "domain model",
+            "visibility",
             8,
             "domain code usually carries core business behavior",
         );
@@ -119,7 +119,7 @@ pub(super) fn add_file_context_signals(
             score,
             signals,
             "role.react-component",
-            "React component",
+            "visibility",
             4,
             "React component findings can affect user-visible behavior",
         );

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -10,7 +10,7 @@ mod tests;
 
 pub use model::{
     FORMULA_VERSION, GraphImpact, RiskAssessment, RiskFormula, RiskInputs, RiskPriority,
-    RiskSignal, priority_for_score,
+    RiskSignal, RiskSignalSource, priority_for_score,
 };
 pub use overlays::{
     apply_baseline_overlay, apply_blast_radius_overlay, apply_cluster_overlay, apply_graph_overlay,

--- a/src/risk/model.rs
+++ b/src/risk/model.rs
@@ -1,7 +1,7 @@
 use crate::baseline::diff::BaselineStatus;
 use serde::{Deserialize, Serialize};
 
-pub const FORMULA_VERSION: &str = "risk-v2";
+pub const FORMULA_VERSION: &str = "risk-v3";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RiskFormula {
@@ -70,6 +70,23 @@ pub struct RiskSignal {
     pub label: String,
     pub weight: i16,
     pub reason: String,
+    #[serde(default)]
+    pub source: RiskSignalSource,
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RiskSignalSource {
+    #[default]
+    Severity,
+    Confidence,
+    Category,
+    Graph,
+    ReviewDiff,
+    Workspace,
+    Baseline,
+    Cluster,
+    Visibility,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -165,6 +182,29 @@ pub(super) fn signal(id: &str, label: &str, weight: i16, reason: &str) -> RiskSi
         label: label.to_string(),
         weight,
         reason: reason.to_string(),
+        source: source_for_signal_id(id),
+    }
+}
+
+fn source_for_signal_id(id: &str) -> RiskSignalSource {
+    if id.starts_with("severity.") {
+        RiskSignalSource::Severity
+    } else if id.starts_with("confidence.") {
+        RiskSignalSource::Confidence
+    } else if id.starts_with("category.") || id.starts_with("knowledge.") {
+        RiskSignalSource::Category
+    } else if id.starts_with("graph.") {
+        RiskSignalSource::Graph
+    } else if id.starts_with("review.") {
+        RiskSignalSource::ReviewDiff
+    } else if id.starts_with("workspace.") {
+        RiskSignalSource::Workspace
+    } else if id.starts_with("baseline.") {
+        RiskSignalSource::Baseline
+    } else if id.starts_with("cluster.") {
+        RiskSignalSource::Cluster
+    } else {
+        RiskSignalSource::Visibility
     }
 }
 

--- a/src/risk/overlays.rs
+++ b/src/risk/overlays.rs
@@ -41,7 +41,7 @@ pub fn apply_review_overlay(findings: &mut [Finding], in_diff: &[bool]) {
                 finding,
                 signal(
                     "review.in-diff",
-                    "changed lines",
+                    "review diff",
                     12,
                     "finding touches changed diff lines",
                 ),
@@ -70,7 +70,7 @@ pub fn apply_workspace_hotspot_overlay(findings: &mut [Finding]) {
                 finding,
                 signal(
                     "workspace.hotspot",
-                    "workspace hotspot",
+                    "workspace",
                     5,
                     "workspace package has multiple high-risk findings",
                 ),
@@ -97,17 +97,12 @@ pub fn apply_graph_overlay(findings: &mut [Finding], graph: &CouplingGraph) {
             continue;
         };
         let signal = match impact {
-            GraphImpact::Hub => signal(
-                "graph.hub",
-                "dependency hub",
-                8,
-                "file has high fan-in or fan-out, so changes can ripple through the codebase",
-            ),
+            GraphImpact::Hub => signal("graph.hub", "graph", 8, "file is an import hub"),
             GraphImpact::Dependency => signal(
                 "graph.dependency",
-                "shared dependency",
+                "graph",
                 5,
-                "file is imported by multiple other files",
+                "file is a shared dependency",
             ),
         };
         apply_overlay_signal(
@@ -145,7 +140,7 @@ pub fn apply_blast_radius_overlay(
                 finding,
                 signal(
                     "review.blast-radius",
-                    "blast radius",
+                    "review diff",
                     6,
                     "finding is in a file impacted by changed import dependencies",
                 ),
@@ -175,7 +170,7 @@ pub fn apply_cluster_overlay(findings: &mut [Finding]) {
             finding,
             signal(
                 "cluster.repeated",
-                "repeated pattern",
+                "cluster",
                 cluster_weight(size),
                 "same rule appears repeatedly in the same repository area",
             ),
@@ -191,13 +186,13 @@ pub(super) fn baseline_signal(status: BaselineStatus) -> RiskSignal {
     match status {
         BaselineStatus::New => signal(
             "baseline.new",
-            "new finding",
+            "baseline",
             10,
             "new findings should be prioritized over accepted existing debt",
         ),
         BaselineStatus::Existing => signal(
             "baseline.existing",
-            "existing finding",
+            "baseline",
             -8,
             "existing baseline findings are already accepted technical debt",
         ),

--- a/src/risk/scoring.rs
+++ b/src/risk/scoring.rs
@@ -38,9 +38,9 @@ pub fn assess_finding(
             &mut score,
             &mut signals,
             "category.security",
-            "security finding",
+            "security",
             RiskFormula::CURRENT.security_category_weight,
-            "security findings usually have higher remediation priority",
+            "security findings are prioritized",
         );
     }
 
@@ -59,7 +59,7 @@ pub fn assess_finding(
             &mut score,
             &mut signals,
             "review.in-diff",
-            "changed lines",
+            "review diff",
             RiskFormula::CURRENT.review_in_diff_weight,
             "finding touches changed diff lines",
         );
@@ -70,7 +70,7 @@ pub fn assess_finding(
             &mut score,
             &mut signals,
             "workspace.hotspot",
-            "workspace hotspot",
+            "workspace",
             RiskFormula::CURRENT.workspace_hotspot_weight,
             "workspace package has multiple high-risk findings",
         );
@@ -85,7 +85,7 @@ pub fn assess_finding(
             &mut score,
             &mut signals,
             "review.blast-radius",
-            "blast radius",
+            "review diff",
             RiskFormula::CURRENT.blast_radius_weight,
             "finding is in a file impacted by changed import dependencies",
         );
@@ -97,7 +97,7 @@ pub fn assess_finding(
             &mut score,
             &mut signals,
             "cluster.repeated",
-            "repeated pattern",
+            "cluster",
             weight,
             "same rule appears repeatedly in the same repository area",
         );
@@ -133,17 +133,17 @@ fn add_graph_signal(impact: GraphImpact, score: &mut i16, signals: &mut Vec<Risk
             score,
             signals,
             "graph.hub",
-            "dependency hub",
+            "graph",
             RiskFormula::CURRENT.graph_hub_weight,
-            "file has high fan-in or fan-out, so changes can ripple through the codebase",
+            "file is an import hub",
         ),
         GraphImpact::Dependency => push_adjustment(
             score,
             signals,
             "graph.dependency",
-            "shared dependency",
+            "graph",
             RiskFormula::CURRENT.graph_dependency_weight,
-            "file is imported by multiple other files",
+            "file is a shared dependency",
         ),
     }
 }
@@ -170,9 +170,9 @@ fn severity_base_score(severity: Severity) -> u8 {
 fn severity_signal(severity: Severity, score: u8) -> RiskSignal {
     signal(
         &format!("severity.{}", severity.lowercase_label()),
-        &format!("{} severity", severity.label()),
+        "severity",
         score as i16,
-        "base score from rule severity",
+        &format!("{} severity finding", severity.lowercase_label()),
     )
 }
 
@@ -188,9 +188,13 @@ fn confidence_delta(base: u8, confidence: Confidence) -> i16 {
 fn confidence_signal(confidence: Confidence, weight: i16) -> RiskSignal {
     signal(
         &format!("confidence.{}", confidence.lowercase_label()),
-        &format!("{} confidence", confidence.label()),
+        "confidence",
         weight,
-        "confidence adjusts certainty without changing rule severity",
+        match confidence {
+            Confidence::Low => "low confidence heuristic signal",
+            Confidence::Medium => "medium confidence signal",
+            Confidence::High => "high confidence signal",
+        },
     )
 }
 

--- a/src/risk/tests.rs
+++ b/src/risk/tests.rs
@@ -4,8 +4,8 @@ use crate::scan::facts::FileFacts;
 use std::path::PathBuf;
 
 #[test]
-fn priority_thresholds_match_v2_plan() {
-    assert_eq!(FORMULA_VERSION, "risk-v2");
+fn priority_thresholds_match_v3_plan() {
+    assert_eq!(FORMULA_VERSION, "risk-v3");
     assert_eq!(RiskFormula::CURRENT.version, FORMULA_VERSION);
     assert_eq!(RiskFormula::CURRENT.severity_critical, 95);
     assert_eq!(RiskFormula::CURRENT.review_in_diff_weight, 12);

--- a/src/rules/lifecycle.rs
+++ b/src/rules/lifecycle.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum RuleLifecycle {
+    Experimental,
+    #[default]
+    Preview,
+    Stable,
+    Deprecated,
+}
+
+impl RuleLifecycle {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Experimental => "experimental",
+            Self::Preview => "preview",
+            Self::Stable => "stable",
+            Self::Deprecated => "deprecated",
+        }
+    }
+}

--- a/src/rules/metadata.rs
+++ b/src/rules/metadata.rs
@@ -1,4 +1,5 @@
-use crate::findings::types::{FindingCategory, Severity};
+use crate::findings::types::{Confidence, FindingCategory, Severity};
+use crate::rules::{RuleLifecycle, SignalSource};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuleMetadata {
@@ -6,7 +7,29 @@ pub struct RuleMetadata {
     pub title: &'static str,
     pub category: FindingCategory,
     pub default_severity: Severity,
+    pub default_confidence: Confidence,
+    pub lifecycle: RuleLifecycle,
+    pub signal_source: SignalSource,
     pub docs_url: Option<&'static str>,
     pub description: &'static str,
     pub recommendation: Option<&'static str>,
+    pub false_positive_notes: Option<&'static str>,
+    pub tags: &'static [&'static str],
+}
+
+impl RuleMetadata {
+    pub const DEFAULT: Self = Self {
+        rule_id: "",
+        title: "",
+        category: FindingCategory::Architecture,
+        default_severity: Severity::Info,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::TextHeuristic,
+        docs_url: None,
+        description: "",
+        recommendation: None,
+        false_positive_notes: None,
+        tags: &[],
+    };
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,5 +1,9 @@
+pub mod lifecycle;
 pub mod metadata;
 pub mod registry;
+pub mod source;
 
+pub use lifecycle::RuleLifecycle;
 pub use metadata::RuleMetadata;
-pub use registry::lookup_rule_metadata;
+pub use registry::{all_rule_metadata, lookup_rule_metadata};
+pub use source::SignalSource;

--- a/src/rules/registry/architecture.rs
+++ b/src/rules/registry/architecture.rs
@@ -1,5 +1,6 @@
-use crate::findings::types::{FindingCategory, Severity};
+use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
+use crate::rules::{RuleLifecycle, SignalSource};
 
 pub(super) static RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -7,87 +8,123 @@ pub(super) static RULES: &[RuleMetadata] = &[
         title: "File exceeds recommended size",
         category: FindingCategory::Architecture,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Experimental,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "This file has more lines of code than the configured threshold. Large files accumulate responsibilities over time and make navigation and testing harder.",
         recommendation: Some(
             "Split the file into smaller, focused modules. Use repopilot.toml `max_file_loc` to adjust the threshold.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "architecture.deep-nesting",
         title: "Directory nesting exceeds recommended depth",
         category: FindingCategory::Architecture,
         default_severity: Severity::Low,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Experimental,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "A directory path is deeper than the configured nesting threshold. Deeply nested structures make file discovery and import paths harder to maintain.",
         recommendation: Some(
             "Flatten the directory structure or consolidate related modules at a higher level.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "architecture.deep-relative-imports",
         title: "Deep relative import found",
         category: FindingCategory::Architecture,
         default_severity: Severity::Low,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "A source file imports across three or more parent directories. Deep relative imports are fragile during refactors and often indicate missing module boundaries or aliases.",
         recommendation: Some(
             "Introduce a stable module boundary, path alias, or facade module instead of importing through multiple parent directories.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "architecture.barrel-file-risk",
         title: "Risky barrel file detected",
         category: FindingCategory::Architecture,
         default_severity: Severity::Low,
+        default_confidence: Confidence::Low,
+        lifecycle: RuleLifecycle::Experimental,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "An index file re-exports many modules or relies heavily on wildcard exports. Large barrel files can become unstable module hubs and make dependency boundaries harder to understand.",
         recommendation: Some(
             "Split the barrel into smaller feature-level entrypoints or replace wildcard exports with explicit, stable public APIs.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "architecture.too-many-modules",
         title: "Directory contains too many modules",
         category: FindingCategory::Architecture,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Experimental,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "A directory contains more files than the configured threshold, suggesting it may need to be broken into sub-packages.",
         recommendation: Some(
             "Group related files into sub-directories. Adjust `max_directory_modules` in repopilot.toml if the current threshold is too strict.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "architecture.circular-dependency",
         title: "Circular import dependency detected",
         category: FindingCategory::Architecture,
         default_severity: Severity::High,
-        docs_url: None,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Stable,
+        signal_source: SignalSource::ImportGraph,
+        docs_url: Some(
+            "https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture",
+        ),
         description: "Two or more files import each other, forming a cycle. Circular dependencies make build order undefined, complicate testing, and prevent dead-code elimination.",
         recommendation: Some(
             "Extract the shared logic into a third module that both files can import without creating a cycle.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "architecture.excessive-fan-out",
         title: "File imports too many project-internal modules",
         category: FindingCategory::Architecture,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Stable,
+        signal_source: SignalSource::ImportGraph,
         docs_url: None,
         description: "This file depends on an unusually large number of other internal modules, making it a fragile integration point that breaks whenever any dependency changes.",
         recommendation: Some(
             "Introduce an abstraction layer or facade to reduce the number of direct imports. Consider splitting responsibilities across multiple files.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "architecture.high-instability-hub",
         title: "High-instability hub: high fan-in and high fan-out",
         category: FindingCategory::Architecture,
         default_severity: Severity::High,
-        docs_url: None,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Stable,
+        signal_source: SignalSource::ImportGraph,
+        docs_url: Some(
+            "https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture",
+        ),
         description: "This file is both widely imported (high fan-in) and depends on many other modules (high fan-out). Changes here ripple across the codebase with no stable upstream to absorb them.",
         recommendation: Some(
             "Separate the stable, widely-imported interface from the volatile implementation details to reduce coupling.",
         ),
+        ..RuleMetadata::DEFAULT
     },
 ];

--- a/src/rules/registry/code_quality.rs
+++ b/src/rules/registry/code_quality.rs
@@ -1,5 +1,6 @@
-use crate::findings::types::{FindingCategory, Severity};
+use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
+use crate::rules::{RuleLifecycle, SignalSource};
 
 pub(super) static RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -7,54 +8,74 @@ pub(super) static RULES: &[RuleMetadata] = &[
         title: "File has high cyclomatic complexity",
         category: FindingCategory::CodeQuality,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "The file's branch count density exceeds the complexity threshold, indicating too many execution paths. High complexity increases the defect rate and testing burden.",
         recommendation: Some(
             "Extract conditionals into well-named helper functions. Prefer early returns to deeply nested if/else chains.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "code-quality.long-function",
         title: "Function body exceeds recommended length",
         category: FindingCategory::CodeQuality,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "A function is longer than the configured line threshold. Long functions are harder to test, understand, and safely refactor.",
         recommendation: Some(
             "Break the function into smaller, single-purpose helpers. Aim for functions that fit on a single screen.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "code-marker.todo",
         title: "TODO marker found",
         category: FindingCategory::CodeQuality,
         default_severity: Severity::Low,
+        default_confidence: Confidence::Low,
+        lifecycle: RuleLifecycle::Experimental,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "A TODO comment marks unfinished work. Unresolved TODOs accumulate as technical debt if not tracked in an issue tracker.",
         recommendation: Some(
             "Convert the TODO into a tracked issue and reference the issue number in the comment, or resolve it immediately.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "code-marker.fixme",
         title: "FIXME marker found",
         category: FindingCategory::CodeQuality,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::Low,
+        lifecycle: RuleLifecycle::Experimental,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "A FIXME comment marks known broken or problematic code that has not yet been addressed.",
         recommendation: Some(
             "Fix the issue or file a bug report and reference its number in the comment.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "code-marker.hack",
         title: "HACK marker found",
         category: FindingCategory::CodeQuality,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::Low,
+        lifecycle: RuleLifecycle::Experimental,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "A HACK comment marks a workaround that bypasses a proper solution. Hacks tend to become permanent and break under refactoring.",
         recommendation: Some(
             "Document why the hack exists and create a tracked issue to replace it with a proper implementation.",
         ),
+        ..RuleMetadata::DEFAULT
     },
 ];

--- a/src/rules/registry/framework.rs
+++ b/src/rules/registry/framework.rs
@@ -1,5 +1,6 @@
-use crate::findings::types::{FindingCategory, Severity};
+use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
+use crate::rules::{RuleLifecycle, SignalSource};
 
 pub(super) static RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -7,125 +8,172 @@ pub(super) static RULES: &[RuleMetadata] = &[
         title: "Inline style object in JSX",
         category: FindingCategory::Framework,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::Ast,
         docs_url: Some("https://reactnative.dev/docs/stylesheet"),
         description: "Inline style objects create a new object on every render, defeating memoization in React.memo and PureComponent children.",
         recommendation: Some("Extract styles into a StyleSheet.create call outside the component."),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react-native.deprecated-api",
         title: "Deprecated React Native API",
         category: FindingCategory::Framework,
         default_severity: Severity::High,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Stable,
+        signal_source: SignalSource::Ast,
         docs_url: Some("https://reactnative.dev/docs/out-of-tree-platforms"),
         description: "A React Native API removed from core is in use. Replace with the community package equivalent.",
         recommendation: Some(
             "Replace the deprecated API with its @react-native-community package equivalent.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react-native.flatlist-missing-key",
         title: "FlatList is missing keyExtractor",
         category: FindingCategory::Framework,
         default_severity: Severity::Low,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::Ast,
         docs_url: Some("https://reactnative.dev/docs/flatlist#keyextractor"),
         description: "A FlatList without keyExtractor falls back to array index keys, breaking list reconciliation when items are reordered or removed.",
         recommendation: Some(
             "Add keyExtractor={(item) => item.id.toString()} or an equivalent unique key.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react-native.async-storage-from-core",
         title: "AsyncStorage imported from 'react-native' core",
         category: FindingCategory::Framework,
         default_severity: Severity::High,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Stable,
+        signal_source: SignalSource::Ast,
         docs_url: Some("https://react-native-async-storage.github.io/async-storage/docs/install"),
         description: "AsyncStorage was removed from react-native core in v0.60 and throws a runtime error on modern versions.",
         recommendation: Some(
             "Replace with `import AsyncStorage from '@react-native-async-storage/async-storage'`.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react-native.old-react-navigation",
         title: "React Navigation v4 (unscoped package) detected",
         category: FindingCategory::Framework,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::DependencyManifest,
         docs_url: Some("https://reactnavigation.org/docs/getting-started"),
         description: "react-navigation (v4) is no longer maintained and is incompatible with React Native 0.70+.",
         recommendation: Some(
             "Migrate to @react-navigation/native v5/v6 following the official migration guide.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react-native.direct-state-mutation",
         title: "Direct mutation of this.state detected",
         category: FindingCategory::Framework,
         default_severity: Severity::High,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Stable,
+        signal_source: SignalSource::Ast,
         docs_url: Some("https://react.dev/reference/react/Component#setstate"),
         description: "Directly assigning to this.state bypasses React change detection; the component will not re-render.",
         recommendation: Some(
             "Use this.setState({ key: value }) in class components or the useState setter in function components.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react-native.old-architecture",
         title: "React Native New Architecture is not enabled",
         category: FindingCategory::Framework,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::FrameworkDetector,
         docs_url: Some("https://reactnative.dev/docs/new-architecture-intro"),
         description: "The project does not have newArchEnabled set. The New Architecture eliminates the async JS bridge and is required by an increasing number of libraries.",
         recommendation: Some(
             "Set `\"newArchEnabled\": true` in app.json or react-native.config.js.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react-native.architecture-mismatch",
         title: "React Native New Architecture settings differ by platform",
         category: FindingCategory::Framework,
         default_severity: Severity::High,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::FrameworkDetector,
         docs_url: Some("https://reactnative.dev/docs/new-architecture-intro"),
         description: "Android, iOS, or Expo configuration disagree about React Native New Architecture. Mismatched platforms produce inconsistent runtime behavior.",
         recommendation: Some(
             "Align newArchEnabled across android/gradle.properties, ios/Podfile.properties.json, and app.json.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react-native.hermes-mismatch",
         title: "Hermes settings differ between Android and iOS",
         category: FindingCategory::Framework,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::FrameworkDetector,
         docs_url: Some("https://reactnative.dev/docs/hermes"),
         description: "Hermes is configured differently across platforms, causing platform-specific runtime and performance behavior.",
         recommendation: Some(
             "Align Hermes settings so both Android and iOS use the same JS engine.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react-native.hermes-disabled",
         title: "Hermes JavaScript engine is disabled",
         category: FindingCategory::Framework,
         default_severity: Severity::Low,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::FrameworkDetector,
         docs_url: Some("https://reactnative.dev/docs/hermes"),
         description: "Hermes is explicitly disabled. Hermes reduces startup time by 2-3x and is the default engine since React Native 0.70.",
         recommendation: Some(
             "Remove the hermes_enabled: false / enableHermes: false flag to enable Hermes.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react-native.codegen-missing",
         title: "React Native Codegen config is missing",
         category: FindingCategory::Framework,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::FrameworkDetector,
         docs_url: Some("https://reactnative.dev/docs/the-new-architecture/codegen"),
         description: "The project uses Turbo Native Modules or Fabric components but package.json does not define codegenConfig.",
         recommendation: Some(
             "Add codegenConfig to package.json so React Native can generate native interfaces consistently.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.js.var-declaration",
         title: "var declaration in JavaScript/TypeScript file",
         category: FindingCategory::Framework,
         default_severity: Severity::Low,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::Ast,
         docs_url: Some(
             "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var",
         ),
@@ -133,34 +181,46 @@ pub(super) static RULES: &[RuleMetadata] = &[
         recommendation: Some(
             "Replace `var` with `const` for values that do not change, or `let` for variables that are reassigned.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.js.console-log",
         title: "console.log call left in source",
         category: FindingCategory::Framework,
         default_severity: Severity::Low,
+        default_confidence: Confidence::Low,
+        lifecycle: RuleLifecycle::Experimental,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "A console.log statement was found outside of test files. Debug logging left in production code leaks information and adds noise.",
         recommendation: Some(
             "Remove the console.log call or replace it with a structured logger that respects log levels.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react.class-component",
         title: "React class component in use",
         category: FindingCategory::Framework,
         default_severity: Severity::Low,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::Ast,
         docs_url: Some("https://react.dev/reference/react/Component"),
         description: "Class components are the legacy React API. Function components with hooks are now the recommended approach and are better supported by the React compiler.",
         recommendation: Some(
             "Migrate the class component to a function component using hooks (useState, useEffect, etc.).",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.react.prop-types",
         title: "PropTypes runtime type checking in use",
         category: FindingCategory::Framework,
         default_severity: Severity::Low,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::Ast,
         docs_url: Some(
             "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes",
         ),
@@ -168,34 +228,46 @@ pub(super) static RULES: &[RuleMetadata] = &[
         recommendation: Some(
             "Replace PropTypes with TypeScript prop type annotations and remove the prop-types package.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.rn-async-storage-legacy",
         title: "Deprecated @react-native-community/async-storage in use",
         category: FindingCategory::Framework,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Stable,
+        signal_source: SignalSource::DependencyManifest,
         docs_url: Some("https://react-native-async-storage.github.io/async-storage/docs/install"),
         description: "`@react-native-community/async-storage` is unmaintained. The actively maintained fork is `@react-native-async-storage/async-storage`.",
         recommendation: Some(
             "Run: `npm remove @react-native-community/async-storage && npm install @react-native-async-storage/async-storage`.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.rn-navigation-compat",
         title: "React Navigation version incompatible with React Native version",
         category: FindingCategory::Framework,
         default_severity: Severity::High,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::DependencyManifest,
         docs_url: Some("https://reactnavigation.org/docs/getting-started"),
         description: "The installed version of `@react-navigation/native` is not compatible with the React Native version in use.",
         recommendation: Some(
             "Upgrade to `@react-navigation/native` v6 or later: `npm install @react-navigation/native@latest`.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.rn-reanimated-compat",
         title: "react-native-reanimated version incompatible with React Native version",
         category: FindingCategory::Framework,
         default_severity: Severity::High,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::DependencyManifest,
         docs_url: Some(
             "https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation",
         ),
@@ -203,56 +275,76 @@ pub(super) static RULES: &[RuleMetadata] = &[
         recommendation: Some(
             "Upgrade to `react-native-reanimated` v3+: `npm install react-native-reanimated@latest`.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.rn-gesture-handler-old",
         title: "react-native-gesture-handler v1 incompatible with React Native version",
         category: FindingCategory::Framework,
         default_severity: Severity::High,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::DependencyManifest,
         docs_url: Some("https://docs.swmansion.com/react-native-gesture-handler/docs/installation"),
         description: "`react-native-gesture-handler` v1 does not support React Native ≥0.72. Gesture responder internals changed in 0.72.",
         recommendation: Some(
             "Upgrade to `react-native-gesture-handler` v2+: `npm install react-native-gesture-handler@latest`.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.rn-new-arch-incompatible-dep",
         title: "Dependency does not support React Native New Architecture",
         category: FindingCategory::Framework,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::DependencyManifest,
         docs_url: Some("https://reactnative.dev/docs/new-architecture-intro"),
         description: "A dependency in use has no New Architecture (TurboModules / Fabric) support and will break when the New Architecture is enabled.",
         recommendation: Some(
             "Check the library's GitHub issues for a New Architecture migration path, or find an actively-maintained alternative.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.django.debug-true",
         title: "DEBUG = True in Django settings",
         category: FindingCategory::Security,
         default_severity: Severity::High,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Stable,
+        signal_source: SignalSource::ConfigFile,
         docs_url: Some("https://docs.djangoproject.com/en/stable/ref/settings/#debug"),
         description: "Django DEBUG mode exposes detailed error pages with stack traces, local variables, and settings values.",
         recommendation: Some(
             "Set DEBUG = False for deployed environments and load debug mode only from local development configuration.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.django.missing-allowed-hosts",
         title: "ALLOWED_HOSTS is empty in Django settings",
         category: FindingCategory::Security,
         default_severity: Severity::High,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Stable,
+        signal_source: SignalSource::ConfigFile,
         docs_url: Some("https://docs.djangoproject.com/en/stable/ref/settings/#allowed-hosts"),
         description: "An empty ALLOWED_HOSTS setting leaves deployed Django services exposed to unsafe Host header handling.",
         recommendation: Some(
             "Set ALLOWED_HOSTS to the explicit domain names and IP addresses the service should accept.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "framework.django.raw-sql-query",
         title: "Raw SQL with string formatting detected",
         category: FindingCategory::Security,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: Some(
             "https://docs.djangoproject.com/en/stable/topics/db/sql/#passing-parameters-into-raw",
         ),
@@ -260,5 +352,6 @@ pub(super) static RULES: &[RuleMetadata] = &[
         recommendation: Some(
             "Pass query parameters separately, for example cursor.execute(sql, [param]), so the database driver escapes values safely.",
         ),
+        ..RuleMetadata::DEFAULT
     },
 ];

--- a/src/rules/registry/language.rs
+++ b/src/rules/registry/language.rs
@@ -1,5 +1,6 @@
-use crate::findings::types::{FindingCategory, Severity};
+use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
+use crate::rules::{RuleLifecycle, SignalSource};
 
 pub(super) static RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -7,54 +8,74 @@ pub(super) static RULES: &[RuleMetadata] = &[
         title: "Risky Rust panic or unwrap usage",
         category: FindingCategory::CodeQuality,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "Rust panic-style operations such as unwrap(), expect(), panic!, todo!, and unimplemented! can be risky in reusable production code. Their severity depends on whether the code is test code, CLI boundary code, library code, or domain code.",
         recommendation: Some(
             "Use context-aware error handling. Prefer Result, ?, typed errors, validation, or explicit fallback behavior in production and library code.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "language.go.panic-exit-risk",
         title: "Risky Go panic or process exit usage",
         category: FindingCategory::CodeQuality,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "Go panic and process-exit operations can terminate the program abruptly. Their risk depends on whether the file is test code, CLI boundary code, library code, or domain code.",
         recommendation: Some(
             "Return errors from reusable code and reserve panic/log.Fatal/os.Exit for narrow process boundaries where callers cannot recover.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "language.python.exception-risk",
         title: "Risky Python exception or assertion pattern",
         category: FindingCategory::CodeQuality,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "Broad exception handlers, production asserts, and NotImplementedError placeholders can hide failures or ship incomplete behaviour. Their severity depends on test, script, and domain context.",
         recommendation: Some(
             "Catch specific exceptions, use explicit runtime validation, and replace placeholders before production release.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "language.javascript.runtime-exit-risk",
         title: "Risky JavaScript runtime exit or library throw",
         category: FindingCategory::CodeQuality,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "Process exits and generic thrown errors have different risk at a CLI boundary than in reusable browser, Node, or package code.",
         recommendation: Some(
             "Prefer returning typed errors, rejecting promises with actionable context, or centralising CLI exit handling at the entrypoint.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "language.managed.fatal-exception-risk",
         title: "Risky JVM or .NET fatal exception placeholder",
         category: FindingCategory::CodeQuality,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "Generic fatal exceptions and not-implemented placeholders in Java, Kotlin, or C# domain/library code can become runtime failures that callers cannot handle precisely.",
         recommendation: Some(
             "Replace placeholders with implemented behaviour and use domain-specific exception or result types where callers need to recover.",
         ),
+        ..RuleMetadata::DEFAULT
     },
 ];

--- a/src/rules/registry/mod.rs
+++ b/src/rules/registry/mod.rs
@@ -6,6 +6,8 @@ mod security;
 mod testing;
 
 use crate::rules::metadata::RuleMetadata;
+use std::collections::HashMap;
+use std::sync::OnceLock;
 
 const RULE_GROUPS: &[&[RuleMetadata]] = &[
     framework::RULES,
@@ -17,15 +19,20 @@ const RULE_GROUPS: &[&[RuleMetadata]] = &[
 ];
 
 pub fn lookup_rule_metadata(rule_id: &str) -> Option<&'static RuleMetadata> {
-    all_rules().find(|rule| rule.rule_id == rule_id)
+    rule_index().get(rule_id).copied()
 }
 
-pub(crate) fn all_rule_metadata() -> impl Iterator<Item = &'static RuleMetadata> {
+pub fn all_rule_metadata() -> impl Iterator<Item = &'static RuleMetadata> {
     all_rules()
 }
 
 fn all_rules() -> impl Iterator<Item = &'static RuleMetadata> {
     RULE_GROUPS.iter().flat_map(|rules| rules.iter())
+}
+
+fn rule_index() -> &'static HashMap<&'static str, &'static RuleMetadata> {
+    static RULE_INDEX: OnceLock<HashMap<&'static str, &'static RuleMetadata>> = OnceLock::new();
+    RULE_INDEX.get_or_init(|| all_rules().map(|rule| (rule.rule_id, rule)).collect())
 }
 
 #[cfg(test)]
@@ -125,6 +132,21 @@ mod tests {
                 rule.recommendation
                     .is_some_and(|recommendation| !recommendation.trim().is_empty()),
                 "rule {} has empty recommendation",
+                rule.rule_id
+            );
+            assert!(
+                !rule.lifecycle.label().is_empty(),
+                "rule {} has empty lifecycle",
+                rule.rule_id
+            );
+            assert!(
+                !rule.signal_source.label().is_empty(),
+                "rule {} has empty signal source",
+                rule.rule_id
+            );
+            assert!(
+                !rule.default_confidence.label().is_empty(),
+                "rule {} has empty default confidence",
                 rule.rule_id
             );
         }

--- a/src/rules/registry/security.rs
+++ b/src/rules/registry/security.rs
@@ -1,5 +1,6 @@
-use crate::findings::types::{FindingCategory, Severity};
+use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
+use crate::rules::{RuleLifecycle, SignalSource};
 
 pub(super) static RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -7,32 +8,48 @@ pub(super) static RULES: &[RuleMetadata] = &[
         title: "Environment file committed to version control",
         category: FindingCategory::Security,
         default_severity: Severity::Critical,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Stable,
+        signal_source: SignalSource::ConfigFile,
         docs_url: Some("https://12factor.net/config"),
         description: "A .env file containing environment variables has been committed. These files frequently contain secrets, API keys, or credentials that should never enter version control.",
         recommendation: Some(
             "Add .env (and .env.*) to .gitignore, rotate any exposed credentials immediately, and use a secrets manager or CI environment variables instead.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "security.private-key-candidate",
         title: "Possible private key in source file",
         category: FindingCategory::Security,
         default_severity: Severity::Critical,
-        docs_url: None,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Stable,
+        signal_source: SignalSource::TextHeuristic,
+        docs_url: Some(
+            "https://github.com/MykytaStel/repopilot/blob/main/docs/security.md#reporting-a-security-issue",
+        ),
         description: "A PEM-encoded private key block was found in a source file. Committed private keys can be extracted from git history even after deletion.",
         recommendation: Some(
             "Remove the key from the file immediately, rotate the key pair, and purge the git history using git-filter-repo or BFG Repo Cleaner.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "security.secret-candidate",
         title: "Possible hardcoded secret or API key",
         category: FindingCategory::Security,
         default_severity: Severity::High,
-        docs_url: None,
+        default_confidence: Confidence::Low,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::TextHeuristic,
+        docs_url: Some(
+            "https://github.com/MykytaStel/repopilot/blob/main/docs/security.md#secret-handling",
+        ),
         description: "A high-entropy string or a pattern matching a known secret format was found in source code. Hardcoded secrets are exposed to everyone with repository access.",
         recommendation: Some(
             "Move the value to an environment variable or secrets manager. If already committed, rotate the credential and consider the old value compromised.",
         ),
+        ..RuleMetadata::DEFAULT
     },
 ];

--- a/src/rules/registry/testing.rs
+++ b/src/rules/registry/testing.rs
@@ -1,5 +1,6 @@
-use crate::findings::types::{FindingCategory, Severity};
+use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
+use crate::rules::{RuleLifecycle, SignalSource};
 
 pub(super) static RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -7,21 +8,29 @@ pub(super) static RULES: &[RuleMetadata] = &[
         title: "No test directory found in project",
         category: FindingCategory::Testing,
         default_severity: Severity::Medium,
+        default_confidence: Confidence::Medium,
+        lifecycle: RuleLifecycle::Experimental,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "The project has no recognisable test directory (tests/, __tests__, spec/). Without tests, correctness can only be verified manually.",
         recommendation: Some(
             "Create a test directory and add at least smoke tests for the core logic.",
         ),
+        ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
         rule_id: "testing.source-without-test",
         title: "Source file has no corresponding test file",
         category: FindingCategory::Testing,
         default_severity: Severity::Low,
+        default_confidence: Confidence::Low,
+        lifecycle: RuleLifecycle::Experimental,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "A source file has no matching test file. Untested code is more likely to regress during refactoring.",
         recommendation: Some(
             "Add a test file alongside the source file, or co-locate tests within the same file following the project's testing conventions.",
         ),
+        ..RuleMetadata::DEFAULT
     },
 ];

--- a/src/rules/source.rs
+++ b/src/rules/source.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum SignalSource {
+    TextHeuristic,
+    Ast,
+    ConfigFile,
+    DependencyManifest,
+    ImportGraph,
+    FrameworkDetector,
+    GitDiff,
+    #[default]
+    Mixed,
+}
+
+impl SignalSource {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::TextHeuristic => "text-heuristic",
+            Self::Ast => "ast",
+            Self::ConfigFile => "config-file",
+            Self::DependencyManifest => "dependency-manifest",
+            Self::ImportGraph => "import-graph",
+            Self::FrameworkDetector => "framework-detector",
+            Self::GitDiff => "git-diff",
+            Self::Mixed => "mixed",
+        }
+    }
+}

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -66,6 +66,13 @@ struct ChangedRepoContextStage {
     elapsed_us: u64,
 }
 
+struct ChangedFindingPipelineStage {
+    enrichment_us: u64,
+    risk_scoring_us: u64,
+    contract_validation_us: u64,
+    diagnostics: Vec<crate::scan::types::ScanDiagnostic>,
+}
+
 impl<'a> ChangedScanEngine<'a> {
     fn new(path: &'a Path, config: &'a ScanConfig, base_ref: Option<&'a str>) -> Self {
         Self {
@@ -82,15 +89,19 @@ impl<'a> ChangedScanEngine<'a> {
         let repo_stage = self.run_repo_context(&discovery.repo_root, &mut file_stage.facts)?;
         let enrichment_us = self.enrich_findings(&discovery.repo_root, &mut file_stage.findings);
         let risk_scoring_us = self.score_findings(&repo_stage, &mut file_stage.findings);
-
-        self.finalize_report(
-            start,
-            discovery,
-            file_stage,
-            repo_stage,
+        let mut diagnostics = Vec::new();
+        let contract_validation_us = crate::engine::pipeline::validate_finding_contract_stage(
+            &file_stage.findings,
+            &mut diagnostics,
+        );
+        let finding_pipeline = ChangedFindingPipelineStage {
             enrichment_us,
             risk_scoring_us,
-        )
+            contract_validation_us,
+            diagnostics,
+        };
+
+        self.finalize_report(start, discovery, file_stage, repo_stage, finding_pipeline)
     }
 
     fn run_discovery(&self) -> io::Result<ChangedDiscoveryStage> {
@@ -413,8 +424,7 @@ impl<'a> ChangedScanEngine<'a> {
         discovery: ChangedDiscoveryStage,
         mut file_stage: ChangedFileAnalysisStage,
         repo_stage: ChangedRepoContextStage,
-        enrichment_us: u64,
-        risk_scoring_us: u64,
+        finding_pipeline: ChangedFindingPipelineStage,
     ) -> io::Result<ScanSummary> {
         let finalization_start = Instant::now();
 
@@ -450,12 +460,13 @@ impl<'a> ChangedScanEngine<'a> {
                     file_scan_us,
                     framework_detection_us: repo_stage.elapsed_us,
                     post_scan_audits_us: 0,
-                    enrichment_us,
-                    risk_scoring_us,
+                    enrichment_us: finding_pipeline.enrichment_us,
+                    risk_scoring_us: finding_pipeline.risk_scoring_us,
+                    contract_validation_us: finding_pipeline.contract_validation_us,
                     report_finalization_us: 0,
                 }),
                 cache_telemetry: Some(file_stage.cache_telemetry),
-                diagnostics: Vec::new(),
+                diagnostics: finding_pipeline.diagnostics,
             },
         );
 

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -81,6 +81,11 @@ impl<'a> ScanEngine<'a> {
             &project_stage.coupling_graph,
             &mut project_stage.findings,
         );
+        let mut diagnostics = Vec::new();
+        let contract_validation_us = crate::engine::pipeline::validate_finding_contract_stage(
+            &project_stage.findings,
+            &mut diagnostics,
+        );
 
         let scan_duration_us = start.elapsed().as_micros() as u64;
         let timings = ScanTimings {
@@ -93,10 +98,11 @@ impl<'a> ScanEngine<'a> {
             post_scan_audits_us: project_stage.elapsed_us,
             enrichment_us,
             risk_scoring_us,
+            contract_validation_us,
             report_finalization_us: 0,
         };
 
-        Ok(self.finalize_report(project_stage, scan_duration_us, timings))
+        Ok(self.finalize_report(project_stage, scan_duration_us, timings, diagnostics))
     }
 
     fn finalize_report(
@@ -104,6 +110,7 @@ impl<'a> ScanEngine<'a> {
         mut project_stage: ProjectAnalysisStage,
         scan_duration_us: u64,
         timings: ScanTimings,
+        diagnostics: Vec<crate::scan::types::ScanDiagnostic>,
     ) -> ScanSummary {
         let finalization_start = Instant::now();
         summary::sort_findings(&mut project_stage.findings);
@@ -119,7 +126,7 @@ impl<'a> ScanEngine<'a> {
                 scan_duration_us,
                 scan_timings: Some(timings),
                 cache_telemetry: None,
-                diagnostics: Vec::new(),
+                diagnostics,
             },
         );
         if let Some(timings) = &mut summary.scan_timings {

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -43,6 +43,9 @@ pub struct ScanTimings {
     /// Time spent applying risk scoring and risk overlays.
     #[serde(default)]
     pub risk_scoring_us: u64,
+    /// Time spent validating the internal finding contract.
+    #[serde(default)]
+    pub contract_validation_us: u64,
     /// Time spent building the final report summary object.
     #[serde(default)]
     pub report_finalization_us: u64,
@@ -59,6 +62,7 @@ impl ScanTimings {
             .saturating_add(self.post_scan_audits_us)
             .saturating_add(self.enrichment_us)
             .saturating_add(self.risk_scoring_us)
+            .saturating_add(self.contract_validation_us)
             .saturating_add(self.report_finalization_us)
     }
 }

--- a/tests/baseline_key.rs
+++ b/tests/baseline_key.rs
@@ -63,6 +63,7 @@ fn finding(rule_id: &str, path: &str, line: usize) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -117,6 +117,7 @@ fn finding(id: &str, rule_id: &str, path: &str, line: usize, severity: Severity)
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/tests/finding_contract.rs
+++ b/tests/finding_contract.rs
@@ -1,0 +1,118 @@
+use repopilot::findings::contract::{
+    FindingContractViolationKind, validate_finding_contract, validate_findings_contract,
+};
+use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
+use repopilot::risk::{RiskInputs, assess_finding};
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::scanner::scan_path_with_config;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+fn valid_finding() -> Finding {
+    let mut finding = Finding {
+        id: "security.secret-candidate:src/config.rs:1".to_string(),
+        rule_id: "security.secret-candidate".to_string(),
+        title: "Possible secret detected".to_string(),
+        description: "A hardcoded secret was found.".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("security.secret-candidate"),
+        category: FindingCategory::Security,
+        severity: Severity::High,
+        confidence: Confidence::High,
+        evidence: vec![Evidence {
+            path: PathBuf::from("src/config.rs"),
+            line_start: 1,
+            line_end: Some(1),
+            snippet: "API_KEY = \"sk_live\"".to_string(),
+        }],
+        workspace_package: None,
+        docs_url: Some("https://example.com/secrets".to_string()),
+        provenance: Default::default(),
+        risk: Default::default(),
+    };
+    finding.risk = assess_finding(&finding, None, RiskInputs::default());
+    finding
+}
+
+#[test]
+fn valid_finding_passes_contract() {
+    let finding = valid_finding();
+    let report = validate_findings_contract(&[finding]);
+
+    assert_eq!(report.findings_checked, 1);
+    assert_eq!(report.valid_findings, 1);
+    assert_eq!(report.invalid_findings, 0);
+    assert!(report.violations.is_empty());
+}
+
+#[test]
+fn invalid_finding_reports_all_required_contract_gaps() {
+    let mut finding = Finding {
+        severity: Severity::High,
+        evidence: vec![Evidence {
+            path: PathBuf::new(),
+            line_start: 0,
+            line_end: Some(0),
+            snippet: String::new(),
+        }],
+        ..Finding::default()
+    };
+    finding.risk.formula_version.clear();
+
+    let violations = validate_finding_contract(&finding)
+        .into_iter()
+        .map(|violation| violation.violation)
+        .collect::<Vec<_>>();
+
+    for expected in [
+        FindingContractViolationKind::EmptyId,
+        FindingContractViolationKind::EmptyRuleId,
+        FindingContractViolationKind::EmptyTitle,
+        FindingContractViolationKind::EmptyDescription,
+        FindingContractViolationKind::EmptyRecommendation,
+        FindingContractViolationKind::InvalidEvidencePath,
+        FindingContractViolationKind::InvalidEvidenceLineRange,
+        FindingContractViolationKind::MissingRiskFormulaVersion,
+        FindingContractViolationKind::MissingRiskSignals,
+        FindingContractViolationKind::MissingDocsForHighSeverity,
+    ] {
+        assert!(
+            violations.contains(&expected),
+            "missing expected violation {expected:?} in {violations:?}"
+        );
+    }
+}
+
+#[test]
+fn generated_findings_from_scan_pass_contract() {
+    let temp = tempdir().expect("temp dir");
+    fs::create_dir_all(temp.path().join("src")).expect("src dir");
+    fs::write(
+        temp.path().join("src/config.rs"),
+        "pub const API_KEY: &str = \"sk_live_repopilot_contract_1234567890abcdef\";\n",
+    )
+    .expect("write source");
+
+    let summary = scan_path_with_config(
+        temp.path(),
+        &ScanConfig {
+            detect_missing_tests: false,
+            ..ScanConfig::default()
+        },
+    )
+    .expect("scan");
+
+    assert!(
+        summary
+            .findings
+            .iter()
+            .any(|finding| finding.rule_id == "security.secret-candidate"),
+        "fixture should produce a generated security finding"
+    );
+    let report = validate_findings_contract(&summary.findings);
+    assert!(
+        report.violations.is_empty(),
+        "generated findings should satisfy contract: {:?}",
+        report.violations
+    );
+}

--- a/tests/finding_model.rs
+++ b/tests/finding_model.rs
@@ -20,6 +20,7 @@ fn finding_contains_evidence() {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     };
 

--- a/tests/fixtures/reports/scan-v015.json
+++ b/tests/fixtures/reports/scan-v015.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "0.15",
+  "repopilot_version": "0.13.0",
+  "report": {
+    "kind": "scan",
+    "schema_version": "0.15",
+    "repopilot_version": "0.13.0"
+  },
+  "root_path": ".",
+  "mode": "full",
+  "changed_files_count": 0,
+  "repo_level_rules_included": true,
+  "files_discovered": 2,
+  "files_analyzed": 2,
+  "directories_count": 1,
+  "non_empty_lines": 12,
+  "large_files_skipped": 0,
+  "files_skipped_low_signal": 0,
+  "binary_files_skipped": 0,
+  "skipped_bytes": 0,
+  "languages": [],
+  "findings": [],
+  "detected_frameworks": [],
+  "framework_projects": [],
+  "scan_duration_us": 100,
+  "health_score": 100,
+  "visible_findings_count": 0,
+  "hidden_suggestions_count": 0,
+  "files_skipped_by_limit": 0,
+  "files_skipped_repopilotignore": 0,
+  "diagnostics": [
+    {
+      "code": "workspace.package-scan-failed",
+      "severity": "warning",
+      "message": "Package scan failed; results are partial.",
+      "path": "packages/api"
+    }
+  ],
+  "risk_summary": {
+    "total": 0,
+    "average_score": 0,
+    "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 }
+  },
+  "signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  }
+}

--- a/tests/fixtures/risk/risk-v3-calibration.json
+++ b/tests/fixtures/risk/risk-v3-calibration.json
@@ -1,0 +1,125 @@
+{
+  "formula_version": "risk-v3",
+  "cases": [
+    {
+      "name": "p3_info_floor",
+      "rule_id": "code-marker.todo",
+      "category": "CODE_QUALITY",
+      "severity": "INFO",
+      "confidence": "MEDIUM",
+      "expected_score": 5,
+      "expected_priority": "P3",
+      "expected_signals": ["severity.info"]
+    },
+    {
+      "name": "p3_low_default",
+      "rule_id": "code-marker.todo",
+      "category": "CODE_QUALITY",
+      "severity": "LOW",
+      "confidence": "MEDIUM",
+      "expected_score": 20,
+      "expected_priority": "P3",
+      "expected_signals": ["severity.low"]
+    },
+    {
+      "name": "p2_medium_default",
+      "rule_id": "code-quality.long-function",
+      "category": "CODE_QUALITY",
+      "severity": "MEDIUM",
+      "confidence": "MEDIUM",
+      "expected_score": 45,
+      "expected_priority": "P2",
+      "expected_signals": ["severity.medium"]
+    },
+    {
+      "name": "p1_high_default",
+      "rule_id": "architecture.large-file",
+      "category": "ARCHITECTURE",
+      "severity": "HIGH",
+      "confidence": "MEDIUM",
+      "expected_score": 75,
+      "expected_priority": "P1",
+      "expected_signals": ["severity.high"]
+    },
+    {
+      "name": "p0_critical_default",
+      "rule_id": "security.private-key-candidate",
+      "category": "SECURITY",
+      "severity": "CRITICAL",
+      "confidence": "MEDIUM",
+      "expected_score": 100,
+      "expected_priority": "P0",
+      "expected_signals": ["severity.critical", "category.security"]
+    },
+    {
+      "name": "low_confidence_can_demote_high_severity",
+      "rule_id": "architecture.large-file",
+      "category": "ARCHITECTURE",
+      "severity": "HIGH",
+      "confidence": "LOW",
+      "expected_score": 60,
+      "expected_priority": "P2",
+      "expected_signals": ["severity.high", "confidence.low"]
+    },
+    {
+      "name": "security_high_boost_stays_p1",
+      "rule_id": "security.secret-candidate",
+      "category": "SECURITY",
+      "severity": "HIGH",
+      "confidence": "MEDIUM",
+      "expected_score": 87,
+      "expected_priority": "P1",
+      "expected_signals": ["severity.high", "category.security"]
+    },
+    {
+      "name": "review_diff_medium_boost",
+      "rule_id": "architecture.large-file",
+      "category": "ARCHITECTURE",
+      "severity": "MEDIUM",
+      "confidence": "MEDIUM",
+      "in_diff": true,
+      "expected_score": 57,
+      "expected_priority": "P2",
+      "expected_signals": ["severity.medium", "review.in-diff"]
+    },
+    {
+      "name": "graph_hub_medium_boost",
+      "rule_id": "code-quality.complex-file",
+      "category": "CODE_QUALITY",
+      "severity": "MEDIUM",
+      "confidence": "MEDIUM",
+      "graph_impact": "hub",
+      "expected_score": 53,
+      "expected_priority": "P2",
+      "expected_signals": ["severity.medium", "graph.hub"]
+    },
+    {
+      "name": "large_cluster_medium_boost",
+      "rule_id": "language.rust.panic-risk",
+      "category": "CODE_QUALITY",
+      "severity": "MEDIUM",
+      "confidence": "MEDIUM",
+      "cluster_size": 16,
+      "expected_score": 52,
+      "expected_priority": "P2",
+      "expected_signals": ["severity.medium", "cluster.repeated"]
+    },
+    {
+      "name": "stacked_security_diff_blast_radius_clamps_to_p0",
+      "rule_id": "security.secret-candidate",
+      "category": "SECURITY",
+      "severity": "HIGH",
+      "confidence": "MEDIUM",
+      "in_diff": true,
+      "blast_radius": true,
+      "expected_score": 100,
+      "expected_priority": "P0",
+      "expected_signals": [
+        "severity.high",
+        "category.security",
+        "review.in-diff",
+        "review.blast-radius"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/language.rust.panic-risk/expected.json
+++ b/tests/fixtures/rules/language.rust.panic-risk/expected.json
@@ -1,0 +1,12 @@
+{
+  "fixtures": [
+    {
+      "path": "true_positive",
+      "expected_rule_ids": ["language.rust.panic-risk"]
+    },
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    }
+  ]
+}

--- a/tests/fixtures/rules/language.rust.panic-risk/false_positive/src/lib.rs
+++ b/tests/fixtures/rules/language.rust.panic-risk/false_positive/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn token(value: Option<&str>) -> Option<&str> {
+    value
+}

--- a/tests/fixtures/rules/language.rust.panic-risk/true_positive/src/lib.rs
+++ b/tests/fixtures/rules/language.rust.panic-risk/true_positive/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn token(value: Option<&str>) -> &str {
+    value.unwrap()
+}

--- a/tests/fixtures/rules/security.secret-candidate/expected.json
+++ b/tests/fixtures/rules/security.secret-candidate/expected.json
@@ -1,0 +1,12 @@
+{
+  "fixtures": [
+    {
+      "path": "true_positive",
+      "expected_rule_ids": ["security.secret-candidate"]
+    },
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    }
+  ]
+}

--- a/tests/fixtures/rules/security.secret-candidate/false_positive/src/config.rs
+++ b/tests/fixtures/rules/security.secret-candidate/false_positive/src/config.rs
@@ -1,0 +1,1 @@
+pub const PUBLIC_LABEL: &str = "local development fixture";

--- a/tests/fixtures/rules/security.secret-candidate/true_positive/src/config.rs
+++ b/tests/fixtures/rules/security.secret-candidate/true_positive/src/config.rs
@@ -1,0 +1,1 @@
+pub const API_KEY: &str = "sk_live_repopilot_fixture_1234567890abcdef";

--- a/tests/inspect_rules_cli.rs
+++ b/tests/inspect_rules_cli.rs
@@ -1,0 +1,116 @@
+use serde_json::Value;
+use std::process::Command;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+#[test]
+fn inspect_rules_lists_and_filters_catalog() {
+    let output = repopilot()
+        .args(["inspect", "rules", "--format", "json"])
+        .output()
+        .expect("inspect rules");
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).expect("rules json");
+    assert!(
+        json["rules"]
+            .as_array()
+            .expect("rules array")
+            .iter()
+            .any(|rule| rule["rule_id"] == "security.secret-candidate")
+    );
+
+    let preview = repopilot()
+        .args([
+            "inspect",
+            "rules",
+            "--lifecycle",
+            "preview",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("inspect rules preview");
+    assert!(preview.status.success());
+    let preview_json: Value = serde_json::from_slice(&preview.stdout).expect("preview json");
+    assert!(
+        preview_json["rules"]
+            .as_array()
+            .expect("preview rules")
+            .iter()
+            .all(|rule| rule["lifecycle"] == "preview")
+    );
+
+    let source = repopilot()
+        .args([
+            "inspect",
+            "rules",
+            "--source",
+            "text-heuristic",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("inspect rules source");
+    assert!(source.status.success());
+    let source_json: Value = serde_json::from_slice(&source.stdout).expect("source json");
+    assert!(
+        source_json["rules"]
+            .as_array()
+            .expect("source rules")
+            .iter()
+            .all(|rule| rule["signal_source"] == "text-heuristic")
+    );
+}
+
+#[test]
+fn inspect_rule_returns_known_rule_and_rejects_unknown_rule() {
+    let known = repopilot()
+        .args([
+            "inspect",
+            "rule",
+            "security.secret-candidate",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("inspect rule");
+    assert!(known.status.success());
+    let json: Value = serde_json::from_slice(&known.stdout).expect("rule json");
+    assert_eq!(json["rule_id"], "security.secret-candidate");
+    assert_eq!(json["lifecycle"], "preview");
+
+    let unknown = repopilot()
+        .args(["inspect", "rule", "missing.rule"])
+        .output()
+        .expect("inspect unknown rule");
+    assert_eq!(unknown.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&unknown.stderr);
+    assert!(stderr.contains("Unknown RepoPilot rule `missing.rule`"));
+}
+
+#[test]
+fn inspect_eval_rules_reports_fixture_quality() {
+    let output = repopilot()
+        .args([
+            "inspect",
+            "eval-rules",
+            "--rule",
+            "security.secret-candidate",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("eval rules");
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).expect("eval json");
+    assert_eq!(json["rules_evaluated"], 1);
+    assert_eq!(json["fixtures_total"], 2);
+    assert_eq!(json["expected_findings"], 1);
+    assert_eq!(json["actual_findings"], 1);
+    assert_eq!(json["missing_findings"], 0);
+    assert_eq!(json["unexpected_findings"], 0);
+    assert_eq!(json["contract_violations"], 0);
+    assert_eq!(json["stable_id_failures"], 0);
+}

--- a/tests/output_console.rs
+++ b/tests/output_console.rs
@@ -31,6 +31,7 @@ fn console_output_includes_versioned_summary_and_grouped_findings() {
             }],
             workspace_package: None,
             docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
         }],
         health_score: 95,

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -39,6 +39,7 @@ fn html_output_escapes_snippets_and_renders_summary() {
             }],
             workspace_package: None,
             docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
         }],
         react_native: None,

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -83,6 +83,7 @@ fn json_findings_include_confidence() {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     };
     finding.risk = assess_finding(&finding, None, RiskInputs::default());
@@ -111,6 +112,16 @@ fn json_findings_include_confidence() {
     assert_eq!(
         parsed["findings"][0]["risk"]["signals"][0]["id"],
         "severity.medium"
+    );
+    assert_eq!(
+        parsed["findings"][0]["risk"]["signals"][0]["source"],
+        "severity"
+    );
+    assert_eq!(parsed["signal_quality"]["findings_total"], 1);
+    assert_eq!(parsed["signal_quality"]["by_confidence"]["high"], 1);
+    assert_eq!(
+        parsed["findings"][0]["provenance"]["rule_lifecycle"],
+        "preview"
     );
     assert_eq!(
         parsed["findings"][0]["recommendation"],

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -51,6 +51,7 @@ fn renders_markdown_scan_summary() {
             }],
             workspace_package: None,
             docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
         }],
         detected_frameworks: vec![],

--- a/tests/output_sarif.rs
+++ b/tests/output_sarif.rs
@@ -22,6 +22,7 @@ fn make_finding_with_package(rule_id: &str, pkg: Option<&str>) -> Finding {
         }],
         workspace_package: pkg.map(str::to_owned),
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }
@@ -83,6 +84,7 @@ fn sarif_rule_uses_title_and_full_description() {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     };
 
@@ -128,6 +130,7 @@ fn sarif_result_includes_partial_fingerprints() {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     };
 

--- a/tests/report_schema_contract.rs
+++ b/tests/report_schema_contract.rs
@@ -3,10 +3,10 @@ use serde_json::Value;
 
 #[test]
 fn current_schema_fixture_documents_scan_report_contract() {
-    let current: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v014.json"))
+    let current: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v015.json"))
         .expect("current report fixture should be valid JSON");
 
-    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.14");
+    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.15");
     assert_eq!(current["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
     assert_eq!(current["report"]["kind"], "scan");
     assert_eq!(
@@ -21,11 +21,13 @@ fn current_schema_fixture_documents_scan_report_contract() {
         current["diagnostics"][0]["code"],
         "workspace.package-scan-failed"
     );
+    assert_eq!(current["signal_quality"]["findings_total"], 0);
+    assert_eq!(current["signal_quality"]["evidence_coverage_percent"], 100);
 }
 
 #[test]
 fn strict_reader_accepts_current_scan_report_shape() {
-    let current = parse_scan_summary_json(include_str!("fixtures/reports/scan-v014.json"))
+    let current = parse_scan_summary_json(include_str!("fixtures/reports/scan-v015.json"))
         .expect("current report should parse into ScanSummary");
 
     assert_eq!(current.files_discovered, 2);
@@ -39,7 +41,7 @@ fn strict_reader_accepts_current_scan_report_shape() {
 fn strict_reader_rejects_legacy_report_shapes() {
     let legacy = parse_scan_summary_json(include_str!("fixtures/reports/scan-v010.json"));
     let previous_envelope =
-        parse_scan_summary_json(include_str!("fixtures/reports/scan-v013.json"));
+        parse_scan_summary_json(include_str!("fixtures/reports/scan-v014.json"));
 
     assert!(legacy.is_err());
     assert!(previous_envelope.is_err());

--- a/tests/review_command.rs
+++ b/tests/review_command.rs
@@ -23,7 +23,7 @@ fn review_reports_working_tree_findings_on_changed_lines() {
 
     let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
 
-    assert_eq!(json["schema_version"], "0.14");
+    assert_eq!(json["schema_version"], "0.15");
     assert_eq!(json["report"]["kind"], "review");
     assert!(json["risk_summary"]["total"].as_u64().is_some());
     assert_eq!(json["review"]["in_diff_findings"], 1);

--- a/tests/risk_calibration.rs
+++ b/tests/risk_calibration.rs
@@ -129,17 +129,17 @@ export function App() {
     let summary = scan_path_with_config(temp.path(), &config).expect("scan");
     let inline_style = first_rule(&summary.findings, "framework.react-native.inline-style");
 
-    assert_eq!(inline_style.risk.formula_version, "risk-v2");
+    assert_eq!(inline_style.risk.formula_version, "risk-v3");
     assert_ne!(inline_style.risk.priority, RiskPriority::P0);
 }
 
 #[test]
-fn risk_v2_calibration_fixture_matches_snapshot_expectations() {
+fn risk_v3_calibration_fixture_matches_snapshot_expectations() {
     let fixture: RiskCalibrationFixture =
-        serde_json::from_str(include_str!("fixtures/risk/risk-v2-calibration.json"))
+        serde_json::from_str(include_str!("fixtures/risk/risk-v3-calibration.json"))
             .expect("risk calibration fixture should parse");
 
-    assert_eq!(fixture.formula_version, "risk-v2");
+    assert_eq!(fixture.formula_version, "risk-v3");
 
     for case in fixture.cases {
         let finding = calibration_finding(&case);
@@ -253,6 +253,7 @@ fn calibration_finding(case: &RiskCalibrationCase) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/tests/risk_engine.rs
+++ b/tests/risk_engine.rs
@@ -310,6 +310,7 @@ fn finding(rule_id: &str, path: &str, severity: Severity) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/tests/rule_registry.rs
+++ b/tests/rule_registry.rs
@@ -97,6 +97,7 @@ fn make_finding(rule_id: &str) -> Finding {
         }],
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/tests/sarif_mapping.rs
+++ b/tests/sarif_mapping.rs
@@ -163,6 +163,7 @@ fn finding(rule_id: &str, severity: Severity, path: Option<&str>, line_start: us
             .unwrap_or_default(),
         workspace_package: None,
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }

--- a/tests/scan_summary.rs
+++ b/tests/scan_summary.rs
@@ -116,6 +116,7 @@ fn health_score_decreases_with_severity() {
             evidence: vec![],
             workspace_package: None,
             docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
         }
     }
@@ -145,6 +146,7 @@ fn health_score_is_clamped_at_zero_for_catastrophic_repos() {
             evidence: vec![],
             workspace_package: None,
             docs_url: None,
+            provenance: Default::default(),
             risk: Default::default(),
         })
         .collect();
@@ -204,8 +206,9 @@ fn timing_accounting_uses_granular_file_pipeline_when_available() {
         post_scan_audits_us: 7,
         enrichment_us: 3,
         risk_scoring_us: 2,
+        contract_validation_us: 4,
         report_finalization_us: 1,
     };
 
-    assert_eq!(timings.accounted_engine_us(), 68);
+    assert_eq!(timings.accounted_engine_us(), 72);
 }

--- a/tests/signal_quality.rs
+++ b/tests/signal_quality.rs
@@ -1,0 +1,38 @@
+use repopilot::findings::quality::summarize_signal_quality;
+use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
+use repopilot::risk::{RiskInputs, assess_finding};
+use std::path::PathBuf;
+
+#[test]
+fn signal_quality_counts_confidence_coverage_and_contract_warnings() {
+    let mut finding = Finding {
+        id: "finding-1".to_string(),
+        rule_id: "code-quality.long-function".to_string(),
+        title: "Long function".to_string(),
+        description: "Function is long.".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("code-quality.long-function"),
+        category: FindingCategory::CodeQuality,
+        severity: Severity::Medium,
+        confidence: Confidence::High,
+        evidence: vec![Evidence {
+            path: PathBuf::from("src/lib.rs"),
+            line_start: 1,
+            line_end: None,
+            snippet: String::new(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+        provenance: Default::default(),
+        risk: Default::default(),
+    };
+    finding.populate_rule_metadata();
+    finding.risk = assess_finding(&finding, None, RiskInputs::default());
+
+    let quality = summarize_signal_quality(&[finding]);
+
+    assert_eq!(quality.findings_total, 1);
+    assert_eq!(quality.by_confidence.high, 1);
+    assert_eq!(quality.evidence_coverage_percent, 100);
+    assert_eq!(quality.recommendation_coverage_percent, 100);
+    assert_eq!(quality.contract_violations, 0);
+}

--- a/tests/workspace_risk.rs
+++ b/tests/workspace_risk.rs
@@ -21,6 +21,7 @@ fn make_finding(pkg: Option<&str>, severity: Severity) -> Finding {
         }],
         workspace_package: pkg.map(str::to_owned),
         docs_url: None,
+        provenance: Default::default(),
         risk: Default::default(),
     }
 }


### PR DESCRIPTION
## Summary

This PR turns RepoPilot 0.13.0 into a stronger core-cleanup release by adding a stricter finding contract, rule lifecycle metadata, finding provenance, signal quality reporting, rule catalog inspection, local rule evaluation fixtures, and explainable `risk-v3` signals.

The goal is not to add more random rules. The goal is to make every reported finding more trustworthy, explainable, measurable, and ready for CI, SARIF, JSON consumers, and AI-assisted remediation workflows.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] Report/schema stabilization
- [x] Breaking change
- [x] 0.13 release hardening

## What changed

- Added finding contract validation:
  - `FindingContractViolation`
  - `FindingContractViolationKind`
  - `FindingContractReport`
  - `validate_finding_contract`
  - `validate_findings_contract`

- Added diagnostics for invalid finding contracts.

- Added finding provenance so findings can explain where their signal came from:
  - detector
  - signal source
  - rule lifecycle
  - analysis scope

- Extended rule metadata with:
  - default confidence
  - lifecycle
  - signal source
  - false-positive notes
  - tags

- Added rule lifecycle and signal source models.

- Added rule catalog inspection commands:
  - `repopilot inspect rules`
  - `repopilot inspect rules --format json`
  - `repopilot inspect rules --lifecycle preview`
  - `repopilot inspect rules --source text-heuristic`
  - `repopilot inspect rule <rule-id>`

- Added local rule evaluation workflow:
  - `repopilot inspect eval-rules`
  - `repopilot inspect eval-rules --rule <rule-id>`
  - fixture-based true-positive / false-positive evaluation
  - missing / unexpected finding accounting
  - contract violation accounting
  - stable ID failure accounting

- Added signal quality summary for scan, baseline, and review reports.

- Updated machine-readable report schema to `0.15`.

- Introduced `risk-v3`.

- Added risk signal source metadata for more explainable risk output.

- Updated output renderers for finding provenance, signal quality, and risk changes.

- Added fixtures for rule evaluation and risk calibration.

- Updated docs for:
  - finding contract
  - rule lifecycle
  - signal quality
  - risk engine / risk model
  - report schema migration
  - rulesets
  - 0.13 release checklist
  - roadmap
  - README / commands

## Why

RepoPilot needs to become more than a scanner that prints warnings.

For the product to be useful in real repositories, every finding should be:

```text
stable
evidence-backed
explainable
risk-ranked
schema-safe
measurable
inspectable
```

This PR adds the foundation for that.

The finding contract makes broken or low-quality findings visible. Rule lifecycle metadata makes it clear whether a rule is stable, preview, or experimental. Signal quality metrics help understand how much of a report is high-confidence, heuristic, documented, and evidence-backed. Rule evaluation fixtures create the first local feedback loop for improving rule precision without telemetry or remote training.

This is a core trust layer for the pre-1.0 line.

## Architecture notes

- No remote services added.
- No telemetry added.
- No LLM API calls added.
- No plugin execution added.
- No legacy CLI aliases reintroduced.
- Finding validation lives in findings.
- Finding provenance lives in findings.
- Rule lifecycle and signal source metadata live in rules.
- Rule catalog and rule evaluation are exposed through inspect.
- Signal quality is derived from findings and report data.
- Risk scoring remains centralized in the risk engine.
- Report DTOs expose new schema fields through the report schema layer.
- CLI orchestration stays separate from scan/rule/report internals.

## Breaking changes

- Scan report schema is updated to 0.15.
- Risk formula version is updated to risk-v3.
- JSON consumers may now receive additional finding provenance, signal quality, and risk signal source fields.
- Compare/report consumers should use the current schema metadata instead of relying on older report shapes.

## Compatibility

- Stable command families remain:
  - scan
  - review
  - baseline
  - compare
  - doctor
  - ai
  - inspect
  - init
  - cache

- Existing product command names remain unchanged.
- The new rule inspection commands are additive under inspect.
- Local-first behavior is preserved:
  - no source upload
  - no telemetry
  - no hosted scanner
  - no external rule execution
  - no LLM API calls

## Verification

Recommended checks:

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```

Product smoke checks:

```
cargo run -- scan . --format json --output /tmp/repopilot-013-scan.json --receipt /tmp/repopilot-013-receipt.json
cargo run -- scan . --format markdown --output /tmp/repopilot-013-scan.md
cargo run -- scan . --format sarif --output /tmp/repopilot-013.sarif
cargo run -- scan . --timing
cargo run -- review . --format json --output /tmp/repopilot-013-review.json
cargo run -- ai context . --budget 2k --output /tmp/repopilot-013-ai-context.md
cargo run -- ai plan . --budget 4k --output /tmp/repopilot-013-ai-plan.md
cargo run -- ai prompt . --budget 4k --output /tmp/repopilot-013-ai-prompt.md
cargo run -- inspect rules
cargo run -- inspect rules --format json --output /tmp/repopilot-013-rules.json
cargo run -- inspect rule security.secret-candidate
cargo run -- inspect eval-rules --format json --output /tmp/repopilot-013-rule-eval.json
```