### PR TITLE
refactor(core): centralize finding enrichment and rule evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,24 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added a 0.13 release checklist for the breaking cleanup release.
 - Added a current `0.15` scan report fixture that documents the supported compare input schema.
 - Added finding contract validation with diagnostics, release-test coverage, and contract timing.
+- Added an indexed rule metadata lookup and registry uniqueness coverage.
 - Added finding provenance with detector, rule lifecycle, signal source, and analysis scope.
 - Added rule lifecycle, signal source, default confidence, false-positive notes, and tags to rule metadata.
 - Added `repopilot inspect rules`, `repopilot inspect rule <rule_id>`, and `repopilot inspect eval-rules`.
 - Added signal quality summaries to JSON, console, and Markdown reports.
 - Added a shared product scan pipeline for scan, review, baseline creation, and AI Markdown commands, including shared runtime diagnostic handling.
 - Added local rule evaluation fixtures for `security.secret-candidate` and `language.rust.panic-risk`.
+- Added per-rule JSON details to `repopilot inspect eval-rules`.
+- Added a product smoke self-scan gate for finding contract violations.
 
 ### Changed
 
 - Bumped the crate, npm wrapper, optional platform package pins, and GitHub Action default version to `0.13.0`.
 - Bumped scan report schema to `0.15` for provenance, signal quality, finding contract diagnostics, and `risk-v3`.
 - Updated risk scoring metadata to `risk-v3` with typed risk signal sources and clearer signal reasons.
+- Centralized scan finding enrichment before risk scoring and report construction.
+- Cached report signal quality on `ScanSummary` so renderers reuse one summary per report path.
+- Split rule inspection catalog, fixture evaluation, and rendering out of the CLI command orchestration.
 - Renamed internal AI modules from legacy context/plan names to `ai_context` and `ai_plan` while keeping the public CLI as `repopilot ai context|plan|prompt`.
 - Updated AI context and AI plan headings to use the stable product names.
 - AI context, AI plan, and AI prompt now use the same default visibility and local feedback behavior as product scans.

--- a/docs/finding-contract.md
+++ b/docs/finding-contract.md
@@ -1,8 +1,9 @@
 # Finding Contract
 
 RepoPilot 0.13.0 validates every rendered finding against an internal contract.
-Validation runs locally after enrichment and risk scoring. Normal scans report
-contract problems as diagnostics; tests and release checks should fail on them.
+Validation runs locally after the single enrichment pass and risk scoring. Normal
+scans report contract problems as diagnostics; tests and release checks should
+fail on them.
 
 A valid finding has:
 
@@ -17,6 +18,16 @@ A valid finding has:
 The contract is intentionally strict because findings are used by baselines,
 SARIF, JSON reports, AI context, and CI gates. RepoPilot should not silently
 render incomplete findings or hide contract warnings through visibility filters.
+
+The scan pipeline is:
+
+```text
+raw findings -> enrich once -> risk scoring -> contract validation -> report finalization
+```
+
+Enrichment fills missing title, description, recommendation, docs URL,
+provenance, and the stable finding id before renderers see the finding. Contract
+validation timing is exposed as `scan_timings.contract_validation_us`.
 
 The validation model is exposed through `repopilot::api::findings` for embedded
 tests and release validation.

--- a/docs/release-checklist-0.13.md
+++ b/docs/release-checklist-0.13.md
@@ -36,6 +36,8 @@ Rule metadata gates:
 - every registered rule has lifecycle, signal source, and default confidence;
 - high/critical findings have docs URLs after enrichment;
 - `repopilot inspect rules`, `inspect rule`, and `inspect eval-rules` pass locally.
+- `scripts/smoke-product.sh` verifies the self-scan JSON report has zero finding
+  contract violations without requiring `jq` or other optional JSON tools.
 
 Smoke commands:
 
@@ -48,6 +50,19 @@ cargo run -- inspect rules --format json --output /tmp/repopilot-013-rules.json
 cargo run -- inspect eval-rules --format json --output /tmp/repopilot-013-rule-eval.json
 ```
 
+Optimization/stabilization verification:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+cargo run -- scan . --timing
+cargo run -- scan . --format json --output /tmp/repopilot-013-optimized.json
+cargo run -- inspect rules --format json --output /tmp/repopilot-rules.json
+cargo run -- inspect eval-rules --format json --output /tmp/repopilot-rule-eval.json
+./scripts/smoke-product.sh --binary ./target/release/repopilot --repo .
+```
+
 ## Breaking-Change Gates
 
 Verify:
@@ -55,6 +70,7 @@ Verify:
 - `repopilot compare` accepts current `0.15` scan reports;
 - `repopilot compare` rejects pre-current scan report shapes clearly;
 - JSON reports include `signal_quality`, finding `provenance`, `risk.signals[].source`, and `risk-v3`;
+- JSON reports include `scan_timings.contract_validation_us` when scan timings are present;
 - active docs describe the current command surface, not removed 0.x aliases;
 - schema migration docs state that historical report compatibility belongs in downstream consumers when needed.
 

--- a/docs/rule-lifecycle.md
+++ b/docs/rule-lifecycle.md
@@ -1,6 +1,8 @@
 # Rule Lifecycle
 
 Every registered rule has lifecycle and signal-source metadata.
+Rule metadata lookup is indexed at runtime, so repeated finding enrichment uses
+a prebuilt rule-id map instead of scanning the full registry for every finding.
 
 Lifecycle values:
 
@@ -32,7 +34,12 @@ repopilot inspect rules --format json
 repopilot inspect rules --lifecycle preview
 repopilot inspect rules --source text-heuristic
 repopilot inspect rule security.secret-candidate
