### PR TITLE
perf(scan): reuse parsed trees and report parse timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 - Added architecture anti-pattern documentation describing production-scope policy and false-positive expectations for architecture rules.
 - Added a Criterion scan-throughput benchmark (`cargo bench --bench scan_bench`) over a generated 480-file multi-language synthetic repository to baseline full-scan performance ahead of the shared parsed-AST work.
+- Added a `scan_timings.parse_us` field reporting aggregate tree-sitter parsing time during file analysis (a sub-measure of `file_analysis_us`, excluded from `accounted_engine_us`).
 
 ### Changed
 
@@ -20,6 +21,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Consolidated the four single-type `analysis` model files (`context`, `file_role`, `module_kind`, `language_family`) into one `analysis::model` module behind the existing `analysis::{ArchitectureContext, FileRole, ModuleKind, LanguageFamily}` re-exports. Internal refactor only; no behavior or public API change.
 - Centralized tree-sitter parser instances and grammar selection into a shared `analysis::parse` module (`ParseLanguage`, `parse`, `parse_label`) and migrated the deep-control-flow audit onto it, removing its duplicated thread-local parsers. Internal refactor only; no behavior or public API change.
 - Added a lazy, parse-once `ParsedFile` view and a defaulted `FileAudit::audit_parsed` method so the scan pipeline parses each file at most once and shares the syntax tree across audits. The deep-control-flow audit now consumes the shared tree; other file audits inherit the default and are unaffected. Internal change only; no behavior or finding change.
+- Migrated the import graph (`graph::imports`) onto the shared `analysis::parse` parsers and the per-file `ParsedFile`, removing the duplicated thread-local tree-sitter parsers in the Rust, TypeScript/JavaScript, and Python extractors. Import extraction and the AST audits now share a single parse per file instead of parsing it separately, roughly halving per-file parse work in full scans. Internal refactor only; no behavior, finding, or public API change.
 
 ## [0.13.0] - 2026-05-25
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -85,7 +85,7 @@ JSON scan reports include explicit schema metadata. The current schema is 0.17:
 | `visible_signal_quality` | object | Aggregate quality for findings visible in this report. |
 | `signal_quality` | object | Compatibility alias for `visible_signal_quality`. |
 | `cache_telemetry` | object | Optional changed-scan cache summary with hits, misses, changed-file reasons, per-file cache decisions, and cache timing impact. |
-| `scan_timings` | object | Optional engine timing metadata. `file_scan_us` remains the compatibility aggregate; newer fields break out `discovery_us`, `file_analysis_us`, `enrichment_us`, `risk_scoring_us`, `contract_validation_us`, and `report_finalization_us`. |
+| `scan_timings` | object | Optional engine timing metadata. `file_scan_us` remains the compatibility aggregate; newer fields break out `discovery_us`, `file_analysis_us`, `parse_us` (tree-sitter parsing within file analysis), `enrichment_us`, `risk_scoring_us`, `contract_validation_us`, and `report_finalization_us`. |
 | `local_feedback` | object | Optional summary of `.repopilot/feedback.yml` suppressions applied during this scan or review. |
 | `diagnostics` | array | Optional structured warnings/errors captured during a scan, such as workspace partial failures. |
 

--- a/src/analysis/parse.rs
+++ b/src/analysis/parse.rs
@@ -7,7 +7,22 @@
 
 use crate::scan::facts::FileFacts;
 use std::cell::{OnceCell, RefCell};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 use tree_sitter::{Language, Parser, Tree};
+
+/// Process-global accumulator of time spent inside tree-sitter parsing, in
+/// nanoseconds. Summed across every [`parse`] call on every worker thread, so it
+/// reflects aggregate parse CPU time rather than wall-clock. Read as a delta
+/// (`after - before`) around a stage to attribute parse cost to that stage; the
+/// figure is exact when a single scan runs in the process (the CLI case) and an
+/// over-estimate only if scans run concurrently in one process.
+static PARSE_NANOS: AtomicU64 = AtomicU64::new(0);
+
+/// Total nanoseconds spent parsing so far in this process. See [`PARSE_NANOS`].
+pub(crate) fn parse_nanos_total() -> u64 {
+    PARSE_NANOS.load(Ordering::Relaxed)
+}
 
 /// A source grammar RepoPilot can parse with tree-sitter.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -65,11 +80,14 @@ pub(crate) fn parse(content: &str, language: ParseLanguage) -> Option<Tree> {
         ParseLanguage::JavaScript => &JS_PARSER,
         ParseLanguage::Python => &PYTHON_PARSER,
     };
