### PR TITLE
fix(architecture): scope anti-pattern checks to production paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ dist/
 !/.repopilot/.gitkeep
 !/.repopilot/config.toml
 !/.repopilot/config.example.toml
+.repopilot-patches/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ## [Unreleased]
 
 ### Added
-- Added product documentation for the architecture anti-pattern family and the expected false-positive policy for architecture rules.
+
+- Added architecture anti-pattern documentation describing production-scope policy and false-positive expectations for architecture rules.
 
 ### Changed
+
 - Scoped `architecture.deep-nesting` through a shared production architecture path policy so fixtures, tests, docs, examples, generated files, vendor trees, and build output do not become user-facing architecture findings.
-
-### Changed
-- Scoped `architecture.deep-nesting` to production architecture candidates so rule fixtures, tests, examples, docs, generated files, vendor trees, and build output do not produce project architecture findings.
 
 ## [0.13.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
-No changes yet.
+### Added
+- Added product documentation for the architecture anti-pattern family and the expected false-positive policy for architecture rules.
+
+### Changed
+- Scoped `architecture.deep-nesting` through a shared production architecture path policy so fixtures, tests, docs, examples, generated files, vendor trees, and build output do not become user-facing architecture findings.
+
+### Changed
+- Scoped `architecture.deep-nesting` to production architecture candidates so rule fixtures, tests, examples, docs, generated files, vendor trees, and build output do not produce project architecture findings.
 
 ## [0.13.0] - 2026-05-25
 

--- a/docs/architecture-antipatterns.md
+++ b/docs/architecture-antipatterns.md
@@ -1,0 +1,61 @@
+# Architecture Anti-patterns
+
+RepoPilot architecture checks are designed to catch product structure risks without turning
+rule fixtures, test corpora, docs, examples, generated files, vendor trees, or build output into
+user-facing architecture noise.
+
+## Product policy
+
+Architecture findings should answer a maintainer question:
+
+```text
+Could this production structure make the codebase harder to review, change, test, or release?
+```
+
+They should not report intentionally unusual non-production layouts, such as:
+
+```text
+tests/fixtures/rules/**
+examples/**
+docs/**
+src/generated/**
+vendor/**
+target/**
+dist/**
+```
+
+Those paths can still be scanned by other rule families when appropriate. They are only excluded
+from broad architecture structure heuristics.
+
+## Current architecture anti-pattern family
+
+| Rule | Product question | Default behavior |
+| --- | --- | --- |
+| `architecture.deep-nesting` | Is production code buried in an over-nested module hierarchy? | Visible only for production architecture candidates. |
+| `architecture.large-file` | Is a production file too large to review and safely maintain? | Should avoid test/generated/vendor noise. |
+| `architecture.too-many-modules` | Does a package/directory expose too many modules for its boundary? | Should focus on product module boundaries. |
+| `architecture.import-coupling` | Is a file coupled to too many internal modules? | Should prefer source code over generated/test corpora. |
+| `architecture.deep-relative-imports` | Are imports crossing too many directory levels? | Should focus on maintainability of production imports. |
+| `architecture.barrel-file-risk` | Is a barrel file hiding coupling or unstable public boundaries? | Should explain why the barrel is risky, not merely that it exists. |
+
+## Visibility guidance
+
+Default profile should show architecture findings when they are:
+
+- production-scoped
+- evidence-backed
+- actionable
+- not better represented as strict-only cleanup
+
+Strict profile can expose broader maintainability suggestions, but the wording should make the
+scope explicit. For example, `fixture/test path` should not be described as normal product
+architecture.
+
+## Rule-author workflow
+
+When adding or changing an architecture rule, include at least:
+
+- one true-positive production fixture
+- one false-positive fixture/test/docs/generated/vendor case
+- one regression test proving default output does not report non-production structure as product risk
+- documentation explaining why the rule is user-facing

--- a/docs/trust-mode.md
+++ b/docs/trust-mode.md
@@ -139,3 +139,27 @@ centralized and semantic. The next improvements should be:
 - validated local feedback with visible `local_feedback` metadata
 - confidence calibration per rule
 - project profile specific visibility defaults
