### PR TITLE
docs(product): reposition README and add boundary review demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ dist/
 !/.repopilot/config.toml
 !/.repopilot/config.example.toml
 .repopilot-patches/
+
+docs/demos/*.tape

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 - Added security-boundary change signals to `repopilot review` (and the `repopilot_review_change` MCP tool). The review now flags when a change touches parts of the repo that decide *who can do what* (auth, sessions, permissions, CORS) or *how the app ships* (CI/workflows, Dockerfiles, IaC, dependency manifests, committed `.env`). It is path/filename classification over the diff — it flags, it does not prove a change is safe, so a false positive costs only a glance. Signals appear in the console and Markdown output and as a structured `boundary_signals` array in the JSON report. Configure or disable via a new `[security_boundary]` config section (`enabled`, `extra_patterns`). Ships at `preview`.
 - Enriched boundary signals with review context only RepoPilot has on hand: each signal now carries its **blast radius** (how many files import the changed boundary file, from the existing coupling graph), and the review reports `boundary_missing_test` when a *code* boundary (auth / request-trust) changed but no test moved in the same diff. Both surface in the console/Markdown output and the JSON report (`boundary_signals[].blast_radius`, `review.boundary_missing_test`).
+- Added a reproducible review demo: `scripts/demo-setup.sh` builds the "small login fix that quietly loosens CORS and touches auth without a test" scenario and `scripts/demo-boundary-review.sh` runs `repopilot review` on it, so the review demo GIF can be recorded reproducibly.
+
+### Changed
+
+- Repositioned and tightened the README around reviewing a change *before you merge* — for humans and for AI agents calling RepoPilot over MCP. The page now leads with the review/boundary workflow and the agent (MCP) angle, demotes `scan` and the rest to a compact capability table, and moves the encyclopedic sections (trust mode, commands, rule quality, reports, CI) to their `docs/` links. Cut from ~326 to ~124 lines, deterministic/local-first framing made explicit.
+- Reworked the README visuals to a single hero demo plus real, current console-output examples (scan, review with boundary signals, and a baseline gate catching a newly introduced secret) instead of a GIF per command. Removed the per-command GIFs, including a misleading baseline GIF that showed an already-adopted repo rather than the gate doing its job.
 
 ## [0.14.0] - 2026-05-31
 

--- a/README.md
+++ b/README.md
@@ -7,239 +7,107 @@
 [![License](https://img.shields.io/crates/l/repopilot.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/MykytaStel/repopilot?style=social)](https://github.com/MykytaStel/repopilot)
 
-**Local-first repository audits for safer human and AI-assisted code changes.**
+**See what your AI agent — or you — just changed, before you merge.**
 
-RepoPilot is a fast Rust CLI that scans a repository locally, ranks evidence-backed risks, supports baseline adoption, reviews branches, and creates AI-ready remediation context without uploading source code.
+RepoPilot is a fast, local-first Rust CLI that reviews a Git change and flags when it crossed a **security boundary** — the parts of your repo that decide *who can do what* (auth, sessions, permissions, CORS) and *how it ships* (CI, Dockerfiles, dependencies, committed `.env`) — then shows how far each changed file reaches. It's deterministic, runs entirely on your machine, and plugs into your AI coding agent over [MCP](#use-with-ai-agents-mcp). Nothing is uploaded.
 
 ```text
-scan -> review risk -> baseline adoption -> CI evidence -> local AI context
+review a change -> boundary + blast radius -> baseline / CI gate -> local AI context
 ```
 
 <p align="center">
-  <img src="docs/demos/01-scan.gif" alt="RepoPilot scanning a repository" width="800">
+  <img src="docs/demos/02-review.gif" alt="RepoPilot reviewing a branch change" width="800">
 </p>
 
-RepoPilot is not a replacement for language linters, formatters, type checkers, or dedicated security scanners. It complements them with repository-level evidence: secrets, runtime footguns, architecture risk, review blast radius, baseline status, and report formats that work in CI.
+> RepoPilot flags *that* a boundary moved and how far it reaches — it does **not** prove the change is safe. Think "open the report before merging," not "security audit." It complements linters, type checkers, and dedicated security scanners; it doesn't replace them.
 
 ## Install
 
-Choose one install method.
-
-Cargo:
-
 ```bash
-cargo install repopilot
+cargo install repopilot     # or: npm install -g repopilot
 ```
 
-npm:
+Homebrew, install script, and from-source: [docs/install.md](docs/install.md).
+
+## Quick start
+
+Review a change — what you'd check before merging, and what an agent can check on its own edits:
 
 ```bash
-npm install -g repopilot
+repopilot review . --base main
 ```
 
-Homebrew:
+```text
+$ repopilot review . --base main
 
-```bash
-brew tap mykytastel/repopilot
-brew install repopilot
+Changed files: 2
+In-diff findings: 2
+
+Blast radius:
+  The following files import changed files and may need extra review:
+  - src/admin.ts
+  - src/routes.ts
+
+Security boundary changed [preview]:
+  ⚑ access control  src/middleware/auth.ts  (imported by 2 files)
+  ⚑ request trust   src/server/cors.ts
+  ⚠ A code boundary changed but no test did — confirm it's still covered.
 ```
 
-Installer:
+Boundary categories: **access control**, **request trust**, **deploy surface**, **supply chain**, **secret config**. Tune or disable them in `repopilot.toml` under `[security_boundary]` (ships at `preview`).
+
+Full audit, a CI gate that fails only on *new* risk, and a local brief for an assistant:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MykytaStel/repopilot/main/install.sh | bash
-```
-
-From source:
-
-```bash
-git clone https://github.com/MykytaStel/repopilot.git
-cd repopilot
-cargo build --release
-```
-
-More: [docs/install.md](docs/install.md).
-
-## Quick Start
-
-Run a local scan:
-
-```bash
-repopilot scan .
-repopilot doctor .
-```
-
-Adopt RepoPilot in an existing repository without failing CI on old debt:
-
-```bash
-repopilot baseline create . --output .repopilot/baseline.json
-repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
-```
-
-Review a branch:
-
-```bash
-repopilot review . --base origin/main
-```
-![Reviewing branch changes](docs/demos/02-review.gif)
-
-Generate local AI context:
-
-```bash
-repopilot ai context . --budget 4k
-```
-
-Save CI evidence:
-
-```bash
-repopilot scan . --format markdown --output repopilot-report.md
-repopilot scan . --format json --output repopilot-report.json --receipt .repopilot/receipt.json
-repopilot scan . --format sarif --output repopilot.sarif
+repopilot scan .                                                         # full local audit (quiet by default)
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high  # fail CI only on newly introduced risk
+repopilot ai context . --budget 4k                                       # budgeted, evidence-backed Markdown
 ```
 
 ## Use with AI agents (MCP)
 
-RepoPilot ships a local [Model Context Protocol](https://modelcontextprotocol.io) server so AI coding agents (Claude Code, Cursor, …) can call it as a tool — auditing what the agent just changed, without anything leaving your machine.
+RepoPilot ships a local [Model Context Protocol](https://modelcontextprotocol.io) server so AI coding agents (Claude Code, Cursor, …) can call it as a tool — the deterministic, private check an agent can run on its **own** edits before handing you the PR.
 
 ```bash
 claude mcp add repopilot -- repopilot mcp
 ```
 
-The server runs locally over stdio (JSON-RPC, no network, no AI calls) and exposes four tools:
+It runs over stdio (JSON-RPC, no network, no AI calls) and exposes four tools:
 
-- `repopilot_review_change` — audit the current Git changes: in-diff vs out-of-diff findings plus blast radius.
-- `repopilot_scan` — full repository audit as a JSON report.
+- `repopilot_review_change` — audit the current Git changes: in-diff vs out-of-diff findings, security-boundary signals, and blast radius (structured JSON).
+- `repopilot_scan` — full repository audit as JSON.
 - `repopilot_context` — a budgeted, AI-ready Markdown brief of the repo.
 - `repopilot_explain_file` — how a single file is classified and which rules apply.
 
 More: [docs/mcp.md](docs/mcp.md).
 
-## What It Checks
+## What RepoPilot does
 
-| Area | Examples |
+| Capability | What it does |
 |---|---|
-| Security | secret candidates, private keys, committed `.env` files |
-| Runtime risk | Rust panic/unwrap paths, JavaScript/Python/Go/JVM/.NET process exits |
-| Architecture | circular dependencies, excessive fan-out, instability hubs |
-| Review risk | changed files, branch context, blast radius |
-| Adoption | baselines, new-vs-existing findings, CI gates |
-| Evidence | JSON, Markdown, SARIF, receipts, report envelopes |
-| AI context | local, budgeted, evidence-backed Markdown for coding assistants |
+| **Review a change** | findings on changed lines, blast radius, and security-boundary signals — for you or your agent (`review`, MCP) |
+| Full scan | repo-wide, evidence-ranked findings — secrets, runtime footguns, architecture — quiet by default ([trust mode](docs/trust-mode.md)) |
+| Baseline + CI gate | accept current debt as a baseline; fail CI only on newly introduced risk |
+| Reports | Console, Markdown, JSON, [SARIF](docs/integrations/github-code-scanning.md), HTML, receipts |
+| AI context | local, budgeted, evidence-backed Markdown brief for coding assistants |
 
-## Trust Mode
+Rules carry an `experimental -> preview -> stable` lifecycle and a quality gate (fixtures, stable IDs, evidence). See [docs/rule-quality-gate.md](docs/rule-quality-gate.md).
 
-Default scans are intentionally quiet. They keep high-trust security, runtime, and import-graph findings visible while summarizing broad maintainability and testing suggestions as strict-only noise.
+## Local-first
 
-```bash
-repopilot scan .                  # compact default output
-repopilot scan . --output-style full
-repopilot scan . --profile strict # full audit output
-```
-
-Use strict mode for cleanup passes, rule development, and release hardening. Use the default profile for day-to-day local checks and CI gates.
-
-More: [docs/trust-mode.md](docs/trust-mode.md).
-
-## Core Commands
-
-```text
-scan | review | baseline | compare | doctor | inspect | ai | init | cache | mcp
-```
-
-Common workflows:
-
-```bash
-repopilot scan .
-repopilot review . --base origin/main
-repopilot baseline create .
-repopilot compare before.json after.json
-repopilot inspect rules
-repopilot inspect eval-rules --format json
-repopilot ai context .
-```
-
-More: [docs/commands.md](docs/commands.md) and [docs/cli.md](docs/cli.md).
-
-## Baseline Adoption
-
-A baseline records current findings as accepted existing debt. Future scans can fail only on newly introduced risk:
-
-```bash
-repopilot baseline create . --output .repopilot/baseline.json
-git add .repopilot/baseline.json
-repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
-```
-
-Review baseline updates like code changes. A baseline is not a suppression file; it is a CI adoption contract.
-
-## Rule Quality
-
-Rules move through a lifecycle:
-
-```text
-experimental -> preview -> stable
-```
-
-Before a rule becomes stable or default-visible, it should have metadata, true-positive and false-positive fixtures, stable finding IDs, concrete evidence, false-positive notes, recommendations, and clean local evaluation:
-
-```bash
-repopilot inspect eval-rules --format json
-```
-
-More: [docs/rule-quality-gate.md](docs/rule-quality-gate.md).
-
-## Local-First
-
-RepoPilot does not upload source code, run a hosted scanner, call LLM APIs implicitly, send telemetry, or require a SaaS account.
-
-AI commands only format local scan evidence as Markdown for tools such as Claude Code, ChatGPT, Cursor, Zed, or another assistant.
-
-## Reports
-
-| Format | Use case |
-|---|---|
-| Console | fast local feedback |
-| Markdown | PR comments and human-readable reports |
-| JSON | automation and internal tooling |
-| SARIF | GitHub Code Scanning |
-| HTML | shareable local reports |
-| Receipt | compact release/CI evidence |
-
-More: [docs/reports.md](docs/reports.md).
-
-## CI
-
-Minimal baseline-aware gate:
-
-```bash
-repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
-```
-
-GitHub Code Scanning:
-
-```bash
-repopilot scan . --format sarif --output repopilot.sarif
-```
-
-Release smoke:
-
-```bash
-./scripts/smoke-product.sh
-```
-
-More: [docs/integrations/github-code-scanning.md](docs/integrations/github-code-scanning.md).
+RepoPilot does not upload source code, run a hosted scanner, call LLM APIs implicitly, send telemetry, or require an account. AI commands only format local scan evidence as Markdown for tools such as Claude Code, Cursor, or Zed.
 
 ## Documentation
 
 | Document | Purpose |
 |---|---|
 | [Install](docs/install.md) | Cargo, npm, Homebrew, curl, and source builds |
-| [Commands](docs/commands.md) | Task-oriented workflows |
-| [CLI](docs/cli.md) | Complete command and flag reference |
-| [Configuration](docs/configuration.md) | `repopilot.toml`, presets, ignores, and baselines |
-| [Rulesets](docs/rulesets.md) | Built-in rules, lifecycle, severity, and confidence |
-| [Trust Mode](docs/trust-mode.md) | Default vs strict visibility policy |
-| [Reports](docs/reports.md) | JSON, SARIF, Markdown, HTML, receipts, and schema fields |
+| [Commands](docs/commands.md) / [CLI](docs/cli.md) | Task-oriented workflows and the full flag reference |
+| [Configuration](docs/configuration.md) | `repopilot.toml`, presets, ignores, baselines |
+| [Rulesets](docs/rulesets.md) / [Rule quality gate](docs/rule-quality-gate.md) | Built-in rules, lifecycle, and the gate |
+| [Trust Mode](docs/trust-mode.md) | Default vs strict visibility |
+| [Reports](docs/reports.md) / [Code Scanning](docs/integrations/github-code-scanning.md) | Formats, schema, and SARIF in CI |
+| [MCP](docs/mcp.md) | Using RepoPilot from AI agents |
 | [Release Process](docs/release.md) | Local and CI release gates |
 
 ## Development
@@ -248,14 +116,7 @@ More: [docs/integrations/github-code-scanning.md](docs/integrations/github-code-
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all
-npm run test:npm
 ./scripts/smoke-product.sh
-```
-
-Run rule evaluation from source:
-
-```bash
-cargo run -- inspect eval-rules --format json
 ```
 
 ## License

--- a/scripts/demo-boundary-review.sh
+++ b/scripts/demo-boundary-review.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Quick local view of the boundary-review demo: build the scenario in a temp
+# repo, run `repopilot review`, then clean up. To record the GIF instead, use
+# docs/demos/02-review.tape (VHS), which reuses scripts/demo-setup.sh.
+#
+# Usage: scripts/demo-boundary-review.sh [path-to-repopilot-binary]
+
+BINARY="${1:-repopilot}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+WORKDIR="$(mktemp -d)"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+"$SCRIPT_DIR/demo-setup.sh" "$WORKDIR"
+(cd "$WORKDIR" && "$BINARY" review .)

--- a/scripts/demo-setup.sh
+++ b/scripts/demo-setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the "innocent login fix that quietly crosses a security boundary"
+# scenario into the target directory. No review, no cleanup — callers drive
+# `repopilot review` and clean up. Shared by scripts/demo-boundary-review.sh
+# (quick local view) and docs/demos/02-review.tape (VHS recording).
+#
+# Usage: scripts/demo-setup.sh <target-dir>
+
+TARGET="${1:?usage: demo-setup.sh <target-dir>}"
+mkdir -p "$TARGET"
+cd "$TARGET"
+
+git init -q
+git config user.email "demo@example.invalid"
+git config user.name "RepoPilot Demo"
+
+mkdir -p src/middleware src/server
+printf 'export const signup = () => {};\n' >src/signup.ts
+printf 'import { authenticate } from "./middleware/auth";\nexport const routes = authenticate;\n' >src/routes.ts
+printf 'import { authenticate } from "./middleware/auth";\nexport const admin = authenticate;\n' >src/admin.ts
+printf 'export const authenticate = () => true;\n' >src/middleware/auth.ts
+git add .
+git commit -qm "app skeleton"
+
+# The "agent edit": a small login fix that also loosens CORS and tweaks the auth
+# middleware — and ships without touching a test.
+printf 'export const authenticate = () => true; // tweak the post-login redirect\n' >src/middleware/auth.ts
+printf 'export const corsOptions = { origin: "*" };\n' >src/server/cors.ts


### PR DESCRIPTION
## Summary

Repositions the RepoPilot README around the strongest current product value: reviewing a change before merge, especially when the change was made by a human or an AI coding agent.

The README now leads with the boundary-review workflow, security-boundary signals, blast radius, and MCP agent use case. It also adds reproducible demo scripts for generating a local boundary-review scenario.

## Type of change

- [x] Documentation
- [x] Feature
- [x] Repository maintenance
- [ ] Refactor
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Reworked the README positioning from a broad repository-audit CLI into:
  - “See what your AI agent — or you — just changed, before you merge.”
- Made `repopilot review` the primary quick-start workflow.
- Added a current console-output example with:
  - changed files
  - in-diff findings
  - blast radius
  - security-boundary signals
  - missing-test warning
- Tightened install instructions and moved expanded setup details to `docs/install.md`.
- Condensed broad sections like trust mode, commands, reports, CI, and rule quality into a capability table and docs links.
- Added `scripts/demo-setup.sh` to create a reproducible boundary-review demo repository.
- Added `scripts/demo-boundary-review.sh` to run the demo quickly against a temp repo.
- Updated `CHANGELOG.md`.
- Ignored local VHS tape files under `docs/demos/*.tape`.

## Why

RepoPilot’s strongest direction is becoming clearer:

> deterministic local review guardrails for human and AI-assisted code changes.

The previous README described many capabilities, but the product story was too broad. This PR makes the first impression sharper:

- review a Git change
- detect security-boundary movement
- show blast radius
- warn when auth/request-trust code changed without tests
- expose the same value to AI agents through MCP
- keep everything local-first

This makes RepoPilot easier to understand, sell, demo, and share.

## Architecture notes

- [x] No core scanner logic changed
- [x] No god files introduced
- [x] Demo setup is isolated in scripts
- [x] README links to deeper docs instead of duplicating full documentation
- [x] Product narrative now matches the recent boundary-review features

The scripts are intentionally small:

```txt
scripts/demo-setup.sh
scripts/demo-boundary-review.sh