### PR TITLE
chore(release): prepare 0.14.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target
 .repopilot/cache/
+# Scan caches written under any nested project root (e.g. when scanning a subdir).
+**/.repopilot/cache/
 .claude/
 dist/
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-31
+
+RepoPilot 0.14 is the AI-guardrail release. Every runtime-risk and code-quality
+rule now detects from a shared, parse-once syntax tree instead of line text —
+fewer false positives, restored `ast` provenance, and one parse per file. And a
+new local `repopilot mcp` server lets AI coding agents call RepoPilot's review,
+scan, context, and explain capabilities directly over stdio, with nothing
+uploaded and no AI service called.
+
 ### Added
 
 - Added `repopilot mcp`, a local Model Context Protocol server over stdio so AI agents (Claude Code, Cursor, …) can call RepoPilot as a tool. It speaks JSON-RPC 2.0 synchronously (no async runtime or extra dependencies) and exposes the `repopilot_review_change` tool, which runs the same local scan + diff review as `repopilot review` and returns a JSON report. Nothing is uploaded and no AI service is called.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repopilot"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repopilot"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Local-first CLI for repository audit, architecture risk detection, baseline tracking, and CI-friendly code review."

--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ repopilot scan . --format json --output repopilot-report.json --receipt .repopil
 repopilot scan . --format sarif --output repopilot.sarif
 ```
 
+## Use with AI agents (MCP)
+
+RepoPilot ships a local [Model Context Protocol](https://modelcontextprotocol.io) server so AI coding agents (Claude Code, Cursor, …) can call it as a tool — auditing what the agent just changed, without anything leaving your machine.
+
+```bash
+claude mcp add repopilot -- repopilot mcp
+```
+
+The server runs locally over stdio (JSON-RPC, no network, no AI calls) and exposes four tools:
+
+- `repopilot_review_change` — audit the current Git changes: in-diff vs out-of-diff findings plus blast radius.
+- `repopilot_scan` — full repository audit as a JSON report.
+- `repopilot_context` — a budgeted, AI-ready Markdown brief of the repo.
+- `repopilot_explain_file` — how a single file is classified and which rules apply.
+
+More: [docs/mcp.md](docs/mcp.md).
+
 ## What It Checks
 
 | Area | Examples |
@@ -121,7 +138,7 @@ More: [docs/trust-mode.md](docs/trust-mode.md).
 ## Core Commands
 
 ```text