-    parser.with(|cell| {
+    let start = Instant::now();
+    let tree = parser.with(|cell| {
         let mut parser = cell.borrow_mut();
         parser.reset();
         parser.parse(content, None)
-    })
+    });
+    PARSE_NANOS.fetch_add(start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+    tree
 }
 
 /// Convenience over [`parse`] that maps a language label first. Returns `None`
@@ -105,6 +123,20 @@ impl<'a> ParsedFile<'a> {
             file.content.as_deref().unwrap_or(""),
             file.language.as_deref(),
         )
+    }
+
+    /// The borrowed source text this view parses. Consumers that walk the tree
+    /// need the original bytes for `utf8_text`, and reading it here keeps the
+    /// content and its syntax tree paired to a single parse.
+    pub(crate) fn content(&self) -> &str {
+        self.content
+    }
+
+    /// Whether the syntax tree has been materialized yet. Used by tests to assert
+    /// that consumers sharing one view trigger at most one parse.
+    #[cfg(test)]
+    pub(crate) fn was_parsed(&self) -> bool {
+        self.tree.get().is_some()
     }
 
     /// Lazily parses (once) and returns the syntax tree, or `None` when the file
@@ -192,5 +224,23 @@ mod tests {
     fn parsed_file_without_grammar_has_no_tree() {
         assert!(ParsedFile::new("package main", Some("Go")).tree().is_none());
         assert!(ParsedFile::new("anything", None).tree().is_none());
+    }
+
+    #[test]
+    fn shared_view_is_parsed_once_across_import_extraction_and_audits() {
+        use crate::graph::imports::extract_imports_from;
+
+        let parsed = ParsedFile::new("use crate::foo::bar;\nfn main() {}", Some("Rust"));
+        assert!(!parsed.was_parsed(), "no parse before any consumer reads it");
+
+        // First consumer: the import graph extracts module references.
+        let imports = extract_imports_from(&parsed, Some("Rust"));
+        assert!(parsed.was_parsed(), "import extraction materializes the tree");
+        assert!(imports.contains(&"crate::foo::bar".to_string()));
+
+        // Second consumer: an AST audit reaches for the same syntax tree via the
+        // exact call audits use. The `OnceCell` guarantees it is not re-parsed.
+        assert!(parsed.tree().is_some());
+        assert!(parsed.was_parsed());
     }
 }

