### PR TITLE
refactor(analysis): add shared tree-sitter parse module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Folded the thin internal `engine` module into the scan pipeline as a co-located `scan::scanner::contract_stage` finding-contract validation stage and tidied scan-engine imports. Internal refactor only; no behavior or public API change.
 - Split the 519-line import `resolver` into per-language submodules (`graph::resolver::{rust, ts, python, go, jvm}`) with the dispatch entry point and shared `probe`/`normalize_path` helpers in the module root. Internal refactor only; no behavior or public API change.
 - Consolidated the four single-type `analysis` model files (`context`, `file_role`, `module_kind`, `language_family`) into one `analysis::model` module behind the existing `analysis::{ArchitectureContext, FileRole, ModuleKind, LanguageFamily}` re-exports. Internal refactor only; no behavior or public API change.
+- Centralized tree-sitter parser instances and grammar selection into a shared `analysis::parse` module (`ParseLanguage`, `parse`, `parse_label`) and migrated the deep-control-flow audit onto it, removing its duplicated thread-local parsers. Internal refactor only; no behavior or public API change.
 
 ## [0.13.0] - 2026-05-25
 

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,4 +1,5 @@
 mod model;
+pub(crate) mod parse;
 pub mod path_classifier;
 
 pub use model::{ArchitectureContext, FileRole, LanguageFamily, ModuleKind};