+
+## Path-aware architecture heuristics
+
+Some repository paths are intentionally deep and should not be treated as production architecture
+risk. Rule fixtures, test corpora, examples, docs, generated files, vendor trees, and build output
+may use nested paths to describe scenarios rather than product structure.
+
+For that reason, broad project-level architecture heuristics such as `architecture.deep-nesting`
+are scoped to production architecture candidates before they emit findings. This keeps rule-author
+fixtures useful for evaluation without turning them into user-facing architecture noise.
+
+```text
+tests/fixtures/rules/** -> fixture corpus -> not a production deep-nesting finding
+src/features/**         -> production source -> eligible for deep-nesting analysis
+```
+
+## Architecture anti-pattern scope
+
+Architecture anti-pattern rules are production-scoped by default. Broad structure heuristics such as
+`architecture.deep-nesting` should not treat rule fixtures, test corpora, docs, examples, generated
+files, vendor trees, or build output as product architecture risk.
+
+This keeps default output quiet while preserving those paths for rule evaluation and other audits
+where they are intentionally useful.

--- a/docs/trust-mode.md
+++ b/docs/trust-mode.md
@@ -140,21 +140,6 @@ centralized and semantic. The next improvements should be:
 - confidence calibration per rule
 - project profile specific visibility defaults
 
-## Path-aware architecture heuristics
-
-Some repository paths are intentionally deep and should not be treated as production architecture
-risk. Rule fixtures, test corpora, examples, docs, generated files, vendor trees, and build output
-may use nested paths to describe scenarios rather than product structure.
-
-For that reason, broad project-level architecture heuristics such as `architecture.deep-nesting`
-are scoped to production architecture candidates before they emit findings. This keeps rule-author
-fixtures useful for evaluation without turning them into user-facing architecture noise.
-
-```text
-tests/fixtures/rules/** -> fixture corpus -> not a production deep-nesting finding
-src/features/**         -> production source -> eligible for deep-nesting analysis
-```
-
 ## Architecture anti-pattern scope
 
 Architecture anti-pattern rules are production-scoped by default. Broad structure heuristics such as
@@ -162,4 +147,4 @@ Architecture anti-pattern rules are production-scoped by default. Broad structur
 files, vendor trees, or build output as product architecture risk.
 
 This keeps default output quiet while preserving those paths for rule evaluation and other audits
-where they are intentionally useful.
+where they are intentionally useful. See `docs/architecture-antipatterns.md` for the full policy.

--- a/src/audits/architecture/deep_nesting.rs
+++ b/src/audits/architecture/deep_nesting.rs
@@ -1,8 +1,9 @@
+use super::path_scope::is_production_architecture_candidate;
 use crate::audits::traits::ProjectAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub struct DeepNestingAudit;
 
