### PR TITLE
feat(runtime-risk): add AST detection for Go panic risks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added a `scan_timings.parse_us` field reporting aggregate tree-sitter parsing time during file analysis (a sub-measure of `file_analysis_us`, excluded from `accounted_engine_us`).
 - Added tree-sitter grammars for Go, Java, C#, and Kotlin so code-quality AST audits analyze real syntax trees for those languages instead of line/brace heuristics.
 - Added true-positive and false-positive rule fixtures for `code-quality.long-function` so `inspect eval-rules` covers it.
-- Added AST-precision false-positive fixtures for the JavaScript/TypeScript and Python runtime-risk rules, asserting that risky tokens inside comments and string literals are not flagged.
+- Added AST-precision false-positive fixtures for the JavaScript/TypeScript, Python, and Go runtime-risk rules, asserting that risky tokens inside comments and string literals are not flagged.
+- Documented an AST-backed vs heuristic-fallback signal-source matrix for the rule catalog in the CLI reference.
 
 ### Changed
 
@@ -27,7 +28,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Migrated the import graph (`graph::imports`) onto the shared `analysis::parse` parsers and the per-file `ParsedFile`, removing the duplicated thread-local tree-sitter parsers in the Rust, TypeScript/JavaScript, and Python extractors. Import extraction and the AST audits now share a single parse per file instead of parsing it separately, roughly halving per-file parse work in full scans. Internal refactor only; no behavior, finding, or public API change.
 - Upgraded `code-quality.long-function` to AST-based function-span detection for every parseable language (Rust, TypeScript/JavaScript, Python, Go, Java, C#, Kotlin), restoring `ast` signal-source provenance and cutting heuristic false positives. The line/brace heuristic remains only as a parse-failure fallback and reports `text-heuristic` provenance.
 - Extended the `code-quality.deep-control-flow` audit to Go, Java, C#, and Kotlin with language-specific control-flow node handling, sharing the same parse-once syntax tree.
-- Upgraded `language.javascript.runtime-exit-risk` and `language.python.exception-risk` to AST-based detection over the shared parse view — `process.exit` calls, library-boundary `throw new Error(...)`, bare `except` clauses, `assert` statements, and `NotImplementedError` are matched from the syntax tree, so the same tokens inside comments or string literals are no longer flagged. This restores `ast` signal-source provenance; a sanitized line scanner with `text-heuristic` provenance remains only as a parse-failure fallback. Go, Java/Kotlin, and C# runtime-risk rules are unchanged (still text-heuristic).
+- Upgraded `language.javascript.runtime-exit-risk` and `language.python.exception-risk` to AST-based detection over the shared parse view — `process.exit` calls, library-boundary `throw new Error(...)`, bare `except` clauses, `assert` statements, and `NotImplementedError` are matched from the syntax tree, so the same tokens inside comments or string literals are no longer flagged. This restores `ast` signal-source provenance; a sanitized line scanner with `text-heuristic` provenance remains only as a parse-failure fallback. Java/Kotlin and C# runtime-risk rules are unchanged (still text-heuristic).
+- Upgraded `language.go.panic-exit-risk` to AST-based detection over the shared parse view — `panic`, `log.Fatal`/`log.Fatalf`, and `os.Exit` calls are matched from the syntax tree, so the same tokens inside comments or string literals are no longer flagged. Restores `ast` provenance; the line scanner remains a parse-failure fallback. The `language.managed.fatal-exception-risk` (Java/Kotlin/C#) and `language.rust.panic-risk` rules remain text-heuristic pending their own AST migration.
 
 ## [0.13.0] - 2026-05-25
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -563,6 +563,27 @@ repopilot inspect rules --lifecycle preview
 repopilot inspect rules --source text-heuristic
 ```
 
+### Signal sources: AST-backed vs heuristic
+
+Each rule reports a `signal_source`. The authoritative, always-current list is the
+tool itself — `repopilot inspect rules --source ast` and
+`repopilot inspect rules --source text-heuristic`. As of now:
+
+| Rule | Detection | Notes |
+|------|-----------|-------|
+| `code-quality.long-function` | AST | Function spans from the syntax tree for Rust, TypeScript/JavaScript, Python, Go, Java, C#, Kotlin; line/brace heuristic only on parse failure. |
+| `code-quality.deep-control-flow` | AST | Same language set as long-function. |
+| `language.go.panic-exit-risk` | AST | `panic`/`log.Fatal`/`os.Exit` calls from the syntax tree. |
+| `language.python.exception-risk` | AST | Bare `except`, `assert`, and `NotImplementedError` from the syntax tree. |
+| `language.javascript.runtime-exit-risk` | AST | `process.exit` calls and library-boundary `throw new Error(...)`. |
+| `language.managed.fatal-exception-risk` | Heuristic | Java/Kotlin/C# fatal exceptions; AST migration pending. |
+| `language.rust.panic-risk` | Heuristic | `unwrap`/`expect`/`panic` paths; AST migration pending. |
+| `code-quality.complex-file`, `code-marker.*`, `architecture.*`, `testing.*` | Heuristic | Structural/text signals by design. |
+
+AST-backed rules ignore risky tokens that appear only in comments or string
+literals; heuristic rules sanitize comments and strings line-by-line but cannot
+reason about full call structure.
+
 ---
 
 ## `inspect rule`

--- a/src/audits/code_quality/language_risk.rs
+++ b/src/audits/code_quality/language_risk.rs
@@ -68,7 +68,7 @@ impl LanguageRiskAudit {
 fn is_ast_runtime_language(language_id: &str) -> bool {
     matches!(
         language_id,
-        "python" | "typescript" | "typescript-react" | "javascript" | "javascript-react"
+        "python" | "go" | "typescript" | "typescript-react" | "javascript" | "javascript-react"
     )
 }
 

--- a/src/audits/code_quality/language_risk/pattern.rs
+++ b/src/audits/code_quality/language_risk/pattern.rs
@@ -102,6 +102,7 @@ fn walk_tree(
 ) {
     match language_id {
         "python" => emit_python_node(node, content, path, file, findings),
+        "go" => emit_go_node(node, content, path, file, findings),
         "typescript" | "typescript-react" | "javascript" | "javascript-react" => {
             emit_js_node(node, content, path, file, findings)
         }
@@ -111,6 +112,52 @@ fn walk_tree(
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         walk_tree(child, language_id, content, path, file, findings);
+    }
+}
+
+fn emit_go_node(
+    node: Node<'_>,
+    content: &str,
+    path: &Path,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    if node.kind() != "call_expression" {
+        return;
+    }
+    let Some(function) = node.child_by_field_name("function") else {
+        return;
+    };
+
+    let pattern = match function.kind() {
+        // `panic(...)`
+        "identifier" if node_text(function, content) == Some("panic") => Some(GoRiskPattern::Panic),
+        // `pkg.Fn(...)` — `log.Fatal`/`log.Fatalf` and `os.Exit`.
+        "selector_expression" => {
+            let package = function
+                .child_by_field_name("operand")
+                .and_then(|n| node_text(n, content));
+            let method = function
+                .child_by_field_name("field")
+                .and_then(|n| node_text(n, content));
+            match (package, method) {
+                (Some("log"), Some("Fatal" | "Fatalf")) => Some(GoRiskPattern::LogFatal),
+                (Some("os"), Some("Exit")) => Some(GoRiskPattern::OsExit),
+                _ => None,
+            }
+        }
+        _ => None,
+    };
+
+    if let Some(pattern) = pattern {
+        push_pattern_finding(
+            &pattern,
+            path,
+            line_of(node),
+            &snippet_of(node, content),
+            file,
+            findings,
+        );
     }
 }
 

--- a/src/audits/code_quality/language_risk/tests.rs
+++ b/src/audits/code_quality/language_risk/tests.rs
@@ -148,6 +148,37 @@ fn js_throw_new_error_outside_library_boundary_is_not_flagged() {
     assert!(findings.is_empty());
 }
 
+#[test]
+fn go_ast_runtime_finding_reports_ast_provenance() {
+    use crate::rules::SignalSource;
+
+    let file = facts(
+        "src/domain/user.go",
+        Some("Go"),
+        "package domain\nfunc Parse() { panic(\"bad\") }\n",
+    );
+
+    let mut findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+    assert_eq!(findings.len(), 1);
+
+    findings[0].populate_rule_metadata();
+    assert_eq!(findings[0].provenance.signal_source, SignalSource::Ast);
+}
+
+#[test]
+fn go_panic_inside_string_literal_is_not_flagged() {
+    let file = facts(
+        "src/domain/user.go",
+        Some("Go"),
+        "package domain\nfunc label() string { return \"panic(\" }\n",
+    );
+
+    let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+    // The text `panic(` lives inside a string, not a call expression.
+    assert!(findings.is_empty());
+}
+
 fn facts(path: &str, language: Option<&str>, content: &str) -> FileFacts {
     FileFacts {
         path: PathBuf::from(path),

--- a/src/rules/registry/language.rs
+++ b/src/rules/registry/language.rs
@@ -25,11 +25,14 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
-        signal_source: SignalSource::TextHeuristic,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "Go panic and process-exit operations can terminate the program abruptly. Their risk depends on whether the file is test code, CLI boundary code, library code, or domain code.",
         recommendation: Some(
             "Return errors from reusable code and reserve panic/log.Fatal/os.Exit for narrow process boundaries where callers cannot recover.",
+        ),
+        false_positive_notes: Some(
+            "`panic`, `log.Fatal`/`log.Fatalf`, and `os.Exit` calls are matched from the parsed syntax tree, so the same text inside comments or string literals is not flagged. A line heuristic with text-heuristic provenance is used only when the file fails to parse.",
         ),
         ..RuleMetadata::DEFAULT
     },

--- a/tests/fixtures/rules/language.go.panic-exit-risk/expected.json
+++ b/tests/fixtures/rules/language.go.panic-exit-risk/expected.json
@@ -5,6 +5,10 @@
       "expected_rule_ids": []
     },
     {
+      "path": "false_positive_in_comments_and_strings",
+      "expected_rule_ids": []
+    },
+    {
       "path": "true_positive",
       "expected_rule_ids": [
         "language.go.panic-exit-risk",

--- a/tests/fixtures/rules/language.go.panic-exit-risk/false_positive_in_comments_and_strings/main.go
+++ b/tests/fixtures/rules/language.go.panic-exit-risk/false_positive_in_comments_and_strings/main.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+// AST precision guard: panic("boom"), log.Fatal("x"), and os.Exit(1) below
+// appear only inside a comment and string literals, so AST detection must NOT
+// flag them.
+func describe() string {
+	note := "call panic(\"x\") only at the boundary; avoid log.Fatal and os.Exit"
+	return fmt.Sprintf("%s", note)
+}


### PR DESCRIPTION
## Summary

Adds AST-based runtime-risk detection for Go panic and exit calls.

Go runtime-risk detection now matches real syntax-tree call expressions instead of relying on text heuristics, reducing false positives from comments and string literals.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Added Go to the AST-backed runtime-risk language set.
- Added AST detection for Go runtime-risk patterns:
  - `panic(...)`
  - `log.Fatal(...)`
  - `log.Fatalf(...)`
  - `os.Exit(...)`
- Added `emit_go_node(...)` in the runtime-risk AST walker.
- Updated `language.go.panic-exit-risk` metadata from `TextHeuristic` to `Ast`.
- Added false-positive notes for the Go runtime-risk rule.
- Added tests verifying:
  - real Go `panic(...)` reports AST provenance;
  - `panic(` inside a string literal is not flagged.
- Added fixture coverage for Go risky tokens inside comments and strings.
- Updated the CLI docs with an AST-backed vs heuristic signal-source matrix.
- Updated `CHANGELOG.md`.

## Why

The old Go runtime-risk rule relied on line/text matching.

That can flag risky-looking tokens inside comments, documentation examples, or string literals.

Now that RepoPilot has shared parse-once syntax trees, Go runtime-risk detection can match real call expressions and avoid those false positives.

## Architecture notes

- `LanguageRiskAudit` continues to use the shared `ParsedFile` parse view.
- Go is now handled by the same AST runtime-risk path as Python and JavaScript/TypeScript.
- `emit_go_node(...)` is isolated inside the language-risk pattern layer.
- The line scanner remains available as parse-failure fallback.
- Go runtime-risk findings now use `SignalSource::Ast`.
- Java/Kotlin/C# managed runtime-risk and Rust panic-risk remain heuristic for now.
- No god file introduced.

## Behavior

This PR can change Go runtime-risk findings.

Expected behavior:

- real `panic(...)` calls are still flagged;
- real `log.Fatal(...)` and `log.Fatalf(...)` calls are still flagged;
- real `os.Exit(...)` calls are still flagged;
- the same risky text inside comments or string literals is no longer flagged;
- parse-failure fallback still uses the line scanner.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .
cargo bench --bench scan_bench