### PR TITLE
test: harden eval-rules fixtures and finding contract coverage

### DIFF
--- a/src/audits/code_quality/language_risk/pattern.rs
+++ b/src/audits/code_quality/language_risk/pattern.rs
@@ -3,6 +3,9 @@ use crate::knowledge::decision::decide_for_file;
 use crate::scan::facts::FileFacts;
 use std::path::Path;
 
+const RUNTIME_ERROR_HANDLING_DOCS_URL: &str =
+    "https://owasp.org/www-community/vulnerabilities/Improper_Error_Handling";
+
 #[path = "go.rs"]
 mod go;
 #[path = "js.rs"]
@@ -150,7 +153,7 @@ fn build_finding(
             snippet: snippet.to_string(),
         }],
         workspace_package: None,
-        docs_url: None,
+        docs_url: Some(RUNTIME_ERROR_HANDLING_DOCS_URL.to_string()),
         provenance: Default::default(),
         risk: Default::default(),
     }

--- a/src/audits/code_quality/rust_panic_risk/finding.rs
+++ b/src/audits/code_quality/rust_panic_risk/finding.rs
@@ -4,6 +4,9 @@ use crate::audits::context::{AuditContext, FileRole, RuntimeKind};
 use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use crate::scan::facts::FileFacts;
 
+const RUST_ERROR_HANDLING_DOCS_URL: &str =
+    "https://doc.rust-lang.org/book/ch09-00-error-handling.html";
+
 pub(super) fn build_finding(
     file: &FileFacts,
     line_number: usize,
@@ -39,7 +42,7 @@ pub(super) fn build_finding(
             snippet: snippet.to_string(),
         }],
         workspace_package: None,
-        docs_url: None,
+        docs_url: Some(RUST_ERROR_HANDLING_DOCS_URL.to_string()),
         provenance: Default::default(),
         risk: Default::default(),
     }

--- a/tests/fixture_secret_safety.rs
+++ b/tests/fixture_secret_safety.rs
@@ -1,0 +1,83 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+// This is a repository safety test, not a secret detector test.
+//
+// Rule fixtures may intentionally contain secret-like variable names so RepoPilot
+// can test its detectors. They must not contain provider-looking fake secrets
+// because GitHub Push Protection can block the branch before CI runs.
+
+const FIXTURE_ROOT: &str = "tests/fixtures/rules";
+
+const FORBIDDEN_PROVIDER_SECRET_MARKERS: &[&str] = &[
+    "sk_live_",
+    "sk_test_",
+    "rk_live_",
+    "rk_test_",
+    "pk_live_",
+    "pk_test_",
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "github_pat_",
+    "xoxb-",
+    "xoxp-",
+    "ya29.",
+    "AKIA",
+    "ASIA",
+    "AIza",
+];
+
+#[test]
+fn given_rule_fixtures_when_scanning_repository_tests_then_no_provider_looking_fake_secrets_exist()
+{
+    // Given
+    let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR")).join(FIXTURE_ROOT);
+    let fixture_files = collect_files(&fixture_root);
+
+    // When / Then
+    for file in fixture_files {
+        let Ok(content) = fs::read_to_string(&file) else {
+            continue;
+        };
+
+        for marker in FORBIDDEN_PROVIDER_SECRET_MARKERS {
+            assert!(
+                !content.contains(marker),
+                "{} contains provider-looking fake secret marker `{}`. Use fixture-only values instead.",
+                file.display(),
+                marker
+            );
+        }
+    }
+}
+
+fn collect_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    collect_files_into(root, &mut files);
+    files
+}
+
+fn collect_files_into(path: &Path, files: &mut Vec<PathBuf>) {
+    let Ok(metadata) = fs::metadata(path) else {
+        return;
+    };
+
+    if metadata.is_file() {
+        files.push(path.to_path_buf());
+        return;
+    }
+
+    if !metadata.is_dir() {
+        return;
+    }
+
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        collect_files_into(&entry.path(), files);
+    }
+}

--- a/tests/fixtures/rules/language.go.panic-exit-risk/expected.json
+++ b/tests/fixtures/rules/language.go.panic-exit-risk/expected.json
@@ -1,0 +1,16 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "language.go.panic-exit-risk",
+        "language.go.panic-exit-risk",
+        "language.go.panic-exit-risk"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/language.go.panic-exit-risk/false_positive/main.go
+++ b/tests/fixtures/rules/language.go.panic-exit-risk/false_positive/main.go
@@ -1,0 +1,10 @@
+package main
+
+import "fmt"
+
+func validate(value string) error {
+    if value == "" {
+        return fmt.Errorf("value is required")
+    }
+    return nil
+}

--- a/tests/fixtures/rules/language.go.panic-exit-risk/true_positive/main.go
+++ b/tests/fixtures/rules/language.go.panic-exit-risk/true_positive/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+    "log"
+    "os"
+)
+
+func main() {
+    panic("boot failed")
+    log.Fatal("cannot continue")
+    os.Exit(1)
+}

--- a/tests/fixtures/rules/language.javascript.runtime-exit-risk/expected.json
+++ b/tests/fixtures/rules/language.javascript.runtime-exit-risk/expected.json
@@ -1,0 +1,15 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "language.javascript.runtime-exit-risk",
+        "language.javascript.runtime-exit-risk"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/language.javascript.runtime-exit-risk/false_positive/app/index.ts
+++ b/tests/fixtures/rules/language.javascript.runtime-exit-risk/false_positive/app/index.ts
@@ -1,0 +1,7 @@
+export function buildError(message: string): Error {
+  return new Error(message);
+}
+
+export function splitText(): string {
+  return "process" + ".exit(";
+}

--- a/tests/fixtures/rules/language.javascript.runtime-exit-risk/true_positive/core/index.ts
+++ b/tests/fixtures/rules/language.javascript.runtime-exit-risk/true_positive/core/index.ts
@@ -1,0 +1,7 @@
+export function stopProcess(): never {
+  process.exit(1);
+}
+
+export function failAtBoundary(): never {
+  throw new Error("generic library boundary failure");
+}

--- a/tests/fixtures/rules/language.managed.fatal-exception-risk/expected.json
+++ b/tests/fixtures/rules/language.managed.fatal-exception-risk/expected.json
@@ -1,0 +1,15 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "language.managed.fatal-exception-risk",
+        "language.managed.fatal-exception-risk"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/language.managed.fatal-exception-risk/false_positive/src/App.java
+++ b/tests/fixtures/rules/language.managed.fatal-exception-risk/false_positive/src/App.java
@@ -1,0 +1,9 @@
+package com.example;
+
+public final class App {
+    public void run(boolean ready) throws IllegalArgumentException {
+        if (!ready) {
+            throw new IllegalArgumentException("not ready");
+        }
+    }
+}

--- a/tests/fixtures/rules/language.managed.fatal-exception-risk/true_positive/src/App.java
+++ b/tests/fixtures/rules/language.managed.fatal-exception-risk/true_positive/src/App.java
@@ -1,0 +1,13 @@
+package com.example;
+
+public final class App {
+    public void run(boolean ready) {
+        if (!ready) {
+            throw new RuntimeException("not ready");
+        }
+    }
+
+    public void later() {
+        throw new NotImplementedError("wire implementation");
+    }
+}

--- a/tests/fixtures/rules/language.python.exception-risk/expected.json
+++ b/tests/fixtures/rules/language.python.exception-risk/expected.json
@@ -1,0 +1,16 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "language.python.exception-risk",
+        "language.python.exception-risk",
+        "language.python.exception-risk"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/language.python.exception-risk/false_positive/app.py
+++ b/tests/fixtures/rules/language.python.exception-risk/false_positive/app.py
@@ -1,0 +1,11 @@
+def parse_payload(raw):
+    try:
+        return raw["payload"]
+    except KeyError:
+        return None
+
+
+def require_ready(value):
+    if value is None:
+        raise ValueError("value is required")
+    return value

--- a/tests/fixtures/rules/language.python.exception-risk/true_positive/app.py
+++ b/tests/fixtures/rules/language.python.exception-risk/true_positive/app.py
@@ -1,0 +1,14 @@
+def parse_payload(raw):
+    try:
+        return raw["payload"]
+    except:
+        return None
+
+
+def require_ready(value):
+    assert value is not None
+    return value
+
+
+def unfinished():
+    raise NotImplementedError("wire provider")

