### PR TITLE
feat(graph): harden context graph inspection and cache behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,15 @@ dist/
 !.env.example
 *.tgz
 /report.md
+/repopilot-report.md
 /repopilot-ci.md
+/review.md
 /scan.json
 /*.sarif
+/.repopilot/feedback.yml
+/.repopilot/receipt.json
+/receipt.json
+/receipts/
 *.log
 *.tmp
 *.bak

--- a/.repopilotignore
+++ b/.repopilotignore
@@ -15,6 +15,12 @@ dist
 .env
 .env.*
 report.md
+repopilot-report.md
 repopilot-ci.md
+review.md
 scan.json
 *.sarif
+.repopilot/feedback.yml
+.repopilot/receipt.json
+receipt.json
+receipts

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -397,6 +397,29 @@ approximate cache size, and stale entry count.
 
 ---
 
+## `inspect graph`
+
+Inspect the local Context Risk Graph for top dependencies, import hubs, cycles,
+risky clusters, and changed-file blast radius when changed context is available.
+
+```bash
+repopilot inspect graph .
+repopilot inspect graph . --format json
+repopilot inspect graph . --format markdown --output graph.md
+```
+
+The command runs a local scan by default so graph metadata reflects the current
+working tree. RepoPilot stores the graph cache under `.repopilot/cache/`; clear
+it with `repopilot cache clear .` when you want to discard local cache state.
+Large graph sections are capped so console, Markdown, and JSON output stay
+readable. If a section is truncated, the graph summary lists the truncated
+section names.
+
+Changed-scope graph and blast-radius details are available only when the scan
+summary has changed-file context; full graph inspection does not invent a diff.
+
+---
+
 ## `inspect feedback`
 
 Validate local feedback suppressions. By default this only parses

--- a/src/audits/context/classify/helpers.rs
+++ b/src/audits/context/classify/helpers.rs
@@ -12,15 +12,9 @@ pub fn normalize(value: &str) -> String {
 }
 
 pub fn path_contains_component(path: &Path, targets: &[&str]) -> bool {
-    path.components().any(|component| {
-        component
-            .as_os_str()
-            .to_str()
-            .map(|value| {
-                let normalized = normalize(value);
-                targets.iter().any(|target| normalized == *target)
-            })
-            .unwrap_or(false)
+    path.to_string_lossy().split(['/', '\\']).any(|component| {
+        let normalized = normalize(component);
+        targets.iter().any(|target| normalized == *target)
     })
 }
 
@@ -149,4 +143,22 @@ pub fn is_app_entrypoint(path: &Path, content: &str, language: LanguageKind) -> 
     ) || (language == LanguageKind::Python && content.contains("if __name__ == \"__main__\""))
         || (language == LanguageKind::Go && content.contains("func main("))
         || (language == LanguageKind::Rust && content.contains("fn main("))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::path_contains_component;
+    use std::path::Path;
+
+    #[test]
+    fn path_component_matching_handles_windows_separators() {
+        assert!(path_contains_component(
+            Path::new(r"tools\scripts\check.js"),
+            &["scripts"],
+        ));
+        assert!(path_contains_component(
+            Path::new(r"src\domain\model.rs"),
+            &["domain"],
+        ));
+    }
 }

--- a/src/commands/graph.rs
+++ b/src/commands/graph.rs
@@ -4,6 +4,7 @@ use crate::commands::product_scan::{
     enforce_diagnostics_exit_policy, run_product_scan,
 };
 use crate::commands::scan_config::ScanConfigOverrides;
+use crate::commands::{CliExit, EXIT_USAGE};
 use repopilot::findings::filter::FindingFilter;
 use repopilot::findings::visibility::FindingVisibilityProfile;
 use repopilot::graph::context::{ContextGraphFileMetric, ContextGraphSummary};
@@ -43,16 +44,27 @@ pub fn run(
 fn render_graph_inspection(
     summary: &ScanSummary,
     format: OutputFormat,
-) -> Result<String, serde_json::Error> {
+) -> Result<String, Box<dyn std::error::Error>> {
     match format {
         OutputFormat::Console => Ok(render_console(summary)),
         OutputFormat::Markdown => Ok(render_markdown(summary)),
-        OutputFormat::Json | OutputFormat::Html | OutputFormat::Sarif => {
-            serde_json::to_string_pretty(&GraphInspectJson::from_summary(summary))
-        }
+        OutputFormat::Json => Ok(serde_json::to_string_pretty(
+            &GraphInspectJson::from_summary(summary),
+        )?),
+        OutputFormat::Html | OutputFormat::Sarif => Err(Box::new(CliExit {
+            code: EXIT_USAGE,
+            message: format!(
+                "`inspect graph` supports only console, markdown, and json output; received {}",
+                output_format_name(format)
+            ),
+        })),
     }
 }
 
+/// Command-local diagnostics DTO for `inspect graph`.
+///
+/// This JSON shape is not the stable scan report contract; product report DTOs
+/// live under `report::schema`.
 #[derive(Serialize)]
 struct GraphInspectJson<'a> {
     kind: &'static str,
@@ -90,6 +102,7 @@ fn render_console(summary: &ScanSummary) -> String {
         "Graph: {} files, {} import edges",
         graph.files, graph.import_edges
     );
+    render_truncation_console(&mut output, graph);
     render_metrics_console(&mut output, "Top dependencies", &graph.top_dependencies);
     render_metrics_console(&mut output, "Top hubs", &graph.top_hubs);
     render_blast_radius_console(&mut output, graph);
@@ -114,6 +127,7 @@ fn render_markdown(summary: &ScanSummary) -> String {
         "- **Graph:** {} files, {} import edges",
         graph.files, graph.import_edges
     );
+    render_truncation_markdown(&mut output, graph);
     render_metrics_markdown(&mut output, "Top Dependencies", &graph.top_dependencies);
     render_metrics_markdown(&mut output, "Top Hubs", &graph.top_hubs);
     render_blast_radius_markdown(&mut output, graph);
@@ -144,6 +158,24 @@ fn render_cache_markdown(output: &mut String, summary: &ScanSummary) {
             cache.cache_path.display()
         );
     }
+}
+
+fn render_truncation_console(output: &mut String, graph: &ContextGraphSummary) {
+    if graph.truncated.is_empty() {
+        return;
+    }
+    let _ = writeln!(output, "Truncated: {}", graph.truncated.join(", "));
+}
+
+fn render_truncation_markdown(output: &mut String, graph: &ContextGraphSummary) {
+    if graph.truncated.is_empty() {
+        return;
+    }
+    let _ = writeln!(
+        output,
+        "- **Truncated:** `{}`",
+        graph.truncated.join("`, `")
+    );
 }
 
 fn render_metrics_console(output: &mut String, title: &str, metrics: &[ContextGraphFileMetric]) {
@@ -277,5 +309,15 @@ fn render_risky_clusters_markdown(output: &mut String, graph: &ContextGraphSumma
             cluster.max_score,
             cluster.priority.label()
         );
+    }
+}
+
+fn output_format_name(format: OutputFormat) -> &'static str {
+    match format {
+        OutputFormat::Console => "console",
+        OutputFormat::Html => "html",
+        OutputFormat::Json => "json",
+        OutputFormat::Markdown => "markdown",
+        OutputFormat::Sarif => "sarif",
     }
 }

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -1,6 +1,6 @@
 use crate::audits::context::{FileRole, classify_file};
 use crate::findings::types::Finding;
-use crate::graph::{CouplingGraph, build_coupling_graph, compute_metrics, detect_cycles};
+use crate::graph::{CouplingGraph, build_coupling_graph, compute_metrics, detect_cycles_bounded};
 use crate::review::diff::{ChangeStatus, ChangedFile};
 use crate::risk::RiskPriority;
 use crate::scan::cache::{cache_dir, config_fingerprint, relative_cache_path, stable_hash_hex};
@@ -14,9 +14,19 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 pub const CONTEXT_GRAPH_CACHE_NAME: &str = "repo_context.json";
-pub const CONTEXT_GRAPH_SCHEMA_VERSION: u32 = 1;
+pub const CONTEXT_GRAPH_SCHEMA_VERSION: u32 = 2;
 pub const CONTEXT_GRAPH_RESOLVER_VERSION: &str = "context-graph-v1";
+pub const MAX_CONTEXT_GRAPH_CYCLES: usize = 20;
+pub const MAX_CONTEXT_GRAPH_METRICS: usize = 10;
+pub const MAX_CONTEXT_GRAPH_RISKY_CLUSTERS: usize = 20;
+pub const MAX_CONTEXT_GRAPH_BLAST_RADIUS: usize = 50;
 
+/// Repository-level graph/context metadata used for import impact analysis.
+///
+/// This cache is intentionally not a full `ScanFacts` or source-content cache:
+/// it preserves file context, imports, detected frameworks, and derived graph
+/// edges. Callers must still scan files when they need source text, file-audit
+/// inputs, or the authoritative current finding set.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RepoContextGraph {
     pub root_path: PathBuf,
@@ -67,6 +77,8 @@ pub struct ContextGraphSummary {
     pub changed_blast_radius: Vec<PathBuf>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub risky_clusters: Vec<ContextRiskCluster>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub truncated: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -105,6 +117,7 @@ pub struct CachedRepoContextGraph {
     pub repopilot_version: String,
     pub config_fingerprint: String,
     pub resolver_version: String,
+    pub input_fingerprint: String,
     pub graph_fingerprint: String,
     pub graph: RepoContextGraph,
 }
@@ -117,3 +130,122 @@ pub struct RepoContextGraphLoad {
 include!("context/graph_impl.rs");
 include!("context/summary.rs");
 include!("context/cache.rs");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+    use crate::risk::{RiskAssessment, priority_for_score};
+
+    #[test]
+    fn summary_caps_cycles_and_marks_truncation() {
+        let mut nodes = Vec::new();
+        let mut edges = BTreeMap::new();
+        for index in 0..(MAX_CONTEXT_GRAPH_CYCLES + 3) {
+            let left = PathBuf::from(format!("src/cycle_{index}_a.rs"));
+            let right = PathBuf::from(format!("src/cycle_{index}_b.rs"));
+            nodes.push(node(&left));
+            nodes.push(node(&right));
+            edges
+                .entry(left.clone())
+                .or_insert_with(BTreeSet::new)
+                .insert(right.clone());
+            edges
+                .entry(right)
+                .or_insert_with(BTreeSet::new)
+                .insert(left);
+        }
+
+        let graph = RepoContextGraph {
+            root_path: PathBuf::from("."),
+            nodes,
+            edges,
+            detected_frameworks: Vec::new(),
+            framework_projects: Vec::new(),
+            react_native: None,
+        };
+
+        let summary = summarize_context_graph(&graph, &[], &[]);
+
+        assert_eq!(summary.cycles.len(), MAX_CONTEXT_GRAPH_CYCLES);
+        assert!(summary.truncated.iter().any(|value| value == "cycles"));
+    }
+
+    #[test]
+    fn summary_caps_risky_clusters_and_marks_truncation() {
+        let findings = (0..(MAX_CONTEXT_GRAPH_RISKY_CLUSTERS + 3))
+            .map(|index| {
+                finding(
+                    &format!("test.rule-{index}"),
+                    &format!("src/area_{index}/file.rs"),
+                    80,
+                )
+            })
+            .collect::<Vec<_>>();
+        let graph = RepoContextGraph {
+            root_path: PathBuf::from("."),
+            nodes: Vec::new(),
+            edges: BTreeMap::new(),
+            detected_frameworks: Vec::new(),
+            framework_projects: Vec::new(),
+            react_native: None,
+        };
+
+        let summary = summarize_context_graph(&graph, &findings, &[]);
+
+        assert_eq!(
+            summary.risky_clusters.len(),
+            MAX_CONTEXT_GRAPH_RISKY_CLUSTERS
+        );
+        assert!(
+            summary
+                .truncated
+                .iter()
+                .any(|value| value == "risky_clusters")
+        );
+    }
+
+    fn node(path: &Path) -> RepoContextNode {
+        RepoContextNode {
+            path: path.to_path_buf(),
+            language: Some("Rust".to_string()),
+            roles: Vec::new(),
+            frameworks: Vec::new(),
+            runtimes: Vec::new(),
+            paradigms: Vec::new(),
+            workspace_package: None,
+            non_empty_lines: 1,
+            imports: Vec::new(),
+            is_test: false,
+            is_generated: false,
+            is_config: false,
+        }
+    }
+
+    fn finding(rule_id: &str, path: &str, score: u8) -> Finding {
+        Finding {
+            id: String::new(),
+            rule_id: rule_id.to_string(),
+            title: String::new(),
+            description: String::new(),
+            recommendation: String::new(),
+            category: FindingCategory::Architecture,
+            severity: Severity::High,
+            confidence: Default::default(),
+            evidence: vec![Evidence {
+                path: PathBuf::from(path),
+                line_start: 1,
+                line_end: None,
+                snippet: String::new(),
+            }],
+            workspace_package: None,
+            docs_url: None,
+            provenance: Default::default(),
+            risk: RiskAssessment {
+                score,
+                priority: priority_for_score(score),
+                ..RiskAssessment::default()
+            },
+        }
+    }
+}

--- a/src/graph/context/cache.rs
+++ b/src/graph/context/cache.rs
@@ -1,11 +1,12 @@
 pub fn load_repo_context_graph(root: &Path, config: &ScanConfig) -> Option<RepoContextGraphLoad> {
     let cache_path = context_graph_cache_path(root);
-    let content = fs::read_to_string(&cache_path).ok()?;
-    let cached = serde_json::from_str::<CachedRepoContextGraph>(&content).ok()?;
+    let cached = read_cached_repo_context_graph(&cache_path)?;
     if !valid_cached_graph(&cached, config) {
         return None;
     }
 
+    // This cache stores graph/context metadata only. Changed scans must still
+    // analyze changed file contents and patch this graph before scoring.
     Some(RepoContextGraphLoad {
         graph: cached.graph,
         cache_info: ContextGraphCacheInfo {
@@ -25,13 +26,28 @@ pub fn write_repo_context_graph(
     if let Some(parent) = cache_path.parent() {
         fs::create_dir_all(parent)?;
     }
+    let input_fingerprint = context_graph_input_fingerprint(graph);
+    let graph_fingerprint = context_graph_fingerprint(graph);
+
+    if let Some(cached) = read_cached_repo_context_graph(&cache_path)
+        && valid_cached_graph(&cached, config)
+        && cached.input_fingerprint == input_fingerprint
+        && cached.graph_fingerprint == graph_fingerprint
+    {
+        return Ok(ContextGraphCacheInfo {
+            status: "hit".to_string(),
+            reason: "valid-context-graph-cache".to_string(),
+            cache_path,
+        });
+    }
 
     let cached = CachedRepoContextGraph {
         schema_version: CONTEXT_GRAPH_SCHEMA_VERSION,
         repopilot_version: env!("CARGO_PKG_VERSION").to_string(),
         config_fingerprint: config_fingerprint(config),
         resolver_version: CONTEXT_GRAPH_RESOLVER_VERSION.to_string(),
-        graph_fingerprint: context_graph_fingerprint(graph),
+        input_fingerprint,
+        graph_fingerprint,
         graph: graph.clone(),
     };
     let rendered = serde_json::to_string_pretty(&cached).map_err(io::Error::other)?;
@@ -64,6 +80,7 @@ fn valid_cached_graph(cached: &CachedRepoContextGraph, config: &ScanConfig) -> b
         && cached.repopilot_version == env!("CARGO_PKG_VERSION")
         && cached.config_fingerprint == config_fingerprint(config)
         && cached.resolver_version == CONTEXT_GRAPH_RESOLVER_VERSION
+        && cached.input_fingerprint == context_graph_input_fingerprint(&cached.graph)
         && cached.graph_fingerprint == context_graph_fingerprint(&cached.graph)
 }
 
@@ -77,11 +94,80 @@ fn context_graph_fingerprint(graph: &RepoContextGraph) -> String {
         "resolver": CONTEXT_GRAPH_RESOLVER_VERSION,
         "risk_formula": crate::risk::FORMULA_VERSION,
         "knowledge_pack": stable_hash_hex(include_bytes!("../../knowledge/packs/core.toml")),
-        "nodes": &graph.nodes,
-        "edges": &graph.edges,
+        "input": context_graph_input_fingerprint(graph),
+        "nodes": stable_node_inputs(graph),
+        "edges": stable_edge_inputs(graph),
         "frameworks": &graph.detected_frameworks,
         "framework_projects": &graph.framework_projects,
         "react_native": &graph.react_native,
     });
     stable_hash_hex(input.to_string().as_bytes())
+}
+
+fn context_graph_input_fingerprint(graph: &RepoContextGraph) -> String {
+    let input = serde_json::json!({
+        "schema": CONTEXT_GRAPH_SCHEMA_VERSION,
+        "resolver": CONTEXT_GRAPH_RESOLVER_VERSION,
+        "nodes": stable_node_inputs(graph),
+        "edges": stable_edge_inputs(graph),
+        "frameworks": &graph.detected_frameworks,
+        "framework_projects": &graph.framework_projects,
+        "react_native": &graph.react_native,
+    });
+    stable_hash_hex(input.to_string().as_bytes())
+}
+
+fn read_cached_repo_context_graph(path: &Path) -> Option<CachedRepoContextGraph> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str::<CachedRepoContextGraph>(&content).ok()
+}
+
+fn stable_node_inputs(graph: &RepoContextGraph) -> Vec<serde_json::Value> {
+    let mut nodes = graph
+        .nodes
+        .iter()
+        .map(|node| {
+            serde_json::json!({
+                "path": stable_path(&node.path),
+                "language": &node.language,
+                "roles": sorted_strings(&node.roles),
+                "frameworks": sorted_strings(&node.frameworks),
+                "runtimes": sorted_strings(&node.runtimes),
+                "paradigms": sorted_strings(&node.paradigms),
+                "workspace_package": &node.workspace_package,
+                "non_empty_lines": node.non_empty_lines,
+                "imports": sorted_strings(&node.imports),
+                "is_test": node.is_test,
+                "is_generated": node.is_generated,
+                "is_config": node.is_config,
+            })
+        })
+        .collect::<Vec<_>>();
+    nodes.sort_by_key(|value| value["path"].as_str().unwrap_or_default().to_string());
+    nodes
+}
+
+fn stable_edge_inputs(graph: &RepoContextGraph) -> Vec<serde_json::Value> {
+    graph
+        .edges
+        .iter()
+        .map(|(source, targets)| {
+            let mut targets = targets.iter().map(|path| stable_path(path)).collect::<Vec<_>>();
+            targets.sort();
+            serde_json::json!({
+                "source": stable_path(source),
+                "targets": targets,
+            })
+        })
+        .collect()
+}
+
+fn stable_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn sorted_strings(values: &[String]) -> Vec<String> {
+    let mut values = values.to_vec();
+    values.sort();
+    values
 }

--- a/src/graph/context/summary.rs
+++ b/src/graph/context/summary.rs
@@ -18,11 +18,15 @@ pub fn summarize_context_graph(
             .then_with(|| right.fan_in.cmp(&left.fan_in))
             .then_with(|| left.path.cmp(&right.path))
     });
-    let top_hubs = metrics
+    let all_top_hubs = metrics
         .iter()
         .filter(|metric| metric.fan_out > 0)
-        .take(5)
         .map(|metric| metric_from_graph(metric, &node_by_path))
+        .collect::<Vec<_>>();
+    let top_hubs_truncated = all_top_hubs.len() > MAX_CONTEXT_GRAPH_METRICS;
+    let top_hubs = all_top_hubs
+        .into_iter()
+        .take(MAX_CONTEXT_GRAPH_METRICS)
         .collect();
 
     metrics.sort_by(|left, right| {
@@ -32,21 +36,50 @@ pub fn summarize_context_graph(
             .then_with(|| right.fan_out.cmp(&left.fan_out))
             .then_with(|| left.path.cmp(&right.path))
     });
-    let top_dependencies = metrics
+    let all_top_dependencies = metrics
         .iter()
         .filter(|metric| metric.fan_in > 0)
-        .take(5)
         .map(|metric| metric_from_graph(metric, &node_by_path))
+        .collect::<Vec<_>>();
+    let top_dependencies_truncated = all_top_dependencies.len() > MAX_CONTEXT_GRAPH_METRICS;
+    let top_dependencies = all_top_dependencies
+        .into_iter()
+        .take(MAX_CONTEXT_GRAPH_METRICS)
         .collect();
+
+    let mut cycles = detect_cycles_bounded(&coupling_graph, MAX_CONTEXT_GRAPH_CYCLES + 1);
+    let cycles_truncated = cycles.len() > MAX_CONTEXT_GRAPH_CYCLES;
+    cycles.truncate(MAX_CONTEXT_GRAPH_CYCLES);
+
+    let (changed_blast_radius, blast_radius_truncated) =
+        changed_blast_radius(&coupling_graph, changed_files);
+    let (risky_clusters, risky_clusters_truncated) = risky_clusters(findings);
+    let mut truncated = Vec::new();
+    if top_hubs_truncated {
+        truncated.push("top_hubs".to_string());
+    }
+    if top_dependencies_truncated {
+        truncated.push("top_dependencies".to_string());
+    }
+    if cycles_truncated {
+        truncated.push("cycles".to_string());
+    }
+    if blast_radius_truncated {
+        truncated.push("changed_blast_radius".to_string());
+    }
+    if risky_clusters_truncated {
+        truncated.push("risky_clusters".to_string());
+    }
 
     ContextGraphSummary {
         files: graph.nodes.len(),
         import_edges: graph.edges.values().map(BTreeSet::len).sum(),
         top_hubs,
         top_dependencies,
-        cycles: detect_cycles(&coupling_graph).into_iter().take(5).collect(),
-        changed_blast_radius: changed_blast_radius(&coupling_graph, changed_files),
-        risky_clusters: risky_clusters(findings),
+        cycles,
+        changed_blast_radius,
+        risky_clusters,
+        truncated,
     }
 }
 
@@ -65,9 +98,12 @@ fn metric_from_graph(
     }
 }
 
-fn changed_blast_radius(graph: &CouplingGraph, changed_files: &[ChangedFile]) -> Vec<PathBuf> {
+fn changed_blast_radius(
+    graph: &CouplingGraph,
+    changed_files: &[ChangedFile],
+) -> (Vec<PathBuf>, bool) {
     if changed_files.is_empty() {
-        return Vec::new();
+        return (Vec::new(), false);
     }
 
     let changed = changed_files
@@ -95,10 +131,17 @@ fn changed_blast_radius(graph: &CouplingGraph, changed_files: &[ChangedFile]) ->
             );
         }
     }
-    impacted.into_iter().take(20).collect()
+    let truncated = impacted.len() > MAX_CONTEXT_GRAPH_BLAST_RADIUS;
+    (
+        impacted
+            .into_iter()
+            .take(MAX_CONTEXT_GRAPH_BLAST_RADIUS)
+            .collect(),
+        truncated,
+    )
 }
 
-fn risky_clusters(findings: &[Finding]) -> Vec<ContextRiskCluster> {
+fn risky_clusters(findings: &[Finding]) -> (Vec<ContextRiskCluster>, bool) {
     let mut clusters: BTreeMap<(String, String), ContextRiskCluster> = BTreeMap::new();
     for finding in findings {
         let scope = finding
@@ -129,8 +172,9 @@ fn risky_clusters(findings: &[Finding]) -> Vec<ContextRiskCluster> {
             .then_with(|| right.count.cmp(&left.count))
             .then_with(|| left.rule_id.cmp(&right.rule_id))
     });
-    clusters.truncate(8);
-    clusters
+    let truncated = clusters.len() > MAX_CONTEXT_GRAPH_RISKY_CLUSTERS;
+    clusters.truncate(MAX_CONTEXT_GRAPH_RISKY_CLUSTERS);
+    (clusters, truncated)
 }
 
 fn cluster_scope(path: &Path) -> String {

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -31,18 +31,30 @@ pub struct FileMetrics {
 // ── Graph construction ────────────────────────────────────────────────────────
 
 pub fn build_coupling_graph(facts: &ScanFacts, root: &Path) -> CouplingGraph {
-    let known_files: HashSet<PathBuf> = facts.files.iter().map(|f| f.path.clone()).collect();
+    let known_file_by_normalized: HashMap<PathBuf, PathBuf> = facts
+        .files
+        .iter()
+        .map(|file| (resolver::normalize_path(&file.path), file.path.clone()))
+        .collect();
+    let known_files: HashSet<PathBuf> = known_file_by_normalized.keys().cloned().collect();
 
     let mut edges: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
 
     for file in &facts.files {
+        let source = file.path.clone();
+        let normalized_source = resolver::normalize_path(&source);
         // Insert into edges (one clone); nodes is derived from edges keys afterwards.
-        let outgoing = edges.entry(file.path.clone()).or_default();
+        let outgoing = edges.entry(source.clone()).or_default();
 
         for raw in &file.imports {
-            if let Some(target) = resolve_import(raw, &file.path, root, &known_files) {
-                if target != file.path {
-                    outgoing.insert(target);
+            if let Some(target) = resolve_import(raw, &normalized_source, root, &known_files) {
+                if target != normalized_source {
+                    outgoing.insert(
+                        known_file_by_normalized
+                            .get(&target)
+                            .cloned()
+                            .unwrap_or(target),
+                    );
                 }
             }
         }
@@ -97,6 +109,14 @@ pub fn compute_metrics(graph: &CouplingGraph) -> Vec<FileMetrics> {
 const MAX_DFS_DEPTH: usize = 512;
 
 pub fn detect_cycles(graph: &CouplingGraph) -> Vec<Vec<PathBuf>> {
+    detect_cycles_bounded(graph, usize::MAX)
+}
+
+pub fn detect_cycles_bounded(graph: &CouplingGraph, max_cycles: usize) -> Vec<Vec<PathBuf>> {
+    if max_cycles == 0 {
+        return Vec::new();
+    }
+
     let nodes: Vec<&PathBuf> = graph.nodes.iter().collect();
     let n = nodes.len();
 
@@ -124,10 +144,23 @@ pub fn detect_cycles(graph: &CouplingGraph) -> Vec<Vec<PathBuf>> {
     let mut state = vec![0u8; n];
     let mut stack: Vec<usize> = Vec::new();
     let mut cycles: Vec<Vec<PathBuf>> = Vec::new();
+    {
+        let mut dfs_state = CycleDfs {
+            adj: &adj,
+            state: &mut state,
+            stack: &mut stack,
+            cycles: &mut cycles,
+            nodes: &nodes,
+            max_cycles,
+        };
 
-    for start in 0..n {
-        if state[start] == 0 {
-            dfs(start, &adj, &mut state, &mut stack, &mut cycles, &nodes, 0);
+        for start in 0..n {
+            if dfs_state.cycles.len() >= max_cycles {
+                break;
+            }
+            if dfs_state.state[start] == 0 {
+                dfs_state.visit(start, 0);
+            }
         }
     }
 
@@ -145,42 +178,55 @@ pub fn detect_cycles(graph: &CouplingGraph) -> Vec<Vec<PathBuf>> {
 
     cycles.sort();
     cycles.dedup();
+    cycles.truncate(max_cycles);
     cycles
 }
 
-fn dfs(
-    node: usize,
-    adj: &[Vec<usize>],
-    state: &mut Vec<u8>,
-    stack: &mut Vec<usize>,
-    cycles: &mut Vec<Vec<PathBuf>>,
-    nodes: &[&PathBuf],
-    depth: usize,
-) {
-    if depth > MAX_DFS_DEPTH {
-        state[node] = 2;
-        return;
-    }
+struct CycleDfs<'a, 'b> {
+    adj: &'a [Vec<usize>],
+    state: &'a mut Vec<u8>,
+    stack: &'a mut Vec<usize>,
+    cycles: &'a mut Vec<Vec<PathBuf>>,
+    nodes: &'a [&'b PathBuf],
+    max_cycles: usize,
+}
 
-    state[node] = 1;
-    stack.push(node);
-
-    for &neighbor in &adj[node] {
-        match state[neighbor] {
-            1 => {
-                // Back edge → cycle; extract the loop from the current stack
-                if let Some(pos) = stack.iter().position(|&n| n == neighbor) {
-                    let cycle = stack[pos..].iter().map(|&i| nodes[i].clone()).collect();
-                    cycles.push(cycle);
-                }
-            }
-            0 => dfs(neighbor, adj, state, stack, cycles, nodes, depth + 1),
-            _ => {}
+impl CycleDfs<'_, '_> {
+    fn visit(&mut self, node: usize, depth: usize) {
+        if self.cycles.len() >= self.max_cycles {
+            return;
         }
-    }
+        if depth > MAX_DFS_DEPTH {
+            self.state[node] = 2;
+            return;
+        }
 
-    stack.pop();
-    state[node] = 2;
+        self.state[node] = 1;
+        self.stack.push(node);
+
+        for &neighbor in &self.adj[node] {
+            if self.cycles.len() >= self.max_cycles {
+                break;
+            }
+            match self.state[neighbor] {
+                1 => {
+                    // Back edge -> cycle; extract the loop from the current stack.
+                    if let Some(pos) = self.stack.iter().position(|&n| n == neighbor) {
+                        let cycle = self.stack[pos..]
+                            .iter()
+                            .map(|&i| self.nodes[i].clone())
+                            .collect();
+                        self.cycles.push(cycle);
+                    }
+                }
+                0 => self.visit(neighbor, depth + 1),
+                _ => {}
+            }
+        }
+
+        self.stack.pop();
+        self.state[node] = 2;
+    }
 }
 
 #[cfg(test)]

--- a/src/output/ai_context/tests.rs
+++ b/src/output/ai_context/tests.rs
@@ -75,5 +75,6 @@ fn context_graph_summary() -> ContextGraphSummary {
             max_score: 60,
             priority: RiskPriority::P2,
         }],
+        truncated: Vec::new(),
     }
 }

--- a/src/scan/cache.rs
+++ b/src/scan/cache.rs
@@ -32,6 +32,8 @@ pub struct FileRoleEntry {
     pub hash: String,
     pub language: Option<String>,
     pub non_empty_lines: usize,
+    #[serde(default)]
+    pub imports: Vec<String>,
     pub roles: Vec<String>,
     pub frameworks: Vec<String>,
     pub runtimes: Vec<String>,

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -5,8 +5,9 @@ use super::changed_git::collect_changed_scope;
 use super::changed_telemetry::{
     change_status_label, finalize_cache_telemetry, record_skipped_cache_file,
 };
+use super::collection;
 use super::file::{SkipReason, process_file_with_content};
-use super::summary::{ScanSummaryParts, build_language_summary, build_scan_summary};
+use super::summary::{self, ScanSummaryParts, build_language_summary, build_scan_summary};
 use crate::audits::pipeline::build_file_audits;
 use crate::findings::enrichment::enrich_findings_timed;
 use crate::findings::quality::{
@@ -137,8 +138,45 @@ impl<'a> ChangedScanEngine<'a> {
     }
 }
 
-include!("changed/file_analysis.rs");
+mod file_analysis;
+mod finalize;
+mod repo_context;
 
-include!("changed/repo_context.rs");
+fn detect_react_native_profile(
+    facts: &ScanFacts,
+) -> Option<crate::frameworks::ReactNativeArchitectureProfile> {
+    if facts
+        .detected_frameworks
+        .iter()
+        .any(|f| matches!(f, DetectedFramework::ReactNative { .. }))
+    {
+        let profile = detect_react_native_architecture(&facts.root_path);
+        if profile.detected {
+            return Some(profile);
+        }
+    }
+    None
+}
 
-include!("changed/finalize.rs");
+fn relative_coupling_graph(graph: CouplingGraph, repo_root: &Path) -> CouplingGraph {
+    CouplingGraph {
+        edges: graph
+            .edges
+            .into_iter()
+            .map(|(source, targets)| {
+                (
+                    PathBuf::from(relative_cache_path(repo_root, &source)),
+                    targets
+                        .into_iter()
+                        .map(|target| PathBuf::from(relative_cache_path(repo_root, &target)))
+                        .collect(),
+                )
+            })
+            .collect(),
+        nodes: graph
+            .nodes
+            .into_iter()
+            .map(|node| PathBuf::from(relative_cache_path(repo_root, &node)))
+            .collect(),
+    }
+}

--- a/src/scan/scanner/changed/file_analysis.rs
+++ b/src/scan/scanner/changed/file_analysis.rs
@@ -1,5 +1,7 @@
+use super::*;
+
 impl<'a> ChangedScanEngine<'a> {
-    fn run_file_analysis(
+    pub(super) fn run_file_analysis(
         &self,
         discovery: &ChangedDiscoveryStage,
     ) -> io::Result<ChangedFileAnalysisStage> {
@@ -142,7 +144,8 @@ impl<'a> ChangedScanEngine<'a> {
                     languages,
                     findings,
                     cache_telemetry,
-                    role_entry,
+                    graph_patch_files,
+                    *role_entry,
                     cached_findings,
                 );
                 return Ok(());
@@ -174,6 +177,7 @@ impl<'a> ChangedScanEngine<'a> {
                             hash: hash_entry.hash.clone(),
                             language: per_file.language.clone(),
                             non_empty_lines: per_file.file_facts.non_empty_lines,
+                            imports: per_file.file_facts.imports.clone(),
                             roles: context.roles,
                             frameworks: context.frameworks,
                             runtimes: context.runtimes,
@@ -242,11 +246,14 @@ impl<'a> ChangedScanEngine<'a> {
         languages: &mut HashMap<String, usize>,
         findings: &mut Vec<Finding>,
         cache_telemetry: &mut ScanCacheTelemetry,
+        graph_patch_files: &mut Vec<FileFacts>,
         role_entry: FileRoleEntry,
         cached_findings: Vec<Finding>,
     ) {
         let reuse_start = Instant::now();
-        record_cached_file(facts, languages, &role_entry);
+        let mut graph_file = record_cached_file(facts, languages, &role_entry);
+        graph_file.content = None;
+        graph_patch_files.push(graph_file);
         findings.extend(cached_findings);
         cache_telemetry.timings.hit_reuse_us = cache_telemetry
             .timings

--- a/src/scan/scanner/changed/finalize.rs
+++ b/src/scan/scanner/changed/finalize.rs
@@ -1,5 +1,7 @@
+use super::*;
+
 impl<'a> ChangedScanEngine<'a> {
-    fn finalize_report(
+    pub(super) fn finalize_report(
         &self,
         scan_start: Instant,
         discovery: ChangedDiscoveryStage,
@@ -68,7 +70,7 @@ impl<'a> ChangedScanEngine<'a> {
         Ok(summary)
     }
 
-    fn finalize_empty_changed(
+    pub(super) fn finalize_empty_changed(
         &self,
         scan_start: Instant,
         discovery: ChangedDiscoveryStage,
@@ -110,44 +112,5 @@ impl<'a> ChangedScanEngine<'a> {
             timings.report_finalization_us = finalization_start.elapsed().as_micros() as u64;
         }
         Ok(summary)
-    }
-}
-
-fn detect_react_native_profile(
-    facts: &ScanFacts,
-) -> Option<crate::frameworks::ReactNativeArchitectureProfile> {
-    if facts
-        .detected_frameworks
-        .iter()
-        .any(|f| matches!(f, DetectedFramework::ReactNative { .. }))
-    {
-        let profile = detect_react_native_architecture(&facts.root_path);
-        if profile.detected {
-            return Some(profile);
-        }
-    }
-    None
-}
-
-fn relative_coupling_graph(graph: CouplingGraph, repo_root: &Path) -> CouplingGraph {
-    CouplingGraph {
-        edges: graph
-            .edges
-            .into_iter()
-            .map(|(source, targets)| {
-                (
-                    PathBuf::from(relative_cache_path(repo_root, &source)),
-                    targets
-                        .into_iter()
-                        .map(|target| PathBuf::from(relative_cache_path(repo_root, &target)))
-                        .collect(),
-                )
-            })
-            .collect(),
-        nodes: graph
-            .nodes
-            .into_iter()
-            .map(|node| PathBuf::from(relative_cache_path(repo_root, &node)))
-            .collect(),
     }
 }

--- a/src/scan/scanner/changed/repo_context.rs
+++ b/src/scan/scanner/changed/repo_context.rs
@@ -1,5 +1,7 @@
+use super::*;
+
 impl<'a> ChangedScanEngine<'a> {
-    fn run_repo_context(
+    pub(super) fn run_repo_context(
         &self,
         discovery: &ChangedDiscoveryStage,
         facts: &mut ScanFacts,
@@ -67,7 +69,7 @@ impl<'a> ChangedScanEngine<'a> {
         })
     }
 
-    fn score_findings(
+    pub(super) fn score_findings(
         &self,
         repo_stage: &ChangedRepoContextStage,
         findings: &mut [Finding],

--- a/src/scan/scanner/changed_cache.rs
+++ b/src/scan/scanner/changed_cache.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 pub(super) enum CacheDecision {
     Hit {
-        role_entry: FileRoleEntry,
+        role_entry: Box<FileRoleEntry>,
         findings: Vec<Finding>,
     },
     Miss {
@@ -27,7 +27,7 @@ pub(super) fn cache_decision(
                 && findings_entry.config_fingerprint == fingerprint =>
         {
             CacheDecision::Hit {
-                role_entry: role_entry.clone(),
+                role_entry: Box::new(role_entry.clone()),
                 findings: findings_entry.findings.clone(),
             }
         }
@@ -62,21 +62,23 @@ pub(super) fn record_cached_file(
     facts: &mut ScanFacts,
     languages: &mut HashMap<String, usize>,
     entry: &FileRoleEntry,
-) {
+) -> FileFacts {
     facts.files_analyzed += 1;
     facts.non_empty_lines += entry.non_empty_lines;
     if let Some(language) = &entry.language {
         *languages.entry(language.clone()).or_insert(0) += 1;
     }
-    facts.files.push(FileFacts {
+    let file_facts = FileFacts {
         path: PathBuf::from(&entry.path),
         language: entry.language.clone(),
         non_empty_lines: entry.non_empty_lines,
         branch_count: 0,
-        imports: Vec::new(),
+        imports: entry.imports.clone(),
         content: None,
         has_inline_tests: entry.is_test,
-    });
+    };
+    facts.files.push(file_facts.clone());
+    file_facts
 }
 
 pub(super) fn normalize_per_file_paths(

--- a/tests/inspect_graph_cli.rs
+++ b/tests/inspect_graph_cli.rs
@@ -56,6 +56,110 @@ fn inspect_graph_renders_markdown_contract() {
     assert!(markdown.contains("## Risky Clusters"));
 }
 
+#[test]
+fn inspect_graph_rejects_unsupported_formats() {
+    let temp = tempdir().expect("temp dir");
+    write_graph_fixture(temp.path());
+
+    for format in ["html", "sarif"] {
+        let output = repopilot()
+            .args(["inspect", "graph", ".", "--format", format])
+            .current_dir(temp.path())
+            .output()
+            .expect("inspect graph unsupported format");
+
+        assert!(
+            !output.status.success(),
+            "inspect graph --format {format} should fail"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("invalid value") || stderr.contains("supports only"),
+            "expected clear usage error for {format}, got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("console") && stderr.contains("markdown") && stderr.contains("json"),
+            "expected supported formats in error for {format}, got:\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn inspect_graph_cache_hits_on_second_run() {
+    let temp = tempdir().expect("temp dir");
+    write_graph_fixture(temp.path());
+
+    let first = inspect_graph_json(temp.path());
+    assert_eq!(first["context_graph_cache"]["status"], "write");
+
+    let second = inspect_graph_json(temp.path());
+    assert_eq!(second["context_graph_cache"]["status"], "hit");
+}
+
+#[test]
+fn inspect_graph_cache_rebuilds_when_import_changes() {
+    let temp = tempdir().expect("temp dir");
+    write_graph_fixture(temp.path());
+    fs::write(temp.path().join("src/b.rs"), "pub fn b() {}\n").expect("write b");
+
+    let first = inspect_graph_json(temp.path());
+    assert_eq!(first["context_graph_cache"]["status"], "write");
+
+    fs::write(
+        temp.path().join("src/lib.rs"),
+        "mod b;\npub fn lib() { b::b(); }\n",
+    )
+    .expect("rewrite lib");
+
+    let changed = inspect_graph_json(temp.path());
+    assert_eq!(changed["context_graph_cache"]["status"], "write");
+    assert!(top_dependencies_include(&changed, "src/b.rs"));
+}
+
+#[test]
+fn inspect_graph_cache_rebuilds_when_source_file_is_added_or_deleted() {
+    let temp = tempdir().expect("temp dir");
+    write_graph_fixture(temp.path());
+
+    let first = inspect_graph_json(temp.path());
+    assert_eq!(first["context_graph_cache"]["status"], "write");
+
+    fs::write(temp.path().join("src/b.rs"), "pub fn b() {}\n").expect("write b");
+    let added = inspect_graph_json(temp.path());
+    assert_eq!(added["context_graph_cache"]["status"], "write");
+    assert_eq!(added["context_graph_summary"]["files"], 3);
+
+    fs::remove_file(temp.path().join("src/a.rs")).expect("delete a");
+    let deleted = inspect_graph_json(temp.path());
+    assert_eq!(deleted["context_graph_cache"]["status"], "write");
+    assert_eq!(deleted["context_graph_summary"]["files"], 2);
+}
+
+fn inspect_graph_json(root: &Path) -> Value {
+    let output = repopilot()
+        .args(["inspect", "graph", ".", "--format", "json"])
+        .current_dir(root)
+        .output()
+        .expect("inspect graph json");
+
+    assert!(
+        output.status.success(),
+        "inspect graph failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    serde_json::from_slice(&output.stdout).expect("graph json")
+}
+
+fn top_dependencies_include(json: &Value, expected_path: &str) -> bool {
+    json["context_graph_summary"]["top_dependencies"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .any(|metric| metric["path"] == expected_path)
+}
+
 fn write_graph_fixture(root: &Path) {
     fs::create_dir_all(root.join("src")).expect("create src");
     fs::write(

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -213,6 +213,50 @@ fn changed_scan_uses_repo_graph_context_for_changed_findings_only() {
 }
 
 #[test]
+fn changed_scan_cache_hit_keeps_changed_file_imports_for_graph_patch() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(temp.path().join("src/old.rs"), "pub fn old() {}\n");
+    write(temp.path().join("src/new.rs"), "pub fn new() {}\n");
+    write(
+        temp.path().join("src/lib.rs"),
+        "use crate::old;\npub fn live() { old::old(); }\n",
+    );
+    commit_all(temp.path(), "initial");
+
+    let initial_graph = inspect_graph_json(temp.path());
+    assert_eq!(initial_graph["context_graph_cache"]["status"], "write");
+    let stale_graph_cache =
+        fs::read(temp.path().join(".repopilot/cache/repo_context.json")).expect("read graph cache");
+
+    write(
+        temp.path().join("src/lib.rs"),
+        "use crate::new;\npub fn live() { new::new(); }\nconst API_KEY: &str = \"abc123xyz987\";\n",
+    );
+    let first_changed = scan_changed_json(temp.path(), &["--changed"]);
+    assert_eq!(
+        first_changed["cache_telemetry"]["changed_files"][0]["cache_status"],
+        "miss"
+    );
+
+    fs::write(
+        temp.path().join(".repopilot/cache/repo_context.json"),
+        stale_graph_cache,
+    )
+    .expect("restore stale graph cache");
+
+    let cached_changed = scan_changed_json(temp.path(), &["--changed"]);
+    assert_eq!(
+        cached_changed["cache_telemetry"]["changed_files"][0]["cache_status"],
+        "hit"
+    );
+    assert!(
+        top_dependencies_include(&cached_changed, "src/new.rs"),
+        "cached changed file imports should patch stale graph cache: {cached_changed:#?}"
+    );
+}
+
+#[test]
 fn since_scan_uses_base_ref_scope() {
     let temp = tempdir().expect("temp dir");
     init_repo(temp.path());
@@ -289,6 +333,31 @@ fn scan_changed_json(root: &Path, args: &[&str]) -> Value {
     );
 
     serde_json::from_slice(&output.stdout).expect("json output")
+}
+
+fn inspect_graph_json(root: &Path) -> Value {
+    let output = repopilot()
+        .args(["inspect", "graph", ".", "--format", "json"])
+        .current_dir(root)
+        .output()
+        .expect("run repopilot inspect graph");
+
+    assert!(
+        output.status.success(),
+        "inspect graph failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    serde_json::from_slice(&output.stdout).expect("json output")
+}
+
+fn top_dependencies_include(json: &Value, expected_path: &str) -> bool {
+    json["context_graph_summary"]["top_dependencies"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .any(|metric| metric["path"] == expected_path)
 }
 
 fn clear_cache(root: &Path) {


### PR DESCRIPTION
## Summary

This PR hardens RepoPilot's Context Risk Graph workflow.

It improves `inspect graph`, adds bounded graph summaries for large repositories, strengthens context graph cache metadata, documents graph inspection behavior, and improves local artifact hygiene so graph/cache/report files do not leak into Git.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] Cache / performance hardening

## What changed

- Added / hardened `repopilot inspect graph`.
- Limited `inspect graph` output formats to:
  - console
  - Markdown
  - JSON
- Rejected unsupported HTML/SARIF output for `inspect graph` with a clear usage error.
- Added Context Risk Graph docs to `docs/commands.md`.
- Documented that `inspect graph` runs a local scan by default.
- Added truncation metadata for large graph sections.
- Added bounds for:
  - cycles
  - top hubs
  - top dependencies
  - risky clusters
  - changed-file blast radius
- Added `truncated` metadata to `ContextGraphSummary`.
- Improved graph cycle detection with bounded cycle collection.
- Added context graph cache input fingerprinting.
- Bumped context graph cache schema.
- Improved path component matching for Windows-style paths.
- Updated `.gitignore` and `.repopilotignore` for local reports, receipts, feedback, and cache artifacts.
- Added tests for:
  - graph inspection output formats
  - graph truncation behavior
  - changed-scan cache behavior
  - Windows-style path component matching

## Why

RepoPilot should explain where repository risk is structurally concentrated without producing huge, noisy, or misleading reports.

The Context Risk Graph helps users understand:

```text
high fan-in files
import hubs
cycles
risky clusters
changed-file blast radius
```

But graph analysis can become expensive on large repositories. This PR makes the output bounded, the cache behavior more explicit, and the command behavior less surprising.

## Architecture notes

No god files introduced.

- Graph domain logic stays under src/graph/context.
- CLI orchestration stays in src/commands/graph.rs.
- Output is bounded before rendering.
- Graph cache metadata is local-only and deterministic.
- inspect graph does not use telemetry, hosted analysis, remote cache, plugins, or LLM calls.
- Command-local graph JSON is documented as diagnostics output, not the stable scan report contract.

## Compatibility

- Existing scan/review commands remain available.
- inspect graph is additive.
- JSON scan report schema includes optional graph metadata.
- Graph cache schema is intentionally bumped.
- Local graph/report artifacts are ignored by Git by default.

## Verification
```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```

Smoke checks:

```
cargo run -- inspect graph .
cargo run -- inspect graph . --format markdown --output /tmp/repopilot-graph.md
cargo run -- inspect graph . --format json --output /tmp/repopilot-graph.json
cargo run -- scan . --changed --format json --output /tmp/repopilot-changed.json
cargo run -- scan . --format json --output /tmp/repopilot-scan.json
```