@@ -10,24 +11,26 @@ impl ProjectAudit for DeepNestingAudit {
     fn audit(&self, facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
         let root_depth = facts.root_path.components().count();
 
-        let deepest = facts
+        facts
             .files
             .iter()
-            .filter_map(|file| {
-                let depth = file.path.components().count().saturating_sub(root_depth);
-                if depth > config.max_directory_depth {
-                    Some((file.path.clone(), depth))
-                } else {
-                    None
-                }
-            })
-            .max_by_key(|(_, depth)| *depth);
-
-        match deepest {
-            None => vec![],
-            Some((path, depth)) => vec![build_finding(path, depth, config.max_directory_depth)],
-        }
+            .filter(|file| is_production_architecture_candidate(&file.path))
+            .filter_map(|file| production_depth_over_threshold(&file.path, root_depth, config))
+            .max_by_key(|(_, depth)| *depth)
+            .map(|(path, depth)| build_finding(path, depth, config.max_directory_depth))
+            .into_iter()
+            .collect()
     }
+}
+
+fn production_depth_over_threshold(
+    path: &Path,
+    root_depth: usize,
+    config: &ScanConfig,
+) -> Option<(PathBuf, usize)> {
+    let depth = path.components().count().saturating_sub(root_depth);
+
+    (depth > config.max_directory_depth).then(|| (path.to_path_buf(), depth))
 }
 
 fn build_finding(deepest_path: PathBuf, depth: usize, threshold: usize) -> Finding {
@@ -35,9 +38,9 @@ fn build_finding(deepest_path: PathBuf, depth: usize, threshold: usize) -> Findi
         id: String::new(),
         rule_id: "architecture.deep-nesting".to_string(),
         recommendation: Finding::recommendation_for_rule_id("architecture.deep-nesting"),
-        title: "Deeply nested directory structure detected".to_string(),
+        title: "Deeply nested production directory structure detected".to_string(),
         description: format!(
-            "The project contains files nested {depth} levels deep, exceeding the threshold of {threshold}. Deep nesting often indicates over-engineered module hierarchies."
+            "Production source contains files nested {depth} levels deep, exceeding the threshold              of {threshold}. Deep nesting often indicates over-engineered module hierarchies."
         ),
         category: FindingCategory::Architecture,
         severity: Severity::Low,
@@ -46,11 +49,109 @@ fn build_finding(deepest_path: PathBuf, depth: usize, threshold: usize) -> Findi
             path: deepest_path,
             line_start: 1,
             line_end: None,
-            snippet: format!("Nesting depth: {depth}; threshold is {threshold}."),
+            snippet: format!("Production nesting depth: {depth}; threshold is {threshold}."),
         }],
         workspace_package: None,
         docs_url: None,
         provenance: Default::default(),
         risk: Default::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::facts::FileFacts;
+
+    #[test]
+    fn ignores_rule_fixtures_when_calculating_deepest_path() {
+        let facts = scan_facts(&[
+            "./src/domain/user.ts",
+            "./tests/fixtures/rules/security.secret-candidate/true_positive_env_value/src/config.ts",
+        ]);
+
+        let findings = audit_with_depth(&facts, 5);
+
+        assert!(
+            findings.is_empty(),
+            "rule fixture paths should not become production architecture findings"
+        );
+    }
+
+    #[test]
+    fn ignores_test_paths_even_when_they_are_deeper_than_source_paths() {
+        let facts = scan_facts(&[
+            "./src/features/payments/service.ts",
+            "./tests/unit/features/payments/checkout/mobile/session/service.test.ts",
+        ]);
+
+        let findings = audit_with_depth(&facts, 5);
+
+        assert!(
+            findings.is_empty(),
+            "test paths are allowed to be deeper than production source paths"
+        );
+    }
+
+    #[test]
+    fn ignores_docs_examples_generated_vendor_and_build_paths() {
+        let facts = scan_facts(&[
+            "./docs/reference/api/v1/generated/client/config.ts",
+            "./examples/react-native/deep/sample/src/App.tsx",
+            "./src/generated/openapi/client/v1/types.generated.ts",
+            "./vendor/company/package/deep/source/file.ts",
+            "./target/debug/build/package/out/generated.rs",
+            "./dist/assets/js/chunks/deep/file.js",
+        ]);
+
+        let findings = audit_with_depth(&facts, 5);
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn reports_deep_production_path() {
+        let production_path = "./src/features/payments/checkout/mobile/session/domain/handler.ts";
+        let facts = scan_facts(&[production_path]);
+
+        let findings = audit_with_depth(&facts, 5);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "architecture.deep-nesting");
+        assert_eq!(findings[0].evidence[0].path, PathBuf::from(production_path));
+        assert!(
+            findings[0].title.contains("production"),
+            "finding copy should make the production scope explicit"
+        );
+    }
+
+    fn audit_with_depth(facts: &ScanFacts, max_directory_depth: usize) -> Vec<Finding> {
+        let audit = DeepNestingAudit;
+        let config = ScanConfig {
+            max_directory_depth,
+            ..ScanConfig::default()
+        };
+
+        audit.audit(facts, &config)
+    }
+
+    fn scan_facts(paths: &[&str]) -> ScanFacts {
+        ScanFacts {
+            root_path: PathBuf::from("."),
+            files: paths.iter().map(|path| file_facts(path)).collect(),
+            ..ScanFacts::default()
+        }
+    }
+
+    fn file_facts(path: &str) -> FileFacts {
+        FileFacts {
+            path: PathBuf::from(path),
+            language: Some("TypeScript".to_string()),
+            non_empty_lines: 1,
+            branch_count: 0,
+            imports: Vec::new(),
+            content: Some("export const value = true;\n".to_string()),
+            has_inline_tests: false,
+        }
     }
 }

