### PR TITLE
refactor: isolate scan report finalization

### DIFF
--- a/src/scan/scanner/finalize.rs
+++ b/src/scan/scanner/finalize.rs
@@ -49,7 +49,9 @@ impl<'a> ScanEngine<'a> {
     }
 }
 
-fn prepare_findings_and_context_graph(project_stage: &mut ProjectAnalysisStage) -> RepoContextGraph {
+fn prepare_findings_and_context_graph(
+    project_stage: &mut ProjectAnalysisStage,
+) -> RepoContextGraph {
     summary::sort_findings(&mut project_stage.findings);
 
     RepoContextGraph::from_scan_facts(

--- a/src/scan/scanner/finalize.rs
+++ b/src/scan/scanner/finalize.rs
@@ -1,0 +1,116 @@
+use super::summary::{ScanSummaryParts, build_scan_summary};
+use super::{ProjectAnalysisStage, ScanEngine, summary};
+use crate::findings::quality::SignalQualitySummary;
+use crate::graph::context::{
+    ContextGraphCacheInfo, ContextGraphSummary, RepoContextGraph, cache_diagnostic,
+    summarize_context_graph, write_repo_context_graph,
+};
+use crate::scan::config::ScanConfig;
+use crate::scan::types::{ScanDiagnostic, ScanMode, ScanSummary, ScanTimings};
+use std::path::Path;
+use std::time::Instant;
+
+struct ContextGraphArtifacts {
+    summary: ContextGraphSummary,
+    cache: Option<ContextGraphCacheInfo>,
+}
+
+impl<'a> ScanEngine<'a> {
+    pub(super) fn finalize_report(
+        &self,
+        mut project_stage: ProjectAnalysisStage,
+        scan_duration_us: u64,
+        timings: ScanTimings,
+        diagnostics: Vec<ScanDiagnostic>,
+        signal_quality: SignalQualitySummary,
+    ) -> ScanSummary {
+        let finalization_start = Instant::now();
+        let context_graph = prepare_findings_and_context_graph(&mut project_stage);
+        let mut diagnostics = diagnostics;
+        let context_graph_artifacts = build_context_graph_artifacts(
+            &project_stage.facts.root_path,
+            self.config,
+            &context_graph,
+            &project_stage.findings,
+            &mut diagnostics,
+        );
+
+        let mut summary = build_final_scan_summary(
+            project_stage,
+            scan_duration_us,
+            timings,
+            diagnostics,
+            signal_quality,
+            context_graph_artifacts,
+        );
+
+        record_report_finalization_timing(&mut summary, finalization_start);
+        summary
+    }
+}
+
+fn prepare_findings_and_context_graph(project_stage: &mut ProjectAnalysisStage) -> RepoContextGraph {
+    summary::sort_findings(&mut project_stage.findings);
+
+    RepoContextGraph::from_scan_facts(
+        &project_stage.facts,
+        &project_stage.facts.root_path,
+        project_stage.coupling_graph.clone(),
+    )
+}
+
+fn build_context_graph_artifacts(
+    root_path: &Path,
+    config: &ScanConfig,
+    context_graph: &RepoContextGraph,
+    findings: &[crate::findings::types::Finding],
+    diagnostics: &mut Vec<ScanDiagnostic>,
+) -> ContextGraphArtifacts {
+    let graph_summary = summarize_context_graph(context_graph, findings, &[]);
+    let cache = match write_repo_context_graph(root_path, config, context_graph) {
+        Ok(cache_info) => Some(cache_info),
+        Err(error) => {
+            diagnostics.push(cache_diagnostic(&error));
+            None
+        }
+    };
+
+    ContextGraphArtifacts {
+        summary: graph_summary,
+        cache,
+    }
+}
+
+fn build_final_scan_summary(
+    project_stage: ProjectAnalysisStage,
+    scan_duration_us: u64,
+    timings: ScanTimings,
+    diagnostics: Vec<ScanDiagnostic>,
+    signal_quality: SignalQualitySummary,
+    context_graph_artifacts: ContextGraphArtifacts,
+) -> ScanSummary {
+    build_scan_summary(
+        project_stage.facts,
+        project_stage.findings,
+        ScanSummaryParts {
+            mode: ScanMode::Full,
+            base_ref: None,
+            changed_files_count: 0,
+            repo_level_rules_included: true,
+            coupling_graph: Some(project_stage.coupling_graph),
+            scan_duration_us,
+            scan_timings: Some(timings),
+            cache_telemetry: None,
+            diagnostics,
+            signal_quality,
+            context_graph_summary: Some(context_graph_artifacts.summary),
+            context_graph_cache: context_graph_artifacts.cache,
+        },
+    )
+}
+
+fn record_report_finalization_timing(summary: &mut ScanSummary, finalization_start: Instant) {
+    if let Some(timings) = &mut summary.scan_timings {
+        timings.report_finalization_us = finalization_start.elapsed().as_micros() as u64;
+    }
+}

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -4,6 +4,7 @@ mod changed_git;
 mod changed_telemetry;
 mod collection;
 mod file;
+mod finalize;
 mod summary;
 mod walker;
 
@@ -15,9 +16,6 @@ use crate::frameworks::{
     DetectedFramework, detect_framework_projects, detect_frameworks,
     detect_react_native_architecture,
 };
-use crate::graph::context::{
-    RepoContextGraph, cache_diagnostic, summarize_context_graph, write_repo_context_graph,
-};
 use crate::knowledge::decision::apply_project_decisions;
 use crate::risk::{apply_cluster_overlay, apply_graph_overlay, assess_findings};
 use crate::scan::config::ScanConfig;
@@ -25,7 +23,6 @@ use crate::scan::types::{ScanMode, ScanSummary, ScanTimings};
 use std::io;
 use std::path::Path;
 use std::time::Instant;
-use summary::{ScanSummaryParts, build_scan_summary};
 
 pub use changed::scan_changed_with_config;
 pub use collection::{collect_scan_facts, collect_scan_facts_with_config};
@@ -116,57 +113,6 @@ impl<'a> ScanEngine<'a> {
         ))
     }
 
-    fn finalize_report(
-        &self,
-        mut project_stage: ProjectAnalysisStage,
-        scan_duration_us: u64,
-        timings: ScanTimings,
-        mut diagnostics: Vec<crate::scan::types::ScanDiagnostic>,
-        signal_quality: crate::findings::quality::SignalQualitySummary,
-    ) -> ScanSummary {
-        let finalization_start = Instant::now();
-        summary::sort_findings(&mut project_stage.findings);
-        let context_graph = RepoContextGraph::from_scan_facts(
-            &project_stage.facts,
-            &project_stage.facts.root_path,
-            project_stage.coupling_graph.clone(),
-        );
-        let context_graph_summary =
-            summarize_context_graph(&context_graph, &project_stage.findings, &[]);
-        let context_graph_cache = match write_repo_context_graph(
-            &project_stage.facts.root_path,
-            self.config,
-            &context_graph,
-        ) {
-            Ok(cache_info) => Some(cache_info),
-            Err(error) => {
-                diagnostics.push(cache_diagnostic(&error));
-                None
-            }
-        };
-        let mut summary = build_scan_summary(
-            project_stage.facts,
-            project_stage.findings,
-            ScanSummaryParts {
-                mode: ScanMode::Full,
-                base_ref: None,
-                changed_files_count: 0,
-                repo_level_rules_included: true,
-                coupling_graph: Some(project_stage.coupling_graph),
-                scan_duration_us,
-                scan_timings: Some(timings),
-                cache_telemetry: None,
-                diagnostics,
-                signal_quality,
-                context_graph_summary: Some(context_graph_summary),
-                context_graph_cache,
-            },
-        );
-        if let Some(timings) = &mut summary.scan_timings {
-            timings.report_finalization_us = finalization_start.elapsed().as_micros() as u64;
-        }
-        summary
-    }
 
     fn run_discovery(&self) -> io::Result<DiscoveryStage> {
         let start = Instant::now();

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -19,7 +19,7 @@ use crate::frameworks::{
 use crate::knowledge::decision::apply_project_decisions;
 use crate::risk::{apply_cluster_overlay, apply_graph_overlay, assess_findings};
 use crate::scan::config::ScanConfig;
-use crate::scan::types::{ScanMode, ScanSummary, ScanTimings};
+use crate::scan::types::{ScanSummary, ScanTimings};
 use std::io;
 use std::path::Path;
 use std::time::Instant;
@@ -112,7 +112,6 @@ impl<'a> ScanEngine<'a> {
             signal_quality,
         ))
     }
-
 
     fn run_discovery(&self) -> io::Result<DiscoveryStage> {
         let start = Instant::now();

--- a/tests/scan_finalization_cli.rs
+++ b/tests/scan_finalization_cli.rs
@@ -1,0 +1,75 @@
+use serde_json::Value;
+use std::fs;
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+fn run_repopilot(args: &[&str]) -> Output {
+    repopilot().args(args).output().expect("run repopilot")
+}
+
+fn fixture_project() -> TempDir {
+    let dir = tempfile::tempdir().expect("create fixture project");
+    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
+    fs::write(
+        dir.path().join("src/lib.rs"),
+        "pub mod domain;\npub fn answer() -> i32 { domain::value() }\n",
+    )
+    .expect("write lib source");
+    fs::write(dir.path().join("src/domain.rs"), "pub fn value() -> i32 { 42 }\n")
+        .expect("write domain source");
+    dir
+}
+
+#[test]
+fn given_small_project_when_scan_runs_then_finalization_artifacts_are_present() {
+    // Given
+    let project = fixture_project();
+    let output_path = project.path().join("scan.json");
+    let project_path = project.path().to_string_lossy().to_string();
+    let output_arg = output_path.to_string_lossy().to_string();
+
+    // When
+    let output = run_repopilot(&[
+        "scan",
+        &project_path,
+        "--format",
+        "json",
+        "--timing",
+        "--output",
+        &output_arg,
+    ]);
+
+    // Then
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("report finalization"),
+        "timing stderr should mention report finalization, got:\n{stderr}"
+    );
+
+    let report: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("scan report should be written"),
+    )
+    .expect("scan report should be valid JSON");
+
+    assert!(
+        report["context_graph_summary"].is_object(),
+        "finalized scan should include context_graph_summary: {report:#?}"
+    );
+    assert!(
+        report["scan_timings"]["report_finalization_us"]
+            .as_u64()
+            .is_some(),
+        "finalized scan should include report_finalization_us timing: {report:#?}"
+    );
+}

