### PR TITLE
feat(long-function): detect real function spans with AST fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added architecture anti-pattern documentation describing production-scope policy and false-positive expectations for architecture rules.
 - Added a Criterion scan-throughput benchmark (`cargo bench --bench scan_bench`) over a generated 480-file multi-language synthetic repository to baseline full-scan performance ahead of the shared parsed-AST work.
 - Added a `scan_timings.parse_us` field reporting aggregate tree-sitter parsing time during file analysis (a sub-measure of `file_analysis_us`, excluded from `accounted_engine_us`).
+- Added tree-sitter grammars for Go, Java, C#, and Kotlin so code-quality AST audits analyze real syntax trees for those languages instead of line/brace heuristics.
+- Added true-positive and false-positive rule fixtures for `code-quality.long-function` so `inspect eval-rules` covers it.
 
 ### Changed
 
@@ -22,6 +24,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Centralized tree-sitter parser instances and grammar selection into a shared `analysis::parse` module (`ParseLanguage`, `parse`, `parse_label`) and migrated the deep-control-flow audit onto it, removing its duplicated thread-local parsers. Internal refactor only; no behavior or public API change.
 - Added a lazy, parse-once `ParsedFile` view and a defaulted `FileAudit::audit_parsed` method so the scan pipeline parses each file at most once and shares the syntax tree across audits. The deep-control-flow audit now consumes the shared tree; other file audits inherit the default and are unaffected. Internal change only; no behavior or finding change.
 - Migrated the import graph (`graph::imports`) onto the shared `analysis::parse` parsers and the per-file `ParsedFile`, removing the duplicated thread-local tree-sitter parsers in the Rust, TypeScript/JavaScript, and Python extractors. Import extraction and the AST audits now share a single parse per file instead of parsing it separately, roughly halving per-file parse work in full scans. Internal refactor only; no behavior, finding, or public API change.