--- a/src/audits/architecture/deep_nesting.rs
+++ b/src/audits/architecture/deep_nesting.rs
@@ -40,7 +40,8 @@ fn build_finding(deepest_path: PathBuf, depth: usize, threshold: usize) -> Findi
         recommendation: Finding::recommendation_for_rule_id("architecture.deep-nesting"),
         title: "Deeply nested production directory structure detected".to_string(),
         description: format!(
-            "Production source contains files nested {depth} levels deep, exceeding the threshold              of {threshold}. Deep nesting often indicates over-engineered module hierarchies."
+            "Production source contains files nested {depth} levels deep, exceeding the threshold \
+             of {threshold}. Deep nesting often indicates over-engineered module hierarchies."
         ),
         category: FindingCategory::Architecture,
         severity: Severity::Low,

--- a/src/audits/architecture/mod.rs
+++ b/src/audits/architecture/mod.rs
@@ -1,3 +1,4 @@
+mod path_scope;
 pub mod barrel_file_risk;
 pub mod deep_nesting;
 pub mod deep_relative_imports;

--- a/src/audits/architecture/mod.rs
+++ b/src/audits/architecture/mod.rs
@@ -1,7 +1,8 @@
-mod path_scope;
 pub mod barrel_file_risk;
 pub mod deep_nesting;
 pub mod deep_relative_imports;
 pub mod import_coupling;
 pub mod large_file;
+mod path_scope;
+
 pub mod too_many_modules;

