### PR TITLE
feat(graph): add context risk graph inspection

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -39,6 +39,14 @@ pub mod report {
     pub use crate::report::writer::write_report;
 }
 
+pub mod graph {
+    pub use crate::graph::CouplingGraph;
+    pub use crate::graph::context::{
+        ContextGraphCacheInfo, ContextGraphFileMetric, ContextGraphSummary, ContextRiskCluster,
+        RepoContextGraph, RepoContextNode,
+    };
+}
+
 pub mod review {
     pub use crate::review::diff::{ChangeStatus, ChangedFile};
     pub use crate::review::model::{ReviewFindingStatus, ReviewReport};

--- a/src/cli/options/inspect.rs
+++ b/src/cli/options/inspect.rs
@@ -42,6 +42,16 @@ repopilot inspect cache . --format markdown --output cache.md"
     )]
     Cache(CacheInspectOptions),
 
+    /// Inspect Context Risk Graph decisions for a repository
+    #[command(
+        about = "Inspect RepoPilot Context Risk Graph decisions",
+        after_help = "EXAMPLES:\n  \
+repopilot inspect graph\n  \
+repopilot inspect graph . --format json\n  \
+repopilot inspect graph . --format markdown --output graph.md"
+    )]
+    Graph(GraphInspectOptions),
+
     /// Inspect local feedback suppressions and validation diagnostics
     #[command(
         about = "Inspect RepoPilot local feedback suppressions",
