### PR TITLE
fix(architecture): stop flagging stylesheet and markup files as large files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Repositioned and tightened the README around reviewing a change *before you merge* — for humans and for AI agents calling RepoPilot over MCP. The page now leads with the review/boundary workflow and the agent (MCP) angle, demotes `scan` and the rest to a compact capability table, and moves the encyclopedic sections (trust mode, commands, rule quality, reports, CI) to their `docs/` links. Cut from ~326 to ~124 lines, deterministic/local-first framing made explicit.
 - Reworked the README visuals to a single hero demo plus real, current console-output examples (scan, review with boundary signals, and a baseline gate catching a newly introduced secret) instead of a GIF per command. Removed the per-command GIFs, including a misleading baseline GIF that showed an already-adopted repo rather than the gate doing its job.
 
+### Fixed
+
+- `architecture.large-file` no longer flags stylesheet and markup files (CSS, SCSS, HTML) as oversized source modules. They are now treated as non-logic the same way JSON, YAML, TOML, and Markdown already were — the rule applies only to logic languages — so a long stylesheet is no longer reported as a large file by `repopilot scan` (and the `repopilot_scan` MCP tool). The line-count threshold and behavior for real source files are unchanged.
+
 ## [0.14.0] - 2026-05-31
 
 RepoPilot 0.14 is the AI-guardrail release. Every runtime-risk and code-quality

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -682,7 +682,7 @@ reason = "Infrastructure-oriented code often contains orchestration or declarati
 [[rules]]
 rule_id = "architecture.large-file"
 minimum_support = "import-aware"
-languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin", "swift", "csharp", "c", "cpp", "c-header", "php", "ruby", "dart", "scala", "shell", "powershell", "sql", "html", "css", "scss"]
+languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin", "swift", "csharp", "c", "cpp", "c-header", "php", "ruby", "dart", "scala", "shell", "powershell", "sql"]
 suppress_low_signal = true
 suppress_config = true
 suppress_generated = true

--- a/tests/large_file_architecture.rs
+++ b/tests/large_file_architecture.rs
@@ -94,6 +94,31 @@ fn large_file_audit_skips_non_code_files() {
 }
 
 #[test]
+fn large_file_audit_skips_stylesheet_and_markup_files() {
+    for (path, language) in [
+        ("src/styles.css", Some("CSS")),
+        ("src/theme.scss", Some("SCSS")),
+        ("src/index.html", Some("HTML")),
+    ] {
+        let file = FileFacts {
+            path: PathBuf::from(path),
+            language: language.map(str::to_string),
+            non_empty_lines: 5_000,
+            branch_count: 0,
+            imports: Vec::new(),
+            content: None,
+            has_inline_tests: false,
+        };
+
+        let findings = LargeFileAudit.audit(&file, &ScanConfig::default());
+        assert!(
+            findings.is_empty(),
+            "stylesheet/markup file must not be flagged as large source: {path}"
+        );
+    }
+}
+
+#[test]
 fn large_file_audit_skips_test_and_fixture_paths() {
     for path in ["tests/large_scan.rs", "src/fixtures/generated.rs"] {
         let file = FileFacts {


### PR DESCRIPTION
## Summary

Stops `architecture.large-file` from flagging stylesheet and markup files as oversized source modules.

CSS, SCSS, and HTML are now excluded from the large-file architecture rule in the core knowledge pack, matching the existing treatment for non-logic file types like JSON, YAML, TOML, and Markdown.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- Removed `html`, `css`, and `scss` from the `architecture.large-file` rule language list in `src/knowledge/packs/core.toml`.
- Added regression coverage for:
  - CSS
  - SCSS
  - HTML
- Updated `CHANGELOG.md`.

## Why

Large stylesheet and markup files can be noisy, but they are not source modules in the same sense as Rust, TypeScript, Python, Go, Java, C#, etc.

RepoPilot should avoid reporting long CSS/SCSS/HTML files as architecture large-file findings, because that creates low-signal noise and distracts from actual oversized logic modules.

## Architecture notes

- [x] No god files introduced
- [x] No hardcoded special case added to `LargeFileAudit`
- [x] The rule behavior is controlled through the knowledge pack
- [x] Existing large-file behavior for real source languages is unchanged
- [x] Regression tests document the expected behavior

## Changelog

- [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo test large_file_audit_skips_stylesheet_and_markup_files
cargo run -- scan .