--- a/src/audits/architecture/path_scope.rs
+++ b/src/audits/architecture/path_scope.rs
@@ -1,0 +1,154 @@
+use std::path::{Component, Path};
+
+const NON_PRODUCTION_ARCHITECTURE_COMPONENTS: &[&str] = &[
+    ".git",
+    ".next",
+    ".nuxt",
+    ".repopilot",
+    ".turbo",
+    "__fixtures__",
+    "__mocks__",
+    "__snapshots__",
+    "__tests__",
+    "build",
+    "coverage",
+    "deriveddata",
+    "dist",
+    "doc",
+    "docs",
+    "example",
+    "examples",
+    "fixture",
+    "fixtures",
+    "generated",
+    "mock",
+    "mocks",
+    "node_modules",
+    "out",
+    "pods",
+    "snapshot",
+    "snapshots",
+    "spec",
+    "specs",
+    "target",
+    "test",
+    "tests",
+    "vendor",
+];
+
+/// Returns true when a path should be considered product/source architecture.
+///
+/// Architecture heuristics should not treat rule fixtures, test corpora, docs,
+/// generated code, vendor trees, or build output as production structure. Those
+/// paths may be intentionally deep or unusual because they describe scenarios,
+/// not product module boundaries.
+pub fn is_production_architecture_candidate(path: &Path) -> bool {
+    !has_blocked_path_component(path, NON_PRODUCTION_ARCHITECTURE_COMPONENTS)
+        && !is_test_or_generated_file_name(path)
+}
+
+fn has_blocked_path_component(path: &Path, blocked_components: &[&str]) -> bool {
+    path.components().any(|component| {
+        let Component::Normal(value) = component else {
+            return false;
+        };
+
+        let Some(value) = value.to_str() else {
+            return false;
+        };
+
+        blocked_components
+            .iter()
+            .any(|blocked| value.eq_ignore_ascii_case(blocked))
+    })
+}
+
+fn is_test_or_generated_file_name(path: &Path) -> bool {
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+
+    has_any_case_insensitive_suffix(
+        file_name,
+        &[
+            ".test.ts",
+            ".test.tsx",
+            ".test.js",
+            ".test.jsx",
+            ".spec.ts",
+            ".spec.tsx",
+            ".spec.js",
+            ".spec.jsx",
+            "_test.rs",
+            "_test.go",
+            ".generated.ts",
+            ".generated.tsx",
+            ".generated.js",
+            ".generated.jsx",
+            ".generated.rs",
+            ".gen.ts",
+            ".gen.tsx",
+            ".gen.js",
+            ".gen.jsx",
+            ".gen.rs",
+        ],
+    )
+}
+
+fn has_any_case_insensitive_suffix(value: &str, suffixes: &[&str]) -> bool {
+    suffixes.iter().any(|suffix| {
+        value.len() >= suffix.len()
+            && value[value.len() - suffix.len()..].eq_ignore_ascii_case(suffix)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn accepts_production_source_paths() {
+        assert!(is_production_architecture_candidate(Path::new(
+            "./src/features/payments/checkout/session/domain/handler.ts"
+        )));
+    }
+
+    #[test]
+    fn rejects_rule_fixture_paths() {
+        assert!(!is_production_architecture_candidate(Path::new(
+            "./tests/fixtures/rules/security.secret-candidate/true_positive_env_value/src/config.ts"
+        )));
+    }
+
+    #[test]
+    fn rejects_test_corpora_and_test_files() {
+        assert!(!is_production_architecture_candidate(Path::new(
+            "./tests/unit/features/payments/session/service.ts"
+        )));
+        assert!(!is_production_architecture_candidate(Path::new(
+            "./src/features/payments/session/service.test.ts"
+        )));
+        assert!(!is_production_architecture_candidate(Path::new(
+            "./src/features/payments/session/service.spec.ts"
+        )));
+    }
+
+    #[test]
+    fn rejects_docs_examples_generated_vendor_and_build_output() {
+        for path in [
+            "./docs/reference/api/v1/generated/client/config.ts",
+            "./examples/react-native/deep/sample/src/App.tsx",
+            "./src/generated/openapi/client/v1/types.generated.ts",
+            "./vendor/company/package/deep/source/file.ts",
+            "./target/debug/build/package/out/generated.rs",
+            "./dist/assets/js/chunks/deep/file.js",
+        ] {
+            assert!(
+                !is_production_architecture_candidate(Path::new(path)),
+                "{path} should not be treated as product architecture"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Hardens RepoPilot's architecture anti-pattern checks by introducing a shared
production path scope and applying it to `architecture.deep-nesting`.

This prevents rule fixtures, test corpora, docs, examples, generated files,
vendor trees, and build output from becoming user-facing architecture findings.

## Why

`architecture.deep-nesting` previously selected the deepest file from all scanned
files. That made intentionally deep rule-author fixture paths appear as product
architecture problems, for example:

`tests/fixtures/rules/security.secret-candidate/true_positive_env_value/src/config.ts`

That finding is technically explainable, but product-wise it is noise: rule
fixtures describe test scenarios, not production module structure.

This PR keeps default scans quieter and more trustworthy while preserving those
paths for rule evaluation and other rule families.

## What changed

- Added a shared production architecture path scope module.
- Scoped `architecture.deep-nesting` to production architecture candidates.
- Excluded fixture/test/docs/example/generated/vendor/build-output paths from
  broad architecture structure heuristics.
- Updated the deep nesting finding copy to make the production scope explicit.
- Added regression tests for:
  - rule fixture paths
  - test paths
  - docs/examples
  - generated/vendor/build output
  - real production deep nesting
- Added architecture anti-pattern product documentation.
- Updated Trust Mode documentation.
- Updated the changelog.

## Product behavior

Default scans should stay quiet and actionable:

- production deep nesting can still be reported
- fixture/test/docs/generated/vendor/build paths are not treated as product architecture
- rule fixtures remain available for rule evaluation and security/runtime tests

## Architecture notes

- No god files introduced.
- Shared path-scope logic is isolated in `architecture/path_scope.rs`.
- `architecture.deep-nesting` now depends on a reusable production-scope policy.
- This creates a foundation for applying the same policy to other architecture
  anti-pattern rules in later PRs.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all`
- [x] `cargo run -- scan .`
- [x] `cargo run -- scan . --profile strict`