### PR TITLE
feat(review): capture diff hunk content for content-based signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Internal: the `repopilot review` diff parser now captures each hunk's added and removed line text (`ChangedFile.hunks`), not just the changed-line ranges it derived before. This is the foundation for content-based review signals; `ranges` and all current output are unchanged and `hunks` is not serialized into the JSON report.
 - Repositioned and tightened the README around reviewing a change *before you merge* — for humans and for AI agents calling RepoPilot over MCP. The page now leads with the review/boundary workflow and the agent (MCP) angle, demotes `scan` and the rest to a compact capability table, and moves the encyclopedic sections (trust mode, commands, rule quality, reports, CI) to their `docs/` links. Cut from ~326 to ~124 lines, deterministic/local-first framing made explicit.
 - Reworked the README visuals to a single hero demo plus real, current console-output examples (scan, review with boundary signals, and a baseline gate catching a newly introduced secret) instead of a GIF per command. Removed the per-command GIFs, including a misleading baseline GIF that showed an already-adopted repo rather than the gate doing its job.
 

--- a/src/review/diff.rs
+++ b/src/review/diff.rs
@@ -17,6 +17,24 @@ pub struct ChangedFile {
     pub path: PathBuf,
     pub status: ChangeStatus,
     pub ranges: Vec<ChangedRange>,
+    /// Per-hunk added/removed line content. Internal to the review layer's
+    /// content-based signals; never serialized into the JSON report (`ranges`
+    /// already carries the public changed-line view).
+    #[serde(skip)]
+    pub hunks: Vec<DiffHunk>,
+}
+
+/// One diff hunk's added and removed line text. `--unified=0` is used, so every
+/// body line is either an addition or a removal — there are no context lines.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffHunk {
+    /// Added-line range in the post-change file. `None` for a pure-deletion
+    /// hunk (`@@ -a,b +c,0 @@`), which carries only removed lines.
+    pub new_range: Option<ChangedRange>,
+    /// Lines added in this hunk, without the leading `+`.
+    pub added_lines: Vec<String>,
+    /// Lines removed in this hunk, without the leading `-`.
+    pub removed_lines: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -138,17 +156,19 @@ pub fn load_changed_files(
 pub fn parse_diff(diff: &str) -> Vec<ChangedFile> {
     let mut files = Vec::new();
     let mut current: Option<ChangedFile> = None;
+    let mut hunk: Option<DiffHunk> = None;
 
     for line in diff.lines() {
         if let Some((_, new_path)) = parse_diff_git_line(line) {
             if let Some(file) = current.take() {
-                files.push(file);
+                files.push(finalize_file(file, hunk.take()));
             }
 
             current = Some(ChangedFile {
                 path: PathBuf::from(new_path),
                 status: ChangeStatus::Modified,
                 ranges: Vec::new(),
+                hunks: Vec::new(),
             });
 
             continue;
@@ -191,16 +211,46 @@ pub fn parse_diff(diff: &str) -> Vec<ChangedFile> {
             continue;
         }
 
-        if let Some(range) = parse_hunk_added_range(line) {
-            file.ranges.push(range);
+        if line.starts_with("@@") {
+            if let Some(done) = hunk.take() {
+                file.hunks.push(done);
+            }
+            hunk = Some(DiffHunk {
+                new_range: parse_hunk_added_range(line),
+                added_lines: Vec::new(),
+                removed_lines: Vec::new(),
+            });
+            continue;
+        }
+
+        if let Some(active) = hunk.as_mut() {
+            if let Some(added) = line.strip_prefix('+') {
+                active.added_lines.push(added.to_string());
+            } else if let Some(removed) = line.strip_prefix('-') {
+                active.removed_lines.push(removed.to_string());
+            }
         }
     }
 
     if let Some(file) = current {
-        files.push(file);
+        files.push(finalize_file(file, hunk.take()));
     }
 
     files
+}
+
+/// Push the trailing hunk (if any) and derive the public `ranges` view from the
+/// captured hunks so existing range consumers see exactly what they did before.
+fn finalize_file(mut file: ChangedFile, trailing: Option<DiffHunk>) -> ChangedFile {
+    if let Some(done) = trailing {
+        file.hunks.push(done);
+    }
+    file.ranges = file
+        .hunks
+        .iter()
+        .filter_map(|hunk| hunk.new_range)
+        .collect();
+    file
 }
 
 include!("diff/helpers.rs");

--- a/src/review/diff/helpers.rs
+++ b/src/review/diff/helpers.rs
@@ -57,6 +57,7 @@ fn load_untracked_files(
                 path: PathBuf::from(path),
                 status: ChangeStatus::Untracked,
                 ranges,
+                hunks: Vec::new(),
             })
         })
         .collect()

--- a/src/review/diff/tests.rs
+++ b/src/review/diff/tests.rs
@@ -10,3 +10,112 @@ fn repopilot_internal_paths_are_excluded_from_review_scope() {
     )));
     assert!(!is_repopilot_internal_path(Path::new("src/lib.rs")));
 }
