### PR TITLE
Finalize 0.13 release docs, smoke checks, and golden fixtures

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -1,13 +1,14 @@
-v0.9 makes RepoPilot ready for practical local-first repository audits across developer machines and CI. Run `repopilot ai context .`, paste the output into Claude Code, ChatGPT, or Cursor, and start fixing with evidence-backed context. No source code leaves your machine.
+RepoPilot 0.13 is the trust and usability release: cleaner default output,
+stronger rule quality checks, safer baseline adoption, and better evidence for
+CI and AI-assisted remediation.
 
 ## Highlights
 
-- **`repopilot ai context`** — scans your repo and formats findings as LLM-ready Markdown.
-- **`repopilot ai plan`** — emits a prioritized remediation plan with locations, rule IDs, and verification commands.
-- **`repopilot ai prompt`** — generates a paste-ready AI remediation prompt with full RepoPilot context.
-- Product docs now cover install paths, security model, AI workflows, language support, and configuration.
-- First-party GitHub Action supports typed inputs for scan, review, compare, and AI workflows.
-- npm, cargo, Homebrew, curl, and GitHub Release binary install paths are documented and smoke-checked.
+- Cleaner default scans keep broad maintainability and testing noise out of the normal CI path.
+- `repopilot inspect eval-rules` validates fixture coverage, stable finding IDs, and finding contracts.
+- Baseline adoption is first-class: create a baseline, then fail only on new high-risk findings.
+- Reports include better evidence for CI: compact console, full diagnostics, JSON, SARIF, Markdown, receipts, and signal quality.
+- AI context uses the same local product scan path and default visibility policy as normal scans.
 
 ## Install
 
@@ -19,21 +20,22 @@ brew install repopilot
 curl -fsSL https://raw.githubusercontent.com/MykytaStel/repopilot/main/install.sh | bash
 ```
 
-## React Native Example
+## Try It
+
+```bash
+repopilot scan .
+repopilot baseline create . --output .repopilot/baseline.json
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
+repopilot ai context . --budget 4k
+repopilot inspect eval-rules --format json
+```
+
+## CI Evidence
 
 ```bash
 repopilot scan . --format markdown --output repopilot-report.md
-repopilot scan . --workspace --min-severity medium
-repopilot review . --base origin/main --baseline .repopilot/baseline.json --fail-on new-high
-```
-
-## AI Workflow Example
-
-```bash
-repopilot ai context .
-repopilot ai context . --focus security --budget 2k
-repopilot ai plan . --focus security
-repopilot ai prompt . --budget 8k
+repopilot scan . --format json --output repopilot-report.json --receipt .repopilot/receipt.json
+repopilot scan . --format sarif --output repopilot.sarif
 ```
 
 ## Links
@@ -41,6 +43,5 @@ repopilot ai prompt . --budget 8k
 - README: https://github.com/MykytaStel/repopilot#readme
 - Changelog: https://github.com/MykytaStel/repopilot/blob/main/CHANGELOG.md
 - Install docs: https://github.com/MykytaStel/repopilot/blob/main/docs/install.md
-- Security docs: https://github.com/MykytaStel/repopilot/blob/main/docs/security.md
-- React Native docs: https://github.com/MykytaStel/repopilot/blob/main/docs/react-native.md
+- Rule quality gate: https://github.com/MykytaStel/repopilot/blob/main/docs/rule-quality-gate.md
 - GitHub Code Scanning: https://github.com/MykytaStel/repopilot/blob/main/docs/integrations/github-code-scanning.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,50 +6,56 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
-### Added
+No changes yet.
 
-- Added 0.13 Smart Baseline release guardrails for self-scan signal quality, rule lifecycle checks, and release evidence.
-- Added documentation for the rule quality gate so default-visible/stable rules have explicit fixture and metadata expectations.
-- Added a local signal-quality checker script for release candidates and CI smoke adoption.
+## [0.13.0] - 2026-05-25
 
-### Changed
-
-- Tightened the 0.13 release story around audit-first positioning: default scans should remain quiet, evidence-backed, and baseline-friendly.
-- Documented noisy heuristic budgets for `code-quality.long-function`, `code-quality.complex-file`, testing-gap rules, and code markers before expanding rule families.
+RepoPilot 0.13 is the trust and usability release: cleaner default output,
+stronger rule quality checks, safer baseline adoption, and better evidence for
+CI and AI-assisted remediation.
 
 ### Added
 
-- Added a 0.13 release checklist for the breaking cleanup release.
-- Added a current `0.17` scan report fixture that documents raw-vs-visible report metrics.
-- Added finding contract validation with diagnostics, release-test coverage, and contract timing.
-- Added an indexed rule metadata lookup and registry uniqueness coverage.
-- Added finding provenance with detector, rule lifecycle, signal source, and analysis scope.
-- Added rule lifecycle, signal source, default confidence, false-positive notes, and tags to rule metadata.
-- Added `repopilot inspect rules`, `repopilot inspect rule <rule_id>`, and `repopilot inspect eval-rules`.
+- Added `repopilot inspect rules`, `repopilot inspect rule <rule_id>`, and
+  `repopilot inspect eval-rules` for local rule catalog and fixture evaluation.
+- Added rule lifecycle, signal source, default confidence, false-positive notes,
+  tags, fixture coverage, false-positive risk, and stability gate status to rule
+  metadata and inspection output.
+- Added finding contract validation with diagnostics, release-test coverage, and
+  scan timing for contract validation.
+- Added finding provenance with detector, rule lifecycle, signal source, and
+  analysis scope.
 - Added signal quality summaries to JSON, console, and Markdown reports.
-- Added a shared product scan pipeline for scan, review, baseline creation, and AI Markdown commands, including shared runtime diagnostic handling.
-- Added local rule evaluation fixtures for `security.secret-candidate` and `language.rust.panic-risk`.
-- Added per-rule JSON details to `repopilot inspect eval-rules`.
-- Added a product smoke self-scan gate for finding contract violations.
-- Added rule quality metadata to `inspect rules` output, including fixture coverage, semantic source, required scope, false-positive risk, and stability gate status.
-- Added launch positioning and performance budget docs for the 0.13 hardening track.
+- Added a local signal-quality checker and made release smoke self-scans fail on
+  visible low-quality noisy findings.
+- Added local rule evaluation fixtures across security, runtime, and
+  import-graph rule families.
+- Added golden output fixtures for compact console, full console, Markdown, JSON,
+  and SARIF report contracts.
+- Added a 0.13 release checklist and announcement focused on trust, usability,
+  baseline adoption, and release evidence.
 
 ### Changed
 
 - Bumped the crate, npm wrapper, optional platform package pins, and GitHub Action default version to `0.13.0`.
 - Bumped scan report schema to `0.17` for raw-vs-visible finding counts and signal quality metrics while accepting `0.15` and `0.16` reports during the transition.
-- Default scan visibility now surfaces high-priority maintainability risks and stable import-graph P2+ risks while keeping low-signal testing and marker noise strict-only.
+- Default scan visibility now surfaces high-trust security, runtime, and stable
+  import-graph risks while keeping low-signal testing, marker, and broad
+  maintainability noise strict-only.
 - Downgraded line/token runtime and long-function rule provenance from `ast` to `text-heuristic` until those rules consume shared parsed facts.
 - Updated risk scoring metadata to `risk-v3` with typed risk signal sources and clearer signal reasons.
 - Centralized scan finding enrichment before risk scoring and report construction.
 - Cached report signal quality on `ScanSummary` so renderers reuse one summary per report path.
 - Split rule inspection catalog, fixture evaluation, and rendering out of the CLI command orchestration.
-- Renamed internal AI modules from legacy context/plan names to `ai_context` and `ai_plan` while keeping the public CLI as `repopilot ai context|plan|prompt`.
-- Updated AI context and AI plan headings to use the stable product names.
+- Updated AI context and AI plan headings to use the stable product names while
+  keeping the public CLI as `repopilot ai context|plan|prompt`.
 - AI context, AI plan, and AI prompt now use the same default visibility and local feedback behavior as product scans.
 - `repopilot review` now uses the shared default product visibility path before diff classification.
 - `repopilot compare` now requires current scan reports with matching top-level and envelope schema metadata instead of migrating older scan report shapes.
 - `repopilot baseline create` now uses the shared product scan path and supports `--config` and `--ignore-feedback`.
+- `scripts/smoke-product.sh` now covers an install-like release path across
+  scan, review, baseline creation, `scan --baseline --fail-on new-high`, AI
+  context, `inspect eval-rules`, JSON, SARIF, and Markdown output.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -9,90 +9,29 @@
 
 **Local-first repository audits for safer human and AI-assisted code changes.**
 
-RepoPilot is a fast Rust CLI that scans your repository locally, ranks evidence-backed risks, helps review pull requests, supports baseline adoption, and generates AI-ready context without uploading your source code.
-
-It is built for maintainers who want practical repository-level signal, not another noisy linter dump.
+RepoPilot is a fast Rust CLI that scans a repository locally, ranks evidence-backed risks, supports baseline adoption, reviews branches, and creates AI-ready remediation context without uploading source code.
 
 ```text