+repopilot inspect eval-rules --format json
 ```
+
+`inspect eval-rules --format json` includes aggregate counts and per-rule
+fixture details, including expected findings, actual findings, missing findings,
+unexpected findings, contract violations, and stable-id failures.
 
 Rule lifecycle does not enable telemetry, hosted scanning, remote model calls, or
 arbitrary plugin execution. It is local metadata used for reports, provenance,

--- a/docs/signal-quality.md
+++ b/docs/signal-quality.md
@@ -1,7 +1,9 @@
 # Signal Quality
 
 RepoPilot 0.13.0 adds a report-level `signal_quality` summary derived from the
-visible findings and the finding contract.
+visible findings and the finding contract. The scan pipeline stores the summary
+on `ScanSummary` after enrichment, risk scoring, and contract validation so JSON,
+console, and Markdown renderers do not rebuild the same summary independently.
 
 JSON reports include:
 
@@ -30,3 +32,6 @@ The summary is meant to help users decide how much trust to place in the current
 report. A report with many experimental or low-confidence findings should be
 treated as review guidance, while stable high-confidence findings should receive
 faster attention.
+
+When filters, local feedback, baseline views, or visibility profiles change the
+visible finding set, RepoPilot refreshes the cached summary for that report path.

--- a/scripts/smoke-product.sh
+++ b/scripts/smoke-product.sh
@@ -149,6 +149,18 @@ validate_json_if_possible() {
   fi
 }
 
+assert_no_contract_violations() {
+  local file="$1"
+
+  if ! grep -Eq '"contract_violations"[[:space:]]*:[[:space:]]*0' "$file"; then
+    echo "Expected self-scan report to have zero finding contract violations: $file" >&2
+    echo "---- file content ----" >&2
+    cat "$file" >&2 || true
+    echo "----------------------" >&2
+    exit 3
+  fi
+}
+
 find_explain_file() {
   local preferred="$REPO_PATH/src/main.rs"
 
@@ -213,6 +225,7 @@ assert_non_empty "$TMP_DIR/doctor.md"
 run_repopilot scan . --format json --output "$TMP_DIR/scan.json" --receipt "$TMP_DIR/receipt.json"
 assert_non_empty "$TMP_DIR/scan.json"
 validate_json_if_possible "$TMP_DIR/scan.json"
+assert_no_contract_violations "$TMP_DIR/scan.json"
 assert_non_empty "$TMP_DIR/receipt.json"
 validate_json_if_possible "$TMP_DIR/receipt.json"
 

--- a/src/commands/rules.rs
+++ b/src/commands/rules.rs
@@ -1,60 +1,10 @@
 use crate::cli::{CompareOutputFormatArg, RuleLifecycleArg, SignalSourceArg};
 use crate::commands::{CliExit, EXIT_RUNTIME, EXIT_USAGE};
-use repopilot::findings::contract::validate_findings_contract;
 use repopilot::output::OutputFormat;
 use repopilot::report::writer::write_report;
-use repopilot::rules::{RuleLifecycle, RuleMetadata, SignalSource, all_rule_metadata};
-use repopilot::scan::config::ScanConfig;
-use repopilot::scan::scanner::scan_path_with_config;
-use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-#[derive(Debug, Serialize)]
-struct RuleCatalogReport {
-    rules: Vec<RuleCatalogItem>,
-}
-
-#[derive(Debug, Serialize)]
-struct RuleCatalogItem {
-    rule_id: &'static str,
-    title: &'static str,
-    category: String,
-    severity: String,
-    confidence: String,
-    lifecycle: RuleLifecycle,
-    signal_source: SignalSource,
-    docs_url: Option<&'static str>,
-    tags: &'static [&'static str],
-    description: &'static str,
-    recommendation: Option<&'static str>,
-    false_positive_notes: Option<&'static str>,
-}
-
-#[derive(Debug, Serialize)]
-pub struct RuleEvaluationReport {
-    pub rules_evaluated: usize,
-    pub fixtures_total: usize,
-    pub expected_findings: usize,
-    pub actual_findings: usize,
-    pub missing_findings: usize,
-    pub unexpected_findings: usize,
-    pub contract_violations: usize,
-    pub stable_id_failures: usize,
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureExpectations {
-    fixtures: Vec<FixtureCase>,
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureCase {
-    path: PathBuf,
-    expected_rule_ids: Vec<String>,
-}
+use repopilot::rules::catalog::{RuleCatalogFilter, inspect_rule as build_rule_report};
+use repopilot::rules::{RuleLifecycle, SignalSource};
+use std::path::PathBuf;
 
 pub fn list_rules(
     format: CompareOutputFormatArg,
@@ -62,15 +12,12 @@ pub fn list_rules(
     source: Option<SignalSourceArg>,
     output: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let lifecycle = lifecycle.map(RuleLifecycle::from);
-    let source = source.map(SignalSource::from);
-    let rules = all_rule_metadata()
-        .filter(|rule| lifecycle.is_none_or(|value| rule.lifecycle == value))
-        .filter(|rule| source.is_none_or(|value| rule.signal_source == value))
-        .map(RuleCatalogItem::from)
-        .collect::<Vec<_>>();
-    let report = RuleCatalogReport { rules };
-    let rendered = render_catalog(&report, OutputFormat::from(format))?;
+    let format = validate_output_format(OutputFormat::from(format))?;
+    let report = repopilot::rules::catalog::list_rule_catalog(RuleCatalogFilter {
+        lifecycle: lifecycle.map(RuleLifecycle::from),
+        source: source.map(SignalSource::from),
+    });
+    let rendered = repopilot::output::rules::render_catalog(&report, format)?;
     write_report(&rendered, output.as_deref())?;
     Ok(())
 }
@@ -80,15 +27,15 @@ pub fn inspect_rule(
     format: CompareOutputFormatArg,
     output: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let Some(rule) = repopilot::rules::lookup_rule_metadata(&rule_id) else {
+    let Some(report) = build_rule_report(&rule_id) else {
         return Err(Box::new(CliExit {
             code: EXIT_USAGE,
             message: format!("Unknown RepoPilot rule `{rule_id}`"),
         }));
     };
 
-    let report = RuleCatalogItem::from(rule);
-    let rendered = render_rule(&report, OutputFormat::from(format))?;
+    let format = validate_output_format(OutputFormat::from(format))?;
+    let rendered = repopilot::output::rules::render_rule(&report, format)?;
     write_report(&rendered, output.as_deref())?;
     Ok(())
 }
@@ -108,312 +55,18 @@ pub fn eval_rules(
         }));
     }
 
-    let report = evaluate_rule_fixtures(rule.as_deref(), fixtures.as_deref())?;
-    let rendered = render_eval_report(&report, OutputFormat::from(format))?;
+    let format = validate_output_format(OutputFormat::from(format))?;
+    let report = repopilot::rules::eval::fixtures::evaluate_rule_fixtures(
+        rule.as_deref(),
+        fixtures.as_deref(),
+    )
+    .map_err(|error| CliExit {
+        code: EXIT_RUNTIME,
+        message: error.to_string(),
+    })?;
+    let rendered = repopilot::output::rules::render_eval_report(&report, format)?;
     write_report(&rendered, output.as_deref())?;
     Ok(())
-}
-
-fn render_catalog(
-    report: &RuleCatalogReport,
-    format: OutputFormat,
-) -> Result<String, Box<dyn std::error::Error>> {
-    match validate_output_format(format)? {
-        OutputFormat::Console => Ok(render_catalog_console(report)),
-        OutputFormat::Markdown => Ok(render_catalog_markdown(report)),
-        OutputFormat::Json => Ok(serde_json::to_string_pretty(report)?),
-        OutputFormat::Html | OutputFormat::Sarif => unreachable!("validated output format"),
-    }
-}
-
-fn render_rule(
-    rule: &RuleCatalogItem,
-    format: OutputFormat,
-) -> Result<String, Box<dyn std::error::Error>> {
-    match validate_output_format(format)? {
-        OutputFormat::Console => Ok(render_rule_console(rule)),
-        OutputFormat::Markdown => Ok(render_rule_markdown(rule)),
-        OutputFormat::Json => Ok(serde_json::to_string_pretty(rule)?),
-        OutputFormat::Html | OutputFormat::Sarif => unreachable!("validated output format"),
-    }
-}
-
-fn render_eval_report(
-    report: &RuleEvaluationReport,
-    format: OutputFormat,
-) -> Result<String, Box<dyn std::error::Error>> {
-    match validate_output_format(format)? {
-        OutputFormat::Console => Ok(format!(
-            "RepoPilot Rule Evaluation\n\nRules evaluated: {}\nFixtures: {}\nExpected findings: {}\nActual findings: {}\nMissing findings: {}\nUnexpected findings: {}\nContract violations: {}\nStable ID failures: {}\n",
-            report.rules_evaluated,
-            report.fixtures_total,
-            report.expected_findings,
-            report.actual_findings,
-            report.missing_findings,
-            report.unexpected_findings,
-            report.contract_violations,
-            report.stable_id_failures,
-        )),
-        OutputFormat::Markdown => Ok(format!(
-            "# RepoPilot Rule Evaluation\n\n- **Rules evaluated:** {}\n- **Fixtures:** {}\n- **Expected findings:** {}\n- **Actual findings:** {}\n- **Missing findings:** {}\n- **Unexpected findings:** {}\n- **Contract violations:** {}\n- **Stable ID failures:** {}\n",
-            report.rules_evaluated,
-            report.fixtures_total,
-            report.expected_findings,
-            report.actual_findings,
-            report.missing_findings,
-            report.unexpected_findings,
-            report.contract_violations,
-            report.stable_id_failures,
-        )),
-        OutputFormat::Json => Ok(serde_json::to_string_pretty(report)?),
-        OutputFormat::Html | OutputFormat::Sarif => unreachable!("validated output format"),
-    }
-}
-
-fn render_catalog_console(report: &RuleCatalogReport) -> String {
-    let mut output = String::new();
-    output.push_str("RepoPilot Rules\n\n");
-    for rule in &report.rules {
-        output.push_str(&format!(
-            "{} [{} {} {}]\n  {}\n",
-            rule.rule_id,
-            rule.severity,
-            rule.lifecycle.label(),
-            rule.signal_source.label(),
-            rule.title
-        ));
-    }
-    output
-}
-
-fn render_catalog_markdown(report: &RuleCatalogReport) -> String {
-    let mut output = String::new();
-    output.push_str("# RepoPilot Rules\n\n");
-    output.push_str("| Rule | Title | Category | Severity | Confidence | Lifecycle | Source |\n");
-    output.push_str("| --- | --- | --- | --- | --- | --- | --- |\n");
-    for rule in &report.rules {
-        output.push_str(&format!(
-            "| `{}` | {} | {} | {} | {} | {} | {} |\n",
-            rule.rule_id,
-            escape_table_cell(rule.title),
-            rule.category,
-            rule.severity,
-            rule.confidence,
-            rule.lifecycle.label(),
-            rule.signal_source.label()
-        ));
-    }
-    output
-}
-
-fn render_rule_console(rule: &RuleCatalogItem) -> String {
-    format!(
-        "RepoPilot Rule\n\nRule: {}\nTitle: {}\nCategory: {}\nSeverity: {}\nConfidence: {}\nLifecycle: {}\nSignal source: {}\nDocs: {}\nTags: {}\nDescription: {}\nRecommendation: {}\nFalse positives: {}\n",
-        rule.rule_id,
-        rule.title,
-        rule.category,
-        rule.severity,
-        rule.confidence,
-        rule.lifecycle.label(),
-        rule.signal_source.label(),
-        rule.docs_url.unwrap_or("none"),
-        if rule.tags.is_empty() {
-            "none".to_string()
-        } else {
-            rule.tags.join(", ")
-        },
-        rule.description,
-        rule.recommendation.unwrap_or("none"),
-        rule.false_positive_notes.unwrap_or("none"),
-    )
-}
-
-fn render_rule_markdown(rule: &RuleCatalogItem) -> String {
-    format!(
-        "# `{}`\n\n- **Title:** {}\n- **Category:** {}\n- **Severity:** {}\n- **Confidence:** {}\n- **Lifecycle:** {}\n- **Signal source:** {}\n- **Docs:** {}\n- **Tags:** {}\n\n{}\n\n**Recommendation:** {}\n\n**False-positive notes:** {}\n",
-        rule.rule_id,
-        rule.title,
-        rule.category,
-        rule.severity,
-        rule.confidence,
-        rule.lifecycle.label(),
-        rule.signal_source.label(),
-        rule.docs_url.unwrap_or("none"),
-        if rule.tags.is_empty() {
-            "none".to_string()
-        } else {
-            rule.tags.join(", ")
-        },
-        rule.description,
-        rule.recommendation.unwrap_or("none"),
-        rule.false_positive_notes.unwrap_or("none"),
-    )
-}
-
-fn evaluate_rule_fixtures(
-    only_rule: Option<&str>,
-    fixture_root: Option<&Path>,
-) -> Result<RuleEvaluationReport, Box<dyn std::error::Error>> {
-    let fixture_root = fixture_root
-        .map(Path::to_path_buf)
-        .unwrap_or_else(default_fixture_root);
-
-    if !fixture_root.exists() {
-        return Err(Box::new(CliExit {
-            code: EXIT_RUNTIME,
-            message: format!(
-                "Rule fixture root does not exist: {}",
-                fixture_root.display()
-            ),
-        }));
-    }
-
-    let mut rules_evaluated = BTreeSet::new();
-    let mut report = RuleEvaluationReport {
-        rules_evaluated: 0,
-        fixtures_total: 0,
-        expected_findings: 0,
-        actual_findings: 0,
-        missing_findings: 0,
-        unexpected_findings: 0,
-        contract_violations: 0,
-        stable_id_failures: 0,
-    };
-
-    for entry in fs::read_dir(&fixture_root)? {
-        let entry = entry?;
-        if !entry.file_type()?.is_dir() {
-            continue;
-        }
-        let rule_id = entry.file_name().to_string_lossy().to_string();
-        if only_rule.is_some_and(|only_rule| only_rule != rule_id) {
-            continue;
-        }
-        rules_evaluated.insert(rule_id.clone());
-        evaluate_one_rule_fixture(&entry.path(), &rule_id, &mut report)?;
-    }
-
-    report.rules_evaluated = rules_evaluated.len();
-    Ok(report)
-}
-
-fn evaluate_one_rule_fixture(
-    rule_root: &Path,
-    rule_id: &str,
-    report: &mut RuleEvaluationReport,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let expected_path = rule_root.join("expected.json");
-    let expectations: FixtureExpectations =
-        serde_json::from_str(&fs::read_to_string(expected_path)?)?;
-    let config = ScanConfig {
-        detect_missing_tests: false,
-        include_low_signal: true,
-        ..ScanConfig::default()
-    };
-
-    for fixture in expectations.fixtures {
-        let path = rule_root.join(&fixture.path);
-        let scan_path = materialize_fixture_for_scan(&path)?;
-        let summary = scan_path_with_config(&scan_path, &config)?;
-        cleanup_materialized_fixture(&scan_path, &path);
-        let actual_rule_ids = summary
-            .findings
-            .iter()
-            .filter(|finding| finding.rule_id == rule_id)
-            .map(|finding| finding.rule_id.clone())
-            .collect::<Vec<_>>();
-        let expected = fixture
-            .expected_rule_ids
-            .iter()
-            .filter(|expected_rule| expected_rule.as_str() == rule_id)
-            .cloned()
-            .collect::<Vec<_>>();
-
-        report.fixtures_total += 1;
-        report.expected_findings += expected.len();
-        report.actual_findings += actual_rule_ids.len();
-        report.missing_findings += missing_count(&expected, &actual_rule_ids);
-        report.unexpected_findings += missing_count(&actual_rule_ids, &expected);
-        report.contract_violations += validate_findings_contract(&summary.findings)
-            .violations
-            .len();
-
-        if has_stable_id_failure(&summary.findings) {
-            report.stable_id_failures += 1;
-        }
-    }
-
-    Ok(())
-}
-
-fn materialize_fixture_for_scan(path: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let path_text = path.to_string_lossy().to_lowercase();
-    if !path_text.contains("fixture") {
-        return Ok(path.to_path_buf());
-    }
-
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    let target = std::env::temp_dir().join(format!(
-        "repopilot-rule-eval-{}-{nanos}",
-        std::process::id()
-    ));
-    copy_dir_all(path, &target)?;
-    Ok(target)
-}
-
-fn cleanup_materialized_fixture(scan_path: &Path, original_path: &Path) {
-    if scan_path != original_path {
-        let _ = fs::remove_dir_all(scan_path);
-    }
-}
-
-fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
-    fs::create_dir_all(to)?;
-    for entry in fs::read_dir(from)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        let target = to.join(entry.file_name());
-        if file_type.is_dir() {
-            copy_dir_all(&entry.path(), &target)?;
-        } else if file_type.is_file() {
-            fs::copy(entry.path(), target)?;
-        }
-    }
-    Ok(())
-}
-
-fn missing_count(expected: &[String], actual: &[String]) -> usize {
-    let mut counts = BTreeMap::<&str, usize>::new();
-    for item in actual {
-        *counts.entry(item.as_str()).or_default() += 1;
-    }
-
-    expected
-        .iter()
-        .filter(|item| {
-            let count = counts.entry(item.as_str()).or_default();
-            if *count == 0 {
-                true
-            } else {
-                *count -= 1;
-                false
-            }
-        })
-        .count()
-}
-
-fn has_stable_id_failure(findings: &[repopilot::findings::types::Finding]) -> bool {
-    let mut seen = BTreeSet::new();
-    findings
-        .iter()
-        .any(|finding| finding.id.trim().is_empty() || !seen.insert(finding.id.as_str()))
-}
-
-fn default_fixture_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rules")
 }
 
 fn validate_output_format(format: OutputFormat) -> Result<OutputFormat, CliExit> {
@@ -423,28 +76,5 @@ fn validate_output_format(format: OutputFormat) -> Result<OutputFormat, CliExit>
             code: EXIT_USAGE,
             message: "`inspect rules` supports only console, markdown, and json output".to_string(),
         }),
-    }
-}
-
-fn escape_table_cell(value: &str) -> String {
-    value.replace('|', "\\|").replace('\n', " ")
-}
-
-impl From<&'static RuleMetadata> for RuleCatalogItem {
-    fn from(rule: &'static RuleMetadata) -> Self {
-        Self {
-            rule_id: rule.rule_id,
-            title: rule.title,
-            category: rule.category.label().to_string(),
-            severity: rule.default_severity.label().to_string(),
-            confidence: rule.default_confidence.label().to_string(),
-            lifecycle: rule.lifecycle,
-            signal_source: rule.signal_source,
-            docs_url: rule.docs_url,
-            tags: rule.tags,
-            description: rule.description,
-            recommendation: rule.recommendation,
-            false_positive_notes: rule.false_positive_notes,
-        }
     }
 }

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -1,15 +1,24 @@
 use crate::engine::diagnostics::finding_contract_diagnostics;
-use crate::findings::contract::validate_findings_contract;
+use crate::findings::contract::{FindingContractReport, validate_findings_contract};
 use crate::findings::types::Finding;
 use crate::scan::types::ScanDiagnostic;
 use std::time::Instant;
 
-pub fn validate_finding_contract_stage(
-    findings: &[Finding],
-    diagnostics: &mut Vec<ScanDiagnostic>,
-) -> u64 {
+pub struct FindingContractValidationStage {
+    pub elapsed_us: u64,
+    pub report: FindingContractReport,
+    pub diagnostics: Vec<ScanDiagnostic>,
+}
+
+pub fn validate_finding_contract_stage(findings: &[Finding]) -> FindingContractValidationStage {
     let start = Instant::now();
     let report = validate_findings_contract(findings);
-    diagnostics.extend(finding_contract_diagnostics(&report));
-    start.elapsed().as_micros() as u64
+    let elapsed_us = start.elapsed().as_micros() as u64;
+    let diagnostics = finding_contract_diagnostics(&report);
+
+    FindingContractValidationStage {
+        elapsed_us,
+        report,
+        diagnostics,
+    }
 }

--- a/src/findings/enrichment.rs
+++ b/src/findings/enrichment.rs
@@ -1,0 +1,21 @@
+use crate::baseline::key::stable_finding_key;
+use crate::findings::types::Finding;
+use std::path::Path;
+use std::time::Instant;
+
+pub fn enrich_findings(findings: &mut [Finding], root: &Path) {
+    for finding in findings {
+        enrich_finding(finding, root);
+    }
+}
+
+pub fn enrich_findings_timed(findings: &mut [Finding], root: &Path) -> u64 {
+    let start = Instant::now();
+    enrich_findings(findings, root);
+    start.elapsed().as_micros() as u64
+}
+
+pub fn enrich_finding(finding: &mut Finding, root: &Path) {
+    finding.populate_rule_metadata();
+    finding.id = stable_finding_key(finding, root);
+}

--- a/src/findings/feedback.rs
+++ b/src/findings/feedback.rs
@@ -1,3 +1,4 @@
+use crate::findings::filter::recompute_summary_metrics;
 use crate::findings::types::Finding;
 use crate::scan::types::{ScanDiagnostic, ScanSummary};
 use serde::{Deserialize, Serialize};
@@ -117,9 +118,7 @@ pub fn apply_local_feedback(
         );
     }
 
-    summary.visible_findings_count = summary.findings.len();
-    summary.health_score =
-        ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
+    recompute_summary_metrics(summary);
     summary.local_feedback = Some(report.clone());
 
     Ok(report)

--- a/src/findings/filter.rs
+++ b/src/findings/filter.rs
@@ -1,3 +1,4 @@
+use crate::findings::quality::summarize_signal_quality;
 use crate::findings::types::{Confidence, Finding, Severity};
 use crate::risk::RiskPriority;
 use crate::scan::types::ScanSummary;
@@ -61,6 +62,7 @@ pub fn recompute_summary_metrics(summary: &mut ScanSummary) {
     summary.visible_findings_count = summary.findings.len();
     summary.health_score =
         ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
+    summary.signal_quality = summarize_signal_quality(&summary.findings);
 }
 
 #[cfg(test)]

--- a/src/findings/mod.rs
+++ b/src/findings/mod.rs
@@ -1,4 +1,5 @@
 pub mod contract;
+pub mod enrichment;
 pub mod feedback;
 pub mod filter;
 pub mod provenance;

--- a/src/findings/quality.rs
+++ b/src/findings/quality.rs
@@ -43,6 +43,14 @@ pub struct SignalSourceCounts {
 }
 
 pub fn summarize_signal_quality(findings: &[Finding]) -> SignalQualitySummary {
+    let contract_violations = validate_findings_contract(findings).violations.len();
+    summarize_signal_quality_with_contract_violations(findings, contract_violations)
+}
+
+pub fn summarize_signal_quality_with_contract_violations(
+    findings: &[Finding],
+    contract_violations: usize,
+) -> SignalQualitySummary {
     let findings_total = findings.len();
     let mut by_confidence = ConfidenceCounts::default();
     let mut by_lifecycle = RuleLifecycleCounts::default();
@@ -103,7 +111,7 @@ pub fn summarize_signal_quality(findings: &[Finding]) -> SignalQualitySummary {
             high_risk_docs_present,
             high_risk_total,
         ),
-        contract_violations: validate_findings_contract(findings).violations.len(),
+        contract_violations,
     }
 }
 

--- a/src/findings/visibility.rs
+++ b/src/findings/visibility.rs
@@ -1,3 +1,4 @@
+use crate::findings::filter::recompute_summary_metrics;
 use crate::findings::types::{Confidence, Finding, FindingCategory, Severity};
 use crate::risk::RiskPriority;
 use crate::scan::types::{HiddenSuggestionSummary, ScanSummary};
@@ -98,6 +99,7 @@ pub fn apply_visibility_profile(summary: &mut ScanSummary, profile: FindingVisib
     summary.hidden_suggestions.clear();
 
     if profile == FindingVisibilityProfile::Strict {
+        recompute_summary_metrics(summary);
         return;
     }
 
@@ -108,8 +110,7 @@ pub fn apply_visibility_profile(summary: &mut ScanSummary, profile: FindingVisib
     summary.visible_findings_count = summary.findings.len();
     summary.hidden_suggestions_count = original_count.saturating_sub(summary.findings.len());
     summary.hidden_suggestions = hidden_suggestions;
-    summary.health_score =
-        ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
+    recompute_summary_metrics(summary);
 }
 
 pub fn is_visible_by_default(finding: &Finding) -> bool {

--- a/src/output/console/sections.rs
+++ b/src/output/console/sections.rs
@@ -4,7 +4,6 @@ use crate::output::color;
 use crate::output::finding_helpers::{clusters_by_rule_scope, example_locations};
 use crate::output::report_stats::{ReportStats, TOOL_VERSION};
 use crate::output::report_text::{console_severity_counts_text, named_counts_text};
-use crate::report::quality::build_signal_quality_summary;
 use crate::risk::RiskPriority;
 use crate::scan::types::{DiagnosticSeverity, ScanSummary};
 use std::fmt::Write;
@@ -297,7 +296,7 @@ pub(crate) fn render_risk_summary(output: &mut String, stats: &ReportStats) {
 }
 
 pub(crate) fn render_signal_quality(output: &mut String, summary: &ScanSummary) {
-    let quality = build_signal_quality_summary(&summary.findings);
+    let quality = &summary.signal_quality;
     output.push_str("Signal quality:\n");
     writeln!(output, "  High confidence: {}", quality.by_confidence.high).unwrap();
     writeln!(

--- a/src/output/finding_helpers.rs
+++ b/src/output/finding_helpers.rs
@@ -115,9 +115,11 @@ fn build_cluster<'a>(
 
 fn cluster_title(finding: &Finding, count: usize, scope: Option<&str>) -> String {
     let base = if count > 1 {
-        crate::rules::lookup_rule_metadata(&finding.rule_id)
-            .map(|metadata| metadata.title)
-            .unwrap_or(finding.rule_id.as_str())
+        if finding.title.trim().is_empty() {
+            finding.rule_id.as_str()
+        } else {
+            finding.title.as_str()
+        }
     } else {
         finding.title.as_str()
     };

--- a/src/output/markdown/sections.rs
+++ b/src/output/markdown/sections.rs
@@ -4,7 +4,6 @@ use crate::output::finding_helpers::{clusters_by_rule_scope, example_locations};
 use crate::output::render_helpers::escape_table_cell;
 use crate::output::report_stats::{ReportStats, TOOL_VERSION};
 use crate::output::report_text::{markdown_severity_counts_text, named_counts_text};
-use crate::report::quality::build_signal_quality_summary;
 use crate::scan::types::{DiagnosticSeverity, ScanSummary};
 use std::fmt::Write;
 
@@ -292,7 +291,7 @@ pub(crate) fn render_risk_summary(output: &mut String, summary: &ScanSummary, st
 }
 
 pub(crate) fn render_signal_quality(output: &mut String, summary: &ScanSummary) {
-    let quality = build_signal_quality_summary(&summary.findings);
+    let quality = &summary.signal_quality;
     output.push_str("## Signal Quality\n\n");
     writeln!(
         output,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -10,6 +10,7 @@ pub mod prompt;
 pub(crate) mod render_helpers;
 pub(crate) mod report_stats;
 pub(crate) mod report_text;
+pub mod rules;
 pub mod sarif;
 
 use crate::baseline::diff::BaselineScanReport;

--- a/src/output/rules.rs
+++ b/src/output/rules.rs
@@ -1,0 +1,199 @@
+use crate::output::OutputFormat;
+use crate::output::render_helpers::escape_table_cell;
+use crate::rules::catalog::{RuleCatalogItem, RuleCatalogReport};
+use crate::rules::eval::RuleEvaluationReport;
+use std::fmt::Write;
+
+pub fn render_catalog(
+    report: &RuleCatalogReport,
+    format: OutputFormat,
+) -> Result<String, serde_json::Error> {
+    match format {
+        OutputFormat::Console => Ok(render_catalog_console(report)),
+        OutputFormat::Markdown => Ok(render_catalog_markdown(report)),
+        OutputFormat::Json => serde_json::to_string_pretty(report),
+        OutputFormat::Html | OutputFormat::Sarif => unreachable!("validated output format"),
+    }
+}
+
+pub fn render_rule(
+    rule: &RuleCatalogItem,
+    format: OutputFormat,
+) -> Result<String, serde_json::Error> {
+    match format {
+        OutputFormat::Console => Ok(render_rule_console(rule)),
+        OutputFormat::Markdown => Ok(render_rule_markdown(rule)),
+        OutputFormat::Json => serde_json::to_string_pretty(rule),
+        OutputFormat::Html | OutputFormat::Sarif => unreachable!("validated output format"),
+    }
+}
+
+pub fn render_eval_report(
+    report: &RuleEvaluationReport,
+    format: OutputFormat,
+) -> Result<String, serde_json::Error> {
+    match format {
+        OutputFormat::Console => Ok(render_eval_report_console(report)),
+        OutputFormat::Markdown => Ok(render_eval_report_markdown(report)),
+        OutputFormat::Json => serde_json::to_string_pretty(report),
+        OutputFormat::Html | OutputFormat::Sarif => unreachable!("validated output format"),
+    }
+}
+
+fn render_catalog_console(report: &RuleCatalogReport) -> String {
+    let mut output = String::new();
+    output.push_str("RepoPilot Rules\n\n");
+    for rule in &report.rules {
+        writeln!(
+            output,
+            "{} [{} {} {}]\n  {}",
+            rule.rule_id,
+            rule.severity,
+            rule.lifecycle.label(),
+            rule.signal_source.label(),
+            rule.title
+        )
+        .unwrap();
+    }
+    output
+}
+
+fn render_catalog_markdown(report: &RuleCatalogReport) -> String {
+    let mut output = String::new();
+    output.push_str("# RepoPilot Rules\n\n");
+    output.push_str("| Rule | Title | Category | Severity | Confidence | Lifecycle | Source |\n");
+    output.push_str("| --- | --- | --- | --- | --- | --- | --- |\n");
+    for rule in &report.rules {
+        writeln!(
+            output,
+            "| `{}` | {} | {} | {} | {} | {} | {} |",
+            rule.rule_id,
+            escape_table_cell(rule.title),
+            rule.category,
+            rule.severity,
+            rule.confidence,
+            rule.lifecycle.label(),
+            rule.signal_source.label()
+        )
+        .unwrap();
+    }
+    output
+}
+
+fn render_rule_console(rule: &RuleCatalogItem) -> String {
+    format!(
+        "RepoPilot Rule\n\nRule: {}\nTitle: {}\nCategory: {}\nSeverity: {}\nConfidence: {}\nLifecycle: {}\nSignal source: {}\nDocs: {}\nTags: {}\nDescription: {}\nRecommendation: {}\nFalse positives: {}\n",
+        rule.rule_id,
+        rule.title,
+        rule.category,
+        rule.severity,
+        rule.confidence,
+        rule.lifecycle.label(),
+        rule.signal_source.label(),
+        rule.docs_url.unwrap_or("none"),
+        if rule.tags.is_empty() {
+            "none".to_string()
+        } else {
+            rule.tags.join(", ")
+        },
+        rule.description,
+        rule.recommendation.unwrap_or("none"),
+        rule.false_positive_notes.unwrap_or("none"),
+    )
+}
+
+fn render_rule_markdown(rule: &RuleCatalogItem) -> String {
+    format!(
+        "# `{}`\n\n- **Title:** {}\n- **Category:** {}\n- **Severity:** {}\n- **Confidence:** {}\n- **Lifecycle:** {}\n- **Signal source:** {}\n- **Docs:** {}\n- **Tags:** {}\n\n{}\n\n**Recommendation:** {}\n\n**False-positive notes:** {}\n",
+        rule.rule_id,
+        rule.title,
+        rule.category,
+        rule.severity,
+        rule.confidence,
+        rule.lifecycle.label(),
+        rule.signal_source.label(),
+        rule.docs_url.unwrap_or("none"),
+        if rule.tags.is_empty() {
+            "none".to_string()
+        } else {
+            rule.tags.join(", ")
+        },
+        rule.description,
+        rule.recommendation.unwrap_or("none"),
+        rule.false_positive_notes.unwrap_or("none"),
+    )
+}
+
+fn render_eval_report_console(report: &RuleEvaluationReport) -> String {
+    format!(
+        "RepoPilot Rule Evaluation\n\nRules evaluated: {}\nFixtures: {}\nExpected findings: {}\nActual findings: {}\nMissing findings: {}\nUnexpected findings: {}\nContract violations: {}\nStable ID failures: {}\n",
+        report.rules_evaluated,
+        report.fixtures_total,
+        report.expected_findings,
+        report.actual_findings,
+        report.missing_findings,
+        report.unexpected_findings,
+        report.contract_violations,
+        report.stable_id_failures,
+    )
+}
+
+fn render_eval_report_markdown(report: &RuleEvaluationReport) -> String {
+    let mut output = String::new();
+    writeln!(output, "# RepoPilot Rule Evaluation\n").unwrap();
+    writeln!(output, "- **Rules evaluated:** {}", report.rules_evaluated).unwrap();
+    writeln!(output, "- **Fixtures:** {}", report.fixtures_total).unwrap();
+    writeln!(
+        output,
+        "- **Expected findings:** {}",
+        report.expected_findings
+    )
+    .unwrap();
+    writeln!(output, "- **Actual findings:** {}", report.actual_findings).unwrap();
+    writeln!(
+        output,
+        "- **Missing findings:** {}",
+        report.missing_findings
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "- **Unexpected findings:** {}",
+        report.unexpected_findings
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "- **Contract violations:** {}",
+        report.contract_violations
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "- **Stable ID failures:** {}\n",
+        report.stable_id_failures
+    )
+    .unwrap();
+
+    if !report.rules.is_empty() {
+        output.push_str("| Rule | Fixtures | Expected | Actual | Missing | Unexpected | Contract | Stable IDs |\n");
+        output.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+        for rule in &report.rules {
+            writeln!(
+                output,
+                "| `{}` | {} | {} | {} | {} | {} | {} | {} |",
+                escape_table_cell(&rule.rule_id),
+                rule.fixtures_total,
+                rule.expected_findings,
+                rule.actual_findings,
+                rule.missing_findings,
+                rule.unexpected_findings,
+                rule.contract_violations,
+                rule.stable_id_failures
+            )
+            .unwrap();
+        }
+    }
+
+    output
+}

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -154,11 +154,7 @@ fn sarif_rules(findings: &[Finding]) -> Vec<SarifRule> {
     rule_map
         .into_iter()
         .map(|(rule_id, finding)| {
-            let meta = crate::rules::lookup_rule_metadata(rule_id);
-            let help_uri = meta
-                .and_then(|m| m.docs_url)
-                .map(str::to_owned)
-                .or_else(|| finding.docs_url.clone());
+            let help_uri = finding.docs_url.clone();
             let help = Some(SarifMessage {
                 text: finding.recommendation_or_default().to_string(),
             });

--- a/src/report/schema.rs
+++ b/src/report/schema.rs
@@ -4,7 +4,6 @@ use crate::findings::feedback::LocalFeedbackReport;
 use crate::findings::types::Finding;
 use crate::frameworks::{DetectedFramework, FrameworkProject, ReactNativeArchitectureProfile};
 use crate::graph::CouplingGraph;
-use crate::report::quality::build_signal_quality_summary;
 use crate::review::diff::ChangedFile;
 use crate::review::model::{ReviewReport, SeverityCounts};
 use crate::risk::RiskSummary;
@@ -146,7 +145,7 @@ impl<'a> ScanJsonReport<'a> {
             local_feedback: summary.local_feedback.as_ref(),
             diagnostics: &summary.diagnostics,
             risk_summary: RiskSummary::from_findings(&summary.findings),
-            signal_quality: build_signal_quality_summary(&summary.findings),
+            signal_quality: summary.signal_quality.clone(),
         }
     }
 }
@@ -213,7 +212,7 @@ impl<'a> BaselineJsonReport<'a> {
             diagnostics: &report.summary.diagnostics,
             languages: &report.summary.languages,
             risk_summary: RiskSummary::from_findings(&report.summary.findings),
-            signal_quality: build_signal_quality_summary(&report.summary.findings),
+            signal_quality: report.summary.signal_quality.clone(),
             baseline: BaselineJsonMetadata {
                 path: report
                     .baseline_path
@@ -287,7 +286,7 @@ impl<'a> ReviewJsonReport<'a> {
                 severity_counts: report.severity_counts(),
             },
             risk_summary: RiskSummary::from_findings(&report.summary.findings),
-            signal_quality: build_signal_quality_summary(&report.summary.findings),
+            signal_quality: report.summary.signal_quality.clone(),
             baseline: ReviewBaselineJsonMetadata {
                 path: report
                     .baseline_path

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -8,6 +8,7 @@ use crate::baseline::diff::{
 };
 use crate::baseline::key::{normalized_relative_path, stable_finding_key};
 use crate::baseline::model::Baseline;
+use crate::findings::filter::recompute_summary_metrics;
 use crate::findings::types::Finding;
 use crate::review::diff::{ChangedFile, DiffTarget, load_changed_files, resolve_git_root};
 use crate::review::model::{ReviewFindingStatus, ReviewReport};
@@ -152,44 +153,45 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
         .collect();
 
     let in_diff_findings: Vec<_> = report.in_diff_findings().into_iter().cloned().collect();
-    let visible_findings_count = in_diff_findings.len();
-    let health_score =
-        ScanSummary::compute_health_score(&in_diff_findings, report.summary.non_empty_lines);
+    let mut summary = ScanSummary {
+        root_path: report.summary.root_path.clone(),
+        mode: report.summary.mode,
+        base_ref: report.summary.base_ref.clone(),
+        changed_files_count: report.summary.changed_files_count,
+        repo_level_rules_included: report.summary.repo_level_rules_included,
+        files_discovered: report.summary.files_discovered,
+        files_analyzed: report.summary.files_analyzed,
+        directories_count: report.summary.directories_count,
+        non_empty_lines: report.summary.non_empty_lines,
+        large_files_skipped: report.summary.large_files_skipped,
+        files_skipped_low_signal: report.summary.files_skipped_low_signal,
+        binary_files_skipped: report.summary.binary_files_skipped,
+        skipped_bytes: report.summary.skipped_bytes,
+        languages: report.summary.languages.clone(),
+        detected_frameworks: report.summary.detected_frameworks.clone(),
+        framework_projects: report.summary.framework_projects.clone(),
+        react_native: report.summary.react_native.clone(),
+        findings: in_diff_findings,
+        coupling_graph: report.summary.coupling_graph.clone(),
+        scan_duration_us: report.summary.scan_duration_us,
+        health_score: 0,
+        visible_findings_count: 0,
+        hidden_suggestions_count: report.summary.hidden_suggestions_count,
+        hidden_suggestions: Vec::new(),
+        visibility_profile: report.summary.visibility_profile.clone(),
+        files_skipped_by_limit: report.summary.files_skipped_by_limit,
+        files_skipped_repopilotignore: report.summary.files_skipped_repopilotignore,
+        repopilotignore_path: report.summary.repopilotignore_path.clone(),
+        scan_timings: None,
+        cache_telemetry: report.summary.cache_telemetry.clone(),
+        local_feedback: report.summary.local_feedback.clone(),
+        diagnostics: report.summary.diagnostics.clone(),
+        signal_quality: Default::default(),
+    };
+    recompute_summary_metrics(&mut summary);
+
     BaselineScanReport {
-        summary: ScanSummary {
-            root_path: report.summary.root_path.clone(),
-            mode: report.summary.mode,
-            base_ref: report.summary.base_ref.clone(),
-            changed_files_count: report.summary.changed_files_count,
-            repo_level_rules_included: report.summary.repo_level_rules_included,
-            files_discovered: report.summary.files_discovered,
-            files_analyzed: report.summary.files_analyzed,
-            directories_count: report.summary.directories_count,
-            non_empty_lines: report.summary.non_empty_lines,
-            large_files_skipped: report.summary.large_files_skipped,
-            files_skipped_low_signal: report.summary.files_skipped_low_signal,
-            binary_files_skipped: report.summary.binary_files_skipped,
-            skipped_bytes: report.summary.skipped_bytes,
-            languages: report.summary.languages.clone(),
-            detected_frameworks: report.summary.detected_frameworks.clone(),
-            framework_projects: report.summary.framework_projects.clone(),
-            react_native: report.summary.react_native.clone(),
-            findings: in_diff_findings,
-            coupling_graph: report.summary.coupling_graph.clone(),
-            scan_duration_us: report.summary.scan_duration_us,
-            health_score,
-            visible_findings_count,
-            hidden_suggestions_count: report.summary.hidden_suggestions_count,
-            hidden_suggestions: Vec::new(),
-            visibility_profile: report.summary.visibility_profile.clone(),
-            files_skipped_by_limit: report.summary.files_skipped_by_limit,
-            files_skipped_repopilotignore: report.summary.files_skipped_repopilotignore,
-            repopilotignore_path: report.summary.repopilotignore_path.clone(),
-            scan_timings: None,
-            cache_telemetry: report.summary.cache_telemetry.clone(),
-            local_feedback: report.summary.local_feedback.clone(),
-            diagnostics: report.summary.diagnostics.clone(),
-        },
+        summary,
         baseline_path: report.baseline_path.clone(),
         findings,
     }

--- a/src/rules/catalog.rs
+++ b/src/rules/catalog.rs
@@ -1,0 +1,68 @@
+use crate::rules::{
+    RuleLifecycle, RuleMetadata, SignalSource, all_rule_metadata, lookup_rule_metadata,
+};
+use serde::Serialize;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RuleCatalogFilter {
+    pub lifecycle: Option<RuleLifecycle>,
+    pub source: Option<SignalSource>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RuleCatalogReport {
+    pub rules: Vec<RuleCatalogItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuleCatalogItem {
+    pub rule_id: &'static str,
+    pub title: &'static str,
+    pub category: String,
+    pub severity: String,
+    pub confidence: String,
+    pub lifecycle: RuleLifecycle,
+    pub signal_source: SignalSource,
+    pub docs_url: Option<&'static str>,
+    pub tags: &'static [&'static str],
+    pub description: &'static str,
+    pub recommendation: Option<&'static str>,
+    pub false_positive_notes: Option<&'static str>,
+}
+
+pub fn list_rule_catalog(filter: RuleCatalogFilter) -> RuleCatalogReport {
+    let rules = all_rule_metadata()
+        .filter(|rule| filter.lifecycle.is_none_or(|value| rule.lifecycle == value))
+        .filter(|rule| {
+            filter
+                .source
+                .is_none_or(|value| rule.signal_source == value)
+        })
+        .map(RuleCatalogItem::from)
+        .collect::<Vec<_>>();
+
+    RuleCatalogReport { rules }
+}
+
+pub fn inspect_rule(rule_id: &str) -> Option<RuleCatalogItem> {
+    lookup_rule_metadata(rule_id).map(RuleCatalogItem::from)
+}
+
+impl From<&'static RuleMetadata> for RuleCatalogItem {
+    fn from(rule: &'static RuleMetadata) -> Self {
+        Self {
+            rule_id: rule.rule_id,
+            title: rule.title,
+            category: rule.category.label().to_string(),
+            severity: rule.default_severity.label().to_string(),
+            confidence: rule.default_confidence.label().to_string(),
+            lifecycle: rule.lifecycle,
+            signal_source: rule.signal_source,
+            docs_url: rule.docs_url,
+            tags: rule.tags,
+            description: rule.description,
+            recommendation: rule.recommendation,
+            false_positive_notes: rule.false_positive_notes,
+        }
+    }
+}

--- a/src/rules/eval/fixtures.rs
+++ b/src/rules/eval/fixtures.rs
@@ -1,0 +1,181 @@
+use crate::findings::contract::validate_findings_contract;
+use crate::findings::types::Finding;
+use crate::rules::eval::{RuleEvaluationReport, RuleEvaluationRuleReport};
+use crate::scan::config::ScanConfig;
+use crate::scan::scanner::scan_path_with_config;
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Deserialize)]
+struct FixtureExpectations {
+    fixtures: Vec<FixtureCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureCase {
+    path: PathBuf,
+    expected_rule_ids: Vec<String>,
+}
+
+pub fn evaluate_rule_fixtures(
+    only_rule: Option<&str>,
+    fixture_root: Option<&Path>,
+) -> Result<RuleEvaluationReport, Box<dyn std::error::Error>> {
+    let fixture_root = fixture_root
+        .map(Path::to_path_buf)
+        .unwrap_or_else(default_fixture_root);
+
+    if !fixture_root.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!(
+                "Rule fixture root does not exist: {}",
+                fixture_root.display()
+            ),
+        )
+        .into());
+    }
+
+    let mut report = RuleEvaluationReport::default();
+    let mut entries = fs::read_dir(&fixture_root)?.collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let rule_id = entry.file_name().to_string_lossy().to_string();
+        if only_rule.is_some_and(|only_rule| only_rule != rule_id) {
+            continue;
+        }
+
+        report.add_rule(evaluate_one_rule_fixture(&entry.path(), &rule_id)?);
+    }
+
+    Ok(report)
+}
+
+fn evaluate_one_rule_fixture(
+    rule_root: &Path,
+    rule_id: &str,
+) -> Result<RuleEvaluationRuleReport, Box<dyn std::error::Error>> {
+    let expected_path = rule_root.join("expected.json");
+    let expectations: FixtureExpectations =
+        serde_json::from_str(&fs::read_to_string(expected_path)?)?;
+    let config = ScanConfig {
+        detect_missing_tests: false,
+        include_low_signal: true,
+        ..ScanConfig::default()
+    };
+    let mut report = RuleEvaluationRuleReport {
+        rule_id: rule_id.to_string(),
+        ..RuleEvaluationRuleReport::default()
+    };
+
+    for fixture in expectations.fixtures {
+        let path = rule_root.join(&fixture.path);
+        let scan_path = materialize_fixture_for_scan(&path)?;
+        let summary = scan_path_with_config(&scan_path, &config)?;
+        cleanup_materialized_fixture(&scan_path, &path);
+        let actual_rule_ids = summary
+            .findings
+            .iter()
+            .filter(|finding| finding.rule_id == rule_id)
+            .map(|finding| finding.rule_id.clone())
+            .collect::<Vec<_>>();
+        let expected = fixture
+            .expected_rule_ids
+            .iter()
+            .filter(|expected_rule| expected_rule.as_str() == rule_id)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        report.fixtures_total += 1;
+        report.expected_findings += expected.len();
+        report.actual_findings += actual_rule_ids.len();
+        report.missing_findings += missing_count(&expected, &actual_rule_ids);
+        report.unexpected_findings += missing_count(&actual_rule_ids, &expected);
+        report.contract_violations += validate_findings_contract(&summary.findings)
+            .violations
+            .len();
+
+        if has_stable_id_failure(&summary.findings) {
+            report.stable_id_failures += 1;
+        }
+    }
+
+    Ok(report)
+}
+
+fn materialize_fixture_for_scan(path: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let path_text = path.to_string_lossy().to_lowercase();
+    if !path_text.contains("fixture") {
+        return Ok(path.to_path_buf());
+    }
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let target = std::env::temp_dir().join(format!(
+        "repopilot-rule-eval-{}-{nanos}",
+        std::process::id()
+    ));
+    copy_dir_all(path, &target)?;
+    Ok(target)
+}
+
+fn cleanup_materialized_fixture(scan_path: &Path, original_path: &Path) {
+    if scan_path != original_path {
+        let _ = fs::remove_dir_all(scan_path);
+    }
+}
+
+fn copy_dir_all(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let target = to.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_all(&entry.path(), &target)?;
+        } else if file_type.is_file() {
+            fs::copy(entry.path(), target)?;
+        }
+    }
+    Ok(())
+}
+
+fn missing_count(expected: &[String], actual: &[String]) -> usize {
+    let mut counts = BTreeMap::<&str, usize>::new();
+    for item in actual {
+        *counts.entry(item.as_str()).or_default() += 1;
+    }
+
+    expected
+        .iter()
+        .filter(|item| {
+            let count = counts.entry(item.as_str()).or_default();
+            if *count == 0 {
+                true
+            } else {
+                *count -= 1;
+                false
+            }
+        })
+        .count()
+}
+
+fn has_stable_id_failure(findings: &[Finding]) -> bool {
+    let mut seen = BTreeSet::new();
+    findings
+        .iter()
+        .any(|finding| finding.id.trim().is_empty() || !seen.insert(finding.id.as_str()))
+}
+
+fn default_fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rules")
+}

--- a/src/rules/eval/mod.rs
+++ b/src/rules/eval/mod.rs
@@ -1,0 +1,42 @@
+pub mod fixtures;
+
+use serde::Serialize;
+
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+pub struct RuleEvaluationReport {
+    pub rules_evaluated: usize,
+    pub fixtures_total: usize,
+    pub expected_findings: usize,
+    pub actual_findings: usize,
+    pub missing_findings: usize,
+    pub unexpected_findings: usize,
+    pub contract_violations: usize,
+    pub stable_id_failures: usize,
+    pub rules: Vec<RuleEvaluationRuleReport>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+pub struct RuleEvaluationRuleReport {
+    pub rule_id: String,
+    pub fixtures_total: usize,
+    pub expected_findings: usize,
+    pub actual_findings: usize,
+    pub missing_findings: usize,
+    pub unexpected_findings: usize,
+    pub contract_violations: usize,
+    pub stable_id_failures: usize,
+}
+
+impl RuleEvaluationReport {
+    pub(crate) fn add_rule(&mut self, rule: RuleEvaluationRuleReport) {
+        self.fixtures_total += rule.fixtures_total;
+        self.expected_findings += rule.expected_findings;
+        self.actual_findings += rule.actual_findings;
+        self.missing_findings += rule.missing_findings;
+        self.unexpected_findings += rule.unexpected_findings;
+        self.contract_violations += rule.contract_violations;
+        self.stable_id_failures += rule.stable_id_failures;
+        self.rules.push(rule);
+        self.rules_evaluated = self.rules.len();
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,3 +1,5 @@
+pub mod catalog;
+pub mod eval;
 pub mod lifecycle;
 pub mod metadata;
 pub mod registry;

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -8,7 +8,10 @@ use super::changed_telemetry::{
 use super::file::{SkipReason, process_file_with_content};
 use super::summary::{ScanSummaryParts, build_language_summary, build_scan_summary};
 use crate::audits::pipeline::build_file_audits;
-use crate::baseline::key::stable_finding_key;
+use crate::findings::enrichment::enrich_findings_timed;
+use crate::findings::quality::{
+    SignalQualitySummary, summarize_signal_quality_with_contract_violations,
+};
 use crate::findings::types::Finding;
 use crate::frameworks::{
     DetectedFramework, detect_framework_projects, detect_frameworks,
@@ -71,6 +74,7 @@ struct ChangedFindingPipelineStage {
     risk_scoring_us: u64,
     contract_validation_us: u64,
     diagnostics: Vec<crate::scan::types::ScanDiagnostic>,
+    signal_quality: SignalQualitySummary,
 }
 
 impl<'a> ChangedScanEngine<'a> {
@@ -87,18 +91,20 @@ impl<'a> ChangedScanEngine<'a> {
         let discovery = self.run_discovery()?;
         let mut file_stage = self.run_file_analysis(&discovery)?;
         let repo_stage = self.run_repo_context(&discovery.repo_root, &mut file_stage.facts)?;
-        let enrichment_us = self.enrich_findings(&discovery.repo_root, &mut file_stage.findings);
+        let enrichment_us = enrich_findings_timed(&mut file_stage.findings, &discovery.repo_root);
         let risk_scoring_us = self.score_findings(&repo_stage, &mut file_stage.findings);
-        let mut diagnostics = Vec::new();
-        let contract_validation_us = crate::engine::pipeline::validate_finding_contract_stage(
+        let contract_stage =
+            crate::engine::pipeline::validate_finding_contract_stage(&file_stage.findings);
+        let signal_quality = summarize_signal_quality_with_contract_violations(
             &file_stage.findings,
-            &mut diagnostics,
+            contract_stage.report.violations.len(),
         );
         let finding_pipeline = ChangedFindingPipelineStage {
             enrichment_us,
             risk_scoring_us,
-            contract_validation_us,
-            diagnostics,
+            contract_validation_us: contract_stage.elapsed_us,
+            diagnostics: contract_stage.diagnostics,
+            signal_quality,
         };
 
         self.finalize_report(start, discovery, file_stage, repo_stage, finding_pipeline)
@@ -397,15 +403,6 @@ impl<'a> ChangedScanEngine<'a> {
         })
     }
 
-    fn enrich_findings(&self, repo_root: &Path, findings: &mut [Finding]) -> u64 {
-        let start = Instant::now();
-        for finding in findings.iter_mut() {
-            finding.populate_recommendation();
-            finding.id = stable_finding_key(finding, repo_root);
-        }
-        start.elapsed().as_micros() as u64
-    }
-
     fn score_findings(
         &self,
         repo_stage: &ChangedRepoContextStage,
@@ -467,6 +464,7 @@ impl<'a> ChangedScanEngine<'a> {
                 }),
                 cache_telemetry: Some(file_stage.cache_telemetry),
                 diagnostics: finding_pipeline.diagnostics,
+                signal_quality: finding_pipeline.signal_quality,
             },
         );
 

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -9,7 +9,8 @@ mod walker;
 
 use crate::audits::architecture::import_coupling::ImportCouplingAudit;
 use crate::audits::pipeline::{build_file_audits, run_framework_audits, run_project_audits};
-use crate::baseline::key::stable_finding_key;
+use crate::findings::enrichment::enrich_findings_timed;
+use crate::findings::quality::summarize_signal_quality_with_contract_violations;
 use crate::frameworks::{
     DetectedFramework, detect_framework_projects, detect_frameworks,
     detect_react_native_architecture,
@@ -75,16 +76,17 @@ impl<'a> ScanEngine<'a> {
         let mut project_stage =
             self.run_project_analysis(framework_stage.facts, file_stage.findings);
 
-        let enrichment_us = self.enrich_findings(&mut project_stage.findings);
+        let enrichment_us = enrich_findings_timed(&mut project_stage.findings, self.path);
         let risk_scoring_us = self.score_findings(
             &project_stage.facts,
             &project_stage.coupling_graph,
             &mut project_stage.findings,
         );
-        let mut diagnostics = Vec::new();
-        let contract_validation_us = crate::engine::pipeline::validate_finding_contract_stage(
+        let contract_stage =
+            crate::engine::pipeline::validate_finding_contract_stage(&project_stage.findings);
+        let signal_quality = summarize_signal_quality_with_contract_violations(
             &project_stage.findings,
-            &mut diagnostics,
+            contract_stage.report.violations.len(),
         );
 
         let scan_duration_us = start.elapsed().as_micros() as u64;
@@ -98,11 +100,17 @@ impl<'a> ScanEngine<'a> {
             post_scan_audits_us: project_stage.elapsed_us,
             enrichment_us,
             risk_scoring_us,
-            contract_validation_us,
+            contract_validation_us: contract_stage.elapsed_us,
             report_finalization_us: 0,
         };
 
-        Ok(self.finalize_report(project_stage, scan_duration_us, timings, diagnostics))
+        Ok(self.finalize_report(
+            project_stage,
+            scan_duration_us,
+            timings,
+            contract_stage.diagnostics,
+            signal_quality,
+        ))
     }
 
     fn finalize_report(
@@ -111,6 +119,7 @@ impl<'a> ScanEngine<'a> {
         scan_duration_us: u64,
         timings: ScanTimings,
         diagnostics: Vec<crate::scan::types::ScanDiagnostic>,
+        signal_quality: crate::findings::quality::SignalQualitySummary,
     ) -> ScanSummary {
         let finalization_start = Instant::now();
         summary::sort_findings(&mut project_stage.findings);
@@ -127,6 +136,7 @@ impl<'a> ScanEngine<'a> {
                 scan_timings: Some(timings),
                 cache_telemetry: None,
                 diagnostics,
+                signal_quality,
             },
         );
         if let Some(timings) = &mut summary.scan_timings {
@@ -215,15 +225,6 @@ impl<'a> ScanEngine<'a> {
             coupling_graph,
             elapsed_us: start.elapsed().as_micros() as u64,
         }
-    }
-
-    fn enrich_findings(&self, findings: &mut [crate::findings::types::Finding]) -> u64 {
-        let start = Instant::now();
-        for finding in findings.iter_mut() {
-            finding.populate_recommendation();
-            finding.id = stable_finding_key(finding, self.path);
-        }
-        start.elapsed().as_micros() as u64
     }
 
     fn score_findings(

--- a/src/scan/scanner/summary.rs
+++ b/src/scan/scanner/summary.rs
@@ -1,3 +1,4 @@
+use crate::findings::quality::SignalQualitySummary;
 use crate::findings::types::Finding;
 use crate::graph::CouplingGraph;
 use crate::scan::facts::ScanFacts;
@@ -38,6 +39,7 @@ pub(super) struct ScanSummaryParts {
     pub(super) cache_telemetry: Option<ScanCacheTelemetry>,
     pub(super) coupling_graph: Option<CouplingGraph>,
     pub(super) diagnostics: Vec<ScanDiagnostic>,
+    pub(super) signal_quality: SignalQualitySummary,
 }
 
 pub(super) fn build_scan_summary(
@@ -81,5 +83,6 @@ pub(super) fn build_scan_summary(
         cache_telemetry: parts.cache_telemetry,
         local_feedback: None,
         diagnostics: parts.diagnostics,
+        signal_quality: parts.signal_quality,
     }
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -1,4 +1,5 @@
 use crate::findings::feedback::LocalFeedbackReport;
+use crate::findings::quality::SignalQualitySummary;
 use crate::findings::types::Finding;
 use crate::frameworks::DetectedFramework;
 use crate::frameworks::FrameworkProject;
@@ -246,6 +247,9 @@ pub struct ScanSummary {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<ScanDiagnostic>,
+
+    #[serde(default)]
+    pub signal_quality: SignalQualitySummary,
 }
 
 fn default_repo_level_rules_included() -> bool {
@@ -287,6 +291,7 @@ impl Default for ScanSummary {
             cache_telemetry: None,
             local_feedback: None,
             diagnostics: Vec::new(),
+            signal_quality: SignalQualitySummary::default(),
         }
     }
 }

--- a/src/scan/workspace_scan.rs
+++ b/src/scan/workspace_scan.rs
@@ -1,3 +1,4 @@
+use crate::findings::filter::recompute_summary_metrics;
 use crate::findings::types::Finding;
 use crate::risk::{apply_cluster_overlay, apply_workspace_hotspot_overlay, sort_findings};
 use crate::scan::config::ScanConfig;
@@ -89,9 +90,7 @@ fn finalize_workspace_summary(merged: &mut ScanSummary, wall_start: Instant) {
     apply_workspace_hotspot_overlay(&mut merged.findings);
     apply_cluster_overlay(&mut merged.findings);
     sort_findings(&mut merged.findings);
-    merged.health_score =
-        ScanSummary::compute_health_score(&merged.findings, merged.non_empty_lines);
-    merged.visible_findings_count = merged.findings.len();
+    recompute_summary_metrics(merged);
     merged.scan_duration_us = wall_start.elapsed().as_micros() as u64;
 }
 

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -96,6 +96,7 @@ fn summary(findings: Vec<Finding>) -> ScanSummary {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        signal_quality: Default::default(),
     }
 }
 

--- a/tests/inspect_rules_cli.rs
+++ b/tests/inspect_rules_cli.rs
@@ -113,4 +113,14 @@ fn inspect_eval_rules_reports_fixture_quality() {
     assert_eq!(json["unexpected_findings"], 0);
     assert_eq!(json["contract_violations"], 0);
     assert_eq!(json["stable_id_failures"], 0);
+    let rules = json["rules"].as_array().expect("per-rule details");
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0]["rule_id"], "security.secret-candidate");
+    assert_eq!(rules[0]["fixtures_total"], 2);
+    assert_eq!(rules[0]["expected_findings"], 1);
+    assert_eq!(rules[0]["actual_findings"], 1);
+    assert_eq!(rules[0]["missing_findings"], 0);
+    assert_eq!(rules[0]["unexpected_findings"], 0);
+    assert_eq!(rules[0]["contract_violations"], 0);
+    assert_eq!(rules[0]["stable_id_failures"], 0);
 }

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -57,6 +57,7 @@ fn html_output_escapes_snippets_and_renders_summary() {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        signal_quality: Default::default(),
     };
 
     let html = render_scan_summary(&summary, OutputFormat::Html).expect("failed to render html");

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -1,3 +1,4 @@
+use repopilot::findings::quality::summarize_signal_quality;
 use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use repopilot::frameworks::ReactNativeArchitectureProfile;
 use repopilot::output::{OutputFormat, render_scan_summary};
@@ -45,6 +46,7 @@ fn renders_valid_json_scan_summary() {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        signal_quality: Default::default(),
     };
 
     let output =
@@ -88,9 +90,11 @@ fn json_findings_include_confidence() {
     };
     finding.risk = assess_finding(&finding, None, RiskInputs::default());
 
+    let findings = vec![finding];
     let summary = ScanSummary {
         root_path: PathBuf::from("demo"),
-        findings: vec![finding],
+        signal_quality: summarize_signal_quality(&findings),
+        findings,
         ..ScanSummary::default()
     };
     let risk_summary = RiskSummary::from_findings(&summary.findings);

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -71,6 +71,7 @@ fn renders_markdown_scan_summary() {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        signal_quality: Default::default(),
     };
 
     let output = render_scan_summary(&summary, OutputFormat::Markdown)
@@ -137,6 +138,7 @@ fn renders_empty_markdown_sections() {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        signal_quality: Default::default(),
     };
 
     let output = render_scan_summary(&summary, OutputFormat::Markdown)
@@ -198,6 +200,7 @@ fn renders_react_native_architecture_section_when_profile_present() {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        signal_quality: Default::default(),
     };
 
     let output = render_scan_summary(&summary, OutputFormat::Markdown)

--- a/tests/parallel_scan.rs
+++ b/tests/parallel_scan.rs
@@ -77,6 +77,13 @@ fn scan_timings_expose_pipeline_stage_breakdown() {
         timings.accounted_engine_us() >= timings.file_scan_us,
         "accounted timing should include file scan plus later pipeline stages"
     );
+    assert!(
+        timings.accounted_engine_us()
+            >= timings
+                .file_scan_us
+                .saturating_add(timings.contract_validation_us),
+        "accounted timing should include contract validation"
+    );
 }
 
 /// Verifies that parallel scan handles an empty directory cleanly without panicking.

--- a/tests/rule_registry.rs
+++ b/tests/rule_registry.rs
@@ -1,6 +1,7 @@
 use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use repopilot::output::sarif::findings_to_sarif;
-use repopilot::rules::{RuleMetadata, lookup_rule_metadata};
+use repopilot::rules::{RuleMetadata, all_rule_metadata, lookup_rule_metadata};
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 // ── lookup correctness ────────────────────────────────────────────────────────
@@ -22,6 +23,31 @@ fn unknown_rule_returns_none() {
 #[test]
 fn empty_rule_id_returns_none() {
     assert!(lookup_rule_metadata("").is_none());
+}
+
+#[test]
+fn all_registered_rule_ids_are_unique() {
+    let mut seen = HashSet::new();
+    for rule in all_rule_metadata() {
+        assert!(
+            seen.insert(rule.rule_id),
+            "duplicate rule id in metadata registry: {}",
+            rule.rule_id
+        );
+    }
+}
+
+#[test]
+fn indexed_lookup_matches_registry_iterator_metadata() {
+    for rule in all_rule_metadata() {
+        let indexed = lookup_rule_metadata(rule.rule_id)
+            .unwrap_or_else(|| panic!("indexed lookup missed {}", rule.rule_id));
+        assert_eq!(
+            indexed, rule,
+            "indexed metadata mismatch for {}",
+            rule.rule_id
+        );
+    }
 }
 
 // ── metadata field correctness ────────────────────────────────────────────────
@@ -103,8 +129,9 @@ fn make_finding(rule_id: &str) -> Finding {
 }
 
 #[test]
-fn sarif_rule_includes_help_uri_from_registry() {
-    let finding = make_finding("framework.react-native.inline-style");
+fn sarif_rule_includes_help_uri_from_enriched_finding() {
+    let mut finding = make_finding("framework.react-native.inline-style");
+    finding.populate_rule_metadata();
     let root = PathBuf::from(".");
     let sarif = findings_to_sarif(&[finding], &root);
     let value = serde_json::to_value(&sarif).unwrap();
@@ -113,7 +140,7 @@ fn sarif_rule_includes_help_uri_from_registry() {
     assert_eq!(
         help_uri.as_str(),
         Some("https://reactnative.dev/docs/stylesheet"),
-        "helpUri must come from the registry for a known rule"
+        "helpUri must come from the enriched finding docs URL"
     );
 }
 
@@ -151,9 +178,9 @@ fn sarif_finding_without_metadata_serializes_safely() {
 }
 
 #[test]
-fn sarif_registry_rule_overrides_finding_docs_url() {
+fn sarif_rule_uses_finding_docs_url_without_renderer_lookup() {
     let mut finding = make_finding("framework.react-native.inline-style");
-    finding.docs_url = Some("https://example.com/wrong-url".to_owned());
+    finding.docs_url = Some("https://example.com/custom-url".to_owned());
     let root = PathBuf::from(".");
     let sarif = findings_to_sarif(&[finding], &root);
     let value = serde_json::to_value(&sarif).unwrap();
@@ -161,8 +188,8 @@ fn sarif_registry_rule_overrides_finding_docs_url() {
     let help_uri = &value["runs"][0]["tool"]["driver"]["rules"][0]["helpUri"];
     assert_eq!(
         help_uri.as_str(),
-        Some("https://reactnative.dev/docs/stylesheet"),
-        "registry docs_url must take precedence over finding.docs_url"
+        Some("https://example.com/custom-url"),
+        "SARIF should use the already-enriched finding docs URL"
     );
 }
 


### PR DESCRIPTION
## Summary

This PR improves RepoPilot's core finding pipeline, signal quality handling, and rule inspection/evaluation architecture.

It centralizes finding enrichment before risk scoring and report construction, stores signal quality directly on `ScanSummary`, splits rule catalog/evaluation/rendering out of CLI orchestration, and adds stronger rule metadata and finding-contract validation coverage.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] Product smoke / release validation

## What changed

- Centralized finding enrichment into shared helpers:
  - `enrich_findings`
  - `enrich_findings_timed`
  - `enrich_finding`
- Ensured findings are enriched once before:
  - risk scoring;
  - contract validation;
  - report construction;
  - output rendering.
- Cached `signal_quality` on `ScanSummary`.
- Updated JSON, console, and Markdown renderers to use `summary.signal_quality` instead of rebuilding the same summary per renderer.
- Added indexed rule metadata lookup for faster repeated rule access.
- Added registry uniqueness coverage for rule IDs.
- Split rule inspection responsibilities out of CLI orchestration:
  - rule catalog construction;
  - single-rule inspection;
  - fixture evaluation;
  - console/Markdown/JSON rendering.
- Added richer `inspect eval-rules --format json` output with per-rule fixture details.
- Added rule fixture evaluation details:
  - expected findings;
  - actual findings;
  - missing findings;
  - unexpected findings;
  - contract violations;
  - stable ID failures.
- Refactored finding contract validation into an explicit validation stage.
- Added `contract_validation_us` timing to scan timings.
- Added product smoke self-scan gate that checks for zero finding contract violations.
- Updated rule lifecycle and signal quality docs.
- Updated 0.13 release checklist with optimization and stabilization verification commands.

## Why

RepoPilot reports are becoming a public product contract used by scans, baselines, reviews, SARIF, receipts, AI context, and CI gates.

That means findings need to be complete, stable, enriched, scored, and validated before any renderer or downstream workflow consumes them.

Before this PR, some report-level signal quality work could be repeated by renderers, and rule inspection/evaluation logic was too close to CLI command orchestration. This made future rule-author workflows and product smoke validation harder to evolve.

This PR improves the core pipeline:

```text
raw findings
-> enrich once
-> risk scoring
-> contract validation
-> report finalization
-> renderers consume stable report data
```