### PR TITLE
chore: add 0.13 Smart Baseline signal quality gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ dist/
 *.jar
 *.war
 *.ear
+
+# RepoPilot local state and generated audit artifacts
+/.repopilot/*
+!/.repopilot/.gitkeep
+!/.repopilot/config.toml
+!/.repopilot/config.example.toml

--- a/.repopilotignore
+++ b/.repopilotignore
@@ -24,3 +24,14 @@ scan.json
 .repopilot/receipt.json
 receipt.json
 receipts
+
+# Local release/audit artifacts
+.repopilot/self-scan-013.json
+.repopilot/self-scan-013.md
+.repopilot/signal-quality-013.json
+repopilot-report.json
+repopilot.sarif
+
+# RepoPilot generated local state
+.repopilot
+.repopilot/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- Added 0.13 Smart Baseline release guardrails for self-scan signal quality, rule lifecycle checks, and release evidence.
+- Added documentation for the rule quality gate so default-visible/stable rules have explicit fixture and metadata expectations.
+- Added a local signal-quality checker script for release candidates and CI smoke adoption.
+
+### Changed
+
+- Tightened the 0.13 release story around audit-first positioning: default scans should remain quiet, evidence-backed, and baseline-friendly.
+- Documented noisy heuristic budgets for `code-quality.long-function`, `code-quality.complex-file`, testing-gap rules, and code markers before expanding rule families.
+
+### Added
+
 - Added a 0.13 release checklist for the breaking cleanup release.
 - Added a current `0.17` scan report fixture that documents raw-vs-visible report metrics.
 - Added finding contract validation with diagnostics, release-test coverage, and contract timing.

--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ repopilot scan . --profile strict
 | [CLI reference](docs/cli.md) | Commands, flags, and exit codes |
 | [Commands guide](docs/commands.md) | Task-oriented command examples |
 | [Rulesets](docs/rulesets.md) | Implemented rules, categories, and severity levels |
+| [Rule quality gate](docs/rule-quality-gate.md) | Fixture, metadata, visibility, and stability expectations for rules |
 | [React Native](docs/react-native.md) | React Native and Expo detection |
 | [GitHub Code Scanning](docs/integrations/github-code-scanning.md) | SARIF workflow and CI setup |
 | [Roadmap](docs/roadmap.md) | Pre-1.0 roadmap and v1 gates |

--- a/docs/rule-quality-gate.md
+++ b/docs/rule-quality-gate.md
@@ -1,0 +1,55 @@
+# Rule quality gate
+
+RepoPilot rules should move through a lifecycle before they become stable or default-visible.
+
+## Lifecycle
+
+```text
+experimental -> preview -> stable
+```
+
+A rule can be experimental while the detector is useful but still noisy. A preview rule can appear in strict/profile-driven scans when it has useful evidence but incomplete fixture coverage. A stable rule can be default-visible only when it passes the quality gate below.
+
+## Stable/default-visible gate
+
+A rule should not be stable and default-visible unless it has:
+
+- rule metadata: title, description, recommendation, lifecycle, confidence, false-positive notes;
+- at least one true-positive fixture;
+- at least one false-positive fixture or a documented reason why that does not apply;
+- stable finding IDs and deterministic output;
+- evidence that points to a concrete file/line/scope;
+- docs URL for high/critical or P0/P1 findings;
+- clean contract validation in `repopilot inspect eval-rules --format json`.
+
+## Default visibility policy
+
+Default scans should prioritize:
+
+- security risks;
+- runtime risks;
+- high-confidence architecture/review risks;
+- actionable findings that a maintainer can fix now.
+
+Strict scans may include:
+
+- long files/functions;
+- testing gaps;
+- TODO/FIXME/HACK markers;
+- broad text heuristics;
+- experimental framework signals.
+
+## Heuristic rules
+
+Text heuristics are allowed, but they should be honest about their source and confidence. A text heuristic should not pretend to be AST-backed. If a rule does not use parsed facts, its metadata should reflect that and its default visibility should be conservative.
+
+## 0.13 focus list
+
+Strengthen before expanding:
+
+- `security.secret-candidate`;
+- private key / committed env checks;
+- Rust panic/unwrap/runtime risks;
+- JavaScript/Python/Go runtime exit risks;
+- import graph / blast-radius rules;
+- review diff rules and baseline status.

--- a/scripts/check-signal-quality.py
+++ b/scripts/check-signal-quality.py
@@ -1,0 +1,190 @@
+
+#!/usr/bin/env python3
+"""RepoPilot signal quality checker.
+
+This is a product-level guard, not a per-release helper.
+
+Examples:
+    cargo run -- scan . --format json --output /tmp/repopilot-self-scan.json
+    python3 scripts/check-signal-quality.py --scan-json /tmp/repopilot-self-scan.json --warn-only
+
+Later, remove --warn-only when the project is ready to make this a hard gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+NOISY_RULE_IDS = {
+    "code-quality.long-function",
+    "code-quality.complex-file",
+    "testing.source-without-test",
+    "testing.missing-test-structure",
+    "code-marker.todo",
+    "code-marker.fixme",
+    "code-marker.hack",
+}
+
+NOISY_RULE_PREFIXES = (
+    "testing.",
+)
+
+DEFAULT_MAX_CONTRACT_VIOLATIONS = 0
+DEFAULT_MAX_VISIBLE_NOISY = 0
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"scan report not found: {path}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid scan report JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise SystemExit("scan report must be a JSON object")
+    return data
+
+
+def get_findings(report: dict[str, Any]) -> list[dict[str, Any]]:
+    direct = report.get("findings")
+    if isinstance(direct, list):
+        return [item for item in direct if isinstance(item, dict)]
+
+    nested = report.get("report")
+    if isinstance(nested, dict) and isinstance(nested.get("findings"), list):
+        return [item for item in nested["findings"] if isinstance(item, dict)]
+
+    return []
+
+
+def get_rule_id(finding: dict[str, Any]) -> str:
+    for key in ("rule_id", "ruleId", "rule", "id"):
+        value = finding.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return "unknown"
+
+
+def get_priority(finding: dict[str, Any]) -> str:
+    for key in ("priority", "risk_priority", "riskPriority"):
+        value = finding.get(key)
+        if isinstance(value, str) and value:
+            return value.lower()
+    return "unknown"
+
+
+def is_visible(finding: dict[str, Any]) -> bool:
+    for key in ("visible", "is_visible", "default_visible", "defaultVisible"):
+        value = finding.get(key)
+        if isinstance(value, bool):
+            return value
+
+    visibility = finding.get("visibility")
+    if isinstance(visibility, str):
+        return visibility.lower() in {
+            "visible",
+            "shown",
+            "default",
+            "default-visible",
+            "default_visible",
+        }
+
+    hidden = finding.get("hidden")
+    if isinstance(hidden, bool):
+        return not hidden
+
+    # Older reports usually only serialized visible findings.
+    return True
+
+
+def is_noisy_rule(rule_id: str) -> bool:
+    return rule_id in NOISY_RULE_IDS or rule_id.startswith(NOISY_RULE_PREFIXES)
+
+
+def get_contract_violations(report: dict[str, Any]) -> int:
+    signal_quality = report.get("signal_quality") or report.get("signalQuality")
+    if isinstance(signal_quality, dict):
+        for key in (
+            "contract_violations",
+            "contractViolations",
+            "contract_violation_count",
+            "contractViolationCount",
+        ):
+            value = signal_quality.get(key)
+            if isinstance(value, int):
+                return value
+
+    diagnostics = report.get("diagnostics")
+    if isinstance(diagnostics, list):
+        return sum(
+            1
+            for item in diagnostics
+            if isinstance(item, dict)
+            and "contract" in str(item.get("kind") or item.get("code") or item.get("message") or "").lower()
+        )
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check RepoPilot scan signal quality.")
+    parser.add_argument("--scan-json", required=True, type=Path)
+    parser.add_argument("--warn-only", action="store_true")
+    parser.add_argument("--max-contract-violations", type=int, default=DEFAULT_MAX_CONTRACT_VIOLATIONS)
+    parser.add_argument("--max-visible-noisy", type=int, default=DEFAULT_MAX_VISIBLE_NOISY)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+
+    report = load_json(args.scan_json)
+    findings = get_findings(report)
+    visible_findings = [finding for finding in findings if is_visible(finding)]
+    noisy_visible = [finding for finding in visible_findings if is_noisy_rule(get_rule_id(finding))]
+    contract_violations = get_contract_violations(report)
+
+    visible_by_rule = Counter(get_rule_id(finding) for finding in visible_findings)
+    visible_by_priority = Counter(get_priority(finding) for finding in visible_findings)
+    noisy_by_rule = Counter(get_rule_id(finding) for finding in noisy_visible)
+
+    failures: list[str] = []
+    if contract_violations > args.max_contract_violations:
+        failures.append(
+            f"contract violations {contract_violations} > {args.max_contract_violations}"
+        )
+    if len(noisy_visible) > args.max_visible_noisy:
+        failures.append(
+            f"visible noisy findings {len(noisy_visible)} > {args.max_visible_noisy}"
+        )
+
+    summary = {
+        "scan_json": str(args.scan_json),
+        "findings_total": len(findings),
+        "findings_visible": len(visible_findings),
+        "visible_by_priority": dict(sorted(visible_by_priority.items())),
+        "top_visible_rules": dict(visible_by_rule.most_common(15)),
+        "contract_violations": contract_violations,
+        "visible_noisy_findings": len(noisy_visible),
+        "visible_noisy_by_rule": dict(sorted(noisy_by_rule.items())),
+        "status": "failed" if failures else "passed",
+        "failures": failures,
+        "mode": "warn-only" if args.warn_only else "gate",
+    }
+
+    rendered = json.dumps(summary, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(rendered + "\n", encoding="utf-8")
+
+    if failures and not args.warn_only:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke-product.sh
+++ b/scripts/smoke-product.sh
@@ -226,6 +226,11 @@ run_repopilot scan . --format json --output "$TMP_DIR/scan.json" --receipt "$TMP
 assert_non_empty "$TMP_DIR/scan.json"
 validate_json_if_possible "$TMP_DIR/scan.json"
 assert_no_contract_violations "$TMP_DIR/scan.json"
+
+# RepoPilot signal-quality smoke check
+if command -v python3 >/dev/null 2>&1 && [[ -f "$ROOT_DIR/scripts/check-signal-quality.py" ]]; then
+  python3 "$ROOT_DIR/scripts/check-signal-quality.py"             --scan-json "$TMP_DIR/scan.json"             --warn-only             --output-json "$TMP_DIR/signal-quality.json"
+fi
 assert_non_empty "$TMP_DIR/receipt.json"
 validate_json_if_possible "$TMP_DIR/receipt.json"
 

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+VERIFY_TMP_DIR="$(mktemp -d)"
+cleanup_verify_tmp() {
+  rm -rf "$VERIFY_TMP_DIR"
+}
+trap cleanup_verify_tmp EXIT
+
 echo "==> RepoPilot release verification"
 
 echo "==> Rust formatting"
@@ -74,6 +80,21 @@ npm pack --dry-run
 
 echo "==> Build release binary"
 cargo build --release
+
+
+
+echo "==> Rule evaluation JSON smoke"
+./target/release/repopilot inspect eval-rules --format json > "$VERIFY_TMP_DIR/eval-rules.json"
+if command -v python3 >/dev/null 2>&1; then
+  python3 -m json.tool "$VERIFY_TMP_DIR/eval-rules.json" >/dev/null
+fi
+
+echo "==> Self-scan signal quality"
+./target/release/repopilot scan . --format json --output "$VERIFY_TMP_DIR/self-scan.json"
+if command -v python3 >/dev/null 2>&1 && [[ -f scripts/check-signal-quality.py ]]; then
+  # RepoPilot release signal-quality checks: warn-only until noisy heuristics are fully calibrated.
+  python3 scripts/check-signal-quality.py                 --scan-json "$VERIFY_TMP_DIR/self-scan.json"                 --warn-only                 --output-json "$VERIFY_TMP_DIR/signal-quality.json"
+fi
 
 echo "==> Product readiness smoke suite"
 ./scripts/smoke-product.sh \


### PR DESCRIPTION
## Summary

This PR prepares RepoPilot 0.13 as the **Smart Baseline** hardening release.

It does not add new rule families. Instead, it strengthens the product contract around audit-first positioning, default scan signal quality, rule lifecycle expectations, and release verification.

## Type of change

- [ ] Feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [x] CI / repository maintenance

## What changed

- Added a reusable `scripts/check-signal-quality.py` product-level guard.
- Added signal-quality smoke checks to `scripts/smoke-product.sh`.
- Added temporary self-scan and `inspect eval-rules` JSON checks to `scripts/verify-release.sh`.
- Updated `.gitignore` and `.repopilotignore` so generated local RepoPilot state does not pollute git or self-scans.
- Added `docs/rule-quality-gate.md` to document expectations for stable/default-visible rules.
- Updated README navigation to expose the rule quality gate.
- Updated `CHANGELOG.md` with the 0.13 Smart Baseline guardrails.

## Why

0.13 should make RepoPilot more reliable before adding more rules.

The main goal is to keep the default scan quiet, evidence-backed, and baseline-friendly while preserving strict mode for broader/noisier heuristics.

This prepares the next 0.13 work:

- broaden `inspect eval-rules` fixture coverage;
- reduce noisy default-visible findings;
- strengthen stable/default-visible rule requirements;
- keep self-audit artifacts out of the repository.

## Architecture notes

- [x] No god files introduced
- [x] Logic is kept in focused scripts/docs
- [x] Scanner, audits, output, and report responsibilities remain separated
- [x] Findings include evidence where applicable

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
./scripts/smoke-product.sh
```