### PR TITLE
feat(mcp): add scan, context, and explain tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Added
 
 - Added `repopilot mcp`, a local Model Context Protocol server over stdio so AI agents (Claude Code, Cursor, …) can call RepoPilot as a tool. It speaks JSON-RPC 2.0 synchronously (no async runtime or extra dependencies) and exposes the `repopilot_review_change` tool, which runs the same local scan + diff review as `repopilot review` and returns a JSON report. Nothing is uploaded and no AI service is called.
+- Added three more MCP tools to `repopilot mcp`: `repopilot_scan` (full repository audit as JSON), `repopilot_context` (budgeted AI-ready Markdown brief, with optional `focus`/`budget`), and `repopilot_explain_file` (how a single file is classified and which rules/signals apply). Each wraps the existing `scan`, `ai context`, and `inspect explain` pipelines and runs entirely locally.
 - Added architecture anti-pattern documentation describing production-scope policy and false-positive expectations for architecture rules.
 - Added a Criterion scan-throughput benchmark (`cargo bench --bench scan_bench`) over a generated 480-file multi-language synthetic repository to baseline full-scan performance ahead of the shared parsed-AST work.
 - Added a `scan_timings.parse_us` field reporting aggregate tree-sitter parsing time during file analysis (a sub-measure of `file_analysis_us`, excluded from `accounted_engine_us`).

--- a/src/commands/mcp/context.rs
+++ b/src/commands/mcp/context.rs
@@ -1,0 +1,70 @@
+//! The `repopilot_context` MCP tool: a budgeted, AI-ready Markdown brief of the
+//! repository, wrapping the same builder the `ai context` command uses.
+
+use crate::commands::focus::parse_focus_category;
+use crate::commands::product_scan::{ProductScanMode, ProductScanRequest, run_product_scan};
+use crate::commands::scan_config::ScanConfigOverrides;
+use repopilot::findings::filter::FindingFilter;
+use repopilot::findings::visibility::FindingVisibilityProfile;
+use repopilot::output::ai_context::{AiContextRenderOptions, DEFAULT_TOKEN_BUDGET, render};
+use serde_json::{Value, json};
+use std::path::PathBuf;
+
+pub const TOOL_NAME: &str = "repopilot_context";
+
+pub fn definition() -> Value {
+    json!({
+        "name": TOOL_NAME,
+        "description": "Generate a budgeted, AI-ready Markdown brief of the repository (risks, hotspots, structure) for an agent to reason over before editing. Built locally from a scan — no AI service is called and nothing is uploaded.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Repository path. Defaults to the current working directory."
+                },
+                "focus": {
+                    "type": "string",
+                    "description": "Optional focus: security, architecture (or arch), quality, framework, or all."
+                },
+                "budget": {
+                    "type": "integer",
+                    "description": "Optional approximate token budget for the brief. Defaults to the standard budget."
+                }
+            },
+            "additionalProperties": false
+        }
+    })
+}
+
+pub fn call(arguments: &Value) -> Result<String, String> {
+    let path = PathBuf::from(arguments.get("path").and_then(Value::as_str).unwrap_or("."));
+    let focus = parse_focus_category(arguments.get("focus").and_then(Value::as_str))
+        .map_err(|error| error.to_string())?;
+    let budget_tokens = arguments
+        .get("budget")
+        .and_then(Value::as_u64)
+        .map_or(DEFAULT_TOKEN_BUDGET, |budget| budget as usize);
+
+    let scan_result = run_product_scan(ProductScanRequest {
+        path,
+        config_path: None,
+        overrides: ScanConfigOverrides::default(),
+        preset: None,
+        mode: ProductScanMode::Full,
+        no_progress: true,
+        ignore_feedback: false,
+        visibility_profile: FindingVisibilityProfile::Default,
+        pre_visibility_filter: FindingFilter::default(),
+    })
+    .map_err(|error| format!("scan failed: {error}"))?;
+
+    let options = AiContextRenderOptions {
+        focus,
+        budget_tokens,
+        no_header: false,
+        no_task: false,
+    };
+
+    Ok(render(&scan_result.summary, &options))
+}