-local scan -> evidence-backed findings -> risk-ranked review -> baseline adoption -> AI-ready local context -> CI gate
+scan -> review risk -> baseline adoption -> CI evidence -> local AI context
 ```
 
-## Why RepoPilot exists
-
-Modern teams move fast, but codebases quietly accumulate risks that are easy to miss one file at a time:
-
-- committed secrets and unsafe configuration files;
-- runtime footguns such as production exits and panic paths;
-- import graph risks and architectural coupling;
-- noisy maintainability issues that should not block every PR;
-- large review blast radius;
-- old findings that need a baseline instead of endless repeated warnings;
-- AI coding sessions that need clean local context instead of random pasted files.
-
-RepoPilot focuses on repository-level evidence and review workflows.
-
-It does **not** replace language linters, formatters, type checkers, or security scanners. It complements them by connecting findings to repository structure, change risk, review context, and local remediation workflows.
-
-## Local-first by design
-
-RepoPilot does not:
-
-- upload your source code;
-- run a hosted scanner;
-- call LLM APIs implicitly;
-- send telemetry;
-- require a SaaS account.
-
-AI-related commands are local formatting/context helpers. They package audit evidence for tools like Claude Code, ChatGPT, Cursor, Zed, or another assistant, but RepoPilot itself stays local-first.
-
-## What RepoPilot checks
-
-RepoPilot is intentionally conservative in the default profile. It prioritizes high-trust findings that are useful during daily development and CI review.
-
-Core focus areas:
-
-| Area | Examples |
-|---|---|
-| Security | secret candidates, private keys, committed env files |
-| Runtime risk | Rust panic/unwrap paths, JavaScript/Python/Go/JVM/.NET runtime exits |
-| Architecture | circular dependencies, excessive fan-out, instability hubs |
-| Review risk | changed files, blast radius, branch-vs-base review context |
-| Baseline adoption | distinguish new risk from accepted existing debt |
-| Reports | JSON, Markdown, SARIF, receipts, report envelopes |
-| AI context | local, budgeted, evidence-backed context for coding assistants |
-
-Broad maintainability signals such as long files, long functions, TODO/FIXME/HACK markers, complex files, and testing gaps are available in strict mode instead of dominating default output.
+RepoPilot is not a replacement for language linters, formatters, type checkers, or dedicated security scanners. It complements them with repository-level evidence: secrets, runtime footguns, architecture risk, review blast radius, baseline status, and report formats that work in CI.
 
 ## Install
 
-Choose one install method.
-
-### Cargo
-
 ```bash
 cargo install repopilot
-```
-
-### npm
-
-```bash
 npm install -g repopilot
+brew tap mykytastel/repopilot && brew install repopilot
 ```
 
-### Homebrew
-
-```bash
-brew tap mykytastel/repopilot
-brew install repopilot
-```
-
-### Linux/macOS installer
+Installer:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MykytaStel/repopilot/main/install.sh | bash
 ```
 
-### Build from source
+From source:
 
 ```bash
 git clone https://github.com/MykytaStel/repopilot.git
@@ -100,49 +39,35 @@ cd repopilot
 cargo build --release
 ```
 
-More install options: [docs/install.md](docs/install.md).
+More: [docs/install.md](docs/install.md).
 
-## First 5 minutes
-
-Run a default local scan:
+## First Run
 
 ```bash
 repopilot scan .
-```
-
-Check whether the repository is ready for adoption:
-
-```bash
 repopilot doctor .
 ```
 
-Create a baseline for existing debt:
+Adopt RepoPilot in an existing repository without failing CI on old debt:
 
 ```bash
 repopilot baseline create . --output .repopilot/baseline.json
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
 ```
 
-Fail only on new high-risk findings:
-
-```bash
-repopilot scan . \
-  --baseline .repopilot/baseline.json \
-  --fail-on new-high
-```
-
-Review your current branch against `main`:
+Review a branch:
 
 ```bash
 repopilot review . --base origin/main
 ```
 
-Generate local AI-ready context:
+Generate local AI context:
 
 ```bash
 repopilot ai context . --budget 4k
 ```
 
-Save audit evidence:
+Save CI evidence:
 
 ```bash
 repopilot scan . --format markdown --output repopilot-report.md
@@ -150,262 +75,147 @@ repopilot scan . --format json --output repopilot-report.json --receipt .repopil
 repopilot scan . --format sarif --output repopilot.sarif
 ```
 
-## Core workflows
+## What It Checks
 
-### 1. Scan the repository
-
-```bash
-repopilot scan .
-```
-
-Use this for day-to-day local checks and CI-friendly repository audits.
-
-### 2. Run a strict audit
-
-```bash
-repopilot scan . --profile strict
-```
-
-Use strict mode for cleanup passes, refactoring work, rule development, and release-hardening audits.
-
-### 3. Review a branch
-
-```bash
-repopilot review . --base origin/main
-```
-
-Use this before opening or merging a PR to understand changed files, review risk, and branch-specific findings.
-
-### 4. Adopt RepoPilot gradually
-
-```bash
-repopilot baseline create . --output .repopilot/baseline.json
-repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
-```
-
-This lets a mature repository start using RepoPilot without failing CI on old accepted debt.
-
-### 5. Generate local AI context
-
-```bash
-repopilot ai context . --budget 4k
-```
-
-Use this when working with an AI coding assistant. RepoPilot produces concise local context based on repository evidence instead of asking you to paste random files manually.
+| Area | Examples |
+|---|---|
+| Security | secret candidates, private keys, committed `.env` files |
+| Runtime risk | Rust panic/unwrap paths, JavaScript/Python/Go/JVM/.NET process exits |
+| Architecture | circular dependencies, excessive fan-out, instability hubs |
+| Review risk | changed files, branch context, blast radius |
+| Adoption | baselines, new-vs-existing findings, CI gates |
+| Evidence | JSON, Markdown, SARIF, receipts, report envelopes |
+| AI context | local, budgeted, evidence-backed Markdown for coding assistants |
 
 ## Trust Mode
 
-RepoPilot's default profile is intentionally quiet.
-
-The default scan answers:
-
-- what can break production;
-- what can leak secrets;
-- what should block a release;
-- what is safe to review later;
-- what belongs in a strict/deep audit workflow.
+Default scans are intentionally quiet. They keep high-trust security, runtime, and import-graph findings visible while summarizing broad maintainability and testing suggestions as strict-only noise.
 
 ```bash
-repopilot scan .                  # default profile
+repopilot scan .                  # compact default output
+repopilot scan . --output-style full
 repopilot scan . --profile strict # full audit output
-repopilot scan . --include-maintainability
 ```
 
-Default profile keeps high-trust security, runtime, and import-graph findings visible.
-
-Strict profile preserves the full raw audit output, including broad maintainability and testing heuristics.
-
-Hidden suggestions are summarized instead of silently dropped, so the default report stays quiet without becoming opaque.
+Use strict mode for cleanup passes, rule development, and release hardening. Use the default profile for day-to-day local checks and CI gates.
 
 More: [docs/trust-mode.md](docs/trust-mode.md).
 
-## Stable command surface
-
-RepoPilot keeps the public top-level CLI small before 1.0:
+## Core Commands
 
 ```text
 scan | review | baseline | compare | doctor | inspect | ai | init | cache
 ```
 
-Common commands:
+Common workflows:
 
 ```bash
 repopilot scan .
-repopilot scan . --profile strict
 repopilot review . --base origin/main
 repopilot baseline create .
 repopilot compare before.json after.json
 repopilot inspect rules
 repopilot inspect eval-rules --format json
 repopilot ai context .
-repopilot cache clear .
 ```
 
-New diagnostics should fit under existing commands instead of adding more top-level workflows.
+More: [docs/commands.md](docs/commands.md) and [docs/cli.md](docs/cli.md).
 
-## Rule quality contract
+## Baseline Adoption
 