--- a/tests/scan_finalization_cli.rs
+++ b/tests/scan_finalization_cli.rs
@@ -19,8 +19,11 @@ fn fixture_project() -> TempDir {
         "pub mod domain;\npub fn answer() -> i32 { domain::value() }\n",
     )
     .expect("write lib source");
-    fs::write(dir.path().join("src/domain.rs"), "pub fn value() -> i32 { 42 }\n")
-        .expect("write domain source");
+    fs::write(
+        dir.path().join("src/domain.rs"),
+        "pub fn value() -> i32 { 42 }\n",
+    )
+    .expect("write domain source");
     dir
 }
 


### PR DESCRIPTION
## Summary

This PR isolates scan report finalization from the main scanner pipeline.

It keeps scanner behavior unchanged, but moves final report assembly into a focused `finalize` module so `ScanEngine::run()` stays readable and the finalization responsibilities are easier to test and evolve.

## Type of change

- [ ] Feature
- [x] Refactor
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- Added `src/scan/scanner/finalize.rs`.
- Moved `ScanEngine::finalize_report(...)` out of `src/scan/scanner/mod.rs`.
- Split report finalization into focused helper steps:
  - sort findings and build the repository context graph;
  - summarize context graph data;
  - write context graph cache or attach a diagnostic;
  - build the final `ScanSummary`;
  - record `report_finalization_us` timing.
- Added `tests/scan_finalization_cli.rs` as a BDD-style regression test.
- The regression test verifies that finalized scan JSON still includes:
  - `context_graph_summary`;
  - `scan_timings.report_finalization_us`.

## Why

`ScanEngine::run()` is the core scan pipeline. It should read as a sequence of stages, not mix pipeline orchestration with report assembly details.

Before this PR, report finalization mixed sorting, context graph generation, cache writing, diagnostic mutation, summary assembly, and final timing updates in the same method.

This refactor makes the scanner core easier to maintain before future performance, caching, and report-finalization work.

## Architecture notes

- [x] No god files introduced
- [x] Scanner core behavior remains unchanged
- [x] Finalization responsibilities are isolated in `scanner/finalize.rs`
- [x] Scanner pipeline stages remain visible in `ScanEngine::run()`
- [x] Output/report responsibilities remain separated from audit logic
- [x] Regression coverage protects finalization artifacts

## Changelog

- [ ] `CHANGELOG.md` updated
- [x] Skipped because this is an internal behavior-preserving refactor

## Verification

```bash
cargo fmt --all -- --check
cargo test --test scan_finalization_cli
cargo test --all
cargo clippy --all-targets --all-features -- -D warnings
./scripts/smoke-product.sh