--- a/src/analysis/parse.rs
+++ b/src/analysis/parse.rs
@@ -1,0 +1,139 @@
+//! Shared tree-sitter parsing.
+//!
+//! Centralizes the tree-sitter parser instances and grammar selection that were
+//! previously duplicated across the AST-based audits and the import graph. Each
+//! thread keeps one reusable parser per grammar via `thread_local!`, so parsing
+//! is cheap to repeat and safe under the parallel file pipeline.
+
+use std::cell::RefCell;
+use tree_sitter::{Language, Parser, Tree};
+
+/// A source grammar RepoPilot can parse with tree-sitter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ParseLanguage {
+    Rust,
+    TypeScript,
+    Tsx,
+    JavaScript,
+    Python,
+}
+
+impl ParseLanguage {
+    /// Maps a RepoPilot language label (as produced by language detection and
+    /// stored on `FileFacts.language`) to a parseable grammar, if any.
+    pub(crate) fn from_label(label: &str) -> Option<Self> {
+        match label {
+            "Rust" => Some(Self::Rust),
+            "TypeScript" => Some(Self::TypeScript),
+            "TypeScript React" => Some(Self::Tsx),
+            "JavaScript" | "JavaScript React" => Some(Self::JavaScript),
+            "Python" => Some(Self::Python),
+            _ => None,
+        }
+    }
+}
+
+thread_local! {
+    static RUST_PARSER: RefCell<Parser> =
+        RefCell::new(parser_for(tree_sitter_rust::LANGUAGE.into()));
+    static TS_PARSER: RefCell<Parser> =
+        RefCell::new(parser_for(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()));
+    static TSX_PARSER: RefCell<Parser> =
+        RefCell::new(parser_for(tree_sitter_typescript::LANGUAGE_TSX.into()));
+    static JS_PARSER: RefCell<Parser> =
+        RefCell::new(parser_for(tree_sitter_javascript::LANGUAGE.into()));
+    static PYTHON_PARSER: RefCell<Parser> =
+        RefCell::new(parser_for(tree_sitter_python::LANGUAGE.into()));
+}
+
+fn parser_for(language: Language) -> Parser {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&language)
+        .expect("tree-sitter grammar should load");
+    parser
+}
+
+/// Parses `content` with the grammar for `language`, reusing this thread's
+/// parser instance. Returns `None` only if tree-sitter fails to produce a tree.
+pub(crate) fn parse(content: &str, language: ParseLanguage) -> Option<Tree> {
+    let parser = match language {
+        ParseLanguage::Rust => &RUST_PARSER,
+        ParseLanguage::TypeScript => &TS_PARSER,
+        ParseLanguage::Tsx => &TSX_PARSER,
+        ParseLanguage::JavaScript => &JS_PARSER,
+        ParseLanguage::Python => &PYTHON_PARSER,
+    };
+    parser.with(|cell| {
+        let mut parser = cell.borrow_mut();
+        parser.reset();
+        parser.parse(content, None)
+    })
+}
+
+/// Convenience over [`parse`] that maps a language label first. Returns `None`
+/// when the label has no parseable grammar or tree-sitter fails.
+pub(crate) fn parse_label(content: &str, label: &str) -> Option<Tree> {
+    parse(content, ParseLanguage::from_label(label)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_known_language_labels() {
+        assert_eq!(ParseLanguage::from_label("Rust"), Some(ParseLanguage::Rust));
+        assert_eq!(
+            ParseLanguage::from_label("TypeScript"),
+            Some(ParseLanguage::TypeScript)
+        );
+        assert_eq!(
+            ParseLanguage::from_label("TypeScript React"),
+            Some(ParseLanguage::Tsx)
+        );
+        assert_eq!(
+            ParseLanguage::from_label("JavaScript"),
+            Some(ParseLanguage::JavaScript)
+        );
+        assert_eq!(
+            ParseLanguage::from_label("JavaScript React"),
+            Some(ParseLanguage::JavaScript)
+        );
+        assert_eq!(
+            ParseLanguage::from_label("Python"),
+            Some(ParseLanguage::Python)
+        );
+    }
+
+    #[test]
+    fn rejects_unparseable_labels() {
+        assert_eq!(ParseLanguage::from_label("Go"), None);
+        assert_eq!(ParseLanguage::from_label("Java"), None);
+        assert_eq!(ParseLanguage::from_label(""), None);
+    }
+
+    #[test]
+    fn parses_each_grammar() {
+        assert!(parse("fn main() {}", ParseLanguage::Rust).is_some());
+        assert!(parse("const x: number = 1;", ParseLanguage::TypeScript).is_some());
+        assert!(parse("const x = <div />;", ParseLanguage::Tsx).is_some());
+        assert!(parse("const x = 1;", ParseLanguage::JavaScript).is_some());
+        assert!(parse("x = 1\n", ParseLanguage::Python).is_some());
+    }
+
+    #[test]
+    fn reuses_thread_parser_across_calls() {
+        // The thread-local parser is reset between calls, so repeated parses on
+        // one thread must keep succeeding.
+        assert!(parse("fn a() {}", ParseLanguage::Rust).is_some());
+        assert!(parse("fn b() {}", ParseLanguage::Rust).is_some());
+    }
+
+    #[test]
+    fn parse_label_matches_grammar_dispatch() {
+        assert!(parse_label("fn main() {}", "Rust").is_some());
+        assert!(parse_label("def f():\n    pass\n", "Python").is_some());
+        assert!(parse_label("package main", "Go").is_none());
+    }
+}

--- a/src/audits/code_quality/deep_control_flow.rs
+++ b/src/audits/code_quality/deep_control_flow.rs
@@ -4,39 +4,10 @@ use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Sev
 use crate::knowledge::decision::apply_file_decision;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
-use std::cell::RefCell;
 use std::path::Path;
-use tree_sitter::{Node, Parser};
+use tree_sitter::Node;
 
 pub struct DeepControlFlowAudit;
-
-thread_local! {
-    static RUST_PARSER: RefCell<Parser> = RefCell::new({
-        let mut parser = Parser::new();
-        let _ = parser.set_language(&tree_sitter_rust::LANGUAGE.into());
-        parser
-    });
-    static TS_PARSER: RefCell<Parser> = RefCell::new({
-        let mut p = Parser::new();
-        let _ = p.set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into());
-        p
-    });
-    static TSX_PARSER: RefCell<Parser> = RefCell::new({
-        let mut p = Parser::new();
-        let _ = p.set_language(&tree_sitter_typescript::LANGUAGE_TSX.into());
-        p
-    });
-    static JS_PARSER: RefCell<Parser> = RefCell::new({
-        let mut p = Parser::new();
-        let _ = p.set_language(&tree_sitter_javascript::LANGUAGE.into());
-        p
-    });
-    static PYTHON_PARSER: RefCell<Parser> = RefCell::new({
-        let mut p = Parser::new();
-        let _ = p.set_language(&tree_sitter_python::LANGUAGE.into());
-        p
-    });
-}
 
 impl FileAudit for DeepControlFlowAudit {
     fn audit(&self, file: &FileFacts, config: &ScanConfig) -> Vec<Finding> {
@@ -57,7 +28,7 @@ impl FileAudit for DeepControlFlowAudit {
             return vec![];
         };
 
-        let Some(tree) = parse_content(content, language) else {
+        let Some(tree) = crate::analysis::parse::parse_label(content, language) else {
             return vec![];
         };
 
@@ -78,37 +49,6 @@ impl FileAudit for DeepControlFlowAudit {
                 apply_file_decision("code-quality.deep-control-flow", file, finding, None)
             })
             .collect()
-    }
-}
-
-fn parse_content(content: &str, language: &str) -> Option<tree_sitter::Tree> {
-    match language {
-        "Rust" => RUST_PARSER.with(|cell| {
-            let mut p = cell.borrow_mut();
-            p.reset();
-            p.parse(content, None)
-        }),
-        "TypeScript" => TS_PARSER.with(|cell| {
-            let mut p = cell.borrow_mut();
-            p.reset();
-            p.parse(content, None)
-        }),
-        "TypeScript React" => TSX_PARSER.with(|cell| {
-            let mut p = cell.borrow_mut();
-            p.reset();
-            p.parse(content, None)
-        }),
-        "JavaScript" | "JavaScript React" => JS_PARSER.with(|cell| {
-            let mut p = cell.borrow_mut();
-            p.reset();
-            p.parse(content, None)
-        }),
-        "Python" => PYTHON_PARSER.with(|cell| {
-            let mut p = cell.borrow_mut();
-            p.reset();
-            p.parse(content, None)
-        }),
-        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary

Centralizes tree-sitter parser setup and grammar dispatch into a shared `analysis::parse` module.

This is an internal refactor with no intended user-facing behavior change.

## Type of change

- [x] Refactor
- [x] Tests
- [x] Repository maintenance
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- Added a shared `analysis::parse` module.
- Added `ParseLanguage` for supported tree-sitter grammars:
  - Rust
  - TypeScript
  - TSX
  - JavaScript
  - Python
- Added `ParseLanguage::from_label(...)` to map RepoPilot language labels to parseable grammars.
- Added shared parse helpers:
  - `parse`
  - `parse_label`
- Centralized reusable thread-local tree-sitter parser instances.
- Migrated `DeepControlFlowAudit` to use `analysis::parse::parse_label`.
- Removed duplicated thread-local parser setup from `deep_control_flow`.
- Added tests for:
  - known language label mapping;
  - unsupported language labels;
  - parsing every supported grammar;
  - parser reuse across repeated calls;
  - `parse_label` dispatch behavior.
- Updated `CHANGELOG.md`.

## Why

AST-based audits should not each own their own tree-sitter parser setup.

Keeping parser initialization and grammar selection in one shared module makes future AST-based work easier, safer, and less duplicated.

This PR prepares RepoPilot for the next performance step: shared parsed-document reuse across audits.

## Architecture notes

- `analysis::parse` owns tree-sitter parser setup and grammar selection.
- AST-based audits can depend on `analysis::parse` instead of managing parser instances themselves.
- `DeepControlFlowAudit` remains responsible only for control-flow nesting logic.
- Parser instances remain thread-local, which keeps them safe for the parallel scan pipeline.
- No CLI behavior changes are expected.
- No public API behavior changes are expected.

## Behavior

No user-facing behavior change is expected.

The same deep-control-flow audit now uses the shared parse module instead of local duplicated parser setup.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .
cargo bench --bench scan_bench