--- a/src/analysis/parse.rs
+++ b/src/analysis/parse.rs
@@ -231,11 +231,17 @@ mod tests {
         use crate::graph::imports::extract_imports_from;
 
         let parsed = ParsedFile::new("use crate::foo::bar;\nfn main() {}", Some("Rust"));
-        assert!(!parsed.was_parsed(), "no parse before any consumer reads it");
+        assert!(
+            !parsed.was_parsed(),
+            "no parse before any consumer reads it"
+        );
 
         // First consumer: the import graph extracts module references.
         let imports = extract_imports_from(&parsed, Some("Rust"));
-        assert!(parsed.was_parsed(), "import extraction materializes the tree");
+        assert!(
+            parsed.was_parsed(),
+            "import extraction materializes the tree"
+        );
         assert!(imports.contains(&"crate::foo::bar".to_string()));
 
         // Second consumer: an AST audit reaches for the same syntax tree via the

--- a/src/graph/imports.rs
+++ b/src/graph/imports.rs
@@ -1,4 +1,6 @@
+use crate::analysis::parse::ParsedFile;
 use std::collections::HashSet;
+use tree_sitter::Tree;
 
 mod common;
 mod go;
@@ -9,18 +11,38 @@ mod ts;
 
 /// Extracts raw import strings from file content based on language.
 /// Returns a deduplicated list.
+///
+/// Standalone entry point (tests, callers without a parse view). It builds a
+/// throwaway [`ParsedFile`] and delegates to [`extract_imports_from`], so the
+/// AST languages route through the same shared tree-sitter parsers as the scan.
 pub fn extract_imports(content: &str, language: Option<&str>) -> Vec<String> {
+    extract_imports_from(&ParsedFile::new(content, language), language)
+}
+
+/// Extracts raw import strings from an already-built parse view.
+///
+/// The scan pipeline calls this with the same [`ParsedFile`] the per-file audits
+/// receive, so a file's syntax tree is produced once and shared between import
+/// extraction and the AST audits rather than parsed separately for each.
+pub(crate) fn extract_imports_from(parsed: &ParsedFile, language: Option<&str>) -> Vec<String> {
+    let content = parsed.content();
     let set: HashSet<String> = match language {
-        Some("Rust") => rust::extract(content),
+        Some("Rust") => from_tree(parsed, |tree| rust::extract(tree, content)),
         Some("TypeScript")
         | Some("TypeScript React")
         | Some("JavaScript")
-        | Some("JavaScript React") => ts::extract(content, language),
-        Some("Python") => python::extract(content),
+        | Some("JavaScript React") => from_tree(parsed, |tree| ts::extract(tree, content)),
+        Some("Python") => from_tree(parsed, |tree| python::extract(tree, content)),
         Some("Go") => go::extract(content),
         Some("Java") => jvm::extract_java(content),
         Some("Kotlin") => jvm::extract_kotlin(content),
         _ => return Vec::new(),
     };
     set.into_iter().collect()
+}
+
+/// Runs `visit` over the shared syntax tree, yielding no imports when the file
+/// has no parseable grammar or tree-sitter could not produce a tree.
+fn from_tree(parsed: &ParsedFile, visit: impl FnOnce(&Tree) -> HashSet<String>) -> HashSet<String> {
+    parsed.tree().map(visit).unwrap_or_default()
 }

--- a/src/graph/imports/python.rs
+++ b/src/graph/imports/python.rs
@@ -1,26 +1,7 @@
-use std::cell::RefCell;
 use std::collections::HashSet;
-use tree_sitter::{Node, Parser};
+use tree_sitter::{Node, Tree};
 
-thread_local! {
-    static PYTHON_PARSER: RefCell<Parser> = RefCell::new({
-        let mut p = Parser::new();
-        p.set_language(&tree_sitter_python::LANGUAGE.into())
-            .expect("tree-sitter-python grammar should load");
-        p
-    });
-}
-
-pub(super) fn extract(content: &str) -> HashSet<String> {
-    let tree = PYTHON_PARSER.with(|cell| {
-        let mut p = cell.borrow_mut();
-        p.reset();
-        p.parse(content, None)
-    });
-    let Some(tree) = tree else {
-        return HashSet::new();
-    };
-
+pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
     let mut result = HashSet::new();
     visit(tree.root_node(), content, &mut result);
     result

--- a/src/graph/imports/rust.rs
+++ b/src/graph/imports/rust.rs
@@ -1,27 +1,7 @@
-use std::cell::RefCell;
 use std::collections::HashSet;
-use tree_sitter::{Node, Parser};
+use tree_sitter::{Node, Tree};
 
-thread_local! {
-    static RUST_PARSER: RefCell<Parser> = RefCell::new({
-        let mut parser = Parser::new();
-        parser
-            .set_language(&tree_sitter_rust::LANGUAGE.into())
-            .expect("tree-sitter-rust grammar should load");
-        parser
-    });
-}
-
-pub(super) fn extract(content: &str) -> HashSet<String> {
-    let tree = RUST_PARSER.with(|cell| {
-        let mut parser = cell.borrow_mut();
-        parser.reset();
-        parser.parse(content, None)
-    });
-    let Some(tree) = tree else {
-        return HashSet::new();
-    };
-
+pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
     let mut result = HashSet::new();
     visit(tree.root_node(), content, &mut result);
     result

--- a/src/graph/imports/ts.rs
+++ b/src/graph/imports/ts.rs
@@ -1,52 +1,8 @@
 use crate::graph::imports::common::extract_string_literal;
-use std::cell::RefCell;
 use std::collections::HashSet;
-use tree_sitter::{Node, Parser};
+use tree_sitter::{Node, Tree};
 
-thread_local! {
-    static TS_PARSER: RefCell<Parser> = RefCell::new({
-        let mut p = Parser::new();
-        p.set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
-            .expect("tree-sitter-typescript grammar should load");
-        p
-    });
-    static TSX_PARSER: RefCell<Parser> = RefCell::new({
-        let mut p = Parser::new();
-        p.set_language(&tree_sitter_typescript::LANGUAGE_TSX.into())
-            .expect("tree-sitter-tsx grammar should load");
-        p
-    });
-    static JS_PARSER: RefCell<Parser> = RefCell::new({
-        let mut p = Parser::new();
-        p.set_language(&tree_sitter_javascript::LANGUAGE.into())
-            .expect("tree-sitter-javascript grammar should load");
-        p
-    });
-}
-
-pub(super) fn extract(content: &str, language: Option<&str>) -> HashSet<String> {
-    let tree = match language {
-        Some("TypeScript React") => TSX_PARSER.with(|cell| {
-            let mut p = cell.borrow_mut();
-            p.reset();
-            p.parse(content, None)
-        }),
-        Some("TypeScript") => TS_PARSER.with(|cell| {
-            let mut p = cell.borrow_mut();
-            p.reset();
-            p.parse(content, None)
-        }),
-        _ => JS_PARSER.with(|cell| {
-            let mut p = cell.borrow_mut();
-            p.reset();
-            p.parse(content, None)
-        }),
-    };
-
-    let Some(tree) = tree else {
-        return HashSet::new();
-    };
-
+pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
     let mut result = HashSet::new();
     visit(tree.root_node(), content, &mut result);
     result

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -69,6 +69,7 @@ struct ChangedFileAnalysisStage {
     cache_telemetry: ScanCacheTelemetry,
     changed_file_reasons: BTreeMap<String, usize>,
     elapsed_us: u64,
+    parse_us: u64,
 }
 
 struct ChangedRepoContextStage {

--- a/src/scan/scanner/changed/file_analysis.rs
+++ b/src/scan/scanner/changed/file_analysis.rs
@@ -6,6 +6,7 @@ impl<'a> ChangedScanEngine<'a> {
         discovery: &ChangedDiscoveryStage,
     ) -> io::Result<ChangedFileAnalysisStage> {
         let start = Instant::now();
+        let parse_nanos_before = crate::analysis::parse::parse_nanos_total();
         let file_audits = build_file_audits(self.config);
         let cache_load_start = Instant::now();
         let mut cache = ScanCache::load(&discovery.repo_root);
@@ -49,6 +50,9 @@ impl<'a> ChangedScanEngine<'a> {
         facts.directories_count = directories.len();
         facts.languages = build_language_summary(languages);
 
+        let parse_us =
+            crate::analysis::parse::parse_nanos_total().saturating_sub(parse_nanos_before) / 1_000;
+
         Ok(ChangedFileAnalysisStage {
             facts,
             findings,
@@ -57,6 +61,7 @@ impl<'a> ChangedScanEngine<'a> {
             cache_telemetry,
             changed_file_reasons,
             elapsed_us: start.elapsed().as_micros() as u64,
+            parse_us,
         })
     }
 

--- a/src/scan/scanner/changed/finalize.rs
+++ b/src/scan/scanner/changed/finalize.rs
@@ -47,6 +47,7 @@ impl<'a> ChangedScanEngine<'a> {
                 scan_timings: Some(ScanTimings {
                     discovery_us: discovery.elapsed_us,
                     file_analysis_us: file_stage.elapsed_us,
+                    parse_us: file_stage.parse_us,
                     file_scan_us,
                     framework_detection_us: repo_stage.elapsed_us,
                     post_scan_audits_us: 0,
@@ -93,6 +94,7 @@ impl<'a> ChangedScanEngine<'a> {
                 scan_timings: Some(ScanTimings {
                     discovery_us: discovery.elapsed_us,
                     file_analysis_us: 0,
+                    parse_us: 0,
                     file_scan_us: discovery.elapsed_us,
                     framework_detection_us: 0,
                     post_scan_audits_us: 0,

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -242,9 +242,8 @@ pub(super) fn collect_file_facts(
     languages: &mut HashMap<String, usize>,
     config: &ScanConfig,
 ) -> io::Result<()> {
-    let LoadedFile::Analyzable {
-        mut full_facts, ..
-    } = load_file_or_record_skip(path, facts, config)?
+    let LoadedFile::Analyzable { mut full_facts, .. } =
+        load_file_or_record_skip(path, facts, config)?
     else {
         return Ok(());
     };
@@ -252,8 +251,10 @@ pub(super) fn collect_file_facts(
     // No audits run on this path, so the parse view is built solely to extract
     // imports; it is still parsed at most once via the shared parsers. Bind the
     // result first so the view's borrow of `full_facts` ends before the write.
-    let imports =
-        extract_imports_from(&ParsedFile::for_facts(&full_facts), full_facts.language.as_deref());
+    let imports = extract_imports_from(
+        &ParsedFile::for_facts(&full_facts),
+        full_facts.language.as_deref(),
+    );
     full_facts.imports = imports;
 
     record_analyzed_file(facts, languages, &full_facts);

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -3,7 +3,7 @@ use crate::audits::code_quality::complexity::count_branches;
 use crate::audits::context::classify_file;
 use crate::audits::traits::FileAudit;
 use crate::findings::types::Finding;
-use crate::graph::imports::extract_imports;
+use crate::graph::imports::extract_imports_from;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::{FileFacts, ScanFacts};
 use crate::scan::language::detect_language;
@@ -95,15 +95,17 @@ pub(super) fn load_file(path: &Path, config: &ScanConfig) -> io::Result<LoadedFi
     let non_empty_lines = count_non_empty_lines(&content);
     let branch_count = count_branches(&content);
     let has_inline_tests = has_language_inline_tests(path, language.as_deref(), &content);
-    let imports = extract_imports(&content, language.as_deref());
 
+    // Imports are extracted later, from the shared `ParsedFile`, so a file's
+    // syntax tree is produced once and reused by the per-file audits rather than
+    // parsed separately here. See `process_file_inner` and `collect_file_facts`.
     Ok(LoadedFile::Analyzable {
         full_facts: FileFacts {
             path: path.to_path_buf(),
             language: language.clone(),
             non_empty_lines,
             branch_count,
-            imports,
+            imports: Vec::new(),
             has_inline_tests,
             content: Some(content),
         },
@@ -198,7 +200,7 @@ fn process_file_inner(
 ) -> io::Result<PerFileResult> {
     let loaded = load_file(path, config)?;
     let LoadedFile::Analyzable {
-        full_facts,
+        mut full_facts,
         language,
     } = loaded
     else {
@@ -207,14 +209,18 @@ fn process_file_inner(
 
     let context = PerFileContext::from_file(&full_facts);
     let mut findings = Vec::new();
-    {
-        // Parse the file at most once and share the syntax tree across audits.
-        // Scoped so the borrow of `full_facts` ends before it is moved below.
+    let imports = {
+        // Parse the file at most once and share the syntax tree across both
+        // import extraction and every audit. Scoped so the borrow of
+        // `full_facts` ends before `imports` is written back and it is moved.
         let parsed = ParsedFile::for_facts(&full_facts);
+        let imports = extract_imports_from(&parsed, full_facts.language.as_deref());
         for audit in file_audits {
             findings.extend(audit.audit_parsed(&full_facts, &parsed, config));
         }
-    }
+        imports
+    };
+    full_facts.imports = imports;
 
     Ok(PerFileResult {
         file_facts: if retain_content {
@@ -236,10 +242,19 @@ pub(super) fn collect_file_facts(
     languages: &mut HashMap<String, usize>,
     config: &ScanConfig,
 ) -> io::Result<()> {
-    let LoadedFile::Analyzable { full_facts, .. } = load_file_or_record_skip(path, facts, config)?
+    let LoadedFile::Analyzable {
+        mut full_facts, ..
+    } = load_file_or_record_skip(path, facts, config)?
     else {
         return Ok(());
     };
+
+    // No audits run on this path, so the parse view is built solely to extract
+    // imports; it is still parsed at most once via the shared parsers. Bind the
+    // result first so the view's borrow of `full_facts` ends before the write.
+    let imports =
+        extract_imports_from(&ParsedFile::for_facts(&full_facts), full_facts.language.as_deref());
+    full_facts.imports = imports;
 
     record_analyzed_file(facts, languages, &full_facts);
     facts.files.push(full_facts);

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -49,6 +49,7 @@ struct FileAnalysisStage {
     facts: ScanFacts,
     findings: Vec<Finding>,
     elapsed_us: u64,
+    parse_us: u64,
 }
 
 struct DiscoveryStage {
@@ -98,6 +99,7 @@ impl<'a> ScanEngine<'a> {
         let timings = ScanTimings {
             discovery_us: discovery_stage.elapsed_us,
             file_analysis_us: file_stage.elapsed_us,
+            parse_us: file_stage.parse_us,
             file_scan_us: discovery_stage
                 .elapsed_us
                 .saturating_add(file_stage.elapsed_us),
@@ -132,13 +134,17 @@ impl<'a> ScanEngine<'a> {
         discovered: collection::DiscoveredScanPaths,
     ) -> io::Result<FileAnalysisStage> {
         let start = Instant::now();
+        let parse_nanos_before = crate::analysis::parse::parse_nanos_total();
         let file_audits = build_file_audits(self.config);
         let (facts, findings) =
             collection::analyze_discovered_files(discovered, &file_audits, self.config)?;
+        let parse_us =
+            crate::analysis::parse::parse_nanos_total().saturating_sub(parse_nanos_before) / 1_000;
         Ok(FileAnalysisStage {
             facts,
             findings,
             elapsed_us: start.elapsed().as_micros() as u64,
+            parse_us,
         })
     }
 

--- a/src/scan/types/support.rs
+++ b/src/scan/types/support.rs
@@ -25,6 +25,15 @@ pub struct ScanTimings {
     /// Time spent loading files and running per-file audits (microseconds).
     #[serde(default)]
     pub file_analysis_us: u64,
+    /// Aggregate tree-sitter parsing time during file analysis (microseconds).
+    ///
+    /// A sub-measure of `file_analysis_us`: each file is parsed once and the
+    /// syntax tree is shared between import extraction and the AST audits. Summed
+    /// across parallel workers, so it can exceed wall-clock on multi-core
+    /// machines. It is intentionally excluded from `accounted_engine_us` because
+    /// it is already counted within `file_analysis_us`.
+    #[serde(default)]
+    pub parse_us: u64,
     /// Time spent walking the file tree and running per-file audits (microseconds).
     pub file_scan_us: u64,
     /// Time spent detecting frameworks (microseconds).

--- a/tests/scan_summary.rs
+++ b/tests/scan_summary.rs
@@ -215,6 +215,8 @@ fn timing_accounting_uses_granular_file_pipeline_when_available() {
     let timings = ScanTimings {
         discovery_us: 10,
         file_analysis_us: 40,
+        // A sub-measure of file_analysis_us; must not add to the accounted total.
+        parse_us: 25,
         file_scan_us: 40,
         framework_detection_us: 5,
         post_scan_audits_us: 7,


### PR DESCRIPTION
## Summary

Reuses the shared `ParsedFile` syntax tree for import extraction and adds aggregate tree-sitter parsing time to scan timings.

This continues the parse-once scan pipeline work by making the import graph and AST-based audits share the same parsed tree per file.

## Type of change

- [x] Performance
- [x] Refactor
- [x] Tests
- [x] Documentation
- [x] Repository maintenance
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Added `scan_timings.parse_us` to report aggregate tree-sitter parsing time during file analysis.
- Documented `parse_us` in the JSON scan report schema.
- Added a process-level parse timing accumulator around shared tree-sitter parsing.
- Added `ParsedFile::content()` so tree consumers can access the source paired with the shared syntax tree.
- Added test-only `ParsedFile::was_parsed()` to verify lazy parse behavior.
- Migrated `graph::imports` to use `ParsedFile`.
- Added `extract_imports_from(...)` for callers that already have a shared parse view.
- Kept `extract_imports(...)` as a standalone compatibility entry point.
- Removed duplicated tree-sitter parser setup from:
  - Rust import extraction;
  - TypeScript / JavaScript import extraction;
  - Python import extraction.
- Updated scan file processing so imports are extracted from the same `ParsedFile` passed to file audits.
- Updated changed-scan timing to include `parse_us`.
- Updated normal scan timing to include `parse_us`.
- Added a regression test proving import extraction and audit access share the same lazy parsed tree.

## Why

After adding `ParsedFile`, the next duplicated parsing path was import extraction.

Before this PR, a full scan could parse the same file once for import extraction and again for AST-based audits. That made AST-heavy scans more expensive than necessary.

Now the scan pipeline creates one parse-once view per file and shares it between import extraction and AST audits.

This reduces duplicated parse work and gives RepoPilot a dedicated `parse_us` metric to track future performance changes.

## Architecture notes

- `analysis::parse` remains the owner of tree-sitter parsing.
- `ParsedFile` is now the shared per-file parse view for both import extraction and AST audits.
- `graph::imports` no longer owns parser instances for Rust, TypeScript/JavaScript, or Python.
- `extract_imports_from(...)` is the scan-pipeline path.
- `extract_imports(...)` remains available for standalone callers and tests.
- `scan_timings.parse_us` is a sub-measure of `file_analysis_us`.
- `parse_us` is intentionally excluded from `accounted_engine_us` because it is already counted inside file analysis.
- No finding behavior change is expected.

## Behavior

No CLI behavior change is expected.

JSON reports now include an additive timing field:

```json
"scan_timings": {
  "parse_us": 1234
}