### PR TITLE
feat(runtime-risk): add AST detection for Rust panic risks

### DIFF
--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -68,28 +68,97 @@ impl RustPanicRiskAudit {
                 fn visit<'a>(
                     node: Node<'a>,
                     content: &str,
+                    in_macro_args: bool,
                     candidates: &mut HashMap<usize, (Node<'a>, RustPanicPattern)>,
                 ) {
-                    if let Some(pattern) = detect_ast_node(node, content) {
-                        let line_number = node.start_position().row + 1;
-                        let keep = if let Some((_, existing_pattern)) = candidates.get(&line_number)
-                        {
-                            pattern.precedence() > existing_pattern.precedence()
-                        } else {
-                            true
-                        };
-                        if keep {
-                            candidates.insert(line_number, (node, pattern));
+                    let kind = node.kind();
+
+                    // Skip comments and string/char literals
+                    if matches!(
+                        kind,
+                        "line_comment"
+                            | "block_comment"
+                            | "string_literal"
+                            | "raw_string_literal"
+                            | "char_literal"
+                    ) {
+                        return;
+                    }
+
+                    if in_macro_args && (kind == "identifier" || kind == "field_identifier") {
+                        if let Ok(text) = node.utf8_text(content.as_bytes()) {
+                            let pattern = match text {
+                                "unwrap" => Some(RustPanicPattern::Unwrap),
+                                "unwrap_err" => Some(RustPanicPattern::UnwrapErr),
+                                "expect" => Some(RustPanicPattern::Expect),
+                                "expect_err" => Some(RustPanicPattern::ExpectErr),
+                                _ => None,
+                            };
+                            if let Some(pat) = pattern {
+                                if is_preceded_by_dot(node, content)
+                                    && is_followed_by_paren(node, content)
+                                {
+                                    let line_number = node.start_position().row + 1;
+                                    let keep = if let Some((_, existing_pattern)) =
+                                        candidates.get(&line_number)
+                                    {
+                                        pat.precedence() > existing_pattern.precedence()
+                                    } else {
+                                        true
+                                    };
+                                    if keep {
+                                        candidates.insert(line_number, (node, pat));
+                                    }
+                                }
+                            }
                         }
                     }
 
+                    let is_panic_macro = if kind == "macro_invocation" {
+                        if let Some(pattern) = detect_ast_node(node, content) {
+                            let line_number = node.start_position().row + 1;
+                            let keep =
+                                if let Some((_, existing_pattern)) = candidates.get(&line_number) {
+                                    pattern.precedence() > existing_pattern.precedence()
+                                } else {
+                                    true
+                                };
+                            if keep {
+                                candidates.insert(line_number, (node, pattern));
+                            }
+                            true
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    };
+
+                    if !is_panic_macro {
+                        if let Some(pattern) = detect_ast_node(node, content) {
+                            let line_number = node.start_position().row + 1;
+                            let keep =
+                                if let Some((_, existing_pattern)) = candidates.get(&line_number) {
+                                    pattern.precedence() > existing_pattern.precedence()
+                                } else {
+                                    true
+                                };
+                            if keep {
+                                candidates.insert(line_number, (node, pattern));
+                            }
+                        }
+                    }
+
+                    let next_in_macro =
+                        in_macro_args || (kind == "macro_invocation" && !is_panic_macro);
+
                     let mut cursor = node.walk();
                     for child in node.children(&mut cursor) {
-                        visit(child, content, candidates);
+                        visit(child, content, next_in_macro, candidates);
                     }
                 }
 
-                visit(tree.root_node(), content, &mut candidates);
+                visit(tree.root_node(), content, false, &mut candidates);
 
                 let mut findings = Vec::new();
                 let mut sorted_lines: Vec<usize> = candidates.keys().copied().collect();
@@ -282,4 +351,26 @@ fn mark_text_heuristic(findings: &mut [Finding]) {
             analysis_scope: AnalysisScope::File,
         };
     }
+}
+
+fn is_preceded_by_dot(node: Node<'_>, content: &str) -> bool {
+    let start_byte = node.start_byte();
+    if start_byte > 0 {
+        let pre_slice = &content.as_bytes()[..start_byte];
+        if let Some(last_char) = pre_slice.iter().rev().find(|&&b| !b.is_ascii_whitespace()) {
+            return *last_char == b'.';
+        }
+    }
+    false
+}
+
+fn is_followed_by_paren(node: Node<'_>, content: &str) -> bool {
+    let end_byte = node.end_byte();
+    if end_byte < content.len() {
+        let post_slice = &content.as_bytes()[end_byte..];
+        if let Some(first_char) = post_slice.iter().find(|&&b| !b.is_ascii_whitespace()) {
+            return *first_char == b'(';
+        }
+    }
+    false
 }

--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -4,26 +4,49 @@ mod pattern;
 #[cfg(test)]
 mod tests;
 
-use self::finding::build_finding;
-use self::pattern::{
-    detect_pattern, is_external_failure_path, is_infallible_render_write_result_unwrap,
-    is_infallible_render_write_start, should_ignore_contextual_panic_pattern,
-};
+use crate::analysis::parse::ParsedFile;
 use crate::audits::code_quality::sanitize::sanitize_c_style;
 use crate::audits::context::{LanguageKind, classify_file};
 use crate::audits::traits::FileAudit;
+use crate::findings::provenance::{AnalysisScope, FindingProvenance};
 use crate::findings::types::{Finding, Severity};
 use crate::knowledge::decision::decide_for_audit_context;
+use crate::rules::{RuleLifecycle, SignalSource, lookup_rule_metadata};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
 use crate::scan::path_classification::is_low_signal_audit_path;
+use std::collections::HashMap;
+use tree_sitter::Node;
+
+use self::finding::build_finding;
+use self::pattern::{
+    RustPanicPattern, detect_pattern, is_external_failure_path,
+    is_infallible_render_write_result_unwrap, is_infallible_render_write_start,
+    is_report_renderer_path, is_structural_infallible_render_write_unwrap,
+    should_ignore_contextual_panic_pattern,
+};
 
 const RULE_ID: &str = "language.rust.panic-risk";
 
 pub struct RustPanicRiskAudit;
 
 impl FileAudit for RustPanicRiskAudit {
-    fn audit(&self, file: &FileFacts, _config: &ScanConfig) -> Vec<Finding> {
+    fn audit(&self, file: &FileFacts, config: &ScanConfig) -> Vec<Finding> {
+        self.analyze(file, &ParsedFile::for_facts(file), config)
+    }
+
+    fn audit_parsed(
+        &self,
+        file: &FileFacts,
+        parsed: &ParsedFile,
+        config: &ScanConfig,
+    ) -> Vec<Finding> {
+        self.analyze(file, parsed, config)
+    }
+}
+
+impl RustPanicRiskAudit {
+    fn analyze(&self, file: &FileFacts, parsed: &ParsedFile, _config: &ScanConfig) -> Vec<Finding> {
         if is_low_signal_audit_path(&file.path) {
             return vec![];
         }
@@ -38,6 +61,105 @@ impl FileAudit for RustPanicRiskAudit {
             return vec![];
         };
 
+        match parsed.tree() {
+            Some(tree) => {
+                let mut candidates: HashMap<usize, (Node<'_>, RustPanicPattern)> = HashMap::new();
+
+                fn visit<'a>(
+                    node: Node<'a>,
+                    content: &str,
+                    candidates: &mut HashMap<usize, (Node<'a>, RustPanicPattern)>,
+                ) {
+                    if let Some(pattern) = detect_ast_node(node, content) {
+                        let line_number = node.start_position().row + 1;
+                        let keep = if let Some((_, existing_pattern)) = candidates.get(&line_number)
+                        {
+                            pattern.precedence() > existing_pattern.precedence()
+                        } else {
+                            true
+                        };
+                        if keep {
+                            candidates.insert(line_number, (node, pattern));
+                        }
+                    }
+
+                    let mut cursor = node.walk();
+                    for child in node.children(&mut cursor) {
+                        visit(child, content, candidates);
+                    }
+                }
+
+                visit(tree.root_node(), content, &mut candidates);
+
+                let mut findings = Vec::new();
+                let mut sorted_lines: Vec<usize> = candidates.keys().copied().collect();
+                sorted_lines.sort_unstable();
+
+                for line_number in sorted_lines {
+                    let (node, pattern) = candidates.get(&line_number).unwrap();
+                    let trimmed_line = content.lines().nth(line_number - 1).unwrap_or("").trim();
+
+                    // Apply infallible write unwrap structural check
+                    if is_report_renderer_path(&file.path)
+                        && is_structural_infallible_render_write_unwrap(*node, content)
+                    {
+                        continue;
+                    }
+
+                    // Apply contextual ignore patterns
+                    if should_ignore_contextual_panic_pattern(*pattern, trimmed_line) {
+                        continue;
+                    }
+
+                    let decision = decide_for_audit_context(
+                        RULE_ID,
+                        &context,
+                        pattern.base_severity(),
+                        Some(pattern.signal()),
+                    );
+
+                    if decision.is_suppressed() {
+                        continue;
+                    }
+
+                    // Sanitize line for external failure checks
+                    let mut in_block_comment = false;
+                    let sanitized = sanitize_c_style(trimmed_line, &mut in_block_comment);
+                    let sanitized = sanitized.trim();
+
+                    let severity =
+                        if is_external_failure_path(*pattern, sanitized) && !context.is_test {
+                            decision.severity.max(Severity::High)
+                        } else {
+                            decision.severity
+                        };
+
+                    findings.push(build_finding(
+                        file,
+                        line_number,
+                        trimmed_line,
+                        *pattern,
+                        &context,
+                        severity,
+                    ));
+                }
+
+                findings
+            }
+            None => {
+                let mut findings = self.line_scan(file, content, &context);
+                mark_text_heuristic(&mut findings);
+                findings
+            }
+        }
+    }
+
+    fn line_scan(
+        &self,
+        file: &FileFacts,
+        content: &str,
+        context: &crate::audits::context::AuditContext,
+    ) -> Vec<Finding> {
         let mut findings = Vec::new();
         let mut in_block_comment = false;
         let mut pending_render_write = false;
@@ -80,7 +202,7 @@ impl FileAudit for RustPanicRiskAudit {
 
             let decision = decide_for_audit_context(
                 RULE_ID,
-                &context,
+                context,
                 pattern.base_severity(),
                 Some(pattern.signal()),
             );
@@ -100,7 +222,7 @@ impl FileAudit for RustPanicRiskAudit {
                 line_number,
                 trimmed,
                 pattern,
-                &context,
+                context,
                 severity,
             ));
 
@@ -110,5 +232,54 @@ impl FileAudit for RustPanicRiskAudit {
         }
 
         findings
+    }
+}
+
+fn detect_ast_node(node: Node<'_>, content: &str) -> Option<RustPanicPattern> {
+    match node.kind() {
+        "macro_invocation" => {
+            let macro_node = node
+                .child_by_field_name("macro")
+                .or_else(|| node.child(0))?;
+            let text = macro_node.utf8_text(content.as_bytes()).ok()?;
+            let macro_name = text.split("::").last()?;
+            match macro_name {
+                "panic" => Some(RustPanicPattern::Panic),
+                "todo" => Some(RustPanicPattern::Todo),
+                "unimplemented" => Some(RustPanicPattern::Unimplemented),
+                _ => None,
+            }
+        }
+        "call_expression" => {
+            let function = node.child_by_field_name("function")?;
+            if function.kind() == "field_expression" {
+                let field = function.child_by_field_name("field")?;
+                let method_name = field.utf8_text(content.as_bytes()).ok()?;
+                match method_name {
+                    "unwrap" => Some(RustPanicPattern::Unwrap),
+                    "unwrap_err" => Some(RustPanicPattern::UnwrapErr),
+                    "expect" => Some(RustPanicPattern::Expect),
+                    "expect_err" => Some(RustPanicPattern::ExpectErr),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn mark_text_heuristic(findings: &mut [Finding]) {
+    for finding in findings {
+        let lifecycle = lookup_rule_metadata(&finding.rule_id)
+            .map(|metadata| metadata.lifecycle)
+            .unwrap_or(RuleLifecycle::Preview);
+        finding.provenance = FindingProvenance {
+            detector: finding.rule_id.clone(),
+            signal_source: SignalSource::TextHeuristic,
+            rule_lifecycle: lifecycle,
+            analysis_scope: AnalysisScope::File,
+        };
     }
 }

--- a/src/audits/code_quality/rust_panic_risk/pattern.rs
+++ b/src/audits/code_quality/rust_panic_risk/pattern.rs
@@ -46,6 +46,21 @@ impl RustPanicPattern {
             | RustPanicPattern::Panic => Severity::Medium,
         }
     }
+
+    /// Precedence used to pick a single pattern when more than one risky site
+    /// lands on the same source line, mirroring the order of [`detect_pattern`]
+    /// so AST detection emits one finding per line just like the line scanner.
+    pub(super) fn precedence(self) -> u8 {
+        match self {
+            RustPanicPattern::Todo => 7,
+            RustPanicPattern::Unimplemented => 6,
+            RustPanicPattern::Panic => 5,
+            RustPanicPattern::UnwrapErr => 4,
+            RustPanicPattern::Unwrap => 3,
+            RustPanicPattern::ExpectErr => 2,
+            RustPanicPattern::Expect => 1,
+        }
+    }
 }
 
 pub(super) fn detect_pattern(trimmed: &str) -> Option<RustPanicPattern> {
@@ -153,7 +168,7 @@ pub(super) fn is_infallible_render_write_start(path: &std::path::Path, trimmed: 
         && (trimmed.starts_with("writeln!(") || trimmed.starts_with("write!("))
 }
 
-fn is_report_renderer_path(path: &std::path::Path) -> bool {
+pub(super) fn is_report_renderer_path(path: &std::path::Path) -> bool {
     let mut previous = None;
     for component in path
         .components()
@@ -165,6 +180,37 @@ fn is_report_renderer_path(path: &std::path::Path) -> bool {
         previous = Some(component);
     }
     false
+}
+
+pub(super) fn is_structural_infallible_render_write_unwrap(
+    node: tree_sitter::Node<'_>,
+    content: &str,
+) -> bool {
+    if node.kind() != "call_expression" {
+        return false;
+    }
+    let Some(function) = node.child_by_field_name("function") else {
+        return false;
+    };
+    if function.kind() != "field_expression" {
+        return false;
+    }
+    let Some(value) = function.child_by_field_name("value") else {
+        return false;
+    };
+    if value.kind() != "macro_invocation" {
+        return false;
+    }
+    let Some(macro_node) = value
+        .child_by_field_name("macro")
+        .or_else(|| value.child(0))
+    else {
+        return false;
+    };
+    let Ok(macro_name) = macro_node.utf8_text(content.as_bytes()) else {
+        return false;
+    };
+    macro_name == "write" || macro_name == "writeln"
 }
 
 pub(super) fn is_infallible_render_write_result_unwrap(

--- a/src/audits/code_quality/rust_panic_risk/tests.rs
+++ b/src/audits/code_quality/rust_panic_risk/tests.rs
@@ -277,7 +277,6 @@ fn does_not_run_without_file_content() {
 
     assert!(findings.is_empty());
 }
-
 fn facts(path: &str, content: &str, has_inline_tests: bool) -> FileFacts {
     FileFacts {
         path: PathBuf::from(path),
@@ -288,4 +287,28 @@ fn facts(path: &str, content: &str, has_inline_tests: bool) -> FileFacts {
         content: Some(content.to_string()),
         has_inline_tests,
     }
+}
+
+#[test]
+fn falls_back_to_line_scanner_when_no_parsed_tree() {
+    use crate::analysis::parse::ParsedFile;
+    use crate::rules::SignalSource;
+
+    let file = facts(
+        "src/domain/parser.rs",
+        "let value = parse().unwrap();",
+        false,
+    );
+
+    // Create a ParsedFile with None for language label to force tree() to return None
+    let parsed = ParsedFile::new("let value = parse().unwrap();", None);
+
+    let findings = RustPanicRiskAudit.audit_parsed(&file, &parsed, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, RULE_ID);
+    assert_eq!(
+        findings[0].provenance.signal_source,
+        SignalSource::TextHeuristic
+    );
 }

--- a/src/audits/code_quality/rust_panic_risk/tests.rs
+++ b/src/audits/code_quality/rust_panic_risk/tests.rs
@@ -155,6 +155,11 @@ fn still_reports_unwraps_inside_renderer_format_arguments() {
         false,
     );
 
+    let parsed = crate::analysis::parse::ParsedFile::for_facts(&file);
+    if let Some(tree) = parsed.tree() {
+        println!("AST TREE: {}", tree.root_node().to_sexp());
+    }
+
     let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
 
     assert_eq!(findings.len(), 1);

--- a/src/rules/registry/language.rs
+++ b/src/rules/registry/language.rs
@@ -10,11 +10,14 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
-        signal_source: SignalSource::TextHeuristic,
+        signal_source: SignalSource::Ast,
         docs_url: None,
         description: "Rust panic-style operations such as unwrap(), expect(), panic!, todo!, and unimplemented! can be risky in reusable production code. Their severity depends on whether the code is test code, CLI boundary code, library code, or domain code.",
         recommendation: Some(
             "Use context-aware error handling. Prefer Result, ?, typed errors, validation, or explicit fallback behavior in production and library code.",
+        ),
+        false_positive_notes: Some(
+            "`unwrap`/`expect`/`unwrap_err`/`expect_err` calls and `panic!`/`todo!`/`unimplemented!` macros are matched from the parsed syntax tree, so the same tokens inside comments or string literals (including multi-line raw strings) are not flagged, and infallible `write!`/`writeln!` result unwraps in report renderers are recognized structurally. Severity context (test/CLI/library/domain) and external-input escalation remain heuristic. A line scanner with text-heuristic provenance is used only when the file fails to parse.",
         ),
         ..RuleMetadata::DEFAULT
     },


### PR DESCRIPTION
## Summary

Upgrades Rust panic-risk detection to AST-based matching.

The `language.rust.panic-risk` rule now detects real Rust call expressions and macro invocations from the shared parsed syntax tree, while keeping the previous line scanner as a parse-failure fallback.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Migrated `RustPanicRiskAudit` to use the shared `ParsedFile` view.
- Added `audit_parsed(...)` support for Rust panic-risk detection.
- Added AST detection for:
  - `.unwrap()`
  - `.unwrap_err()`
  - `.expect()`
  - `.expect_err()`
  - `panic!`
  - `todo!`
  - `unimplemented!`
- Preserved the existing line scanner as a parse-failure fallback.
- Added fallback provenance override so line-scanner findings report `SignalSource::TextHeuristic`.
- Updated `language.rust.panic-risk` rule metadata from `TextHeuristic` to `Ast`.
- Added false-positive notes explaining AST detection and fallback behavior.
- Added precedence handling so AST detection emits one finding per line, matching the previous line-scanner behavior.
- Added structural detection for infallible `write!` / `writeln!` result unwraps in report renderers.
- Added regression coverage for fallback behavior when no parsed tree is available.

## Why

Rust panic-risk detection was still text-heuristic while other runtime-risk rules were moving to AST-backed detection.

Text matching can produce false positives when risky tokens appear inside comments, strings, raw strings, or unrelated text.

AST detection improves precision by matching real Rust syntax nodes instead of raw text.

## Architecture notes

- `analysis::parse::ParsedFile` remains the shared parse view.
- `RustPanicRiskAudit` now consumes `ParsedFile` through `audit_parsed`.
- AST-specific detection is isolated in `detect_ast_node(...)`.
- The previous line scanner remains available as fallback.
- Fallback findings are explicitly stamped as `TextHeuristic`.
- Rule metadata now declares `SignalSource::Ast`.
- Existing contextual severity logic is preserved.
- Existing report-renderer false-positive handling is preserved and improved structurally.
- No god file introduced.

## Behavior

This PR can change Rust panic-risk findings.

Expected behavior:

- real `.unwrap()` / `.expect()` calls are still flagged;
- real `panic!`, `todo!`, and `unimplemented!` macros are still flagged;
- risky tokens inside comments or string literals should no longer be flagged by the AST path;
- parse-failure fallback still uses the line scanner;
- fallback findings report `text-heuristic` provenance.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan .
cargo bench --bench scan_bench