--- a/src/commands/mcp/explain_file.rs
+++ b/src/commands/mcp/explain_file.rs
@@ -1,0 +1,52 @@
+//! The `repopilot_explain_file` MCP tool: how RepoPilot classifies one file and
+//! which rules/signals apply, wrapping the `inspect explain` builder.
+
+use repopilot::explain::{build_explain_report, render_explain_report};
+use repopilot::findings::types::Severity;
+use repopilot::output::OutputFormat;
+use serde_json::{Value, json};
+use std::path::PathBuf;
+
+pub const TOOL_NAME: &str = "repopilot_explain_file";
+
+pub fn definition() -> Value {
+    json!({
+        "name": TOOL_NAME,
+        "description": "Explain how RepoPilot classifies a single file (role, language, test/production context) and which rules and signals apply, with the resulting severity decisions. Returns a JSON explanation. Local-only.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file to explain."
+                },
+                "rule": {
+                    "type": "string",
+                    "description": "Optional rule id to focus the explanation on."
+                },
+                "signal": {
+                    "type": "string",
+                    "description": "Optional signal id to focus the explanation on."
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        }
+    })
+}
+
+pub fn call(arguments: &Value) -> Result<String, String> {
+    let Some(path) = arguments.get("path").and_then(Value::as_str) else {
+        return Err("`path` is required".to_string());
+    };
+    let path = PathBuf::from(path);
+    let rule = arguments.get("rule").and_then(Value::as_str);
+    let signal = arguments.get("signal").and_then(Value::as_str);
+
+    // Lowest base severity so the explanation surfaces every applicable rule.
+    let report = build_explain_report(&path, rule, signal, Severity::Info)
+        .map_err(|error| format!("explain failed: {error}"))?;
+
+    render_explain_report(&report, OutputFormat::Json)
+        .map_err(|error| format!("render failed: {error}"))
+}

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -8,8 +8,11 @@
 //! RepoPilot's local-first promise (nothing is uploaded; no AI service is
 //! called).
 
+mod context;
+mod explain_file;
 mod jsonrpc;
 mod review_change;
+mod scan;
 
 #[cfg(test)]
 mod tests;
@@ -89,7 +92,14 @@ fn initialize_result(params: &Value) -> Value {
 }
 
 fn tools_list_result() -> Value {
-    json!({ "tools": [review_change::definition()] })
+    json!({
+        "tools": [
+            review_change::definition(),
+            scan::definition(),
+            context::definition(),
+            explain_file::definition(),
+        ]
+    })
 }
 
 fn handle_tools_call(id: Value, params: &Value) -> Response {
@@ -104,6 +114,9 @@ fn handle_tools_call(id: Value, params: &Value) -> Response {
 
     let outcome = match name {
         review_change::TOOL_NAME => review_change::call(&arguments),
+        scan::TOOL_NAME => scan::call(&arguments),
+        context::TOOL_NAME => context::call(&arguments),
+        explain_file::TOOL_NAME => explain_file::call(&arguments),
         other => Err(format!("unknown tool: {other}")),
     };
 

--- a/src/commands/mcp/scan.rs
+++ b/src/commands/mcp/scan.rs
@@ -1,0 +1,51 @@
+//! The `repopilot_scan` MCP tool: a full repository audit, wrapping the same
+//! scan pipeline the `scan` command uses and returning the JSON report.
+
+use crate::commands::product_scan::{ProductScanMode, ProductScanRequest, run_product_scan};
+use crate::commands::scan_config::ScanConfigOverrides;
+use repopilot::findings::filter::FindingFilter;
+use repopilot::findings::visibility::FindingVisibilityProfile;
+use repopilot::output::{OutputFormat, render_scan_summary};
+use serde_json::{Value, json};
+use std::path::PathBuf;
+
+pub const TOOL_NAME: &str = "repopilot_scan";
+
+pub fn definition() -> Value {
+    json!({
+        "name": TOOL_NAME,
+        "description": "Audit a repository, folder, or file for findings across architecture, coupling, code quality, security, and testing, and return the full JSON scan report (findings, metrics, risk summary). Runs entirely on disk — nothing is uploaded.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to scan. Defaults to the current working directory."
+                }
+            },
+            "additionalProperties": false
+        }
+    })
+}
+
+pub fn call(arguments: &Value) -> Result<String, String> {
+    let path = PathBuf::from(arguments.get("path").and_then(Value::as_str).unwrap_or("."));
+
+    let scan_result = run_product_scan(ProductScanRequest {
+        path,
+        config_path: None,
+        overrides: ScanConfigOverrides::default(),
+        preset: None,
+        mode: ProductScanMode::Full,
+        // The stdio transport owns stdout; progress would corrupt the JSON-RPC
+        // stream, so it is always disabled here.
+        no_progress: true,
+        ignore_feedback: false,
+        visibility_profile: FindingVisibilityProfile::Default,
+        pre_visibility_filter: FindingFilter::default(),
+    })
+    .map_err(|error| format!("scan failed: {error}"))?;
+
+    render_scan_summary(&scan_result.summary, OutputFormat::Json)
+        .map_err(|error| format!("render failed: {error}"))
+}