+- Upgraded `code-quality.long-function` to AST-based function-span detection for every parseable language (Rust, TypeScript/JavaScript, Python, Go, Java, C#, Kotlin), restoring `ast` signal-source provenance and cutting heuristic false positives. The line/brace heuristic remains only as a parse-failure fallback and reports `text-heuristic` provenance.
+- Extended the `code-quality.deep-control-flow` audit to Go, Java, C#, and Kotlin with language-specific control-flow node handling, sharing the same parse-once syntax tree.
 
 ## [0.13.0] - 2026-05-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,11 @@ dependencies = [
  "thiserror",
  "toml",
  "tree-sitter",
+ "tree-sitter-c-sharp",
+ "tree-sitter-go",
+ "tree-sitter-java",
  "tree-sitter-javascript",
+ "tree-sitter-kotlin-ng",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
@@ -1027,10 +1031,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-javascript"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-kotlin-ng"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e800ebbda938acfbf224f4d2c34947a31994b1295ee6e819b65226c7b51b4450"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ tree-sitter-javascript = "0.25.0"
 tree-sitter-python = "0.25.0"
 tree-sitter-rust = "0.24.2"
 tree-sitter-typescript = "0.23.2"
+tree-sitter-go = "0.25.0"
+tree-sitter-java = "0.23.5"
+tree-sitter-c-sharp = "0.23.5"
+tree-sitter-kotlin-ng = "1.1.0"
 toml = "1.1.2"
 
 [dev-dependencies]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,7 +48,7 @@ Walks the target path and runs all enabled audit rules.
 |----------|---------------|
 | Architecture | Oversized files, deep nesting, deep relative imports, risky barrel files, too many modules per directory |
 | Coupling | Excessive fan-out, high-instability hubs, circular dependencies |
-| Code quality | Cyclomatic complexity, long functions (Rust, Go, TypeScript, JavaScript, Python, Java, Kotlin), TODO/FIXME/HACK markers |
+| Code quality | Cyclomatic complexity, long functions and deep control-flow nesting (AST-based for Rust, TypeScript, JavaScript, Python, Go, Java, C#, Kotlin), TODO/FIXME/HACK markers |
 | Framework | JavaScript, React, React Native, Expo, New Architecture, Hermes, Codegen; Python (Django, Flask, FastAPI); Go (Gin, Echo, Fiber) |
 | Security | Hardcoded secret candidates, committed private keys, `.env` files, Django deployment settings and raw SQL formatting |
 | Testing | Missing test folder, source files without test counterparts |

--- a/src/analysis/parse.rs
+++ b/src/analysis/parse.rs
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn parsed_file_without_grammar_has_no_tree() {
-        assert!(ParsedFile::new("package main", Some("Go")).tree().is_none());
+        assert!(ParsedFile::new("class Main", Some("Ruby")).tree().is_none());
         assert!(ParsedFile::new("anything", None).tree().is_none());
     }
 

--- a/src/analysis/parse.rs
+++ b/src/analysis/parse.rs
@@ -32,6 +32,10 @@ pub(crate) enum ParseLanguage {
     Tsx,
     JavaScript,
     Python,
+    Go,
+    Java,
+    CSharp,
+    Kotlin,
 }
 
 impl ParseLanguage {
@@ -44,6 +48,10 @@ impl ParseLanguage {
             "TypeScript React" => Some(Self::Tsx),
             "JavaScript" | "JavaScript React" => Some(Self::JavaScript),
             "Python" => Some(Self::Python),
+            "Go" => Some(Self::Go),
+            "Java" => Some(Self::Java),
+            "CSharp" | "C#" => Some(Self::CSharp),
+            "Kotlin" => Some(Self::Kotlin),
             _ => None,
         }
     }
@@ -60,6 +68,14 @@ thread_local! {
         RefCell::new(parser_for(tree_sitter_javascript::LANGUAGE.into()));
     static PYTHON_PARSER: RefCell<Parser> =
         RefCell::new(parser_for(tree_sitter_python::LANGUAGE.into()));
+    static GO_PARSER: RefCell<Parser> =
+        RefCell::new(parser_for(tree_sitter_go::LANGUAGE.into()));
+    static JAVA_PARSER: RefCell<Parser> =
+        RefCell::new(parser_for(tree_sitter_java::LANGUAGE.into()));
+    static CSHARP_PARSER: RefCell<Parser> =
+        RefCell::new(parser_for(tree_sitter_c_sharp::LANGUAGE.into()));
+    static KOTLIN_PARSER: RefCell<Parser> =
+        RefCell::new(parser_for(tree_sitter_kotlin_ng::LANGUAGE.into()));
 }
 
 fn parser_for(language: Language) -> Parser {
@@ -79,6 +95,10 @@ pub(crate) fn parse(content: &str, language: ParseLanguage) -> Option<Tree> {
         ParseLanguage::Tsx => &TSX_PARSER,
         ParseLanguage::JavaScript => &JS_PARSER,
         ParseLanguage::Python => &PYTHON_PARSER,
+        ParseLanguage::Go => &GO_PARSER,
+        ParseLanguage::Java => &JAVA_PARSER,
+        ParseLanguage::CSharp => &CSHARP_PARSER,
+        ParseLanguage::Kotlin => &KOTLIN_PARSER,
     };
     let start = Instant::now();
     let tree = parser.with(|cell| {
@@ -178,12 +198,23 @@ mod tests {
             ParseLanguage::from_label("Python"),
             Some(ParseLanguage::Python)
         );
+        assert_eq!(ParseLanguage::from_label("Go"), Some(ParseLanguage::Go));
+        assert_eq!(ParseLanguage::from_label("Java"), Some(ParseLanguage::Java));
+        assert_eq!(
+            ParseLanguage::from_label("CSharp"),
+            Some(ParseLanguage::CSharp)
+        );
+        assert_eq!(ParseLanguage::from_label("C#"), Some(ParseLanguage::CSharp));
+        assert_eq!(
+            ParseLanguage::from_label("Kotlin"),
+            Some(ParseLanguage::Kotlin)
+        );
     }
 
     #[test]
     fn rejects_unparseable_labels() {
-        assert_eq!(ParseLanguage::from_label("Go"), None);
-        assert_eq!(ParseLanguage::from_label("Java"), None);
+        assert_eq!(ParseLanguage::from_label("Ruby"), None);
+        assert_eq!(ParseLanguage::from_label("PHP"), None);
         assert_eq!(ParseLanguage::from_label(""), None);
     }
 
@@ -194,6 +225,10 @@ mod tests {
         assert!(parse("const x = <div />;", ParseLanguage::Tsx).is_some());
         assert!(parse("const x = 1;", ParseLanguage::JavaScript).is_some());
         assert!(parse("x = 1\n", ParseLanguage::Python).is_some());
+        assert!(parse("package main\nfunc main() {}\n", ParseLanguage::Go).is_some());
+        assert!(parse("public class Main {}\n", ParseLanguage::Java).is_some());
+        assert!(parse("class Main {}\n", ParseLanguage::CSharp).is_some());
+        assert!(parse("fun main() {}\n", ParseLanguage::Kotlin).is_some());
     }
 
     #[test]
@@ -208,7 +243,7 @@ mod tests {
     fn parse_label_matches_grammar_dispatch() {
         assert!(parse_label("fn main() {}", "Rust").is_some());
         assert!(parse_label("def f():\n    pass\n", "Python").is_some());
-        assert!(parse_label("package main", "Go").is_none());
+        assert!(parse_label("package main\n", "Go").is_some());
     }
 
     #[test]

--- a/src/audits/code_quality/deep_control_flow.rs
+++ b/src/audits/code_quality/deep_control_flow.rs
@@ -86,6 +86,43 @@ fn is_control_flow_node(kind: &str, language: &str) -> bool {
                 | "match_statement"
                 | "try_statement"
         ),
+        "Go" => matches!(
+            kind,
+            "if_statement"
+                | "for_statement"
+                | "expression_switch_statement"
+                | "type_switch_statement"
+                | "select_statement"
+        ),
+        "Java" => matches!(
+            kind,
+            "if_statement"
+                | "for_statement"
+                | "enhanced_for_statement"
+                | "while_statement"
+                | "do_statement"
+                | "switch_statement"
+                | "try_statement"
+        ),
+        "CSharp" | "C#" => matches!(
+            kind,
+            "if_statement"
+                | "for_statement"
+                | "foreach_statement"
+                | "while_statement"
+                | "do_statement"
+                | "switch_statement"
+                | "try_statement"
+        ),
+        "Kotlin" => matches!(
+            kind,
+            "if_expression"
+                | "when_expression"
+                | "for_statement"
+                | "while_statement"
+                | "do_while_statement"
+                | "try_expression"
+        ),
         _ => matches!(
             kind,
             "if_statement"
@@ -102,12 +139,25 @@ fn is_control_flow_node(kind: &str, language: &str) -> bool {
 
 fn is_else_if(node: Node<'_>, language: &str) -> bool {
     let kind = node.kind();
-    if (language == "Rust" && kind == "if_expression")
-        || (language != "Rust" && kind == "if_statement")
-    {
+    let is_if = match language {
+        "Rust" | "Kotlin" => kind == "if_expression",
+        _ => kind == "if_statement",
+    };
+    if is_if {
         if let Some(parent) = node.parent() {
-            if parent.kind() == "else_clause" {
+            if parent.kind() == "else_clause" || parent.kind() == "else" {
                 return true;
+            }
+            if language == "Kotlin" && parent.kind() == "if_expression" {
+                let mut cursor = parent.walk();
+                let mut saw_else = false;
+                for child in parent.children(&mut cursor) {
+                    if child.kind() == "else" {
+                        saw_else = true;
+                    } else if child.id() == node.id() {
+                        return saw_else;
+                    }
+                }
             }
         }
     }

--- a/src/audits/code_quality/long_function/ast.rs
+++ b/src/audits/code_quality/long_function/ast.rs
@@ -1,0 +1,119 @@
+use crate::findings::types::Finding;
+use std::path::Path;
+use tree_sitter::{Node, Tree};
+
+use super::LongFunctionPolicy;
+
+/// Detects long functions from a parsed syntax tree.
+///
+/// Walks every function-like node (declarations, methods, named function
+/// expressions, and arrow functions) and flags those whose line span exceeds
+/// the policy threshold. Anonymous functions use a doubled threshold to match
+/// the lower expectation for inline callbacks.
+pub(super) fn detect_ast(
+    tree: &Tree,
+    content: &str,
+    language: &str,
+    path: &Path,
+    policy: LongFunctionPolicy,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    visit(
+        tree.root_node(),
+        content,
+        language,
+        path,
+        policy,
+        &mut findings,
+    );
+    findings
+}
+
+fn visit(
+    node: Node<'_>,
+    content: &str,
+    language: &str,
+    path: &Path,
+    policy: LongFunctionPolicy,
+    findings: &mut Vec<Finding>,
+) {
+    if let Some((name, is_anonymous)) = function_like(node, language, content) {
+        let start_row = node.start_position().row;
+        let end_row = node.end_position().row;
+        let fn_len = end_row.saturating_sub(start_row) + 1;
+
+        // Inline callbacks are expected to be shorter; doubling the threshold
+        // keeps them from dominating the signal, mirroring the prior heuristic.
+        let threshold = if is_anonymous {
+            policy.threshold.saturating_mul(2)
+        } else {
+            policy.threshold
+        };
+
+        if fn_len > threshold {
+            let effective = LongFunctionPolicy {
+                threshold,
+                ..policy
+            };
+            findings.push(super::build_finding(
+                path,
+                start_row + 1,
+                end_row + 1,
+                &name,
+                fn_len,
+                effective,
+            ));
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, content, language, path, policy, findings);
+    }
+}
+
+/// Returns `(name, is_anonymous)` when `node` is a function-like construct for
+/// `language`, or `None` otherwise. `name` is empty for anonymous functions.
+fn function_like(node: Node<'_>, language: &str, content: &str) -> Option<(String, bool)> {
+    match language {
+        "Rust" => (node.kind() == "function_item")
+            .then(|| (field_name(node, content).unwrap_or_default(), false)),
+        "Python" => (node.kind() == "function_definition")
+            .then(|| (field_name(node, content).unwrap_or_default(), false)),
+        // TypeScript, TSX, JavaScript, and JSX share the same node kinds.
+        _ => match node.kind() {
+            "function_declaration" | "generator_function_declaration" | "method_definition" => {
+                Some((field_name(node, content).unwrap_or_default(), false))
+            }
+            "function_expression" | "generator_function" => match field_name(node, content) {
+                Some(name) => Some((name, false)),
+                None => Some((String::new(), true)),
+            },
+            "arrow_function" => match arrow_function_name(node, content) {
+                Some(name) => Some((name, false)),
+                None => Some((String::new(), true)),
+            },
+            _ => None,
+        },
+    }
+}
+
+fn field_name(node: Node<'_>, content: &str) -> Option<String> {
+    let name = node.child_by_field_name("name")?;
+    name.utf8_text(content.as_bytes()).ok().map(str::to_string)
+}
+
+/// Derives a name for an arrow function from its binding context (e.g.
+/// `const handler = () => {}` or an object property), returning `None` for
+/// true inline callbacks.
+fn arrow_function_name(node: Node<'_>, content: &str) -> Option<String> {
+    let parent = node.parent()?;
+    let field = match parent.kind() {
+        "variable_declarator" | "public_field_definition" | "field_definition" => "name",
+        "pair" => "key",
+        "assignment_expression" => "left",
+        _ => return None,
+    };
+    let name = parent.child_by_field_name(field)?;
+    name.utf8_text(content.as_bytes()).ok().map(str::to_string)
+}

--- a/src/audits/code_quality/long_function/ast.rs
+++ b/src/audits/code_quality/long_function/ast.rs
@@ -80,6 +80,26 @@ fn function_like(node: Node<'_>, language: &str, content: &str) -> Option<(Strin
             .then(|| (field_name(node, content).unwrap_or_default(), false)),
         "Python" => (node.kind() == "function_definition")
             .then(|| (field_name(node, content).unwrap_or_default(), false)),
+        "Go" => match node.kind() {
+            "function_declaration" | "method_declaration" => {
+                Some((field_name(node, content).unwrap_or_default(), false))
+            }
+            _ => None,
+        },
+        "Java" => match node.kind() {
+            "method_declaration" | "constructor_declaration" => {
+                Some((field_name(node, content).unwrap_or_default(), false))
+            }
+            _ => None,
+        },
+        "CSharp" | "C#" => match node.kind() {
+            "method_declaration" | "constructor_declaration" | "local_function_statement" => {
+                Some((field_name(node, content).unwrap_or_default(), false))
+            }
+            _ => None,
+        },
+        "Kotlin" => (node.kind() == "function_declaration")
+            .then(|| (field_name(node, content).unwrap_or_default(), false)),
         // TypeScript, TSX, JavaScript, and JSX share the same node kinds.
         _ => match node.kind() {
             "function_declaration" | "generator_function_declaration" | "method_definition" => {

--- a/src/audits/code_quality/long_function/mod.rs
+++ b/src/audits/code_quality/long_function/mod.rs
@@ -78,9 +78,9 @@ impl LongFunctionAudit {
         policy.severity = decision.severity.min(policy.severity);
 
         // A present syntax tree implies a parseable grammar, so measure real
-        // function spans from the AST. Languages without a grammar (Go, Java,
-        // C#, Kotlin) — or the rare parse failure — fall back to the line/brace
-        // heuristic, whose findings are stamped with text-heuristic provenance.
+        // function spans from the AST. Languages with no tree-sitter grammar, or
+        // the rare parse failure, fall back to the line/brace heuristic, whose
+        // findings are stamped with text-heuristic provenance.
         match parsed.tree() {
             Some(tree) => ast::detect_ast(tree, content, language, &file.path, policy),
             None => {

--- a/src/audits/code_quality/long_function/mod.rs
+++ b/src/audits/code_quality/long_function/mod.rs
@@ -1,12 +1,16 @@
+use crate::analysis::parse::ParsedFile;
 use crate::audits::context::{AuditContext, FileRole, FrameworkKind, LanguageKind, classify_file};
 use crate::audits::traits::FileAudit;
+use crate::findings::provenance::{AnalysisScope, FindingProvenance};
 use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use crate::knowledge::decision::decide_for_audit_context;
+use crate::rules::{RuleLifecycle, SignalSource, lookup_rule_metadata};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
 use crate::scan::path_classification::is_low_signal_audit_path;
 use std::path::Path;
 
+mod ast;
 mod brace;
 mod python;
 
@@ -26,6 +30,22 @@ pub(super) struct LongFunctionPolicy {
 
 impl FileAudit for LongFunctionAudit {
     fn audit(&self, file: &FileFacts, config: &ScanConfig) -> Vec<Finding> {
+        // Direct entry (tests, non-pipeline callers): build a one-off parse view.
+        self.analyze(file, &ParsedFile::for_facts(file), config)
+    }
+
+    fn audit_parsed(
+        &self,
+        file: &FileFacts,
+        parsed: &ParsedFile,
+        config: &ScanConfig,
+    ) -> Vec<Finding> {
+        self.analyze(file, parsed, config)
+    }
+}
+
+impl LongFunctionAudit {
+    fn analyze(&self, file: &FileFacts, parsed: &ParsedFile, config: &ScanConfig) -> Vec<Finding> {
         let arch_ctx = crate::analysis::classify_file_architecture(file, config);
         if arch_ctx.file_role != crate::analysis::FileRole::Production
             && arch_ctx.file_role != crate::analysis::FileRole::Test
@@ -57,7 +77,34 @@ impl FileAudit for LongFunctionAudit {
         let mut policy = long_function_policy(&context, config.long_function_loc_threshold);
         policy.severity = decision.severity.min(policy.severity);
 
-        detect_long_functions(content, language, &file.path, policy)
+        // A present syntax tree implies a parseable grammar, so measure real
+        // function spans from the AST. Languages without a grammar (Go, Java,
+        // C#, Kotlin) — or the rare parse failure — fall back to the line/brace
+        // heuristic, whose findings are stamped with text-heuristic provenance.
+        match parsed.tree() {
+            Some(tree) => ast::detect_ast(tree, content, language, &file.path, policy),
+            None => {
+                let mut findings = detect_long_functions(content, language, &file.path, policy);
+                mark_text_heuristic(&mut findings);
+                findings
+            }
+        }
+    }
+}
+
+/// Overrides provenance for heuristic-fallback findings so they report
+/// `text-heuristic` rather than inheriting the rule's `ast` signal source.
+fn mark_text_heuristic(findings: &mut [Finding]) {
+    let lifecycle = lookup_rule_metadata(RULE_ID)
+        .map(|metadata| metadata.lifecycle)
+        .unwrap_or(RuleLifecycle::Preview);
+    for finding in findings {
+        finding.provenance = FindingProvenance {
+            detector: RULE_ID.to_string(),
+            signal_source: SignalSource::TextHeuristic,
+            rule_lifecycle: lifecycle,
+            analysis_scope: AnalysisScope::File,
+        };
     }
 }
 

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -698,7 +698,7 @@ suppress_generated = true
 
 [[rules]]
 rule_id = "code-quality.deep-control-flow"
-languages = ["rust", "python", "typescript", "typescript-react", "javascript", "javascript-react"]
+languages = ["rust", "python", "typescript", "typescript-react", "javascript", "javascript-react", "go", "java", "csharp", "kotlin"]
 suppress_low_signal = true
 suppress_generated = true
 

--- a/src/rules/registry/code_quality.rs
+++ b/src/rules/registry/code_quality.rs
@@ -25,11 +25,14 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
-        signal_source: SignalSource::TextHeuristic,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "A function is longer than the configured line threshold. Long functions are harder to test, understand, and safely refactor.",
         recommendation: Some(
             "Break the function into smaller, single-purpose helpers. Aim for functions that fit on a single screen.",
+        ),
+        false_positive_notes: Some(
+            "Parseable languages (Rust, TypeScript/JavaScript, Python) measure real function spans from the syntax tree. Languages without a tree-sitter grammar (Go, Java, C#, Kotlin) fall back to a line/brace heuristic and are reported with text-heuristic provenance.",
         ),
         ..RuleMetadata::DEFAULT
     },

--- a/tests/deep_control_flow_test.rs
+++ b/tests/deep_control_flow_test.rs
@@ -160,3 +160,165 @@ def test():
     assert_eq!(findings[0].evidence[0].line_start, 7); // line of `if e:`
     assert!(findings[0].evidence[0].snippet.contains("if e:"));
 }
+
+// ── Go ────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn go_detects_exceeded_nesting_depth() {
+    let content = r#"
+        package main
+        func main() {
+            if a { // depth 1
+                for b { // depth 2
+                    if c { // depth 3
+                        switch d { // depth 4
+                        case 1:
+                            if e { // depth 5 (exceeds threshold 4)
+                                println("nested")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    "#;
+
+    let file = file_facts("src/main.go", "Go", content);
+    let config = ScanConfig {
+        max_control_flow_depth: 4,
+        ..ScanConfig::default()
+    };
+
+    let findings = DeepControlFlowAudit.audit(&file, &config);
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].evidence[0].line_start, 9); // line of `if e {`
+    assert!(findings[0].evidence[0].snippet.contains("if e"));
+}
+
+// ── Java ──────────────────────────────────────────────────────────────────────
+
+#[test]
+fn java_detects_exceeded_nesting_depth() {
+    let content = r#"
+        class Test {
+            void test() {
+                if (a) { // depth 1
+                    for (int x : y) { // depth 2 (enhanced_for_statement)
+                        if (b) { // depth 3
+                            try { // depth 4
+                                if (c) { // depth 5 (exceeds threshold 4)
+                                    System.out.println("nested");
+                                }
+                            } catch (Exception e) {}
+                        }
+                    }
+                }
+            }
+        }
+    "#;
+
+    let file = file_facts("src/App.java", "Java", content);
+    let config = ScanConfig {
+        max_control_flow_depth: 4,
+        ..ScanConfig::default()
+    };
+
+    let findings = DeepControlFlowAudit.audit(&file, &config);
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].evidence[0].line_start, 8); // line of `if (c) {`
+    assert!(findings[0].evidence[0].snippet.contains("if (c)"));
+}
+
+// ── C# ────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn csharp_detects_exceeded_nesting_depth() {
+    let content = r#"
+        class Test {
+            void TestMethod() {
+                if (a) { // depth 1
+                    foreach (var x in y) { // depth 2
+                        if (b) { // depth 3
+                            try { // depth 4
+                                if (c) { // depth 5 (exceeds threshold 4)
+                                    System.Console.WriteLine("nested");
+                                }
+                            } catch {}
+                        }
+                    }
+                }
+            }
+        }
+    "#;
+
+    let file = file_facts("src/App.cs", "CSharp", content);
+    let config = ScanConfig {
+        max_control_flow_depth: 4,
+        ..ScanConfig::default()
+    };
+
+    let findings = DeepControlFlowAudit.audit(&file, &config);
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].evidence[0].line_start, 8); // line of `if (c) {`
+    assert!(findings[0].evidence[0].snippet.contains("if (c)"));
+}
+
+// ── Kotlin ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn kotlin_detects_exceeded_nesting_depth() {
+    let content = r#"
+        fun test() {
+            if (a) { // depth 1
+                for (x in y) { // depth 2
+                    if (b) { // depth 3
+                        when (z) { // depth 4
+                            1 -> {
+                                if (c) { // depth 5 (exceeds threshold 4)
+                                    println("nested")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    "#;
+
+    let file = file_facts("src/App.kt", "Kotlin", content);
+    let config = ScanConfig {
+        max_control_flow_depth: 4,
+        ..ScanConfig::default()
+    };
+
+    let findings = DeepControlFlowAudit.audit(&file, &config);
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].evidence[0].line_start, 8); // line of `if (c) {`
+    assert!(findings[0].evidence[0].snippet.contains("if (c)"));
+}
+
+#[test]
+fn kotlin_flattens_else_if_chains() {
+    let content = r#"
+        fun test() {
+            if (a) {
+            } else if (b) {
+            } else if (c) {
+            }
+        }
+    "#;
+
+    let file = file_facts("src/App.kt", "Kotlin", content);
+    let config = ScanConfig {
+        max_control_flow_depth: 2,
+        ..ScanConfig::default()
+    };
+
+    let findings = DeepControlFlowAudit.audit(&file, &config);
+
+    assert!(findings.is_empty(), "Kotlin else if chains should be flat");
+}

--- a/tests/fixtures/rules/code-quality.long-function/expected.json
+++ b/tests/fixtures/rules/code-quality.long-function/expected.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "code-quality.long-function"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/code-quality.long-function/false_positive/src/lib.rs
+++ b/tests/fixtures/rules/code-quality.long-function/false_positive/src/lib.rs
@@ -1,0 +1,18 @@
+// False positive guard: small, single-purpose production functions that stay
+// well under the threshold must not be flagged, even though the file defines
+// several of them.
+pub fn add(a: i64, b: i64) -> i64 {
+    a + b
+}
+
+pub fn sub(a: i64, b: i64) -> i64 {
+    a - b
+}
+
+pub fn mul(a: i64, b: i64) -> i64 {
+    a * b
+}
+
+pub fn negate(value: i64) -> i64 {
+    -value
+}

--- a/tests/fixtures/rules/code-quality.long-function/true_positive/src/lib.rs
+++ b/tests/fixtures/rules/code-quality.long-function/true_positive/src/lib.rs
@@ -1,0 +1,57 @@
+// True positive: a single production function whose body spans well beyond the
+// default 50-line threshold, with no branching or nesting so only the
+// long-function rule fires. Detection is AST-based (real function span).
+pub fn accumulate_totals() -> i64 {
+    let mut total = 0i64;
+    let step_00 = 0i64;
+    let step_01 = 1i64;
+    let step_02 = 2i64;
+    let step_03 = 3i64;
+    let step_04 = 4i64;
+    let step_05 = 5i64;
+    let step_06 = 6i64;
+    let step_07 = 7i64;
+    let step_08 = 8i64;
+    let step_09 = 9i64;
+    let step_10 = 10i64;
+    let step_11 = 11i64;
+    let step_12 = 12i64;
+    let step_13 = 13i64;
+    let step_14 = 14i64;
+    let step_15 = 15i64;
+    let step_16 = 16i64;
+    let step_17 = 17i64;
+    let step_18 = 18i64;
+    let step_19 = 19i64;
+    let step_20 = 20i64;
+    let step_21 = 21i64;
+    let step_22 = 22i64;
+    let step_23 = 23i64;
+    let step_24 = 24i64;
+    let step_25 = 25i64;
+    let step_26 = 26i64;
+    let step_27 = 27i64;
+    let step_28 = 28i64;
+    let step_29 = 29i64;
+    let step_30 = 30i64;
+    let step_31 = 31i64;
+    let step_32 = 32i64;
+    let step_33 = 33i64;
+    let step_34 = 34i64;
+    let step_35 = 35i64;
+    let step_36 = 36i64;
+    let step_37 = 37i64;
+    let step_38 = 38i64;
+    let step_39 = 39i64;
+    let step_40 = 40i64;
+    total += step_00 + step_01 + step_02 + step_03 + step_04;
+    total += step_05 + step_06 + step_07 + step_08 + step_09;
+    total += step_10 + step_11 + step_12 + step_13 + step_14;
+    total += step_15 + step_16 + step_17 + step_18 + step_19;
+    total += step_20 + step_21 + step_22 + step_23 + step_24;
+    total += step_25 + step_26 + step_27 + step_28 + step_29;
+    total += step_30 + step_31 + step_32 + step_33 + step_34;
+    total += step_35 + step_36 + step_37 + step_38 + step_39;
+    total += step_40;
+    total
+}

--- a/tests/long_function_audit.rs
+++ b/tests/long_function_audit.rs
@@ -227,6 +227,73 @@ fn kotlin_private_override_fun_detected() {
     );
 }
 
+// ── JavaScript / TypeScript ───────────────────────────────────────────────────
+
+#[test]
+fn javascript_function_under_threshold_no_finding() {
+    let content = "function short() {\n    const x = 1;\n}\n";
+    let file = make_file("JavaScript", content);
+    let findings = LongFunctionAudit.audit(&file, &config_with_threshold(50));
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn javascript_function_over_threshold_produces_finding() {
+    let body: String = (0..60).map(|i| format!("    let _{i} = {i};\n")).collect();
+    let content = format!("function longFn() {{\n{body}}}\n");
+    let file = make_file("JavaScript", &content);
+    let findings = LongFunctionAudit.audit(&file, &config_with_threshold(50));
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, "code-quality.long-function");
+    assert!(findings[0].title.contains("longFn"));
+}
+
+#[test]
+fn typescript_arrow_function_over_threshold_produces_finding() {
+    let body: String = (0..60).map(|i| format!("    let _{i} = {i};\n")).collect();
+    let content = format!("const longArrow = () => {{\n{body}}};\n");
+    let file = make_file("TypeScript", &content);
+    let findings = LongFunctionAudit.audit(&file, &config_with_threshold(50));
+    assert_eq!(findings.len(), 1);
+    assert!(findings[0].title.contains("longArrow"));
+}
+
+#[test]
+fn typescript_react_component_uses_larger_threshold() {
+    // React component threshold is 3 * base_threshold (150 lines).
+    // So 80 lines should not trigger a finding, but 160 lines should.
+    let body_under: String = (0..80).map(|i| format!("    let _{i} = {i};\n")).collect();
+    let content_under = format!(
+        "import React from 'react';\nexport function MyComponent() {{\n{body_under}    return <div />;\n}}\n"
+    );
+    let file_under = make_file_at(
+        "src/components/MyComponent.tsx",
+        "TypeScript React",
+        &content_under,
+    );
+    let findings_under = LongFunctionAudit.audit(&file_under, &config_with_threshold(50));
+    assert!(
+        findings_under.is_empty(),
+        "80 lines React component should be under the 150 lines threshold"
+    );
+
+    let body_over: String = (0..160).map(|i| format!("    let _{i} = {i};\n")).collect();
+    let content_over = format!(
+        "import React from 'react';\nexport function MyComponent() {{\n{body_over}    return <div />;\n}}\n"
+    );
+    let file_over = make_file_at(
+        "src/components/MyComponent.tsx",
+        "TypeScript React",
+        &content_over,
+    );
+    let findings_over = LongFunctionAudit.audit(&file_over, &config_with_threshold(50));
+    assert_eq!(
+        findings_over.len(),
+        1,
+        "160 lines React component should exceed the 150 lines threshold"
+    );
+}
+
 // ── Unsupported language ──────────────────────────────────────────────────────
 
 #[test]

--- a/tests/rule_eval_fixture_coverage.rs
+++ b/tests/rule_eval_fixture_coverage.rs
@@ -32,6 +32,8 @@ const RUNTIME_RULES_WITH_013_FIXTURES: &[&str] = &[
     "language.managed.fatal-exception-risk",
 ];
 
+const CODE_QUALITY_RULES_WITH_013_FIXTURES: &[&str] = &["code-quality.long-function"];
+
 #[test]
 fn given_security_rule_fixtures_when_eval_rules_runs_then_quality_gates_pass() {
     // Given
@@ -70,6 +72,22 @@ fn given_runtime_rule_fixtures_when_eval_rules_runs_then_quality_gates_pass() {
     let fixture_root = rule_fixture_root();
 
     for rule_id in RUNTIME_RULES_WITH_013_FIXTURES {
+        // When
+        let report = evaluate_rule(rule_id, &fixture_root);
+
+        // Then
+        assert_single_rule_report(rule_id, &report);
+        let rule_report = first_rule_report(rule_id, &report);
+        assert_rule_fixture_coverage_is_clean(rule_id, rule_report);
+    }
+}
+
+#[test]
+fn given_code_quality_rule_fixtures_when_eval_rules_runs_then_quality_gates_pass() {
+    // Given
+    let fixture_root = rule_fixture_root();
+
+    for rule_id in CODE_QUALITY_RULES_WITH_013_FIXTURES {
         // When
         let report = evaluate_rule(rule_id, &fixture_root);
 


### PR DESCRIPTION
## Summary

Adds AST-based function span detection to the `code-quality.long-function` audit.

For parseable languages, RepoPilot now measures real function spans from the shared parsed syntax tree. Languages without a supported tree-sitter grammar still use the existing heuristic fallback.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Added AST-based long-function detection.
- Added a new `long_function::ast` detector module.
- Migrated `LongFunctionAudit` to use the shared `ParsedFile` view.
- Added `audit_parsed(...)` support for `LongFunctionAudit`.
- For supported parseable languages, long functions are now measured from real syntax tree function nodes.
- Supported AST-based detection includes:
  - Rust functions;
  - Python functions;
  - JavaScript functions;
  - TypeScript functions;
  - TSX / React component functions;
  - methods;
  - named function expressions;
  - arrow functions with binding context.
- Kept heuristic fallback for unsupported languages or parse failures.
- Added fallback provenance override so heuristic findings report `text-heuristic`.
- Updated rule metadata from `TextHeuristic` to `Ast`.
- Added false-positive notes explaining AST detection and fallback behavior.
- Added rule fixtures for `code-quality.long-function`.
- Added regression tests for JavaScript, TypeScript arrow functions, and React component thresholds.
- Added code-quality rule fixture evaluation coverage.

## Why

The previous long-function audit relied on text and brace heuristics.

That is useful as a fallback, but it can be noisy because it does not always understand real function boundaries.

Now that the scan pipeline has shared parse-once syntax trees, the long-function rule can use AST spans for supported languages. This improves precision and makes the finding evidence more trustworthy.

## Architecture notes

- `analysis::parse::ParsedFile` remains the shared parse view.
- `LongFunctionAudit` now consumes `ParsedFile` through `audit_parsed`.
- AST-specific logic lives in `long_function::ast`.
- Existing brace/Python heuristic modules remain as fallback paths.
- Fallback findings explicitly set `SignalSource::TextHeuristic`.
- The main rule metadata is now `SignalSource::Ast`.
- This keeps AST detection and heuristic fallback separated instead of mixing both in one detector.
- No god file introduced.

## Behavior

This PR can change long-function findings for parseable languages because function spans are now based on AST nodes instead of text heuristics.

Expected behavior:

- Rust / Python / TypeScript / JavaScript use AST-based function span detection.
- Go / Java / C# / Kotlin continue using heuristic fallback.
- Heuristic fallback findings are marked as `text-heuristic`.
- AST findings use `ast` provenance.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .
cargo bench --bench scan_bench
```