+
+#[test]
+fn parses_modified_file_added_and_removed_lines() {
+    let diff = "\
+diff --git a/src/app.ts b/src/app.ts
+index 1111111..2222222 100644
+--- a/src/app.ts
++++ b/src/app.ts
+@@ -10,2 +10,3 @@ fn main()
+-old one
+-old two
++new one
++new two
++new three
+";
+
+    let files = parse_diff(diff);
+    assert_eq!(files.len(), 1);
+    let file = &files[0];
+    assert_eq!(file.path, PathBuf::from("src/app.ts"));
+    assert_eq!(file.status, ChangeStatus::Modified);
+    // `ranges` stays the public added-line view, derived from the hunk.
+    assert_eq!(file.ranges, vec![ChangedRange { start: 10, end: 12 }]);
+    assert_eq!(file.hunks.len(), 1);
+    let hunk = &file.hunks[0];
+    assert_eq!(hunk.new_range, Some(ChangedRange { start: 10, end: 12 }));
+    assert_eq!(hunk.added_lines, vec!["new one", "new two", "new three"]);
+    assert_eq!(hunk.removed_lines, vec!["old one", "old two"]);
+}
+
+#[test]
+fn parses_added_file_content() {
+    let diff = "\
+diff --git a/src/new.ts b/src/new.ts
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/src/new.ts
+@@ -0,0 +1,2 @@
++hello
++world
+";
+
+    let files = parse_diff(diff);
+    let file = &files[0];
+    assert_eq!(file.path, PathBuf::from("src/new.ts"));
+    assert_eq!(file.status, ChangeStatus::Added);
+    assert_eq!(file.ranges, vec![ChangedRange { start: 1, end: 2 }]);
+    assert_eq!(file.hunks[0].added_lines, vec!["hello", "world"]);
+    assert!(file.hunks[0].removed_lines.is_empty());
+}
+
+#[test]
+fn parses_deleted_file_removed_lines_with_no_range() {
+    let diff = "\
+diff --git a/src/old.ts b/src/old.ts
+deleted file mode 100644
+index 4444444..0000000
+--- a/src/old.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-line a
+-line b
+-line c
+";
+
+    let files = parse_diff(diff);
+    let file = &files[0];
+    assert_eq!(file.path, PathBuf::from("src/old.ts"));
+    assert_eq!(file.status, ChangeStatus::Deleted);
+    // A pure-deletion hunk contributes no added-line range, just like before.
+    assert!(file.ranges.is_empty());
+    assert_eq!(file.hunks[0].new_range, None);
+    assert_eq!(
+        file.hunks[0].removed_lines,
+        vec!["line a", "line b", "line c"]
+    );
+}
+
+#[test]
+fn captures_multiple_hunks_independently() {
+    let diff = "\
+diff --git a/src/multi.ts b/src/multi.ts
+index 5555555..6666666 100644
+--- a/src/multi.ts
++++ b/src/multi.ts
+@@ -1 +1 @@
+-first old
++first new
+@@ -20,0 +21,2 @@
++added a
++added b
+";
+
+    let files = parse_diff(diff);
+    let file = &files[0];
+    assert_eq!(file.hunks.len(), 2);
+    assert_eq!(
+        file.ranges,
+        vec![
+            ChangedRange { start: 1, end: 1 },
+            ChangedRange { start: 21, end: 22 },
+        ]
+    );
+    assert_eq!(file.hunks[0].added_lines, vec!["first new"]);
+    assert_eq!(file.hunks[0].removed_lines, vec!["first old"]);
+    assert_eq!(file.hunks[1].added_lines, vec!["added a", "added b"]);
+    assert!(file.hunks[1].removed_lines.is_empty());
+}

--- a/src/review/signals/tests.rs
+++ b/src/review/signals/tests.rs
@@ -12,6 +12,7 @@ fn changed(path: &str, status: ChangeStatus) -> ChangedFile {
         path: PathBuf::from(path),
         status,
         ranges: Vec::new(),
+        hunks: Vec::new(),
     }
 }
 

--- a/tests/review_blast_radius.rs
+++ b/tests/review_blast_radius.rs
@@ -180,6 +180,7 @@ fn changed_file(path: &str) -> ChangedFile {
         path: PathBuf::from(path),
         status: ChangeStatus::Modified,
         ranges: Vec::new(),
+        hunks: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

Enhances the `repopilot review` diff parser so each changed file can retain per-hunk added and removed line content.

Before this PR, review logic only had changed-line ranges. Now it also has internal hunk content through `ChangedFile.hunks`, while keeping the existing public `ranges` behavior unchanged.

This is the foundation for future content-based review signals.

## Type of change

- [x] Feature
- [x] Refactor
- [x] Tests
- [x] Documentation
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Added `DiffHunk` to represent one diff hunk.
- Added `ChangedFile.hunks` for review-layer internal use.
- Captured per-hunk:
  - added line range
  - added lines
  - removed lines
- Kept `ChangedFile.ranges` as the existing public changed-line view.
- Derived `ranges` from captured hunks to preserve existing behavior.
- Skipped hunk content from JSON serialization with `#[serde(skip)]`.
- Updated untracked-file handling to initialize empty hunks.
- Updated tests and fixtures that construct `ChangedFile`.
- Added parser tests for:
  - modified files
  - added files
  - deleted files
  - multiple hunks
  - unchanged public range behavior
- Updated `CHANGELOG.md`.

## Why

RepoPilot is moving from path-based review signals into richer content-based review intelligence.

To detect future signals like:

- auth logic loosened
- CORS changed to wildcard
- permission checks removed
- dependency scripts added
- CI permissions widened
- security headers removed

the review layer needs access to the actual added and removed lines from the diff.

This PR adds that capability without changing current output or report schemas.

## Architecture notes

- [x] No god files introduced
- [x] Diff parsing stays inside `src/review/diff.rs`
- [x] Hunk content is internal to the review layer
- [x] Public `ranges` behavior is preserved
- [x] JSON report output is not expanded with raw diff content
- [x] Existing review consumers can keep using `ranges`
- [x] Future content-based signals can consume `ChangedFile.hunks`

The important design decision is this:

```rust
#[serde(skip)]
pub hunks: Vec<DiffHunk>,