--- a/tests/fixtures/rules/language.rust.panic-risk/expected.json
+++ b/tests/fixtures/rules/language.rust.panic-risk/expected.json
@@ -1,12 +1,25 @@
 {
   "fixtures": [
     {
-      "path": "true_positive",
-      "expected_rule_ids": ["language.rust.panic-risk"]
-    },
-    {
       "path": "false_positive",
       "expected_rule_ids": []
+    },
+    {
+      "path": "false_positive_contextual_expect",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "language.rust.panic-risk"
+      ]
+    },
+    {
+      "path": "true_positive_external_io",
+      "expected_rule_ids": [
+        "language.rust.panic-risk",
+        "language.rust.panic-risk"
+      ]
     }
   ]
 }

--- a/tests/fixtures/rules/language.rust.panic-risk/false_positive_contextual_expect/src/lib.rs
+++ b/tests/fixtures/rules/language.rust.panic-risk/false_positive_contextual_expect/src/lib.rs
@@ -1,0 +1,7 @@
+pub fn build_regex() {
+    let _pattern = Regex::new("^[a-z]+$").expect("valid regex");
+}
+
+pub fn comment_only() {
+    // panic!("this is documentation inside a comment");
+}

--- a/tests/fixtures/rules/language.rust.panic-risk/true_positive_external_io/src/lib.rs
+++ b/tests/fixtures/rules/language.rust.panic-risk/true_positive_external_io/src/lib.rs
@@ -1,0 +1,7 @@
+pub fn load_config() -> String {
+    std::fs::read_to_string("config.json").unwrap()
+}
+
+pub fn future_work() {
+    todo!("replace placeholder before release");
+}

--- a/tests/fixtures/rules/security.private-key-candidate/expected.json
+++ b/tests/fixtures/rules/security.private-key-candidate/expected.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "security.private-key-candidate"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/security.private-key-candidate/false_positive/docs/private-key-example.md
+++ b/tests/fixtures/rules/security.private-key-candidate/false_positive/docs/private-key-example.md
@@ -1,0 +1,7 @@
+# Private key docs example
+
+This fixture intentionally mentions a PEM header in documentation only:
+
+-----BEGIN OPENSSH PRIVATE KEY-----
+
+Markdown docs should not create a private-key finding.

--- a/tests/fixtures/rules/security.private-key-candidate/true_positive/prod_key.pem
+++ b/tests/fixtures/rules/security.private-key-candidate/true_positive/prod_key.pem
@@ -1,0 +1,3 @@
+-----BEGIN OPENSSH PRIVATE KEY-----
+fake-fixture-body-not-a-real-key
+-----END OPENSSH PRIVATE KEY-----

--- a/tests/fixtures/rules/security.secret-candidate/expected.json
+++ b/tests/fixtures/rules/security.secret-candidate/expected.json
@@ -1,12 +1,25 @@
 {
   "fixtures": [
     {
-      "path": "true_positive",
-      "expected_rule_ids": ["security.secret-candidate"]
-    },
-    {
       "path": "false_positive",
       "expected_rule_ids": []
+    },
+    {
+      "path": "false_positive_documentation",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "security.secret-candidate"
+      ]
+    },
+    {
+      "path": "true_positive_env_value",
+      "expected_rule_ids": [
+        "security.secret-candidate",
+        "security.secret-candidate"
+      ]
     }
   ]
 }

--- a/tests/fixtures/rules/security.secret-candidate/false_positive_documentation/docs/secrets.md
+++ b/tests/fixtures/rules/security.secret-candidate/false_positive_documentation/docs/secrets.md
@@ -1,0 +1,4 @@
+# Secrets documentation
+
+Use environment variables such as API_KEY and CLIENT_SECRET.
+Do not commit actual values here.

--- a/tests/fixtures/rules/security.secret-candidate/true_positive/src/config.rs
+++ b/tests/fixtures/rules/security.secret-candidate/true_positive/src/config.rs
@@ -1,1 +1,1 @@
-pub const API_KEY: &str = "sk_live_repopilot_fixture_1234567890abcdef";
+pub const API_KEY: &str = "fixtureKey-Q7m2vK9pL4xR8tN6zB3wY5cD1sF0";

