### PR TITLE
feat(security): add review security-boundary change signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- Added security-boundary change signals to `repopilot review` (and the `repopilot_review_change` MCP tool). The review now flags when a change touches parts of the repo that decide *who can do what* (auth, sessions, permissions, CORS) or *how the app ships* (CI/workflows, Dockerfiles, IaC, dependency manifests, committed `.env`). It is path/filename classification over the diff — it flags, it does not prove a change is safe, so a false positive costs only a glance. Signals appear in the console and Markdown output and as a structured `boundary_signals` array in the JSON report. Configure or disable via a new `[security_boundary]` config section (`enabled`, `extra_patterns`). Ships at `preview`.
+
 ## [0.14.0] - 2026-05-31
 
 RepoPilot 0.14 is the AI-guardrail release. Every runtime-risk and code-quality

--- a/repopilot.toml
+++ b/repopilot.toml
@@ -39,5 +39,9 @@ detect_missing_tests = true
 [security]
 detect_secret_like_names = true
 
+[security_boundary]
+enabled = true
+extra_patterns = []
+
 [output]
 default_format = "console"

--- a/src/commands/mcp/review_change.rs
+++ b/src/commands/mcp/review_change.rs
@@ -65,8 +65,16 @@ pub fn call(arguments: &Value) -> Result<String, String> {
     })
     .map_err(|error| format!("scan failed: {error}"))?;
 
-    let review_report = build_review_report(scan_result.summary, &path, base, head, None)
-        .map_err(|error| format!("review failed: {error}"))?;
+    let boundary_config = scan_result.repo_config.security_boundary;
+    let review_report = build_review_report(
+        scan_result.summary,
+        &path,
+        base,
+        head,
+        None,
+        &boundary_config,
+    )
+    .map_err(|error| format!("review failed: {error}"))?;
 
     render(&review_report, OutputFormat::Json, None)
         .map_err(|error| format!("render failed: {error}"))

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -62,6 +62,7 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
         options.base.as_deref(),
         options.head.as_deref(),
         baseline_ref,
+        &scan_result.repo_config.security_boundary,
     )?;
     if !priority_filter.is_empty() {
         review_report.apply_filter(&priority_filter);

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -17,6 +17,7 @@ pub struct RepoPilotConfig {
     pub code_quality: CodeQualitySection,
     pub testing: TestingSection,
     pub security: SecuritySection,
+    pub security_boundary: SecurityBoundarySection,
     pub output: OutputSection,
 }
 
@@ -141,6 +142,29 @@ impl Default for SecuritySection {
     fn default() -> Self {
         Self {
             detect_secret_like_names: true,
+        }
+    }
+}
+
+/// Configures the `review` security-boundary change signals. The detector flags
+/// (it does not prove) when a change touches who-can-do-what or how the app
+/// ships. See `src/review/signals.rs`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct SecurityBoundarySection {
+    /// Whether to surface boundary signals at all. Defaults to enabled.
+    pub enabled: bool,
+    /// Extra glob patterns (matched against repo-relative paths) to flag as
+    /// boundary changes, in addition to the built-in defaults. Reported under
+    /// the `custom` category.
+    pub extra_patterns: Vec<String>,
+}
+
+impl Default for SecurityBoundarySection {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            extra_patterns: Vec::new(),
         }
     }
 }

--- a/src/config/template.rs
+++ b/src/config/template.rs
@@ -43,6 +43,15 @@ detect_missing_tests = true
 [security]
 detect_secret_like_names = true
 
+[security_boundary]
+# `review` flags when a change touches who-can-do-what or how the app ships
+# (auth, CORS, CI/deploy, dependency manifests, committed .env). It flags, it
+# does not prove the change is safe. Set enabled = false to silence it.
+enabled = true
+# Extra glob patterns (repo-relative) to also treat as boundary changes:
+# extra_patterns = ["infra/**/*.tf", "**/secrets/**"]
+extra_patterns = []
+
 [output]
 default_format = "console"
 "#

--- a/src/report/schema/review.rs
+++ b/src/report/schema/review.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::review::signals::BoundarySignal;
 
 #[derive(Debug, Serialize)]
 pub struct ReviewJsonReport<'a> {
