### PR TITLE
feat(runtime-risk): use AST detection for JS and Python risks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added a `scan_timings.parse_us` field reporting aggregate tree-sitter parsing time during file analysis (a sub-measure of `file_analysis_us`, excluded from `accounted_engine_us`).
 - Added tree-sitter grammars for Go, Java, C#, and Kotlin so code-quality AST audits analyze real syntax trees for those languages instead of line/brace heuristics.
 - Added true-positive and false-positive rule fixtures for `code-quality.long-function` so `inspect eval-rules` covers it.
+- Added AST-precision false-positive fixtures for the JavaScript/TypeScript and Python runtime-risk rules, asserting that risky tokens inside comments and string literals are not flagged.
 
 ### Changed
 
@@ -26,6 +27,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Migrated the import graph (`graph::imports`) onto the shared `analysis::parse` parsers and the per-file `ParsedFile`, removing the duplicated thread-local tree-sitter parsers in the Rust, TypeScript/JavaScript, and Python extractors. Import extraction and the AST audits now share a single parse per file instead of parsing it separately, roughly halving per-file parse work in full scans. Internal refactor only; no behavior, finding, or public API change.
 - Upgraded `code-quality.long-function` to AST-based function-span detection for every parseable language (Rust, TypeScript/JavaScript, Python, Go, Java, C#, Kotlin), restoring `ast` signal-source provenance and cutting heuristic false positives. The line/brace heuristic remains only as a parse-failure fallback and reports `text-heuristic` provenance.
 - Extended the `code-quality.deep-control-flow` audit to Go, Java, C#, and Kotlin with language-specific control-flow node handling, sharing the same parse-once syntax tree.
+- Upgraded `language.javascript.runtime-exit-risk` and `language.python.exception-risk` to AST-based detection over the shared parse view — `process.exit` calls, library-boundary `throw new Error(...)`, bare `except` clauses, `assert` statements, and `NotImplementedError` are matched from the syntax tree, so the same tokens inside comments or string literals are no longer flagged. This restores `ast` signal-source provenance; a sanitized line scanner with `text-heuristic` provenance remains only as a parse-failure fallback. Go, Java/Kotlin, and C# runtime-risk rules are unchanged (still text-heuristic).
 
 ## [0.13.0] - 2026-05-25
 

--- a/src/audits/code_quality/language_risk.rs
+++ b/src/audits/code_quality/language_risk.rs
@@ -1,7 +1,10 @@
+use crate::analysis::parse::ParsedFile;
 use crate::audits::code_quality::sanitize::{sanitize_c_style, sanitize_python_line};
 use crate::audits::traits::FileAudit;
+use crate::findings::provenance::{AnalysisScope, FindingProvenance};
 use crate::findings::types::Finding;
 use crate::knowledge::language::language_id_for_name;
+use crate::rules::{RuleLifecycle, SignalSource, lookup_rule_metadata};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
 use std::path::Path;
@@ -9,7 +12,23 @@ use std::path::Path;
 pub struct LanguageRiskAudit;
 
 impl FileAudit for LanguageRiskAudit {
-    fn audit(&self, file: &FileFacts, _config: &ScanConfig) -> Vec<Finding> {
+    fn audit(&self, file: &FileFacts, config: &ScanConfig) -> Vec<Finding> {
+        // Direct entry (tests, non-pipeline callers): build a one-off parse view.
+        self.analyze(file, &ParsedFile::for_facts(file), config)
+    }
+
+    fn audit_parsed(
+        &self,
+        file: &FileFacts,
+        parsed: &ParsedFile,
+        config: &ScanConfig,
+    ) -> Vec<Finding> {
+        self.analyze(file, parsed, config)
+    }
+}
+
+impl LanguageRiskAudit {
+    fn analyze(&self, file: &FileFacts, parsed: &ParsedFile, _config: &ScanConfig) -> Vec<Finding> {
         let Some(content) = file
             .content
             .as_deref()
@@ -22,7 +41,50 @@ impl FileAudit for LanguageRiskAudit {
             return vec![];
         };
 
-        detect_language_risks(language_id, content, &file.path, file)
+        if !is_ast_runtime_language(language_id) {
+            // Languages without an AST runtime detector (Go, Java/Kotlin, C#)
+            // keep the sanitized line scanner and text-heuristic provenance.
+            return detect_language_risks(language_id, content, &file.path, file);
+        }
+
+        match parsed.tree() {
+            Some(tree) => {
+                let mut findings = Vec::new();
+                emit_findings_for_tree(language_id, tree, content, &file.path, file, &mut findings);
+                findings
+            }
+            None => {
+                // The file did not parse; fall back to the line scanner but keep
+                // provenance honest by stamping the findings as text-heuristic.
+                let mut findings = detect_language_risks(language_id, content, &file.path, file);
+                mark_text_heuristic(&mut findings);
+                findings
+            }
+        }
+    }
+}
+
+/// Runtime-risk languages with an AST detector (matched from the syntax tree).
+fn is_ast_runtime_language(language_id: &str) -> bool {
+    matches!(
+        language_id,
+        "python" | "typescript" | "typescript-react" | "javascript" | "javascript-react"
+    )
+}
+
+/// Overrides provenance for line-scanner fallback findings so they report
+/// `text-heuristic` rather than inheriting the rule's `ast` signal source.
+fn mark_text_heuristic(findings: &mut [Finding]) {
+    for finding in findings {
+        let lifecycle = lookup_rule_metadata(&finding.rule_id)
+            .map(|metadata| metadata.lifecycle)
+            .unwrap_or(RuleLifecycle::Preview);
+        finding.provenance = FindingProvenance {
+            detector: finding.rule_id.clone(),
+            signal_source: SignalSource::TextHeuristic,
+            rule_lifecycle: lifecycle,
+            analysis_scope: AnalysisScope::File,
+        };
     }
 }
 
@@ -66,7 +128,7 @@ fn detect_language_risks(
 
 mod pattern;
 
-use self::pattern::emit_findings_for_line;
+use self::pattern::{emit_findings_for_line, emit_findings_for_tree};
 
 #[cfg(test)]
 mod tests;

--- a/src/audits/code_quality/language_risk/pattern.rs
+++ b/src/audits/code_quality/language_risk/pattern.rs
@@ -2,6 +2,7 @@ use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use crate::knowledge::decision::decide_for_file;
 use crate::scan::facts::FileFacts;
 use std::path::Path;
+use tree_sitter::{Node, Tree};
 
 const RUNTIME_ERROR_HANDLING_DOCS_URL: &str =
     "https://owasp.org/www-community/vulnerabilities/Improper_Error_Handling";
@@ -32,21 +33,14 @@ pub(super) fn emit_findings_for_line(
     macro_rules! push_if_matched {
         ($pattern:expr) => {
             if $pattern.matches(trimmed, path) {
-                let decision = decide_for_file(
-                    $pattern.rule_id(),
+                push_pattern_finding(
+                    $pattern,
+                    path,
+                    line_index + 1,
+                    raw_line.trim(),
                     file,
-                    $pattern.base_severity(),
-                    Some($pattern.signal()),
+                    findings,
                 );
-                if !decision.is_suppressed() {
-                    findings.push(build_finding(
-                        path,
-                        line_index + 1,
-                        raw_line.trim(),
-                        $pattern,
-                        decision.severity,
-                    ));
-                }
             }
         };
     }
@@ -79,6 +73,177 @@ pub(super) fn emit_findings_for_line(
         }
         _ => {}
     }
+}
+
+// ── AST detection (parseable languages) ────────────────────────────────────────
+
+/// Emits runtime-risk findings for `language_id` by walking the parsed syntax
+/// tree, so matches reflect real call/clause structure rather than line text.
+/// Only the AST-backed languages (Python, TypeScript/JavaScript) are handled
+/// here; other languages keep the line scanner in [`emit_findings_for_line`].
+pub(super) fn emit_findings_for_tree(
+    language_id: &str,
+    tree: &Tree,
+    content: &str,
+    path: &Path,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    walk_tree(tree.root_node(), language_id, content, path, file, findings);
+}
+
+fn walk_tree(
+    node: Node<'_>,
+    language_id: &str,
+    content: &str,
+    path: &Path,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    match language_id {
+        "python" => emit_python_node(node, content, path, file, findings),
+        "typescript" | "typescript-react" | "javascript" | "javascript-react" => {
+            emit_js_node(node, content, path, file, findings)
+        }
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_tree(child, language_id, content, path, file, findings);
+    }
+}
+
+fn emit_js_node(
+    node: Node<'_>,
+    content: &str,
+    path: &Path,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    let pattern = match node.kind() {
+        "call_expression" if is_process_exit_call(node, content) => {
+            Some(JsRiskPattern::ProcessExit)
+        }
+        "throw_statement" if throws_new_error(node, content) && is_library_boundary_path(path) => {
+            Some(JsRiskPattern::ThrowError)
+        }
+        _ => None,
+    };
+    if let Some(pattern) = pattern {
+        push_pattern_finding(
+            &pattern,
+            path,
+            line_of(node),
+            &snippet_of(node, content),
+            file,
+            findings,
+        );
+    }
+}
+
+fn emit_python_node(
+    node: Node<'_>,
+    content: &str,
+    path: &Path,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    let pattern = match node.kind() {
+        "except_clause" if is_bare_except(node) => Some(PythonRiskPattern::BroadExcept),
+        "assert_statement" => Some(PythonRiskPattern::Assert),
+        "call" if is_not_implemented_call(node, content) => Some(PythonRiskPattern::NotImplemented),
+        "raise_statement" if raises_bare_not_implemented(node, content) => {
+            Some(PythonRiskPattern::NotImplemented)
+        }
+        _ => None,
+    };
+    if let Some(pattern) = pattern {
+        push_pattern_finding(
+            &pattern,
+            path,
+            line_of(node),
+            &snippet_of(node, content),
+            file,
+            findings,
+        );
+    }
+}
+
+fn line_of(node: Node<'_>) -> usize {
+    node.start_position().row + 1
+}
+
+fn snippet_of(node: Node<'_>, content: &str) -> String {
+    content
+        .lines()
+        .nth(node.start_position().row)
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+fn node_text<'a>(node: Node<'_>, content: &'a str) -> Option<&'a str> {
+    node.utf8_text(content.as_bytes()).ok()
+}
+
+/// `process.exit(...)` — a call whose callee is the `process.exit` member.
+fn is_process_exit_call(node: Node<'_>, content: &str) -> bool {
+    let Some(function) = node.child_by_field_name("function") else {
+        return false;
+    };
+    if function.kind() != "member_expression" {
+        return false;
+    }
+    let object = function
+        .child_by_field_name("object")
+        .and_then(|n| node_text(n, content));
+    let property = function
+        .child_by_field_name("property")
+        .and_then(|n| node_text(n, content));
+    object == Some("process") && property == Some("exit")
+}
+
+/// `throw new Error(...)` — a throw whose direct expression constructs `Error`.
+fn throws_new_error(node: Node<'_>, content: &str) -> bool {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .any(|child| is_new_error(child, content))
+}
+
+fn is_new_error(node: Node<'_>, content: &str) -> bool {
+    node.kind() == "new_expression"
+        && node
+            .child_by_field_name("constructor")
+            .and_then(|c| node_text(c, content))
+            == Some("Error")
+}
+
+/// A bare `except:` clause — an `except_clause` with no exception type before
+/// its body block.
+fn is_bare_except(node: Node<'_>) -> bool {
+    let mut cursor = node.walk();
+    !node
+        .named_children(&mut cursor)
+        .any(|child| child.kind() != "block" && child.kind() != "comment")
+}
+
+/// A call to `NotImplementedError(...)`.
+fn is_not_implemented_call(node: Node<'_>, content: &str) -> bool {
+    node.child_by_field_name("function")
+        .and_then(|function| node_text(function, content))
+        .map(|text| text == "NotImplementedError" || text.ends_with(".NotImplementedError"))
+        .unwrap_or(false)
+}
+
+/// `raise NotImplementedError` with no call — the raised expression is the bare
+/// `NotImplementedError` identifier (the call form is handled separately so a
+/// single `raise NotImplementedError(...)` is not counted twice).
+fn raises_bare_not_implemented(node: Node<'_>, content: &str) -> bool {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).any(|child| {
+        child.kind() == "identifier" && node_text(child, content) == Some("NotImplementedError")
+    })
 }
 
 // ── Shared ────────────────────────────────────────────────────────────────────
@@ -125,6 +290,34 @@ impl_risk_pattern!(GoRiskPattern);
 impl_risk_pattern!(PythonRiskPattern);
 impl_risk_pattern!(JsRiskPattern);
 impl_risk_pattern!(ManagedRiskPattern);
+
+/// Applies the per-file decision and pushes a finding for a matched pattern.
+/// Shared by the line scanner and the AST walker so both produce identical
+/// findings (title, recommendation, severity decision) for the same pattern.
+fn push_pattern_finding(
+    pattern: &dyn RiskPattern,
+    path: &Path,
+    line_number: usize,
+    snippet: &str,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    let decision = decide_for_file(
+        pattern.rule_id(),
+        file,
+        pattern.base_severity(),
+        Some(pattern.signal()),
+    );
+    if !decision.is_suppressed() {
+        findings.push(build_finding(
+            path,
+            line_number,
+            snippet,
+            pattern,
+            decision.severity,
+        ));
+    }
+}
 
 fn build_finding(
     path: &Path,

--- a/src/rules/registry/language.rs
+++ b/src/rules/registry/language.rs
@@ -40,11 +40,14 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
-        signal_source: SignalSource::TextHeuristic,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "Broad exception handlers, production asserts, and NotImplementedError placeholders can hide failures or ship incomplete behaviour. Their severity depends on test, script, and domain context.",
         recommendation: Some(
             "Catch specific exceptions, use explicit runtime validation, and replace placeholders before production release.",
+        ),
+        false_positive_notes: Some(
+            "Matches come from the parsed syntax tree (bare `except` clauses, `assert` statements, and `NotImplementedError`), so the same tokens inside comments or string literals are not flagged. A line heuristic with text-heuristic provenance is used only when the file fails to parse.",
         ),
         ..RuleMetadata::DEFAULT
     },
@@ -55,11 +58,14 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
-        signal_source: SignalSource::TextHeuristic,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "Process exits and generic thrown errors have different risk at a CLI boundary than in reusable browser, Node, or package code.",
         recommendation: Some(
             "Prefer returning typed errors, rejecting promises with actionable context, or centralising CLI exit handling at the entrypoint.",
+        ),
+        false_positive_notes: Some(
+            "`process.exit` calls and `throw new Error(...)` are matched from the parsed syntax tree, so the same text inside comments or string literals is not flagged. A line heuristic with text-heuristic provenance is used only when the file fails to parse.",
         ),
         ..RuleMetadata::DEFAULT
     },

--- a/tests/fixtures/rules/language.javascript.runtime-exit-risk/expected.json
+++ b/tests/fixtures/rules/language.javascript.runtime-exit-risk/expected.json
@@ -5,6 +5,10 @@
       "expected_rule_ids": []
     },
     {
+      "path": "false_positive_in_comments_and_strings",
+      "expected_rule_ids": []
+    },
+    {
       "path": "true_positive",
       "expected_rule_ids": [
         "language.javascript.runtime-exit-risk",

--- a/tests/fixtures/rules/language.javascript.runtime-exit-risk/false_positive_in_comments_and_strings/lib/index.ts
+++ b/tests/fixtures/rules/language.javascript.runtime-exit-risk/false_positive_in_comments_and_strings/lib/index.ts
@@ -1,0 +1,12 @@
+// AST precision guard: this file lives under a library boundary ("lib"), so a
+// real `throw new Error(...)` here would be flagged. The risky tokens below
+// appear only inside comments and string literals, so AST detection must NOT
+// flag them.
+
+// Docs: call process.exit(1) only at the CLI entrypoint, never in a library.
+export const usage = "throw new Error('boom') is discouraged in shared modules";
+
+export function describe(): string {
+  // throw new Error("this is commented out, not thrown");
+  return "process.exit(1) only appears inside this string literal";
+}

--- a/tests/fixtures/rules/language.python.exception-risk/expected.json
+++ b/tests/fixtures/rules/language.python.exception-risk/expected.json
@@ -5,6 +5,10 @@
       "expected_rule_ids": []
     },
     {
+      "path": "false_positive_in_comments_and_strings",
+      "expected_rule_ids": []
+    },
+    {
       "path": "true_positive",
       "expected_rule_ids": [
         "language.python.exception-risk",

--- a/tests/fixtures/rules/language.python.exception-risk/false_positive_in_comments_and_strings/app.py
+++ b/tests/fixtures/rules/language.python.exception-risk/false_positive_in_comments_and_strings/app.py
@@ -1,0 +1,10 @@
+# AST precision guard: the risky tokens below appear only inside comments and
+# string literals, so AST detection must NOT flag them.
+
+# Avoid a bare "except:" and production "assert" statements.
+USAGE = "raise NotImplementedError once the provider is wired"
+
+
+def describe():
+    note = "use assert only in tests; never a bare except: in production"
+    return note


### PR DESCRIPTION
## Summary

Upgrades JavaScript/TypeScript and Python runtime-risk detection to AST-based matching.

This reduces false positives by detecting real syntax nodes instead of matching risky tokens inside comments or string literals.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Migrated `LanguageRiskAudit` to use the shared `ParsedFile` view.
- Added `audit_parsed(...)` support for runtime-risk detection.
- Added AST-based runtime-risk detection for:
  - JavaScript
  - JavaScript React
  - TypeScript
  - TypeScript React
  - Python
- JavaScript / TypeScript AST detection now matches:
  - `process.exit(...)`
  - `throw new Error(...)` at library boundaries
- Python AST detection now matches:
  - bare `except:`
  - `assert` statements
  - `NotImplementedError(...)`
  - bare `raise NotImplementedError`
- Kept sanitized line-scanner fallback for parse failures.
- Kept Go, Java/Kotlin, and C# runtime-risk rules on text-heuristic detection.
- Added provenance override so parse-fallback findings are reported as `text-heuristic`.
- Updated rule metadata for JS and Python runtime-risk rules from `TextHeuristic` to `Ast`.
- Added false-positive notes explaining AST detection and fallback behavior.
- Added false-positive fixtures proving risky tokens inside comments and string literals are not flagged.
- Updated `CHANGELOG.md`.

## Why

The previous runtime-risk detection used sanitized line scanning.

That works as a broad fallback, but it can still produce false positives when risky tokens appear inside comments, documentation examples, or string literals.

Now that RepoPilot has a shared parse-once syntax tree, JS/TS and Python runtime-risk rules can match real syntax structures instead of raw text.

This makes findings more precise and improves trust in runtime-risk reports.

## Architecture notes

- `analysis::parse::ParsedFile` remains the shared parse view.
- `LanguageRiskAudit` now consumes `ParsedFile` through `audit_parsed`.
- AST-backed runtime-risk detection lives in the language-risk pattern layer.
- Line-based detection remains as fallback, not the main path for JS/TS/Python.
- Fallback findings use `SignalSource::TextHeuristic`.
- AST findings use `SignalSource::Ast`.
- Go, Java/Kotlin, and C# runtime-risk rules are unchanged.
- No god file introduced.

## Behavior

This PR can change findings for JavaScript/TypeScript and Python.

Expected behavior:

- real `process.exit(...)` calls are still flagged;
- real `throw new Error(...)` at library boundaries is still flagged;
- real Python bare `except:`, `assert`, and `NotImplementedError` are still flagged;
- the same risky text inside comments or string literals is no longer flagged;
- parse-failure fallback still uses the sanitized line scanner.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .
cargo bench --bench scan_bench