-RepoPilot rules move through a lifecycle:
+A baseline records current findings as accepted existing debt. Future scans can fail only on newly introduced risk:
+
+```bash
+repopilot baseline create . --output .repopilot/baseline.json
+git add .repopilot/baseline.json
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
+```
+
+Review baseline updates like code changes. A baseline is not a suppression file; it is a CI adoption contract.
+
+## Rule Quality
+
+Rules move through a lifecycle:
 
 ```text
 experimental -> preview -> stable
 ```
 
-A rule should become stable only when it has:
-
-- complete rule metadata;
-- true-positive fixtures;
-- false-positive fixtures;
-- deterministic stable finding IDs;
-- evidence pointing to concrete files, lines, or scopes;
-- false-positive notes;
-- docs URL for high/critical findings;
-- clean local validation through `inspect eval-rules`.
-
-Run the rule quality gate:
+Before a rule becomes stable or default-visible, it should have metadata, true-positive and false-positive fixtures, stable finding IDs, concrete evidence, false-positive notes, recommendations, and clean local evaluation:
 
 ```bash
 repopilot inspect eval-rules --format json
 ```
-
-Evaluate one rule:
-
-```bash
-repopilot inspect eval-rules --rule security.env-file-committed --format json
-```
-
-The gate reports fixture coverage, missing findings, unexpected findings, contract violations, stable ID failures, and quality gate failures.
 
 More: [docs/rule-quality-gate.md](docs/rule-quality-gate.md).
 
-## CI example
+## Local-First
 
-Minimal CI gate:
+RepoPilot does not upload source code, run a hosted scanner, call LLM APIs implicitly, send telemetry, or require a SaaS account. AI commands only format local scan evidence as Markdown for tools such as Claude Code, ChatGPT, Cursor, Zed, or another assistant.
+
+## Reports
+
+| Format | Use case |
+|---|---|
+| Console | fast local feedback |
+| Markdown | PR comments and human-readable reports |
+| JSON | automation and internal tooling |
+| SARIF | GitHub Code Scanning |
+| HTML | shareable local reports |
+| Receipt | compact release/CI evidence |
+
+More: [docs/reports.md](docs/reports.md).
+
+## CI
+
+Minimal baseline-aware gate:
 
 ```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all
-npm run test:npm
-./scripts/smoke-product.sh
-repopilot inspect eval-rules --format json
-repopilot scan .
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
 ```
 
-GitHub Actions with SARIF upload:
+GitHub Code Scanning:
 
 ```bash
 repopilot scan . --format sarif --output repopilot.sarif
 ```
 
+Release smoke:
+
+```bash
+./scripts/smoke-product.sh
+```
+
 More: [docs/integrations/github-code-scanning.md](docs/integrations/github-code-scanning.md).
-
-## Output formats
-
-RepoPilot can produce:
-
-| Format | Use case |
-|---|---|
-| Console | fast local feedback |
-| Markdown | PR comments, human-readable reports |
-| JSON | automation and internal tooling |
-| SARIF | GitHub code scanning |
-| HTML | shareable local reports |
-| Receipt | reproducible scan metadata |
-
-More: [docs/reports.md](docs/reports.md).
-
-## Configuration
-
-RepoPilot can be configured with `repopilot.toml`.
-
-Use configuration for:
-
-- ignores;
-- presets;
-- rule tuning;
-- baseline adoption;
-- scan behavior;
-- report settings.
-
-More: [docs/configuration.md](docs/configuration.md).
-
-## Project status
-
-RepoPilot is pre-1.0.
-
-The current product direction is to strengthen trust, fixture-backed rules, baseline adoption, review workflows, and local-first AI context before expanding into too many rule families.
-
-The pre-1.0 release line prioritizes:
-
-- trustworthy default output;
-- stable command surface;
-- strong rule lifecycle;
-- clean self-audit behavior;
-- verified distribution through crates.io, npm, GitHub Releases, Homebrew, and installer scripts.
-
-Release-specific plans, checklists, and historical notes live outside the README so this page can stay useful across future versions.
-
-More: [docs/roadmap.md](docs/roadmap.md).
 
 ## Documentation
 
 | Document | Purpose |
 |---|---|
 | [Install](docs/install.md) | Cargo, npm, Homebrew, curl, and source builds |
-| [Commands](docs/commands.md) | Task-oriented CLI workflows |
-| [Configuration](docs/configuration.md) | `repopilot.toml`, presets, ignores, and baseline adoption |
+| [Commands](docs/commands.md) | Task-oriented workflows |
+| [CLI](docs/cli.md) | Complete command and flag reference |
+| [Configuration](docs/configuration.md) | `repopilot.toml`, presets, ignores, and baselines |
 | [Rulesets](docs/rulesets.md) | Built-in rules, lifecycle, severity, and confidence |
 | [Trust Mode](docs/trust-mode.md) | Default vs strict visibility policy |
-| [Rule lifecycle](docs/rule-lifecycle.md) | Experimental, preview, and stable rule expectations |
-| [Rule quality gate](docs/rule-quality-gate.md) | Fixture-backed stable/default-visible rule contract |
 | [Reports](docs/reports.md) | JSON, SARIF, Markdown, HTML, receipts, and schema fields |
-| [CI/GitHub](docs/integrations/github-code-scanning.md) | GitHub Actions and SARIF upload |
-| [Roadmap](docs/roadmap.md) | Pre-1.0 product direction, release themes, and v1 gates |
+| [Release Process](docs/release.md) | Local and CI release gates |
 
 ## Development
-
-Run local checks:
 
 ```bash
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all
 npm run test:npm
-```
-
-Run product smoke checks:
-
-```bash
 ./scripts/smoke-product.sh
 ```
 
-Run a self-scan:
-
-```bash
-cargo run -- scan .
-```
-
-Run rule quality evaluation from source:
+Run rule evaluation from source:
 
 ```bash
 cargo run -- inspect eval-rules --format json
 ```
-
-## Contributing
-
-RepoPilot values small, focused changes.
-
-Good contributions include:
-
-- fixture-backed rule improvements;
-- false-positive reductions;
-- clearer evidence in findings;
-- better baseline/review ergonomics;
-- docs that make local adoption easier;
-- tests that protect rule precision and output contracts.
-
-Before marking a rule stable or default-visible, make sure it has true-positive and false-positive fixtures, metadata, false-positive notes, deterministic output, and a clean `inspect eval-rules` result.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,25 @@ RepoPilot is not a replacement for language linters, formatters, type checkers, 
 
 ## Install
 
+Choose one install method.
+
+Cargo:
+
 ```bash
 cargo install repopilot
+```
+
+npm:
+
+```bash
 npm install -g repopilot
-brew tap mykytastel/repopilot && brew install repopilot
+```
+
+Homebrew:
+
+```bash
+brew tap mykytastel/repopilot
+brew install repopilot
 ```
 
 Installer:
@@ -41,7 +56,9 @@ cargo build --release
 
 More: [docs/install.md](docs/install.md).
 
