### PR TITLE
Improve scan UX with compact output, render limits, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,90 @@
 
 **Local-first repository audits for safer human and AI-assisted code changes.**
 
-RepoPilot scans a repository on your machine, ranks evidence-backed risks, helps
-review pull requests, and produces local AI-ready context. It does not upload
-source code, run a hosted scanner, call LLM APIs, or send telemetry.
+RepoPilot is a fast Rust CLI that scans your repository locally, ranks evidence-backed risks, helps review pull requests, supports baseline adoption, and generates AI-ready context without uploading your source code.
 
-RepoPilot is not a language linter replacement. It focuses on repository-level
-signals that are easy to miss one file at a time: secrets, runtime footguns,
-import graph risk, review blast radius, baseline adoption, and concise local
-remediation context.
+It is built for maintainers who want practical repository-level signal, not another noisy linter dump.
+
+```text
+local scan -> evidence-backed findings -> risk-ranked review -> baseline adoption -> AI-ready local context -> CI gate
+```
+
+## Why RepoPilot exists
+
+Modern teams move fast, but codebases quietly accumulate risks that are easy to miss one file at a time:
+
+- committed secrets and unsafe configuration files;
+- runtime footguns such as production exits and panic paths;
+- import graph risks and architectural coupling;
+- noisy maintainability issues that should not block every PR;
+- large review blast radius;
+- old findings that need a baseline instead of endless repeated warnings;
+- AI coding sessions that need clean local context instead of random pasted files.
+
+RepoPilot focuses on repository-level evidence and review workflows.
+
+It does **not** replace language linters, formatters, type checkers, or security scanners. It complements them by connecting findings to repository structure, change risk, review context, and local remediation workflows.
+
+## Local-first by design
+
+RepoPilot does not:
+
+- upload your source code;
+- run a hosted scanner;
+- call LLM APIs implicitly;
+- send telemetry;
+- require a SaaS account.
+
+AI-related commands are local formatting/context helpers. They package audit evidence for tools like Claude Code, ChatGPT, Cursor, Zed, or another assistant, but RepoPilot itself stays local-first.
+
+## What RepoPilot checks
+
+RepoPilot is intentionally conservative in the default profile. It prioritizes high-trust findings that are useful during daily development and CI review.
+
+Core focus areas:
+
+| Area | Examples |
+|---|---|
+| Security | secret candidates, private keys, committed env files |
+| Runtime risk | Rust panic/unwrap paths, JavaScript/Python/Go/JVM/.NET runtime exits |
+| Architecture | circular dependencies, excessive fan-out, instability hubs |
+| Review risk | changed files, blast radius, branch-vs-base review context |
+| Baseline adoption | distinguish new risk from accepted existing debt |
+| Reports | JSON, Markdown, SARIF, receipts, report envelopes |
+| AI context | local, budgeted, evidence-backed context for coding assistants |
+
+Broad maintainability signals such as long files, long functions, TODO/FIXME/HACK markers, complex files, and testing gaps are available in strict mode instead of dominating default output.
 
 ## Install
 
+Choose one install method.
+
+### Cargo
+
 ```bash
 cargo install repopilot
+```
+
+### npm
+
+```bash
 npm install -g repopilot
-brew tap mykytastel/repopilot && brew install repopilot
+```
+
+### Homebrew
+
+```bash
+brew tap mykytastel/repopilot
+brew install repopilot
+```
+
+### Linux/macOS installer
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/MykytaStel/repopilot/main/install.sh | bash
 ```
 
-Build from source:
+### Build from source
 
 ```bash
 git clone https://github.com/MykytaStel/repopilot.git
@@ -37,24 +102,45 @@ cargo build --release
 
 More install options: [docs/install.md](docs/install.md).
 
-## First 5 Minutes
+## First 5 minutes
+
+Run a default local scan:
 
 ```bash
 repopilot scan .
-repopilot doctor .
-repopilot baseline create . --output .repopilot/baseline.json
-repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
-repopilot review . --base origin/main
-repopilot ai context . --budget 4k
 ```
 
-That path answers:
+Check whether the repository is ready for adoption:
 
-- what is high-risk right now;
-- whether the repo is ready for CI adoption;
-- which findings are accepted existing debt;
-- what the current branch changed;
-- what local context to give an AI coding assistant.
+```bash
+repopilot doctor .
+```
+
+Create a baseline for existing debt:
+
+```bash
+repopilot baseline create . --output .repopilot/baseline.json
+```
+
+Fail only on new high-risk findings:
+
+```bash
+repopilot scan . \
+  --baseline .repopilot/baseline.json \
+  --fail-on new-high
+```
+
+Review your current branch against `main`:
+
+```bash
+repopilot review . --base origin/main
+```
+
+Generate local AI-ready context:
+
+```bash
+repopilot ai context . --budget 4k
+```
 
 Save audit evidence:
 
@@ -64,12 +150,60 @@ repopilot scan . --format json --output repopilot-report.json --receipt .repopil
 repopilot scan . --format sarif --output repopilot.sarif
 ```
 
+## Core workflows
+
+### 1. Scan the repository
+
+```bash
+repopilot scan .
+```
+
+Use this for day-to-day local checks and CI-friendly repository audits.
+
+### 2. Run a strict audit
+
+```bash
+repopilot scan . --profile strict
+```
+
+Use strict mode for cleanup passes, refactoring work, rule development, and release-hardening audits.
+
+### 3. Review a branch
+
+```bash
+repopilot review . --base origin/main
+```
+
+Use this before opening or merging a PR to understand changed files, review risk, and branch-specific findings.
+
+### 4. Adopt RepoPilot gradually
+
+```bash
+repopilot baseline create . --output .repopilot/baseline.json
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
+```
+
+This lets a mature repository start using RepoPilot without failing CI on old accepted debt.
+
+### 5. Generate local AI context
+
+```bash
+repopilot ai context . --budget 4k
+```
+
+Use this when working with an AI coding assistant. RepoPilot produces concise local context based on repository evidence instead of asking you to paste random files manually.
+
 ## Trust Mode
 
-The default scan profile is intentionally quiet. It keeps high-trust security,
-runtime, and import-graph findings visible, while broad maintainability,
-TODO/FIXME/HACK, long-function, complex-file, and testing-gap heuristics stay in
-strict mode.
+RepoPilot's default profile is intentionally quiet.
+
+The default scan answers:
+
+- what can break production;
+- what can leak secrets;
+- what should block a release;
+- what is safe to review later;
+- what belongs in a strict/deep audit workflow.
 
 ```bash
 repopilot scan .                  # default profile
@@ -77,19 +211,21 @@ repopilot scan . --profile strict # full audit output
 repopilot scan . --include-maintainability
 ```
 
-Hidden suggestions are summarized by intent, rule, category, and reason, so the
-default report stays quiet without pretending strict-only findings do not exist.
+Default profile keeps high-trust security, runtime, and import-graph findings visible.
 
-## Stable Command Surface
+Strict profile preserves the full raw audit output, including broad maintainability and testing heuristics.
 
-RepoPilot's public top-level commands stay focused before 1.0:
+Hidden suggestions are summarized instead of silently dropped, so the default report stays quiet without becoming opaque.
+
+More: [docs/trust-mode.md](docs/trust-mode.md).
+
+## Stable command surface
+
+RepoPilot keeps the public top-level CLI small before 1.0:
 
 ```text
 scan | review | baseline | compare | doctor | inspect | ai | init | cache
 ```
-
-New diagnostics should fit under existing commands rather than adding new
-top-level workflows.
 
 Common commands:
 
@@ -105,25 +241,46 @@ repopilot ai context .
 repopilot cache clear .
 ```
 
-## Rule Quality
+New diagnostics should fit under existing commands instead of adding more top-level workflows.
 
-Rules move through `experimental -> preview -> stable`.
+## Rule quality contract
 
-A rule can be `stable` only when it has true-positive and false-positive
-fixtures, clean finding-contract output, metadata, false-positive notes, docs
-for high/critical findings, and a clean `repopilot inspect eval-rules` result.
+RepoPilot rules move through a lifecycle:
 
-Before 0.20.0, RepoPilot prioritizes depth over breadth:
+```text
+experimental -> preview -> stable
+```
 
-- secrets and private keys;
-- Rust panic/runtime risk;
-- JavaScript, Python, Go, JVM, and .NET runtime exits;
-- import graph risks;
-- review diff and blast-radius behavior.
+A rule should become stable only when it has:
 
-## CI Gate
+- complete rule metadata;
+- true-positive fixtures;
+- false-positive fixtures;
+- deterministic stable finding IDs;
+- evidence pointing to concrete files, lines, or scopes;
+- false-positive notes;
+- docs URL for high/critical findings;
+- clean local validation through `inspect eval-rules`.
 
-Minimal release gates:
+Run the rule quality gate:
+
+```bash
+repopilot inspect eval-rules --format json
+```
+
+Evaluate one rule:
+
+```bash
+repopilot inspect eval-rules --rule security.env-file-committed --format json
+```
+
+The gate reports fixture coverage, missing findings, unexpected findings, contract violations, stable ID failures, and quality gate failures.
+
+More: [docs/rule-quality-gate.md](docs/rule-quality-gate.md).
+
+## CI example
+
+Minimal CI gate:
 
 ```bash
 cargo fmt --all -- --check
@@ -135,7 +292,63 @@ repopilot inspect eval-rules --format json
 repopilot scan .
 ```
 
-## Docs
+GitHub Actions with SARIF upload:
+
+```bash
+repopilot scan . --format sarif --output repopilot.sarif
+```
+
+More: [docs/integrations/github-code-scanning.md](docs/integrations/github-code-scanning.md).
+
+## Output formats
+
+RepoPilot can produce:
+
+| Format | Use case |
+|---|---|
+| Console | fast local feedback |
+| Markdown | PR comments, human-readable reports |
+| JSON | automation and internal tooling |
+| SARIF | GitHub code scanning |
+| HTML | shareable local reports |
+| Receipt | reproducible scan metadata |
+
+More: [docs/reports.md](docs/reports.md).
+
+## Configuration
+
+RepoPilot can be configured with `repopilot.toml`.
+
+Use configuration for:
+
+- ignores;
+- presets;
+- rule tuning;
+- baseline adoption;
+- scan behavior;
+- report settings.
+
+More: [docs/configuration.md](docs/configuration.md).
+
+## Project status
+
+RepoPilot is pre-1.0.
+
+The current product direction is to strengthen trust, fixture-backed rules, baseline adoption, review workflows, and local-first AI context before expanding into too many rule families.
+
+The pre-1.0 release line prioritizes:
+
+- trustworthy default output;
+- stable command surface;
+- strong rule lifecycle;
+- clean self-audit behavior;
+- verified distribution through crates.io, npm, GitHub Releases, Homebrew, and installer scripts.
+
+Release-specific plans, checklists, and historical notes live outside the README so this page can stay useful across future versions.
+
+More: [docs/roadmap.md](docs/roadmap.md).
+
+## Documentation
 
 | Document | Purpose |
 |---|---|