@@ -12,6 +13,7 @@ pub struct ReviewJsonReport<'a> {
     pub non_empty_lines: usize,
     pub changed_files: &'a [ChangedFile],
     pub blast_radius: Vec<String>,
+    pub boundary_signals: &'a [BoundarySignal],
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_graph_summary: Option<&'a ContextGraphSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -48,6 +50,7 @@ impl<'a> ReviewJsonReport<'a> {
                 .iter()
                 .map(|path| path.to_string_lossy().to_string())
                 .collect(),
+            boundary_signals: &report.boundary_signals,
             context_graph_summary: report.summary.artifacts.context_graph_summary.as_ref(),
             context_graph_cache: report.summary.artifacts.context_graph_cache.as_ref(),
             review: ReviewJsonMetadata {
@@ -55,6 +58,7 @@ impl<'a> ReviewJsonReport<'a> {
                 out_of_diff_findings: report.out_of_diff_count(),
                 new_in_diff_findings: report.new_in_diff_count(),
                 existing_in_diff_findings: report.existing_in_diff_count(),
+                boundary_signals: report.boundary_signals.len(),
                 severity_counts: report.severity_counts(),
             },
             risk_summary: RiskSummary::from_findings(&report.summary.artifacts.findings),
@@ -97,6 +101,7 @@ pub struct ReviewJsonMetadata {
     pub out_of_diff_findings: usize,
     pub new_in_diff_findings: usize,
     pub existing_in_diff_findings: usize,
+    pub boundary_signals: usize,
     pub severity_counts: SeverityCounts,
 }
 

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -1,6 +1,7 @@
 pub mod diff;
 pub mod model;
 pub mod render;
+pub mod signals;
 
 use crate::baseline::diff::{
     BaselineScanReport, BaselineStatus, FindingBaselineStatus, all_findings_new,
@@ -8,11 +9,13 @@ use crate::baseline::diff::{
 };
 use crate::baseline::key::{normalized_relative_path, stable_finding_key};
 use crate::baseline::model::Baseline;
+use crate::config::model::SecurityBoundarySection;
 use crate::findings::filter::recompute_summary_metrics;
 use crate::findings::quality::summarize_signal_quality;
 use crate::findings::types::{Evidence, Finding, FindingCategory};
 use crate::review::diff::{ChangedFile, DiffTarget, load_changed_files, resolve_git_root};
 use crate::review::model::{ReviewFindingStatus, ReviewReport};
+use crate::review::signals::{BoundarySignal, detect_boundary_signals};
 use crate::risk::{apply_blast_radius_overlay, apply_review_overlay};
 use crate::scan::types::{ScanArtifacts, ScanMetadata, ScanMetrics, ScanSummary};
 use std::collections::{BTreeMap, BTreeSet};
@@ -24,11 +27,13 @@ pub fn build_review_report(
     base: Option<&str>,
     head: Option<&str>,
     baseline: Option<(&Baseline, PathBuf)>,
+    boundary_config: &SecurityBoundarySection,
 ) -> Result<ReviewReport, diff::GitDiffError> {
     let repo_root = resolve_git_root(scan_path)?;
     let target = DiffTarget::from_refs(base, head);
     let pathspec = pathspec_for_scan_path(scan_path, &repo_root);
     let changed_files = load_changed_files(&repo_root, target, pathspec.as_deref())?;
+    let boundary_signals = detect_boundary_signals(&changed_files, boundary_config);
 
     let baseline_report = match baseline {
         Some((baseline, baseline_path)) => {
@@ -37,13 +42,19 @@ pub fn build_review_report(
         None => all_findings_new(summary),
     };
 
-    Ok(classify_findings(baseline_report, repo_root, changed_files))
+    Ok(classify_findings(
+        baseline_report,
+        repo_root,
+        changed_files,
+        boundary_signals,
+    ))
 }
 
 fn classify_findings(
     baseline_report: BaselineScanReport,
     repo_root: PathBuf,
     changed_files: Vec<ChangedFile>,
+    boundary_signals: Vec<BoundarySignal>,
 ) -> ReviewReport {
     let mut summary = baseline_report.summary;
     let blast_radius = compute_blast_radius(&summary, &repo_root, &changed_files);
@@ -78,6 +89,7 @@ fn classify_findings(
         baseline_path: baseline_report.baseline_path,
         changed_files,
         blast_radius,
+        boundary_signals,
         findings,
     }
 }

--- a/src/review/model.rs
+++ b/src/review/model.rs
@@ -2,6 +2,7 @@ use crate::baseline::diff::BaselineStatus;
 use crate::findings::filter::{FindingFilter, recompute_summary_metrics};
 use crate::findings::types::{Finding, Severity};
 use crate::review::diff::{ChangeStatus, ChangedFile};
+use crate::review::signals::BoundarySignal;
 use crate::scan::types::ScanSummary;
 use serde::Serialize;
 use std::path::PathBuf;
@@ -13,6 +14,7 @@ pub struct ReviewReport {
     pub baseline_path: Option<PathBuf>,
     pub changed_files: Vec<ChangedFile>,
     pub blast_radius: Vec<PathBuf>,
+    pub boundary_signals: Vec<BoundarySignal>,
     pub findings: Vec<ReviewFindingStatus>,
 }
 

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -56,6 +56,7 @@ pub fn render_console(report: &ReviewReport, ci_gate: Option<&CiGateResult>) -> 
     }
 
     render_blast_radius(&mut output, report);
+    render_boundary_signals(&mut output, report);
     render_findings_group(&mut output, "In-diff findings", &report.in_diff_findings());
     render_findings_group(
         &mut output,
@@ -76,6 +77,25 @@ fn render_blast_radius(output: &mut String, report: &ReviewReport) {
 
     for path in &report.blast_radius {
         output.push_str(&format!("  - {}\n", path.display()));
+    }
+}
+
+fn render_boundary_signals(output: &mut String, report: &ReviewReport) {
+    if report.boundary_signals.is_empty() {
+        return;
+    }
+
+    output.push_str("\nSecurity boundary changed [preview]:\n");
+    output.push_str(
+        "  These changes touch who-can-do-what or how the app ships. Open the report before merging.\n",
+    );
+
+    for signal in &report.boundary_signals {
+        output.push_str(&format!(
+            "  \u{2691} {:<15} {}\n",
+            signal.category.label(),
+            signal.path
+        ));
     }
 }
 

--- a/src/review/render/markdown.rs
+++ b/src/review/render/markdown.rs
@@ -63,6 +63,7 @@ pub fn render_markdown(report: &ReviewReport, ci_gate: Option<&CiGateResult>) ->
     }
 
     render_markdown_blast_radius(&mut output, report);
+    render_markdown_boundary_signals(&mut output, report);
     render_markdown_findings_group(
         &mut output,
         "In-Diff Findings",
@@ -97,6 +98,30 @@ fn render_markdown_blast_radius(output: &mut String, report: &ReviewReport) {
 
     for path in &report.blast_radius {
         output.push_str(&format!("- `{}`\n", path.display()));
+    }
+
+    output.push('\n');
+}
+
+fn render_markdown_boundary_signals(output: &mut String, report: &ReviewReport) {
+    if report.boundary_signals.is_empty() {
+        return;
+    }
+
+    output.push_str("## Security Boundary Changed (preview)\n\n");
+    output.push_str(
+        "These changes touch who-can-do-what or how the app ships — open the report before merging.\n\n",
+    );
+    output.push_str("| Category | Path | Status |\n");
+    output.push_str("| --- | --- | --- |\n");
+
+    for signal in &report.boundary_signals {
+        output.push_str(&format!(
+            "| {} | `{}` | {:?} |\n",
+            signal.category.label(),
+            signal.path,
+            signal.status
+        ));
     }
 
     output.push('\n');

--- a/src/review/signals.rs
+++ b/src/review/signals.rs
@@ -1,0 +1,432 @@
+//! Security-boundary change signals for `repopilot review`.
+//!
+//! These are review-layer signals, not scan-engine rules: they answer a single
+//! question from the diff's changed-file list — *did this change touch a part of
+//! the repo that decides who can do what, or how the app ships?*
+//!
+//! They **flag, they do not prove.** A false positive costs a glance, so the
+//! defaults lean toward surfacing rather than staying silent. This is the
+//! opposite trade-off from a security scanner, where every false alarm is waste.
+//! The detector is purely path/filename classification over `changed_files`;
+//! it never inspects code semantics and never claims a change is safe or unsafe.
+//! Ships at `preview` — the default pattern set will need tuning from real repos.
+
+use crate::config::model::SecurityBoundarySection;
+use crate::review::diff::{ChangeStatus, ChangedFile};
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use serde::Serialize;
+use std::collections::HashSet;
+
+/// The kind of security boundary a changed file belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BoundaryCategory {
+    /// Who can do what: auth, sessions, permissions, RBAC, identity.
+    AccessControl,
+    /// Whether the boundary trusts a request: CORS, CSP, security headers.
+    RequestTrust,
+    /// How the app ships: CI/workflows, Dockerfiles, IaC, deploy config.
+    DeploySurface,
+    /// What code runs: dependency manifests and lockfiles.
+    SupplyChain,
+    /// Where secrets/config live: committed `.env` files.
+    SecretConfig,
+    /// A user-supplied `extra_patterns` match from `repopilot.toml`.
+    Custom,
+}
+
+impl BoundaryCategory {
+    /// Human-readable label used in console/markdown output.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::AccessControl => "access control",
+            Self::RequestTrust => "request trust",
+            Self::DeploySurface => "deploy surface",
+            Self::SupplyChain => "supply chain",
+            Self::SecretConfig => "secret config",
+            Self::Custom => "custom",
+        }
+    }
+}
+
+/// One changed file that crossed a security boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BoundarySignal {
+    pub category: BoundaryCategory,
+    pub path: String,
+    pub status: ChangeStatus,
+}
+
+/// Classify each changed file against the security-boundary categories.
+///
+/// Returns at most one signal per changed file (the first category it matches,
+/// in priority order). Sorted by category then path for deterministic output.
+pub fn detect_boundary_signals(
+    changed_files: &[ChangedFile],
+    config: &SecurityBoundarySection,
+) -> Vec<BoundarySignal> {
+    if !config.enabled {
+        return Vec::new();
+    }
+
+    let custom = build_custom_globset(&config.extra_patterns);
+
+    let mut signals: Vec<BoundarySignal> = changed_files
+        .iter()
+        .filter_map(|file| {
+            let path = file.path_string();
+            classify_boundary(&path, custom.as_ref()).map(|category| BoundarySignal {
+                category,
+                path,
+                status: file.status,
+            })
+        })
+        .collect();
+
+    signals.sort_by(|left, right| {
+        left.category
+            .cmp(&right.category)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    signals
+}
+
+fn classify_boundary(path: &str, custom: Option<&GlobSet>) -> Option<BoundaryCategory> {
+    let lower = path.to_ascii_lowercase();
+    let file_name = lower.rsplit('/').next().unwrap_or(lower.as_str());
+
+    // Priority order: the more specific / path-anchored categories win so a
+    // workflow file named `auth.yml` is reported as deploy surface, not access
+    // control.
+    if is_deploy_surface(&lower, file_name) {
+        return Some(BoundaryCategory::DeploySurface);
+    }
+    if is_supply_chain(file_name) {
+        return Some(BoundaryCategory::SupplyChain);
+    }
+    if is_secret_config(file_name) {
+        return Some(BoundaryCategory::SecretConfig);
+    }
+
+    let tokens = tokenize(path);
+    if is_request_trust(&tokens) {
+        return Some(BoundaryCategory::RequestTrust);
+    }
+    if is_access_control(&lower, &tokens) {
+        return Some(BoundaryCategory::AccessControl);
+    }
+
+    if let Some(set) = custom
+        && set.is_match(path)
+    {
+        return Some(BoundaryCategory::Custom);
+    }
+
+    None
+}
+
+fn is_deploy_surface(lower: &str, file_name: &str) -> bool {
+    lower.contains(".github/workflows/")
+        || lower.contains("/.circleci/")
+        || lower.starts_with(".circleci/")
+        || lower.ends_with(".tf")
+        || lower.ends_with(".tfvars")
+        || file_name == "containerfile"
+        || file_name == "jenkinsfile"
+        || file_name == "action.yml"
+        || file_name == "action.yaml"
+        || file_name == ".gitlab-ci.yml"
+        || file_name == "azure-pipelines.yml"
+        || file_name == "azure-pipelines.yaml"
+        || file_name == "dockerfile"
+        || file_name.starts_with("dockerfile.")
+}
+
+fn is_supply_chain(file_name: &str) -> bool {
+    matches!(
+        file_name,
+        "package.json"
+            | "package-lock.json"
+            | "yarn.lock"
+            | "pnpm-lock.yaml"
+            | "npm-shrinkwrap.json"
+            | "cargo.toml"
+            | "cargo.lock"
+            | "go.mod"
+            | "go.sum"
+            | "requirements.txt"
+            | "pyproject.toml"
+            | "poetry.lock"
+            | "pipfile"
+            | "pipfile.lock"
+            | "pom.xml"
+            | "build.gradle"
+            | "build.gradle.kts"
+            | "gemfile"
+            | "gemfile.lock"
+    )
+}
+
+fn is_secret_config(file_name: &str) -> bool {
+    file_name == ".env" || file_name.starts_with(".env.")
+}
+
+fn is_request_trust(tokens: &HashSet<String>) -> bool {
+    tokens.contains("cors") || tokens.contains("csp") || tokens.contains("helmet")
+}
+
+fn is_access_control(lower: &str, tokens: &HashSet<String>) -> bool {
+    // High-specificity substrings: collisions in real paths are negligible.
+    // `authentic` covers authenticate/authentication/authenticator; `authoriz`
+    // covers authorize/authorization/authorized (but not the vaguer `authority`).
+    const STRONG: &[&str] = &["oauth", "jwt", "rbac", "passport", "authentic", "authoriz"];
+    if STRONG.iter().any(|needle| lower.contains(needle)) {
+        return true;
+    }
+
+    // Token-equality (after camelCase + separator splitting) keeps `auth` from
+    // matching `authors`, and `session` from matching `sessionize`, etc. Design
+    // tokens (`token`, `policy`) are deliberately excluded to avoid noisy false
+    // positives in front-end repos; users can add them via `extra_patterns`.
+    const TOKENS: &[&str] = &[
+        "auth",
+        "authz",
+        "authn",
+        "login",
+        "logout",
+        "signin",
+        "signout",
+        "session",
+        "sessions",
+        "permission",
+        "permissions",
+        "acl",
+        "guard",
+        "guards",
+        "identity",
+        "credential",
+        "credentials",
+    ];
+    TOKENS.iter().any(|token| tokens.contains(*token))
+}
+
+/// Split a path into lowercase alphanumeric tokens, breaking on separators and
+/// on lowercase→uppercase transitions so `authMiddleware.ts` yields `auth`.
+fn tokenize(text: &str) -> HashSet<String> {
+    let mut tokens = HashSet::new();
+    let mut current = String::new();
+
+    for ch in text.chars() {
+        if !ch.is_ascii_alphanumeric() {
+            flush(&mut current, &mut tokens);
+            continue;
+        }
+        if ch.is_ascii_uppercase()
+            && current
+                .chars()
+                .last()
+                .is_some_and(|last| last.is_ascii_lowercase() || last.is_ascii_digit())
+        {
+            flush(&mut current, &mut tokens);
+        }
+        current.push(ch.to_ascii_lowercase());
+    }
+    flush(&mut current, &mut tokens);
+    tokens
+}
+
+fn flush(current: &mut String, tokens: &mut HashSet<String>) {
+    if !current.is_empty() {
+        tokens.insert(std::mem::take(current));
+    }
+}
+
+fn build_custom_globset(patterns: &[String]) -> Option<GlobSet> {
+    if patterns.is_empty() {
+        return None;
+    }
+
+    let mut builder = GlobSetBuilder::new();
+    let mut added = false;
+    for pattern in patterns {
+        if let Ok(glob) = Glob::new(pattern) {
+            builder.add(glob);
+            added = true;
+        }
+    }
+
+    if !added {
+        return None;
+    }
+    builder.build().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::diff::{ChangeStatus, ChangedFile};
+    use std::path::PathBuf;
+
+    fn changed(path: &str, status: ChangeStatus) -> ChangedFile {
+        ChangedFile {
+            path: PathBuf::from(path),
+            status,
+            ranges: Vec::new(),
+        }
+    }
+
+    fn classify(path: &str) -> Option<BoundaryCategory> {
+        classify_boundary(path, None)
+    }
+
+    #[test]
+    fn access_control_matches_auth_paths_and_filenames() {
+        assert_eq!(
+            classify("src/middleware/auth.ts"),
+            Some(BoundaryCategory::AccessControl)
+        );
+        assert_eq!(
+            classify("src/authMiddleware.ts"),
+            Some(BoundaryCategory::AccessControl)
+        );
+        assert_eq!(
+            classify("internal/session/store.go"),
+            Some(BoundaryCategory::AccessControl)
+        );
+        assert_eq!(
+            classify("src/auth/jwt_verify.rs"),
+            Some(BoundaryCategory::AccessControl)
+        );
+        assert_eq!(
+            classify("app/Http/Middleware/Authenticate.php"),
+            Some(BoundaryCategory::AccessControl)
+        );
+    }
+
+    #[test]
+    fn access_control_does_not_match_lookalike_tokens() {
+        // `authors`, design `tokens`, and privacy `policy` are common non-boundary files.
+        assert_eq!(classify("src/components/authors.tsx"), None);
+        assert_eq!(classify("src/theme/tokens.ts"), None);
+        assert_eq!(classify("docs/privacy-policy.md"), None);
+        assert_eq!(classify("src/utils/format.ts"), None);
+    }
+
+    #[test]
+    fn request_trust_matches_cors_and_helmet() {
+        assert_eq!(
+            classify("src/server/cors.ts"),
+            Some(BoundaryCategory::RequestTrust)
+        );
+        assert_eq!(
+            classify("config/helmet.js"),
+            Some(BoundaryCategory::RequestTrust)
+        );
+        assert_eq!(
+            classify("src/corsConfig.ts"),
+            Some(BoundaryCategory::RequestTrust)
+        );
+    }
+
+    #[test]
+    fn deploy_surface_matches_ci_docker_and_iac() {
+        assert_eq!(
+            classify(".github/workflows/deploy.yml"),
+            Some(BoundaryCategory::DeploySurface)
+        );
+        assert_eq!(
+            classify("Dockerfile"),
+            Some(BoundaryCategory::DeploySurface)
+        );
+        assert_eq!(
+            classify("Dockerfile.prod"),
+            Some(BoundaryCategory::DeploySurface)
+        );
+        assert_eq!(
+            classify("infra/main.tf"),
+            Some(BoundaryCategory::DeploySurface)
+        );
+        assert_eq!(
+            classify(".gitlab-ci.yml"),
+            Some(BoundaryCategory::DeploySurface)
+        );
+    }
+
+    #[test]
+    fn deploy_surface_wins_over_access_control_for_workflow_named_auth() {
+        assert_eq!(
+            classify(".github/workflows/auth.yml"),
+            Some(BoundaryCategory::DeploySurface)
+        );
+    }
+
+    #[test]
+    fn supply_chain_matches_manifests_and_lockfiles() {
+        assert_eq!(
+            classify("package.json"),
+            Some(BoundaryCategory::SupplyChain)
+        );
+        assert_eq!(
+            classify("frontend/package-lock.json"),
+            Some(BoundaryCategory::SupplyChain)
+        );
+        assert_eq!(classify("Cargo.toml"), Some(BoundaryCategory::SupplyChain));
+        assert_eq!(classify("go.sum"), Some(BoundaryCategory::SupplyChain));
+    }
+
+    #[test]
+    fn secret_config_matches_env_files() {
+        assert_eq!(classify(".env"), Some(BoundaryCategory::SecretConfig));
+        assert_eq!(
+            classify(".env.production"),
+            Some(BoundaryCategory::SecretConfig)
+        );
+        assert_eq!(classify("src/config/settings.ts"), None);
+    }
+
+    #[test]
+    fn disabled_config_yields_no_signals() {
+        let config = SecurityBoundarySection {
+            enabled: false,
+            extra_patterns: Vec::new(),
+        };
+        let files = vec![changed("src/auth/login.ts", ChangeStatus::Modified)];
+        assert!(detect_boundary_signals(&files, &config).is_empty());
+    }
+
+    #[test]
+    fn extra_patterns_flag_custom_boundaries() {
+        let config = SecurityBoundarySection {
+            enabled: true,
+            extra_patterns: vec!["**/secrets/**".to_string()],
+        };
+        let files = vec![
+            changed("ops/secrets/keys.yaml", ChangeStatus::Added),
+            changed("src/utils/format.ts", ChangeStatus::Modified),
+        ];
+        let signals = detect_boundary_signals(&files, &config);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].category, BoundaryCategory::Custom);
+        assert_eq!(signals[0].path, "ops/secrets/keys.yaml");
+    }
+
+    #[test]
+    fn detect_sorts_by_category_then_path() {
+        let config = SecurityBoundarySection::default();
+        let files = vec![
+            changed("package.json", ChangeStatus::Modified),
+            changed("src/auth/login.ts", ChangeStatus::Modified),
+            changed(".github/workflows/ci.yml", ChangeStatus::Modified),
+        ];
+        let signals = detect_boundary_signals(&files, &config);
+        let categories: Vec<_> = signals.iter().map(|signal| signal.category).collect();
+        assert_eq!(
+            categories,
+            vec![
+                BoundaryCategory::AccessControl,
+                BoundaryCategory::DeploySurface,
+                BoundaryCategory::SupplyChain,
+            ]
+        );
+    }
+}

--- a/tests/review_blast_radius.rs
+++ b/tests/review_blast_radius.rs
@@ -1,3 +1,4 @@
+use repopilot::config::model::SecurityBoundarySection;
 use repopilot::graph::CouplingGraph;
 use repopilot::review::diff::{ChangeStatus, ChangedFile};
 use repopilot::review::model::ReviewReport;
@@ -147,6 +148,7 @@ fn render_console_includes_blast_radius_section_when_present() {
         baseline_path: None,
         changed_files: vec![changed_file("src/a.ts")],
         blast_radius: vec![PathBuf::from("src/b.ts")],
+        boundary_signals: vec![],
         findings: vec![],
     };
 
@@ -158,8 +160,15 @@ fn render_console_includes_blast_radius_section_when_present() {
 
 fn run_review_json(root: &Path) -> Value {
     let summary = scan_path_with_config(root, &ScanConfig::default()).expect("failed to scan");
-    let report =
-        build_review_report(summary, root, None, None, None).expect("failed to build review");
+    let report = build_review_report(
+        summary,
+        root,
+        None,
+        None,
+        None,
+        &SecurityBoundarySection::default(),
+    )
+    .expect("failed to build review");
     let output = render_json(&report, None).expect("failed to render review json");
 
     serde_json::from_str(&output).expect("expected JSON output")

--- a/tests/review_boundary_signals.rs
+++ b/tests/review_boundary_signals.rs
@@ -1,0 +1,179 @@
+//! End-to-end coverage for the `review` security-boundary change signals
+//! (`src/review/signals.rs`). Unit-level true/false-positive cases live next to
+//! the detector; these tests prove the signals flow through the real `review`
+//! command and the JSON report (the agent-facing `repopilot_review_change` shape).
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+#[test]
+fn review_flags_boundary_changes_in_json() {
+    let temp = tempdir().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_covered_source(temp.path(), "lib", "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+
+    // Three untracked boundary files across distinct categories.
+    write(
+        temp.path(),
+        "src/auth/session.ts",
+        "export const session = {};\n",
+    );
+    write(
+        temp.path(),
+        ".github/workflows/deploy.yml",
+        "name: deploy\non: push\njobs: {}\n",
+    );
+    write(temp.path(), "package.json", "{\n  \"name\": \"demo\"\n}\n");
+
+    let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
+
+    let signals = json["boundary_signals"]
+        .as_array()
+        .expect("boundary_signals array");
+    assert_eq!(json["review"]["boundary_signals"], signals.len() as u64);
+
+    let by_category = |category: &str, path: &str| {
+        signals
+            .iter()
+            .any(|signal| signal["category"] == category && signal["path"] == path)
+    };
+
+    assert!(by_category("access-control", "src/auth/session.ts"));
+    assert!(by_category(
+        "deploy-surface",
+        ".github/workflows/deploy.yml"
+    ));
+    assert!(by_category("supply-chain", "package.json"));
+}
+
+#[test]
+fn review_omits_boundary_signals_for_ordinary_changes() {
+    let temp = tempdir().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_covered_source(temp.path(), "lib", "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+
+    fs::write(
+        temp.path().join("src/lib.rs"),
+        "pub fn live() {}\n// TODO: ordinary change\n",
+    )
+    .expect("failed to modify source file");
+
+    let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
+
+    assert_eq!(json["review"]["boundary_signals"], 0);
+    assert!(json["boundary_signals"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn review_console_shows_boundary_section() {
+    let temp = tempdir().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_covered_source(temp.path(), "lib", "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+
+    write(
+        temp.path(),
+        "src/middleware/auth.ts",
+        "export const auth = () => {};\n",
+    );
+
+    let output = repopilot()
+        .args(["review", "."])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run review");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Security boundary changed"));
+    assert!(stdout.contains("access control"));
+    assert!(stdout.contains("src/middleware/auth.ts"));
+}
+
+#[test]
+fn review_respects_disabled_boundary_config() {
+    let temp = tempdir().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_covered_source(temp.path(), "lib", "pub fn live() {}\n");
+    commit_all(temp.path(), "initial");
+
+    fs::write(
+        temp.path().join("repopilot.toml"),
+        "[security_boundary]\nenabled = false\n",
+    )
+    .expect("failed to write config");
+    write(
+        temp.path(),
+        "src/middleware/auth.ts",
+        "export const auth = () => {};\n",
+    );
+
+    let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
+
+    assert_eq!(json["review"]["boundary_signals"], 0);
+}
+
+fn run_review_json(root: &Path, args: &[&str]) -> Value {
+    let output = repopilot()
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("failed to run review");
+
+    assert!(output.status.success());
+    serde_json::from_slice(&output.stdout).expect("expected JSON output")
+}
+
+fn write(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create parent dir");
+    }
+    fs::write(path, content).expect("failed to write file");
+}
+
+fn write_covered_source(root: &Path, module: &str, content: &str) {
+    fs::create_dir_all(root.join("src")).expect("failed to create src dir");
+    fs::create_dir_all(root.join("tests")).expect("failed to create tests dir");
+    fs::write(root.join(format!("src/{module}.rs")), content).expect("failed to write source");
+    fs::write(
+        root.join(format!("tests/{module}.rs")),
+        format!("fn covers_{module}() {{}}\n"),
+    )
+    .expect("failed to write test");
+}
+
+fn init_repo(root: &Path) {
+    git(root, &["init"]);
+    git(root, &["config", "user.email", "repopilot@example.invalid"]);
+    git(root, &["config", "user.name", "RepoPilot Test"]);
+}
+
+fn commit_all(root: &Path, message: &str) {
+    git(root, &["add", "."]);
+    git(root, &["commit", "-m", message]);
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("failed to run git");
+
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

Adds security-boundary change signals to `repopilot review` and the `repopilot_review_change` MCP tool.

The review flow now flags changed files that touch sensitive repository boundaries: access control, request trust, deployment surface, supply chain, secret/config files, and custom user-defined patterns.

This is intentionally a review-layer signal, not a full security scanner. It flags risky areas for human review but does not claim that a change is safe or unsafe.

## Type of change

- [x] Feature
- [x] Tests
- [x] Documentation
- [ ] Refactor
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Added a new `src/review/signals.rs` module for security-boundary detection.
- Added `[security_boundary]` config support with:
  - `enabled`
  - `extra_patterns`
- Wired boundary signals into:
  - `repopilot review`
  - `repopilot_review_change` MCP tool
  - JSON review report
  - console output
  - Markdown output
- Added boundary signal count to review metadata.
- Updated the config template and default `repopilot.toml`.
- Updated `CHANGELOG.md`.
- Added tests for boundary signal detection and review behavior.

## Why

`repopilot review` should not only show findings inside a diff. It should also highlight when a change touches parts of the repository that are high-impact even if no static finding is produced.

Examples:

- auth/session/permission changes
- CORS or request-trust changes
- Docker/CI/deployment changes
- dependency manifest or lockfile changes
- committed `.env` files
- project-specific sensitive paths configured by the user

This makes RepoPilot more useful as an AI-assisted review guardrail before merge.

## Architecture notes

- [x] No god files introduced
- [x] Review-layer logic stays inside `src/review`
- [x] Config parsing stays inside `src/config`
- [x] Report schema changes stay inside `src/report/schema`
- [x] Console and Markdown rendering stay inside `src/review/render`
- [x] MCP review tool reuses the same review report pipeline
- [x] Signals are structured data, not only rendered text

The detector is intentionally based on changed file paths, not semantic code analysis. This keeps it fast, predictable, and safe for preview release behavior.

## Changelog

- [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- review .
cargo run -- review . --format markdown
cargo run -- review . --format json
```