-scan | review | baseline | compare | doctor | inspect | ai | init | cache
+scan | review | baseline | compare | doctor | inspect | ai | init | cache | mcp
 ```
 
 Common workflows:

--- a/docs/archive/release-checklist-0.14.md
+++ b/docs/archive/release-checklist-0.14.md
@@ -1,0 +1,98 @@
+# RepoPilot 0.14.0 Release Checklist
+
+RepoPilot 0.14.0 is the AI-guardrail release for the pre-1.0 line.
+
+Main release promise:
+
+```text
+parse once -> AST-precise findings -> local MCP tools for AI agents -> still nothing leaves your machine
+```
+
+## Release Scope
+
+- Keep the primary CLI families: `scan`, `review`, `baseline`, `compare`, `doctor`, `ai`, `inspect`, `init`, `cache`, and the new `mcp`.
+- Keep runtime commands local-first: no telemetry, source upload, hosted scanner, plugin runtime, external rule execution, or LLM API calls.
+- The `repopilot mcp` server is local-first too: stdio JSON-RPC only, no network egress, no AI service calls, and no source upload. Its tools run the same on-disk analysis as the CLI.
+- Use `repopilot::api::*` as the supported Rust embedding facade; treat direct internal modules as unsupported implementation detail.
+- Keep rule growth limited to regression fixes only; this release upgrades detection precision (AST), not rule coverage.
+
+## Engine Contract Gates
+
+Verify every rendered finding has:
+
+- stable `id`;
+- non-empty `rule_id`;
+- non-empty title and description;
+- non-empty recommendation;
+- at least one evidence item;
+- risk score, priority, formula version, and risk signals;
+- provenance with detector, lifecycle, signal source, and scope;
+- schema-safe serialization in JSON and SARIF.
+
+Rule metadata gates:
+
+- every registered rule has non-empty title, description, recommendation;
+- every registered rule has lifecycle, signal source, and default confidence;
+- runtime-risk and long-function rules report `ast` signal source (line scanner remains a parse-failure fallback only);
+- `repopilot inspect rules`, `inspect rule`, and `inspect eval-rules` pass locally;
+- `scripts/smoke-product.sh` verifies the self-scan JSON report has zero finding contract violations and zero default-visible noisy findings.
+
+## MCP Gates
+
+```bash
+cargo test --test mcp_cli
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | cargo run -- mcp
+```
+
+Verify:
+
+- `initialize` returns `serverInfo.name = "repopilot"` and a `tools` capability;
+- `tools/list` advertises `repopilot_review_change`, `repopilot_scan`, `repopilot_context`, and `repopilot_explain_file`, each with an object input schema;
+- `tools/call` returns local results and reports tool failures in-band (`isError: true`) rather than as transport errors;
+- the server performs no network egress and calls no AI service.
+
+## Smoke commands
+
+```bash
+cargo run -- scan . --format json --output /tmp/repopilot-014-scan.json --receipt /tmp/repopilot-014-receipt.json
+cargo run -- scan . --format sarif --output /tmp/repopilot-014.sarif
+cargo run -- baseline create . --output /tmp/repopilot-014-baseline.json
+cargo run -- scan . --baseline /tmp/repopilot-014-baseline.json --fail-on new-high
+cargo run -- review . --format json --output /tmp/repopilot-014-review.json
+cargo run -- ai context . --budget 2k --output /tmp/repopilot-014-ai-context.md
+cargo run -- inspect rules --format json --output /tmp/repopilot-014-rules.json
+cargo run -- inspect eval-rules --format json --output /tmp/repopilot-014-rule-eval.json
+```
+
+## Required Local Checks
+
+Run from the repository root:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+npm run test:npm
+npm pack --dry-run
+cargo package --list
+cargo publish --dry-run
+./scripts/verify-release.sh
+cargo build --release
+./scripts/smoke-product.sh --binary ./target/release/repopilot --repo .
+```
+
+## Version Consistency
+
+Before tagging, verify:
+
+```bash
+grep '^version = "0.14.0"' Cargo.toml
+grep '"version": "0.14.0"' package.json
+grep '## \[0.14.0\]' CHANGELOG.md
+rg -n '0\.13\.0|release-checklist-0\.13' Cargo.toml package.json action.yml README.md docs .github scripts install.sh Formula examples
+```
+
+The final search should only report historical changelog entries, old release
+checklists, old release announcements, and examples intentionally pinned to old
+versions.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,6 +35,7 @@ Use `-h` for a short summary or `--help` for the full description and examples.
 | [`baseline create`](#baseline-create) | — | Scan a path and store current findings as accepted debt |
 | [`doctor`](#doctor) | `d` | Diagnose audit readiness |
 | [`init`](#init) | — | Generate a default `repopilot.toml` configuration file |
+| [`mcp`](#mcp) | — | Run a local Model Context Protocol server over stdio |
 
 ---
 
@@ -802,6 +803,39 @@ repopilot init [OPTIONS]
 repopilot init
 repopilot init --force
 repopilot init --path ./config/repopilot.toml
+```
+
+---
+
+## `mcp`
+
+Runs a local Model Context Protocol (MCP) server over stdio so AI agents can call RepoPilot as a tool. It speaks JSON-RPC 2.0 on stdin/stdout and is launched by the MCP client, not run interactively. Nothing is uploaded and no AI service is called; each tool runs the same local analysis as the CLI.
+
+See [docs/mcp.md](mcp.md) for the tool catalog, schemas, and agent registration.
+
+### Synopsis
+
+```
+repopilot mcp
+```
+
+### Tools
+
+| Tool | Description |
+|------|-------------|
+| `repopilot_review_change` | Audit the current Git changes: in-diff vs out-of-diff findings plus blast radius |
+| `repopilot_scan` | Full repository audit as a JSON report |
+| `repopilot_context` | Budgeted, AI-ready Markdown brief (optional `focus`, `budget`) |
+| `repopilot_explain_file` | How one file is classified and which rules and signals apply |
+
+### Examples
+
+```bash
+# Register with Claude Code
+claude mcp add repopilot -- repopilot mcp
+
+# Manual smoke test (list the available tools)
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | repopilot mcp
 ```
 
 ---

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,124 @@
+# MCP server
+
+`repopilot mcp` runs a local [Model Context Protocol](https://modelcontextprotocol.io)
+server so AI coding agents (Claude Code, Cursor, and other MCP clients) can call
+RepoPilot as a tool — for example, to audit a change the agent just made before
+proposing it.
+
+It is the same engine as the CLI, exposed over a different transport:
+
+- **Local-first.** The server runs on your machine over stdio. No source is
+  uploaded, no telemetry is sent, and no AI service is called. Every tool runs
+  the same on-disk analysis as the corresponding command.
+- **Lean and synchronous.** The transport is a small JSON-RPC 2.0 loop over
+  stdin/stdout — no async runtime and no extra dependencies. The protocol surface
+  is intentionally small enough to audit.
+
+## Register with an agent
+
+The client launches `repopilot mcp` for you; you only register the command once.
+
+Claude Code:
+
+```bash
+claude mcp add repopilot -- repopilot mcp
+```
+
+Any other MCP client uses the same idea — a stdio server whose command is
+`repopilot mcp`. A typical client config entry:
+
+```json
+{
+  "mcpServers": {
+    "repopilot": {
+      "command": "repopilot",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Make sure `repopilot` is on `PATH` (see [install.md](install.md)).
+
+## Tools
+
+All tools take a `path` that defaults to the current working directory and return
+their result as text content (JSON, except `repopilot_context` which returns
+Markdown). A tool that fails returns an MCP error result (`isError: true`) with a
+message, rather than tearing down the connection.
+
+### `repopilot_review_change`
+
+Audit the current Git changes: scans the repository, splits findings into those
+touching changed diff lines vs. the rest, and reports blast radius (files that
+import the changed files). Mirrors `repopilot review`.
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `path` | string | Repository path. Defaults to the current directory. |
+| `base` | string | Base Git ref to diff against (e.g. `origin/main`). Optional; defaults to the working tree vs `HEAD`. |
+| `head` | string | Head Git ref. Optional; only valid together with `base`. |
+
+Returns the JSON review report (findings, in-diff status, blast radius).
+
+### `repopilot_scan`
+
+Full repository audit across architecture, coupling, code quality, security, and
+testing. Mirrors `repopilot scan`.
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `path` | string | Path to scan. Defaults to the current directory. |
+
+Returns the JSON scan report (findings, metrics, risk summary).
+
+### `repopilot_context`
+
+A budgeted, AI-ready Markdown brief of the repository (risks, hotspots, structure)
+for the agent to reason over before editing. Mirrors `repopilot ai context`.
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `path` | string | Repository path. Defaults to the current directory. |
+| `focus` | string | Optional focus: `security`, `architecture` (or `arch`), `quality`, `framework`, or `all`. |
+| `budget` | integer | Optional approximate token budget. Defaults to the standard budget. |
+
+Returns the brief as Markdown.
+
+### `repopilot_explain_file`
+
+Explains how RepoPilot classifies one file (role, language, test/production
+context) and which rules and signals apply, with the resulting severity
+decisions. Mirrors `repopilot inspect explain`.
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `path` | string | Path to the file to explain. Required. |
+| `rule` | string | Optional rule id to focus the explanation on. |
+| `signal` | string | Optional signal id to focus on. |
+
+Returns the JSON explanation.
+
+## How it works
+
+The server handles the MCP `initialize`, `tools/list`, and `tools/call` methods.
+On `tools/call` it dispatches to one of the tools above, which calls the same
+library entry points the CLI uses (`build_review_report`, the product scan,
+`ai_context::render`, and the explain builder) and returns the rendered result.
+
+Because stdout carries the JSON-RPC stream, the tools always run with progress
+output disabled so nothing corrupts the protocol.
+
+## Manual smoke test
+
+You can drive the server by hand with newline-delimited JSON-RPC messages:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"repopilot_scan","arguments":{"path":"."}}}' \
+  | repopilot mcp
+```
+
+Each response is one line of JSON on stdout.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repopilot",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"description": "Local-first CLI for repository audit, architecture risk detection, baseline tracking, and CI-friendly code review.",
 	"license": "MIT OR Apache-2.0",
 	"repository": {
@@ -26,11 +26,11 @@
 		"LICENSE"
 	],
 	"optionalDependencies": {
-		"@repopilot/darwin-arm64": "0.13.0",
-		"@repopilot/darwin-x64": "0.13.0",
-		"@repopilot/linux-arm64-gnu": "0.13.0",
-		"@repopilot/linux-x64-gnu": "0.13.0",
-		"@repopilot/win32-x64-msvc": "0.13.0"
+		"@repopilot/darwin-arm64": "0.14.0",
+		"@repopilot/darwin-x64": "0.14.0",
+		"@repopilot/linux-arm64-gnu": "0.14.0",
+		"@repopilot/linux-x64-gnu": "0.14.0",
+		"@repopilot/win32-x64-msvc": "0.14.0"
 	},
 	"keywords": [
 		"cli",

--- a/tests/mcp_cli.rs
+++ b/tests/mcp_cli.rs
@@ -1,0 +1,120 @@
+//! End-to-end test for the `repopilot mcp` stdio server: spawn the real binary,
+//! drive it with JSON-RPC over stdin, and assert the tool surface and a local
+//! tool call. The whole exchange runs offline from on-disk files, exercising the
+//! local-first promise (no network, no AI service).
+
+use serde_json::Value;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// Runs `repopilot mcp` over `requests` (one JSON-RPC message each) and returns
+/// the decoded responses in order. Closing stdin ends the server loop.
+fn run_mcp(requests: &[&str], cwd: &Path) -> Vec<Value> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_repopilot"))
+        .arg("mcp")
+        .current_dir(cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn `repopilot mcp`");
+
+    {
+        let mut stdin = child.stdin.take().expect("child stdin");
+        for request in requests {
+            stdin.write_all(request.as_bytes()).expect("write request");
+            stdin.write_all(b"\n").expect("write newline");
+        }
+        // Dropping stdin sends EOF, which ends the server's read loop.
+    }
+
+    let output = child.wait_with_output().expect("wait for `repopilot mcp`");
+    assert!(
+        output.status.success(),
+        "server exited with {:?}",
+        output.status.code()
+    );
+
+    String::from_utf8(output.stdout)
+        .expect("stdout is utf-8")
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("response line is json"))
+        .collect()
+}
+
+#[test]
+fn mcp_server_initializes_lists_tools_and_runs_scan_locally() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    fs::create_dir_all(temp.path().join("src")).expect("src dir");
+    fs::write(
+        temp.path().join("src/lib.rs"),
+        "pub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n",
+    )
+    .expect("source file");
+
+    let responses = run_mcp(
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+            r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"repopilot_scan","arguments":{"path":"."}}}"#,
+        ],
+        temp.path(),
+    );
+
+    assert_eq!(responses.len(), 3, "one response per request");
+
+    // initialize advertises the server identity.
+    assert_eq!(responses[0]["result"]["serverInfo"]["name"], "repopilot");
+
+    // tools/list exposes the full tool surface in order.
+    let names: Vec<&str> = responses[1]["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|tool| tool["name"].as_str().expect("tool name"))
+        .collect();
+    assert_eq!(
+        names,
+        [
+            "repopilot_review_change",
+            "repopilot_scan",
+            "repopilot_context",
+            "repopilot_explain_file",
+        ]
+    );
+
+    // tools/call runs the scan entirely from local files and returns a JSON report.
+    let result = &responses[2]["result"];
+    assert_eq!(result["isError"], false, "scan should succeed");
+    let text = result["content"][0]["text"].as_str().expect("text content");
+    let report: Value = serde_json::from_str(text).expect("scan report is json");
+    assert!(
+        report["schema_version"].is_string(),
+        "scan report carries schema metadata"
+    );
+    assert!(report["report"].is_object(), "scan report carries findings");
+}
+
+#[test]
+fn mcp_server_reports_unknown_tool_as_in_band_error() {
+    let temp = tempfile::tempdir().expect("temp dir");
+
+    let responses = run_mcp(
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"nope","arguments":{}}}"#,
+        ],
+        temp.path(),
+    );
+
+    let result = &responses[0]["result"];
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .expect("text")
+            .contains("unknown tool")
+    );
+}


### PR DESCRIPTION
## Summary

Prepares the RepoPilot `0.14.0` release.

This release focuses on AST-precise findings, parse-once analysis, and the new local MCP server for AI-assisted development workflows.

## Type of change

- [x] Documentation
- [x] Repository maintenance
- [x] CI / release preparation
- [ ] Feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Tests

## What changed

- Bumped RepoPilot version to `0.14.0`.
- Added the `0.14.0` changelog entry.
- Positioned `0.14.0` as the AI-guardrail release.
- Added the `0.14.0` release checklist.
- Updated README with the new MCP workflow.
- Added MCP documentation and tool reference.
- Updated CLI docs with the new `mcp` command.
- Updated the core command list to include `mcp`.
- Added `.repopilot/cache` ignore coverage for nested project roots.
- Documented local-first MCP behavior:
  - stdio JSON-RPC transport;
  - no network upload;
  - no AI service calls;
  - tools reuse existing local RepoPilot pipelines.

## Why

`0.14.0` contains a large set of user-facing improvements:

- shared parse-once syntax-tree analysis;
- AST-backed runtime-risk and code-quality findings;
- lower false-positive noise from comments and strings;
- restored `ast` provenance for syntax-aware rules;
- local MCP support for AI agents.

This PR prepares the release materials so the version can be tagged, verified, and published consistently.

## Architecture notes

- No production scanner logic changed in this PR.
- This PR documents and packages the completed release scope.
- MCP remains local-first and stdio-based.
- Release checklist includes verification gates for finding contracts, rule metadata, MCP behavior, and smoke commands.
- No god files introduced.

## Behavior

This PR prepares the `0.14.0` release.

Expected user-facing release highlights:

- `repopilot mcp` is available as a new local MCP server.
- MCP tools expose review, scan, context, and explain workflows.
- Runtime-risk and code-quality rules now use AST-backed detection where supported.
- Rule provenance is clearer: AST-backed rules report `ast`, parse-failure fallback reports `text-heuristic`.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run test:npm
npm pack --dry-run
cargo package --list
cargo publish --dry-run
./scripts/verify-release.sh
cargo build --release
./scripts/smoke-product.sh --binary ./target/release/repopilot --repo .