### PR TITLE
refactor: split scan command flow into focused stages

### DIFF
--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -1,15 +1,14 @@
+mod baseline_flow;
+mod timing;
+mod validation;
+
 use crate::cli::ScanOptions;
 use crate::commands::filters::{scan_pre_visibility_filter, scan_priority_filter};
 use crate::commands::product_scan::{
-    ProductScanMode, ProductScanRequest, enforce_diagnostics_exit_policy, run_product_scan,
+    ProductScanRequest, enforce_diagnostics_exit_policy, run_product_scan,
 };
 use crate::commands::scan_config::ScanConfigOverrides;
-use crate::commands::{CliExit, EXIT_FINDINGS, EXIT_USAGE};
-use repopilot::baseline::diff::{all_findings_new, diff_summary_against_baseline};
-use repopilot::baseline::gate::{FailOn, evaluate_ci_gate};
-use repopilot::baseline::reader::read_baseline;
-use repopilot::findings::visibility::FindingVisibilityProfile;
-use repopilot::output::{render_baseline_scan_report, render_scan_summary};
+use repopilot::output::render_scan_summary;
 use repopilot::receipt::{build_audit_receipt, render_receipt_json};
 use repopilot::report::writer::write_report;
 use repopilot::scan::types::ScanSummary;
@@ -17,38 +16,14 @@ use std::path::Path;
 use std::time::Instant;
 
 pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
+    validation::validate_scan_options(&options)?;
+
     let pre_visibility_filter = scan_pre_visibility_filter(&options);
     let priority_filter = scan_priority_filter(&options);
     let fail_on_priority = options.fail_on_priority.map(Into::into);
+    let visibility_profile = validation::scan_visibility_profile(&options);
+    let scan_mode = validation::scan_mode_from_options(&options);
 
-    if options.fail_on.is_some() && fail_on_priority.is_some() {
-        return Err(Box::new(CliExit {
-            code: EXIT_USAGE,
-            message: "`--fail-on` and `--fail-on-priority` cannot be used together".to_string(),
-        }));
-    }
-    if options.changed && options.since.is_some() {
-        return Err(Box::new(CliExit {
-            code: EXIT_USAGE,
-            message: "`--changed` and `--since` cannot be used together".to_string(),
-        }));
-    }
-    if options.workspace && (options.changed || options.since.is_some()) {
-        return Err(Box::new(CliExit {
-            code: EXIT_USAGE,
-            message: "`--workspace` cannot be used with changed scans".to_string(),
-        }));
-    }
-    let visibility_profile = scan_visibility_profile(&options);
-    let scan_mode = if options.changed || options.since.is_some() {
-        ProductScanMode::Changed {
-            since: options.since.clone(),
-        }
-    } else if options.workspace {
-        ProductScanMode::Workspace
-    } else {
-        ProductScanMode::Full
-    };
     let scan_result = run_product_scan(ProductScanRequest {
         path: options.path.clone(),
         config_path: options.config.clone(),
@@ -67,6 +42,7 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
         visibility_profile,
         pre_visibility_filter,
     })?;
+
     let mut summary = scan_result.summary;
     let scan_elapsed = scan_result.scan_elapsed;
     let output_format = options
@@ -74,60 +50,15 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
         .map(Into::into)
         .unwrap_or(scan_result.repo_config.output.default_format);
 
