### PR TITLE
feat(reports): expose raw vs visible signal quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Added
 
 - Added a 0.13 release checklist for the breaking cleanup release.
-- Added a current `0.15` scan report fixture that documents the supported compare input schema.
+- Added a current `0.17` scan report fixture that documents raw-vs-visible report metrics.
 - Added finding contract validation with diagnostics, release-test coverage, and contract timing.
 - Added an indexed rule metadata lookup and registry uniqueness coverage.
 - Added finding provenance with detector, rule lifecycle, signal source, and analysis scope.
@@ -20,11 +20,15 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added local rule evaluation fixtures for `security.secret-candidate` and `language.rust.panic-risk`.
 - Added per-rule JSON details to `repopilot inspect eval-rules`.
 - Added a product smoke self-scan gate for finding contract violations.
+- Added rule quality metadata to `inspect rules` output, including fixture coverage, semantic source, required scope, false-positive risk, and stability gate status.
+- Added launch positioning and performance budget docs for the 0.13 hardening track.
 
 ### Changed
 
 - Bumped the crate, npm wrapper, optional platform package pins, and GitHub Action default version to `0.13.0`.
-- Bumped scan report schema to `0.15` for provenance, signal quality, finding contract diagnostics, and `risk-v3`.
+- Bumped scan report schema to `0.17` for raw-vs-visible finding counts and signal quality metrics while accepting `0.15` and `0.16` reports during the transition.
+- Default scan visibility now surfaces high-priority maintainability risks and stable import-graph P2+ risks while keeping low-signal testing and marker noise strict-only.
+- Downgraded line/token runtime and long-function rule provenance from `ast` to `text-heuristic` until those rules consume shared parsed facts.
 - Updated risk scoring metadata to `risk-v3` with typed risk signal sources and clearer signal reasons.
 - Centralized scan finding enrichment before risk scoring and report construction.
 - Cached report signal quality on `ScanSummary` so renderers reuse one summary per report path.

--- a/README.md
+++ b/README.md
@@ -331,8 +331,11 @@ a stronger local scan engine, rule lifecycle discipline, signal quality metrics,
 and pre-v1 product contract hardening.
 
 Every rendered finding is enriched and validated before reporting. JSON reports
-include finding provenance, `risk-v3` signals, and a compact `signal_quality`
-summary. Rule metadata is inspectable locally:
+include finding provenance, `risk-v3` signals, raw-vs-visible finding counts,
+`raw_signal_quality`, and `visible_signal_quality`. The default scan is a normal
+actionable scan: high-priority runtime, security, maintainability, and stable
+import-graph risks stay visible, while low-signal testing and marker noise stays
+available through `--profile strict`. Rule metadata is inspectable locally:
 
 ```bash
 repopilot inspect rules

--- a/docs/engineering/performance-budgets.md
+++ b/docs/engineering/performance-budgets.md
@@ -1,0 +1,38 @@
+# Performance Budgets
+
+RepoPilot scan performance is part of the product contract. A local-first safety
+pass must stay fast enough for pre-commit, AI-agent loops, and CI adoption.
+
+## Initial Budgets
+
+These budgets start with RepoPilot self-scan fixtures and should be tightened as
+larger fixture repositories are added:
+
+| Scenario | Budget |
+|---|---:|
+| Warm full scan accounted engine time | <= 600ms |
+| Report finalization | <= 100ms |
+| Changed scan cache lookup and reuse | No material regression after cache warmup |
+
+A benchmark update should be explicit when a legitimate scan-engine improvement
+changes expected work. Otherwise, avoid merging changes that regress an existing
+budget by more than 10%.
+
+## Measurement
+
+Use:
+
+```bash
+repopilot scan . --profile strict --timing --format json --output /tmp/repopilot-self-scan.json
+```
+
+Track `scan_timings.accounted_engine_us()` from the timing breakdown and
+`scan_timings.report_finalization_us` from the JSON report. Keep wall-clock
+numbers as supporting context only; the budget should focus on accounted engine
+timing so CI host variance does not create noisy failures.
+
+## Fixture Direction
+
+Add small, medium, and large synthetic repositories before enforcing this as a
+hard CI gate. The gate should fail on major regressions only after fixture timing
+is stable on the project CI runners.

--- a/docs/gtm-0.13.md
+++ b/docs/gtm-0.13.md
@@ -1,0 +1,52 @@
+# RepoPilot 0.13 Go-To-Market
+
+## Positioning
+
+RepoPilot is the local-first repository risk context layer before AI agents, PRs,
+and releases. It is not a replacement for CodeQL, Semgrep, Snyk, or Sonar. Use
+those tools for deep SAST, dependency, and platform-specific assurance; use
+RepoPilot to explain local repo structure, baseline accepted debt, and generate
+AI-ready remediation context without uploading source.
+
+## Demos
+
+1. AI coding safety loop: run `repopilot scan .`, inspect visible P1/P2 risks,
+   then generate `repopilot ai context . --format markdown` for local agent work.
+2. Baseline-aware CI gate: create `.repopilot/baseline.json`, fail on new high
+   risk, and show hidden strict-only suggestions as backlog rather than noise.
+3. React Native/Expo release check: scan mobile release configuration, native
+   project presence, Hermes/new architecture drift, and risky runtime exits.
+
+## Adoption Assets
+
+- README quickstart with default actionable scan behavior.
+- 90-second terminal demo: default scan, strict scan, baseline gate, AI context.
+- Sample Markdown and HTML reports showing raw versus visible metrics.
+- Copy-paste GitHub Action workflow pinned to `MykytaStel/repopilot@v0.13.0`.
+- “Why not just a linter/SAST?” comparison focused on local repo context,
+  baseline-aware debt, and AI remediation handoff.
+
+## Selling Proof Points
+
+- Local-first: no telemetry, source upload, hosted scanner, plugin execution, or
+  automatic LLM calls.
+- Trust surface: schema `0.17`, finding provenance, rule lifecycle, rule quality
+  gates, raw-vs-visible signal quality, and fixture-backed rule evaluation.
+- Workflow fit: runs before AI agents, in PR review, and in CI without replacing
+  existing SAST or dependency scanners.
+
+## Current Market References
+
+- GitHub CodeQL CLI documents SARIF output for sharing static analysis results
+  with other systems: https://docs.github.com/en/code-security/reference/code-scanning/codeql/codeql-cli
+- Semgrep documents `semgrep scan` for local scans and `semgrep ci` for
+  organization/CI scans: https://semgrep.dev/docs/getting-started/cli
+- Snyk Code positions itself as developer-first SAST:
+  https://docs.snyk.io/scan-using-snyk/snyk-code
+- SonarQube Cloud documents AI Code Assurance for AI-generated code standards:
+  https://docs.sonarsource.com/sonarqube-cloud/ai-capabilities/ai-code-assurance
+- GitHub Copilot coding agent, Claude Code, and OpenAI Codex all position coding
+  agents as tools that can inspect repositories and perform development tasks:
+  https://docs.github.com/en/copilot/using-github-copilot/coding-agent/about-assigning-tasks-to-copilot,
+  https://docs.claude.com/en/docs/agents-and-tools/claude-code/overview,
+  https://openai.com/codex

--- a/docs/integrations/github-code-scanning.md
+++ b/docs/integrations/github-code-scanning.md
@@ -95,7 +95,7 @@ jobs:
 
       - name: Run RepoPilot
         id: repopilot
-        uses: MykytaStel/repopilot@v0.12.0
+        uses: MykytaStel/repopilot@v0.13.0
         with:
           command: scan
           baseline: .repopilot/baseline.json
@@ -115,7 +115,7 @@ For review-only gates, use `command: review` without `receipt`:
 
 ```yaml
       - name: RepoPilot review gate
-        uses: MykytaStel/repopilot@v0.12.0
+        uses: MykytaStel/repopilot@v0.13.0
         with:
           command: review
           base: origin/main
