### PR TITLE
refactor(graph): replace include splits with module boundaries

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -418,6 +418,8 @@ section names.
 Changed-scope graph and blast-radius details are available only when the scan
 summary has changed-file context; full graph inspection does not invent a diff.
 
+Performance note: `inspect graph` builds its view from a local scan summary. It should not scan again during rendering. Large graph sections are bounded and listed in the `truncated` field when capped.
+
 ---
 
 ## `inspect feedback`

--- a/docs/engineering/graph-scan-hardening.md
+++ b/docs/engineering/graph-scan-hardening.md
@@ -1,0 +1,43 @@
+# Graph and scan hardening notes
+
+RepoPilot's Context Risk Graph is a repository-context optimization, not a
+replacement for source scanning.
+
+## Rules
+
+- `RepoContextGraph` may cache file context, imports, framework metadata, graph
+  edges, and derived graph summaries.
+- It must not be treated as a full `ScanFacts` or source-content cache.
+- Changed scans must still analyze changed file contents before scoring.
+- Renderers must never trigger another scan.
+- Commands should build one `ScanSummary` and pass it through filters,
+  visibility, report schema, and renderers.
+- Graph output must stay bounded for large repositories.
+
+## Large repository limits
+
+Graph output should stay capped:
+
+```text
+MAX_CONTEXT_GRAPH_CYCLES
+MAX_CONTEXT_GRAPH_METRICS
+MAX_CONTEXT_GRAPH_RISKY_CLUSTERS
+MAX_CONTEXT_GRAPH_BLAST_RADIUS
+```
+
+If a section is truncated, the report should say which section was truncated
+instead of silently hiding the limit.
+
+## Cache invalidation
+
+Context graph cache must be invalidated when any of these change:
+
+- graph schema version;
+- resolver version;
+- RepoPilot version;
+- scan configuration fingerprint;
+- relevant graph inputs: files, imports, roles, frameworks, runtimes,
+  paradigms, detected frameworks, React Native profile.
+
+If a future optimization uses file hashes or mtime snapshots, it must remain
+local-first and deterministic.

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -127,9 +127,15 @@ pub struct RepoContextGraphLoad {
     pub cache_info: ContextGraphCacheInfo,
 }
 
-include!("context/graph_impl.rs");
-include!("context/summary.rs");
-include!("context/cache.rs");
+mod cache;
+mod graph_impl;
+mod summary;
+
+pub use cache::{
+    cache_diagnostic, context_graph_cache_miss, context_graph_cache_path, load_repo_context_graph,
+    write_repo_context_graph,
+};
+pub use summary::summarize_context_graph;
 
 #[cfg(test)]
 mod tests {

--- a/src/graph/context/cache.rs
+++ b/src/graph/context/cache.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 pub fn load_repo_context_graph(root: &Path, config: &ScanConfig) -> Option<RepoContextGraphLoad> {
     let cache_path = context_graph_cache_path(root);
     let cached = read_cached_repo_context_graph(&cache_path)?;
@@ -152,7 +154,10 @@ fn stable_edge_inputs(graph: &RepoContextGraph) -> Vec<serde_json::Value> {
         .edges
         .iter()
         .map(|(source, targets)| {
-            let mut targets = targets.iter().map(|path| stable_path(path)).collect::<Vec<_>>();
+            let mut targets = targets
+                .iter()
+                .map(|path| stable_path(path))
+                .collect::<Vec<_>>();
             targets.sort();
             serde_json::json!({
                 "source": stable_path(source),

--- a/src/graph/context/graph_impl.rs
+++ b/src/graph/context/graph_impl.rs
@@ -1,3 +1,6 @@
+use super::summary::{build_language_summary, directory_count};
+use super::*;
+
 impl RepoContextGraph {
     pub fn from_scan_facts(facts: &ScanFacts, root: &Path, coupling_graph: CouplingGraph) -> Self {
         Self {

--- a/src/graph/context/summary.rs
+++ b/src/graph/context/summary.rs
@@ -1,3 +1,5 @@
+use super::*;
+
 pub fn summarize_context_graph(
     graph: &RepoContextGraph,
     findings: &[Finding],
@@ -194,7 +196,7 @@ fn cluster_scope(path: &Path) -> String {
     }
 }
 
-fn build_language_summary(
+pub(super) fn build_language_summary(
     languages: HashMap<String, usize>,
 ) -> Vec<crate::scan::types::LanguageSummary> {
     let mut languages = languages
@@ -215,7 +217,7 @@ fn build_language_summary(
     languages
 }
 
-fn directory_count(files: &[FileFacts]) -> usize {
+pub(super) fn directory_count(files: &[FileFacts]) -> usize {
     files
         .iter()
         .filter_map(|file| file.path.parent().map(Path::to_path_buf))


### PR DESCRIPTION
## Summary

This PR hardens the Context Risk Graph and changed-scan internals after the graph inspection/cache work.

It replaces remaining `include!`-based module splits with normal Rust module boundaries, keeps changed-scan stages separated, and documents the graph/cache rules that prevent future misuse of `RepoContextGraph` as a full scan cache.

## Type of change

- [x] Refactor
- [x] Documentation
- [x] Architecture cleanup
- [x] Scan/graph hardening

## What changed

- Replaced `include!("context/...")` in graph context code with normal modules:
  - `cache`
  - `graph_impl`
  - `summary`
- Replaced `include!("changed/...")` in changed scan code with normal modules:
  - `file_analysis`
  - `repo_context`
  - `finalize`
- Added focused `pub(super)` visibility for helpers that should not become public API.
- Added engineering documentation for graph/cache boundaries.
- Documented that `RepoContextGraph` is not a full `ScanFacts` or source-content cache.
- Documented that renderers must not trigger another scan.
- Documented large repository graph output limits and truncation rules.
- Added a performance note for `inspect graph` in command docs.

## Why

The previous split removed god-file pressure, but `include!` still keeps modules textually merged at compile time. That makes boundaries weaker and easier to misuse later.

This PR makes the split real:

```text
changed scan orchestration -> normal Rust modules
context graph internals -> normal Rust modules
cache rules -> documented engineering boundary
```

This makes future work safer around changed scans, graph cache invalidation, large-repo behavior, and report rendering.

## Architecture notes

- No god files introduced.
- Changed scan remains staged:
  - discovery
  - file analysis
  - repo context
  - finding pipeline
  - finalization
- Context graph internals remain separated:
  - cache
  - graph implementation
  - summary
-RepoContextGraph remains a context/graph cache, not a full scan cache.
-Renderers should consume ScanSummary and must not run scans.

## Verification

```
cargo fmt --all -- --check
cargo test --all
cargo clippy --all-targets --all-features -- -D warnings
```

Smoke checks:

```
cargo run -- inspect graph .
cargo run -- inspect graph . --format json --output /tmp/repopilot-graph.json
cargo run -- scan . --changed --format json --output /tmp/repopilot-changed.json
cargo run -- scan . --format json --output /tmp/repopilot-scan.json
```