-## First Run
+## Quick Start
+
+Run a local scan:
 
 ```bash
 repopilot scan .
@@ -151,7 +168,9 @@ More: [docs/rule-quality-gate.md](docs/rule-quality-gate.md).
 
 ## Local-First
 
-RepoPilot does not upload source code, run a hosted scanner, call LLM APIs implicitly, send telemetry, or require a SaaS account. AI commands only format local scan evidence as Markdown for tools such as Claude Code, ChatGPT, Cursor, Zed, or another assistant.
+RepoPilot does not upload source code, run a hosted scanner, call LLM APIs implicitly, send telemetry, or require a SaaS account.
+
+AI commands only format local scan evidence as Markdown for tools such as Claude Code, ChatGPT, Cursor, Zed, or another assistant.
 
 ## Reports
 

--- a/docs/archive/gtm-0.13.md
+++ b/docs/archive/gtm-0.13.md
@@ -11,7 +11,7 @@ AI-ready remediation context without uploading source.
 ## Demos
 
 1. AI coding safety loop: run `repopilot scan .`, inspect visible P1/P2 risks,
-   then generate `repopilot ai context . --format markdown` for local agent work.
+   then generate `repopilot ai context . --output ai-context.md` for local agent work.
 2. Baseline-aware CI gate: create `.repopilot/baseline.json`, fail on new high
    risk, and show hidden strict-only suggestions as backlog rather than noise.
 3. React Native/Expo release check: scan mobile release configuration, native

--- a/docs/archive/release-announcement-0.13.md
+++ b/docs/archive/release-announcement-0.13.md
@@ -1,0 +1,72 @@
+# RepoPilot 0.13.0 Release Announcement
+
+RepoPilot 0.13 is the trust and usability release: cleaner default output,
+stronger rule quality checks, safer baseline adoption, and better evidence for
+CI and AI-assisted remediation.
+
+## Suggested Post
+
+RepoPilot 0.13.0 is ready.
+
+This release is about making repository audits easier to trust and easier to
+adopt:
+
+- cleaner default scans that keep broad maintainability and testing noise out of
+  the normal CI path;
+- stronger rule quality checks through `inspect eval-rules`, fixture coverage,
+  stable finding IDs, and finding contract validation;
+- safer adoption with `.repopilot/baseline.json` and
+  `scan --baseline --fail-on new-high`;
+- better evidence for teams: compact console output, full diagnostics on demand,
+  JSON, SARIF, Markdown, receipts, and signal-quality summaries;
+- local AI remediation context that uses the same product scan path and default
+  visibility policy as normal scans.
+
+Try it:
+
+```bash
+repopilot scan .
+repopilot baseline create . --output .repopilot/baseline.json
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
+repopilot ai context . --budget 4k
+repopilot inspect eval-rules --format json
+```
+
+CI evidence:
+
+```bash
+repopilot scan . --format markdown --output repopilot-report.md
+repopilot scan . --format json --output repopilot-report.json --receipt .repopilot/receipt.json
+repopilot scan . --format sarif --output repopilot.sarif
+```
+
+GitHub Actions:
+
+```yaml
+- uses: MykytaStel/repopilot@v0.13.0
+  with:
+    command: scan
+    baseline: .repopilot/baseline.json
+    fail-on: new-high
+    receipt: repopilot-receipt.json
+```
+
+Positioning:
+
+```text
+RepoPilot 0.13 is the trust and usability release:
+cleaner default output, stronger rule quality checks, safer baseline adoption,
+and better evidence for CI and AI-assisted remediation.
+```
+
+## Post-Publish Checks
+
+Run after publishing completes:
+
+```bash
+npm view repopilot version
+cargo search repopilot
+gh release list --repo MykytaStel/repopilot --limit 5
+```
+
+Expected public version: `0.13.0`.

--- a/docs/archive/release-checklist-0.13.md
+++ b/docs/archive/release-checklist-0.13.md
@@ -1,11 +1,11 @@
 # RepoPilot 0.13.0 Release Checklist
 
-RepoPilot 0.13.0 is the breaking cleanup release for the pre-1.0 line.
+RepoPilot 0.13.0 is the trust and usability release for the pre-1.0 line.
 
 Main release promise:
 
 ```text
-finding contract -> rule lifecycle -> signal quality -> risk-v3 -> local-first audit evidence
+less noise -> stronger rule quality -> safer baseline adoption -> better CI and AI evidence
 ```
 
 ## Release Scope
@@ -37,13 +37,18 @@ Rule metadata gates:
 - high/critical findings have docs URLs after enrichment;
 - `repopilot inspect rules`, `inspect rule`, and `inspect eval-rules` pass locally.
 - `scripts/smoke-product.sh` verifies the self-scan JSON report has zero finding
-  contract violations without requiring `jq` or other optional JSON tools.
+  contract violations and zero default-visible noisy findings without requiring
+  `jq` or other optional JSON tools.
+- `scripts/smoke-product.sh` verifies baseline adoption through
+  `baseline create` followed by `scan --baseline --fail-on new-high`.
 
 Smoke commands:
 
 ```bash
 cargo run -- scan . --format json --output /tmp/repopilot-013-scan.json --receipt /tmp/repopilot-013-receipt.json
 cargo run -- scan . --format sarif --output /tmp/repopilot-013.sarif
+cargo run -- baseline create . --output /tmp/repopilot-013-baseline.json
+cargo run -- scan . --baseline /tmp/repopilot-013-baseline.json --fail-on new-high
 cargo run -- review . --format json --output /tmp/repopilot-013-review.json
 cargo run -- ai context . --budget 2k --output /tmp/repopilot-013-ai-context.md
 cargo run -- inspect rules --format json --output /tmp/repopilot-013-rules.json
@@ -98,7 +103,7 @@ Before tagging, verify:
 ```bash
 grep '^version = "0.13.0"' Cargo.toml
 grep '"version": "0.13.0"' package.json
-grep '## \[0.13.0\]' CHANGELOG.md || grep '## \[Unreleased\]' CHANGELOG.md
+grep '## \[0.13.0\]' CHANGELOG.md
 rg -n '0\.12\.0|release-checklist-0\.12' Cargo.toml package.json action.yml README.md docs .github scripts install.sh Formula examples
 ```
 

--- a/docs/product-readiness.md
+++ b/docs/product-readiness.md
@@ -29,7 +29,8 @@ RepoPilot should not become a random collection of commands or rules. Every rele
 
 ## Product readiness smoke suite
 
-Run the product smoke suite from the repository root:
+`scripts/smoke-product.sh` is the single install-like release smoke gate. Run it
+from the repository root:
 
 ```bash
 ./scripts/smoke-product.sh
@@ -60,18 +61,26 @@ version
 help
 init
 doctor
+scan console
 scan JSON + receipt
 scan Markdown
+scan SARIF
+baseline create
+scan --baseline --fail-on new-high
 review Markdown
 ai context
 ai plan
 ai prompt
 inspect knowledge
+inspect eval-rules
 inspect explain
 inspect feedback
+self-scan signal quality
 ```
 
 `review` is skipped when the target path is not inside a Git repository.
+The self-scan signal-quality gate fails on finding contract violations or
+default-visible low-quality noisy findings.
 
 ---
 
@@ -88,10 +97,14 @@ repopilot scan .
 repopilot scan . --format json --output /tmp/repopilot-scan.json
 repopilot scan . --format json --output /tmp/repopilot-scan.json --receipt /tmp/repopilot-receipt.json
 repopilot scan . --format markdown --output /tmp/repopilot-scan.md
+repopilot scan . --format sarif --output /tmp/repopilot.sarif
+repopilot baseline create . --output .repopilot/baseline.json
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
 repopilot review .
 repopilot ai context .
 repopilot ai plan .
 repopilot ai prompt .
+repopilot inspect eval-rules --format json
 repopilot inspect knowledge
 repopilot inspect explain src/main.rs
 repopilot inspect feedback .
@@ -187,6 +200,11 @@ Before release, verify:
   and a CI gate using `--baseline .repopilot/baseline.json --fail-on new-high`;
 - `.repopilot/baseline.json` updates are reviewed as accepted existing debt and
   are not used just to make CI green;
+- `repopilot inspect eval-rules --format json` reports zero missing findings,
+  unexpected findings, contract violations, stable-id failures, and
+  quality-gate failures;
+- `scripts/check-signal-quality.py --scan-json <self-scan.json>` passes without
+  `--warn-only` for the default RepoPilot self-scan;
 - `repopilot doctor .` reports no adoption warnings for the repository;
 - `scripts/smoke-product.sh` passes against the release binary.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -18,14 +18,26 @@ Use the current date for the release entry in `CHANGELOG.md`.
 
 ## 2. Verify locally
 
+Run the full release gate:
+
+```bash
+./scripts/verify-release.sh
+```
+
+The release gate runs formatting, clippy, tests, dependency checks, packaging
+dry-runs, rule evaluation, self-scan signal quality, and the install-like product
+smoke suite.
+
+The core checks are:
+
 ```bash
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all
 npm run test:npm
-./scripts/smoke-product.sh
 repopilot inspect eval-rules --format json
-repopilot scan .
+repopilot scan . --format json --output /tmp/repopilot-self-scan.json
+python3 scripts/check-signal-quality.py --scan-json /tmp/repopilot-self-scan.json
 cargo audit
 cargo deny check advisories licenses
 cargo package --list
@@ -49,7 +61,9 @@ node scripts/build-npm-platform-packages.js --dist dist --out /tmp/repopilot-npm
 
 Install `cargo-audit`, `cargo-deny`, `shellcheck`, and `actionlint` before running the local release checks.
 For older version-specific gate lists, use `docs/archive/release-checklist-*.md`.
-The product smoke suite validates the adoption flow, including receipt generation.
+The product smoke suite validates the install-like adoption flow: `scan`,
+`review`, `baseline create`, `scan --baseline --fail-on new-high`, `ai context`,
+`inspect eval-rules`, JSON, SARIF, Markdown, and receipt generation.
 
 ## npm Trusted Publishing setup
 
@@ -133,7 +147,7 @@ for pkg in \
 done
 npm install -g repopilot@0.13.0
 repopilot --version
-repopilot scan . --format json --output /tmp/repopilot-0.12-smoke.json
+repopilot scan . --format json --output /tmp/repopilot-0.13-smoke.json
 gh attestation verify path/to/repopilot-*.tar.gz --owner MykytaStel
 ```
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -118,7 +118,7 @@ matching the current schema.
 
 Schema `0.15` adds finding provenance, typed risk signal sources, `risk-v3`,
 finding-contract diagnostics, and `signal_quality` metrics. This is part of the