--- a/src/commands/mcp/tests.rs
+++ b/src/commands/mcp/tests.rs
@@ -44,7 +44,7 @@ fn initialize_reports_server_info_and_tools_capability() {
 }
 
 #[test]
-fn tools_list_advertises_review_change_with_schema() {
+fn tools_list_advertises_all_tools_with_schemas() {
     let responses = exchange(&[json!({
         "jsonrpc": "2.0",
         "id": 2,
@@ -54,9 +54,29 @@ fn tools_list_advertises_review_change_with_schema() {
     let tools = responses[0]["result"]["tools"]
         .as_array()
         .expect("tools array");
-    assert_eq!(tools.len(), 1);
-    assert_eq!(tools[0]["name"], "repopilot_review_change");
-    assert_eq!(tools[0]["inputSchema"]["type"], "object");
+
+    let names: Vec<&str> = tools
+        .iter()
+        .map(|tool| tool["name"].as_str().expect("tool name"))
+        .collect();
+    assert_eq!(
+        names,
+        [
+            "repopilot_review_change",
+            "repopilot_scan",
+            "repopilot_context",
+            "repopilot_explain_file",
+        ]
+    );
+
+    // Every advertised tool exposes an object input schema.
+    for tool in tools {
+        assert_eq!(
+            tool["inputSchema"]["type"], "object",
+            "tool {}",
+            tool["name"]
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Expands `repopilot mcp` with three additional local tools for AI-assisted repository work.

The MCP server now exposes tools for scanning a repository, generating an AI-ready context brief, and explaining how RepoPilot classifies a specific file.

## Type of change

- [x] Feature
- [x] Tests
- [x] Documentation
- [x] Repository maintenance
- [ ] Refactor
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Added `repopilot_scan`.
- Added `repopilot_context`.
- Added `repopilot_explain_file`.
- Updated `tools/list` to advertise all MCP tools:
  - `repopilot_review_change`
  - `repopilot_scan`
  - `repopilot_context`
  - `repopilot_explain_file`
- Wired `tools/call` dispatch for the new tools.
- `repopilot_scan` wraps the existing full scan pipeline and returns JSON.
- `repopilot_context` wraps the AI context renderer and supports optional `focus` and `budget`.
- `repopilot_explain_file` wraps the inspect explain pipeline and returns JSON.
- Updated MCP tests to assert all tools are listed with object schemas.
- Updated `CHANGELOG.md`.

## Why

`repopilot mcp` should be useful as a local tool provider for AI agents, not only as a change-review endpoint.

With this PR, an agent can:

- scan the repository before editing;
- request a compact AI-ready project brief;
- inspect why a specific file is classified a certain way;
- review current changes through the existing review tool.

This makes RepoPilot more practical for Claude Code, Cursor, and other MCP clients while keeping all analysis local.

## Architecture notes

- MCP tools remain isolated under `src/commands/mcp`.
- Each tool has its own focused module.
- Existing RepoPilot pipelines are reused instead of duplicated.
- MCP mode still disables progress output so stdout stays valid JSON-RPC.
- All tools run locally and do not call external AI services.
- No god file introduced.

## Behavior

This PR adds three new MCP tools:

```text
repopilot_scan
repopilot_context
repopilot_explain_file