@@ -133,6 +143,25 @@ pub struct CacheInspectOptions {
     pub path: PathBuf,
 
     /// Output format for cache diagnostics
+    #[arg(long, value_enum, default_value = "console")]
+    pub format: CompareOutputFormatArg,
+
+    /// Write report to a file instead of stdout
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct GraphInspectOptions {
+    /// Repository or project path whose Context Risk Graph should be inspected
+    #[arg(default_value = ".")]
+    pub path: PathBuf,
+
+    /// Path to a repopilot.toml config file
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+
+    /// Output format for graph diagnostics
     #[arg(long, value_enum, default_value = "console")]
     pub format: CompareOutputFormatArg,
 

--- a/src/commands/graph.rs
+++ b/src/commands/graph.rs
@@ -1,0 +1,281 @@
+use crate::cli::CompareOutputFormatArg;
+use crate::commands::product_scan::{
+    ProductScanMode, ProductScanRequest, emit_report_only_diagnostics,
+    enforce_diagnostics_exit_policy, run_product_scan,
+};
+use crate::commands::scan_config::ScanConfigOverrides;
+use repopilot::findings::filter::FindingFilter;
+use repopilot::findings::visibility::FindingVisibilityProfile;
+use repopilot::graph::context::{ContextGraphFileMetric, ContextGraphSummary};
+use repopilot::output::OutputFormat;
+use repopilot::report::writer::write_report;
+use repopilot::scan::types::ScanSummary;
+use serde::Serialize;
+use std::fmt::Write as FmtWrite;
+use std::path::PathBuf;
+
+pub fn run(
+    path: PathBuf,
+    config: Option<PathBuf>,
+    format: CompareOutputFormatArg,
+    output: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let scan_result = run_product_scan(ProductScanRequest {
+        path,
+        config_path: config,
+        overrides: ScanConfigOverrides::default(),
+        preset: None,
+        mode: ProductScanMode::Full,
+        ignore_feedback: true,
+        visibility_profile: FindingVisibilityProfile::Strict,
+        pre_visibility_filter: FindingFilter::default(),
+    })?;
+    let summary = scan_result.summary;
+
+    emit_report_only_diagnostics(&summary);
+    let rendered = render_graph_inspection(&summary, OutputFormat::from(format))?;
+    write_report(&rendered, output.as_deref())?;
+    enforce_diagnostics_exit_policy(&summary)?;
+
+    Ok(())
+}
+
+fn render_graph_inspection(
+    summary: &ScanSummary,
+    format: OutputFormat,
+) -> Result<String, serde_json::Error> {
+    match format {
+        OutputFormat::Console => Ok(render_console(summary)),
+        OutputFormat::Markdown => Ok(render_markdown(summary)),
+        OutputFormat::Json | OutputFormat::Html | OutputFormat::Sarif => {
+            serde_json::to_string_pretty(&GraphInspectJson::from_summary(summary))
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct GraphInspectJson<'a> {
+    kind: &'static str,
+    root_path: String,
+    context_graph_summary: Option<&'a ContextGraphSummary>,
+    context_graph_cache: Option<&'a repopilot::graph::context::ContextGraphCacheInfo>,
+    diagnostics: &'a [repopilot::scan::types::ScanDiagnostic],
+}
+
+impl<'a> GraphInspectJson<'a> {
+    fn from_summary(summary: &'a ScanSummary) -> Self {
+        Self {
+            kind: "context-graph",
+            root_path: summary.root_path.to_string_lossy().to_string(),
+            context_graph_summary: summary.context_graph_summary.as_ref(),
+            context_graph_cache: summary.context_graph_cache.as_ref(),
+            diagnostics: &summary.diagnostics,
+        }
+    }
+}
+
+fn render_console(summary: &ScanSummary) -> String {
+    let mut output = String::new();
+    let _ = writeln!(output, "RepoPilot Context Risk Graph\n");
+    let _ = writeln!(output, "Path: {}", summary.root_path.display());
+    render_cache_console(&mut output, summary);
+
+    let Some(graph) = &summary.context_graph_summary else {
+        output.push_str("No context graph summary available.\n");
+        return output;
+    };
+
+    let _ = writeln!(
+        output,
+        "Graph: {} files, {} import edges",
+        graph.files, graph.import_edges
+    );
+    render_metrics_console(&mut output, "Top dependencies", &graph.top_dependencies);
+    render_metrics_console(&mut output, "Top hubs", &graph.top_hubs);
+    render_blast_radius_console(&mut output, graph);
+    render_cycles_console(&mut output, graph);
+    render_risky_clusters_console(&mut output, graph);
+    output
+}
+
+fn render_markdown(summary: &ScanSummary) -> String {
+    let mut output = String::new();
+    let _ = writeln!(output, "# RepoPilot Context Risk Graph\n");
+    let _ = writeln!(output, "- **Path:** `{}`", summary.root_path.display());
+    render_cache_markdown(&mut output, summary);
+
+    let Some(graph) = &summary.context_graph_summary else {
+        output.push_str("\nNo context graph summary available.\n");
+        return output;
+    };
+
+    let _ = writeln!(
+        output,
+        "- **Graph:** {} files, {} import edges",
+        graph.files, graph.import_edges
+    );
+    render_metrics_markdown(&mut output, "Top Dependencies", &graph.top_dependencies);
+    render_metrics_markdown(&mut output, "Top Hubs", &graph.top_hubs);
+    render_blast_radius_markdown(&mut output, graph);
+    render_cycles_markdown(&mut output, graph);
+    render_risky_clusters_markdown(&mut output, graph);
+    output
+}
+
+fn render_cache_console(output: &mut String, summary: &ScanSummary) {
+    if let Some(cache) = &summary.context_graph_cache {
+        let _ = writeln!(
+            output,
+            "Cache: {} ({}) at {}",
+            cache.status,
+            cache.reason,
+            cache.cache_path.display()
+        );
+    }
+}
+
+fn render_cache_markdown(output: &mut String, summary: &ScanSummary) {
+    if let Some(cache) = &summary.context_graph_cache {
+        let _ = writeln!(
+            output,
+            "- **Cache:** `{}` ({}) at `{}`",
+            cache.status,
+            cache.reason,
+            cache.cache_path.display()
+        );
+    }
+}
+
+fn render_metrics_console(output: &mut String, title: &str, metrics: &[ContextGraphFileMetric]) {
+    let _ = writeln!(output, "\n{title}:");
+    if metrics.is_empty() {
+        output.push_str("  none\n");
+        return;
+    }
+    for metric in metrics {
+        let _ = writeln!(
+            output,
+            "  {} fan-in={} fan-out={} instability={:.2}",
+            metric.path.display(),
+            metric.fan_in,
+            metric.fan_out,
+            metric.instability
+        );
+    }
+}
+
+fn render_metrics_markdown(output: &mut String, title: &str, metrics: &[ContextGraphFileMetric]) {
+    let _ = writeln!(output, "\n## {title}\n");
+    if metrics.is_empty() {
+        output.push_str("No files detected.\n");
+        return;
+    }
+    output.push_str("| File | Fan-in | Fan-out | Instability | Roles |\n");
+    output.push_str("| --- | ---: | ---: | ---: | --- |\n");
+    for metric in metrics {
+        let roles = if metric.roles.is_empty() {
+            "n/a".to_string()
+        } else {
+            metric.roles.join(", ")
+        };
+        let _ = writeln!(
+            output,
+            "| `{}` | {} | {} | {:.2} | {} |",
+            metric.path.display(),
+            metric.fan_in,
+            metric.fan_out,
+            metric.instability,
+            roles
+        );
+    }
+}
+
+fn render_blast_radius_console(output: &mut String, graph: &ContextGraphSummary) {
+    output.push_str("\nBlast radius:\n");
+    if graph.changed_blast_radius.is_empty() {
+        output.push_str("  none\n");
+        return;
+    }
+    for path in &graph.changed_blast_radius {
+        let _ = writeln!(output, "  {}", path.display());
+    }
+}
+
+fn render_blast_radius_markdown(output: &mut String, graph: &ContextGraphSummary) {
+    output.push_str("\n## Blast Radius\n\n");
+    if graph.changed_blast_radius.is_empty() {
+        output.push_str("No changed-file blast radius in this full graph inspection.\n");
+        return;
+    }
+    for path in &graph.changed_blast_radius {
+        let _ = writeln!(output, "- `{}`", path.display());
+    }
+}
+
+fn render_cycles_console(output: &mut String, graph: &ContextGraphSummary) {
+    let _ = writeln!(output, "\nCycles: {}", graph.cycles.len());
+    for cycle in &graph.cycles {
+        let rendered = cycle
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(" -> ");
+        let _ = writeln!(output, "  {rendered}");
+    }
+}
+
+fn render_cycles_markdown(output: &mut String, graph: &ContextGraphSummary) {
+    output.push_str("\n## Cycles\n\n");
+    if graph.cycles.is_empty() {
+        output.push_str("No import cycles detected.\n");
+        return;
+    }
+    for cycle in &graph.cycles {
+        let rendered = cycle
+            .iter()
+            .map(|path| format!("`{}`", path.display()))
+            .collect::<Vec<_>>()
+            .join(" -> ");
+        let _ = writeln!(output, "- {rendered}");
+    }
+}
+
+fn render_risky_clusters_console(output: &mut String, graph: &ContextGraphSummary) {
+    output.push_str("\nRisky clusters:\n");
+    if graph.risky_clusters.is_empty() {
+        output.push_str("  none\n");
+        return;
+    }
+    for cluster in &graph.risky_clusters {
+        let _ = writeln!(
+            output,
+            "  {} in {}: {} finding(s), max risk {}, {}",
+            cluster.rule_id,
+            cluster.scope,
+            cluster.count,
+            cluster.max_score,
+            cluster.priority.label()
+        );
+    }
+}
+
+fn render_risky_clusters_markdown(output: &mut String, graph: &ContextGraphSummary) {
+    output.push_str("\n## Risky Clusters\n\n");
+    if graph.risky_clusters.is_empty() {
+        output.push_str("No risky clusters detected.\n");
+        return;
+    }
+    output.push_str("| Rule | Scope | Count | Max risk | Priority |\n");
+    output.push_str("| --- | --- | ---: | ---: | --- |\n");
+    for cluster in &graph.risky_clusters {
+        let _ = writeln!(
+            output,
+            "| `{}` | `{}` | {} | {} | {} |",
+            cluster.rule_id,
+            cluster.scope,
+            cluster.count,
+            cluster.max_score,
+            cluster.priority.label()
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod explain;
 pub mod feedback;
 pub(crate) mod filters;
 pub(crate) mod focus;
+pub mod graph;
 pub mod init;
 pub mod knowledge;
 mod llm;
@@ -88,6 +89,9 @@ fn run_inspect(command: InspectCommands) -> Result<(), Box<dyn std::error::Error
         }
         InspectCommands::Cache(options) => {
             cache_inspect::run(options.path, options.format, options.output)
+        }
+        InspectCommands::Graph(options) => {
+            graph::run(options.path, options.config, options.format, options.output)
         }
         InspectCommands::Feedback(options) => feedback::run(
             options.path,

--- a/src/findings/visibility.rs
+++ b/src/findings/visibility.rs
@@ -311,7 +311,7 @@ fn is_maintainability_rule(rule_id: &str) -> bool {
             | "architecture.too-many-modules"
             | "architecture.large-file"
             | "architecture.barrel-file-risk"
-            | "architecture.deep-relative-import"
+            | "architecture.deep-relative-imports"
             | "code-quality.long-function"
             | "code-quality.complex-file"
             | "code-quality.cyclomatic-complexity"
@@ -343,7 +343,7 @@ fn is_script_boundary_runtime_exit(finding: &Finding) -> bool {
 }
 
 fn is_script_or_tooling_path(path: &Path) -> bool {
-    let path_text = path.to_string_lossy().replace("\"", "/").to_lowercase();
+    let path_text = path.to_string_lossy().replace('\\', "/").to_lowercase();
 
     if path_text.contains("/src/") || path_text.starts_with("src/") {
         return false;
@@ -426,6 +426,20 @@ mod tests {
     }
 
     #[test]
+    fn default_profile_hides_deep_relative_imports() {
+        let finding = finding(
+            "architecture.deep-relative-imports",
+            FindingCategory::Architecture,
+            Severity::High,
+        );
+
+        let decision = classify_visibility(&finding);
+
+        assert_eq!(decision.intent, FindingIntent::Maintainability);
+        assert!(!decision.visible_by_default);
+    }
+
+    #[test]
     fn default_profile_keeps_validated_secret_candidates() {
         let finding = finding(
             "security.secret-candidate",
@@ -446,6 +460,21 @@ mod tests {
             FindingCategory::CodeQuality,
             Severity::High,
             "scripts/verify-release.mjs",
+        );
+
+        let decision = classify_visibility(&finding);
+
+        assert_eq!(decision.intent, FindingIntent::RuntimeRisk);
+        assert!(!decision.visible_by_default);
+    }
+
+    #[test]
+    fn default_profile_hides_windows_script_process_exit() {
+        let finding = finding_with_path(
+            "language.javascript.runtime-exit-risk",
+            FindingCategory::CodeQuality,
+            Severity::High,
+            r"tools\verify-release.mjs",
         );
 
         let decision = classify_visibility(&finding);

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -1,0 +1,554 @@
+use crate::audits::context::{FileRole, classify_file};
+use crate::findings::types::Finding;
+use crate::graph::{CouplingGraph, build_coupling_graph, compute_metrics, detect_cycles};
+use crate::review::diff::{ChangeStatus, ChangedFile};
+use crate::risk::RiskPriority;
+use crate::scan::cache::{cache_dir, config_fingerprint, relative_cache_path, stable_hash_hex};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::{FileFacts, ScanFacts};
+use crate::scan::types::ScanDiagnostic;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub const CONTEXT_GRAPH_CACHE_NAME: &str = "repo_context.json";
+pub const CONTEXT_GRAPH_SCHEMA_VERSION: u32 = 1;
+pub const CONTEXT_GRAPH_RESOLVER_VERSION: &str = "context-graph-v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepoContextGraph {
+    pub root_path: PathBuf,
+    pub nodes: Vec<RepoContextNode>,
+    pub edges: BTreeMap<PathBuf, BTreeSet<PathBuf>>,
+    #[serde(default)]
+    pub detected_frameworks: Vec<crate::frameworks::DetectedFramework>,
+    #[serde(default)]
+    pub framework_projects: Vec<crate::frameworks::FrameworkProject>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub react_native: Option<crate::frameworks::ReactNativeArchitectureProfile>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepoContextNode {
+    pub path: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub roles: Vec<String>,
+    #[serde(default)]
+    pub frameworks: Vec<String>,
+    #[serde(default)]
+    pub runtimes: Vec<String>,
+    #[serde(default)]
+    pub paradigms: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_package: Option<String>,
+    pub non_empty_lines: usize,
+    #[serde(default)]
+    pub imports: Vec<String>,
+    pub is_test: bool,
+    pub is_generated: bool,
+    pub is_config: bool,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContextGraphSummary {
+    pub files: usize,
+    pub import_edges: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub top_hubs: Vec<ContextGraphFileMetric>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub top_dependencies: Vec<ContextGraphFileMetric>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cycles: Vec<Vec<PathBuf>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_blast_radius: Vec<PathBuf>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub risky_clusters: Vec<ContextRiskCluster>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ContextGraphFileMetric {
+    pub path: PathBuf,
+    pub fan_in: usize,
+    pub fan_out: usize,
+    pub instability: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roles: Vec<String>,
+}
+
+impl Eq for ContextGraphFileMetric {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContextRiskCluster {
+    pub rule_id: String,
+    pub scope: String,
+    pub count: usize,
+    pub max_score: u8,
+    pub priority: RiskPriority,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContextGraphCacheInfo {
+    pub status: String,
+    pub reason: String,
+    pub cache_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CachedRepoContextGraph {
+    pub schema_version: u32,
+    pub repopilot_version: String,
+    pub config_fingerprint: String,
+    pub resolver_version: String,
+    pub graph_fingerprint: String,
+    pub graph: RepoContextGraph,
+}
+
+pub struct RepoContextGraphLoad {
+    pub graph: RepoContextGraph,
+    pub cache_info: ContextGraphCacheInfo,
+}
+
+impl RepoContextGraph {
+    pub fn from_scan_facts(facts: &ScanFacts, root: &Path, coupling_graph: CouplingGraph) -> Self {
+        Self {
+            root_path: root.to_path_buf(),
+            nodes: facts
+                .files
+                .iter()
+                .map(|file| RepoContextNode::from_file(file, root))
+                .collect(),
+            edges: relative_edges(coupling_graph.edges, root),
+            detected_frameworks: facts.detected_frameworks.clone(),
+            framework_projects: facts.framework_projects.clone(),
+            react_native: facts.react_native.clone(),
+        }
+    }
+
+    pub fn to_scan_facts(&self) -> ScanFacts {
+        let files = self
+            .nodes
+            .iter()
+            .map(RepoContextNode::to_file_facts)
+            .collect::<Vec<_>>();
+
+        let mut languages = HashMap::new();
+        let mut non_empty_lines = 0usize;
+        for file in &files {
+            non_empty_lines += file.non_empty_lines;
+            if let Some(language) = &file.language {
+                *languages.entry(language.clone()).or_insert(0usize) += 1;
+            }
+        }
+
+        ScanFacts {
+            root_path: self.root_path.clone(),
+            files_discovered: files.len(),
+            files_analyzed: files.len(),
+            directories_count: directory_count(&files),
+            non_empty_lines,
+            languages: build_language_summary(languages),
+            files,
+            detected_frameworks: self.detected_frameworks.clone(),
+            framework_projects: self.framework_projects.clone(),
+            react_native: self.react_native.clone(),
+            ..ScanFacts::default()
+        }
+    }
+
+    pub fn coupling_graph(&self) -> CouplingGraph {
+        let nodes = self
+            .nodes
+            .iter()
+            .map(|node| node.path.clone())
+            .chain(
+                self.edges
+                    .values()
+                    .flat_map(|targets| targets.iter().cloned()),
+            )
+            .collect::<BTreeSet<_>>();
+
+        CouplingGraph {
+            edges: self.edges.clone(),
+            nodes,
+        }
+    }
+
+    pub fn apply_changed_facts(
+        &mut self,
+        repo_root: &Path,
+        changed_files: &[ChangedFile],
+        patch_files: &[FileFacts],
+    ) {
+        let removed = changed_files
+            .iter()
+            .filter(|file| file.status == ChangeStatus::Deleted)
+            .map(|file| file.path.clone())
+            .collect::<HashSet<_>>();
+
+        self.nodes.retain(|node| !removed.contains(&node.path));
+        self.nodes
+            .retain(|node| !patch_files.iter().any(|file| file.path == node.path));
+        self.nodes.extend(
+            patch_files
+                .iter()
+                .map(|file| RepoContextNode::from_file(file, repo_root)),
+        );
+        self.nodes.sort_by(|left, right| left.path.cmp(&right.path));
+
+        let mut facts = self.to_scan_facts();
+        for file in &mut facts.files {
+            if file.path.is_relative() {
+                file.path = repo_root.join(&file.path);
+            }
+        }
+        self.edges = relative_edges(build_coupling_graph(&facts, repo_root).edges, repo_root);
+    }
+}
+
+impl RepoContextNode {
+    fn from_file(file: &FileFacts, root: &Path) -> Self {
+        let context = classify_file(file);
+        let roles = context.role_ids().into_iter().map(str::to_string).collect();
+        let frameworks = context
+            .framework_ids()
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let runtimes = context
+            .runtime_ids()
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let paradigms = context
+            .paradigm_ids()
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let is_generated = context.has_role(FileRole::Generated);
+        let is_config = context.has_role(FileRole::Config);
+
+        Self {
+            path: relative_graph_path(root, &file.path),
+            language: file.language.clone(),
+            roles,
+            frameworks,
+            runtimes,
+            paradigms,
+            workspace_package: None,
+            non_empty_lines: file.non_empty_lines,
+            imports: file.imports.clone(),
+            is_test: context.is_test,
+            is_generated,
+            is_config,
+        }
+    }
+
+    fn to_file_facts(&self) -> FileFacts {
+        FileFacts {
+            path: self.path.clone(),
+            language: self.language.clone(),
+            non_empty_lines: self.non_empty_lines,
+            branch_count: 0,
+            imports: self.imports.clone(),
+            content: None,
+            has_inline_tests: self.is_test,
+        }
+    }
+}
+
+fn relative_edges(
+    edges: BTreeMap<PathBuf, BTreeSet<PathBuf>>,
+    root: &Path,
+) -> BTreeMap<PathBuf, BTreeSet<PathBuf>> {
+    edges
+        .into_iter()
+        .map(|(source, targets)| {
+            (
+                relative_graph_path(root, &source),
+                targets
+                    .into_iter()
+                    .map(|target| relative_graph_path(root, &target))
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
+fn relative_graph_path(root: &Path, path: &Path) -> PathBuf {
+    PathBuf::from(relative_cache_path(root, path))
+}
+
+pub fn summarize_context_graph(
+    graph: &RepoContextGraph,
+    findings: &[Finding],
+    changed_files: &[ChangedFile],
+) -> ContextGraphSummary {
+    let coupling_graph = graph.coupling_graph();
+    let mut metrics = compute_metrics(&coupling_graph);
+    let node_by_path = graph
+        .nodes
+        .iter()
+        .map(|node| (node.path.clone(), node))
+        .collect::<HashMap<_, _>>();
+
+    metrics.sort_by(|left, right| {
+        right
+            .fan_out
+            .cmp(&left.fan_out)
+            .then_with(|| right.fan_in.cmp(&left.fan_in))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    let top_hubs = metrics
+        .iter()
+        .filter(|metric| metric.fan_out > 0)
+        .take(5)
+        .map(|metric| metric_from_graph(metric, &node_by_path))
+        .collect();
+
+    metrics.sort_by(|left, right| {
+        right
+            .fan_in
+            .cmp(&left.fan_in)
+            .then_with(|| right.fan_out.cmp(&left.fan_out))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    let top_dependencies = metrics
+        .iter()
+        .filter(|metric| metric.fan_in > 0)
+        .take(5)
+        .map(|metric| metric_from_graph(metric, &node_by_path))
+        .collect();
+
+    ContextGraphSummary {
+        files: graph.nodes.len(),
+        import_edges: graph.edges.values().map(BTreeSet::len).sum(),
+        top_hubs,
+        top_dependencies,
+        cycles: detect_cycles(&coupling_graph).into_iter().take(5).collect(),
+        changed_blast_radius: changed_blast_radius(&coupling_graph, changed_files),
+        risky_clusters: risky_clusters(findings),
+    }
+}
+
+pub fn load_repo_context_graph(root: &Path, config: &ScanConfig) -> Option<RepoContextGraphLoad> {
+    let cache_path = context_graph_cache_path(root);
+    let content = fs::read_to_string(&cache_path).ok()?;
+    let cached = serde_json::from_str::<CachedRepoContextGraph>(&content).ok()?;
+    if !valid_cached_graph(&cached, config) {
+        return None;
+    }
+
+    Some(RepoContextGraphLoad {
+        graph: cached.graph,
+        cache_info: ContextGraphCacheInfo {
+            status: "hit".to_string(),
+            reason: "valid-context-graph-cache".to_string(),
+            cache_path,
+        },
+    })
+}
+
+pub fn write_repo_context_graph(
+    root: &Path,
+    config: &ScanConfig,
+    graph: &RepoContextGraph,
+) -> io::Result<ContextGraphCacheInfo> {
+    let cache_path = context_graph_cache_path(root);
+    if let Some(parent) = cache_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let cached = CachedRepoContextGraph {
+        schema_version: CONTEXT_GRAPH_SCHEMA_VERSION,
+        repopilot_version: env!("CARGO_PKG_VERSION").to_string(),
+        config_fingerprint: config_fingerprint(config),
+        resolver_version: CONTEXT_GRAPH_RESOLVER_VERSION.to_string(),
+        graph_fingerprint: context_graph_fingerprint(graph),
+        graph: graph.clone(),
+    };
+    let rendered = serde_json::to_string_pretty(&cached).map_err(io::Error::other)?;
+    fs::write(&cache_path, rendered)?;
+
+    Ok(ContextGraphCacheInfo {
+        status: "write".to_string(),
+        reason: "context-graph-cache-updated".to_string(),
+        cache_path,
+    })
+}
+
+pub fn context_graph_cache_miss(root: &Path, reason: &str) -> ContextGraphCacheInfo {
+    ContextGraphCacheInfo {
+        status: "miss".to_string(),
+        reason: reason.to_string(),
+        cache_path: context_graph_cache_path(root),
+    }
+}
+
+pub fn cache_diagnostic(error: &io::Error) -> ScanDiagnostic {
+    ScanDiagnostic::warning(
+        "context-graph.cache-write-failed",
+        format!("Could not write context graph cache: {error}"),
+    )
+}
+
+fn valid_cached_graph(cached: &CachedRepoContextGraph, config: &ScanConfig) -> bool {
+    cached.schema_version == CONTEXT_GRAPH_SCHEMA_VERSION
+        && cached.repopilot_version == env!("CARGO_PKG_VERSION")
+        && cached.config_fingerprint == config_fingerprint(config)
+        && cached.resolver_version == CONTEXT_GRAPH_RESOLVER_VERSION
+        && cached.graph_fingerprint == context_graph_fingerprint(&cached.graph)
+}
+
+pub fn context_graph_cache_path(root: &Path) -> PathBuf {
+    cache_dir(root).join(CONTEXT_GRAPH_CACHE_NAME)
+}
+
+fn context_graph_fingerprint(graph: &RepoContextGraph) -> String {
+    let input = serde_json::json!({
+        "schema": CONTEXT_GRAPH_SCHEMA_VERSION,
+        "resolver": CONTEXT_GRAPH_RESOLVER_VERSION,
+        "risk_formula": crate::risk::FORMULA_VERSION,
+        "knowledge_pack": stable_hash_hex(include_bytes!("../knowledge/packs/core.toml")),
+        "nodes": &graph.nodes,
+        "edges": &graph.edges,
+        "frameworks": &graph.detected_frameworks,
+        "framework_projects": &graph.framework_projects,
+        "react_native": &graph.react_native,
+    });
+    stable_hash_hex(input.to_string().as_bytes())
+}
+
+fn metric_from_graph(
+    metric: &crate::graph::FileMetrics,
+    node_by_path: &HashMap<PathBuf, &RepoContextNode>,
+) -> ContextGraphFileMetric {
+    let node = node_by_path.get(&metric.path);
+    ContextGraphFileMetric {
+        path: metric.path.clone(),
+        fan_in: metric.fan_in,
+        fan_out: metric.fan_out,
+        instability: metric.instability,
+        language: node.and_then(|node| node.language.clone()),
+        roles: node.map(|node| node.roles.clone()).unwrap_or_default(),
+    }
+}
+
+fn changed_blast_radius(graph: &CouplingGraph, changed_files: &[ChangedFile]) -> Vec<PathBuf> {
+    if changed_files.is_empty() {
+        return Vec::new();
+    }
+
+    let changed = changed_files
+        .iter()
+        .map(|file| file.path.clone())
+        .collect::<HashSet<_>>();
+    let mut importers_by_target: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
+    for (source, targets) in &graph.edges {
+        for target in targets {
+            importers_by_target
+                .entry(target.clone())
+                .or_default()
+                .insert(source.clone());
+        }
+    }
+
+    let mut impacted = BTreeSet::new();
+    for path in &changed {
+        if let Some(importers) = importers_by_target.get(path) {
+            impacted.extend(
+                importers
+                    .iter()
+                    .filter(|importer| !changed.contains(*importer))
+                    .cloned(),
+            );
+        }
+    }
+    impacted.into_iter().take(20).collect()
+}
+
+fn risky_clusters(findings: &[Finding]) -> Vec<ContextRiskCluster> {
+    let mut clusters: BTreeMap<(String, String), ContextRiskCluster> = BTreeMap::new();
+    for finding in findings {
+        let scope = finding
+            .evidence
+            .first()
+            .map(|evidence| cluster_scope(&evidence.path))
+            .unwrap_or_else(|| ".".to_string());
+        let key = (finding.rule_id.clone(), scope.clone());
+        let entry = clusters.entry(key).or_insert_with(|| ContextRiskCluster {
+            rule_id: finding.rule_id.clone(),
+            scope,
+            count: 0,
+            max_score: 0,
+            priority: RiskPriority::P3,
+        });
+        entry.count += 1;
+        entry.max_score = entry.max_score.max(finding.risk.score);
+        if finding.risk.priority.rank() < entry.priority.rank() {
+            entry.priority = finding.risk.priority;
+        }
+    }
+
+    let mut clusters = clusters.into_values().collect::<Vec<_>>();
+    clusters.sort_by(|left, right| {
+        right
+            .max_score
+            .cmp(&left.max_score)
+            .then_with(|| right.count.cmp(&left.count))
+            .then_with(|| left.rule_id.cmp(&right.rule_id))
+    });
+    clusters.truncate(8);
+    clusters
+}
+
+fn cluster_scope(path: &Path) -> String {
+    let parts = path
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(value) => Some(value.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    match (parts.first(), parts.get(1)) {
+        (Some(first), Some(second)) if second.contains('.') => first.clone(),
+        (Some(first), Some(second)) => format!("{first}/{second}"),
+        (Some(first), None) => first.clone(),
+        _ => ".".to_string(),
+    }
+}
+
+fn build_language_summary(
+    languages: HashMap<String, usize>,
+) -> Vec<crate::scan::types::LanguageSummary> {
+    let mut languages = languages
+        .into_iter()
+        .map(
+            |(name, files_analyzed)| crate::scan::types::LanguageSummary {
+                name,
+                files_analyzed,
+            },
+        )
+        .collect::<Vec<_>>();
+    languages.sort_by(|left, right| {
+        right
+            .files_analyzed
+            .cmp(&left.files_analyzed)
+            .then_with(|| left.name.cmp(&right.name))
+    });
+    languages
+}
+
+fn directory_count(files: &[FileFacts]) -> usize {
+    files
+        .iter()
+        .filter_map(|file| file.path.parent().map(Path::to_path_buf))
+        .collect::<HashSet<_>>()
+        .len()
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,3 +1,4 @@
+pub mod context;
 pub mod imports;
 pub mod resolver;
 

--- a/src/output/ai_context/hotfiles.rs
+++ b/src/output/ai_context/hotfiles.rs
@@ -1,8 +1,14 @@
 use crate::graph::compute_metrics;
+use crate::graph::context::{ContextGraphFileMetric, ContextGraphSummary};
 use crate::scan::types::ScanSummary;
 use std::fmt::Write as FmtWrite;
 
 pub(super) fn render_hot_files(out: &mut String, summary: &ScanSummary) {
+    if let Some(graph) = &summary.context_graph_summary {
+        render_context_risk_graph(out, summary, graph);
+        return;
+    }
+
     let graph = match &summary.coupling_graph {
         Some(g) => g,
         None => return,
@@ -27,4 +33,132 @@ pub(super) fn render_hot_files(out: &mut String, summary: &ScanSummary) {
         );
     }
     out.push('\n');
+}
+
+fn render_context_risk_graph(out: &mut String, summary: &ScanSummary, graph: &ContextGraphSummary) {
+    if graph.files == 0 {
+        return;
+    }
+
+    let _ = writeln!(out, "## Context Risk Graph\n");
+    if let Some(cache) = &summary.context_graph_cache {
+        let _ = writeln!(
+            out,
+            "- Cache: {} ({})",
+            cache.status,
+            cache.reason.replace('|', "/")
+        );
+    }
+    let _ = writeln!(
+        out,
+        "- Graph size: {} files, {} import edges",
+        graph.files, graph.import_edges
+    );
+
+    render_edit_order(out, graph);
+    render_blast_radius(out, graph);
+    render_high_context_files(out, graph);
+    render_verification_focus(out, graph);
+    out.push('\n');
+}
+
+fn render_edit_order(out: &mut String, graph: &ContextGraphSummary) {
+    let _ = writeln!(out, "\n### Edit Order");
+    if graph.risky_clusters.is_empty() && graph.top_dependencies.is_empty() {
+        let _ = writeln!(
+            out,
+            "- Start with the changed files, then shared dependencies."
+        );
+        return;
+    }
+
+    for cluster in graph.risky_clusters.iter().take(4) {
+        let _ = writeln!(
+            out,
+            "- {} in `{}`: {} finding(s), max risk {}",
+            cluster.rule_id, cluster.scope, cluster.count, cluster.max_score
+        );
+    }
+    for file in graph.top_dependencies.iter().take(3) {
+        let _ = writeln!(
+            out,
+            "- Shared dependency `{}` before downstream callers (fan-in {}, fan-out {})",
+            file.path.display(),
+            file.fan_in,
+            file.fan_out
+        );
+    }
+}
+
+fn render_blast_radius(out: &mut String, graph: &ContextGraphSummary) {
+    let _ = writeln!(out, "\n### Blast Radius");
+    if graph.changed_blast_radius.is_empty() {
+        let _ = writeln!(
+            out,
+            "- No import-based downstream files detected for this scope."
+        );
+        return;
+    }
+
+    for path in graph.changed_blast_radius.iter().take(8) {
+        let _ = writeln!(out, "- `{}`", path.display());
+    }
+}
+
+fn render_high_context_files(out: &mut String, graph: &ContextGraphSummary) {
+    let _ = writeln!(out, "\n### High-Context Files");
+    let mut rendered = 0usize;
+    for file in graph.top_dependencies.iter().take(5) {
+        render_file_metric(out, "dependency", file);
+        rendered += 1;
+    }
+    for file in graph.top_hubs.iter().take(5usize.saturating_sub(rendered)) {
+        render_file_metric(out, "hub", file);
+    }
+}
+
+fn render_file_metric(out: &mut String, label: &str, file: &ContextGraphFileMetric) {
+    let roles = if file.roles.is_empty() {
+        String::new()
+    } else {
+        format!("; roles {}", file.roles.join(","))
+    };
+    let _ = writeln!(
+        out,
+        "- `{}`: {label}, fan-in {}, fan-out {}, instability {:.2}{}",
+        file.path.display(),
+        file.fan_in,
+        file.fan_out,
+        file.instability,
+        roles
+    );
+}
+
+fn render_verification_focus(out: &mut String, graph: &ContextGraphSummary) {
+    let _ = writeln!(out, "\n### Verification Focus");
+    if !graph.cycles.is_empty() {
+        let _ = writeln!(
+            out,
+            "- Re-run architecture checks around {} import cycle(s).",
+            graph.cycles.len()
+        );
+    }
+    if !graph.risky_clusters.is_empty() {
+        let _ = writeln!(out, "- Re-scan the top risky clusters after edits.");
+    }
+    if !graph.changed_blast_radius.is_empty() {
+        let _ = writeln!(
+            out,
+            "- Test files in the blast radius, not only touched files."
+        );
+    }
+    if graph.cycles.is_empty()
+        && graph.risky_clusters.is_empty()
+        && graph.changed_blast_radius.is_empty()
+    {
+        let _ = writeln!(
+            out,
+            "- Run the focused scan command for the selected severity scope."
+        );
+    }
 }

--- a/src/output/ai_context/tests.rs
+++ b/src/output/ai_context/tests.rs
@@ -1,6 +1,8 @@
 use super::header::risk_level;
 use super::{AiContextRenderOptions, AiFocusCategory, render};
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::graph::context::{ContextGraphFileMetric, ContextGraphSummary, ContextRiskCluster};
+use crate::risk::RiskPriority;
 use crate::scan::types::ScanSummary;
 use std::path::PathBuf;
 
@@ -319,6 +321,21 @@ fn top_recommendations_shown_for_high_findings() {
 }
 
 #[test]
+fn ai_context_includes_context_risk_graph_sections() {
+    let mut summary = make_summary(vec![]);
+    summary.context_graph_summary = Some(context_graph_summary());
+
+    let output = render(&summary, &AiContextRenderOptions::default());
+
+    assert!(output.contains("## Context Risk Graph"));
+    assert!(output.contains("### Edit Order"));
+    assert!(output.contains("### Blast Radius"));
+    assert!(output.contains("### High-Context Files"));
+    assert!(output.contains("### Verification Focus"));
+    assert!(output.contains("src/core.rs"));
+}
+
+#[test]
 fn empty_scan_renders_without_panic() {
     let summary = make_summary(vec![]);
     let output = render(&summary, &AiContextRenderOptions::default());
@@ -334,4 +351,29 @@ fn ai_context_category_from_str() {
     assert_eq!("framework".parse(), Ok(AiFocusCategory::Framework));
     assert_eq!("all".parse(), Ok(AiFocusCategory::All));
     assert_eq!("unknown".parse::<AiFocusCategory>(), Err(()));
+}
+
+fn context_graph_summary() -> ContextGraphSummary {
+    ContextGraphSummary {
+        files: 3,
+        import_edges: 2,
+        top_hubs: Vec::new(),
+        top_dependencies: vec![ContextGraphFileMetric {
+            path: PathBuf::from("src/core.rs"),
+            fan_in: 3,
+            fan_out: 1,
+            instability: 0.25,
+            language: Some("Rust".to_string()),
+            roles: vec!["source".to_string()],
+        }],
+        cycles: Vec::new(),
+        changed_blast_radius: vec![PathBuf::from("src/caller.rs")],
+        risky_clusters: vec![ContextRiskCluster {
+            rule_id: "architecture.large-file".to_string(),
+            scope: "src".to_string(),
+            count: 2,
+            max_score: 60,
+            priority: RiskPriority::P2,
+        }],
+    }
 }

--- a/src/output/ai_plan.rs
+++ b/src/output/ai_plan.rs
@@ -1,4 +1,5 @@
 use crate::findings::types::{Finding, FindingCategory, Severity};
+use crate::graph::context::{ContextGraphFileMetric, ContextGraphSummary};
 use crate::output::ai_context::{AiFocusCategory, DEFAULT_TOKEN_BUDGET, project_name};
 use crate::output::finding_helpers::{
     RuleCluster, category_rank, clusters_by_rule_scope, example_locations, finding_recommendation,
@@ -43,6 +44,7 @@ pub fn render(summary: &ScanSummary, opts: &AiPlanOptions) -> String {
         "Prioritized remediation plan generated locally from RepoPilot findings. Start at P0 and stop when the remaining risk is acceptable for this release.\n"
     );
     render_summary(&mut out, &findings);
+    render_context_graph_plan(&mut out, summary.context_graph_summary.as_ref());
 
     if findings.is_empty() {
         let _ = writeln!(out, "No findings matched the selected scope.");
@@ -103,6 +105,103 @@ fn render_summary(out: &mut String, findings: &[&Finding]) {
         out,
         "## Priority Summary\n\n- Total: {} findings\n- Critical: {critical}\n- High: {high}\n- Medium: {medium}\n- Low: {low}",
         findings.len()
+    );
+}
+
+fn render_context_graph_plan(out: &mut String, graph: Option<&ContextGraphSummary>) {
+    let Some(graph) = graph.filter(|graph| graph.files > 0) else {
+        return;
+    };
+
+    let _ = writeln!(out, "\n## Context Risk Graph\n");
+    let _ = writeln!(
+        out,
+        "- Scope: {} files, {} import edges",
+        graph.files, graph.import_edges
+    );
+
+    let _ = writeln!(out, "\n### Edit Order");
+    if graph.risky_clusters.is_empty() && graph.top_dependencies.is_empty() {
+        let _ = writeln!(
+            out,
+            "- Start with the changed files and keep edits isolated."
+        );
+    } else {
+        for cluster in graph.risky_clusters.iter().take(5) {
+            let _ = writeln!(
+                out,
+                "- `{}` in `{}`: {} finding(s), max risk {}",
+                cluster.rule_id, cluster.scope, cluster.count, cluster.max_score
+            );
+        }
+        for file in graph.top_dependencies.iter().take(3) {
+            let _ = writeln!(
+                out,
+                "- Edit shared dependency `{}` before callers.",
+                file.path.display()
+            );
+        }
+    }
+
+    render_graph_file_list(out, "Blast Radius", &graph.changed_blast_radius);
+    render_graph_metrics(out, "High-Context Files", graph);
+
+    let _ = writeln!(out, "\n### Verification Focus");
+    if !graph.changed_blast_radius.is_empty() {
+        let _ = writeln!(out, "- Run tests covering blast-radius files.");
+    }
+    if !graph.cycles.is_empty() {
+        let _ = writeln!(
+            out,
+            "- Re-check import cycles after edits ({} detected).",
+            graph.cycles.len()
+        );
+    }
+    if !graph.risky_clusters.is_empty() {
+        let _ = writeln!(out, "- Re-run the scan and verify risky clusters shrink.");
+    }
+    if graph.changed_blast_radius.is_empty()
+        && graph.cycles.is_empty()
+        && graph.risky_clusters.is_empty()
+    {
+        let _ = writeln!(out, "- Use the focused scan and review commands below.");
+    }
+}
+
+fn render_graph_file_list(out: &mut String, title: &str, files: &[std::path::PathBuf]) {
+    let _ = writeln!(out, "\n### {title}");
+    if files.is_empty() {
+        let _ = writeln!(out, "- No import-based downstream files detected.");
+        return;
+    }
+    for path in files.iter().take(10) {
+        let _ = writeln!(out, "- `{}`", path.display());
+    }
+}
+
+fn render_graph_metrics(out: &mut String, title: &str, graph: &ContextGraphSummary) {
+    let _ = writeln!(out, "\n### {title}");
+    let mut rendered = 0usize;
+    for metric in graph.top_dependencies.iter().take(5) {
+        render_graph_metric(out, "dependency", metric);
+        rendered += 1;
+    }
+    for metric in graph.top_hubs.iter().take(5usize.saturating_sub(rendered)) {
+        render_graph_metric(out, "hub", metric);
+    }
+    if rendered == 0 && graph.top_hubs.is_empty() {
+        let _ = writeln!(out, "- No shared dependency or hub files detected.");
+    }
+}
+
+fn render_graph_metric(out: &mut String, label: &str, metric: &ContextGraphFileMetric) {
+    let _ = writeln!(
+        out,
+        "- `{}`: {label}, fan-in {}, fan-out {}, instability {:.2}",
+        metric.path.display(),
+        metric.fan_in,
+        metric.fan_out,
+        metric.instability
     );
 }
 

--- a/src/output/console/findings.rs
+++ b/src/output/console/findings.rs
@@ -1,7 +1,8 @@
 use crate::findings::types::Finding;
 use crate::output::color;
 use crate::output::report_stats::{
-    category_order, findings_for_category, findings_for_rule, first_location, rule_ids_for_findings,
+    category_order, first_location, indexed_findings_for_category, indexed_findings_for_rule,
+    rule_ids_for_indexed_findings,
 };
 use crate::output::report_text::{category_title, first_sentence};
 use std::fmt::Write;
@@ -18,21 +19,17 @@ where
     }
 
     for category in category_order() {
-        let category_findings = findings_for_category(findings, &category);
+        let category_findings = indexed_findings_for_category(findings, &category);
         if category_findings.is_empty() {
             continue;
         }
 
         writeln!(output, "  {}:", category_title(&category)).unwrap();
-        let rules = rule_ids_for_findings(&category_findings);
+        let rules = rule_ids_for_indexed_findings(&category_findings);
         for rule_id in rules {
-            let rule_findings = findings_for_rule(&category_findings, &rule_id);
+            let rule_findings = indexed_findings_for_rule(&category_findings, &rule_id);
             writeln!(output, "    {} ({})", rule_id, rule_findings.len()).unwrap();
-            for finding in rule_findings {
-                let index = findings
-                    .iter()
-                    .position(|candidate| std::ptr::eq(candidate, finding))
-                    .unwrap_or(0);
+            for (index, finding) in rule_findings {
                 render_finding(output, finding, status_for(index));
             }
         }

--- a/src/output/html/finding.rs
+++ b/src/output/html/finding.rs
@@ -1,7 +1,8 @@
 use super::escape::escape_html;
 use crate::findings::types::{Finding, FindingCategory};
 use crate::output::report_stats::{
-    category_order, findings_for_category, findings_for_rule, first_location, rule_ids_for_findings,
+    category_order, first_location, indexed_findings_for_category, indexed_findings_for_rule,
+    rule_ids_for_indexed_findings,
 };
 use crate::scan::types::ScanSummary;
 
@@ -15,7 +16,7 @@ where
 
     let mut output = String::new();
     for category in category_order() {
-        let category_findings = findings_for_category(&summary.findings, &category);
+        let category_findings = indexed_findings_for_category(&summary.findings, &category);
         if category_findings.is_empty() {
             continue;
         }
@@ -26,21 +27,16 @@ where
             category_title(&category)
         ));
 
-        let rules = rule_ids_for_findings(&category_findings);
+        let rules = rule_ids_for_indexed_findings(&category_findings);
         for rule_id in rules {
-            let rule_findings = findings_for_rule(&category_findings, &rule_id);
+            let rule_findings = indexed_findings_for_rule(&category_findings, &rule_id);
             output.push_str(&format!(
                 r#"<section class="rule-group" data-rule="{}"><h4><code>{}</code> ({})</h4>"#,
                 escape_html(&rule_id),
                 escape_html(&rule_id),
                 rule_findings.len()
             ));
-            for finding in rule_findings {
-                let index = summary
-                    .findings
-                    .iter()
-                    .position(|candidate| std::ptr::eq(candidate, finding))
-                    .unwrap_or(0);
+            for (index, finding) in rule_findings {
                 output.push_str(&render_finding_card(finding, status_for(index)));
             }
             output.push_str("</section>");

--- a/src/output/markdown/findings.rs
+++ b/src/output/markdown/findings.rs
@@ -2,7 +2,8 @@ use crate::baseline::diff::BaselineScanReport;
 use crate::findings::types::{Finding, Severity};
 use crate::output::render_helpers::escape_table_cell;
 use crate::output::report_stats::{
-    category_order, findings_for_category, findings_for_rule, first_location, rule_ids_for_findings,
+    category_order, first_location, indexed_findings_for_category, indexed_findings_for_rule,
+    rule_ids_for_indexed_findings,
 };
 use crate::output::report_text::{category_label_rank, category_title, first_sentence};
 use std::collections::BTreeMap;
@@ -71,22 +72,18 @@ where
     }
 
     for category in category_order() {
-        let category_findings = findings_for_category(findings, &category);
+        let category_findings = indexed_findings_for_category(findings, &category);
         if category_findings.is_empty() {
             continue;
         }
 
         writeln!(output, "### {}\n", category_title(&category)).unwrap();
-        let rules = rule_ids_for_findings(&category_findings);
+        let rules = rule_ids_for_indexed_findings(&category_findings);
         for rule_id in rules {
-            let rule_findings = findings_for_rule(&category_findings, &rule_id);
+            let rule_findings = indexed_findings_for_rule(&category_findings, &rule_id);
             writeln!(output, "#### `{rule_id}` ({})\n", rule_findings.len()).unwrap();
 
-            for finding in rule_findings {
-                let index = findings
-                    .iter()
-                    .position(|candidate| std::ptr::eq(candidate, finding))
-                    .unwrap_or(0);
+            for (index, finding) in rule_findings {
                 render_finding_detail(output, finding, status_for(index));
             }
         }

--- a/src/output/report_stats.rs
+++ b/src/output/report_stats.rs
@@ -138,37 +138,37 @@ pub(crate) fn category_order() -> [FindingCategory; 5] {
     ]
 }
 
-pub(crate) fn sorted_findings(findings: &[Finding]) -> Vec<&Finding> {
-    let mut sorted = findings.iter().collect::<Vec<_>>();
-    sorted.sort_by(|left, right| crate::risk::compare_findings(left, right));
+pub(crate) fn indexed_sorted_findings(findings: &[Finding]) -> Vec<(usize, &Finding)> {
+    let mut sorted = findings.iter().enumerate().collect::<Vec<_>>();
+    sorted.sort_by(|(_, left), (_, right)| crate::risk::compare_findings(left, right));
     sorted
 }
 
-pub(crate) fn findings_for_category<'a>(
+pub(crate) fn indexed_findings_for_category<'a>(
     findings: &'a [Finding],
     category: &FindingCategory,
-) -> Vec<&'a Finding> {
-    sorted_findings(findings)
+) -> Vec<(usize, &'a Finding)> {
+    indexed_sorted_findings(findings)
         .into_iter()
-        .filter(|finding| &finding.category == category)
+        .filter(|(_, finding)| &finding.category == category)
         .collect()
 }
 
-pub(crate) fn findings_for_rule<'a>(
-    findings: &'a [&'a Finding],
+pub(crate) fn indexed_findings_for_rule<'a>(
+    findings: &[(usize, &'a Finding)],
     rule_id: &str,
-) -> Vec<&'a Finding> {
+) -> Vec<(usize, &'a Finding)> {
     findings
         .iter()
         .copied()
-        .filter(|finding| finding.rule_id == rule_id)
+        .filter(|(_, finding)| finding.rule_id == rule_id)
         .collect()
 }
 
-pub(crate) fn rule_ids_for_findings(findings: &[&Finding]) -> Vec<String> {
+pub(crate) fn rule_ids_for_indexed_findings(findings: &[(usize, &Finding)]) -> Vec<String> {
     let mut rules = findings
         .iter()
-        .map(|finding| finding.rule_id.clone())
+        .map(|(_, finding)| finding.rule_id.clone())
         .collect::<Vec<_>>();
     rules.sort();
     rules.dedup();

--- a/src/report/schema.rs
+++ b/src/report/schema.rs
@@ -4,6 +4,7 @@ use crate::findings::feedback::LocalFeedbackReport;
 use crate::findings::types::Finding;
 use crate::frameworks::{DetectedFramework, FrameworkProject, ReactNativeArchitectureProfile};
 use crate::graph::CouplingGraph;
+use crate::graph::context::{ContextGraphCacheInfo, ContextGraphSummary};
 use crate::review::diff::ChangedFile;
 use crate::review::model::{ReviewReport, SeverityCounts};
 use crate::risk::RiskSummary;
@@ -16,7 +17,8 @@ use serde_json::Value;
 use std::io;
 use std::path::PathBuf;
 
-pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.15";
+pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.16";
+const ACCEPTED_SCAN_REPORT_SCHEMA_VERSIONS: &[&str] = &["0.15", SCAN_REPORT_SCHEMA_VERSION];
 pub const REPOPILOT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -82,6 +84,10 @@ pub struct ScanJsonReport<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub react_native: Option<&'a ReactNativeArchitectureProfile>,
     pub coupling_graph: Option<&'a CouplingGraph>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_graph_summary: Option<&'a ContextGraphSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_graph_cache: Option<&'a ContextGraphCacheInfo>,
     pub scan_duration_us: u64,
     pub health_score: u8,
     pub visible_findings_count: usize,
@@ -131,6 +137,8 @@ impl<'a> ScanJsonReport<'a> {
             framework_projects: &summary.framework_projects,
             react_native: summary.react_native.as_ref(),
             coupling_graph: summary.coupling_graph.as_ref(),
+            context_graph_summary: summary.context_graph_summary.as_ref(),
+            context_graph_cache: summary.context_graph_cache.as_ref(),
             scan_duration_us: summary.scan_duration_us,
             health_score: summary.health_score,
             visible_findings_count: summary.visible_findings_count,
@@ -175,6 +183,10 @@ pub struct BaselineJsonReport<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_telemetry: Option<&'a ScanCacheTelemetry>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_graph_summary: Option<&'a ContextGraphSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_graph_cache: Option<&'a ContextGraphCacheInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub local_feedback: Option<&'a LocalFeedbackReport>,
     #[serde(skip_serializing_if = "diagnostics_empty")]
     pub diagnostics: &'a [ScanDiagnostic],
@@ -208,6 +220,8 @@ impl<'a> BaselineJsonReport<'a> {
             hidden_suggestions: &report.summary.hidden_suggestions,
             visibility_profile: report.summary.visibility_profile.as_deref(),
             cache_telemetry: report.summary.cache_telemetry.as_ref(),
+            context_graph_summary: report.summary.context_graph_summary.as_ref(),
+            context_graph_cache: report.summary.context_graph_cache.as_ref(),
             local_feedback: report.summary.local_feedback.as_ref(),
             diagnostics: &report.summary.diagnostics,
             languages: &report.summary.languages,
@@ -248,6 +262,10 @@ pub struct ReviewJsonReport<'a> {
     pub non_empty_lines: usize,
     pub changed_files: &'a [ChangedFile],
     pub blast_radius: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_graph_summary: Option<&'a ContextGraphSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_graph_cache: Option<&'a ContextGraphCacheInfo>,
     pub review: ReviewJsonMetadata,
     pub risk_summary: RiskSummary,
     pub signal_quality: crate::findings::quality::SignalQualitySummary,
@@ -278,6 +296,8 @@ impl<'a> ReviewJsonReport<'a> {
                 .iter()
                 .map(|path| path.to_string_lossy().to_string())
                 .collect(),
+            context_graph_summary: report.summary.context_graph_summary.as_ref(),
+            context_graph_cache: report.summary.context_graph_cache.as_ref(),
             review: ReviewJsonMetadata {
                 in_diff_findings: report.in_diff_count(),
                 out_of_diff_findings: report.out_of_diff_count(),
@@ -398,9 +418,9 @@ fn validate_current_scan_report(value: &Value) -> Result<(), serde_json::Error> 
         .and_then(|report| report.get("schema_version"))
         .and_then(Value::as_str);
 
-    if schema_version == Some(SCAN_REPORT_SCHEMA_VERSION)
+    if schema_version.is_some_and(is_accepted_scan_schema_version)
         && report_kind == Some("scan")
-        && report_schema_version == Some(SCAN_REPORT_SCHEMA_VERSION)
+        && report_schema_version.is_some_and(is_accepted_scan_schema_version)
     {
         return Ok(());
     }
@@ -412,4 +432,8 @@ fn validate_current_scan_report(value: &Value) -> Result<(), serde_json::Error> 
             SCAN_REPORT_SCHEMA_VERSION
         ),
     )))
+}
+
+fn is_accepted_scan_schema_version(version: &str) -> bool {
+    ACCEPTED_SCAN_REPORT_SCHEMA_VERSIONS.contains(&version)
 }

--- a/src/review/diff.rs
+++ b/src/review/diff.rs
@@ -130,6 +130,7 @@ pub fn load_changed_files(
         files.extend(load_untracked_files(repo_root, pathspec)?);
     }
 
+    files.retain(|file| !is_repopilot_internal_path(&file.path));
     files.sort_by(|left, right| left.path.cmp(&right.path));
     Ok(files)
 }
@@ -266,6 +267,11 @@ fn load_untracked_files(
         .collect()
 }
 
+fn is_repopilot_internal_path(path: &Path) -> bool {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    normalized == ".repopilot" || normalized.starts_with(".repopilot/")
+}
+
 fn git_output(cwd: &Path, args: &[&str], command_label: &str) -> Result<String, GitDiffError> {
     let output = Command::new("git").args(args).current_dir(cwd).output()?;
 
@@ -320,4 +326,20 @@ fn parse_hunk_added_range(line: &str) -> Option<ChangedRange> {
         start,
         end: start + count - 1,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repopilot_internal_paths_are_excluded_from_review_scope() {
+        assert!(is_repopilot_internal_path(Path::new(
+            ".repopilot/cache/repo_context.json"
+        )));
+        assert!(is_repopilot_internal_path(Path::new(
+            r".repopilot\cache\repo_context.json"
+        )));
+        assert!(!is_repopilot_internal_path(Path::new("src/lib.rs")));
+    }
 }

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -173,6 +173,8 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
         react_native: report.summary.react_native.clone(),
         findings: in_diff_findings,
         coupling_graph: report.summary.coupling_graph.clone(),
+        context_graph_summary: report.summary.context_graph_summary.clone(),
+        context_graph_cache: report.summary.context_graph_cache.clone(),
         scan_duration_us: report.summary.scan_duration_us,
         health_score: 0,
         visible_findings_count: 0,

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -17,6 +17,10 @@ use crate::frameworks::{
     DetectedFramework, detect_framework_projects, detect_frameworks,
     detect_react_native_architecture,
 };
+use crate::graph::context::{
+    ContextGraphCacheInfo, RepoContextGraph, cache_diagnostic, context_graph_cache_miss,
+    load_repo_context_graph, summarize_context_graph, write_repo_context_graph,
+};
 use crate::graph::{CouplingGraph, build_coupling_graph};
 use crate::review::diff::{ChangeStatus, ChangedFile};
 use crate::risk::{apply_cluster_overlay, apply_graph_overlay, assess_findings};
@@ -25,9 +29,10 @@ use crate::scan::cache::{
     relative_cache_path,
 };
 use crate::scan::config::ScanConfig;
-use crate::scan::facts::ScanFacts;
+use crate::scan::facts::{FileFacts, ScanFacts};
 use crate::scan::types::{
-    ChangedFileCacheTelemetry, ScanCacheTelemetry, ScanMode, ScanSummary, ScanTimings,
+    ChangedFileCacheTelemetry, ScanCacheTelemetry, ScanDiagnostic, ScanMode, ScanSummary,
+    ScanTimings,
 };
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io;
@@ -57,6 +62,7 @@ struct ChangedDiscoveryStage {
 struct ChangedFileAnalysisStage {
     facts: ScanFacts,
     findings: Vec<Finding>,
+    graph_patch_files: Vec<FileFacts>,
     cache: ScanCache,
     cache_telemetry: ScanCacheTelemetry,
     changed_file_reasons: BTreeMap<String, usize>,
@@ -66,6 +72,9 @@ struct ChangedFileAnalysisStage {
 struct ChangedRepoContextStage {
     repo_context: ScanFacts,
     coupling_graph: CouplingGraph,
+    context_graph: RepoContextGraph,
+    cache_info: ContextGraphCacheInfo,
+    diagnostics: Vec<ScanDiagnostic>,
     elapsed_us: u64,
 }
 
@@ -89,8 +98,15 @@ impl<'a> ChangedScanEngine<'a> {
     fn run(self) -> io::Result<ScanSummary> {
         let start = Instant::now();
         let discovery = self.run_discovery()?;
+        if discovery.changed_files.is_empty() {
+            return self.finalize_empty_changed(start, discovery);
+        }
         let mut file_stage = self.run_file_analysis(&discovery)?;
-        let repo_stage = self.run_repo_context(&discovery.repo_root, &mut file_stage.facts)?;
+        let repo_stage = self.run_repo_context(
+            &discovery,
+            &mut file_stage.facts,
+            &file_stage.graph_patch_files,
+        )?;
         let enrichment_us = enrich_findings_timed(&mut file_stage.findings, &discovery.repo_root);
         let risk_scoring_us = self.score_findings(&repo_stage, &mut file_stage.findings);
         let contract_stage =
@@ -144,6 +160,7 @@ impl<'a> ChangedScanEngine<'a> {
         };
         let mut languages: HashMap<String, usize> = HashMap::new();
         let mut findings = Vec::new();
+        let mut graph_patch_files = Vec::new();
         let mut directories = HashSet::new();
         let mut changed_file_reasons: BTreeMap<String, usize> = BTreeMap::new();
 
@@ -160,6 +177,7 @@ impl<'a> ChangedScanEngine<'a> {
                 &mut cache,
                 &mut cache_telemetry,
                 &mut changed_file_reasons,
+                &mut graph_patch_files,
             )?;
         }
 
@@ -169,6 +187,7 @@ impl<'a> ChangedScanEngine<'a> {
         Ok(ChangedFileAnalysisStage {
             facts,
             findings,
+            graph_patch_files,
             cache,
             cache_telemetry,
             changed_file_reasons,
@@ -190,6 +209,7 @@ impl<'a> ChangedScanEngine<'a> {
         cache: &mut ScanCache,
         cache_telemetry: &mut ScanCacheTelemetry,
         changed_file_reasons: &mut BTreeMap<String, usize>,
+        graph_patch_files: &mut Vec<FileFacts>,
     ) -> io::Result<()> {
         let change_reason = change_status_label(changed_file.status).to_string();
         *changed_file_reasons
@@ -310,6 +330,10 @@ impl<'a> ChangedScanEngine<'a> {
                     },
                 );
 
+                let mut graph_file = per_file.file_facts.clone();
+                graph_file.content = None;
+                graph_patch_files.push(graph_file);
+
                 facts.files.push(per_file.file_facts);
                 findings.extend(per_file.findings);
             }
@@ -378,10 +402,38 @@ impl<'a> ChangedScanEngine<'a> {
 
     fn run_repo_context(
         &self,
-        repo_root: &Path,
+        discovery: &ChangedDiscoveryStage,
         facts: &mut ScanFacts,
+        graph_patch_files: &[FileFacts],
     ) -> io::Result<ChangedRepoContextStage> {
         let start = Instant::now();
+        let mut diagnostics = Vec::new();
+        let repo_root = &discovery.repo_root;
+
+        if let Some(mut load) = load_repo_context_graph(repo_root, self.config) {
+            load.graph
+                .apply_changed_facts(repo_root, &discovery.changed_files, graph_patch_files);
+            if let Err(error) = write_repo_context_graph(repo_root, self.config, &load.graph) {
+                diagnostics.push(cache_diagnostic(&error));
+            }
+
+            let repo_context = load.graph.to_scan_facts();
+            let coupling_graph = load.graph.coupling_graph();
+
+            facts.detected_frameworks = repo_context.detected_frameworks.clone();
+            facts.framework_projects = repo_context.framework_projects.clone();
+            facts.react_native = repo_context.react_native.clone();
+
+            return Ok(ChangedRepoContextStage {
+                repo_context,
+                coupling_graph,
+                context_graph: load.graph,
+                cache_info: load.cache_info,
+                diagnostics,
+                elapsed_us: start.elapsed().as_micros() as u64,
+            });
+        }
+
         let mut repo_context =
             super::collection::collect_scan_facts_without_content(repo_root, self.config)?;
 
@@ -391,6 +443,16 @@ impl<'a> ChangedScanEngine<'a> {
 
         let coupling_graph =
             relative_coupling_graph(build_coupling_graph(&repo_context, repo_root), repo_root);
+        let context_graph =
+            RepoContextGraph::from_scan_facts(&repo_context, repo_root, coupling_graph.clone());
+        let mut cache_info =
+            context_graph_cache_miss(repo_root, "missing-or-invalid-context-graph-cache");
+        match write_repo_context_graph(repo_root, self.config, &context_graph) {
+            Ok(_) => {
+                cache_info.reason.push_str("; cache-updated");
+            }
+            Err(error) => diagnostics.push(cache_diagnostic(&error)),
+        }
 
         facts.detected_frameworks = repo_context.detected_frameworks.clone();
         facts.framework_projects = repo_context.framework_projects.clone();
@@ -399,6 +461,9 @@ impl<'a> ChangedScanEngine<'a> {
         Ok(ChangedRepoContextStage {
             repo_context,
             coupling_graph,
+            context_graph,
+            cache_info,
+            diagnostics,
             elapsed_us: start.elapsed().as_micros() as u64,
         })
     }
@@ -426,6 +491,13 @@ impl<'a> ChangedScanEngine<'a> {
         let finalization_start = Instant::now();
 
         super::summary::sort_findings(&mut file_stage.findings);
+        let context_graph_summary = summarize_context_graph(
+            &repo_stage.context_graph,
+            &file_stage.findings,
+            &discovery.changed_files,
+        );
+        let mut diagnostics = repo_stage.diagnostics;
+        diagnostics.extend(finding_pipeline.diagnostics);
 
         let cache_write_start = Instant::now();
         file_stage.cache.write(&discovery.repo_root)?;
@@ -463,7 +535,9 @@ impl<'a> ChangedScanEngine<'a> {
                     report_finalization_us: 0,
                 }),
                 cache_telemetry: Some(file_stage.cache_telemetry),
-                diagnostics: finding_pipeline.diagnostics,
+                context_graph_summary: Some(context_graph_summary),
+                context_graph_cache: Some(repo_stage.cache_info),
+                diagnostics,
                 signal_quality: finding_pipeline.signal_quality,
             },
         );
@@ -472,6 +546,50 @@ impl<'a> ChangedScanEngine<'a> {
             timings.report_finalization_us = finalization_start.elapsed().as_micros() as u64;
         }
 
+        Ok(summary)
+    }
+
+    fn finalize_empty_changed(
+        &self,
+        scan_start: Instant,
+        discovery: ChangedDiscoveryStage,
+    ) -> io::Result<ScanSummary> {
+        let finalization_start = Instant::now();
+        let scan_duration_us = scan_start.elapsed().as_micros() as u64;
+        let mut summary = build_scan_summary(
+            ScanFacts {
+                root_path: self.path.to_path_buf(),
+                ..ScanFacts::default()
+            },
+            Vec::new(),
+            ScanSummaryParts {
+                mode: ScanMode::Changed,
+                base_ref: self.base_ref.map(str::to_string),
+                changed_files_count: 0,
+                repo_level_rules_included: false,
+                coupling_graph: None,
+                scan_duration_us,
+                scan_timings: Some(ScanTimings {
+                    discovery_us: discovery.elapsed_us,
+                    file_analysis_us: 0,
+                    file_scan_us: discovery.elapsed_us,
+                    framework_detection_us: 0,
+                    post_scan_audits_us: 0,
+                    enrichment_us: 0,
+                    risk_scoring_us: 0,
+                    contract_validation_us: 0,
+                    report_finalization_us: 0,
+                }),
+                cache_telemetry: None,
+                context_graph_summary: None,
+                context_graph_cache: None,
+                diagnostics: Vec::new(),
+                signal_quality: SignalQualitySummary::default(),
+            },
+        );
+        if let Some(timings) = &mut summary.scan_timings {
+            timings.report_finalization_us = finalization_start.elapsed().as_micros() as u64;
+        }
         Ok(summary)
     }
 }

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -15,6 +15,9 @@ use crate::frameworks::{
     DetectedFramework, detect_framework_projects, detect_frameworks,
     detect_react_native_architecture,
 };
+use crate::graph::context::{
+    RepoContextGraph, cache_diagnostic, summarize_context_graph, write_repo_context_graph,
+};
 use crate::knowledge::decision::apply_project_decisions;
 use crate::risk::{apply_cluster_overlay, apply_graph_overlay, assess_findings};
 use crate::scan::config::ScanConfig;
@@ -118,11 +121,29 @@ impl<'a> ScanEngine<'a> {
         mut project_stage: ProjectAnalysisStage,
         scan_duration_us: u64,
         timings: ScanTimings,
-        diagnostics: Vec<crate::scan::types::ScanDiagnostic>,
+        mut diagnostics: Vec<crate::scan::types::ScanDiagnostic>,
         signal_quality: crate::findings::quality::SignalQualitySummary,
     ) -> ScanSummary {
         let finalization_start = Instant::now();
         summary::sort_findings(&mut project_stage.findings);
+        let context_graph = RepoContextGraph::from_scan_facts(
+            &project_stage.facts,
+            &project_stage.facts.root_path,
+            project_stage.coupling_graph.clone(),
+        );
+        let context_graph_summary =
+            summarize_context_graph(&context_graph, &project_stage.findings, &[]);
+        let context_graph_cache = match write_repo_context_graph(
+            &project_stage.facts.root_path,
+            self.config,
+            &context_graph,
+        ) {
+            Ok(cache_info) => Some(cache_info),
+            Err(error) => {
+                diagnostics.push(cache_diagnostic(&error));
+                None
+            }
+        };
         let mut summary = build_scan_summary(
             project_stage.facts,
             project_stage.findings,
@@ -137,6 +158,8 @@ impl<'a> ScanEngine<'a> {
                 cache_telemetry: None,
                 diagnostics,
                 signal_quality,
+                context_graph_summary: Some(context_graph_summary),
+                context_graph_cache,
             },
         );
         if let Some(timings) = &mut summary.scan_timings {

--- a/src/scan/scanner/summary.rs
+++ b/src/scan/scanner/summary.rs
@@ -1,6 +1,9 @@
 use crate::findings::quality::SignalQualitySummary;
 use crate::findings::types::Finding;
 use crate::graph::CouplingGraph;
+use crate::graph::context::{
+    ContextGraphCacheInfo, ContextGraphSummary, RepoContextGraph, summarize_context_graph,
+};
 use crate::scan::facts::ScanFacts;
 use crate::scan::types::LanguageSummary;
 use crate::scan::types::{ScanCacheTelemetry, ScanDiagnostic, ScanMode, ScanSummary, ScanTimings};
@@ -38,6 +41,8 @@ pub(super) struct ScanSummaryParts {
     pub(super) scan_timings: Option<ScanTimings>,
     pub(super) cache_telemetry: Option<ScanCacheTelemetry>,
     pub(super) coupling_graph: Option<CouplingGraph>,
+    pub(super) context_graph_summary: Option<ContextGraphSummary>,
+    pub(super) context_graph_cache: Option<ContextGraphCacheInfo>,
     pub(super) diagnostics: Vec<ScanDiagnostic>,
     pub(super) signal_quality: SignalQualitySummary,
 }
@@ -49,6 +54,20 @@ pub(super) fn build_scan_summary(
 ) -> ScanSummary {
     let health_score = ScanSummary::compute_health_score(&findings, facts.non_empty_lines);
     let visible_findings_count = findings.len();
+    let context_graph_summary =
+        parts
+            .context_graph_summary
+            .or_else(|| match parts.coupling_graph.as_ref() {
+                Some(coupling_graph) => {
+                    let graph = RepoContextGraph::from_scan_facts(
+                        &facts,
+                        &facts.root_path,
+                        coupling_graph.clone(),
+                    );
+                    Some(summarize_context_graph(&graph, &findings, &[]))
+                }
+                None => None,
+            });
 
     ScanSummary {
         root_path: facts.root_path,
@@ -70,6 +89,8 @@ pub(super) fn build_scan_summary(
         react_native: facts.react_native,
         findings,
         coupling_graph: parts.coupling_graph,
+        context_graph_summary,
+        context_graph_cache: parts.context_graph_cache,
         scan_duration_us: parts.scan_duration_us,
         health_score,
         visible_findings_count,

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -5,6 +5,7 @@ use crate::frameworks::DetectedFramework;
 use crate::frameworks::FrameworkProject;
 use crate::frameworks::ReactNativeArchitectureProfile;
 use crate::graph::CouplingGraph;
+use crate::graph::context::{ContextGraphCacheInfo, ContextGraphSummary};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -214,6 +215,10 @@ pub struct ScanSummary {
     pub react_native: Option<ReactNativeArchitectureProfile>,
     #[serde(default)]
     pub coupling_graph: Option<CouplingGraph>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_graph_summary: Option<ContextGraphSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_graph_cache: Option<ContextGraphCacheInfo>,
     #[serde(default)]
     pub scan_duration_us: u64,
     /// 0–100 health score: 100 = no findings, decreases with severity-weighted finding density.
@@ -278,6 +283,8 @@ impl Default for ScanSummary {
             framework_projects: Vec::new(),
             react_native: None,
             coupling_graph: None,
+            context_graph_summary: None,
+            context_graph_cache: None,
             scan_duration_us: 0,
             health_score: 0,
             visible_findings_count: 0,

--- a/tests/ai_plan_prompt_command.rs
+++ b/tests/ai_plan_prompt_command.rs
@@ -55,6 +55,8 @@ fn ai_plan_default_output_succeeds() {
     assert!(stdout.contains("P0 - Immediate risk"));
     assert!(stdout.contains("Possible secret detected"));
     assert!(stdout.contains("Move the value to an environment variable or secrets manager"));
+    assert!(stdout.contains("## Context Risk Graph"));
+    assert!(stdout.contains("### Edit Order"));
     assert!(stdout.contains("## Verify"));
 }
 

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -83,6 +83,8 @@ fn summary(findings: Vec<Finding>) -> ScanSummary {
         framework_projects: vec![],
         react_native: None,
         coupling_graph: None,
+        context_graph_summary: None,
+        context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
         visible_findings_count,

--- a/tests/fixtures/reports/scan-v016.json
+++ b/tests/fixtures/reports/scan-v016.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "0.16",
+  "repopilot_version": "0.13.0",
+  "report": {
+    "kind": "scan",
+    "schema_version": "0.16",
+    "repopilot_version": "0.13.0"
+  },
+  "root_path": ".",
+  "mode": "full",
+  "changed_files_count": 0,
+  "repo_level_rules_included": true,
+  "files_discovered": 2,
+  "files_analyzed": 2,
+  "directories_count": 1,
+  "non_empty_lines": 12,
+  "large_files_skipped": 0,
+  "files_skipped_low_signal": 0,
+  "binary_files_skipped": 0,
+  "skipped_bytes": 0,
+  "languages": [],
+  "findings": [],
+  "detected_frameworks": [],
+  "framework_projects": [],
+  "coupling_graph": null,
+  "context_graph_summary": {
+    "files": 2,
+    "import_edges": 0
+  },
+  "context_graph_cache": {
+    "status": "write",
+    "reason": "context-graph-cache-updated",
+    "cache_path": ".repopilot/cache/repo_context.json"
+  },
+  "scan_duration_us": 100,
+  "health_score": 100,
+  "visible_findings_count": 0,
+  "hidden_suggestions_count": 0,
+  "files_skipped_by_limit": 0,
+  "files_skipped_repopilotignore": 0,
+  "diagnostics": [
+    {
+      "code": "workspace.package-scan-failed",
+      "severity": "warning",
+      "message": "Package scan failed; results are partial.",
+      "path": "packages/api"
+    }
+  ],
+  "risk_summary": {
+    "total": 0,
+    "average_score": 0,
+    "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 }
+  },
+  "signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  }
+}

--- a/tests/inspect_graph_cli.rs
+++ b/tests/inspect_graph_cli.rs
@@ -1,0 +1,67 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+#[test]
+fn inspect_graph_renders_json_contract() {
+    let temp = tempdir().expect("temp dir");
+    write_graph_fixture(temp.path());
+
+    let output = repopilot()
+        .args(["inspect", "graph", ".", "--format", "json"])
+        .current_dir(temp.path())
+        .output()
+        .expect("inspect graph json");
+
+    assert!(
+        output.status.success(),
+        "inspect graph failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("graph json");
+
+    assert_eq!(json["kind"], "context-graph");
+    assert_eq!(json["context_graph_summary"]["files"], 2);
+    assert_eq!(json["context_graph_cache"]["status"], "write");
+    assert!(
+        temp.path()
+            .join(".repopilot/cache/repo_context.json")
+            .is_file()
+    );
+}
+
+#[test]
+fn inspect_graph_renders_markdown_contract() {
+    let temp = tempdir().expect("temp dir");
+    write_graph_fixture(temp.path());
+
+    let output = repopilot()
+        .args(["inspect", "graph", ".", "--format", "markdown"])
+        .current_dir(temp.path())
+        .output()
+        .expect("inspect graph markdown");
+
+    assert!(output.status.success());
+    let markdown = String::from_utf8_lossy(&output.stdout);
+
+    assert!(markdown.contains("# RepoPilot Context Risk Graph"));
+    assert!(markdown.contains("## Top Dependencies"));
+    assert!(markdown.contains("## Risky Clusters"));
+}
+
+fn write_graph_fixture(root: &Path) {
+    fs::create_dir_all(root.join("src")).expect("create src");
+    fs::write(
+        root.join("src/lib.rs"),
+        "mod a;\npub fn lib() { a::a(); }\n",
+    )
+    .expect("write lib");
+    fs::write(root.join("src/a.rs"), "pub fn a() {}\n").expect("write a");
+}

--- a/tests/output_console.rs
+++ b/tests/output_console.rs
@@ -1,5 +1,6 @@
+use repopilot::baseline::diff::{BaselineScanReport, BaselineStatus, FindingBaselineStatus};
 use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
-use repopilot::output::{OutputFormat, render_scan_summary};
+use repopilot::output::{OutputFormat, render_baseline_scan_report, render_scan_summary};
 use repopilot::scan::types::{
     ChangedFileCacheTelemetry, ChangedFileReasonSummary, HiddenSuggestionSummary,
     ScanCacheTelemetry, ScanCacheTimings, ScanSummary,
@@ -114,6 +115,22 @@ fn console_output_includes_cache_telemetry_for_changed_scans() {
     assert!(output.contains("src/lib.rs: hit (modified, unchanged-content-and-config)"));
 }
 
+#[test]
+fn console_baseline_status_stays_aligned_for_duplicate_findings() {
+    let report = duplicate_status_report();
+
+    let output = render_baseline_scan_report(&report, OutputFormat::Console, None)
+        .expect("failed to render baseline console");
+
+    let existing = output
+        .find("Baseline: existing")
+        .expect("existing status should render");
+    let new = output
+        .find("Baseline: new")
+        .expect("new status should render");
+    assert!(existing < new);
+}
+
 fn cache_telemetry() -> ScanCacheTelemetry {
     ScanCacheTelemetry {
         hits: 1,
@@ -139,5 +156,52 @@ fn cache_telemetry() -> ScanCacheTelemetry {
             write_us: 6_000,
             estimated_time_saved_us: Some(7_000),
         },
+    }
+}
+
+fn duplicate_status_report() -> BaselineScanReport {
+    BaselineScanReport {
+        summary: ScanSummary {
+            root_path: PathBuf::from("demo"),
+            findings: vec![
+                duplicate_finding("existing", 7),
+                duplicate_finding("new", 8),
+            ],
+            ..ScanSummary::default()
+        },
+        baseline_path: None,
+        findings: vec![
+            FindingBaselineStatus {
+                key: "existing".to_string(),
+                status: BaselineStatus::Existing,
+            },
+            FindingBaselineStatus {
+                key: "new".to_string(),
+                status: BaselineStatus::New,
+            },
+        ],
+    }
+}
+
+fn duplicate_finding(id: &str, line: usize) -> Finding {
+    Finding {
+        id: id.to_string(),
+        rule_id: "code-quality.long-function".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("code-quality.long-function"),
+        title: "Duplicate-looking finding".to_string(),
+        description: "Duplicate-looking finding for renderer status alignment.".to_string(),
+        category: FindingCategory::CodeQuality,
+        severity: Severity::Medium,
+        confidence: Default::default(),
+        evidence: vec![Evidence {
+            path: PathBuf::from("src/lib.rs"),
+            line_start: line,
+            line_end: None,
+            snippet: "fn duplicate() {}".to_string(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+        provenance: Default::default(),
+        risk: Default::default(),
     }
 }

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -1,5 +1,6 @@
+use repopilot::baseline::diff::{BaselineScanReport, BaselineStatus, FindingBaselineStatus};
 use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
-use repopilot::output::{OutputFormat, render_scan_summary};
+use repopilot::output::{OutputFormat, render_baseline_scan_report, render_scan_summary};
 use repopilot::scan::types::{HiddenSuggestionSummary, ScanSummary};
 use std::path::PathBuf;
 
@@ -44,6 +45,8 @@ fn html_output_escapes_snippets_and_renders_summary() {
         }],
         react_native: None,
         coupling_graph: None,
+        context_graph_summary: None,
+        context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
         visible_findings_count: 1,
@@ -103,4 +106,67 @@ fn html_output_includes_hidden_suggestion_breakdown() {
     assert!(html.contains("Top Hidden Suggestions"));
     assert!(html.contains("language.javascript.runtime-exit-risk"));
     assert!(html.contains("code-quality"));
+}
+
+#[test]
+fn html_baseline_status_stays_aligned_for_duplicate_findings() {
+    let report = duplicate_status_report();
+
+    let html = render_baseline_scan_report(&report, OutputFormat::Html, None)
+        .expect("failed to render baseline html");
+
+    let existing = html
+        .find("baseline: existing")
+        .expect("existing status should render");
+    let new = html
+        .find("baseline: new")
+        .expect("new status should render");
+    assert!(existing < new);
+}
+
+fn duplicate_status_report() -> BaselineScanReport {
+    BaselineScanReport {
+        summary: ScanSummary {
+            root_path: PathBuf::from("demo"),
+            findings: vec![
+                duplicate_finding("existing", 7),
+                duplicate_finding("new", 8),
+            ],
+            ..ScanSummary::default()
+        },
+        baseline_path: None,
+        findings: vec![
+            FindingBaselineStatus {
+                key: "existing".to_string(),
+                status: BaselineStatus::Existing,
+            },
+            FindingBaselineStatus {
+                key: "new".to_string(),
+                status: BaselineStatus::New,
+            },
+        ],
+    }
+}
+
+fn duplicate_finding(id: &str, line: usize) -> Finding {
+    Finding {
+        id: id.to_string(),
+        rule_id: "code-quality.long-function".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("code-quality.long-function"),
+        title: "Duplicate-looking finding".to_string(),
+        description: "Duplicate-looking finding for renderer status alignment.".to_string(),
+        category: FindingCategory::CodeQuality,
+        severity: Severity::Medium,
+        confidence: Default::default(),
+        evidence: vec![Evidence {
+            path: PathBuf::from("src/lib.rs"),
+            line_start: line,
+            line_end: None,
+            snippet: "fn duplicate() {}".to_string(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+        provenance: Default::default(),
+        risk: Default::default(),
+    }
 }

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -33,6 +33,8 @@ fn renders_valid_json_scan_summary() {
         framework_projects: vec![],
         react_native: None,
         coupling_graph: None,
+        context_graph_summary: None,
+        context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
         visible_findings_count: 0,

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -1,6 +1,7 @@
+use repopilot::baseline::diff::{BaselineScanReport, BaselineStatus, FindingBaselineStatus};
 use repopilot::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use repopilot::frameworks::ReactNativeArchitectureProfile;
-use repopilot::output::{OutputFormat, render_scan_summary};
+use repopilot::output::{OutputFormat, render_baseline_scan_report, render_scan_summary};
 use repopilot::scan::types::{
     ChangedFileCacheTelemetry, ChangedFileReasonSummary, HiddenSuggestionSummary, LanguageSummary,
     ScanCacheTelemetry, ScanCacheTimings, ScanSummary,
@@ -58,6 +59,8 @@ fn renders_markdown_scan_summary() {
         framework_projects: vec![],
         react_native: None,
         coupling_graph: None,
+        context_graph_summary: None,
+        context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
         visible_findings_count: 1,
@@ -125,6 +128,8 @@ fn renders_empty_markdown_sections() {
         framework_projects: vec![],
         react_native: None,
         coupling_graph: None,
+        context_graph_summary: None,
+        context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
         visible_findings_count: 0,
@@ -187,6 +192,8 @@ fn renders_react_native_architecture_section_when_profile_present() {
             ..ReactNativeArchitectureProfile::default()
         }),
         coupling_graph: None,
+        context_graph_summary: None,
+        context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
         visible_findings_count: 0,
@@ -269,6 +276,22 @@ fn markdown_output_includes_cache_telemetry() {
     assert!(output.contains("`src/lib.rs`: hit (modified, unchanged-content-and-config)"));
 }
 
+#[test]
+fn markdown_baseline_status_stays_aligned_for_duplicate_findings() {
+    let report = duplicate_status_report();
+
+    let output = render_baseline_scan_report(&report, OutputFormat::Markdown, None)
+        .expect("failed to render baseline markdown");
+
+    let existing = output
+        .find("Baseline: existing")
+        .expect("existing status should render");
+    let new = output
+        .find("Baseline: new")
+        .expect("new status should render");
+    assert!(existing < new);
+}
+
 fn cache_telemetry() -> ScanCacheTelemetry {
     ScanCacheTelemetry {
         hits: 1,
@@ -294,5 +317,52 @@ fn cache_telemetry() -> ScanCacheTelemetry {
             write_us: 6_000,
             estimated_time_saved_us: Some(7_000),
         },
+    }
+}
+
+fn duplicate_status_report() -> BaselineScanReport {
+    BaselineScanReport {
+        summary: ScanSummary {
+            root_path: PathBuf::from("demo"),
+            findings: vec![
+                duplicate_finding("existing", 7),
+                duplicate_finding("new", 8),
+            ],
+            ..ScanSummary::default()
+        },
+        baseline_path: None,
+        findings: vec![
+            FindingBaselineStatus {
+                key: "existing".to_string(),
+                status: BaselineStatus::Existing,
+            },
+            FindingBaselineStatus {
+                key: "new".to_string(),
+                status: BaselineStatus::New,
+            },
+        ],
+    }
+}
+
+fn duplicate_finding(id: &str, line: usize) -> Finding {
+    Finding {
+        id: id.to_string(),
+        rule_id: "code-quality.long-function".to_string(),
+        recommendation: Finding::recommendation_for_rule_id("code-quality.long-function"),
+        title: "Duplicate-looking finding".to_string(),
+        description: "Duplicate-looking finding for renderer status alignment.".to_string(),
+        category: FindingCategory::CodeQuality,
+        severity: Severity::Medium,
+        confidence: Default::default(),
+        evidence: vec![Evidence {
+            path: PathBuf::from("src/lib.rs"),
+            line_start: line,
+            line_end: None,
+            snippet: "fn duplicate() {}".to_string(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+        provenance: Default::default(),
+        risk: Default::default(),
     }
 }

--- a/tests/report_schema_contract.rs
+++ b/tests/report_schema_contract.rs
@@ -3,10 +3,10 @@ use serde_json::Value;
 
 #[test]
 fn current_schema_fixture_documents_scan_report_contract() {
-    let current: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v015.json"))
+    let current: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v016.json"))
         .expect("current report fixture should be valid JSON");
 
-    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.15");
+    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.16");
     assert_eq!(current["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
     assert_eq!(current["report"]["kind"], "scan");
     assert_eq!(
@@ -23,11 +23,13 @@ fn current_schema_fixture_documents_scan_report_contract() {
     );
     assert_eq!(current["signal_quality"]["findings_total"], 0);
     assert_eq!(current["signal_quality"]["evidence_coverage_percent"], 100);
+    assert_eq!(current["context_graph_summary"]["files"], 2);
+    assert_eq!(current["context_graph_cache"]["status"], "write");
 }
 
 #[test]
 fn strict_reader_accepts_current_scan_report_shape() {
-    let current = parse_scan_summary_json(include_str!("fixtures/reports/scan-v015.json"))
+    let current = parse_scan_summary_json(include_str!("fixtures/reports/scan-v016.json"))
         .expect("current report should parse into ScanSummary");
 
     assert_eq!(current.files_discovered, 2);
@@ -35,6 +37,29 @@ fn strict_reader_accepts_current_scan_report_shape() {
     assert_eq!(current.non_empty_lines, 12);
     assert_eq!(current.diagnostics.len(), 1);
     assert_eq!(current.diagnostics[0].code, "workspace.package-scan-failed");
+    assert_eq!(
+        current
+            .context_graph_summary
+            .as_ref()
+            .map(|graph| graph.files),
+        Some(2)
+    );
+    assert_eq!(
+        current
+            .context_graph_cache
+            .as_ref()
+            .map(|cache| cache.status.as_str()),
+        Some("write")
+    );
+}
+
+#[test]
+fn strict_reader_accepts_previous_scan_report_shape() {
+    let previous = parse_scan_summary_json(include_str!("fixtures/reports/scan-v015.json"))
+        .expect("0.15 report should parse during 0.16 transition");
+
+    assert_eq!(previous.files_discovered, 2);
+    assert!(previous.context_graph_summary.is_none());
 }
 
 #[test]

--- a/tests/review_command.rs
+++ b/tests/review_command.rs
@@ -23,7 +23,7 @@ fn review_reports_working_tree_findings_on_changed_lines() {
 
     let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
 
-    assert_eq!(json["schema_version"], "0.15");
+    assert_eq!(json["schema_version"], "0.16");
     assert_eq!(json["report"]["kind"], "review");
     assert!(json["risk_summary"]["total"].as_u64().is_some());
     assert_eq!(json["review"]["in_diff_findings"], 1);

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -50,11 +50,14 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
             .is_some()
     );
     assert_rule_present(&first, "security.secret-candidate");
+    assert_eq!(first["context_graph_cache"]["status"], "miss");
+    assert!(first["context_graph_summary"]["files"].as_u64().is_some());
 
     let cache_dir = temp.path().join(".repopilot/cache");
     assert!(cache_dir.join("file_hashes.json").is_file());
     assert!(cache_dir.join("file_roles.json").is_file());
     assert!(cache_dir.join("findings.json").is_file());
+    assert!(cache_dir.join("repo_context.json").is_file());
     assert_eq!(
         read_json(&cache_dir.join("file_hashes.json"))["schema_version"],
         2
@@ -70,6 +73,7 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
     rewrite_cached_finding_title(&cache_dir.join("findings.json"), "Cached secret title");
     let cached = scan_changed_json(temp.path(), &["--changed"]);
     assert_eq!(cached["cache_telemetry"]["hits"], 1);
+    assert_eq!(cached["context_graph_cache"]["status"], "hit");
     assert_eq!(cached["cache_telemetry"]["misses"], 0);
     assert_eq!(cached["cache_telemetry"]["hit_rate_percent"], 100);
     assert_eq!(
@@ -100,6 +104,24 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
 }
 
 #[test]
+fn changed_scan_with_no_changes_skips_repo_context_and_cache_write() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(temp.path().join("src/lib.rs"), "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+
+    let json = scan_changed_json(temp.path(), &["--changed", "--timing"]);
+
+    assert_eq!(json["mode"], "changed");
+    assert_eq!(json["changed_files_count"], 0);
+    assert!(json.get("cache_telemetry").is_none());
+    assert!(json.get("context_graph_summary").is_none());
+    assert!(json.get("context_graph_cache").is_none());
+    assert_eq!(json["scan_timings"]["framework_detection_us"], 0);
+    assert!(!temp.path().join(".repopilot/cache").exists());
+}
+
+#[test]
 fn changed_scan_invalidates_cache_when_config_changes() {
     let temp = tempdir().expect("temp dir");
     init_repo(temp.path());
@@ -115,6 +137,7 @@ fn changed_scan_invalidates_cache_when_config_changes() {
 
     assert_eq!(changed_config["cache_telemetry"]["hits"], 0);
     assert_eq!(changed_config["cache_telemetry"]["misses"], 1);
+    assert_eq!(changed_config["context_graph_cache"]["status"], "miss");
     assert_eq!(
         changed_config["cache_telemetry"]["changed_files"][0]["cache_reason"],
         "config-changed"


### PR DESCRIPTION
## Summary

This PR adds RepoPilot's Context Risk Graph inspection workflow.

It introduces a repository context graph model, graph summary metadata, cache support, and a new `repopilot inspect graph` command that helps users understand structural risk signals such as import hubs, high-dependency files, cycles, changed-file blast radius, and risky finding clusters.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] Report/schema update

## What changed

- Added `repopilot inspect graph`.
- Added graph inspection output for:
  - console;
  - Markdown;
  - JSON.
- Added `RepoContextGraph`.
- Added `RepoContextNode`.
- Added `ContextGraphSummary`.
- Added `ContextGraphFileMetric`.
- Added `ContextRiskCluster`.
- Added `ContextGraphCacheInfo`.
- Added context graph cache support.
- Added context graph summary/cache fields to `ScanSummary`.
- Added context graph fields to JSON scan and baseline reports.
- Bumped scan report schema to `0.16`.
- Added context graph exports to the public API facade.
- Added tests for graph inspection CLI behavior and output formats.
- Updated related output/report tests for schema `0.16`.
- Fixed visibility handling for:
  - `architecture.deep-relative-imports`;
  - Windows-style script/tooling paths.

## Why

RepoPilot should not only list findings. It should explain where risk concentrates in a repository.

A finding in a leaf file and the same finding in a central dependency hub do not have the same engineering impact. The Context Risk Graph adds the foundation for understanding structural risk:

```text
file context
+ import relationships
+ fan-in / fan-out
+ cycles
+ blast radius
+ finding clusters
= better prioritization
```

This helps users answer:

- Which files are depended on the most?
- Which files import too much?
- Where are cycles forming?
- Which findings are concentrated in the same area?
- Which changed files may affect broader repository structure?

## Architecture notes

- No god files introduced.
- Context graph domain structures live under src/graph/context.rs.
- CLI orchestration lives in src/commands/graph.rs.
- Command options live under src/cli/options/inspect.rs.
- Report schema ownership remains in src/report/schema.rs.
- Scan summary carries graph summary/cache metadata.
- Graph data is exposed through the public API facade.
- Output rendering is currently command-local for graph inspection.
- The implementation remains local-first:
  - no telemetry;
  - no hosted graph service;
  - no remote cache;
  - no LLM calls.

## Compatibility

- Existing scan/review commands remain available.
- JSON scan report schema is bumped to 0.16.
- Scan JSON now includes optional:
- context_graph_summary
- context_graph_cache
- Baseline JSON also includes optional context graph metadata.
- inspect graph is additive.
- Existing coupling graph behavior remains available.

## Verification

Recommended checks:

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```

Smoke checks:

```
cargo run -- inspect graph .
cargo run -- inspect graph . --format markdown --output /tmp/repopilot-context-graph.md
cargo run -- inspect graph . --format json --output /tmp/repopilot-context-graph.json
cargo run -- scan . --format json --output /tmp/repopilot-scan-016.json
cargo run -- scan . --changed --format json --output /tmp/repopilot-changed-016.json
cargo run -- review . --format json --output /tmp/repopilot-review-016.json
```