--- a/tests/fixtures/rules/security.secret-candidate/true_positive_env_value/src/config.ts
+++ b/tests/fixtures/rules/security.secret-candidate/true_positive_env_value/src/config.ts
@@ -1,0 +1,2 @@
+export const API_KEY = "fixtureKey-Q7m2vK9pL4xR8tN6zB3wY5cD1sF0";
+export const CLIENT_SECRET = "fixtureSecret-Z4rT8mP2qL7vX9nC5bA1yD6eH3";

--- a/tests/inspect_rules_cli.rs
+++ b/tests/inspect_rules_cli.rs
@@ -1,49 +1,72 @@
 use serde_json::Value;
-use std::process::Command;
+use std::process::{Command, Output};
+
+const SECRET_RULE_ID: &str = "security.secret-candidate";
+const SECRET_RULE_FIXTURES_TOTAL: i64 = 4;
+const SECRET_RULE_EXPECTED_FINDINGS: i64 = 3;
 
 fn repopilot() -> Command {
     Command::new(env!("CARGO_BIN_EXE_repopilot"))
 }
 
-#[test]
-fn inspect_rules_lists_and_filters_catalog() {
-    let output = repopilot()
-        .args(["inspect", "rules", "--format", "json"])
-        .output()
-        .expect("inspect rules");
-    assert!(output.status.success());
-    let json: Value = serde_json::from_slice(&output.stdout).expect("rules json");
+fn run_repopilot(args: &[&str]) -> Output {
+    repopilot().args(args).output().expect("run repopilot")
+}
+
+fn parse_json_stdout(output: &Output, context: &str) -> Value {
     assert!(
-        json["rules"]
-            .as_array()
-            .expect("rules array")
-            .iter()
-            .any(|rule| rule["rule_id"] == "security.secret-candidate")
+        output.status.success(),
+        "{context} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
     );
-    let secret_rule = json["rules"]
-        .as_array()
-        .expect("rules array")
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "failed to parse {context} JSON: {error}\nstdout:\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    })
+}
+
+#[test]
+fn given_rule_catalog_when_inspect_rules_runs_then_metadata_and_filters_are_reported() {
+    // Given / When
+    let json = parse_json_stdout(
+        &run_repopilot(&["inspect", "rules", "--format", "json"]),
+        "inspect rules",
+    );
+
+    // Then
+    let rules = json["rules"].as_array().expect("rules array");
+    assert!(rules.iter().any(|rule| rule["rule_id"] == SECRET_RULE_ID));
+
+    let secret_rule = rules
         .iter()
-        .find(|rule| rule["rule_id"] == "security.secret-candidate")
+        .find(|rule| rule["rule_id"] == SECRET_RULE_ID)
         .expect("secret rule should be present");
+
     assert_eq!(secret_rule["semantic_source"], "text-heuristic");
     assert_eq!(secret_rule["required_scope"], "file-content");
-    assert_eq!(secret_rule["fixture_coverage"]["fixtures_total"], 2);
+    assert_eq!(
+        secret_rule["fixture_coverage"]["fixtures_total"],
+        SECRET_RULE_FIXTURES_TOTAL
+    );
     assert_eq!(secret_rule["stability_gate_status"], "fixture-covered");
 
-    let preview = repopilot()
-        .args([
+    // Given / When
+    let preview_json = parse_json_stdout(
+        &run_repopilot(&[
             "inspect",
             "rules",
             "--lifecycle",
             "preview",
             "--format",
             "json",
-        ])
-        .output()
-        .expect("inspect rules preview");
-    assert!(preview.status.success());
-    let preview_json: Value = serde_json::from_slice(&preview.stdout).expect("preview json");
+        ]),
+        "inspect rules preview",
+    );
+
+    // Then
     assert!(
         preview_json["rules"]
             .as_array()
@@ -52,19 +75,20 @@ fn inspect_rules_lists_and_filters_catalog() {
             .all(|rule| rule["lifecycle"] == "preview")
     );
 
-    let source = repopilot()
-        .args([
+    // Given / When
+    let source_json = parse_json_stdout(
+        &run_repopilot(&[
             "inspect",
             "rules",
             "--source",
             "text-heuristic",
             "--format",
             "json",
-        ])
-        .output()
-        .expect("inspect rules source");
-    assert!(source.status.success());
-    let source_json: Value = serde_json::from_slice(&source.stdout).expect("source json");
+        ]),
+        "inspect rules source",
+    );
+
+    // Then
     assert!(
         source_json["rules"]
             .as_array()
@@ -75,61 +99,58 @@ fn inspect_rules_lists_and_filters_catalog() {
 }
 
 #[test]
-fn inspect_rule_returns_known_rule_and_rejects_unknown_rule() {
-    let known = repopilot()
-        .args([
-            "inspect",
-            "rule",
-            "security.secret-candidate",
-            "--format",
-            "json",
-        ])
-        .output()
-        .expect("inspect rule");
-    assert!(known.status.success());
-    let json: Value = serde_json::from_slice(&known.stdout).expect("rule json");
-    assert_eq!(json["rule_id"], "security.secret-candidate");
+fn given_rule_id_when_inspect_rule_runs_then_known_rule_succeeds_and_unknown_rule_fails() {
+    // Given / When
+    let json = parse_json_stdout(
+        &run_repopilot(&["inspect", "rule", SECRET_RULE_ID, "--format", "json"]),
+        "inspect rule",
+    );
+
+    // Then
+    assert_eq!(json["rule_id"], SECRET_RULE_ID);
     assert_eq!(json["lifecycle"], "preview");
     assert_eq!(json["false_positive_risk"], "high");
 
-    let unknown = repopilot()
-        .args(["inspect", "rule", "missing.rule"])
-        .output()
-        .expect("inspect unknown rule");
+    // Given / When
+    let unknown = run_repopilot(&["inspect", "rule", "missing.rule"]);
+
+    // Then
     assert_eq!(unknown.status.code(), Some(2));
     let stderr = String::from_utf8_lossy(&unknown.stderr);
     assert!(stderr.contains("Unknown RepoPilot rule `missing.rule`"));
 }
 
 #[test]
-fn inspect_eval_rules_reports_fixture_quality() {
-    let output = repopilot()
-        .args([
+fn given_secret_rule_fixtures_when_eval_rules_runs_then_fixture_quality_is_reported() {
+    // Given / When
+    let json = parse_json_stdout(
+        &run_repopilot(&[
             "inspect",
             "eval-rules",
             "--rule",
-            "security.secret-candidate",
+            SECRET_RULE_ID,
             "--format",
             "json",
-        ])
-        .output()
-        .expect("eval rules");
-    assert!(output.status.success());
-    let json: Value = serde_json::from_slice(&output.stdout).expect("eval json");
+        ]),
+        "inspect eval-rules",
+    );
+
+    // Then
     assert_eq!(json["rules_evaluated"], 1);
-    assert_eq!(json["fixtures_total"], 2);
-    assert_eq!(json["expected_findings"], 1);
-    assert_eq!(json["actual_findings"], 1);
+    assert_eq!(json["fixtures_total"], SECRET_RULE_FIXTURES_TOTAL);
+    assert_eq!(json["expected_findings"], SECRET_RULE_EXPECTED_FINDINGS);
+    assert_eq!(json["actual_findings"], SECRET_RULE_EXPECTED_FINDINGS);
     assert_eq!(json["missing_findings"], 0);
     assert_eq!(json["unexpected_findings"], 0);
     assert_eq!(json["contract_violations"], 0);
     assert_eq!(json["stable_id_failures"], 0);
+
     let rules = json["rules"].as_array().expect("per-rule details");
     assert_eq!(rules.len(), 1);
-    assert_eq!(rules[0]["rule_id"], "security.secret-candidate");
-    assert_eq!(rules[0]["fixtures_total"], 2);
-    assert_eq!(rules[0]["expected_findings"], 1);
-    assert_eq!(rules[0]["actual_findings"], 1);
+    assert_eq!(rules[0]["rule_id"], SECRET_RULE_ID);
+    assert_eq!(rules[0]["fixtures_total"], SECRET_RULE_FIXTURES_TOTAL);
+    assert_eq!(rules[0]["expected_findings"], SECRET_RULE_EXPECTED_FINDINGS);
+    assert_eq!(rules[0]["actual_findings"], SECRET_RULE_EXPECTED_FINDINGS);
     assert_eq!(rules[0]["missing_findings"], 0);
     assert_eq!(rules[0]["unexpected_findings"], 0);
     assert_eq!(rules[0]["contract_violations"], 0);

--- a/tests/rule_eval_fixture_coverage.rs
+++ b/tests/rule_eval_fixture_coverage.rs
@@ -1,0 +1,80 @@
+use std::path::Path;
+
+use repopilot::rules::eval::fixtures::evaluate_rule_fixtures;
+use repopilot::rules::eval::{RuleEvaluationReport, RuleEvaluationRuleReport};
+
+// Test taxonomy for this file:
+//
+// Layer: integration / fixture contract tests
+// Scope: inspect eval-rules quality gate
+// Style: BDD-style Given / When / Then
+//
+// Keep unit tests close to pure modules. Use this file only for end-to-end
+// fixture evaluation across real fixture projects.
+
+const RULES_WITH_013_FIXTURES: &[&str] = &[
+    "security.secret-candidate",
+    "security.private-key-candidate",
+    "language.rust.panic-risk",
+    "language.go.panic-exit-risk",
+    "language.python.exception-risk",
+    "language.javascript.runtime-exit-risk",
+    "language.managed.fatal-exception-risk",
+];
+
+#[test]
+fn given_013_rule_fixtures_when_eval_rules_runs_then_quality_gates_pass() {
+    // Given
+    let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rules");
+
+    for rule_id in RULES_WITH_013_FIXTURES {
+        // When
+        let report = evaluate_rule_fixtures(Some(rule_id), Some(&fixture_root))
+            .unwrap_or_else(|error| panic!("failed to evaluate fixtures for {rule_id}: {error}"));
+
+        // Then
+        assert_single_rule_report(rule_id, &report);
+        let rule_report = first_rule_report(rule_id, &report);
+        assert_rule_fixture_coverage_is_clean(rule_id, rule_report);
+    }
+}
+
+fn assert_single_rule_report(rule_id: &str, report: &RuleEvaluationReport) {
+    assert_eq!(
+        report.rules_evaluated, 1,
+        "expected exactly one evaluated rule for {rule_id}: {report:#?}"
+    );
+}
+
+fn first_rule_report<'a>(
+    rule_id: &str,
+    report: &'a RuleEvaluationReport,
+) -> &'a RuleEvaluationRuleReport {
+    report
+        .rules
+        .first()
+        .unwrap_or_else(|| panic!("missing rule report for {rule_id}"))
+}
+
+fn assert_rule_fixture_coverage_is_clean(rule_id: &str, rule_report: &RuleEvaluationRuleReport) {
+    assert!(
+        rule_report.fixtures_total >= 2,
+        "expected true-positive and false-positive fixtures for {rule_id}: {rule_report:#?}"
+    );
+    assert_eq!(
+        rule_report.missing_findings, 0,
+        "fixture is missing expected findings for {rule_id}: {rule_report:#?}"
+    );
+    assert_eq!(
+        rule_report.unexpected_findings, 0,
+        "fixture has unexpected findings for {rule_id}: {rule_report:#?}"
+    );
+    assert_eq!(
+        rule_report.contract_violations, 0,
+        "fixture produced finding contract violations for {rule_id}: {rule_report:#?}"
+    );
+    assert_eq!(
+        rule_report.stable_id_failures, 0,
+        "fixture produced unstable/duplicate finding IDs for {rule_id}: {rule_report:#?}"
+    );
+}

--- a/tests/rule_eval_fixture_coverage.rs
+++ b/tests/rule_eval_fixture_coverage.rs
@@ -9,12 +9,15 @@ use repopilot::rules::eval::{RuleEvaluationReport, RuleEvaluationRuleReport};
 // Scope: inspect eval-rules quality gate
 // Style: BDD-style Given / When / Then
 //
-// Keep unit tests close to pure modules. Use this file only for end-to-end
+// Unit tests should stay close to pure modules. This file is for end-to-end
 // fixture evaluation across real fixture projects.
 
-const RULES_WITH_013_FIXTURES: &[&str] = &[
+const SECURITY_RULES_WITH_013_FIXTURES: &[&str] = &[
     "security.secret-candidate",
     "security.private-key-candidate",
+];
+
+const RUNTIME_RULES_WITH_013_FIXTURES: &[&str] = &[
     "language.rust.panic-risk",
     "language.go.panic-exit-risk",
     "language.python.exception-risk",
@@ -23,20 +26,44 @@ const RULES_WITH_013_FIXTURES: &[&str] = &[
 ];
 
 #[test]
-fn given_013_rule_fixtures_when_eval_rules_runs_then_quality_gates_pass() {
+fn given_security_rule_fixtures_when_eval_rules_runs_then_quality_gates_pass() {
     // Given
-    let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rules");
+    let fixture_root = rule_fixture_root();
 
-    for rule_id in RULES_WITH_013_FIXTURES {
+    for rule_id in SECURITY_RULES_WITH_013_FIXTURES {
         // When
-        let report = evaluate_rule_fixtures(Some(rule_id), Some(&fixture_root))
-            .unwrap_or_else(|error| panic!("failed to evaluate fixtures for {rule_id}: {error}"));
+        let report = evaluate_rule(rule_id, &fixture_root);
 
         // Then
         assert_single_rule_report(rule_id, &report);
         let rule_report = first_rule_report(rule_id, &report);
         assert_rule_fixture_coverage_is_clean(rule_id, rule_report);
     }
+}
+
+#[test]
+fn given_runtime_rule_fixtures_when_eval_rules_runs_then_quality_gates_pass() {
+    // Given
+    let fixture_root = rule_fixture_root();
+
+    for rule_id in RUNTIME_RULES_WITH_013_FIXTURES {
+        // When
+        let report = evaluate_rule(rule_id, &fixture_root);
+
+        // Then
+        assert_single_rule_report(rule_id, &report);
+        let rule_report = first_rule_report(rule_id, &report);
+        assert_rule_fixture_coverage_is_clean(rule_id, rule_report);
+    }
+}
+
+fn rule_fixture_root() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rules")
+}
+
+fn evaluate_rule(rule_id: &str, fixture_root: &Path) -> RuleEvaluationReport {
+    evaluate_rule_fixtures(Some(rule_id), Some(fixture_root))
+        .unwrap_or_else(|error| panic!("failed to evaluate fixtures for {rule_id}: {error}"))
 }
 
 fn assert_single_rule_report(rule_id: &str, report: &RuleEvaluationReport) {


### PR DESCRIPTION
## Summary

This PR hardens the RepoPilot 0.13 Smart Baseline test surface around `inspect eval-rules`.

It expands rule fixture coverage for runtime and security rules, adds BDD-style integration tests for fixture quality, prevents provider-looking fake secrets from being committed in rule fixtures, and fixes finding contract metadata for high-severity runtime findings.

## Type of change

- [ ] Feature
- [ ] Refactor
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [x] CI / repository maintenance

## What changed

- Added true-positive and false-positive `eval-rules` fixtures for:
  - `security.private-key-candidate`
  - `language.go.panic-exit-risk`
  - `language.python.exception-risk`
  - `language.javascript.runtime-exit-risk`
  - `language.managed.fatal-exception-risk`
- Expanded existing fixtures for:
  - `security.secret-candidate`
  - `language.rust.panic-risk`
- Added BDD-style fixture contract tests split by security and runtime rule groups.
- Updated CLI contract tests for the new fixture totals.
- Added `fixture_secret_safety` coverage to prevent provider-looking fake secrets such as Stripe/GitHub/AWS-style prefixes in test fixtures.
- Replaced provider-looking fake secret values with fixture-only values.
- Added docs URLs to high-severity Rust and runtime-risk findings so they satisfy the finding contract.

## Why

0.13 should improve trust before adding more rules.

`inspect eval-rules` should be useful as a real quality gate for stable/default-visible rules. These fixtures verify that expected findings are detected, false positives stay clean, finding contracts are valid, and generated finding IDs remain stable.

The fixture safety test also prevents a repeat of GitHub Push Protection blocking the branch because of realistic fake secret values.

## Architecture notes

- [x] No god files introduced
- [x] Logic is split into focused test files
- [x] Scanner, audits, output, and report responsibilities remain separated
- [x] Findings include evidence where applicable
- [x] High-severity findings include documentation URLs for contract compliance

## Changelog

- [ ] `CHANGELOG.md` updated
- [x] Skipped because this PR is test/contract hardening under the existing 0.13 Smart Baseline work

## Verification

```bash
cargo fmt --all -- --check
cargo test --test fixture_secret_safety
cargo test --test rule_eval_fixture_coverage
cargo test --test inspect_rules_cli
cargo test --all
cargo run -- inspect eval-rules --format json