### PR TITLE
perf(scan): add lazy parse-once file view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Split the 519-line import `resolver` into per-language submodules (`graph::resolver::{rust, ts, python, go, jvm}`) with the dispatch entry point and shared `probe`/`normalize_path` helpers in the module root. Internal refactor only; no behavior or public API change.
 - Consolidated the four single-type `analysis` model files (`context`, `file_role`, `module_kind`, `language_family`) into one `analysis::model` module behind the existing `analysis::{ArchitectureContext, FileRole, ModuleKind, LanguageFamily}` re-exports. Internal refactor only; no behavior or public API change.
 - Centralized tree-sitter parser instances and grammar selection into a shared `analysis::parse` module (`ParseLanguage`, `parse`, `parse_label`) and migrated the deep-control-flow audit onto it, removing its duplicated thread-local parsers. Internal refactor only; no behavior or public API change.
+- Added a lazy, parse-once `ParsedFile` view and a defaulted `FileAudit::audit_parsed` method so the scan pipeline parses each file at most once and shares the syntax tree across audits. The deep-control-flow audit now consumes the shared tree; other file audits inherit the default and are unaffected. Internal change only; no behavior or finding change.
 
 ## [0.13.0] - 2026-05-25
 

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,5 +1,6 @@
 mod model;
-pub(crate) mod parse;
+#[doc(hidden)]
+pub mod parse;
 pub mod path_classifier;
 
 pub use model::{ArchitectureContext, FileRole, LanguageFamily, ModuleKind};

--- a/src/analysis/parse.rs
+++ b/src/analysis/parse.rs
@@ -5,7 +5,8 @@
 //! thread keeps one reusable parser per grammar via `thread_local!`, so parsing
 //! is cheap to repeat and safe under the parallel file pipeline.
 
-use std::cell::RefCell;
+use crate::scan::facts::FileFacts;
+use std::cell::{OnceCell, RefCell};
 use tree_sitter::{Language, Parser, Tree};
 
 /// A source grammar RepoPilot can parse with tree-sitter.
@@ -77,6 +78,47 @@ pub(crate) fn parse_label(content: &str, label: &str) -> Option<Tree> {
     parse(content, ParseLanguage::from_label(label)?)
 }
 