-0.13.0 breaking cleanup release.
+0.13.0 trust and usability release.
 
 Schema `0.16` adds context graph report and cache diagnostics. Schema `0.17`
 adds raw-vs-visible finding and signal-quality metrics so default-profile

--- a/docs/rule-quality-gate.md
+++ b/docs/rule-quality-gate.md
@@ -31,6 +31,26 @@ The local gate reports `has_true_positive_fixture`,
 `has_false_positive_fixture`, `contract_violations`, `stable_id_failures`, and
 `quality_gate_failures` for each evaluated rule.
 
+## Release and smoke gate
+
+`inspect eval-rules` is part of the release smoke gate. Before a release, this
+must pass:
+
+```bash
+repopilot inspect eval-rules --format json --output /tmp/repopilot-rule-eval.json
+```
+
+The aggregate JSON fields must be zero:
+
+- `missing_findings`;
+- `unexpected_findings`;
+- `contract_violations`;
+- `stable_id_failures`;
+- `quality_gate_failures`.
+
+`scripts/smoke-product.sh` and `scripts/verify-release.sh` enforce these checks
+without requiring `jq`.
+
 ## Default visibility policy
 
 Default scans should prioritize:

--- a/docs/signal-quality.md
+++ b/docs/signal-quality.md
@@ -35,3 +35,17 @@ faster attention.
 
 When filters, local feedback, baseline views, or visibility profiles change the
 visible finding set, RepoPilot refreshes the cached summary for that report path.
+
+## Self-scan gate
+
+RepoPilot's release smoke checks run a default self-scan and then validate the
+JSON report with:
+
+```bash
+python3 scripts/check-signal-quality.py --scan-json /tmp/repopilot-self-scan.json
+```
+
+This gate fails when the self-scan has finding contract violations or
+default-visible low-quality noisy findings from broad testing, marker, or
+maintainability heuristics. Those signals can still exist in strict mode, but
+they should not dominate the default RepoPilot report.

--- a/scripts/check-signal-quality.py
+++ b/scripts/check-signal-quality.py
@@ -6,9 +6,8 @@ This is a product-level guard, not a per-release helper.
 
 Examples:
     cargo run -- scan . --format json --output /tmp/repopilot-self-scan.json
+    python3 scripts/check-signal-quality.py --scan-json /tmp/repopilot-self-scan.json
     python3 scripts/check-signal-quality.py --scan-json /tmp/repopilot-self-scan.json --warn-only