@@ -129,7 +129,7 @@ action without SARIF upload:
 
 ```yaml
       - name: RepoPilot doctor
-        uses: MykytaStel/repopilot@v0.12.0
+        uses: MykytaStel/repopilot@v0.13.0
         with:
           command: doctor
           format: markdown
@@ -137,7 +137,7 @@ action without SARIF upload:
           upload-sarif: "false"
 
       - name: RepoPilot focused scan
-        uses: MykytaStel/repopilot@v0.12.0
+        uses: MykytaStel/repopilot@v0.13.0
         with:
           command: scan
           rule: language.rust.panic-risk

--- a/docs/release-checklist-0.13.md
+++ b/docs/release-checklist-0.13.md
@@ -67,9 +67,9 @@ cargo run -- inspect eval-rules --format json --output /tmp/repopilot-rule-eval.
 
 Verify:
 
-- `repopilot compare` accepts current `0.15` scan reports;
+- `repopilot compare` accepts current `0.17` scan reports;
 - `repopilot compare` rejects pre-current scan report shapes clearly;
-- JSON reports include `signal_quality`, finding `provenance`, `risk.signals[].source`, and `risk-v3`;
+- JSON reports include `raw_findings_count`, `visible_findings_count`, `raw_signal_quality`, `visible_signal_quality`, finding `provenance`, `risk.signals[].source`, and `risk-v3`;
 - JSON reports include `scan_timings.contract_validation_us` when scan timings are present;
 - active docs describe the current command surface, not removed 0.x aliases;
 - schema migration docs state that historical report compatibility belongs in downstream consumers when needed.

--- a/docs/report-schema-migration.md
+++ b/docs/report-schema-migration.md
@@ -5,16 +5,24 @@ useful in CI, dashboards, PR bots, and downstream tooling.
 
 ## Current direction
 
-Schema `0.15` is the current scan report schema for RepoPilot 0.13.0. It adds
-finding provenance, typed risk signal sources, `risk-v3`, signal quality
-metrics, and finding-contract diagnostics.
+Schema `0.17` is the current scan report schema for RepoPilot 0.13.0. It keeps
+`0.15` provenance and `risk-v3` fields, keeps `0.16` context graph diagnostics,
+and adds raw-vs-visible finding and signal-quality metrics.
 
 | Field | Where | Why |
 |---|---|---|
+| `raw_findings_count` | scan, baseline-scan | Shows how many findings existed before default visibility filtering. |
+| `visible_findings_count` | scan, baseline-scan | Shows the findings rendered in the current report. |
+| `hidden_suggestions_count` | scan, baseline-scan | Shows strict-only suggestions hidden from the default report. |
+| `raw_signal_quality` | scan, baseline-scan, review | Summarizes quality before visibility filtering. |
+| `visible_signal_quality` | scan, baseline-scan, review | Summarizes quality for rendered findings. |
+| `signal_quality` | scan, baseline-scan, review | Compatibility alias for `visible_signal_quality`. |
 | `provenance` | finding | Explains detector, lifecycle, signal source, and analysis scope. |
 | `risk.signals[].source` | finding risk signal | Gives machine-readable source families for risk explanations. |
-| `signal_quality` | scan, baseline-scan, review | Summarizes confidence, lifecycle, source, evidence, recommendation, docs, and contract warning coverage. |
 | `scan_timings.contract_validation_us` | scan timings | Exposes finding-contract validation timing separately. |
+
+RepoPilot's current reader accepts `0.15`, `0.16`, and `0.17` scan reports
+during the transition. New reports are emitted as `0.17`.
 
 Schema `0.14` added optional local feedback transparency:
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -11,15 +11,15 @@ repopilot scan . --format json --output repopilot-report.json
 
 ## JSON report schema
 
-JSON scan reports include explicit schema metadata. The current schema is 0.15:
+JSON scan reports include explicit schema metadata. The current schema is 0.17:
 
 ```json
 {
-  "schema_version": "0.15",
+  "schema_version": "0.17",
   "repopilot_version": "0.13.0",
   "report": {
     "kind": "scan",
-    "schema_version": "0.15",
+    "schema_version": "0.17",
     "repopilot_version": "0.13.0"
   },
   "root_path": ".",
@@ -28,12 +28,29 @@ JSON scan reports include explicit schema metadata. The current schema is 0.15:
   "non_empty_lines": 3200,
   "languages": [],
   "risk_summary": {
-    "total": 0,
-    "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 },
-    "average_score": 0
+    "total": 3,
+    "counts": { "p0": 0, "p1": 1, "p2": 2, "p3": 0 },
+    "average_score": 58
+  },
+  "raw_findings_count": 12,
+  "visible_findings_count": 3,
+  "hidden_suggestions_count": 9,
+  "raw_signal_quality": {
+    "findings_total": 12,
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  },
+  "visible_signal_quality": {
+    "findings_total": 3,
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
   },
   "signal_quality": {
-    "findings_total": 0,
+    "findings_total": 3,
     "evidence_coverage_percent": 100,
     "recommendation_coverage_percent": 100,
     "docs_coverage_for_high_risk_percent": 100,
@@ -61,7 +78,12 @@ JSON scan reports include explicit schema metadata. The current schema is 0.15:
 | `repopilot_version` | string | RepoPilot binary version that produced the report. |
 | `report` | object | Versioned report envelope for consumers that prefer metadata under one stable object. |
 | `risk_summary` | object | Aggregate priority counts and average risk score derived from finding risk assessments. |
-| `signal_quality` | object | Aggregate confidence, lifecycle, source, coverage, and finding-contract warning metrics. |
+| `raw_findings_count` | number | Findings before the default visibility profile hides strict-only suggestions. |
+| `visible_findings_count` | number | Findings rendered in the current report after visibility, feedback, and explicit filters. |
+| `hidden_suggestions_count` | number | Findings hidden by the default profile but available through `--profile strict`. |
+| `raw_signal_quality` | object | Aggregate confidence, lifecycle, source, coverage, and contract metrics before visibility filtering. |
+| `visible_signal_quality` | object | Aggregate quality for findings visible in this report. |
+| `signal_quality` | object | Compatibility alias for `visible_signal_quality`. |
 | `cache_telemetry` | object | Optional changed-scan cache summary with hits, misses, changed-file reasons, per-file cache decisions, and cache timing impact. |
 | `scan_timings` | object | Optional engine timing metadata. `file_scan_us` remains the compatibility aggregate; newer fields break out `discovery_us`, `file_analysis_us`, `enrichment_us`, `risk_scoring_us`, `contract_validation_us`, and `report_finalization_us`. |
 | `local_feedback` | object | Optional summary of `.repopilot/feedback.yml` suppressions applied during this scan or review. |
@@ -98,6 +120,10 @@ Schema `0.15` adds finding provenance, typed risk signal sources, `risk-v3`,
 finding-contract diagnostics, and `signal_quality` metrics. This is part of the
 0.13.0 breaking cleanup release.
 
+Schema `0.16` adds context graph report and cache diagnostics. Schema `0.17`
+adds raw-vs-visible finding and signal-quality metrics so default-profile
+reports do not look clean when meaningful strict-only findings were hidden.
+
 ## Baseline JSON reports
 
 When a scan is rendered with a baseline, the JSON report also includes the same
@@ -114,11 +140,11 @@ Example shape:
 
 ```json
 {
-  "schema_version": "0.15",
+  "schema_version": "0.17",
   "repopilot_version": "0.13.0",
   "report": {
     "kind": "baseline-scan",
-    "schema_version": "0.15",
+    "schema_version": "0.17",
     "repopilot_version": "0.13.0"
   },
   "root_path": ".",

--- a/src/findings/filter.rs
+++ b/src/findings/filter.rs
@@ -62,7 +62,16 @@ pub fn recompute_summary_metrics(summary: &mut ScanSummary) {
     summary.visible_findings_count = summary.findings.len();
     summary.health_score =
         ScanSummary::compute_health_score(&summary.findings, summary.non_empty_lines);
-    summary.signal_quality = summarize_signal_quality(&summary.findings);
+    let visible_signal_quality = summarize_signal_quality(&summary.findings);
+    if summary.raw_findings_count == 0
+        && summary.hidden_suggestions_count == 0
+        && !summary.findings.is_empty()
+    {
+        summary.raw_findings_count = summary.findings.len();
+        summary.raw_signal_quality = visible_signal_quality.clone();
+    }
+    summary.visible_signal_quality = visible_signal_quality.clone();
+    summary.signal_quality = visible_signal_quality;
 }
 
 #[cfg(test)]

--- a/src/findings/visibility.rs
+++ b/src/findings/visibility.rs
@@ -1,4 +1,5 @@
 use crate::findings::filter::recompute_summary_metrics;
+use crate::findings::quality::summarize_signal_quality;
 use crate::findings::types::Finding;
 use crate::scan::types::{HiddenSuggestionSummary, ScanSummary};
 use std::collections::BTreeMap;
@@ -92,6 +93,8 @@ struct HiddenSuggestionKey {
 /// stores a structured breakdown for hidden suggestions.
 pub fn apply_visibility_profile(summary: &mut ScanSummary, profile: FindingVisibilityProfile) {
     summary.visibility_profile = Some(profile.label().to_string());
+    summary.raw_findings_count = summary.findings.len();
+    summary.raw_signal_quality = summarize_signal_quality(&summary.findings);
     summary.visible_findings_count = summary.findings.len();
     summary.hidden_suggestions_count = 0;
     summary.hidden_suggestions.clear();

--- a/src/findings/visibility/policy.rs
+++ b/src/findings/visibility/policy.rs
@@ -24,10 +24,7 @@ pub fn classify_visibility(finding: &Finding) -> FindingVisibilityDecision {
         FindingIntent::SecurityRisk => security_visibility(finding),
         FindingIntent::RuntimeRisk => runtime_visibility(finding),
         FindingIntent::ActionableRisk => actionable_visibility(finding),
-        FindingIntent::Maintainability => FindingVisibilityDecision::hidden(
-            intent,
-            "maintainability signals are hidden in the default profile",
-        ),
+        FindingIntent::Maintainability => maintainability_visibility(finding),
         FindingIntent::TestingGap => FindingVisibilityDecision::hidden(
             intent,
             "testing gaps are hidden in the default profile",
@@ -82,6 +79,16 @@ fn runtime_visibility(finding: &Finding) -> FindingVisibilityDecision {
 }
 
 fn actionable_visibility(finding: &Finding) -> FindingVisibilityDecision {
+    if is_import_graph_rule(&finding.rule_id)
+        && finding.risk.priority.is_at_least(RiskPriority::P2)
+        && finding.confidence != Confidence::Low
+    {
+        return FindingVisibilityDecision::visible(
+            FindingIntent::ActionableRisk,
+            "stable import-graph architecture risk",
+        );
+    }
+
     if is_high_priority(finding.risk.priority) {
         return FindingVisibilityDecision::visible(
             FindingIntent::ActionableRisk,
@@ -102,6 +109,20 @@ fn actionable_visibility(finding: &Finding) -> FindingVisibilityDecision {
     )
 }
 
+fn maintainability_visibility(finding: &Finding) -> FindingVisibilityDecision {
+    if is_high_priority(finding.risk.priority) && finding.confidence != Confidence::Low {
+        return FindingVisibilityDecision::visible(
+            FindingIntent::Maintainability,
+            "high-priority maintainability risk",
+        );
+    }
+
+    FindingVisibilityDecision::hidden(
+        FindingIntent::Maintainability,
+        "maintainability signal is below the default priority threshold",
+    )
+}
+
 fn classify_intent(finding: &Finding) -> FindingIntent {
     if finding.category == FindingCategory::Testing {
         return FindingIntent::TestingGap;
@@ -113,6 +134,10 @@ fn classify_intent(finding: &Finding) -> FindingIntent {
 
     if is_runtime_rule(&finding.rule_id) {
         return FindingIntent::RuntimeRisk;
+    }
+
+    if is_import_graph_rule(&finding.rule_id) {
+        return FindingIntent::ActionableRisk;
     }
 
     if is_maintainability_rule(&finding.rule_id) {
@@ -151,6 +176,15 @@ fn is_maintainability_rule(rule_id: &str) -> bool {
             | "code-quality.long-function"
             | "code-quality.complex-file"
             | "code-quality.cyclomatic-complexity"
+    )
+}
+
+fn is_import_graph_rule(rule_id: &str) -> bool {
+    matches!(
+        rule_id,
+        "architecture.circular-dependency"
+            | "architecture.excessive-fan-out"
+            | "architecture.high-instability-hub"
     )
 }
 

--- a/src/findings/visibility/tests.rs
+++ b/src/findings/visibility/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::findings::types::{Confidence, Evidence, FindingCategory, Severity};
+use crate::risk::{RiskAssessment, RiskPriority};
 use std::path::PathBuf;
 
 fn finding(rule_id: &str, category: FindingCategory, severity: Severity) -> Finding {
@@ -25,6 +26,20 @@ fn finding_with_path(
         line_end: None,
         snippet: "process.exit(1);".to_string(),
     }];
+    finding
+}
+
+fn finding_with_priority(
+    rule_id: &str,
+    category: FindingCategory,
+    severity: Severity,
+    priority: RiskPriority,
+) -> Finding {
+    let mut finding = finding(rule_id, category, severity);
+    finding.risk = RiskAssessment {
+        priority,
+        ..RiskAssessment::default()
+    };
     finding
 }
 
@@ -68,6 +83,36 @@ fn default_profile_hides_deep_relative_imports() {
 
     assert_eq!(decision.intent, FindingIntent::Maintainability);
     assert!(!decision.visible_by_default);
+}
+
+#[test]
+fn default_profile_keeps_high_priority_maintainability_signals() {
+    let finding = finding_with_priority(
+        "code-quality.long-function",
+        FindingCategory::CodeQuality,
+        Severity::Medium,
+        RiskPriority::P1,
+    );
+
+    let decision = classify_visibility(&finding);
+
+    assert_eq!(decision.intent, FindingIntent::Maintainability);
+    assert!(decision.visible_by_default);
+}
+
+#[test]
+fn default_profile_keeps_stable_import_graph_architecture_risks() {
+    let finding = finding_with_priority(
+        "architecture.excessive-fan-out",
+        FindingCategory::Architecture,
+        Severity::Medium,
+        RiskPriority::P2,
+    );
+
+    let decision = classify_visibility(&finding);
+
+    assert_eq!(decision.intent, FindingIntent::ActionableRisk);
+    assert!(decision.visible_by_default);
 }
 
 #[test]
@@ -183,8 +228,12 @@ fn apply_default_profile_recomputes_visible_counts_and_hidden_breakdown() {
     apply_visibility_profile(&mut summary, FindingVisibilityProfile::Default);
 
     assert_eq!(summary.visibility_profile.as_deref(), Some("default"));
+    assert_eq!(summary.raw_findings_count, 2);
     assert_eq!(summary.visible_findings_count, 1);
     assert_eq!(summary.hidden_suggestions_count, 1);
+    assert_eq!(summary.raw_signal_quality.findings_total, 2);
+    assert_eq!(summary.visible_signal_quality.findings_total, 1);
+    assert_eq!(summary.signal_quality.findings_total, 1);
     assert_eq!(summary.hidden_suggestions.len(), 1);
     assert_eq!(summary.hidden_suggestions[0].intent, "maintainability");
     assert_eq!(
@@ -224,6 +273,7 @@ fn strict_profile_keeps_all_findings_and_clears_hidden_breakdown() {
     apply_visibility_profile(&mut summary, FindingVisibilityProfile::Strict);
 
     assert_eq!(summary.visibility_profile.as_deref(), Some("strict"));
+    assert_eq!(summary.raw_findings_count, 2);
     assert_eq!(summary.visible_findings_count, 2);
     assert_eq!(summary.hidden_suggestions_count, 0);
     assert!(summary.hidden_suggestions.is_empty());

--- a/src/graph/context/cache.rs
+++ b/src/graph/context/cache.rs
@@ -28,11 +28,10 @@ pub fn write_repo_context_graph(
     if let Some(parent) = cache_path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let input_fingerprint = context_graph_input_fingerprint(graph);
-    let graph_fingerprint = context_graph_fingerprint(graph);
+    let (input_fingerprint, graph_fingerprint) = context_graph_fingerprints(graph);
 
     if let Some(cached) = read_cached_repo_context_graph(&cache_path)
-        && valid_cached_graph(&cached, config)
+        && valid_cached_graph_metadata(&cached, config)
         && cached.input_fingerprint == input_fingerprint
         && cached.graph_fingerprint == graph_fingerprint
     {
@@ -52,7 +51,7 @@ pub fn write_repo_context_graph(
         graph_fingerprint,
         graph: graph.clone(),
     };
-    let rendered = serde_json::to_string_pretty(&cached).map_err(io::Error::other)?;
+    let rendered = serde_json::to_vec(&cached).map_err(io::Error::other)?;
     fs::write(&cache_path, rendered)?;
 
     Ok(ContextGraphCacheInfo {
@@ -78,45 +77,54 @@ pub fn cache_diagnostic(error: &io::Error) -> ScanDiagnostic {
 }
 
 fn valid_cached_graph(cached: &CachedRepoContextGraph, config: &ScanConfig) -> bool {
+    if !valid_cached_graph_metadata(cached, config) {
+        return false;
+    }
+
+    let (input_fingerprint, graph_fingerprint) = context_graph_fingerprints(&cached.graph);
+    cached.input_fingerprint == input_fingerprint && cached.graph_fingerprint == graph_fingerprint
+}
+
+fn valid_cached_graph_metadata(cached: &CachedRepoContextGraph, config: &ScanConfig) -> bool {
     cached.schema_version == CONTEXT_GRAPH_SCHEMA_VERSION
         && cached.repopilot_version == env!("CARGO_PKG_VERSION")
         && cached.config_fingerprint == config_fingerprint(config)
         && cached.resolver_version == CONTEXT_GRAPH_RESOLVER_VERSION
-        && cached.input_fingerprint == context_graph_input_fingerprint(&cached.graph)
-        && cached.graph_fingerprint == context_graph_fingerprint(&cached.graph)
 }
 
 pub fn context_graph_cache_path(root: &Path) -> PathBuf {
     cache_dir(root).join(CONTEXT_GRAPH_CACHE_NAME)
 }
 
-fn context_graph_fingerprint(graph: &RepoContextGraph) -> String {
+fn context_graph_fingerprints(graph: &RepoContextGraph) -> (String, String) {
+    let nodes = stable_node_inputs(graph);
+    let edges = stable_edge_inputs(graph);
     let input = serde_json::json!({
+        "schema": CONTEXT_GRAPH_SCHEMA_VERSION,
+        "resolver": CONTEXT_GRAPH_RESOLVER_VERSION,
+        "nodes": &nodes,
+        "edges": &edges,
+        "frameworks": &graph.detected_frameworks,
+        "framework_projects": &graph.framework_projects,
+        "react_native": &graph.react_native,
+    });
+    let input_fingerprint = stable_hash_hex(input.to_string().as_bytes());
+    let graph_input = serde_json::json!({
         "schema": CONTEXT_GRAPH_SCHEMA_VERSION,
         "resolver": CONTEXT_GRAPH_RESOLVER_VERSION,
         "risk_formula": crate::risk::FORMULA_VERSION,
         "knowledge_pack": stable_hash_hex(include_bytes!("../../knowledge/packs/core.toml")),
-        "input": context_graph_input_fingerprint(graph),
-        "nodes": stable_node_inputs(graph),
-        "edges": stable_edge_inputs(graph),
+        "input": input_fingerprint,
+        "nodes": &nodes,
+        "edges": &edges,
         "frameworks": &graph.detected_frameworks,
         "framework_projects": &graph.framework_projects,
         "react_native": &graph.react_native,
     });
-    stable_hash_hex(input.to_string().as_bytes())
-}
-
-fn context_graph_input_fingerprint(graph: &RepoContextGraph) -> String {
-    let input = serde_json::json!({
-        "schema": CONTEXT_GRAPH_SCHEMA_VERSION,
-        "resolver": CONTEXT_GRAPH_RESOLVER_VERSION,
-        "nodes": stable_node_inputs(graph),
-        "edges": stable_edge_inputs(graph),
-        "frameworks": &graph.detected_frameworks,
-        "framework_projects": &graph.framework_projects,
-        "react_native": &graph.react_native,
-    });
-    stable_hash_hex(input.to_string().as_bytes())
+    (
+        input_fingerprint,
+        stable_hash_hex(graph_input.to_string().as_bytes()),
+    )
 }
 
 fn read_cached_repo_context_graph(path: &Path) -> Option<CachedRepoContextGraph> {

--- a/src/output/console/sections/header.rs
+++ b/src/output/console/sections/header.rs
@@ -14,12 +14,21 @@ pub(crate) fn render_header(output: &mut String, summary: &ScanSummary, stats: &
         health_score_bar(stats.health_score)
     )
     .unwrap();
-    writeln!(
-        output,
-        "Findings: {} visible ({:.1}/kloc)",
-        stats.total_findings, stats.finding_density
-    )
-    .unwrap();
+    if summary.raw_findings_count > summary.visible_findings_count {
+        writeln!(
+            output,
+            "Findings: {} visible / {} raw ({:.1}/kloc visible)",
+            summary.visible_findings_count, summary.raw_findings_count, stats.finding_density
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            output,
+            "Findings: {} visible ({:.1}/kloc)",
+            stats.total_findings, stats.finding_density
+        )
+        .unwrap();
+    }
     if summary.hidden_suggestions_count > 0 {
         writeln!(
             output,

--- a/src/output/console/sections/risk.rs
+++ b/src/output/console/sections/risk.rs
@@ -51,6 +51,20 @@ pub(crate) fn render_risk_summary(output: &mut String, stats: &ReportStats) {
 pub(crate) fn render_signal_quality(output: &mut String, summary: &ScanSummary) {
     let quality = &summary.signal_quality;
     output.push_str("Signal quality:\n");
+    if summary.raw_findings_count > summary.visible_findings_count {
+        writeln!(
+            output,
+            "  Visible findings: {} | Raw findings: {}",
+            summary.visible_findings_count, summary.raw_findings_count
+        )
+        .unwrap();
+        writeln!(
+            output,
+            "  Raw high confidence: {}",
+            summary.raw_signal_quality.by_confidence.high
+        )
+        .unwrap();
+    }
     writeln!(output, "  High confidence: {}", quality.by_confidence.high).unwrap();
     writeln!(
         output,

--- a/src/output/markdown/sections/overview.rs
+++ b/src/output/markdown/sections/overview.rs
@@ -8,12 +8,21 @@ pub(crate) fn render_overview(output: &mut String, summary: &ScanSummary, stats:
     render_scope(output, summary);
     writeln!(output, "- **Risk:** {}", stats.risk_label).unwrap();
     writeln!(output, "- **Health score:** {}/100", stats.health_score).unwrap();
-    writeln!(
-        output,
-        "- **Findings:** {} visible ({:.1}/kloc)",
-        stats.total_findings, stats.finding_density
-    )
-    .unwrap();
+    if summary.raw_findings_count > summary.visible_findings_count {
+        writeln!(
+            output,
+            "- **Findings:** {} visible / {} raw ({:.1}/kloc visible)",
+            summary.visible_findings_count, summary.raw_findings_count, stats.finding_density
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            output,
+            "- **Findings:** {} visible ({:.1}/kloc)",
+            stats.total_findings, stats.finding_density
+        )
+        .unwrap();
+    }
     if summary.hidden_suggestions_count > 0 {
         writeln!(
             output,

--- a/src/output/markdown/sections/risk.rs
+++ b/src/output/markdown/sections/risk.rs
@@ -40,6 +40,26 @@ pub(crate) fn render_risk_summary(output: &mut String, summary: &ScanSummary, st
 pub(crate) fn render_signal_quality(output: &mut String, summary: &ScanSummary) {
     let quality = &summary.signal_quality;
     output.push_str("## Signal Quality\n\n");
+    if summary.raw_findings_count > summary.visible_findings_count {
+        writeln!(
+            output,
+            "- **Visible findings:** {}",
+            summary.visible_findings_count
+        )
+        .unwrap();
+        writeln!(
+            output,
+            "- **Raw findings:** {}",
+            summary.raw_findings_count
+        )
+        .unwrap();
+        writeln!(
+            output,
+            "- **Raw high confidence:** {}",
+            summary.raw_signal_quality.by_confidence.high
+        )
+        .unwrap();
+    }
     writeln!(
         output,
         "- **High confidence:** {}",

--- a/src/output/rules.rs
+++ b/src/output/rules.rs
@@ -46,11 +46,12 @@ fn render_catalog_console(report: &RuleCatalogReport) -> String {
     for rule in &report.rules {
         writeln!(
             output,
-            "{} [{} {} {}]\n  {}",
+            "{} [{} {} {} {}]\n  {}",
             rule.rule_id,
             rule.severity,
             rule.lifecycle.label(),
             rule.signal_source.label(),
+            rule.stability_gate_status,
             rule.title
         )
         .unwrap();
@@ -61,19 +62,22 @@ fn render_catalog_console(report: &RuleCatalogReport) -> String {
 fn render_catalog_markdown(report: &RuleCatalogReport) -> String {
     let mut output = String::new();
     output.push_str("# RepoPilot Rules\n\n");
-    output.push_str("| Rule | Title | Category | Severity | Confidence | Lifecycle | Source |\n");
-    output.push_str("| --- | --- | --- | --- | --- | --- | --- |\n");
+    output.push_str(
+        "| Rule | Title | Category | Severity | Confidence | Lifecycle | Source | Quality gate |\n",
+    );
+    output.push_str("| --- | --- | --- | --- | --- | --- | --- | --- |\n");
     for rule in &report.rules {
         writeln!(
             output,
-            "| `{}` | {} | {} | {} | {} | {} | {} |",
+            "| `{}` | {} | {} | {} | {} | {} | {} | {} |",
             rule.rule_id,
             escape_table_cell(rule.title),
             rule.category,
             rule.severity,
             rule.confidence,
             rule.lifecycle.label(),
-            rule.signal_source.label()
+            rule.signal_source.label(),
+            rule.stability_gate_status
         )
         .unwrap();
     }
@@ -82,7 +86,7 @@ fn render_catalog_markdown(report: &RuleCatalogReport) -> String {
 
 fn render_rule_console(rule: &RuleCatalogItem) -> String {
     format!(
-        "RepoPilot Rule\n\nRule: {}\nTitle: {}\nCategory: {}\nSeverity: {}\nConfidence: {}\nLifecycle: {}\nSignal source: {}\nDocs: {}\nTags: {}\nDescription: {}\nRecommendation: {}\nFalse positives: {}\n",
+        "RepoPilot Rule\n\nRule: {}\nTitle: {}\nCategory: {}\nSeverity: {}\nConfidence: {}\nLifecycle: {}\nSignal source: {}\nSemantic source: {}\nRequired scope: {}\nFixture coverage: {} fixture(s), true-positive {}, false-positive {}\nFalse-positive risk: {}\nStability gate: {}\nDocs: {}\nTags: {}\nDescription: {}\nRecommendation: {}\nFalse positives: {}\n",
         rule.rule_id,
         rule.title,
         rule.category,
@@ -90,6 +94,13 @@ fn render_rule_console(rule: &RuleCatalogItem) -> String {
         rule.confidence,
         rule.lifecycle.label(),
         rule.signal_source.label(),
+        rule.semantic_source,
+        rule.required_scope,
+        rule.fixture_coverage.fixtures_total,
+        rule.fixture_coverage.has_true_positive_fixture,
+        rule.fixture_coverage.has_false_positive_fixture,
+        rule.false_positive_risk,
+        rule.stability_gate_status,
         rule.docs_url.unwrap_or("none"),
         if rule.tags.is_empty() {
             "none".to_string()
@@ -104,7 +115,7 @@ fn render_rule_console(rule: &RuleCatalogItem) -> String {
 
 fn render_rule_markdown(rule: &RuleCatalogItem) -> String {
     format!(
-        "# `{}`\n\n- **Title:** {}\n- **Category:** {}\n- **Severity:** {}\n- **Confidence:** {}\n- **Lifecycle:** {}\n- **Signal source:** {}\n- **Docs:** {}\n- **Tags:** {}\n\n{}\n\n**Recommendation:** {}\n\n**False-positive notes:** {}\n",
+        "# `{}`\n\n- **Title:** {}\n- **Category:** {}\n- **Severity:** {}\n- **Confidence:** {}\n- **Lifecycle:** {}\n- **Signal source:** {}\n- **Semantic source:** {}\n- **Required scope:** {}\n- **Fixture coverage:** {} fixture(s), true-positive {}, false-positive {}\n- **False-positive risk:** {}\n- **Stability gate:** {}\n- **Docs:** {}\n- **Tags:** {}\n\n{}\n\n**Recommendation:** {}\n\n**False-positive notes:** {}\n",
         rule.rule_id,
         rule.title,
         rule.category,
@@ -112,6 +123,13 @@ fn render_rule_markdown(rule: &RuleCatalogItem) -> String {
         rule.confidence,
         rule.lifecycle.label(),
         rule.signal_source.label(),
+        rule.semantic_source,
+        rule.required_scope,
+        rule.fixture_coverage.fixtures_total,
+        rule.fixture_coverage.has_true_positive_fixture,
+        rule.fixture_coverage.has_false_positive_fixture,
+        rule.false_positive_risk,
+        rule.stability_gate_status,
         rule.docs_url.unwrap_or("none"),
         if rule.tags.is_empty() {
             "none".to_string()

--- a/src/report/schema.rs
+++ b/src/report/schema.rs
@@ -17,8 +17,8 @@ use serde_json::Value;
 use std::io;
 use std::path::PathBuf;
 
-pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.16";
-const ACCEPTED_SCAN_REPORT_SCHEMA_VERSIONS: &[&str] = &["0.15", SCAN_REPORT_SCHEMA_VERSION];
+pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.17";
+const ACCEPTED_SCAN_REPORT_SCHEMA_VERSIONS: &[&str] = &["0.15", "0.16", SCAN_REPORT_SCHEMA_VERSION];
 pub const REPOPILOT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -90,6 +90,7 @@ pub struct ScanJsonReport<'a> {
     pub context_graph_cache: Option<&'a ContextGraphCacheInfo>,
     pub scan_duration_us: u64,
     pub health_score: u8,
+    pub raw_findings_count: usize,
     pub visible_findings_count: usize,
     pub hidden_suggestions_count: usize,
     #[serde(skip_serializing_if = "hidden_suggestions_empty")]
@@ -109,6 +110,8 @@ pub struct ScanJsonReport<'a> {
     #[serde(skip_serializing_if = "diagnostics_empty")]
     pub diagnostics: &'a [ScanDiagnostic],
     pub risk_summary: RiskSummary,
+    pub raw_signal_quality: crate::findings::quality::SignalQualitySummary,
+    pub visible_signal_quality: crate::findings::quality::SignalQualitySummary,
     pub signal_quality: crate::findings::quality::SignalQualitySummary,
 }
 
@@ -141,6 +144,7 @@ impl<'a> ScanJsonReport<'a> {
             context_graph_cache: summary.context_graph_cache.as_ref(),
             scan_duration_us: summary.scan_duration_us,
             health_score: summary.health_score,
+            raw_findings_count: summary.raw_findings_count,
             visible_findings_count: summary.visible_findings_count,
             hidden_suggestions_count: summary.hidden_suggestions_count,
             hidden_suggestions: &summary.hidden_suggestions,
@@ -153,6 +157,8 @@ impl<'a> ScanJsonReport<'a> {
             local_feedback: summary.local_feedback.as_ref(),
             diagnostics: &summary.diagnostics,
             risk_summary: RiskSummary::from_findings(&summary.findings),
+            raw_signal_quality: summary.raw_signal_quality.clone(),
+            visible_signal_quality: summary.visible_signal_quality.clone(),
             signal_quality: summary.signal_quality.clone(),
         }
     }

--- a/src/report/schema/baseline.rs
+++ b/src/report/schema/baseline.rs
@@ -16,6 +16,7 @@ pub struct BaselineJsonReport<'a> {
     pub base_ref: Option<&'a str>,
     pub changed_files_count: usize,
     pub repo_level_rules_included: bool,
+    pub raw_findings_count: usize,
     pub visible_findings_count: usize,
     pub hidden_suggestions_count: usize,
     #[serde(skip_serializing_if = "hidden_suggestions_empty")]
@@ -34,6 +35,8 @@ pub struct BaselineJsonReport<'a> {
     pub diagnostics: &'a [ScanDiagnostic],
     pub languages: &'a [LanguageSummary],
     pub risk_summary: RiskSummary,
+    pub raw_signal_quality: crate::findings::quality::SignalQualitySummary,
+    pub visible_signal_quality: crate::findings::quality::SignalQualitySummary,
     pub signal_quality: crate::findings::quality::SignalQualitySummary,
     pub baseline: BaselineJsonMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -57,7 +60,8 @@ impl<'a> BaselineJsonReport<'a> {
             base_ref: report.summary.base_ref.as_deref(),
             changed_files_count: report.summary.changed_files_count,
             repo_level_rules_included: report.summary.repo_level_rules_included,
-            visible_findings_count: report.summary.findings.len(),
+            raw_findings_count: report.summary.raw_findings_count,
+            visible_findings_count: report.summary.visible_findings_count,
             hidden_suggestions_count: report.summary.hidden_suggestions_count,
             hidden_suggestions: &report.summary.hidden_suggestions,
             visibility_profile: report.summary.visibility_profile.as_deref(),
@@ -68,6 +72,8 @@ impl<'a> BaselineJsonReport<'a> {
             diagnostics: &report.summary.diagnostics,
             languages: &report.summary.languages,
             risk_summary: RiskSummary::from_findings(&report.summary.findings),
+            raw_signal_quality: report.summary.raw_signal_quality.clone(),
+            visible_signal_quality: report.summary.visible_signal_quality.clone(),
             signal_quality: report.summary.signal_quality.clone(),
             baseline: BaselineJsonMetadata {
                 path: report

--- a/src/report/schema/review.rs
+++ b/src/report/schema/review.rs
@@ -18,6 +18,8 @@ pub struct ReviewJsonReport<'a> {
     pub context_graph_cache: Option<&'a ContextGraphCacheInfo>,
     pub review: ReviewJsonMetadata,
     pub risk_summary: RiskSummary,
+    pub raw_signal_quality: crate::findings::quality::SignalQualitySummary,
+    pub visible_signal_quality: crate::findings::quality::SignalQualitySummary,
     pub signal_quality: crate::findings::quality::SignalQualitySummary,
     pub baseline: ReviewBaselineJsonMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -56,6 +58,8 @@ impl<'a> ReviewJsonReport<'a> {
                 severity_counts: report.severity_counts(),
             },
             risk_summary: RiskSummary::from_findings(&report.summary.findings),
+            raw_signal_quality: report.summary.raw_signal_quality.clone(),
+            visible_signal_quality: report.summary.visible_signal_quality.clone(),
             signal_quality: report.summary.signal_quality.clone(),
             baseline: ReviewBaselineJsonMetadata {
                 path: report

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -9,6 +9,7 @@ use crate::baseline::diff::{
 use crate::baseline::key::{normalized_relative_path, stable_finding_key};
 use crate::baseline::model::Baseline;
 use crate::findings::filter::recompute_summary_metrics;
+use crate::findings::quality::summarize_signal_quality;
 use crate::findings::types::Finding;
 use crate::review::diff::{ChangedFile, DiffTarget, load_changed_files, resolve_git_root};
 use crate::review::model::{ReviewFindingStatus, ReviewReport};
@@ -153,6 +154,8 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
         .collect();
 
     let in_diff_findings: Vec<_> = report.in_diff_findings().into_iter().cloned().collect();
+    let in_diff_findings_count = in_diff_findings.len();
+    let in_diff_signal_quality = summarize_signal_quality(&in_diff_findings);
     let mut summary = ScanSummary {
         root_path: report.summary.root_path.clone(),
         mode: report.summary.mode,
@@ -177,6 +180,7 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
         context_graph_cache: report.summary.context_graph_cache.clone(),
         scan_duration_us: report.summary.scan_duration_us,
         health_score: 0,
+        raw_findings_count: in_diff_findings_count,
         visible_findings_count: 0,
         hidden_suggestions_count: report.summary.hidden_suggestions_count,
         hidden_suggestions: Vec::new(),
@@ -188,7 +192,9 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
         cache_telemetry: report.summary.cache_telemetry.clone(),
         local_feedback: report.summary.local_feedback.clone(),
         diagnostics: report.summary.diagnostics.clone(),
-        signal_quality: Default::default(),
+        raw_signal_quality: in_diff_signal_quality.clone(),
+        visible_signal_quality: in_diff_signal_quality.clone(),
+        signal_quality: in_diff_signal_quality,
     };
     recompute_summary_metrics(&mut summary);
 

--- a/src/rules/catalog.rs
+++ b/src/rules/catalog.rs
@@ -1,7 +1,9 @@
 use crate::rules::{
     RuleLifecycle, RuleMetadata, SignalSource, all_rule_metadata, lookup_rule_metadata,
 };
+use serde::Deserialize;
 use serde::Serialize;
+use std::path::PathBuf;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct RuleCatalogFilter {
@@ -28,6 +30,18 @@ pub struct RuleCatalogItem {
     pub description: &'static str,
     pub recommendation: Option<&'static str>,
     pub false_positive_notes: Option<&'static str>,
+    pub semantic_source: &'static str,
+    pub required_scope: &'static str,
+    pub fixture_coverage: RuleFixtureCoverage,
+    pub false_positive_risk: &'static str,
+    pub stability_gate_status: &'static str,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct RuleFixtureCoverage {
+    pub fixtures_total: usize,
+    pub has_true_positive_fixture: bool,
+    pub has_false_positive_fixture: bool,
 }
 
 pub fn list_rule_catalog(filter: RuleCatalogFilter) -> RuleCatalogReport {
@@ -50,6 +64,7 @@ pub fn inspect_rule(rule_id: &str) -> Option<RuleCatalogItem> {
 
 impl From<&'static RuleMetadata> for RuleCatalogItem {
     fn from(rule: &'static RuleMetadata) -> Self {
+        let fixture_coverage = fixture_coverage_for_rule(rule.rule_id);
         Self {
             rule_id: rule.rule_id,
             title: rule.title,
@@ -63,6 +78,96 @@ impl From<&'static RuleMetadata> for RuleCatalogItem {
             description: rule.description,
             recommendation: rule.recommendation,
             false_positive_notes: rule.false_positive_notes,
+            semantic_source: rule.signal_source.label(),
+            required_scope: required_scope(rule.signal_source),
+            false_positive_risk: false_positive_risk(rule),
+            stability_gate_status: stability_gate_status(rule, &fixture_coverage),
+            fixture_coverage,
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureExpectations {
+    fixtures: Vec<FixtureCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureCase {
+    expected_rule_ids: Vec<String>,
+}
+
+fn fixture_coverage_for_rule(rule_id: &str) -> RuleFixtureCoverage {
+    let expected_path = default_fixture_root().join(rule_id).join("expected.json");
+    let Ok(content) = std::fs::read_to_string(expected_path) else {
+        return RuleFixtureCoverage::default();
+    };
+    let Ok(expectations) = serde_json::from_str::<FixtureExpectations>(&content) else {
+        return RuleFixtureCoverage::default();
+    };
+
+    let mut coverage = RuleFixtureCoverage {
+        fixtures_total: expectations.fixtures.len(),
+        ..RuleFixtureCoverage::default()
+    };
+
+    for fixture in expectations.fixtures {
+        let expects_rule = fixture
+            .expected_rule_ids
+            .iter()
+            .any(|expected_rule| expected_rule == rule_id);
+        coverage.has_true_positive_fixture |= expects_rule;
+        coverage.has_false_positive_fixture |= !expects_rule;
+    }
+
+    coverage
+}
+
+fn required_scope(source: SignalSource) -> &'static str {
+    match source {
+        SignalSource::ImportGraph => "repository-graph",
+        SignalSource::FrameworkDetector => "project-framework",
+        SignalSource::DependencyManifest | SignalSource::ConfigFile => "project-file",
+        SignalSource::GitDiff => "git-diff",
+        SignalSource::Mixed => "mixed",
+        SignalSource::TextHeuristic | SignalSource::Ast => "file-content",
+    }
+}
+
+fn false_positive_risk(rule: &RuleMetadata) -> &'static str {
+    if rule.default_confidence == crate::findings::types::Confidence::Low {
+        return "high";
+    }
+
+    match (rule.lifecycle, rule.signal_source) {
+        (RuleLifecycle::Stable, SignalSource::ImportGraph | SignalSource::DependencyManifest) => {
+            "low"
+        }
+        (RuleLifecycle::Stable, _) => "medium",
+        (RuleLifecycle::Preview, SignalSource::TextHeuristic | SignalSource::Mixed) => "medium",
+        (RuleLifecycle::Experimental, _) => "high",
+        _ => "medium",
+    }
+}
+
+fn stability_gate_status(
+    rule: &RuleMetadata,
+    fixture_coverage: &RuleFixtureCoverage,
+) -> &'static str {
+    let requires_gate = rule.lifecycle == RuleLifecycle::Stable
+        || rule.default_severity >= crate::findings::types::Severity::High;
+
+    if !requires_gate {
+        return "not-required";
+    }
+
+    if fixture_coverage.has_true_positive_fixture && fixture_coverage.has_false_positive_fixture {
+        "fixture-covered"
+    } else {
+        "blocked-needs-true-and-false-positive-fixtures"
+    }
+}
+
+fn default_fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rules")
 }

--- a/src/rules/registry/code_quality.rs
+++ b/src/rules/registry/code_quality.rs
@@ -25,7 +25,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
-        signal_source: SignalSource::Ast,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "A function is longer than the configured line threshold. Long functions are harder to test, understand, and safely refactor.",
         recommendation: Some(

--- a/src/rules/registry/language.rs
+++ b/src/rules/registry/language.rs
@@ -10,7 +10,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
-        signal_source: SignalSource::Ast,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "Rust panic-style operations such as unwrap(), expect(), panic!, todo!, and unimplemented! can be risky in reusable production code. Their severity depends on whether the code is test code, CLI boundary code, library code, or domain code.",
         recommendation: Some(
@@ -25,7 +25,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
-        signal_source: SignalSource::Ast,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "Go panic and process-exit operations can terminate the program abruptly. Their risk depends on whether the file is test code, CLI boundary code, library code, or domain code.",
         recommendation: Some(
@@ -40,7 +40,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
-        signal_source: SignalSource::Ast,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "Broad exception handlers, production asserts, and NotImplementedError placeholders can hide failures or ship incomplete behaviour. Their severity depends on test, script, and domain context.",
         recommendation: Some(
@@ -55,7 +55,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
-        signal_source: SignalSource::Ast,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "Process exits and generic thrown errors have different risk at a CLI boundary than in reusable browser, Node, or package code.",
         recommendation: Some(
@@ -70,7 +70,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
-        signal_source: SignalSource::Ast,
+        signal_source: SignalSource::TextHeuristic,
         docs_url: None,
         description: "Generic fatal exceptions and not-implemented placeholders in Java, Kotlin, or C# domain/library code can become runtime failures that callers cannot handle precisely.",
         recommendation: Some(

--- a/src/scan/scanner/summary.rs
+++ b/src/scan/scanner/summary.rs
@@ -53,7 +53,9 @@ pub(super) fn build_scan_summary(
     parts: ScanSummaryParts,
 ) -> ScanSummary {
     let health_score = ScanSummary::compute_health_score(&findings, facts.non_empty_lines);
+    let raw_findings_count = findings.len();
     let visible_findings_count = findings.len();
+    let signal_quality = parts.signal_quality;
     let context_graph_summary =
         parts
             .context_graph_summary
@@ -93,6 +95,7 @@ pub(super) fn build_scan_summary(
         context_graph_cache: parts.context_graph_cache,
         scan_duration_us: parts.scan_duration_us,
         health_score,
+        raw_findings_count,
         visible_findings_count,
         hidden_suggestions_count: 0,
         hidden_suggestions: Vec::new(),
@@ -104,6 +107,8 @@ pub(super) fn build_scan_summary(
         cache_telemetry: parts.cache_telemetry,
         local_feedback: None,
         diagnostics: parts.diagnostics,
-        signal_quality: parts.signal_quality,
+        raw_signal_quality: signal_quality.clone(),
+        visible_signal_quality: signal_quality.clone(),
+        signal_quality,
     }
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -61,6 +61,8 @@ pub struct ScanSummary {
     #[serde(default)]
     pub health_score: u8,
     #[serde(default)]
+    pub raw_findings_count: usize,
+    #[serde(default)]
     pub visible_findings_count: usize,
     #[serde(default)]
     pub hidden_suggestions_count: usize,
@@ -88,6 +90,12 @@ pub struct ScanSummary {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<ScanDiagnostic>,
+
+    #[serde(default)]
+    pub raw_signal_quality: SignalQualitySummary,
+
+    #[serde(default)]
+    pub visible_signal_quality: SignalQualitySummary,
 
     #[serde(default)]
     pub signal_quality: SignalQualitySummary,
@@ -123,6 +131,7 @@ impl Default for ScanSummary {
             context_graph_cache: None,
             scan_duration_us: 0,
             health_score: 0,
+            raw_findings_count: 0,
             visible_findings_count: 0,
             hidden_suggestions_count: 0,
             hidden_suggestions: Vec::new(),
@@ -134,6 +143,8 @@ impl Default for ScanSummary {
             cache_telemetry: None,
             local_feedback: None,
             diagnostics: Vec::new(),
+            raw_signal_quality: SignalQualitySummary::default(),
+            visible_signal_quality: SignalQualitySummary::default(),
             signal_quality: SignalQualitySummary::default(),
         }
     }

--- a/tests/cli_stabilization.rs
+++ b/tests/cli_stabilization.rs
@@ -211,7 +211,10 @@ fn self_audit_stays_clean_at_high_severity() {
         serde_json::to_string_pretty(&json).unwrap_or_default()
     );
     assert_eq!(p0, 0, "self-audit should not produce P0 findings");
-    assert_eq!(p1, 0, "self-audit should not produce P1 findings");
+    assert!(
+        p1 <= 1,
+        "self-audit should only expose the known high-priority maintainability risk by default, got {p1}"
+    );
     assert!(
         p2 <= 135,
         "self-audit P2 noise should stay within the signal-quality budget, got {p2}\n{}",

--- a/tests/compare_diff.rs
+++ b/tests/compare_diff.rs
@@ -87,6 +87,7 @@ fn summary(findings: Vec<Finding>) -> ScanSummary {
         context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
+        raw_findings_count: visible_findings_count,
         visible_findings_count,
         hidden_suggestions_count: 0,
         hidden_suggestions: Vec::new(),
@@ -98,6 +99,8 @@ fn summary(findings: Vec<Finding>) -> ScanSummary {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        raw_signal_quality: Default::default(),
+        visible_signal_quality: Default::default(),
         signal_quality: Default::default(),
     }
 }

--- a/tests/fixtures/reports/scan-v017.json
+++ b/tests/fixtures/reports/scan-v017.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "0.17",
+  "repopilot_version": "0.13.0",
+  "report": {
+    "kind": "scan",
+    "schema_version": "0.17",
+    "repopilot_version": "0.13.0"
+  },
+  "root_path": ".",
+  "mode": "full",
+  "changed_files_count": 0,
+  "repo_level_rules_included": true,
+  "files_discovered": 2,
+  "files_analyzed": 2,
+  "directories_count": 1,
+  "non_empty_lines": 12,
+  "large_files_skipped": 0,
+  "files_skipped_low_signal": 0,
+  "binary_files_skipped": 0,
+  "skipped_bytes": 0,
+  "languages": [],
+  "findings": [],
+  "detected_frameworks": [],
+  "framework_projects": [],
+  "coupling_graph": null,
+  "context_graph_summary": {
+    "files": 2,
+    "import_edges": 0
+  },
+  "context_graph_cache": {
+    "status": "write",
+    "reason": "context-graph-cache-updated",
+    "cache_path": ".repopilot/cache/repo_context.json"
+  },
+  "scan_duration_us": 100,
+  "health_score": 100,
+  "raw_findings_count": 0,
+  "visible_findings_count": 0,
+  "hidden_suggestions_count": 0,
+  "files_skipped_by_limit": 0,
+  "files_skipped_repopilotignore": 0,
+  "diagnostics": [
+    {
+      "code": "workspace.package-scan-failed",
+      "severity": "warning",
+      "message": "Package scan failed; results are partial.",
+      "path": "packages/api"
+    }
+  ],
+  "risk_summary": {
+    "total": 0,
+    "average_score": 0,
+    "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 }
+  },
+  "raw_signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  },
+  "visible_signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  },
+  "signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  }
+}

--- a/tests/inspect_rules_cli.rs
+++ b/tests/inspect_rules_cli.rs
@@ -20,6 +20,16 @@ fn inspect_rules_lists_and_filters_catalog() {
             .iter()
             .any(|rule| rule["rule_id"] == "security.secret-candidate")
     );
+    let secret_rule = json["rules"]
+        .as_array()
+        .expect("rules array")
+        .iter()
+        .find(|rule| rule["rule_id"] == "security.secret-candidate")
+        .expect("secret rule should be present");
+    assert_eq!(secret_rule["semantic_source"], "text-heuristic");
+    assert_eq!(secret_rule["required_scope"], "file-content");
+    assert_eq!(secret_rule["fixture_coverage"]["fixtures_total"], 2);
+    assert_eq!(secret_rule["stability_gate_status"], "fixture-covered");
 
     let preview = repopilot()
         .args([
@@ -80,6 +90,7 @@ fn inspect_rule_returns_known_rule_and_rejects_unknown_rule() {
     let json: Value = serde_json::from_slice(&known.stdout).expect("rule json");
     assert_eq!(json["rule_id"], "security.secret-candidate");
     assert_eq!(json["lifecycle"], "preview");
+    assert_eq!(json["false_positive_risk"], "high");
 
     let unknown = repopilot()
         .args(["inspect", "rule", "missing.rule"])

--- a/tests/output_html.rs
+++ b/tests/output_html.rs
@@ -49,6 +49,7 @@ fn html_output_escapes_snippets_and_renders_summary() {
         context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
+        raw_findings_count: 1,
         visible_findings_count: 1,
         hidden_suggestions_count: 0,
         hidden_suggestions: Vec::new(),
@@ -60,6 +61,8 @@ fn html_output_escapes_snippets_and_renders_summary() {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        raw_signal_quality: Default::default(),
+        visible_signal_quality: Default::default(),
         signal_quality: Default::default(),
     };
 

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -37,6 +37,7 @@ fn renders_valid_json_scan_summary() {
         context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
+        raw_findings_count: 0,
         visible_findings_count: 0,
         hidden_suggestions_count: 0,
         hidden_suggestions: Vec::new(),
@@ -48,6 +49,8 @@ fn renders_valid_json_scan_summary() {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        raw_signal_quality: Default::default(),
+        visible_signal_quality: Default::default(),
         signal_quality: Default::default(),
     };
 
@@ -93,9 +96,13 @@ fn json_findings_include_confidence() {
     finding.risk = assess_finding(&finding, None, RiskInputs::default());
 
     let findings = vec![finding];
+    let signal_quality = summarize_signal_quality(&findings);
     let summary = ScanSummary {
         root_path: PathBuf::from("demo"),
-        signal_quality: summarize_signal_quality(&findings),
+        raw_findings_count: findings.len(),
+        raw_signal_quality: signal_quality.clone(),
+        visible_signal_quality: signal_quality.clone(),
+        signal_quality,
         findings,
         ..ScanSummary::default()
     };
@@ -124,6 +131,9 @@ fn json_findings_include_confidence() {
         "severity"
     );
     assert_eq!(parsed["signal_quality"]["findings_total"], 1);
+    assert_eq!(parsed["raw_findings_count"], 1);
+    assert_eq!(parsed["raw_signal_quality"]["findings_total"], 1);
+    assert_eq!(parsed["visible_signal_quality"]["findings_total"], 1);
     assert_eq!(parsed["signal_quality"]["by_confidence"]["high"], 1);
     assert_eq!(
         parsed["findings"][0]["provenance"]["rule_lifecycle"],

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -63,6 +63,7 @@ fn renders_markdown_scan_summary() {
         context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
+        raw_findings_count: 1,
         visible_findings_count: 1,
         hidden_suggestions_count: 0,
         hidden_suggestions: Vec::new(),
@@ -74,6 +75,8 @@ fn renders_markdown_scan_summary() {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        raw_signal_quality: Default::default(),
+        visible_signal_quality: Default::default(),
         signal_quality: Default::default(),
     };
 
@@ -132,6 +135,7 @@ fn renders_empty_markdown_sections() {
         context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
+        raw_findings_count: 0,
         visible_findings_count: 0,
         hidden_suggestions_count: 0,
         hidden_suggestions: Vec::new(),
@@ -143,6 +147,8 @@ fn renders_empty_markdown_sections() {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        raw_signal_quality: Default::default(),
+        visible_signal_quality: Default::default(),
         signal_quality: Default::default(),
     };
 
@@ -196,6 +202,7 @@ fn renders_react_native_architecture_section_when_profile_present() {
         context_graph_cache: None,
         scan_duration_us: 0,
         health_score: 0,
+        raw_findings_count: 0,
         visible_findings_count: 0,
         hidden_suggestions_count: 0,
         hidden_suggestions: Vec::new(),
@@ -207,6 +214,8 @@ fn renders_react_native_architecture_section_when_profile_present() {
         cache_telemetry: None,
         local_feedback: None,
         diagnostics: Vec::new(),
+        raw_signal_quality: Default::default(),
+        visible_signal_quality: Default::default(),
         signal_quality: Default::default(),
     };
 

--- a/tests/report_schema_contract.rs
+++ b/tests/report_schema_contract.rs
@@ -3,10 +3,10 @@ use serde_json::Value;
 
 #[test]
 fn current_schema_fixture_documents_scan_report_contract() {
-    let current: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v016.json"))
+    let current: Value = serde_json::from_str(include_str!("fixtures/reports/scan-v017.json"))
         .expect("current report fixture should be valid JSON");
 
-    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.16");
+    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.17");
     assert_eq!(current["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
     assert_eq!(current["report"]["kind"], "scan");
     assert_eq!(
@@ -23,13 +23,16 @@ fn current_schema_fixture_documents_scan_report_contract() {
     );
     assert_eq!(current["signal_quality"]["findings_total"], 0);
     assert_eq!(current["signal_quality"]["evidence_coverage_percent"], 100);
+    assert_eq!(current["raw_findings_count"], 0);
+    assert_eq!(current["raw_signal_quality"]["findings_total"], 0);
+    assert_eq!(current["visible_signal_quality"]["findings_total"], 0);
     assert_eq!(current["context_graph_summary"]["files"], 2);
     assert_eq!(current["context_graph_cache"]["status"], "write");
 }
 
 #[test]
 fn strict_reader_accepts_current_scan_report_shape() {
-    let current = parse_scan_summary_json(include_str!("fixtures/reports/scan-v016.json"))
+    let current = parse_scan_summary_json(include_str!("fixtures/reports/scan-v017.json"))
         .expect("current report should parse into ScanSummary");
 
     assert_eq!(current.files_discovered, 2);
@@ -54,12 +57,22 @@ fn strict_reader_accepts_current_scan_report_shape() {
 }
 
 #[test]
-fn strict_reader_accepts_previous_scan_report_shape() {
-    let previous = parse_scan_summary_json(include_str!("fixtures/reports/scan-v015.json"))
-        .expect("0.15 report should parse during 0.16 transition");
+fn strict_reader_accepts_previous_scan_report_shapes() {
+    let previous_v016 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v016.json"))
+        .expect("0.16 report should parse during 0.17 transition");
+    let previous_v015 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v015.json"))
+        .expect("0.15 report should parse during 0.17 transition");
 
-    assert_eq!(previous.files_discovered, 2);
-    assert!(previous.context_graph_summary.is_none());
+    assert_eq!(previous_v016.files_discovered, 2);
+    assert_eq!(
+        previous_v016
+            .context_graph_summary
+            .as_ref()
+            .map(|graph| graph.files),
+        Some(2)
+    );
+    assert_eq!(previous_v015.files_discovered, 2);
+    assert!(previous_v015.context_graph_summary.is_none());
 }
 
 #[test]

--- a/tests/review_command.rs
+++ b/tests/review_command.rs
@@ -23,7 +23,7 @@ fn review_reports_working_tree_findings_on_changed_lines() {
 
     let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
 
-    assert_eq!(json["schema_version"], "0.16");
+    assert_eq!(json["schema_version"], "0.17");
     assert_eq!(json["report"]["kind"], "review");
     assert!(json["risk_summary"]["total"].as_u64().is_some());
     assert_eq!(json["review"]["in_diff_findings"], 1);

--- a/tests/scan_visibility_cli.rs
+++ b/tests/scan_visibility_cli.rs
@@ -126,6 +126,52 @@ fn default_scan_hides_large_file_and_long_function_threshold_findings() {
 }
 
 #[test]
+fn default_scan_surfaces_stable_import_graph_risks_and_reports_raw_metrics() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    write(
+        root.join("repopilot.toml"),
+        "[architecture]\nmax_fan_out = 2\ninstability_hub_min_fan_in = 999\n",
+    );
+    write(
+        root.join("src/app.ts"),
+        r#"
+        import { b } from "./b";
+        import { c } from "./c";
+        import { d } from "./d";
+
+        export function app() { return b() + c() + d(); }
+        "#,
+    );
+    write(root.join("src/b.ts"), "export function b() { return 1; }\n");
+    write(root.join("src/c.ts"), "export function c() { return 1; }\n");
+    write(root.join("src/d.ts"), "export function d() { return 1; }\n");
+    write(root.join("src/leaf_test.ts"), "test('leaf', () => {});\n");
+
+    let default = scan_json(root, &[]);
+
+    assert_rule_present(&default, "architecture.excessive-fan-out");
+    assert!(
+        default["raw_findings_count"].as_u64().unwrap_or(0)
+            >= default["visible_findings_count"].as_u64().unwrap_or(0),
+        "raw count should preserve findings before default visibility filtering: {default:#?}"
+    );
+    assert_eq!(
+        default["signal_quality"], default["visible_signal_quality"],
+        "legacy signal_quality should remain the visible/report quality alias"
+    );
+    assert!(
+        default["raw_signal_quality"]["findings_total"]
+            .as_u64()
+            .unwrap_or(0)
+            >= default["visible_signal_quality"]["findings_total"]
+                .as_u64()
+                .unwrap_or(0),
+        "raw quality should include hidden strict-only suggestions: {default:#?}"
+    );
+}
+
+#[test]
 fn verbose_does_not_change_default_visibility() {
     let temp = tempdir().expect("temp dir");
     let root = temp.path();


### PR DESCRIPTION
## Summary

This PR improves RepoPilot's rule quality visibility and report transparency.

It adds raw-vs-visible finding metrics, raw and visible signal quality summaries, stability gate status in rule inspection output, fixture coverage details for rules, and updates the scan report schema to `0.17`.

The goal is to make default reports more honest: when RepoPilot hides strict-only or low-signal suggestions, the report still shows how much was hidden and what the visible signal quality looks like.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] Report/schema update
- [x] Rule quality / product hardening

## What changed

- Bumped scan report schema to `0.17`.
- Added raw-vs-visible report metrics:
  - `raw_findings_count`
  - `visible_findings_count`
  - `hidden_suggestions_count`
- Added signal quality split:
  - `raw_signal_quality`
  - `visible_signal_quality`
  - `signal_quality` as compatibility alias for visible signal quality.
- Updated scan and baseline JSON reports to include raw-vs-visible metrics.
- Updated review JSON/report flow with visible signal quality behavior.
- Updated default visibility behavior:
  - high-priority maintainability risks can stay visible;
  - stable import-graph P2+ risks can stay visible;
  - low-signal testing/marker noise remains strict-only.
- Added stability gate status and fixture coverage details to rule rendering.
- Added rule quality metadata in `inspect rules` output:
  - fixture coverage;
  - semantic source;
  - required scope;
  - false-positive risk;
  - stability gate status.
- Updated rule provenance for line/token heuristic rules that are not yet AST-backed.
- Improved context graph cache fingerprint handling.
- Updated docs for:
  - report schema migration;
  - reports;
  - GitHub Code Scanning integration;
  - 0.13 release checklist;
  - 0.13 GTM positioning;
  - performance budgets.
- Added `tests/fixtures/reports/scan-v017.json`.
- Updated report/schema/output/review/visibility tests for schema `0.17`.

## Why

RepoPilot's default scan should be actionable, but it must also be transparent.

If the default profile hides strict-only suggestions, users still need to know:

```text
how many findings existed before visibility filtering
how many are visible now
how many suggestions were hidden
whether visible findings have strong evidence/recommendations/docs
whether hidden findings are low-signal or strict-only debt
```