@@ -143,9 +356,56 @@ repopilot scan .
 | [Commands](docs/commands.md) | Task-oriented CLI workflows |
 | [Configuration](docs/configuration.md) | `repopilot.toml`, presets, ignores, and baseline adoption |
 | [Rulesets](docs/rulesets.md) | Built-in rules, lifecycle, severity, and confidence |
+| [Trust Mode](docs/trust-mode.md) | Default vs strict visibility policy |
+| [Rule lifecycle](docs/rule-lifecycle.md) | Experimental, preview, and stable rule expectations |
+| [Rule quality gate](docs/rule-quality-gate.md) | Fixture-backed stable/default-visible rule contract |
 | [Reports](docs/reports.md) | JSON, SARIF, Markdown, HTML, receipts, and schema fields |
 | [CI/GitHub](docs/integrations/github-code-scanning.md) | GitHub Actions and SARIF upload |
-| [Roadmap](docs/roadmap.md) | 0.x product cuts, 0.13.x focus, and v1 gates |
+| [Roadmap](docs/roadmap.md) | Pre-1.0 product direction, release themes, and v1 gates |
+
+## Development
+
+Run local checks:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+npm run test:npm
+```
+
+Run product smoke checks:
+
+```bash
+./scripts/smoke-product.sh
+```
+
+Run a self-scan:
+
+```bash
+cargo run -- scan .
+```
+
+Run rule quality evaluation from source:
+
+```bash
+cargo run -- inspect eval-rules --format json
+```
+
+## Contributing
+
+RepoPilot values small, focused changes.
+
+Good contributions include:
+
+- fixture-backed rule improvements;
+- false-positive reductions;
+- clearer evidence in findings;
+- better baseline/review ergonomics;
+- docs that make local adoption easier;
+- tests that protect rule precision and output contracts.
+
+Before marking a rule stable or default-visible, make sure it has true-positive and false-positive fixtures, metadata, false-positive notes, deterministic output, and a clean `inspect eval-rules` result.
 
 ## License
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,7 +23,12 @@ Use `-h` for a short summary or `--help` for the full description and examples.
 | [`ai prompt`](#ai-prompt) | — | Generate an AI-ready remediation prompt |
 | [`inspect explain`](#inspect-explain) | — | Explain file classification and rule decisions |
 | [`inspect knowledge`](#inspect-knowledge) | — | Inspect bundled Knowledge Engine data |
+| [`inspect cache`](#inspect-cache) | — | Inspect local changed-scan cache diagnostics |
+| [`inspect graph`](#inspect-graph) | — | Inspect Context Risk Graph decisions |
 | [`inspect feedback`](#inspect-feedback) | — | Validate local feedback suppressions |
+| [`inspect rules`](#inspect-rules) | — | List registered rules with lifecycle and signal metadata |
+| [`inspect rule`](#inspect-rule) | — | Inspect one registered rule |
+| [`inspect eval-rules`](#inspect-eval-rules) | — | Evaluate registered rules against bundled fixtures |
 | [`compare`](#compare) | `cmp` | Compare two JSON scan reports and show what changed |
 | [`cache`](#cache) | — | Manage local changed-scan cache files |
 | [`baseline`](#baseline) | `bl` | Manage accepted baseline findings |
@@ -69,11 +74,18 @@ repopilot s <PATH> [OPTIONS]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--format` | `console\|json\|markdown\|html\|sarif` | `console` | Output format |
+| `--output-style` | `compact\|full` | `compact` | Console output style; use `full` for detailed diagnostics |
+| `--quiet` | flag | — | Suppress progress indicators and next-step hints while keeping findings and status |
+| `--no-progress` | flag | — | Disable progress indicators |
+| `--max-findings` | `N\|none` | compact: 5, full/Markdown: all | Limit rendered human-format finding details; JSON and SARIF remain complete |
+| `--color` | `auto\|always\|never` | `auto` | Console color mode |
+| `--no-color` | flag | — | Disable ANSI color in console output |
 | `-o, --output` | path | stdout | Write report to a file instead of stdout |
 | `--receipt` | path | — | Write a compact audit receipt JSON file with tool, git, scope, finding, language, and health metadata |
 | `--config` | path | auto-detected | Path to a `repopilot.toml` config file |
 | `--baseline` | path | — | Path to a baseline file; marks findings as new or existing |
 | `--fail-on` | threshold | — | Exit code 1 when findings meet this threshold (see [Thresholds](#thresholds)) |
+| `--fail-on-priority` | `p0\|p1\|p2\|p3` | — | Exit code 1 when findings meet this risk priority threshold |
 | `--ignore-feedback` | flag | — | Ignore `.repopilot/feedback.yml` local suppressions |
 | `--max-file-loc` | integer | `300` | Maximum non-empty LOC before a file is flagged as large |
 | `--max-directory-modules` | integer | `20` | Maximum files per directory before flagging |
@@ -89,8 +101,11 @@ repopilot s <PATH> [OPTIONS]
 | `--min-confidence` | `low\|medium\|high` | — | Only show findings at or above this confidence |
 | `--min-priority` | `p0\|p1\|p2\|p3` | — | Only show findings at or above this risk priority |
 | `--verbose` | flag | — | Print scan/render timing after the report |
+| `--profile` | `default\|strict` | `default` | Default hides low-signal suggestions; strict shows all findings |
+| `--include-maintainability` | flag | — | Include maintainability and testing suggestions hidden by the default profile |
 | `--timing` | flag | — | Print pipeline timing for discovery, file analysis, framework detection, audits, enrichment, risk scoring, and report finalization |
-| `--preset` | `strict\|balanced\|lenient` | `balanced` | Apply a threshold preset without editing config |
+| `--preset` | `strict\|balanced\|lenient` | — | Apply a threshold preset without editing config |
+| `--rule` | rule ID | — | Only show findings for specific rule IDs; repeatable |
 
 `files_discovered` in JSON output means files found after gitignore, `.repopilotignore`, built-in ignores, and `--exclude` filters. `files_analyzed` means analyzed text files; skipped large files, low-signal paths, binary/unreadable files, and files beyond `--max-files` are not included. JSON also includes `files_skipped_low_signal` and `binary_files_skipped`.
 
@@ -109,6 +124,12 @@ repopilot s <PATH> [OPTIONS]
 # Basic scan
 repopilot scan .
 repopilot scan src/
+repopilot scan . --output-style full
+repopilot scan . --quiet
+repopilot scan . --no-progress
+repopilot scan . --max-findings 20
+repopilot scan . --max-findings none
+repopilot scan . --no-color
 
 # Save report to a file
 repopilot scan . --format json --output report.json
@@ -147,6 +168,7 @@ repopilot scan . --since main
 
 # One-shot threshold presets and timing
 repopilot scan . --preset strict
+repopilot scan . --profile strict
 repopilot scan . --verbose
 ```
 
@@ -210,6 +232,8 @@ repopilot r [PATH] [OPTIONS]
 | `--config` | path | auto-detected | Path to a `repopilot.toml` config file |
 | `--baseline` | path | — | Path to a baseline file |
 | `--fail-on` | threshold | — | Exit code 1 when **in-diff** findings meet this threshold |
+| `--fail-on-priority` | `p0\|p1\|p2\|p3` | — | Exit code 1 when **in-diff** findings meet this risk priority threshold |
+| `--no-progress` | flag | — | Disable progress indicators |
 | `--ignore-feedback` | flag | — | Ignore `.repopilot/feedback.yml` local suppressions |
 | `--max-file-loc` | integer | `300` | Maximum non-empty LOC before a file is flagged as large |
 | `--max-directory-modules` | integer | `20` | Maximum files per directory before flagging |
@@ -236,12 +260,14 @@ repopilot review .
 # Review a branch in CI
 repopilot review . --base origin/main
 repopilot review . --base origin/main --head HEAD
+repopilot review . --base origin/main --no-progress
 
 # Save a Markdown review report
 repopilot review . --base origin/main --format markdown --output review.md
 
 # Baseline-aware CI gate on in-diff findings only
 repopilot review . --baseline .repopilot/baseline.json --fail-on new-high
+repopilot review . --base origin/main --fail-on-priority p1
 
 # Review without local feedback suppressions
 repopilot review . --ignore-feedback
@@ -450,6 +476,146 @@ repopilot inspect feedback .
 repopilot inspect feedback . --format json
 repopilot inspect feedback . --evaluate --format json
 repopilot inspect feedback . --format markdown --output feedback.md
+```
+
+---
+
+## `inspect cache`
+
+Reports local changed-scan cache path, cache existence, entry counts, and cache metadata. It is read-only.
+
+### Synopsis
+
+```
+repopilot inspect cache [PATH] [OPTIONS]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `console\|json\|markdown` | `console` | Output format |
+| `-o, --output` | path | stdout | Write report to a file instead of stdout |
+
+### Examples
+
+```bash
+repopilot inspect cache .
+repopilot inspect cache . --format json
+repopilot inspect cache . --format markdown --output cache.md
+```
+
+---
+
+## `inspect graph`
+
+Builds a local scan summary and renders Context Risk Graph diagnostics without starting a second scan during rendering.
+
+### Synopsis
+
+```
+repopilot inspect graph [PATH] [OPTIONS]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--config` | path | auto-detected | Path to a `repopilot.toml` config file |
+| `--format` | `console\|json\|markdown` | `console` | Output format |
+| `-o, --output` | path | stdout | Write report to a file instead of stdout |
+
+### Examples
+
+```bash
+repopilot inspect graph .
+repopilot inspect graph . --format json
+repopilot inspect graph . --format markdown --output graph.md
+```
+
+---
+
+## `inspect rules`
+
+Lists registered rules with lifecycle, signal source, default visibility, fixture coverage, and stability metadata.
+
+### Synopsis
+
+```
+repopilot inspect rules [OPTIONS]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `console\|json\|markdown` | `console` | Output format |
+| `--lifecycle` | `experimental\|preview\|stable\|deprecated` | — | Filter by lifecycle |
+| `--source` | signal source | — | Filter by signal source, for example `text-heuristic` |
+| `-o, --output` | path | stdout | Write report to a file instead of stdout |
+
+### Examples
+
+```bash
+repopilot inspect rules
+repopilot inspect rules --format json
+repopilot inspect rules --lifecycle preview
+repopilot inspect rules --source text-heuristic
+```
+
+---
+
+## `inspect rule`
+
+Shows metadata for one registered rule.
+
+### Synopsis
+
+```
+repopilot inspect rule <RULE_ID> [OPTIONS]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `console\|json\|markdown` | `console` | Output format |
+| `-o, --output` | path | stdout | Write report to a file instead of stdout |
+
+### Examples
+
+```bash
+repopilot inspect rule security.secret-candidate
+repopilot inspect rule architecture.circular-dependency --format json
+```
+
+---
+
+## `inspect eval-rules`
+
+Runs local fixture projects for registered rules and reports missing, unexpected, contract, stability, and fixture-quality failures.
+
+### Synopsis
+
+```
+repopilot inspect eval-rules [OPTIONS]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--rule` | rule ID | — | Evaluate only one rule |
+| `--fixtures` | path | `tests/fixtures/rules` | Fixture root |
+| `--format` | `console\|json\|markdown` | `console` | Output format |
+| `-o, --output` | path | stdout | Write report to a file instead of stdout |
+
+### Examples
+
+```bash
+repopilot inspect eval-rules
+repopilot inspect eval-rules --rule security.secret-candidate
+repopilot inspect eval-rules --format json
 ```
 
 ---

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -109,6 +109,26 @@ Size values accept raw bytes plus `kb`, `mb`, and `gb` suffixes. By default, low
 
 JSON reports expose this accounting with `files_discovered`, `files_analyzed` (analyzed text files), `files_skipped_low_signal`, `binary_files_skipped`, `large_files_skipped`, and `skipped_bytes`.
 
+### CI and output controls
+
+Use `--quiet` for CI logs where status and findings should remain visible but
+next-step hints and progress indicators should be suppressed. Use
+`--no-progress` when only the spinner should be disabled.
+
+```bash
+repopilot scan . --quiet
+repopilot scan . --no-progress
+```
+
+Use `--max-findings` to cap rendered human-format finding details. JSON and
+SARIF stay complete unless you apply a real filter such as `--min-severity`,
+`--min-priority`, or `--rule`.
+
+```bash
+repopilot scan . --max-findings 20
+repopilot scan . --max-findings none
+```
+
 ### Filtering by severity, confidence, and priority
 
 Use `--min-severity` and `--min-confidence` to reduce local report noise while keeping the same rules enabled:
@@ -128,6 +148,18 @@ repopilot scan . --min-priority p2
 repopilot review . --base origin/main --min-priority p1
 repopilot scan . --rule language.rust.panic-risk --timing
 ```
+
+The default console report is compact. Use `--output-style full` when you need
+the diagnostic report with scan input, signal quality, hidden suggestion
+breakdown, risk clusters, rule counts, language inventory, and full finding
+details:
+
+```bash
+repopilot scan . --output-style full
+```
+
+Use `--color auto|always|never` or `--no-color` to control ANSI color. Auto mode
+only emits color for terminal stdout outside CI.
 
 Use `--verbose` when you need scan and render timing:
 
@@ -468,8 +500,9 @@ silently disappearing.
 Do not commit `.repopilot/feedback.yml` by default. Commit it only when the
 suppressions are intentionally team-reviewed and part of repository policy.
 Personal or temporary suppressions should stay local and uncommitted.
-\n\n\n## Engine pipeline contract
+
+## Engine pipeline contract
 
 RepoPilot commands should scan once and render many outputs from the resulting
 `ScanSummary`. Renderers are not allowed to trigger repository scans. This keeps
-large repositories predictable and makes timing/cache metadata easier to trust.\n
+large repositories predictable and makes timing/cache metadata easier to trust.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,7 +1,7 @@
 use clap::ValueEnum;
 use repopilot::baseline::gate::FailOn;
 use repopilot::findings::types::{Confidence, Severity};
-use repopilot::output::OutputFormat;
+use repopilot::output::{ColorChoice, ConsoleOutputStyle, FindingRenderLimit, OutputFormat};
 use repopilot::risk::RiskPriority;
 use repopilot::rules::{RuleLifecycle, SignalSource};
 
@@ -19,6 +19,19 @@ pub enum CompareOutputFormatArg {
     Console,
     Json,
     Markdown,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum ScanOutputStyleArg {
+    Compact,
+    Full,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
+pub enum ColorArg {
+    Auto,
+    Always,
+    Never,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -49,6 +62,12 @@ pub enum PriorityArg {
 pub enum ScanProfileArg {
     Default,
     Strict,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MaxFindingsArg {
+    Limit(usize),
+    Unlimited,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -111,6 +130,34 @@ impl From<OutputFormatArg> for OutputFormat {
             OutputFormatArg::Json => OutputFormat::Json,
             OutputFormatArg::Markdown => OutputFormat::Markdown,
             OutputFormatArg::Sarif => OutputFormat::Sarif,
+        }
+    }
+}
+
+impl From<ScanOutputStyleArg> for ConsoleOutputStyle {
+    fn from(style: ScanOutputStyleArg) -> Self {
+        match style {
+            ScanOutputStyleArg::Compact => ConsoleOutputStyle::Compact,
+            ScanOutputStyleArg::Full => ConsoleOutputStyle::Full,
+        }
+    }
+}
+
+impl From<MaxFindingsArg> for FindingRenderLimit {
+    fn from(value: MaxFindingsArg) -> Self {
+        match value {
+            MaxFindingsArg::Limit(limit) => FindingRenderLimit::Limit(limit),
+            MaxFindingsArg::Unlimited => FindingRenderLimit::Unlimited,
+        }
+    }
+}
+
+impl From<ColorArg> for ColorChoice {
+    fn from(color: ColorArg) -> Self {
+        match color {
+            ColorArg::Auto => ColorChoice::Auto,
+            ColorArg::Always => ColorChoice::Always,
+            ColorArg::Never => ColorChoice::Never,
         }
     }
 }
@@ -193,6 +240,21 @@ pub fn parse_token_budget(value: &str) -> Result<usize, String> {
     }
 
     Ok(tokens)
+}
+
+pub fn parse_max_findings(value: &str) -> Result<MaxFindingsArg, String> {
+    if value.eq_ignore_ascii_case("none") {
+        return Ok(MaxFindingsArg::Unlimited);
+    }
+
+    let limit = value
+        .parse::<usize>()
+        .map_err(|_| "expected a positive integer or 'none'".to_string())?;
+    if limit == 0 {
+        return Err("max-findings must be greater than zero or 'none'".to_string());
+    }
+
+    Ok(MaxFindingsArg::Limit(limit))
 }
 
 pub fn parse_byte_size(value: &str) -> Result<u64, String> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,8 +2,9 @@ mod args;
 mod options;
 
 pub use args::{
-    CompareOutputFormatArg, ConfidenceArg, FailOnArg, KnowledgeSectionArg, OutputFormatArg,
-    PriorityArg, RuleLifecycleArg, ScanProfileArg, SeverityArg, SignalSourceArg, parse_byte_size,
+    ColorArg, CompareOutputFormatArg, ConfidenceArg, FailOnArg, KnowledgeSectionArg,
+    MaxFindingsArg, OutputFormatArg, PriorityArg, RuleLifecycleArg, ScanOutputStyleArg,
+    ScanProfileArg, SeverityArg, SignalSourceArg, parse_byte_size, parse_max_findings,
     parse_token_budget,
 };
 pub use options::*;

--- a/src/cli/options/review.rs
+++ b/src/cli/options/review.rs
@@ -36,6 +36,10 @@ pub struct ReviewOptions {
     #[arg(long, value_enum, default_value = "console")]
     pub format: CompareOutputFormatArg,
 
+    /// Disable progress indicators
+    #[arg(long)]
+    pub no_progress: bool,
+
     /// Write report to a file instead of stdout
     #[arg(short, long)]
     pub output: Option<PathBuf>,

--- a/src/cli/options/scan.rs
+++ b/src/cli/options/scan.rs
@@ -1,6 +1,7 @@
+use crate::cli::MaxFindingsArg;
 use crate::cli::{
-    ConfidenceArg, FailOnArg, OutputFormatArg, PriorityArg, ScanProfileArg, SeverityArg,
-    parse_byte_size,
+    ColorArg, ConfidenceArg, FailOnArg, OutputFormatArg, PriorityArg, ScanOutputStyleArg,
+    ScanProfileArg, SeverityArg, parse_byte_size, parse_max_findings,
 };
 use clap::Args;
 use std::path::PathBuf;
@@ -13,6 +14,30 @@ pub struct ScanOptions {
     /// Output format; defaults to repopilot.toml output.default_format or console
     #[arg(long, value_enum)]
     pub format: Option<OutputFormatArg>,
+
+    /// Console output style; compact is the default for scan console output
+    #[arg(long, value_enum)]
+    pub output_style: Option<ScanOutputStyleArg>,
+
+    /// Suppress progress indicators and next-step hints in console output
+    #[arg(long)]
+    pub quiet: bool,
+
+    /// Disable progress indicators
+    #[arg(long)]
+    pub no_progress: bool,
+
+    /// Limit rendered human-format finding details; use 'none' for all
+    #[arg(long, value_name = "N|none", value_parser = parse_max_findings)]
+    pub max_findings: Option<MaxFindingsArg>,
+
+    /// Console color mode
+    #[arg(long, value_enum)]
+    pub color: Option<ColorArg>,
+
+    /// Disable ANSI color in console output
+    #[arg(long)]
+    pub no_color: bool,
 
     /// Write report to a file instead of stdout
     #[arg(short, long)]

--- a/src/commands/baseline.rs
+++ b/src/commands/baseline.rs
@@ -27,6 +27,7 @@ pub fn run(command: BaselineCommands) -> Result<(), Box<dyn std::error::Error>> 
                 overrides: ScanConfigOverrides::default(),
                 preset: None,
                 mode: ProductScanMode::Full,
+                no_progress: false,
                 ignore_feedback,
                 visibility_profile: FindingVisibilityProfile::Default,
                 pre_visibility_filter: FindingFilter::default(),

--- a/src/commands/graph.rs
+++ b/src/commands/graph.rs
@@ -27,6 +27,7 @@ pub fn run(
         overrides: ScanConfigOverrides::default(),
         preset: None,
         mode: ProductScanMode::Full,
+        no_progress: false,
         ignore_feedback: true,
         visibility_profile: FindingVisibilityProfile::Strict,
         pre_visibility_filter: FindingFilter::default(),

--- a/src/commands/llm.rs
+++ b/src/commands/llm.rs
@@ -35,6 +35,7 @@ where
         overrides: ScanConfigOverrides::default(),
         preset: None,
         mode: ProductScanMode::Full,
+        no_progress: false,
         ignore_feedback: false,
         visibility_profile: FindingVisibilityProfile::Default,
         pre_visibility_filter: FindingFilter::default(),

--- a/src/commands/product_scan.rs
+++ b/src/commands/product_scan.rs
@@ -25,6 +25,7 @@ pub struct ProductScanRequest {
     pub overrides: ScanConfigOverrides,
     pub preset: Option<String>,
     pub mode: ProductScanMode,
+    pub no_progress: bool,
     pub ignore_feedback: bool,
     pub visibility_profile: FindingVisibilityProfile,
     pub pre_visibility_filter: FindingFilter,
@@ -53,7 +54,11 @@ pub fn run_product_scan(
     }
 
     let scan_config = build_scan_config(&repo_config, request.overrides);
-    let pb = make_spinner("Scanning...");
+    let pb = if request.no_progress {
+        None
+    } else {
+        make_spinner("Scanning...")
+    };
     let scan_start = Instant::now();
     let scan_result = match &request.mode {
         ProductScanMode::Full => scan_path_with_config(&request.path, &scan_config),

--- a/src/commands/progress.rs
+++ b/src/commands/progress.rs
@@ -1,9 +1,10 @@
 use indicatif::{ProgressBar, ProgressStyle};
+use std::env;
 use std::io::IsTerminal;
 use std::time::Duration;
 
 pub fn make_spinner(message: &'static str) -> Option<ProgressBar> {
-    if !std::io::stderr().is_terminal() {
+    if !std::io::stderr().is_terminal() || env::var_os("CI").is_some() {
         return None;
     }
 

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -42,6 +42,7 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
         },
         preset: None,
         mode: ProductScanMode::Full,
+        no_progress: options.no_progress,
         ignore_feedback: options.ignore_feedback,
         visibility_profile: FindingVisibilityProfile::Strict,
         pre_visibility_filter: pre_diff_filter,

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -8,7 +8,10 @@ use crate::commands::product_scan::{
     ProductScanRequest, enforce_diagnostics_exit_policy, run_product_scan,
 };
 use crate::commands::scan_config::ScanConfigOverrides;
-use repopilot::output::render_scan_summary;
+use repopilot::output::{
+    ColorChoice, ColorDestination, ConsoleOutputStyle, FindingRenderLimit, RenderOptions,
+    render_scan_summary_with_options,
+};
 use repopilot::receipt::{build_audit_receipt, render_receipt_json};
 use repopilot::report::writer::write_report;
 use repopilot::scan::types::ScanSummary;
@@ -38,6 +41,7 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
         },
         preset: options.preset.clone(),
         mode: scan_mode,
+        no_progress: options.no_progress || options.quiet,
         ignore_feedback: options.ignore_feedback,
         visibility_profile,
         pre_visibility_filter,
@@ -65,8 +69,10 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
         priority_filter.apply_to_summary(&mut summary);
     }
 
+    let render_options = render_options_for_scan(&options);
     let render_start = Instant::now();
-    let rendered_report = render_scan_summary(&summary, output_format)?;
+    let rendered_report =
+        render_scan_summary_with_options(&summary, output_format, render_options)?;
     let render_elapsed = render_start.elapsed();
 
     write_scan_receipt_if_requested(&summary, options.receipt.as_deref())?;
@@ -83,6 +89,30 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     enforce_diagnostics_exit_policy(&summary)?;
 
     Ok(())
+}
+
+pub(super) fn render_options_for_scan(options: &ScanOptions) -> RenderOptions {
+    RenderOptions {
+        console_output_style: options
+            .output_style
+            .map(Into::into)
+            .unwrap_or(ConsoleOutputStyle::Compact),
+        color_choice: if options.no_color {
+            ColorChoice::Never
+        } else {
+            options.color.map(Into::into).unwrap_or(ColorChoice::Auto)
+        },
+        color_destination: if options.output.is_some() {
+            ColorDestination::File
+        } else {
+            ColorDestination::Stdout
+        },
+        quiet: options.quiet,
+        findings_limit: options
+            .max_findings
+            .map(Into::into)
+            .unwrap_or(FindingRenderLimit::Default),
+    }
 }
 
 pub(super) fn write_scan_receipt_if_requested(

--- a/src/commands/scan/baseline_flow.rs
+++ b/src/commands/scan/baseline_flow.rs
@@ -5,7 +5,7 @@ use repopilot::baseline::diff::{all_findings_new, diff_summary_against_baseline}
 use repopilot::baseline::gate::{FailOn, evaluate_ci_gate};
 use repopilot::baseline::reader::read_baseline;
 use repopilot::findings::filter::FindingFilter;
-use repopilot::output::{OutputFormat, render_baseline_scan_report};
+use repopilot::output::{OutputFormat, render_baseline_scan_report_with_options};
 use repopilot::report::writer::write_report;
 use repopilot::risk::RiskPriority;
 use repopilot::scan::types::ScanSummary;
@@ -45,8 +45,12 @@ pub(super) fn run_baseline_scan_flow(
         });
 
     let render_start = Instant::now();
-    let rendered_report =
-        render_baseline_scan_report(&baseline_report, output_format, ci_gate.as_ref())?;
+    let rendered_report = render_baseline_scan_report_with_options(
+        &baseline_report,
+        output_format,
+        ci_gate.as_ref(),
+        super::render_options_for_scan(options),
+    )?;
     let render_elapsed = render_start.elapsed();
 
     super::write_scan_receipt_if_requested(&baseline_report.summary, options.receipt.as_deref())?;

--- a/src/commands/scan/validation.rs
+++ b/src/commands/scan/validation.rs
@@ -27,6 +27,13 @@ pub(super) fn validate_scan_options(
         }));
     }
 
+    if options.no_color && matches!(options.color, Some(crate::cli::ColorArg::Always)) {
+        return Err(Box::new(CliExit {
+            code: EXIT_USAGE,
+            message: "`--color always` cannot be used with `--no-color`".to_string(),
+        }));
+    }
+
     Ok(())
 }
 

--- a/src/output/color.rs
+++ b/src/output/color.rs
@@ -1,9 +1,67 @@
 use crate::findings::types::Severity;
+use std::cell::Cell;
+use std::env;
 use std::io::IsTerminal;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ColorChoice {
+    Auto,
+    Always,
+    Never,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ColorDestination {
+    Stdout,
+    File,
+}
+
+thread_local! {
+    static COLOR_OVERRIDE: Cell<Option<bool>> = const { Cell::new(None) };
+}
+
+pub fn resolve_color_enabled(choice: ColorChoice, destination: ColorDestination) -> bool {
+    match choice {
+        ColorChoice::Always => true,
+        ColorChoice::Never => false,
+        ColorChoice::Auto => {
+            destination == ColorDestination::Stdout
+                && std::io::stdout().is_terminal()
+                && env::var_os("NO_COLOR").is_none()
+                && env::var_os("CI").is_none()
+        }
+    }
+}
+
+pub fn with_color_enabled<T>(enabled: bool, render: impl FnOnce() -> T) -> T {
+    let _guard = ColorOverrideGuard::new(enabled);
+    render()
+}
+
+struct ColorOverrideGuard {
+    previous: Option<bool>,
+}
+
+impl ColorOverrideGuard {
+    fn new(enabled: bool) -> Self {
+        let previous = COLOR_OVERRIDE.with(|override_cell| {
+            let previous = override_cell.get();
+            override_cell.set(Some(enabled));
+            previous
+        });
+        Self { previous }
+    }
+}
+
+impl Drop for ColorOverrideGuard {
+    fn drop(&mut self) {
+        COLOR_OVERRIDE.with(|override_cell| override_cell.set(self.previous));
+    }
+}
 
 /// Colors a severity label string like `[HIGH]` or `[Critical]`.
 pub fn severity_label(label: &str) -> String {
-    if !std::io::stdout().is_terminal() {
+    if !colors_enabled() {
         return label.to_string();
     }
     match label {
@@ -17,16 +75,42 @@ pub fn severity_label(label: &str) -> String {
 
 /// Renders text in dim/faint style for secondary information.
 pub fn dim(text: &str) -> String {
-    if !std::io::stdout().is_terminal() {
+    if !colors_enabled() {
         return text.to_string();
     }
     format!("\x1b[2m{text}\x1b[0m")
 }
 
+pub fn status_label(label: &str) -> String {
+    if !colors_enabled() {
+        return label.to_string();
+    }
+    match label {
+        "Clean" => format!("\x1b[32m{label}\x1b[0m"),
+        "Attention needed" | "Scan completed with warnings" => {
+            format!("\x1b[33m{label}\x1b[0m")
+        }
+        "Scan completed with errors" => format!("\x1b[31m{label}\x1b[0m"),
+        _ => label.to_string(),
+    }
+}
+
+pub fn risk_label(label: &str) -> String {
+    if !colors_enabled() {
+        return label.to_string();
+    }
+    match label {
+        "High" | "Elevated" => format!("\x1b[31m{label}\x1b[0m"),
+        "Medium" | "Moderate" => format!("\x1b[33m{label}\x1b[0m"),
+        "Low" => format!("\x1b[36m{label}\x1b[0m"),
+        _ => label.to_string(),
+    }
+}
+
 /// Formats `"<n> <label>"` (e.g. `"3 high"`) with the correct severity color.
 pub fn severity_count(severity: Severity, n: usize) -> String {
     let text = format!("{n} {}", severity.lowercase_label());
-    if !std::io::stdout().is_terminal() {
+    if !colors_enabled() {
         return text;
     }
     match severity {
@@ -36,4 +120,10 @@ pub fn severity_count(severity: Severity, n: usize) -> String {
         Severity::Low => format!("\x1b[36m{text}\x1b[0m"),
         Severity::Info => format!("\x1b[90m{text}\x1b[0m"),
     }
+}
+
+fn colors_enabled() -> bool {
+    COLOR_OVERRIDE
+        .with(|override_cell| override_cell.get())
+        .unwrap_or_else(|| resolve_color_enabled(ColorChoice::Auto, ColorDestination::Stdout))
 }

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -1,4 +1,5 @@
 mod baseline;
+mod compact;
 mod findings;
 mod react_native;
 mod sections;
@@ -16,9 +17,25 @@ use crate::output::console::sections::{
 };
 use crate::output::console::workspace::workspace_risk_table;
 use crate::output::report_stats::build_report_stats;
+use crate::output::{ConsoleOutputStyle, RenderOptions};
 use crate::scan::types::ScanSummary;
 
 pub fn render(summary: &ScanSummary) -> String {
+    render_full(summary)
+}
+
+pub fn render_with_options(summary: &ScanSummary, options: RenderOptions) -> String {
+    match options.console_output_style {
+        ConsoleOutputStyle::Compact => compact::render_with_options(summary, options),
+        ConsoleOutputStyle::Full => render_full_with_options(summary, options),
+    }
+}
+
+fn render_full(summary: &ScanSummary) -> String {
+    render_full_with_options(summary, RenderOptions::default())
+}
+
+fn render_full_with_options(summary: &ScanSummary, options: RenderOptions) -> String {
     let stats = build_report_stats(summary);
     let mut output = String::new();
 
@@ -34,12 +51,45 @@ pub fn render(summary: &ScanSummary) -> String {
         render_react_native_section(&mut output, rn);
     }
     workspace_risk_table(&mut output, &summary.findings);
-    render_grouped_findings(&mut output, &summary.findings, |_| None);
+    render_grouped_findings(
+        &mut output,
+        &summary.findings,
+        options.findings_limit,
+        |_| None,
+    );
 
     output
 }
 
 pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGateResult>) -> String {
+    render_full_with_baseline(report, ci_gate)
+}
+
+pub fn render_baseline_with_options(
+    report: &BaselineScanReport,
+    ci_gate: Option<&CiGateResult>,
+    options: RenderOptions,
+) -> String {
+    match options.console_output_style {
+        ConsoleOutputStyle::Compact => {
+            compact::render_baseline_with_options(report, ci_gate, options)
+        }
+        ConsoleOutputStyle::Full => render_full_baseline_with_options(report, ci_gate, options),
+    }
+}
+
+fn render_full_with_baseline(
+    report: &BaselineScanReport,
+    ci_gate: Option<&CiGateResult>,
+) -> String {
+    render_full_baseline_with_options(report, ci_gate, RenderOptions::default())
+}
+
+fn render_full_baseline_with_options(
+    report: &BaselineScanReport,
+    ci_gate: Option<&CiGateResult>,
+    options: RenderOptions,
+) -> String {
     let summary = &report.summary;
     let stats = build_report_stats(summary);
     let mut output = String::new();
@@ -57,9 +107,12 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
         render_react_native_section(&mut output, rn);
     }
     workspace_risk_table(&mut output, &summary.findings);
-    render_grouped_findings(&mut output, &summary.findings, |index| {
-        Some(report.finding_status(index).lowercase_label())
-    });
+    render_grouped_findings(
+        &mut output,
+        &summary.findings,
+        options.findings_limit,
+        |index| Some(report.finding_status(index).lowercase_label()),
+    );
 
     output
 }

--- a/src/output/console/compact.rs
+++ b/src/output/console/compact.rs
@@ -1,0 +1,304 @@
+use crate::baseline::diff::BaselineScanReport;
+use crate::baseline::gate::CiGateResult;
+use crate::findings::types::Finding;
+use crate::output::color;
+use crate::output::report_stats::{
+    ReportStats, build_report_stats, first_location, indexed_sorted_findings,
+};
+use crate::output::{FindingRenderLimit, RenderOptions};
+use crate::scan::types::{DiagnosticSeverity, ScanSummary};
+use std::fmt::Write;
+use std::path::Path;
+
+pub(crate) fn render_with_options(summary: &ScanSummary, options: RenderOptions) -> String {
+    let stats = build_report_stats(summary);
+    let mut output = String::new();
+
+    render_summary_header(&mut output, summary, &stats);
+    render_findings_block(&mut output, summary, options.findings_limit);
+    if !options.quiet {
+        render_next_steps(&mut output, summary);
+    }
+
+    output
+}
+
+pub(crate) fn render_baseline_with_options(
+    report: &BaselineScanReport,
+    ci_gate: Option<&CiGateResult>,
+    options: RenderOptions,
+) -> String {
+    let summary = &report.summary;
+    let stats = build_report_stats(summary);
+    let mut output = String::new();
+
+    render_summary_header(&mut output, summary, &stats);
+    render_baseline_block(&mut output, report, ci_gate);
+    render_findings_block(&mut output, summary, options.findings_limit);
+    if !options.quiet {
+        render_next_steps(&mut output, summary);
+    }
+
+    output
+}
+
+fn render_summary_header(output: &mut String, summary: &ScanSummary, stats: &ReportStats) {
+    let visible_count = visible_findings_count(summary);
+    let status = status_label(summary, visible_count);
+    let risk = compact_risk_label(stats);
+
+    output.push_str("RepoPilot Scan\n\n");
+    writeln!(output, "Status: {}", color::status_label(status)).unwrap();
+    writeln!(output, "Risk: {}", color::risk_label(risk)).unwrap();
+    writeln!(output, "Health: {}/100", stats.health_score).unwrap();
+    writeln!(output, "Profile: {}", profile_label(summary)).unwrap();
+    writeln!(
+        output,
+        "Path: {}",
+        display_path(summary.root_path.as_path())
+    )
+    .unwrap();
+    render_scope(output, summary);
+    render_scope_accounting(output, summary);
+    render_diagnostics_line(output, summary);
+    render_local_feedback_line(output, summary);
+    output.push('\n');
+}
+
+fn render_findings_block(
+    output: &mut String,
+    summary: &ScanSummary,
+    findings_limit: FindingRenderLimit,
+) {
+    let visible_count = visible_findings_count(summary);
+    writeln!(output, "Findings: {visible_count} visible").unwrap();
+    writeln!(
+        output,
+        "Hidden suggestions: {} strict-only",
+        summary.hidden_suggestions_count
+    )
+    .unwrap();
+    output.push('\n');
+
+    if summary.findings.is_empty() {
+        output.push_str("No visible risks found.\n\n");
+        return;
+    }
+
+    output.push_str("Top findings:\n");
+    let shown = findings_limit.compact_limit(summary.findings.len());
+    for (_, finding) in indexed_sorted_findings(&summary.findings)
+        .into_iter()
+        .take(shown)
+    {
+        render_top_finding(output, finding);
+    }
+    if matches!(findings_limit, FindingRenderLimit::Limit(_)) && shown < summary.findings.len() {
+        writeln!(
+            output,
+            "  showing {shown} of {} findings (--max-findings none shows all)",
+            summary.findings.len()
+        )
+        .unwrap();
+    }
+    output.push('\n');
+}
+
+fn render_top_finding(output: &mut String, finding: &Finding) {
+    let priority = finding.risk.priority.label();
+    let location = first_location(finding).unwrap_or_else(|| ".".to_string());
+    writeln!(
+        output,
+        "  {:<3} {:<34} {}",
+        priority, finding.rule_id, location
+    )
+    .unwrap();
+}
+
+fn render_baseline_block(
+    output: &mut String,
+    report: &BaselineScanReport,
+    ci_gate: Option<&CiGateResult>,
+) {
+    match &report.baseline_path {
+        Some(path) => writeln!(output, "Baseline: {}", path.display()).unwrap(),
+        None => output.push_str("Baseline: none (all findings treated as new)\n"),
+    }
+    writeln!(output, "New findings: {}", report.new_count()).unwrap();
+    writeln!(output, "Existing findings: {}", report.existing_count()).unwrap();
+    if let Some(ci_gate) = ci_gate {
+        let status = if ci_gate.passed() { "passed" } else { "failed" };
+        writeln!(output, "CI gate: {status} ({})", ci_gate.label()).unwrap();
+    }
+    output.push('\n');
+}
+
+fn render_next_steps(output: &mut String, summary: &ScanSummary) {
+    let path = command_path(summary.root_path.as_path());
+    output.push_str("Next:\n");
+    if summary.hidden_suggestions_count > 0 {
+        writeln!(output, "  repopilot scan {path} --profile strict").unwrap();
+    }
+    writeln!(
+        output,
+        "  repopilot scan {path} --format markdown --output report.md"
+    )
+    .unwrap();
+    if summary.findings.is_empty() && profile_label(summary) == "default" {
+        output.push_str("  repopilot inspect eval-rules --format json\n");
+    }
+}
+
+fn render_scope(output: &mut String, summary: &ScanSummary) {
+    if summary.mode != crate::scan::types::ScanMode::Changed {
+        return;
+    }
+
+    let base = summary
+        .base_ref
+        .as_ref()
+        .map(|base| format!(" since {base}"))
+        .unwrap_or_else(|| " against HEAD".to_string());
+    writeln!(
+        output,
+        "Scope: changed files{base} ({})",
+        summary.changed_files_count
+    )
+    .unwrap();
+}
+
+fn render_scope_accounting(output: &mut String, summary: &ScanSummary) {
+    let skipped = skipped_files_count(summary);
+    if skipped > 0 {
+        writeln!(
+            output,
+            "Files: {} discovered, {} analyzed, {skipped} skipped",
+            summary.files_discovered, summary.files_analyzed
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            output,
+            "Files: {} discovered, {} analyzed",
+            summary.files_discovered, summary.files_analyzed
+        )
+        .unwrap();
+    }
+}
+
+fn skipped_files_count(summary: &ScanSummary) -> usize {
+    summary
+        .files_skipped_low_signal
+        .saturating_add(summary.files_skipped_by_limit)
+        .saturating_add(summary.large_files_skipped)
+        .saturating_add(summary.binary_files_skipped)
+        .saturating_add(summary.files_skipped_repopilotignore)
+}
+
+fn render_diagnostics_line(output: &mut String, summary: &ScanSummary) {
+    if summary.diagnostics.is_empty() {
+        return;
+    }
+
+    let warnings = summary
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == DiagnosticSeverity::Warning)
+        .count();
+    let errors = summary
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == DiagnosticSeverity::Error)
+        .count();
+
+    if errors > 0 && warnings > 0 {
+        writeln!(
+            output,
+            "Diagnostics: {errors} error(s), {warnings} warning(s)"
+        )
+        .unwrap();
+    } else if errors > 0 {
+        writeln!(output, "Diagnostics: {errors} error(s)").unwrap();
+    } else if warnings > 0 {
+        writeln!(output, "Diagnostics: {warnings} warning(s)").unwrap();
+    }
+}
+
+fn render_local_feedback_line(output: &mut String, summary: &ScanSummary) {
+    let Some(feedback) = &summary.local_feedback else {
+        return;
+    };
+
+    if feedback.suppressed_findings_count == 0
+        && feedback.unmatched_suppressions_count == 0
+        && feedback.invalid_suppressions_count == 0
+    {
+        return;
+    }
+
+    writeln!(
+        output,
+        "Local feedback: {} suppressed, {} unmatched, {} invalid",
+        feedback.suppressed_findings_count,
+        feedback.unmatched_suppressions_count,
+        feedback.invalid_suppressions_count
+    )
+    .unwrap();
+}
+
+fn status_label(summary: &ScanSummary, visible_count: usize) -> &'static str {
+    if summary.has_error_diagnostics() {
+        "Scan completed with errors"
+    } else if visible_count > 0 {
+        "Attention needed"
+    } else if summary
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == DiagnosticSeverity::Warning)
+    {
+        "Scan completed with warnings"
+    } else {
+        "Clean"
+    }
+}
+
+fn compact_risk_label(stats: &ReportStats) -> &'static str {
+    match stats.risk_label {
+        "Clean" | "Low" => "Low",
+        "Moderate" => "Medium",
+        "Elevated" | "High" => "High",
+        other => other,
+    }
+}
+
+fn visible_findings_count(summary: &ScanSummary) -> usize {
+    if summary.visible_findings_count == 0 && !summary.findings.is_empty() {
+        summary.findings.len()
+    } else {
+        summary.visible_findings_count
+    }
+}
+
+fn profile_label(summary: &ScanSummary) -> &str {
+    summary.visibility_profile.as_deref().unwrap_or("default")
+}
+
+fn display_path(path: &Path) -> String {
+    if path.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        path.display().to_string()
+    }
+}
+
+fn command_path(path: &Path) -> String {
+    let path = display_path(path);
+    if path
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-'))
+    {
+        return path;
+    }
+
+    format!("'{}'", path.replace('\'', "'\\''"))
+}

--- a/src/output/console/findings.rs
+++ b/src/output/console/findings.rs
@@ -1,14 +1,19 @@
 use crate::findings::types::Finding;
+use crate::output::FindingRenderLimit;
 use crate::output::color;
 use crate::output::report_stats::{
-    category_order, first_location, indexed_findings_for_category, indexed_findings_for_rule,
+    category_order, first_location, indexed_findings_for_rule, indexed_sorted_findings,
     rule_ids_for_indexed_findings,
 };
 use crate::output::report_text::{category_title, first_sentence};
 use std::fmt::Write;
 
-pub(crate) fn render_grouped_findings<F>(output: &mut String, findings: &[Finding], status_for: F)
-where
+pub(crate) fn render_grouped_findings<F>(
+    output: &mut String,
+    findings: &[Finding],
+    findings_limit: FindingRenderLimit,
+    status_for: F,
+) where
     F: Fn(usize) -> Option<&'static str>,
 {
     output.push_str("Findings:\n");
@@ -18,8 +23,26 @@ where
         return;
     }
 
+    let shown = findings_limit.detailed_limit(findings.len());
+    let indexed_findings = indexed_sorted_findings(findings)
+        .into_iter()
+        .take(shown)
+        .collect::<Vec<_>>();
+    if matches!(findings_limit, FindingRenderLimit::Limit(_)) && shown < findings.len() {
+        writeln!(
+            output,
+            "  showing {shown} of {} findings (--max-findings none shows all)",
+            findings.len()
+        )
+        .unwrap();
+    }
+
     for category in category_order() {
-        let category_findings = indexed_findings_for_category(findings, &category);
+        let category_findings = indexed_findings
+            .iter()
+            .copied()
+            .filter(|(_, finding)| finding.category == category)
+            .collect::<Vec<_>>();
         if category_findings.is_empty() {
             continue;
         }

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -6,6 +6,7 @@ mod workspace;
 
 use crate::baseline::diff::BaselineScanReport;
 use crate::baseline::gate::CiGateResult;
+use crate::output::RenderOptions;
 use crate::output::markdown::baseline::render_baseline_section;
 use crate::output::markdown::findings::{render_findings_index, render_grouped_findings};
 use crate::output::markdown::react_native::render_react_native_section;
@@ -19,6 +20,10 @@ use crate::output::report_stats::build_report_stats;
 use crate::scan::types::ScanSummary;
 
 pub fn render(summary: &ScanSummary) -> String {
+    render_with_options(summary, RenderOptions::default())
+}
+
+pub fn render_with_options(summary: &ScanSummary, options: RenderOptions) -> String {
     let stats = build_report_stats(summary);
     let mut output = String::new();
 
@@ -35,13 +40,26 @@ pub fn render(summary: &ScanSummary) -> String {
         render_react_native_section(&mut output, rn);
     }
     render_workspace_risk_table(&mut output, &summary.findings);
-    render_findings_index(&mut output, &summary.findings, None);
-    render_grouped_findings(&mut output, &summary.findings, |_| None);
+    render_findings_index(&mut output, &summary.findings, None, options.findings_limit);
+    render_grouped_findings(
+        &mut output,
+        &summary.findings,
+        options.findings_limit,
+        |_| None,
+    );
 
     output
 }
 
 pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGateResult>) -> String {
+    render_baseline_with_options(report, ci_gate, RenderOptions::default())
+}
+
+pub fn render_baseline_with_options(
+    report: &BaselineScanReport,
+    ci_gate: Option<&CiGateResult>,
+    options: RenderOptions,
+) -> String {
     let summary = &report.summary;
     let stats = build_report_stats(summary);
     let mut output = String::new();
@@ -60,10 +78,18 @@ pub fn render_with_baseline(report: &BaselineScanReport, ci_gate: Option<&CiGate
         render_react_native_section(&mut output, rn);
     }
     render_workspace_risk_table(&mut output, &summary.findings);
-    render_findings_index(&mut output, &summary.findings, Some(report));
-    render_grouped_findings(&mut output, &summary.findings, |index| {
-        Some(report.finding_status(index).lowercase_label())
-    });
+    render_findings_index(
+        &mut output,
+        &summary.findings,
+        Some(report),
+        options.findings_limit,
+    );
+    render_grouped_findings(
+        &mut output,
+        &summary.findings,
+        options.findings_limit,
+        |index| Some(report.finding_status(index).lowercase_label()),
+    );
 
     output
 }

--- a/src/output/markdown/findings.rs
+++ b/src/output/markdown/findings.rs
@@ -1,8 +1,9 @@
 use crate::baseline::diff::BaselineScanReport;
 use crate::findings::types::{Finding, Severity};
+use crate::output::FindingRenderLimit;
 use crate::output::render_helpers::escape_table_cell;
 use crate::output::report_stats::{
-    category_order, first_location, indexed_findings_for_category, indexed_findings_for_rule,
+    category_order, first_location, indexed_findings_for_rule, indexed_sorted_findings,
     rule_ids_for_indexed_findings,
 };
 use crate::output::report_text::{category_label_rank, category_title, first_sentence};
@@ -13,6 +14,7 @@ pub(crate) fn render_findings_index(
     output: &mut String,
     findings: &[Finding],
     baseline: Option<&BaselineScanReport>,
+    findings_limit: FindingRenderLimit,
 ) {
     output.push_str("## Findings Index\n\n");
 
@@ -21,7 +23,15 @@ pub(crate) fn render_findings_index(
         return;
     }
 
-    let rows = grouped_index_rows(findings, baseline);
+    let indexed_findings = limited_indexed_findings(findings, findings_limit);
+    render_limit_note(
+        output,
+        findings.len(),
+        indexed_findings.len(),
+        findings_limit,
+    );
+
+    let rows = grouped_index_rows(&indexed_findings, baseline);
     if baseline.is_some() {
         output.push_str(
             "| Category | Rule | Max severity | Count | New | Existing | First location |\n",
@@ -60,8 +70,12 @@ pub(crate) fn render_findings_index(
     output.push('\n');
 }
 
-pub(crate) fn render_grouped_findings<F>(output: &mut String, findings: &[Finding], status_for: F)
-where
+pub(crate) fn render_grouped_findings<F>(
+    output: &mut String,
+    findings: &[Finding],
+    findings_limit: FindingRenderLimit,
+    status_for: F,
+) where
     F: Fn(usize) -> Option<&'static str>,
 {
     output.push_str("## Findings\n\n");
@@ -71,8 +85,14 @@ where
         return;
     }
 
+    let indexed_findings = limited_indexed_findings(findings, findings_limit);
+
     for category in category_order() {
-        let category_findings = indexed_findings_for_category(findings, &category);
+        let category_findings = indexed_findings
+            .iter()
+            .copied()
+            .filter(|(_, finding)| finding.category == category)
+            .collect::<Vec<_>>();
         if category_findings.is_empty() {
             continue;
         }
@@ -176,12 +196,12 @@ struct IndexRow {
 }
 
 fn grouped_index_rows(
-    findings: &[Finding],
+    findings: &[(usize, &Finding)],
     baseline: Option<&BaselineScanReport>,
 ) -> Vec<IndexRow> {
     let mut rows: BTreeMap<(String, String), IndexRow> = BTreeMap::new();
 
-    for (index, finding) in findings.iter().enumerate() {
+    for (index, finding) in findings.iter().copied() {
         let key = (
             finding.category.label().to_string(),
             finding.rule_id.clone(),
@@ -218,6 +238,32 @@ fn grouped_index_rows(
             .then_with(|| left.rule_id.cmp(&right.rule_id))
     });
     rows
+}
+
+fn limited_indexed_findings(
+    findings: &[Finding],
+    findings_limit: FindingRenderLimit,
+) -> Vec<(usize, &Finding)> {
+    let shown = findings_limit.detailed_limit(findings.len());
+    indexed_sorted_findings(findings)
+        .into_iter()
+        .take(shown)
+        .collect()
+}
+
+fn render_limit_note(
+    output: &mut String,
+    total: usize,
+    shown: usize,
+    findings_limit: FindingRenderLimit,
+) {
+    if matches!(findings_limit, FindingRenderLimit::Limit(_)) && shown < total {
+        writeln!(
+            output,
+            "Showing {shown} of {total} findings. Use `--max-findings none` to render all findings.\n"
+        )
+        .unwrap();
+    }
 }
 
 fn inline_snippet(snippet: &str) -> String {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -18,6 +18,8 @@ use crate::baseline::gate::CiGateResult;
 use crate::scan::types::ScanSummary;
 use serde::Deserialize;
 
+pub use color::{ColorChoice, ColorDestination};
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum OutputFormat {
@@ -28,15 +30,82 @@ pub enum OutputFormat {
     Sarif,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConsoleOutputStyle {
+    Compact,
+    Full,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FindingRenderLimit {
+    Default,
+    Limit(usize),
+    Unlimited,
+}
+
+impl FindingRenderLimit {
+    pub fn compact_limit(self, total: usize) -> usize {
+        match self {
+            Self::Default => total.min(5),
+            Self::Limit(limit) => total.min(limit),
+            Self::Unlimited => total,
+        }
+    }
+
+    pub fn detailed_limit(self, total: usize) -> usize {
+        match self {
+            Self::Default | Self::Unlimited => total,
+            Self::Limit(limit) => total.min(limit),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RenderOptions {
+    pub console_output_style: ConsoleOutputStyle,
+    pub color_choice: ColorChoice,
+    pub color_destination: ColorDestination,
+    pub quiet: bool,
+    pub findings_limit: FindingRenderLimit,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            console_output_style: ConsoleOutputStyle::Full,
+            color_choice: ColorChoice::Auto,
+            color_destination: ColorDestination::Stdout,
+            quiet: false,
+            findings_limit: FindingRenderLimit::Default,
+        }
+    }
+}
+
+impl RenderOptions {
+    fn color_enabled(self) -> bool {
+        color::resolve_color_enabled(self.color_choice, self.color_destination)
+    }
+}
+
 pub fn render_scan_summary(
     summary: &ScanSummary,
     format: OutputFormat,
 ) -> Result<String, serde_json::Error> {
+    render_scan_summary_with_options(summary, format, RenderOptions::default())
+}
+
+pub fn render_scan_summary_with_options(
+    summary: &ScanSummary,
+    format: OutputFormat,
+    options: RenderOptions,
+) -> Result<String, serde_json::Error> {
     match format {
-        OutputFormat::Console => Ok(console::render(summary)),
+        OutputFormat::Console => Ok(color::with_color_enabled(options.color_enabled(), || {
+            console::render_with_options(summary, options)
+        })),
         OutputFormat::Html => Ok(html::render(summary)),
         OutputFormat::Json => json::render(summary),
-        OutputFormat::Markdown => Ok(markdown::render(summary)),
+        OutputFormat::Markdown => Ok(markdown::render_with_options(summary, options)),
         OutputFormat::Sarif => sarif::render(summary),
     }
 }
@@ -46,11 +115,24 @@ pub fn render_baseline_scan_report(
     format: OutputFormat,
     ci_gate: Option<&CiGateResult>,
 ) -> Result<String, serde_json::Error> {
+    render_baseline_scan_report_with_options(report, format, ci_gate, RenderOptions::default())
+}
+
+pub fn render_baseline_scan_report_with_options(
+    report: &BaselineScanReport,
+    format: OutputFormat,
+    ci_gate: Option<&CiGateResult>,
+    options: RenderOptions,
+) -> Result<String, serde_json::Error> {
     match format {
-        OutputFormat::Console => Ok(console::render_with_baseline(report, ci_gate)),
+        OutputFormat::Console => Ok(color::with_color_enabled(options.color_enabled(), || {
+            console::render_baseline_with_options(report, ci_gate, options)
+        })),
         OutputFormat::Html => Ok(html::render_with_baseline(report, ci_gate)),
         OutputFormat::Json => json::render_with_baseline(report, ci_gate),
-        OutputFormat::Markdown => Ok(markdown::render_with_baseline(report, ci_gate)),
+        OutputFormat::Markdown => Ok(markdown::render_baseline_with_options(
+            report, ci_gate, options,
+        )),
         OutputFormat::Sarif => sarif::render_with_baseline(report),
     }
 }

--- a/src/scan/scanner/collection.rs
+++ b/src/scan/scanner/collection.rs
@@ -45,6 +45,7 @@ pub(super) fn discover_scan_paths(
 
     let collected = collect_paths(path, config)?;
     let mut file_paths = collected.file_paths;
+    file_paths.sort();
 
     facts.files_discovered = file_paths.len();
     facts.files_skipped_repopilotignore = collected.files_skipped_repopilotignore;
@@ -155,6 +156,7 @@ fn collect_directory_facts(
 ) -> io::Result<()> {
     let collected = collect_paths(path, config)?;
     let mut file_paths = collected.file_paths;
+    file_paths.sort();
 
     facts.files_discovered = file_paths.len();
     facts.files_skipped_repopilotignore = collected.files_skipped_repopilotignore;

--- a/tests/cli_stabilization.rs
+++ b/tests/cli_stabilization.rs
@@ -78,10 +78,14 @@ fn scan_and_review_help_have_flag_descriptions() {
     assert!(scan_help.contains("Path to project, folder, or file to scan"));
     assert!(scan_help.contains("Write report to a file instead of stdout"));
     assert!(scan_help.contains("Scan each detected workspace package separately"));
+    assert!(scan_help.contains("Disable progress indicators"));
+    assert!(scan_help.contains("Suppress progress indicators and next-step hints"));
+    assert!(scan_help.contains("Limit rendered human-format finding details"));
 
     assert!(review_help.contains("Path to project, folder, or file to review"));
     assert!(review_help.contains("Base Git ref for branch/CI review"));
     assert!(review_help.contains("Exit with code 1 when in-diff findings"));
+    assert!(review_help.contains("Disable progress indicators"));
 }
 
 #[test]

--- a/tests/config_scan_cli.rs
+++ b/tests/config_scan_cli.rs
@@ -188,10 +188,23 @@ fn scan_max_files_caps_analyzed_files_and_console_labels_limit() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
-    assert_console_metric(&stdout, "Files discovered:", 2);
-    assert_console_metric(&stdout, "Files skipped (limit):", 1);
-    assert_console_metric(&stdout, "Files analyzed:", 1);
+    assert!(stdout.contains("Files: 2 discovered, 1 analyzed, 1 skipped"));
+    assert!(!stdout.contains("Files discovered:"));
+    assert!(!stdout.contains("Files analyzed:"));
     assert!(!stdout.contains("Files skipped (ignore):"));
+
+    let full_output = repopilot()
+        .args(["scan", ".", "--max-files", "1", "--output-style", "full"])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot scan");
+
+    assert!(full_output.status.success());
+    let full_stdout = String::from_utf8(full_output.stdout).expect("stdout should be UTF-8");
+    assert_console_metric(&full_stdout, "Files discovered:", 2);
+    assert_console_metric(&full_stdout, "Files skipped (limit):", 1);
+    assert_console_metric(&full_stdout, "Files analyzed:", 1);
+    assert!(!full_stdout.contains("Files skipped (ignore):"));
 }
 
 #[test]

--- a/tests/scan_command_cli.rs
+++ b/tests/scan_command_cli.rs
@@ -22,6 +22,17 @@ fn fixture_project() -> TempDir {
     dir
 }
 
+fn fixture_project_with_repeated_findings() -> TempDir {
+    let dir = tempfile::tempdir().expect("create findings fixture project");
+    fs::create_dir_all(dir.path().join("src")).expect("create src dir");
+    fs::write(
+        dir.path().join("src/lib.rs"),
+        "pub fn answer() -> i32 { 42 }\n// TODO: first tracked issue\n// TODO: second tracked issue\n// TODO: third tracked issue\n",
+    )
+    .expect("write source file");
+    dir
+}
+
 #[test]
 fn given_conflicting_fail_flags_when_scan_runs_then_usage_error_is_returned() {
     // Given
@@ -114,4 +125,395 @@ fn given_small_project_when_scan_runs_with_json_output_then_report_is_written() 
     )
     .expect("scan report should be valid JSON");
     assert!(report["files_analyzed"].as_u64().unwrap_or_default() >= 1);
+}
+
+#[test]
+fn given_clean_repo_when_scan_runs_default_then_compact_clean_summary_is_printed() {
+    // Given
+    let project = fixture_project();
+
+    // When
+    let output = repopilot()
+        .args(["scan", "."])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot");
+
+    // Then
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("RepoPilot Scan"));
+    assert!(stdout.contains("Status: Clean"));
+    assert!(stdout.contains("Risk: Low"));
+    assert!(stdout.contains("Health: 100/100"));
+    assert!(stdout.contains("Profile: default"));
+    assert!(stdout.contains("Path: ."));
+    assert!(stdout.contains("Findings: 0 visible"));
+    assert!(stdout.contains("Hidden suggestions:"));
+    assert!(stdout.contains("No visible risks found."));
+    assert!(stdout.contains("Next:"));
+    assert!(!stdout.contains("Risk Summary:"));
+    assert!(!stdout.contains("Signal quality:"));
+    assert!(!stdout.contains("Top Rules:"));
+    assert!(!stdout.contains("Scan input:"));
+    assert!(!stdout.contains("Files analyzed:"));
+}
+
+#[test]
+fn given_quiet_when_scan_runs_then_next_steps_are_omitted() {
+    // Given
+    let project = fixture_project();
+
+    // When
+    let output = repopilot()
+        .args(["scan", ".", "--quiet"])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot");
+
+    // Then
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("RepoPilot Scan"));
+    assert!(stdout.contains("Status: Clean"));
+    assert!(stdout.contains("Findings: 0 visible"));
+    assert!(!stdout.contains("Next:"));
+}
+
+#[test]
+fn given_no_progress_when_scan_runs_then_command_succeeds() {
+    // Given
+    let project = fixture_project();
+
+    // When
+    let output = repopilot()
+        .args(["scan", ".", "--no-progress"])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot");
+
+    // Then
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("RepoPilot Scan"));
+    assert!(stdout.contains("Next:"));
+}
+
+#[test]
+fn given_repo_with_visible_findings_when_scan_runs_default_then_top_findings_are_printed() {
+    // Given
+    let project = tempfile::tempdir().expect("create fixture project");
+    fs::write(project.path().join(".env"), "API_KEY=abc123xyz987\n").expect("write env file");
+
+    // When
+    let output = repopilot()
+        .args(["scan", "."])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot");
+
+    // Then
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Status: Attention needed"));
+    assert!(stdout.contains("Findings: 1 visible"));
+    assert!(stdout.contains("Top findings:"));
+    assert!(stdout.contains("security.env-file-committed"));
+    assert!(stdout.contains(".env"));
+    assert!(!stdout.contains("Recommendation:"));
+    assert!(!stdout.contains("Evidence:"));
+}
+
+#[test]
+fn given_max_findings_when_scan_runs_full_console_then_finding_details_are_limited() {
+    // Given
+    let project = fixture_project_with_repeated_findings();
+
+    // When
+    let output = repopilot()
+        .args([
+            "scan",
+            ".",
+            "--profile",
+            "strict",
+            "--output-style",
+            "full",
+            "--max-findings",
+            "1",
+        ])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot");
+
+    // Then
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("showing 1 of"));
+    assert!(stdout.contains("--max-findings none shows all"));
+    assert_eq!(stdout.matches("Recommendation:").count(), 1);
+}
+
+#[test]
+fn given_max_findings_when_scan_runs_markdown_then_finding_details_are_limited() {
+    // Given
+    let project = fixture_project_with_repeated_findings();
+
+    // When
+    let output = repopilot()
+        .args([
+            "scan",
+            ".",
+            "--format",
+            "markdown",
+            "--profile",
+            "strict",
+            "--max-findings",
+            "1",
+        ])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot");
+
+    // Then
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Showing 1 of"));
+    assert!(stdout.contains("Use `--max-findings none`"));
+    assert_eq!(stdout.matches("  - Recommendation:").count(), 1);
+}
+
+#[test]
+fn given_max_findings_when_scan_runs_json_then_machine_output_is_complete() {
+    // Given
+    let project = fixture_project_with_repeated_findings();
+
+    // When
+    let output = repopilot()
+        .args([
+            "scan",
+            ".",
+            "--format",
+            "json",
+            "--profile",
+            "strict",
+            "--max-findings",
+            "1",
+        ])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot");
+
+    // Then
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("json output");
+    let findings = report["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert!(
+        findings.len() > 1,
+        "JSON findings should stay complete when rendered console findings are capped"
+    );
+}
+
+#[test]
+fn given_scan_when_output_style_full_then_diagnostic_sections_are_preserved() {
+    // Given
+    let project = fixture_project();
+
+    // When
+    let output = repopilot()
+        .args(["scan", ".", "--output-style", "full"])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot");
+
+    // Then
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Scan input:"));
+    assert!(stdout.contains("Directories analyzed:"));
+    assert!(stdout.contains("Non-empty lines:"));
+    assert!(stdout.contains("Risk Summary:"));
+    assert!(stdout.contains("Signal quality:"));
+    assert!(stdout.contains("Hidden suggestions breakdown:"));
+    assert!(stdout.contains("Top Risk Clusters:"));
+    assert!(stdout.contains("Top Rules:"));
+    assert!(stdout.contains("Languages:"));
+    assert!(stdout.contains("Findings:"));
+}
+
+#[test]
+fn given_no_color_when_scan_runs_then_stdout_has_no_ansi_sequences() {
+    // Given
+    let project = tempfile::tempdir().expect("create fixture project");
+    fs::write(project.path().join(".env"), "API_KEY=abc123xyz987\n").expect("write env file");
+
+    // When
+    let forced_color = repopilot()
+        .args(["scan", ".", "--color", "always"])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot with color");
+    let no_color = repopilot()
+        .args(["scan", ".", "--no-color"])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot without color");
+    let color_never = repopilot()
+        .args(["scan", ".", "--color", "never"])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot with color never");
+
+    // Then
+    assert!(forced_color.status.success());
+    assert!(has_ansi(&forced_color.stdout));
+    assert!(no_color.status.success());
+    assert_no_ansi(&no_color.stdout);
+    assert!(color_never.status.success());
+    assert_no_ansi(&color_never.stdout);
+}
+
+#[test]
+fn given_ci_or_non_tty_when_color_auto_then_output_is_plain_and_stable() {
+    // Given
+    let project = fixture_project();
+
+    // When
+    let output = repopilot()
+        .args(["scan", ".", "--color", "auto"])
+        .env("CI", "true")
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot in CI");
+
+    // Then
+    assert!(output.status.success());
+    assert_no_ansi(&output.stdout);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("RepoPilot Scan"));
+    assert!(stdout.contains("Status: Clean"));
+}
+
+#[test]
+fn given_machine_readable_formats_when_scan_runs_then_reports_are_unchanged() {
+    // Given
+    let project = tempfile::tempdir().expect("create fixture project");
+    fs::write(project.path().join(".env"), "API_KEY=abc123xyz987\n").expect("write env file");
+
+    // When / Then
+    let json = scan_format(project.path(), "json");
+    let json_report: Value = serde_json::from_slice(&json.stdout).expect("json output");
+    assert!(json_report["findings"].as_array().is_some());
+    assert_no_ansi(&json.stdout);
+
+    let sarif = scan_format(project.path(), "sarif");
+    let sarif_report: Value = serde_json::from_slice(&sarif.stdout).expect("sarif output");
+    assert_eq!(sarif_report["version"], "2.1.0");
+    assert_no_ansi(&sarif.stdout);
+
+    let markdown = scan_format(project.path(), "markdown");
+    let markdown_stdout = String::from_utf8_lossy(&markdown.stdout);
+    assert!(markdown_stdout.contains("# RepoPilot Scan Report"));
+    assert_no_ansi(&markdown.stdout);
+
+    let html = scan_format(project.path(), "html");
+    let html_stdout = String::from_utf8_lossy(&html.stdout);
+    assert!(html_stdout.contains("RepoPilot Scan Report"));
+    assert_no_ansi(&html.stdout);
+}
+
+#[test]
+fn given_conflicting_color_flags_when_scan_runs_then_usage_error_is_returned() {
+    // Given
+    let project = fixture_project();
+
+    // When
+    let output = repopilot()
+        .args(["scan", ".", "--color", "always", "--no-color"])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot");
+
+    // Then
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("`--color always` cannot be used with `--no-color`"));
+}
+
+fn scan_format(root: &std::path::Path, format: &str) -> Output {
+    let output = repopilot()
+        .args([
+            "scan",
+            ".",
+            "--format",
+            format,
+            "--output-style",
+            "full",
+            "--color",
+            "always",
+        ])
+        .current_dir(root)
+        .output()
+        .expect("run repopilot scan");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn has_ansi(output: &[u8]) -> bool {
+    String::from_utf8_lossy(output).contains("\u{1b}[")
+}
+
+fn assert_no_ansi(output: &[u8]) {
+    assert!(
+        !has_ansi(output),
+        "expected no ANSI escape sequences in:\n{}",
+        String::from_utf8_lossy(output)
+    );
 }

--- a/tests/scan_sarif_cli.rs
+++ b/tests/scan_sarif_cli.rs
@@ -76,5 +76,7 @@ fn scan_default_text_output_still_works() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
     assert!(stdout.contains("RepoPilot Scan"));
-    assert!(stdout.contains("Files analyzed:"));
+    assert!(stdout.contains("Status: Clean"));
+    assert!(stdout.contains("Findings: 0 visible"));
+    assert!(!stdout.contains("Files analyzed:"));
 }


### PR DESCRIPTION
## Summary

This PR improves the RepoPilot scan experience for the 0.13 release by making the default console output more compact, adding explicit render controls, and updating the documentation around the current product workflow.

The goal is to keep day-to-day scans readable while preserving full diagnostic output for deeper audits.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Added compact console scan output as the default scan presentation.
- Added `--output-style compact|full` so users can switch back to full diagnostic output.
- Added `--max-findings N|none` to limit rendered human-format finding details.
- Added `--quiet` and `--no-progress` for cleaner CI and scripted usage.
- Added `--color auto|always|never` and `--no-color` for ANSI color control.
- Updated Markdown rendering to support finding limits while keeping JSON and SARIF complete.
- Preserved full diagnostic sections in `--output-style full`.
- Improved deterministic scan path ordering.
- Expanded README and CLI docs around output controls, trust mode, rule quality, and core workflows.
- Added CLI tests for compact output, quiet mode, finding limits, color behavior, and machine-readable output stability.

## Why

The previous default console output was too verbose for normal local usage and CI logs. This made RepoPilot feel noisy even when the underlying signal was useful.

This change separates daily scan UX from deep diagnostic output:

- default scan output is compact and readable;
- full output is still available for audits and debugging;
- human reports can be capped with `--max-findings`;
- machine-readable reports remain complete for automation;
- CI logs can be made quieter without losing important findings.

## Architecture notes

- [x] No god files introduced
- [x] Logic is split into focused modules
- [x] Scanner, audits, output, and report responsibilities remain separated
- [x] Findings include evidence where applicable

Implementation notes:

- `RenderOptions` centralizes output style, color, quiet mode, and finding render limits.
- Compact console rendering lives in a dedicated `src/output/console/compact.rs` module.
- Existing full console rendering remains available through `--output-style full`.
- JSON and SARIF rendering are intentionally not truncated by `--max-findings`.
- Baseline scan rendering now receives the same render options as normal scan output.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .
cargo run -- scan . --output-style full
cargo run -- scan . --max-findings 1
cargo run -- scan . --max-findings none
cargo run -- scan . --quiet
cargo run -- scan . --no-progress
cargo run -- scan . --color always
cargo run -- scan . --no-color
cargo run -- scan . --format json
cargo run -- scan . --format sarif
cargo run -- scan . --format markdown --max-findings 1