-
-Later, remove --warn-only when the project is ready to make this a hard gate.
 """
 
 from __future__ import annotations
@@ -76,6 +75,13 @@ def get_priority(finding: dict[str, Any]) -> str:
         value = finding.get(key)
         if isinstance(value, str) and value:
             return value.lower()
+
+    risk = finding.get("risk")
+    if isinstance(risk, dict):
+        value = risk.get("priority")
+        if isinstance(value, str) and value:
+            return value.lower()
+
     return "unknown"
 
 

--- a/scripts/smoke-product.sh
+++ b/scripts/smoke-product.sh
@@ -161,6 +161,38 @@ assert_no_contract_violations() {
   fi
 }
 
+assert_json_number_field() {
+  local file="$1"
+  local field="$2"
+  local expected="$3"
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$file" "$field" "$expected" <<'PY'
+import json
+import sys
+
+path, field, expected_raw = sys.argv[1], sys.argv[2], sys.argv[3]
+expected = int(expected_raw)
+
+with open(path, encoding="utf-8") as handle:
+    data = json.load(handle)
+
+value = data.get(field)
+if value != expected:
+    raise SystemExit(f"Expected {path} field {field} to be {expected}, got {value!r}")
+PY
+    return
+  fi
+
+  if ! grep -Eq "\"$field\"[[:space:]]*:[[:space:]]*$expected([,}])" "$file"; then
+    echo "Expected '$file' JSON field '$field' to be: $expected" >&2
+    echo "---- file content ----" >&2
+    cat "$file" >&2 || true
+    echo "----------------------" >&2
+    exit 3
+  fi
+}
+
 find_explain_file() {
   local preferred="$REPO_PATH/src/main.rs"
 
@@ -227,9 +259,12 @@ assert_non_empty "$TMP_DIR/scan.json"
 validate_json_if_possible "$TMP_DIR/scan.json"
 assert_no_contract_violations "$TMP_DIR/scan.json"
 
-# RepoPilot signal-quality smoke check
+# RepoPilot self-scan signal-quality gate.
 if command -v python3 >/dev/null 2>&1 && [[ -f "$ROOT_DIR/scripts/check-signal-quality.py" ]]; then
-  python3 "$ROOT_DIR/scripts/check-signal-quality.py"             --scan-json "$TMP_DIR/scan.json"             --warn-only             --output-json "$TMP_DIR/signal-quality.json"
+  python3 "$ROOT_DIR/scripts/check-signal-quality.py" \
+    --scan-json "$TMP_DIR/scan.json" \
+    --output-json "$TMP_DIR/signal-quality.json"
+  assert_non_empty "$TMP_DIR/signal-quality.json"
 fi
 assert_non_empty "$TMP_DIR/receipt.json"
 validate_json_if_possible "$TMP_DIR/receipt.json"
@@ -246,8 +281,33 @@ run_repopilot_in "$PRIORITY_GATE_PROJECT" scan . --format json --fail-on-priorit
 assert_non_empty "$TMP_DIR/scan-priority-gate.json"
 validate_json_if_possible "$TMP_DIR/scan-priority-gate.json"
 
+BASELINE_ADOPTION_PROJECT="$TMP_DIR/baseline-adoption-project"
+mkdir -p "$BASELINE_ADOPTION_PROJECT/src" "$BASELINE_ADOPTION_PROJECT/tests"
+SMOKE_SECRET_KEY='API_KEY'
+SMOKE_SECRET_VALUE='abc12345'
+printf 'const %s: &str = "%s";\n' "$SMOKE_SECRET_KEY" "$SMOKE_SECRET_VALUE" > "$BASELINE_ADOPTION_PROJECT/src/config.rs"
+printf 'fn covers_config() {}\n' > "$BASELINE_ADOPTION_PROJECT/tests/config.rs"
+run_repopilot_in "$BASELINE_ADOPTION_PROJECT" baseline create . --output .repopilot/baseline.json > "$TMP_DIR/baseline-create.txt"
+assert_non_empty "$TMP_DIR/baseline-create.txt"
+assert_non_empty "$BASELINE_ADOPTION_PROJECT/.repopilot/baseline.json"
+validate_json_if_possible "$BASELINE_ADOPTION_PROJECT/.repopilot/baseline.json"
+run_repopilot_in "$BASELINE_ADOPTION_PROJECT" scan . --baseline .repopilot/baseline.json --fail-on new-high --format json --output "$TMP_DIR/baseline-pass.json"
+assert_non_empty "$TMP_DIR/baseline-pass.json"
+validate_json_if_possible "$TMP_DIR/baseline-pass.json"
+printf 'const %s: &str = "%s";\n' "$SMOKE_SECRET_KEY" "$SMOKE_SECRET_VALUE" > "$BASELINE_ADOPTION_PROJECT/src/creds.rs"
+if run_repopilot_in "$BASELINE_ADOPTION_PROJECT" scan . --baseline .repopilot/baseline.json --fail-on new-high > "$TMP_DIR/baseline-fail.txt" 2> "$TMP_DIR/baseline-fail.err"; then
+  echo "Expected baseline new-high gate to fail after adding a new high-risk finding" >&2
+  exit 3
+fi
+assert_contains "$TMP_DIR/baseline-fail.txt" "CI gate: failed (new-high)"
+
 run_repopilot scan . --format markdown --output "$TMP_DIR/scan.md"
 assert_non_empty "$TMP_DIR/scan.md"
+
+run_repopilot scan . --format sarif --output "$TMP_DIR/scan.sarif"
+assert_non_empty "$TMP_DIR/scan.sarif"
+validate_json_if_possible "$TMP_DIR/scan.sarif"
+assert_contains "$TMP_DIR/scan.sarif" '"version": "2.1.0"'
 
 if git -C "$REPO_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   run_repopilot review . --format markdown --output "$TMP_DIR/review.md"
@@ -271,6 +331,19 @@ validate_json_if_possible "$TMP_DIR/inspect-knowledge.json"
 
 run_repopilot inspect knowledge --section rules --format markdown --output "$TMP_DIR/inspect-knowledge-rules.md"
 assert_non_empty "$TMP_DIR/inspect-knowledge-rules.md"
+
+run_repopilot inspect feedback . --format json --output "$TMP_DIR/inspect-feedback.json"
+assert_non_empty "$TMP_DIR/inspect-feedback.json"
+validate_json_if_possible "$TMP_DIR/inspect-feedback.json"
+
+run_repopilot inspect eval-rules --format json --output "$TMP_DIR/eval-rules.json"
+assert_non_empty "$TMP_DIR/eval-rules.json"
+validate_json_if_possible "$TMP_DIR/eval-rules.json"
+assert_json_number_field "$TMP_DIR/eval-rules.json" "missing_findings" 0
+assert_json_number_field "$TMP_DIR/eval-rules.json" "unexpected_findings" 0
+assert_json_number_field "$TMP_DIR/eval-rules.json" "contract_violations" 0
+assert_json_number_field "$TMP_DIR/eval-rules.json" "stable_id_failures" 0
+assert_json_number_field "$TMP_DIR/eval-rules.json" "quality_gate_failures" 0
 
 run_repopilot inspect explain "$EXPLAIN_FILE" --format json --output "$TMP_DIR/inspect-explain.json"
 assert_non_empty "$TMP_DIR/inspect-explain.json"

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -87,13 +87,32 @@ echo "==> Rule evaluation JSON smoke"
 ./target/release/repopilot inspect eval-rules --format json > "$VERIFY_TMP_DIR/eval-rules.json"
 if command -v python3 >/dev/null 2>&1; then
   python3 -m json.tool "$VERIFY_TMP_DIR/eval-rules.json" >/dev/null
+  python3 - "$VERIFY_TMP_DIR/eval-rules.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    report = json.load(handle)
+
+fields = [
+    "missing_findings",
+    "unexpected_findings",
+    "contract_violations",
+    "stable_id_failures",
+    "quality_gate_failures",
+]
+failures = {field: report.get(field) for field in fields if report.get(field) != 0}
+if failures:
+    raise SystemExit(f"Rule quality gate failed: {failures}")
+PY
 fi
 
 echo "==> Self-scan signal quality"
 ./target/release/repopilot scan . --format json --output "$VERIFY_TMP_DIR/self-scan.json"
 if command -v python3 >/dev/null 2>&1 && [[ -f scripts/check-signal-quality.py ]]; then
-  # RepoPilot release signal-quality checks: warn-only until noisy heuristics are fully calibrated.
-  python3 scripts/check-signal-quality.py                 --scan-json "$VERIFY_TMP_DIR/self-scan.json"                 --warn-only                 --output-json "$VERIFY_TMP_DIR/signal-quality.json"
+  python3 scripts/check-signal-quality.py \
+    --scan-json "$VERIFY_TMP_DIR/self-scan.json" \
+    --output-json "$VERIFY_TMP_DIR/signal-quality.json"
 fi
 
 echo "==> Product readiness smoke suite"

--- a/tests/cli_release_smoke.rs
+++ b/tests/cli_release_smoke.rs
@@ -61,11 +61,7 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    let output = Command::new(repopilot_bin())
-        .current_dir(cwd)
-        .args(args)
-        .output()
-        .expect("failed to run repopilot");
+    let output = run(cwd, args);
 
     assert!(
         output.status.success(),
@@ -76,6 +72,18 @@ where
     );
 
     output
+}
+
+fn run<I, S>(cwd: &Path, args: I) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    Command::new(repopilot_bin())
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .expect("failed to run repopilot")
 }
 
 fn read_non_empty(path: &Path) -> String {
@@ -131,6 +139,107 @@ fn scan_writes_valid_json_report() {
         json["findings"].is_array(),
         "scan JSON should include findings array"
     );
+}
+
+#[test]
+fn release_smoke_covers_rule_quality_gate() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let output_path = temp.path().join("eval-rules.json");
+
+    run_ok(
+        temp.path(),
+        [
+            "inspect",
+            "eval-rules",
+            "--format",
+            "json",
+            "--output",
+            output_path.to_str().expect("non-utf8 output path"),
+        ],
+    );
+
+    let content = read_non_empty(&output_path);
+    let json: Value =
+        serde_json::from_str(&content).expect("eval-rules output should be valid JSON");
+
+    assert_eq!(json["missing_findings"], 0);
+    assert_eq!(json["unexpected_findings"], 0);
+    assert_eq!(json["contract_violations"], 0);
+    assert_eq!(json["stable_id_failures"], 0);
+    assert_eq!(json["quality_gate_failures"], 0);
+}
+
+#[test]
+fn release_smoke_covers_baseline_adoption_path() {
+    let project = create_demo_project();
+    let baseline_path = project.path().join(".repopilot").join("baseline.json");
+    let pass_output_path = project.path().join("baseline-pass.json");
+    fs::write(
+        project.path().join("src").join("config.rs"),
+        "const API_KEY: &str = \"abc12345\";\n",
+    )
+    .expect("failed to write baseline secret file");
+
+    run_ok(
+        project.path(),
+        [
+            "baseline",
+            "create",
+            ".",
+            "--output",
+            baseline_path.to_str().expect("non-utf8 baseline path"),
+        ],
+    );
+
+    let baseline: Value = serde_json::from_str(&read_non_empty(&baseline_path))
+        .expect("baseline should be valid JSON");
+    assert_eq!(baseline["schema_version"], 1);
+
+    run_ok(
+        project.path(),
+        [
+            "scan",
+            ".",
+            "--baseline",
+            baseline_path.to_str().expect("non-utf8 baseline path"),
+            "--fail-on",
+            "new-high",
+            "--format",
+            "json",
+            "--output",
+            pass_output_path.to_str().expect("non-utf8 output path"),
+        ],
+    );
+
+    let pass_report: Value = serde_json::from_str(&read_non_empty(&pass_output_path))
+        .expect("scan output should be valid JSON");
+    assert_eq!(pass_report["baseline"]["new_findings"], 0);
+
+    fs::write(
+        project.path().join("src").join("creds.rs"),
+        "const API_KEY: &str = \"abc12345\";\n",
+    )
+    .expect("failed to write new secret file");
+
+    let failed = run(
+        project.path(),
+        [
+            "scan",
+            ".",
+            "--baseline",
+            baseline_path.to_str().expect("non-utf8 baseline path"),
+            "--fail-on",
+            "new-high",
+        ],
+    );
+
+    assert!(
+        !failed.status.success(),
+        "new high finding should fail the baseline gate\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&failed.stdout),
+        String::from_utf8_lossy(&failed.stderr)
+    );
+    assert!(String::from_utf8_lossy(&failed.stdout).contains("CI gate: failed (new-high)"));
 }
 
 #[test]

--- a/tests/fixtures/golden/scan-console-compact.txt
+++ b/tests/fixtures/golden/scan-console-compact.txt
@@ -1,0 +1,18 @@
+RepoPilot Scan
+
+Status: Attention needed
+Risk: Medium
+Health: 90/100
+Profile: default
+Path: demo-project
+Files: 4 discovered, 2 analyzed
+
+Findings: 1 visible
+Hidden suggestions: 2 strict-only
+
+Top findings:
+  P0  security.secret-candidate          src/config.ts:3
+
+Next:
+  repopilot scan demo-project --profile strict
+  repopilot scan demo-project --format markdown --output report.md

--- a/tests/fixtures/golden/scan-console-full.txt
+++ b/tests/fixtures/golden/scan-console-full.txt
@@ -1,0 +1,53 @@
+RepoPilot Scan
+Version: {{VERSION}}
+Path: demo-project
+Profile: default
+Scope: full scan | repo-level rules: included
+Risk: Moderate | Health score: 90/100 [##########] Excellent
+Findings: 1 visible (23.8/kloc)
+Hidden suggestions: 2 strict-only suggestions
+Note: 2 strict-only suggestions hidden. Run with --profile strict or --include-maintainability to view.
+Hidden suggestions breakdown:
+     2  code-quality / maintainability / code-quality.long-function (maintainability signals are hidden in the default profile)
+Directories analyzed: 2 | Non-empty lines: 42
+Scan input:
+ Files discovered:       4
+ Files analyzed:       2
+
+Risk Summary:
+  Severity: 1 high
+  Priority: P0 1, P1 0, P2 0, P3 0 | highest P0 | avg score 95
+  Categories: security (1)
+  Top paths: src/config.ts (1)
+
+Signal quality:
+  High confidence: 1
+  Medium confidence: 0
+  Low confidence: 0
+  Evidence coverage: 100%
+  Recommendation coverage: 100%
+  Contract warnings: 0
+
+Top Risk Clusters:
+  P0 risk  95    1 finding(s)  security.secret-candidate in src  `src/config.ts:3`
+
+Top Rules:
+     1  [HIGH] security.secret-candidate
+
+Languages:
+  Rust: 1 files
+  TypeScript: 1 files
+
+Findings:
+  Security:
+    security.secret-candidate (1)
+      [HIGH] Possible hardcoded secret or API key
+        Confidence: HIGH
+        Priority: P0 (risk 95/100)
+        Risk signals: +75 severity: high severity finding, +8 confidence: high confidence signal, +12 security: security findings are prioritized
+        Location: src/config.ts:3
+        Evidence: src/config.ts:3 - export const API_TOKEN = "<redacted>";
+        A high-entropy string or a pattern matching a known secret format was found in source code
+        Recommendation: Move the value to an environment variable or secrets manager
+        Docs: https://github.com/MykytaStel/repopilot/blob/main/docs/security.md#secret-handling
+

--- a/tests/fixtures/golden/scan-json-schema.golden.json
+++ b/tests/fixtures/golden/scan-json-schema.golden.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": "0.17",
+  "repopilot_version": "{{VERSION}}",
+  "report": {
+    "kind": "scan",
+    "schema_version": "0.17",
+    "repopilot_version": "{{VERSION}}"
+  },
+  "root_path": "demo-project",
+  "mode": "full",
+  "changed_files_count": 0,
+  "repo_level_rules_included": true,
+  "files_discovered": 4,
+  "files_analyzed": 2,
+  "directories_count": 2,
+  "non_empty_lines": 42,
+  "large_files_skipped": 0,
+  "files_skipped_low_signal": 0,
+  "binary_files_skipped": 0,
+  "skipped_bytes": 0,
+  "languages": [
+    {
+      "name": "Rust",
+      "files_analyzed": 1
+    },
+    {
+      "name": "TypeScript",
+      "files_analyzed": 1
+    }
+  ],
+  "findings": [
+    {
+      "id": "security.secret-candidate:src/config.ts:3",
+      "rule_id": "security.secret-candidate",
+      "title": "Possible hardcoded secret or API key",
+      "description": "A high-entropy string or a pattern matching a known secret format was found in source code. Hardcoded secrets are exposed to everyone with repository access.",
+      "recommendation": "Move the value to an environment variable or secrets manager. If already committed, rotate the credential and consider the old value compromised.",
+      "category": "SECURITY",
+      "severity": "HIGH",
+      "confidence": "HIGH",
+      "evidence": [
+        {
+          "path": "src/config.ts",
+          "line_start": 3,
+          "line_end": null,
+          "snippet": "export const API_TOKEN = \"<redacted>\";"
+        }
+      ],
+      "docs_url": "https://github.com/MykytaStel/repopilot/blob/main/docs/security.md#secret-handling",
+      "provenance": {
+        "detector": "security.secret-candidate",
+        "signal_source": "text-heuristic",
+        "rule_lifecycle": "preview",
+        "analysis_scope": "file"
+      },
+      "risk": {
+        "score": 95,
+        "priority": "P0",
+        "signals": [
+          {
+            "id": "severity.high",
+            "label": "severity",
+            "weight": 75,
+            "reason": "high severity finding",
+            "source": "severity"
+          },
+          {
+            "id": "confidence.high",
+            "label": "confidence",
+            "weight": 8,
+            "reason": "high confidence signal",
+            "source": "confidence"
+          },
+          {
+            "id": "category.security",
+            "label": "security",
+            "weight": 12,
+            "reason": "security findings are prioritized",
+            "source": "category"
+          }
+        ],
+        "formula_version": "risk-v3"
+      }
+    }
+  ],
+  "detected_frameworks": [],
+  "framework_projects": [],
+  "coupling_graph": null,
+  "scan_duration_us": 0,
+  "health_score": 90,
+  "raw_findings_count": 1,
+  "visible_findings_count": 1,
+  "hidden_suggestions_count": 2,
+  "hidden_suggestions": [
+    {
+      "intent": "maintainability",
+      "rule_id": "code-quality.long-function",
+      "category": "code-quality",
+      "reason": "maintainability signals are hidden in the default profile",
+      "count": 2
+    }
+  ],
+  "visibility_profile": "default",
+  "files_skipped_by_limit": 0,
+  "files_skipped_repopilotignore": 0,
+  "risk_summary": {
+    "total": 1,
+    "counts": {
+      "p0": 1,
+      "p1": 0,
+      "p2": 0,
+      "p3": 0
+    },
+    "highest_priority": "P0",
+    "average_score": 95
+  },
+  "raw_signal_quality": {
+    "findings_total": 1,
+    "by_confidence": {
+      "low": 0,
+      "medium": 0,
+      "high": 1
+    },
+    "by_lifecycle": {
+      "experimental": 0,
+      "preview": 1,
+      "stable": 0,
+      "deprecated": 0
+    },
+    "by_signal_source": {
+      "text_heuristic": 1,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  },
+  "visible_signal_quality": {
+    "findings_total": 1,
+    "by_confidence": {
+      "low": 0,
+      "medium": 0,
+      "high": 1
+    },
+    "by_lifecycle": {
+      "experimental": 0,
+      "preview": 1,
+      "stable": 0,
+      "deprecated": 0
+    },
+    "by_signal_source": {
+      "text_heuristic": 1,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  },
+  "signal_quality": {
+    "findings_total": 1,
+    "by_confidence": {
+      "low": 0,
+      "medium": 0,
+      "high": 1
+    },
+    "by_lifecycle": {
+      "experimental": 0,
+      "preview": 1,
+      "stable": 0,
+      "deprecated": 0
+    },
+    "by_signal_source": {
+      "text_heuristic": 1,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  }
+}

--- a/tests/fixtures/golden/scan-markdown.md
+++ b/tests/fixtures/golden/scan-markdown.md
@@ -1,0 +1,75 @@
+# RepoPilot Scan Report
+
+## Overview
+
+- **RepoPilot version:** {{VERSION}}
+- **Path:** `demo-project`
+- **Profile:** `default`
+- **Scope:** full scan; repo-level rules included
+- **Risk:** Moderate
+- **Health score:** 90/100
+- **Findings:** 1 visible (23.8/kloc)
+- **Hidden suggestions:** 2 strict-only suggestions
+- **Note:** 2 strict-only suggestions hidden. Run with `--profile strict` or `--include-maintainability` to view.
+- **Top hidden suggestions:**
+  - `code-quality` / `maintainability` / `code-quality.long-function`: 2 - maintainability signals are hidden in the default profile
+- **Files analyzed:** 2
+- **Directories analyzed:** 2
+- **Non-empty lines:** 42
+
+## Risk Summary
+
+- **Severity:** 1 high
+- **Categories:** security (1)
+- **Top paths:** src/config.ts (1)
+
+## Signal Quality
+
+- **High confidence:** 1
+- **Medium confidence:** 0
+- **Low confidence:** 0
+- **Evidence coverage:** 100%
+- **Recommendation coverage:** 100%
+- **Contract warnings:** 0
+
+## Top Risk Clusters
+
+| Priority | Area | Rule | Count | Max severity | Max risk | Examples |
+| --- | --- | --- | ---: | --- | ---: | --- |
+| P0 | `src` | `security.secret-candidate` | 1 | HIGH | 95 | `src/config.ts:3` |
+
+## Top Rules
+
+| Rule | Count | Max severity |
+| --- | ---: | --- |
+| `security.secret-candidate` | 1 | HIGH |
+
+## Languages
+
+| Language | Files |
+| --- | ---: |
+| Rust | 1 |
+| TypeScript | 1 |
+
+## Findings Index
+
+| Category | Rule | Max severity | Count | First location |
+| --- | --- | --- | ---: | --- |
+| security | `security.secret-candidate` | HIGH | 1 | src/config.ts:3 |
+
+## Findings
+
+### Security
+
+#### `security.secret-candidate` (1)
+
+- **[HIGH] Possible hardcoded secret or API key**
+  - Confidence: HIGH
+  - Priority: P0 (risk 95/100)
+  - Risk signals: +75 severity: high severity finding, +8 confidence: high confidence signal, +12 security: security findings are prioritized
+  - Location: `src/config.ts:3`
+  - Evidence: `src/config.ts:3` - export const API_TOKEN = "<redacted>";
+  - Context: A high-entropy string or a pattern matching a known secret format was found in source code
+  - Recommendation: Move the value to an environment variable or secrets manager
+  - Docs: https://github.com/MykytaStel/repopilot/blob/main/docs/security.md#secret-handling
+

--- a/tests/fixtures/golden/scan-sarif.golden.json
+++ b/tests/fixtures/golden/scan-sarif.golden.json
@@ -1,0 +1,67 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "RepoPilot",
+          "version": "{{VERSION}}",
+          "informationUri": "https://github.com/MykytaStel/repopilot",
+          "rules": [
+            {
+              "id": "security.secret-candidate",
+              "name": "security.secret-candidate",
+              "shortDescription": {
+                "text": "Possible hardcoded secret or API key"
+              },
+              "fullDescription": {
+                "text": "A high-entropy string or a pattern matching a known secret format was found in source code. Hardcoded secrets are exposed to everyone with repository access."
+              },
+              "helpUri": "https://github.com/MykytaStel/repopilot/blob/main/docs/security.md#secret-handling",
+              "help": {
+                "text": "Move the value to an environment variable or secrets manager. If already committed, rotate the credential and consider the old value compromised."
+              }
+            }
+          ]
+        }
+      },
+      "properties": {
+        "report": {
+          "kind": "sarif",
+          "schema_version": "2.1.0",
+          "repopilot_version": "{{VERSION}}"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "security.secret-candidate",
+          "level": "error",
+          "message": {
+            "text": "Possible hardcoded secret or API key"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/config.ts"
+                },
+                "region": {
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash/v1": "security.secret-candidate:src/config.ts:3"
+          },
+          "properties": {
+            "category": "security",
+            "confidence": "HIGH",
+            "recommendation": "Move the value to an environment variable or secrets manager. If already committed, rotate the credential and consider the old value compromised."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/output_golden_fixtures.rs
+++ b/tests/output_golden_fixtures.rs
@@ -1,0 +1,174 @@
+use repopilot::findings::quality::summarize_signal_quality;
+use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
+use repopilot::output::{
+    ColorChoice, ColorDestination, ConsoleOutputStyle, FindingRenderLimit, OutputFormat,
+    RenderOptions, render_scan_summary_with_options,
+};
+use repopilot::risk::{RiskInputs, assess_finding};
+use repopilot::scan::types::{HiddenSuggestionSummary, LanguageSummary, ScanSummary};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn golden_console_compact_output_stays_stable() {
+    let output = render(OutputFormat::Console, ConsoleOutputStyle::Compact);
+
+    assert_golden(
+        "scan-console-compact.txt",
+        output,
+        include_str!("fixtures/golden/scan-console-compact.txt"),
+    );
+}
+
+#[test]
+fn golden_console_full_output_stays_stable() {
+    let output = render(OutputFormat::Console, ConsoleOutputStyle::Full);
+
+    assert_golden(
+        "scan-console-full.txt",
+        output,
+        include_str!("fixtures/golden/scan-console-full.txt"),
+    );
+}
+
+#[test]
+fn golden_markdown_output_stays_stable() {
+    let output = render(OutputFormat::Markdown, ConsoleOutputStyle::Full);
+
+    assert_golden(
+        "scan-markdown.md",
+        output,
+        include_str!("fixtures/golden/scan-markdown.md"),
+    );
+}
+
+#[test]
+fn golden_json_schema_output_stays_stable() {
+    let output = render(OutputFormat::Json, ConsoleOutputStyle::Full);
+
+    assert_golden(
+        "scan-json-schema.golden.json",
+        output,
+        include_str!("fixtures/golden/scan-json-schema.golden.json"),
+    );
+}
+
+#[test]
+fn golden_sarif_output_stays_stable() {
+    let output = render(OutputFormat::Sarif, ConsoleOutputStyle::Full);
+
+    assert_golden(
+        "scan-sarif.golden.json",
+        output,
+        include_str!("fixtures/golden/scan-sarif.golden.json"),
+    );
+}
+
+fn render(format: OutputFormat, console_output_style: ConsoleOutputStyle) -> String {
+    render_scan_summary_with_options(
+        &golden_summary(),
+        format,
+        RenderOptions {
+            console_output_style,
+            color_choice: ColorChoice::Never,
+            color_destination: ColorDestination::Stdout,
+            quiet: false,
+            findings_limit: FindingRenderLimit::Default,
+        },
+    )
+    .expect("golden output should render")
+}
+
+fn golden_summary() -> ScanSummary {
+    let findings = vec![secret_finding()];
+    let signal_quality = summarize_signal_quality(&findings);
+
+    ScanSummary {
+        root_path: PathBuf::from("demo-project"),
+        files_discovered: 4,
+        files_analyzed: 2,
+        directories_count: 2,
+        non_empty_lines: 42,
+        languages: vec![
+            LanguageSummary {
+                name: "Rust".to_string(),
+                files_analyzed: 1,
+            },
+            LanguageSummary {
+                name: "TypeScript".to_string(),
+                files_analyzed: 1,
+            },
+        ],
+        findings,
+        health_score: 90,
+        raw_findings_count: 1,
+        visible_findings_count: 1,
+        hidden_suggestions_count: 2,
+        hidden_suggestions: vec![HiddenSuggestionSummary {
+            intent: "maintainability".to_string(),
+            rule_id: "code-quality.long-function".to_string(),
+            category: "code-quality".to_string(),
+            reason: "maintainability signals are hidden in the default profile".to_string(),
+            count: 2,
+        }],
+        visibility_profile: Some("default".to_string()),
+        raw_signal_quality: signal_quality.clone(),
+        visible_signal_quality: signal_quality.clone(),
+        signal_quality,
+        ..ScanSummary::default()
+    }
+}
+
+fn secret_finding() -> Finding {
+    let mut finding = Finding {
+        id: "security.secret-candidate:src/config.ts:3".to_string(),
+        rule_id: "security.secret-candidate".to_string(),
+        title: String::new(),
+        description: String::new(),
+        recommendation: String::new(),
+        category: FindingCategory::Security,
+        severity: Severity::High,
+        confidence: Confidence::High,
+        evidence: vec![Evidence {
+            path: PathBuf::from("src/config.ts"),
+            line_start: 3,
+            line_end: None,
+            snippet: r#"export const API_TOKEN = "<redacted>";"#.to_string(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+        provenance: Default::default(),
+        risk: Default::default(),
+    };
+    finding.populate_rule_metadata();
+    finding.risk = assess_finding(&finding, None, RiskInputs::default());
+    finding
+}
+
+fn assert_golden(name: &str, actual: String, expected: &str) {
+    let actual = normalize_snapshot(actual);
+
+    if std::env::var_os("REPOPILOT_UPDATE_GOLDEN").is_some() {
+        fs::write(golden_path(name), actual).expect("failed to update golden fixture");
+        return;
+    }
+
+    assert_eq!(actual, expected, "golden fixture changed: {name}");
+}
+
+fn normalize_snapshot(output: String) -> String {
+    let mut output = output.replace("\r\n", "\n");
+    output = output.replace(env!("CARGO_PKG_VERSION"), "{{VERSION}}");
+    if !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+fn golden_path(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("golden")
+        .join(name)
+}


### PR DESCRIPTION
## Summary

This PR finalizes the RepoPilot 0.13 release documentation and release-readiness checks.

The main goal is to make 0.13 feel like a complete trust and usability release: cleaner README positioning, stronger smoke checks, baseline adoption verification, signal-quality validation, rule quality documentation, and golden output fixtures.

## Type of change

- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] CI / repository maintenance
- [ ] Feature
- [ ] Bug fix

## What changed

- Simplified the README into a clearer product-focused overview.
- Updated the 0.13 changelog and release announcement.
- Refined the 0.13 release checklist around trust, usability, baseline adoption, and CI evidence.
- Added/updated product readiness and release documentation.
- Added signal quality documentation and a local signal-quality checker script.
- Expanded `scripts/smoke-product.sh` to cover release-critical workflows.
- Added golden fixtures for compact console, full console, Markdown, JSON, and SARIF output.
- Added release smoke coverage for baseline adoption and output stability.

## Why

0.13 should be stronger than 0.12 not only by adding more functionality, but by improving trust, adoption, and release confidence.

This PR makes the release story clearer:

- default scans should be less noisy;
- rules should have stronger quality expectations;
- existing repositories should adopt RepoPilot safely through baselines;
- CI should produce useful evidence;
- report output should remain stable and testable.

## Architecture notes

- [x] No god files introduced
- [x] Logic is split into focused modules
- [x] Scanner, audits, output, and report responsibilities remain separated
- [x] Findings include evidence where applicable

## Changelog

- [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run test:npm
./scripts/smoke-product.sh
./scripts/verify-release.sh