+/// A parse-once view over a single file's source.
+///
+/// The syntax tree is produced lazily on the first [`ParsedFile::tree`] call and
+/// cached, so multiple audits inspecting the same file share one parse instead
+/// of re-parsing per audit. Files that no audit inspects are never parsed.
+pub struct ParsedFile<'a> {
+    content: &'a str,
+    language_label: Option<&'a str>,
+    tree: OnceCell<Option<Tree>>,
+}
+
+impl<'a> ParsedFile<'a> {
+    pub(crate) fn new(content: &'a str, language_label: Option<&'a str>) -> Self {
+        Self {
+            content,
+            language_label,
+            tree: OnceCell::new(),
+        }
+    }
+
+    /// Builds a parse view from a file's facts, borrowing its content and
+    /// detected language label. Parsing is deferred until [`ParsedFile::tree`].
+    pub(crate) fn for_facts(file: &'a FileFacts) -> Self {
+        Self::new(
+            file.content.as_deref().unwrap_or(""),
+            file.language.as_deref(),
+        )
+    }
+
+    /// Lazily parses (once) and returns the syntax tree, or `None` when the file
+    /// has no parseable grammar or tree-sitter cannot produce a tree.
+    pub(crate) fn tree(&self) -> Option<&Tree> {
+        self.tree
+            .get_or_init(|| {
+                self.language_label
+                    .and_then(|label| parse_label(self.content, label))
+            })
+            .as_ref()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -135,5 +177,20 @@ mod tests {
         assert!(parse_label("fn main() {}", "Rust").is_some());
         assert!(parse_label("def f():\n    pass\n", "Python").is_some());
         assert!(parse_label("package main", "Go").is_none());
+    }
+
+    #[test]
+    fn parsed_file_parses_once_and_caches() {
+        let parsed = ParsedFile::new("fn main() {}", Some("Rust"));
+        let first = parsed.tree().expect("rust source should parse") as *const Tree;
+        let second = parsed.tree().expect("cached tree should be returned") as *const Tree;
+        // Same cached tree instance on repeat access => parsed at most once.
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn parsed_file_without_grammar_has_no_tree() {
+        assert!(ParsedFile::new("package main", Some("Go")).tree().is_none());
+        assert!(ParsedFile::new("anything", None).tree().is_none());
     }
 }

--- a/src/audits/code_quality/deep_control_flow.rs
+++ b/src/audits/code_quality/deep_control_flow.rs
@@ -1,4 +1,4 @@
-use crate::analysis::{FileRole, classify_file_architecture};
+use crate::analysis::{FileRole, classify_file_architecture, parse::ParsedFile};
 use crate::audits::traits::FileAudit;
 use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use crate::knowledge::decision::apply_file_decision;
@@ -11,6 +11,22 @@ pub struct DeepControlFlowAudit;
 
 impl FileAudit for DeepControlFlowAudit {
     fn audit(&self, file: &FileFacts, config: &ScanConfig) -> Vec<Finding> {
+        // Direct entry (tests, non-pipeline callers): build a one-off parse view.
+        self.analyze(file, &ParsedFile::for_facts(file), config)
+    }
+
+    fn audit_parsed(
+        &self,
+        file: &FileFacts,
+        parsed: &ParsedFile,
+        config: &ScanConfig,
+    ) -> Vec<Finding> {
+        self.analyze(file, parsed, config)
+    }
+}
+
+impl DeepControlFlowAudit {
+    fn analyze(&self, file: &FileFacts, parsed: &ParsedFile, config: &ScanConfig) -> Vec<Finding> {
         let arch_ctx = classify_file_architecture(file, config);
         if arch_ctx.file_role != FileRole::Production {
             return vec![];
@@ -28,7 +44,7 @@ impl FileAudit for DeepControlFlowAudit {
             return vec![];
         };
 
-        let Some(tree) = crate::analysis::parse::parse_label(content, language) else {
+        let Some(tree) = parsed.tree() else {
             return vec![];
         };
 

--- a/src/audits/traits.rs
+++ b/src/audits/traits.rs
@@ -1,9 +1,23 @@
+use crate::analysis::parse::ParsedFile;
 use crate::findings::types::Finding;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::{FileFacts, ScanFacts};
 
 pub trait FileAudit: Send + Sync {
     fn audit(&self, file: &FileFacts, config: &ScanConfig) -> Vec<Finding>;
+
+    /// Audits a file with a shared, parse-once [`ParsedFile`] view. The scan
+    /// pipeline calls this so AST-based audits can reuse one syntax tree per
+    /// file instead of each re-parsing. Audits that need an AST override this;
+    /// the default ignores the parsed view and delegates to [`FileAudit::audit`].
+    fn audit_parsed(
+        &self,
+        file: &FileFacts,
+        _parsed: &ParsedFile,
+        config: &ScanConfig,
+    ) -> Vec<Finding> {
+        self.audit(file, config)
+    }
 }
 
 pub trait ProjectAudit {

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -1,3 +1,4 @@
+use crate::analysis::parse::ParsedFile;
 use crate::audits::code_quality::complexity::count_branches;
 use crate::audits::context::classify_file;
 use crate::audits::traits::FileAudit;
@@ -206,8 +207,13 @@ fn process_file_inner(
 
     let context = PerFileContext::from_file(&full_facts);
     let mut findings = Vec::new();
-    for audit in file_audits {
-        findings.extend(audit.audit(&full_facts, config));
+    {
+        // Parse the file at most once and share the syntax tree across audits.
+        // Scoped so the borrow of `full_facts` ends before it is moved below.
+        let parsed = ParsedFile::for_facts(&full_facts);
+        for audit in file_audits {
+            findings.extend(audit.audit_parsed(&full_facts, &parsed, config));
+        }
     }
 
     Ok(PerFileResult {


### PR DESCRIPTION
## Summary

Adds a lazy parse-once `ParsedFile` view so file audits can share the same syntax tree during scan processing.

This builds on the shared `analysis::parse` module and prepares RepoPilot for more AST-based audits without repeatedly parsing the same file.

## Type of change

- [x] Refactor
- [x] Performance
- [x] Tests
- [x] Repository maintenance
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- Added `ParsedFile`, a lazy parse-once view over a file's source.
- `ParsedFile::tree()` parses on first access and caches the result.
- Added `ParsedFile::for_facts(...)` to build a parsed view from `FileFacts`.
- Added a default `FileAudit::audit_parsed(...)` method.
- Updated the scan pipeline to create one `ParsedFile` per processed file and pass it to all file audits.
- Migrated `DeepControlFlowAudit` to consume the shared parsed tree.
- Kept non-AST audits unaffected through the default `audit_parsed` implementation.
- Added tests proving:
  - parsed trees are cached;
  - unsupported languages return no tree;
  - repeated tree access returns the same cached instance.
- Updated `CHANGELOG.md`.

## Why

RepoPilot is adding more AST-based code-quality and architecture rules.

Without a shared parsed-file view, every AST-based audit can end up parsing the same file independently. That creates duplicated work and makes future performance harder to control.

This PR moves parsing closer to the scan pipeline and lets audits reuse the same syntax tree.

## Architecture notes

- `analysis::parse` owns parsing primitives.
- `ParsedFile` owns lazy per-file parse state.
- `FileAudit::audit_parsed` gives AST-aware audits access to the shared parse view.
- Non-AST audits continue using the existing `audit` flow through the default implementation.
- `DeepControlFlowAudit` now focuses on control-flow analysis instead of owning parse mechanics.
- The scan pipeline remains responsible for per-file orchestration.
- No finding behavior change is expected.

## Behavior

No CLI behavior change is expected.

The same audits should produce the same findings, but AST-based audits can now share a parsed syntax tree per file.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .
cargo bench --bench scan_bench