### PR TITLE
test(runtime-risk): cover Go fatalf and fallback provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added true-positive and false-positive rule fixtures for `code-quality.long-function` so `inspect eval-rules` covers it.
 - Added AST-precision false-positive fixtures for the JavaScript/TypeScript, Python, and Go runtime-risk rules, asserting that risky tokens inside comments and string literals are not flagged.
 - Documented an AST-backed vs heuristic-fallback signal-source matrix for the rule catalog in the CLI reference.
+- Added a `log.Fatalf` case to the `language.go.panic-exit-risk` true-positive fixture so the variadic fatal-log form is covered by `inspect eval-rules`.
+- Added a regression test asserting the runtime-risk AST audits stamp `text-heuristic` provenance on the line-scanner fallback path and that enrichment does not overwrite it.
+- Added a `repopilot inspect rules --source ast` example to the CLI reference.
 
 ### Changed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -560,6 +560,7 @@ repopilot inspect rules [OPTIONS]
 repopilot inspect rules
 repopilot inspect rules --format json
 repopilot inspect rules --lifecycle preview
+repopilot inspect rules --source ast
 repopilot inspect rules --source text-heuristic
 ```
 

--- a/src/audits/code_quality/language_risk/tests.rs
+++ b/src/audits/code_quality/language_risk/tests.rs
@@ -179,6 +179,33 @@ fn go_panic_inside_string_literal_is_not_flagged() {
     assert!(findings.is_empty());
 }
 
+#[test]
+fn parse_failure_fallback_reports_text_heuristic_provenance() {
+    use crate::analysis::parse::ParsedFile;
+    use crate::rules::SignalSource;
+
+    // A parse view with no available grammar yields no tree — the same `None`
+    // tree-sitter returns on a parse failure — so this drives the line-scanner
+    // fallback for an AST runtime language.
+    let file = facts(
+        "src/domain/user.go",
+        Some("Go"),
+        "package domain\nfunc Parse() { panic(\"bad\") }\n",
+    );
+    let unparsed = ParsedFile::new(file.content.as_deref().unwrap(), Some("Ruby"));
+
+    let mut findings = LanguageRiskAudit.analyze(&file, &unparsed, &ScanConfig::default());
+    assert_eq!(findings.len(), 1);
+
+    // The fallback stamps the finding text-heuristic up front; enrichment must
+    // not overwrite that back to the rule's declared `ast` signal source.
+    findings[0].populate_rule_metadata();
+    assert_eq!(
+        findings[0].provenance.signal_source,
+        SignalSource::TextHeuristic
+    );
+}
+
 fn facts(path: &str, language: Option<&str>, content: &str) -> FileFacts {
     FileFacts {
         path: PathBuf::from(path),

--- a/tests/fixtures/rules/language.go.panic-exit-risk/expected.json
+++ b/tests/fixtures/rules/language.go.panic-exit-risk/expected.json
@@ -13,6 +13,7 @@
       "expected_rule_ids": [
         "language.go.panic-exit-risk",
         "language.go.panic-exit-risk",
+        "language.go.panic-exit-risk",
         "language.go.panic-exit-risk"
       ]
     }

--- a/tests/fixtures/rules/language.go.panic-exit-risk/true_positive/main.go
+++ b/tests/fixtures/rules/language.go.panic-exit-risk/true_positive/main.go
@@ -8,5 +8,6 @@ import (
 func main() {
     panic("boot failed")
     log.Fatal("cannot continue")
+    log.Fatalf("exit code %d", 1)
     os.Exit(1)
 }


### PR DESCRIPTION
## Summary

Adds regression coverage for Go runtime-risk AST detection and fallback provenance.

This locks the behavior introduced by the Go AST runtime-risk migration.

## Type of change

- [x] Tests
- [x] Documentation
- [x] Repository maintenance
- [ ] Feature
- [ ] Refactor
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Added `log.Fatalf(...)` to the `language.go.panic-exit-risk` true-positive fixture.
- Updated the expected fixture output to include the additional Go runtime-risk finding.
- Added a regression test for parse-failure fallback provenance.
- Verified that fallback findings are stamped as `SignalSource::TextHeuristic`.
- Verified that rule metadata enrichment does not overwrite fallback provenance back to `Ast`.
- Added `repopilot inspect rules --source ast` to the CLI reference examples.
- Updated `CHANGELOG.md`.

## Why

The Go runtime-risk rule now uses AST detection by default.

That means we need regression coverage for two important guarantees:

- all supported Go fatal-exit forms are covered, including `log.Fatalf(...)`;
- parse-failure fallback remains honest and reports `text-heuristic` provenance.

Without this test, a future metadata/enrichment refactor could accidentally relabel fallback findings as AST-backed.

## Architecture notes

- No production detection logic changed.
- The Go runtime-risk rule remains AST-backed.
- The line scanner remains the parse-failure fallback.
- Fallback provenance is explicitly tested.
- Rule metadata enrichment behavior is tested through `populate_rule_metadata`.
- CLI docs now show how to inspect AST-backed rules.
- No god file introduced.

## Behavior

No CLI behavior change is expected.

This PR adds tests and documentation only.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .