### PR TITLE
feat(benchmark): add baseline scan performance benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Added
 
 - Added architecture anti-pattern documentation describing production-scope policy and false-positive expectations for architecture rules.
+- Added a Criterion scan-throughput benchmark (`cargo bench --bench scan_bench`) over a generated 480-file multi-language synthetic repository to baseline full-scan performance ahead of the shared parsed-AST work.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +150,33 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -220,6 +259,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +316,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -361,6 +440,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +470,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hybrid-array"
@@ -462,10 +558,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -535,6 +651,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pin-project-lite"
@@ -637,6 +759,7 @@ version = "0.13.0"
 dependencies = [
  "chrono",
  "clap",
+ "criterion",
  "globset",
  "ignore",
  "indicatif",
@@ -838,6 +961,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1273,6 +1406,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tree-sitter-typescript = "0.23.2"
 toml = "1.1.2"
 
 [dev-dependencies]
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 tempfile = "3"
 
 [profile.release]
@@ -38,3 +39,7 @@ opt-level = 3
 lto = "thin"
 codegen-units = 1
 strip = true
+
+[[bench]]
+name = "scan_bench"
+harness = false

--- a/benches/scan_bench.rs
+++ b/benches/scan_bench.rs
@@ -1,0 +1,169 @@
+//! Baseline scan-throughput benchmark.
+//!
+//! Builds a synthetic multi-language repository in a temp directory once, then
+//! measures `scan_path_with_config` wall time. This establishes a performance
+//! baseline before the shared parsed-AST work (PR 5–7) so the dedup win is
+//! provable, and guards against scan regressions afterwards.
+//!
+//! Run with: `cargo bench --bench scan_bench`
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use repopilot::api::scan::{ScanConfig, scan_path_with_config};
+use std::fs;
+use std::hint::black_box;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Files generated per language. 120 × 4 languages = 480 source files, enough
+/// to exercise the parallel file pipeline, the AST audits, and the import graph
+/// at a realistic small-repo scale without making the benchmark slow.
+const FILES_PER_LANG: usize = 120;
+
+const RUST_TEMPLATE: &str = r#"use crate::file_PREVNUM;
+
+pub fn compute_IDXNUM(input: i64) -> i64 {
+    let mut total = 0_i64;
+    for outer in 0..input {
+        if outer % 2 == 0 {
+            for inner in 0..outer {
+                if inner % 3 == 0 {
+                    total += outer * inner;
+                } else {
+                    total -= inner;
+                }
+            }
+        }
+    }
+    total
+}
+"#;
+
+const TS_TEMPLATE: &str = r#"import { compute } from "./file_PREVNUM";
+
+export function run_IDXNUM(input: number): number {
+    let total = 0;
+    for (let outer = 0; outer < input; outer++) {
+        if (outer % 2 === 0) {
+            for (let inner = 0; inner < outer; inner++) {
+                if (inner % 3 === 0) {
+                    total += outer * inner;
+                } else {
+                    total -= inner;
+                }
+            }
+        }
+    }
+    return total + compute;
+}
+"#;
+
+const PY_TEMPLATE: &str = r#"from .file_PREVNUM import compute
+
+
+def run_IDXNUM(value):
+    total = 0
+    for outer in range(value):
+        if outer % 2 == 0:
+            for inner in range(outer):
+                if inner % 3 == 0:
+                    total += outer * inner
+                else:
+                    total -= inner
+    return total + compute
+"#;
+
+const GO_TEMPLATE: &str = r#"package gopkg
+
+import "fmt"
+
+func RunIDXNUM(value int) int {
+    total := 0
+    for outer := 0; outer < value; outer++ {
+        if outer%2 == 0 {
+            for inner := 0; inner < outer; inner++ {
+                if inner%3 == 0 {
+                    total += outer * inner
+                } else {
+                    total -= inner
+                }
+            }
+        }
+    }
+    fmt.Sprintln(total)
+    return total
+}
+"#;
+
+fn render(template: &str, index: usize) -> String {
+    let prev = index.saturating_sub(1);
+    template
+        .replace("PREVNUM", &prev.to_string())
+        .replace("IDXNUM", &index.to_string())
+}
+
+fn write_file(root: &Path, subdir: &str, name: String, contents: String) {
+    let dir = root.join(subdir);
+    fs::create_dir_all(&dir).expect("create fixture subdir");
+    fs::write(dir.join(name), contents).expect("write fixture file");
+}
+
+fn build_synthetic_repo() -> TempDir {
+    let dir = tempfile::tempdir().expect("create temp repo");
+    let root = dir.path();
+
+    // A go.mod lets the Go resolver attempt module-relative resolution.
+    fs::write(root.join("go.mod"), "module benchmod\n\ngo 1.22\n").expect("write go.mod");
+
+    for index in 0..FILES_PER_LANG {
+        write_file(
+            root,
+            "src",
+            format!("file_{index}.rs"),
+            render(RUST_TEMPLATE, index),
+        );
+        write_file(
+            root,
+            "web",
+            format!("file_{index}.ts"),
+            render(TS_TEMPLATE, index),
+        );
+        write_file(
+            root,
+            "py",
+            format!("file_{index}.py"),
+            render(PY_TEMPLATE, index),
+        );
+        write_file(
+            root,
+            "gopkg",
+            format!("file_{index}.go"),
+            render(GO_TEMPLATE, index),
+        );
+    }
+
+    dir
+}
+
+fn bench_scan(c: &mut Criterion) {
+    let repo = build_synthetic_repo();
+    let root = repo.path().to_path_buf();
+    let config = ScanConfig::default();
+
+    c.bench_function("scan_synthetic_480_files", |b| {
+        b.iter(|| {
+            let summary = scan_path_with_config(black_box(&root), black_box(&config))
+                .expect("scan synthetic repo");
+            black_box(summary);
+        });
+    });
+}
+
+criterion_group! {
+    name = benches;
+    // A 480-file scan runs ~180ms, so the default 100 samples would take ~19s.
+    // 20 samples keeps `cargo bench` fast while still detecting the meaningful
+    // (>10%) change the shared parsed-AST work targets.
+    config = Criterion::default().sample_size(20);
+    targets = bench_scan
+}
+criterion_main!(benches);

--- a/docs/engineering/performance-budgets.md
+++ b/docs/engineering/performance-budgets.md
@@ -31,8 +31,25 @@ Track `scan_timings.accounted_engine_us()` from the timing breakdown and
 numbers as supporting context only; the budget should focus on accounted engine
 timing so CI host variance does not create noisy failures.
 
+## Benchmark
+
+A Criterion benchmark builds a synthetic 480-file multi-language repository
+(Rust, TypeScript, Python, Go) in a temp directory and measures full-scan wall
+time:
+
+```bash
+cargo bench --bench scan_bench
+```
+
+The benchmark lives in `benches/scan_bench.rs`. Use it to record a baseline
+before scan-engine changes — notably the shared parsed-AST work — and to prove
+the expected speedup afterwards. Criterion stores results under
+`target/criterion` and reports the delta versus the previous run, so benchmark
+`main` first, then the change branch.
+
 ## Fixture Direction
 
 Add small, medium, and large synthetic repositories before enforcing this as a
 hard CI gate. The gate should fail on major regressions only after fixture timing
-is stable on the project CI runners.
+is stable on the project CI runners. The `scan_bench` synthetic repository is the
+first such fixture.


### PR DESCRIPTION
## Summary

Adds a Criterion benchmark for measuring RepoPilot full-scan throughput on a generated multi-language synthetic repository.

This establishes a baseline before deeper performance work, especially shared parsed-AST reuse and scan pipeline optimization.

## Type of change

- [x] Feature
- [x] Tests
- [x] Documentation
- [x] Repository maintenance
- [ ] Refactor
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Added Criterion as a dev dependency.
- Added a new benchmark target:

```bash
cargo bench --bench scan_bench
```

- Added benches/scan_bench.rs.
- The benchmark generates a synthetic repository with 480 source files:

  - Rust
  - TypeScript
  - Python
  - Go

- The benchmark measures scan_path_with_config over the generated repo.
- Added synthetic source templates that exercise:

  - file discovery
  - language detection
  - AST-based audits
  - control-flow nesting checks
  - import graph resolution
  - scan summary generation

- Updated CHANGELOG.md.

## Why

RepoPilot is getting more language-aware and architecture-aware.

Before adding shared parsed-AST caching and deeper scan optimizations, we need a repeatable benchmark that shows whether scan performance improves or regresses.

This benchmark gives us a stable baseline for future performance PRs.

## Architecture notes

- The benchmark uses the public scan API instead of reaching into internal scanner modules.
- Benchmark fixture generation is isolated inside the benchmark file.
- No production scan behavior is changed.
- No CLI behavior is changed.
- Criterion remains a dev dependency only.
- This prepares the project for measurable performance work instead of guessing whether refactors are faster.


## Behavior

No user-facing CLI behavior change is expected.

The new benchmark can be run manually with:
`cargo bench --bench scan_bench`

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo bench --bench scan_bench
cargo run -- scan .
```