-    if options.baseline.is_some() || options.fail_on.is_some() || fail_on_priority.is_some() {
-        let mut baseline_report = match options.baseline.clone() {
-            Some(baseline_path) => {
-                let baseline_file = read_baseline(&baseline_path)?;
-                diff_summary_against_baseline(summary, &baseline_file, baseline_path)
-            }
-            None => all_findings_new(summary),
-        };
-        if !priority_filter.is_empty() {
-            baseline_report.apply_filter(&priority_filter);
-        }
-
-        let ci_gate = options
-            .fail_on
-            .map(Into::into)
-            .map(|fail_on| evaluate_ci_gate(&baseline_report, fail_on))
-            .or_else(|| {
-                fail_on_priority
-                    .map(|priority| evaluate_ci_gate(&baseline_report, FailOn::Priority(priority)))
-            });
-        let render_start = Instant::now();
-        let rendered_report =
-            render_baseline_scan_report(&baseline_report, output_format, ci_gate.as_ref())?;
-        let render_elapsed = render_start.elapsed();
-
-        write_scan_receipt_if_requested(&baseline_report.summary, options.receipt.as_deref())?;
-        write_report(&rendered_report, options.output.as_deref())?;
-
-        if options.verbose {
-            let internal_us = baseline_report.summary.scan_duration_us;
-            let total_ms = scan_elapsed.as_millis();
-            let render_ms = render_elapsed.as_millis();
-            eprintln!(
-                "\n[verbose] Scan: {total_ms}ms (engine: {}ms) · Render: {render_ms}ms",
-                internal_us / 1000
-            );
-        }
-
-        if options.timing {
-            print_timing_breakdown(&baseline_report.summary);
-        }
-
-        enforce_diagnostics_exit_policy(&baseline_report.summary)?;
-
-        if let Some(ci_gate) = ci_gate
-            && let Some(message) = ci_gate.failure_message()
-        {
-            return Err(Box::new(CliExit {
-                code: EXIT_FINDINGS,
-                message,
-            }));
-        }
-
-        return Ok(());
+    if baseline_flow::uses_baseline_flow(&options) {
+        return baseline_flow::run_baseline_scan_flow(
+            summary,
+            &options,
+            priority_filter,
+            fail_on_priority,
+            output_format,
+            scan_elapsed,
+        );
     }
 
     if !priority_filter.is_empty() {
@@ -142,17 +73,11 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     write_report(&rendered_report, options.output.as_deref())?;
 
     if options.verbose {
-        let internal_us = summary.scan_duration_us;
-        let total_ms = scan_elapsed.as_millis();
-        let render_ms = render_elapsed.as_millis();
-        eprintln!(
-            "\n[verbose] Scan: {total_ms}ms (engine: {:.0}ms) · Render: {render_ms}ms",
-            internal_us as f64 / 1000.0
-        );
+        timing::print_verbose_scan_timing(&summary, scan_elapsed, render_elapsed);
     }
 
     if options.timing {
-        print_timing_breakdown(&summary);
+        timing::print_timing_breakdown(&summary);
     }
 
     enforce_diagnostics_exit_policy(&summary)?;
@@ -160,57 +85,7 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn scan_visibility_profile(options: &ScanOptions) -> FindingVisibilityProfile {
-    if options.include_maintainability || !options.rule.is_empty() {
-        return FindingVisibilityProfile::Strict;
-    }
-
-    match options.profile {
-        Some(crate::cli::ScanProfileArg::Strict) => FindingVisibilityProfile::Strict,
-        Some(crate::cli::ScanProfileArg::Default) | None => FindingVisibilityProfile::Default,
-    }
-}
-
-fn print_timing_breakdown(summary: &ScanSummary) {
-    if let Some(timings) = &summary.scan_timings {
-        eprintln!(
-            "\n[timing] File scan: {}ms · Framework detection: {}ms · Post-scan audits: {}ms · Engine total: {}ms",
-            timings.file_scan_us / 1000,
-            timings.framework_detection_us / 1000,
-            timings.post_scan_audits_us / 1000,
-            timings.accounted_engine_us() / 1000,
-        );
-        eprintln!(
-            "[timing] Pipeline: discovery {}ms · file analysis {}ms · enrichment {}ms · risk scoring {}ms · contract validation {}ms · report finalization {}ms",
-            timings.discovery_us / 1000,
-            timings.file_analysis_us / 1000,
-            timings.enrichment_us / 1000,
-            timings.risk_scoring_us / 1000,
-            timings.contract_validation_us / 1000,
-            timings.report_finalization_us / 1000,
-        );
-    }
-
-    if let Some(cache) = &summary.cache_telemetry {
-        let estimated_saved = cache
-            .timings
-            .estimated_time_saved_us
-            .map(|value| format!("{}ms", value / 1000))
-            .unwrap_or_else(|| "n/a".to_string());
-        eprintln!(
-            "[timing] Cache: load {}ms · hash {}ms · lookup {}ms · hit reuse {}ms · miss scan {}ms · write {}ms · estimated saved {}",
-            cache.timings.load_us / 1000,
-            cache.timings.file_hash_us / 1000,
-            cache.timings.lookup_us / 1000,
-            cache.timings.hit_reuse_us / 1000,
-            cache.timings.miss_scan_us / 1000,
-            cache.timings.write_us / 1000,
-            estimated_saved,
-        );
-    }
-}
-
-fn write_scan_receipt_if_requested(
+pub(super) fn write_scan_receipt_if_requested(
     summary: &ScanSummary,
     receipt_path: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/commands/scan/baseline_flow.rs
+++ b/src/commands/scan/baseline_flow.rs
@@ -1,0 +1,79 @@
+use crate::cli::ScanOptions;
+use crate::commands::product_scan::enforce_diagnostics_exit_policy;
+use crate::commands::{CliExit, EXIT_FINDINGS};
+use repopilot::baseline::diff::{all_findings_new, diff_summary_against_baseline};
+use repopilot::baseline::gate::{FailOn, evaluate_ci_gate};
+use repopilot::baseline::reader::read_baseline;
+use repopilot::findings::filter::FindingFilter;
+use repopilot::output::{OutputFormat, render_baseline_scan_report};
+use repopilot::report::writer::write_report;
+use repopilot::risk::RiskPriority;
+use repopilot::scan::types::ScanSummary;
+use std::time::{Duration, Instant};
+
+pub(super) fn uses_baseline_flow(options: &ScanOptions) -> bool {
+    options.baseline.is_some() || options.fail_on.is_some() || options.fail_on_priority.is_some()
+}
+
+pub(super) fn run_baseline_scan_flow(
+    summary: ScanSummary,
+    options: &ScanOptions,
+    priority_filter: FindingFilter,
+    fail_on_priority: Option<RiskPriority>,
+    output_format: OutputFormat,
+    scan_elapsed: Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut baseline_report = match options.baseline.clone() {
+        Some(baseline_path) => {
+            let baseline_file = read_baseline(&baseline_path)?;
+            diff_summary_against_baseline(summary, &baseline_file, baseline_path)
+        }
+        None => all_findings_new(summary),
+    };
+
+    if !priority_filter.is_empty() {
+        baseline_report.apply_filter(&priority_filter);
+    }
+
+    let ci_gate = options
+        .fail_on
+        .map(Into::into)
+        .map(|fail_on| evaluate_ci_gate(&baseline_report, fail_on))
+        .or_else(|| {
+            fail_on_priority
+                .map(|priority| evaluate_ci_gate(&baseline_report, FailOn::Priority(priority)))
+        });
+
+    let render_start = Instant::now();
+    let rendered_report =
+        render_baseline_scan_report(&baseline_report, output_format, ci_gate.as_ref())?;
+    let render_elapsed = render_start.elapsed();
+
+    super::write_scan_receipt_if_requested(&baseline_report.summary, options.receipt.as_deref())?;
+    write_report(&rendered_report, options.output.as_deref())?;
+
+    if options.verbose {
+        super::timing::print_verbose_scan_timing(
+            &baseline_report.summary,
+            scan_elapsed,
+            render_elapsed,
+        );
+    }
+
+    if options.timing {
+        super::timing::print_timing_breakdown(&baseline_report.summary);
+    }
+
+    enforce_diagnostics_exit_policy(&baseline_report.summary)?;
+
+    if let Some(ci_gate) = ci_gate
+        && let Some(message) = ci_gate.failure_message()
+    {
+        return Err(Box::new(CliExit {
+            code: EXIT_FINDINGS,
+            message,
+        }));
+    }
+
+    Ok(())
+}

--- a/src/commands/scan/timing.rs
+++ b/src/commands/scan/timing.rs
@@ -1,0 +1,56 @@
+use repopilot::scan::types::ScanSummary;
+use std::time::Duration;
+
+pub(super) fn print_verbose_scan_timing(
+    summary: &ScanSummary,
+    scan_elapsed: Duration,
+    render_elapsed: Duration,
+) {
+    let internal_us = summary.scan_duration_us;
+    let total_ms = scan_elapsed.as_millis();
+    let render_ms = render_elapsed.as_millis();
+
+    eprintln!(
+        "\n[verbose] Scan: {total_ms}ms (engine: {:.0}ms) · Render: {render_ms}ms",
+        internal_us as f64 / 1000.0
+    );
+}
+
+pub(super) fn print_timing_breakdown(summary: &ScanSummary) {
+    if let Some(timings) = &summary.scan_timings {
+        eprintln!(
+            "\n[timing] File scan: {}ms · Framework detection: {}ms · Post-scan audits: {}ms · Engine total: {}ms",
+            timings.file_scan_us / 1000,
+            timings.framework_detection_us / 1000,
+            timings.post_scan_audits_us / 1000,
+            timings.accounted_engine_us() / 1000,
+        );
+        eprintln!(
+            "[timing] Pipeline: discovery {}ms · file analysis {}ms · enrichment {}ms · risk scoring {}ms · contract validation {}ms · report finalization {}ms",
+            timings.discovery_us / 1000,
+            timings.file_analysis_us / 1000,
+            timings.enrichment_us / 1000,
+            timings.risk_scoring_us / 1000,
+            timings.contract_validation_us / 1000,
+            timings.report_finalization_us / 1000,
+        );
+    }
+
+    if let Some(cache) = &summary.cache_telemetry {
+        let estimated_saved = cache
+            .timings
+            .estimated_time_saved_us
+            .map(|value| format!("{}ms", value / 1000))
+            .unwrap_or_else(|| "n/a".to_string());
+        eprintln!(
+            "[timing] Cache: load {}ms · hash {}ms · lookup {}ms · hit reuse {}ms · miss scan {}ms · write {}ms · estimated saved {}",
+            cache.timings.load_us / 1000,
+            cache.timings.file_hash_us / 1000,
+            cache.timings.lookup_us / 1000,
+            cache.timings.hit_reuse_us / 1000,
+            cache.timings.miss_scan_us / 1000,
+            cache.timings.write_us / 1000,
+            estimated_saved,
+        );
+    }
+}

--- a/src/commands/scan/validation.rs
+++ b/src/commands/scan/validation.rs
@@ -1,0 +1,54 @@
+use crate::cli::ScanOptions;
+use crate::commands::product_scan::ProductScanMode;
+use crate::commands::{CliExit, EXIT_USAGE};
+use repopilot::findings::visibility::FindingVisibilityProfile;
+
+pub(super) fn validate_scan_options(
+    options: &ScanOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if options.fail_on.is_some() && options.fail_on_priority.is_some() {
+        return Err(Box::new(CliExit {
+            code: EXIT_USAGE,
+            message: "`--fail-on` and `--fail-on-priority` cannot be used together".to_string(),
+        }));
+    }
+
+    if options.changed && options.since.is_some() {
+        return Err(Box::new(CliExit {
+            code: EXIT_USAGE,
+            message: "`--changed` and `--since` cannot be used together".to_string(),
+        }));
+    }
+
+    if options.workspace && (options.changed || options.since.is_some()) {
+        return Err(Box::new(CliExit {
+            code: EXIT_USAGE,
+            message: "`--workspace` cannot be used with changed scans".to_string(),
+        }));
+    }
+
+    Ok(())
+}
+
+pub(super) fn scan_mode_from_options(options: &ScanOptions) -> ProductScanMode {
+    if options.changed || options.since.is_some() {
+        ProductScanMode::Changed {
+            since: options.since.clone(),
+        }
+    } else if options.workspace {
+        ProductScanMode::Workspace
+    } else {
+        ProductScanMode::Full
+    }
+}
+
+pub(super) fn scan_visibility_profile(options: &ScanOptions) -> FindingVisibilityProfile {
+    if options.include_maintainability || !options.rule.is_empty() {
+        return FindingVisibilityProfile::Strict;
+    }
+
+    match options.profile {
+        Some(crate::cli::ScanProfileArg::Strict) => FindingVisibilityProfile::Strict,
+        Some(crate::cli::ScanProfileArg::Default) | None => FindingVisibilityProfile::Default,
+    }
+}

--- a/tests/scan_command_cli.rs
+++ b/tests/scan_command_cli.rs
@@ -1,0 +1,117 @@
+use serde_json::Value;
+use std::fs;
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+fn run_repopilot(args: &[&str]) -> Output {
+    repopilot().args(args).output().expect("run repopilot")
+}
+
+fn fixture_project() -> TempDir {
+    let dir = tempfile::tempdir().expect("create fixture project");
+    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
+    fs::write(
+        dir.path().join("src/lib.rs"),
+        "pub fn answer() -> i32 { 42 }\n",
+    )
+    .expect("write source file");
+    dir
+}
+
+#[test]
+fn given_conflicting_fail_flags_when_scan_runs_then_usage_error_is_returned() {
+    // Given
+    let project = fixture_project();
+    let path = project.path().to_string_lossy().to_string();
+
+    // When
+    let output = run_repopilot(&[
+        "scan",
+        &path,
+        "--fail-on",
+        "high",
+        "--fail-on-priority",
+        "p1",
+    ]);
+
+    // Then
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`--fail-on` and `--fail-on-priority` cannot be used together"),
+        "stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn given_changed_and_since_flags_when_scan_runs_then_usage_error_is_returned() {
+    // Given
+    let project = fixture_project();
+    let path = project.path().to_string_lossy().to_string();
+
+    // When
+    let output = run_repopilot(&["scan", &path, "--changed", "--since", "HEAD~1"]);
+
+    // Then
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`--changed` and `--since` cannot be used together"),
+        "stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn given_workspace_and_changed_flags_when_scan_runs_then_usage_error_is_returned() {
+    // Given
+    let project = fixture_project();
+    let path = project.path().to_string_lossy().to_string();
+
+    // When
+    let output = run_repopilot(&["scan", &path, "--workspace", "--changed"]);
+
+    // Then
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`--workspace` cannot be used with changed scans"),
+        "stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn given_small_project_when_scan_runs_with_json_output_then_report_is_written() {
+    // Given
+    let project = fixture_project();
+    let output_path = project.path().join("scan.json");
+    let project_path = project.path().to_string_lossy().to_string();
+    let output_arg = output_path.to_string_lossy().to_string();
+
+    // When
+    let output = run_repopilot(&[
+        "scan",
+        &project_path,
+        "--format",
+        "json",
+        "--output",
+        &output_arg,
+    ]);
+
+    // Then
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("scan report should be written"),
+    )
+    .expect("scan report should be valid JSON");
+    assert!(report["files_analyzed"].as_u64().unwrap_or_default() >= 1);
+}


### PR DESCRIPTION
## Summary

This PR refactors the `scan` command flow into focused modules without changing scanner core behavior.

The goal is to make the user-facing scan command easier to reason about, test, and evolve before adding more product behavior on top of it.

## Type of change

- [ ] Feature
- [x] Refactor
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- Split scan option validation into `src/commands/scan/validation.rs`.
- Split baseline / CI-gate flow into `src/commands/scan/baseline_flow.rs`.
- Split verbose and timing output into `src/commands/scan/timing.rs`.
- Kept `src/commands/scan.rs` as the orchestration layer.
- Added BDD-style CLI tests for scan command validation:
  - conflicting `--fail-on` and `--fail-on-priority`
  - conflicting `--changed` and `--since`
  - invalid `--workspace` with changed scans
  - positive JSON output smoke for a small fixture project

## Why

`scan` is one of RepoPilot's most important product commands. It currently owns validation, scan mode selection, product scan execution, baseline diffing, CI gates, rendering, receipt writing, diagnostics, and timing output in one file.

Splitting the flow makes future changes safer:

- command validation can be tested directly through CLI behavior;
- baseline and CI-gate behavior has a focused boundary;
- timing output no longer clutters the command orchestration;
- future scan features can be added without growing a command god file.

## Architecture notes

- [x] No god files introduced
- [x] Logic is split into focused modules
- [x] Scanner core behavior remains unchanged
- [x] Scanner, audits, output, and report responsibilities remain separated
- [x] User-facing command behavior is covered by CLI tests

## Changelog

- [ ] `CHANGELOG.md` updated
- [x] Skipped because this is an internal refactor with behavior-preserving CLI tests

## Verification

```bash
cargo fmt --all -- --check
cargo test --test scan_command_cli
cargo test --all
./scripts/smoke-product.sh