### PR TITLE
fix(review): reduce false positives in boundary and behavioral signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- Hardened `repopilot review`'s coarse (non-AST) behavioral fallback, which scans raw diff lines when a changed file can't be parsed. It now matches whole tokens instead of substrings, so a removed `author` line no longer reads as a removed `auth` check and a `catchy` variable no longer reads as a removed `catch` block (high-specificity auth substrings like `oauth`/`jwt`/`authentic`/`authoriz` still match). Coarse fallback signals are also demoted out of the *definitely sensitive* tier into *large diff / noise* — they remain visible as hints but no longer sit beside AST-confirmed findings. AST-based detection on parseable files is unchanged.
+- `repopilot review` no longer raises a security-boundary signal for *test* files. A change to `auth_service_test.ts` previously matched the access-control boundary on its filename and landed in the *definitely sensitive* tier, even though a test for a boundary decides neither who-can-do-what nor how the app ships. Boundary detection now skips test files; whether a test *moved alongside* a code-boundary change remains a separate signal (`review.boundary_missing_test`), which is unchanged.
 - `architecture.large-file` no longer flags stylesheet and markup files (CSS, SCSS, HTML) as oversized source modules. They are now treated as non-logic the same way JSON, YAML, TOML, and Markdown already were — the rule applies only to logic languages — so a long stylesheet is no longer reported as a large file by `repopilot scan` (and the `repopilot_scan` MCP tool). The line-count threshold and behavior for real source files are unchanged.
 
 ## [0.14.0] - 2026-05-31

--- a/src/review/signals/behavioral.rs
+++ b/src/review/signals/behavioral.rs
@@ -9,6 +9,7 @@ mod csharp;
 mod go;
 mod js;
 mod jvm;
+mod keywords;
 mod python;
 mod removed;
 mod rust;
@@ -36,6 +37,17 @@ pub enum BehavioralKind {
     AuthCheckRemoved,
 }
 
+/// How a behavioral signal was detected. Confidence — and therefore tiering —
+/// keys off this structured source, never off the user-facing `detail` text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BehavioralSignalSource {
+    /// Matched structurally against the parsed syntax tree.
+    Ast,
+    /// Matched by scanning raw diff lines because the file could not be parsed.
+    CoarseFallback,
+}
+
 /// A behavioral signal detected in a changed file.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BehavioralSignal {
@@ -43,6 +55,16 @@ pub struct BehavioralSignal {
     pub path: String,
     pub line: usize,
     pub detail: String,
+    pub source: BehavioralSignalSource,
+}
+
+impl BehavioralSignal {
+    /// Whether this signal came from the coarse (non-AST) fallback, which only
+    /// runs when the file can't be parsed. Coarse signals are hints, not
+    /// confident findings, and are demoted in the tiered view.
+    pub fn is_coarse(&self) -> bool {
+        self.source == BehavioralSignalSource::CoarseFallback
+    }
 }
 
 /// Detects newly added behavioral signals in a post-change source.
@@ -59,6 +81,7 @@ pub fn detect_behavioral_added(
             path: file.path_string(),
             line: 1,
             detail: "New database migration script added".to_string(),
+            source: BehavioralSignalSource::Ast,
         });
     }
 
@@ -143,6 +166,7 @@ fn match_node(
                     path: path_str.to_string(),
                     line,
                     detail: format!("Raw SQL query: {}", truncate_str(unquoted, 60)),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }

--- a/src/review/signals/behavioral/csharp.rs
+++ b/src/review/signals/behavioral/csharp.rs
@@ -1,4 +1,6 @@
-use crate::review::signals::behavioral::{BehavioralKind, BehavioralSignal, truncate_str};
+use crate::review::signals::behavioral::{
+    BehavioralKind, BehavioralSignal, BehavioralSignalSource, truncate_str,
+};
 use tree_sitter::Node;
 
 pub(super) fn match_csharp(
@@ -16,6 +18,7 @@ pub(super) fn match_csharp(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if text.contains("Process.Start") {
@@ -24,6 +27,7 @@ pub(super) fn match_csharp(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if text.contains("File.WriteAll")
@@ -35,6 +39,7 @@ pub(super) fn match_csharp(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if text.contains("Environment.GetEnvironmentVariable") {
@@ -43,6 +48,7 @@ pub(super) fn match_csharp(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }
@@ -52,6 +58,7 @@ pub(super) fn match_csharp(
                 path: path_str.to_string(),
                 line,
                 detail: format!("Imported using namespace: {}", text.trim_end_matches(';')),
+                source: BehavioralSignalSource::Ast,
             });
         }
         _ => {}

--- a/src/review/signals/behavioral/go.rs
+++ b/src/review/signals/behavioral/go.rs
@@ -1,5 +1,5 @@
 use crate::review::signals::behavioral::{
-    BehavioralKind, BehavioralSignal, extract_string_literal, truncate_str,
+    BehavioralKind, BehavioralSignal, BehavioralSignalSource, extract_string_literal, truncate_str,
 };
 use tree_sitter::Node;
 
@@ -21,6 +21,7 @@ pub(super) fn match_go(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if func_text.starts_with("exec.Command") {
@@ -29,6 +30,7 @@ pub(super) fn match_go(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if func_text.starts_with("os.WriteFile")
@@ -41,6 +43,7 @@ pub(super) fn match_go(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if func_text == "os.Getenv" || func_text == "os.LookupEnv" {
@@ -49,6 +52,7 @@ pub(super) fn match_go(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if func_text.ends_with(".Query")
@@ -60,6 +64,7 @@ pub(super) fn match_go(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }
@@ -72,6 +77,7 @@ pub(super) fn match_go(
                         path: path_str.to_string(),
                         line,
                         detail: format!("Imported package '{val}'"),
+                        source: BehavioralSignalSource::Ast,
                     });
                 }
             }

--- a/src/review/signals/behavioral/js.rs
+++ b/src/review/signals/behavioral/js.rs
@@ -1,5 +1,6 @@
 use crate::review::signals::behavioral::{
-    BehavioralKind, BehavioralSignal, extract_string_literal, is_local_import, truncate_str,
+    BehavioralKind, BehavioralSignal, BehavioralSignalSource, extract_string_literal,
+    is_local_import, truncate_str,
 };
 use tree_sitter::Node;
 
@@ -27,6 +28,7 @@ pub(super) fn match_js(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if callee_text == "exec"
@@ -41,6 +43,7 @@ pub(super) fn match_js(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if callee_text.contains("writeFile")
@@ -56,6 +59,7 @@ pub(super) fn match_js(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if callee_text == "require" || callee_text == "import" {
@@ -68,6 +72,7 @@ pub(super) fn match_js(
                                 path: path_str.to_string(),
                                 line,
                                 detail: format!("Imported dependency '{val}'"),
+                                source: BehavioralSignalSource::Ast,
                             });
                         }
                     }
@@ -83,6 +88,7 @@ pub(super) fn match_js(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }
@@ -95,6 +101,7 @@ pub(super) fn match_js(
                     path: path_str.to_string(),
                     line,
                     detail: "new WebSocket(...)".to_string(),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }
@@ -106,6 +113,7 @@ pub(super) fn match_js(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }
@@ -119,6 +127,7 @@ pub(super) fn match_js(
                             path: path_str.to_string(),
                             line,
                             detail: format!("Imported dependency '{val}'"),
+                            source: BehavioralSignalSource::Ast,
                         });
                     }
                 }

--- a/src/review/signals/behavioral/jvm.rs
+++ b/src/review/signals/behavioral/jvm.rs
@@ -1,4 +1,6 @@
-use crate::review::signals::behavioral::{BehavioralKind, BehavioralSignal, truncate_str};
+use crate::review::signals::behavioral::{
+    BehavioralKind, BehavioralSignal, BehavioralSignalSource, truncate_str,
+};
 use tree_sitter::Node;
 
 pub(super) fn match_jvm(
@@ -21,6 +23,7 @@ pub(super) fn match_jvm(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if text.contains("ProcessBuilder") || text.contains(".exec(") {
@@ -29,6 +32,7 @@ pub(super) fn match_jvm(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if text.contains("FileWriter")
@@ -41,6 +45,7 @@ pub(super) fn match_jvm(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if text.contains("System.getenv") {
@@ -49,6 +54,7 @@ pub(super) fn match_jvm(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if text.contains("executeQuery")
@@ -60,6 +66,7 @@ pub(super) fn match_jvm(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }
@@ -69,6 +76,7 @@ pub(super) fn match_jvm(
                 path: path_str.to_string(),
                 line,
                 detail: format!("Imported package: {}", text.trim_end_matches(';')),
+                source: BehavioralSignalSource::Ast,
             });
         }
         _ => {}

--- a/src/review/signals/behavioral/keywords.rs
+++ b/src/review/signals/behavioral/keywords.rs
@@ -1,0 +1,109 @@
+//! Keyword sets and token matching for the coarse (non-AST) removed-signal
+//! fallback in [`super::removed`].
+//!
+//! The coarse path scans raw diff lines, so it must avoid lookalikes: `catch`
+//! must not match `catchy`, `auth` must not match `author`. We tokenize each
+//! line (splitting on non-alphanumerics and on lowercase→uppercase transitions,
+//! mirroring the boundary classifier) and match whole tokens, plus a few
+//! high-specificity prefixes for the longer auth words so `authenticate` and
+//! `authorization` still count while `author` does not.
+
+use std::collections::HashSet;
+
+/// Error-handling keywords, matched by exact token equality.
+const ERROR_TOKENS: &[&str] = &["catch", "except"];
+
+/// High-specificity auth substrings whose collisions in real code are
+/// negligible. Checked against the whole lowercased line (not tokens) so they
+/// survive the camelCase split that would shred acronyms like `JWT`.
+/// `authentic` covers authenticate/authentication; `authoriz` covers
+/// authorize/authorization (but not the vaguer `authority`/`author`).
+const AUTH_STRONG: &[&str] = &["oauth", "jwt", "rbac", "passport", "authentic", "authoriz"];
+
+/// Short, ambiguous auth keywords, matched by exact token equality so they do
+/// not fire on substrings (`auth` must not match `author`).
+const AUTH_TOKENS: &[&str] = &[
+    "auth",
+    "login",
+    "logout",
+    "signin",
+    "signout",
+    "permission",
+    "permissions",
+    "session",
+    "sessions",
+    "role",
+    "roles",
+];
+
+/// True when a removed/added line carries an error-handling keyword as a token.
+pub(super) fn line_has_error_handling(line: &str) -> bool {
+    let tokens = tokenize(line);
+    ERROR_TOKENS.iter().any(|needle| tokens.contains(*needle))
+}
+
+/// True when a removed/added line carries an auth keyword — a high-specificity
+/// substring, or one of the short ambiguous keywords as a whole token.
+pub(super) fn line_has_auth(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    if AUTH_STRONG.iter().any(|needle| lower.contains(needle)) {
+        return true;
+    }
+    let tokens = tokenize(line);
+    AUTH_TOKENS.iter().any(|needle| tokens.contains(*needle))
+}
+
+/// Split text into lowercase alphanumeric tokens, breaking on separators and on
+/// lowercase→uppercase transitions so `requireAuth` yields `auth`.
+fn tokenize(text: &str) -> HashSet<String> {
+    let mut tokens = HashSet::new();
+    let mut current = String::new();
+
+    for ch in text.chars() {
+        if !ch.is_ascii_alphanumeric() {
+            flush(&mut current, &mut tokens);
+            continue;
+        }
+        if ch.is_ascii_uppercase()
+            && current
+                .chars()
+                .last()
+                .is_some_and(|last| last.is_ascii_lowercase() || last.is_ascii_digit())
+        {
+            flush(&mut current, &mut tokens);
+        }
+        current.push(ch.to_ascii_lowercase());
+    }
+    flush(&mut current, &mut tokens);
+    tokens
+}
+
+fn flush(current: &mut String, tokens: &mut HashSet<String>) {
+    if !current.is_empty() {
+        tokens.insert(std::mem::take(current));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{line_has_auth, line_has_error_handling};
+
+    #[test]
+    fn error_handling_matches_real_catch_not_lookalikes() {
+        assert!(line_has_error_handling("} catch (e) {"));
+        assert!(line_has_error_handling("        except ValueError:"));
+        assert!(!line_has_error_handling("const catchy = makeCatcher();"));
+        assert!(!line_has_error_handling("// nothing to see here"));
+    }
+
+    #[test]
+    fn auth_matches_real_tokens_and_prefixes_not_author() {
+        assert!(line_has_auth("if (!isAuthenticated(req)) return 401;"));
+        assert!(line_has_auth("requireAuth(req, res);"));
+        assert!(line_has_auth("checkPermission(user, 'admin');"));
+        assert!(line_has_auth("const token = verifyJWT(header);"));
+        // Lookalikes that must NOT fire.
+        assert!(!line_has_auth("const author = post.author;"));
+        assert!(!line_has_auth("import { Authority } from './authority';"));
+    }
+}

--- a/src/review/signals/behavioral/python.rs
+++ b/src/review/signals/behavioral/python.rs
@@ -1,4 +1,6 @@
-use crate::review::signals::behavioral::{BehavioralKind, BehavioralSignal, truncate_str};
+use crate::review::signals::behavioral::{
+    BehavioralKind, BehavioralSignal, BehavioralSignalSource, truncate_str,
+};
 use tree_sitter::Node;
 
 pub(super) fn match_python(
@@ -25,6 +27,7 @@ pub(super) fn match_python(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if callee_text.starts_with("subprocess.")
@@ -37,6 +40,7 @@ pub(super) fn match_python(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if callee_text.starts_with("pathlib.") && callee_text.contains("write") {
@@ -45,6 +49,7 @@ pub(super) fn match_python(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if callee_text == "open" {
@@ -64,6 +69,7 @@ pub(super) fn match_python(
                             path: path_str.to_string(),
                             line,
                             detail: truncate_str(text, 60),
+                            source: BehavioralSignalSource::Ast,
                         });
                     }
                 }
@@ -74,6 +80,7 @@ pub(super) fn match_python(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }
@@ -89,6 +96,7 @@ pub(super) fn match_python(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }
@@ -100,6 +108,7 @@ pub(super) fn match_python(
                     path: path_str.to_string(),
                     line,
                     detail: format!("Imported module: {text}"),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }

--- a/src/review/signals/behavioral/removed.rs
+++ b/src/review/signals/behavioral/removed.rs
@@ -1,5 +1,8 @@
+use super::keywords;
 use crate::review::diff::{ChangeStatus, ChangedFile};
-use crate::review::signals::behavioral::{BehavioralKind, BehavioralSignal};
+use crate::review::signals::behavioral::{
+    BehavioralKind, BehavioralSignal, BehavioralSignalSource,
+};
 use crate::review::signals::content::ReviewSource;
 use tree_sitter::{Node, Tree};
 
@@ -21,6 +24,7 @@ pub fn detect_behavioral_removed(
                 path: path_str.clone(),
                 line: 1,
                 detail: "Test file was deleted".to_string(),
+                source: BehavioralSignalSource::Ast,
             });
             return signals;
         } else if file.status == ChangeStatus::Modified || file.status == ChangeStatus::Renamed {
@@ -34,6 +38,7 @@ pub fn detect_behavioral_removed(
                         path: path_str.clone(),
                         line: 1,
                         detail: "All test cases were removed from test file".to_string(),
+                        source: BehavioralSignalSource::Ast,
                     });
                 }
             } else if let Some(post_src) = post_source {
@@ -43,6 +48,7 @@ pub fn detect_behavioral_removed(
                         path: path_str.clone(),
                         line: 1,
                         detail: "Test file was emptied".to_string(),
+                        source: BehavioralSignalSource::Ast,
                     });
                 }
             }
@@ -72,6 +78,7 @@ pub fn detect_behavioral_removed(
                         "Error handling block(s) removed (try/catch blocks: {} -> {})",
                         pre_try, post_try
                     ),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
 
@@ -87,6 +94,7 @@ pub fn detect_behavioral_removed(
                         "Authentication/authorization check removed (auth calls: {} -> {})",
                         pre_auth, post_auth
                     ),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
 
@@ -95,41 +103,28 @@ pub fn detect_behavioral_removed(
     }
 
     if !ast_success {
+        // Coarse fallback: no parse tree, so scan raw diff lines. Token matching
+        // (not substring) keeps `catch` off `catchy` and `auth` off `author`.
+        // Signals carry `BehavioralSignalSource::CoarseFallback` so the tiered
+        // view demotes them — confidence keys off the source, not the detail text.
         let mut try_removed = false;
         let mut auth_removed = false;
 
         for hunk in &file.hunks {
+            let added_has_error = hunk
+                .added_lines
+                .iter()
+                .any(|line| keywords::line_has_error_handling(line));
+            let added_has_auth = hunk
+                .added_lines
+                .iter()
+                .any(|line| keywords::line_has_auth(line));
             for line in &hunk.removed_lines {
-                let line_lower = line.to_lowercase();
-                if line_lower.contains("catch")
-                    || line_lower.contains("except:")
-                    || line_lower.contains("except ")
-                {
-                    let added_has_catch = hunk.added_lines.iter().any(|l| {
-                        let l_low = l.to_lowercase();
-                        l_low.contains("catch")
-                            || l_low.contains("except:")
-                            || l_low.contains("except ")
-                    });
-                    if !added_has_catch {
-                        try_removed = true;
-                    }
+                if !added_has_error && keywords::line_has_error_handling(line) {
+                    try_removed = true;
                 }
-                if line_lower.contains("auth")
-                    || line_lower.contains("login")
-                    || line_lower.contains("jwt")
-                    || line_lower.contains("permission")
-                {
-                    let added_has_auth = hunk.added_lines.iter().any(|l| {
-                        let l_low = l.to_lowercase();
-                        l_low.contains("auth")
-                            || l_low.contains("login")
-                            || l_low.contains("jwt")
-                            || l_low.contains("permission")
-                    });
-                    if !added_has_auth {
-                        auth_removed = true;
-                    }
+                if !added_has_auth && keywords::line_has_auth(line) {
+                    auth_removed = true;
                 }
             }
         }
@@ -140,6 +135,7 @@ pub fn detect_behavioral_removed(
                 path: path_str.clone(),
                 line: get_first_removed_line(file).unwrap_or(1),
                 detail: "Error handling removed (coarse fallback)".to_string(),
+                source: BehavioralSignalSource::CoarseFallback,
             });
         }
         if auth_removed {
@@ -148,6 +144,7 @@ pub fn detect_behavioral_removed(
                 path: path_str.clone(),
                 line: get_first_removed_line(file).unwrap_or(1),
                 detail: "Authentication/authorization check removed (coarse fallback)".to_string(),
+                source: BehavioralSignalSource::CoarseFallback,
             });
         }
     }

--- a/src/review/signals/behavioral/rust.rs
+++ b/src/review/signals/behavioral/rust.rs
@@ -1,4 +1,6 @@
-use crate::review::signals::behavioral::{BehavioralKind, BehavioralSignal, truncate_str};
+use crate::review::signals::behavioral::{
+    BehavioralKind, BehavioralSignal, BehavioralSignalSource, truncate_str,
+};
 use tree_sitter::Node;
 
 pub(super) fn match_rust(
@@ -19,6 +21,7 @@ pub(super) fn match_rust(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if func_text.contains("Command::new") {
@@ -27,6 +30,7 @@ pub(super) fn match_rust(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if func_text.contains("fs::write")
@@ -38,6 +42,7 @@ pub(super) fn match_rust(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
             if func_text.contains("env::var") || func_text.contains("std::env::var") {
@@ -46,6 +51,7 @@ pub(super) fn match_rust(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }
@@ -62,6 +68,7 @@ pub(super) fn match_rust(
                     path: path_str.to_string(),
                     line,
                     detail: truncate_str(text, 60),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }
@@ -80,6 +87,7 @@ pub(super) fn match_rust(
                     path: path_str.to_string(),
                     line,
                     detail: format!("Imported Rust crate/module: {}", text.trim_end_matches(';')),
+                    source: BehavioralSignalSource::Ast,
                 });
             }
         }

--- a/src/review/signals/behavioral_tests.rs
+++ b/src/review/signals/behavioral_tests.rs
@@ -1,4 +1,6 @@
-use super::behavioral::{BehavioralKind, detect_behavioral_added, detect_behavioral_removed};
+use super::behavioral::{
+    BehavioralKind, BehavioralSignalSource, detect_behavioral_added, detect_behavioral_removed,
+};
 use super::content::ReviewSource;
 use crate::review::diff::{ChangeStatus, ChangedFile, ChangedRange};
 use std::path::PathBuf;
@@ -198,6 +200,61 @@ doSomething();
 }
 
 #[test]
+fn coarse_fallback_uses_token_matching_no_ast() {
+    // With no sources the AST path is skipped, so the coarse fallback scans raw
+    // hunk lines. Real auth/error tokens fire and are marked coarse.
+    let file = file_with_hunk(
+        "src/legacy.php",
+        ChangeStatus::Modified,
+        Some((1, 4)),
+        Some((1, 2)),
+        vec![
+            "} catch (Exception $e) {",
+            "if (!isAuthenticated($req)) { abort(401); }",
+        ],
+        vec![],
+    );
+    let signals = detect_behavioral_removed(&file, None, None);
+    let kinds: Vec<_> = signals.iter().map(|s| s.kind).collect();
+    assert!(
+        kinds.contains(&BehavioralKind::ErrorHandlingRemoved),
+        "expected ErrorHandlingRemoved in {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&BehavioralKind::AuthCheckRemoved),
+        "expected AuthCheckRemoved in {kinds:?}"
+    );
+    assert!(
+        signals
+            .iter()
+            .all(|signal| signal.source == BehavioralSignalSource::CoarseFallback),
+        "coarse fallback signals must carry the CoarseFallback source: {signals:?}"
+    );
+    assert!(
+        signals.iter().all(|signal| signal.is_coarse()),
+        "is_coarse() must be true for CoarseFallback signals: {signals:?}"
+    );
+}
+
+#[test]
+fn coarse_fallback_ignores_lookalike_tokens() {
+    // `author` and `catchy` must not be mistaken for `auth` and `catch`.
+    let file = file_with_hunk(
+        "src/legacy.php",
+        ChangeStatus::Modified,
+        Some((1, 3)),
+        Some((1, 1)),
+        vec!["$author = $post->author;", "$catchy = makeCatcher();"],
+        vec![],
+    );
+    let signals = detect_behavioral_removed(&file, None, None);
+    assert!(
+        signals.is_empty(),
+        "lookalike tokens (author, catchy) must not fire coarse signals: {signals:?}"
+    );
+}
+
+#[test]
 fn auth_check_removed() {
     let pre_code = r#"
 function run() {
@@ -224,4 +281,7 @@ function run() {
     let signals = detect_behavioral_removed(&file, Some(&pre_src), Some(&post_src));
     assert_eq!(signals.len(), 1);
     assert_eq!(signals[0].kind, BehavioralKind::AuthCheckRemoved);
+    // AST-confirmed signals carry the Ast source and are not coarse.
+    assert_eq!(signals[0].source, BehavioralSignalSource::Ast);
+    assert!(!signals[0].is_coarse());
 }

--- a/src/review/signals/mod.rs
+++ b/src/review/signals/mod.rs
@@ -31,6 +31,7 @@ pub mod tiered;
 #[cfg(test)]
 mod tiered_tests;
 
+use crate::audits::context::classify::helpers::is_test_file;
 use crate::config::model::SecurityBoundarySection;
 use crate::review::diff::{ChangeStatus, ChangedFile};
 use serde::Serialize;
@@ -91,6 +92,13 @@ pub struct BoundarySignal {
 /// Returns at most one signal per changed file (the first category it matches,
 /// in priority order). Sorted by category then path for deterministic output.
 /// `blast_radius` is left at `0` here; callers enrich it via [`composites`].
+///
+/// Test files are skipped: a boundary signal means "the change touched code that
+/// decides who-can-do-what or how the app ships," and a test for that boundary
+/// decides neither. Without this, `auth_service_test.ts` would land in the
+/// top confidence tier as "access control changed." Whether a test *moved
+/// alongside* a code-boundary change is a separate signal — see
+/// [`composites::missing_test_for_code_boundary`].
 pub fn detect_boundary_signals(
     changed_files: &[ChangedFile],
     config: &SecurityBoundarySection,
@@ -103,6 +111,7 @@ pub fn detect_boundary_signals(
 
     let mut signals: Vec<BoundarySignal> = changed_files
         .iter()
+        .filter(|file| !is_test_file(&file.path, false))
         .filter_map(|file| {
             let path = file.path_string();
             classify::classify_boundary(&path, custom.as_ref()).map(|category| BoundarySignal {

--- a/src/review/signals/tests.rs
+++ b/src/review/signals/tests.rs
@@ -161,6 +161,22 @@ fn extra_patterns_flag_custom_boundaries() {
 }
 
 #[test]
+fn detect_skips_test_files_even_when_path_looks_like_a_boundary() {
+    let config = SecurityBoundarySection::default();
+    let files = vec![
+        changed("src/auth/login.ts", ChangeStatus::Modified),
+        changed("src/auth/login.test.ts", ChangeStatus::Modified),
+        changed("tests/auth_service_test.py", ChangeStatus::Modified),
+        changed("src/__tests__/cors.spec.ts", ChangeStatus::Modified),
+    ];
+    let signals = detect_boundary_signals(&files, &config);
+    // Only the production auth file is a boundary; the three test files are not.
+    assert_eq!(signals.len(), 1);
+    assert_eq!(signals[0].path, "src/auth/login.ts");
+    assert_eq!(signals[0].category, BoundaryCategory::AccessControl);
+}
+
+#[test]
 fn detect_sorts_by_category_then_path() {
     let config = SecurityBoundarySection::default();
     let files = vec![

--- a/src/review/signals/tiered.rs
+++ b/src/review/signals/tiered.rs
@@ -129,7 +129,7 @@ pub fn build_tiered(
         let in_access = access_paths.contains(signal.path.as_str());
         tiered.push(ReviewSignal {
             family: SignalFamily::Behavioral,
-            tier: behavioral_tier(signal.kind, in_access),
+            tier: behavioral_tier(signal.kind, in_access, signal.is_coarse()),
             path: signal.path.clone(),
             line: Some(signal.line),
             headline: behavioral_headline(signal.kind).to_string(),
@@ -206,8 +206,13 @@ fn from_boundary(signal: &BoundarySignal) -> ReviewSignal {
     }
 }
 
-fn behavioral_tier(kind: BehavioralKind, in_access_boundary: bool) -> ConfidenceTier {
+fn behavioral_tier(kind: BehavioralKind, in_access_boundary: bool, coarse: bool) -> ConfidenceTier {
     use BehavioralKind::*;
+    // Coarse (non-AST) signals are best-effort hints from a file we couldn't
+    // parse; keep them visible but never above the large-diff/noise tier.
+    if coarse {
+        return ConfidenceTier::LargeDiffOrNoise;
+    }
     match kind {
         SubprocessAdded | EnvVarIntroduced | MigrationAdded | ErrorHandlingRemoved
         | TestDeletedOrEmptied | AuthCheckRemoved => ConfidenceTier::DefinitelySensitive,

--- a/src/review/signals/tiered_tests.rs
+++ b/src/review/signals/tiered_tests.rs
@@ -1,5 +1,5 @@
 use super::algorithmic::{AlgorithmicKind, AlgorithmicSignal};
-use super::behavioral::{BehavioralKind, BehavioralSignal};
+use super::behavioral::{BehavioralKind, BehavioralSignal, BehavioralSignalSource};
 use super::tiered::{ConfidenceTier, build_tiered};
 use super::{BoundaryCategory, BoundarySignal};
 use crate::review::diff::{ChangeStatus, ChangedFile, ChangedRange};
@@ -20,6 +20,7 @@ fn behavioral(kind: BehavioralKind, path: &str) -> BehavioralSignal {
         path: path.to_string(),
         line: 1,
         detail: "detail".to_string(),
+        source: BehavioralSignalSource::Ast,
     }
 }
 
@@ -67,6 +68,40 @@ fn behavioral_kinds_tier_by_sensitivity() {
     // env var is a definite boundary crossing; a plain network call is maybe.
     assert_eq!(tiered.definitely.len(), 1);
     assert_eq!(tiered.maybe.len(), 1);
+}
+
+#[test]
+fn coarse_behavioral_signals_are_demoted_to_noise() {
+    // An AuthCheckRemoved from the coarse (non-AST) fallback would normally be
+    // "definitely sensitive"; its CoarseFallback source drops it to the noise tier.
+    let coarse = BehavioralSignal {
+        kind: BehavioralKind::AuthCheckRemoved,
+        path: "src/legacy.php".to_string(),
+        line: 1,
+        detail: "Authentication/authorization check removed (coarse fallback)".to_string(),
+        source: BehavioralSignalSource::CoarseFallback,
+    };
+    let tiered = build_tiered(&[], &[coarse], &[], &[]);
+    assert!(tiered.definitely.is_empty());
+    assert!(tiered.maybe.is_empty());
+    assert_eq!(tiered.noise.len(), 1);
+    assert_eq!(tiered.noise[0].tier, ConfidenceTier::LargeDiffOrNoise);
+}
+
+#[test]
+fn same_kind_is_definitely_when_ast_sourced() {
+    // The identical kind, but AST-sourced, stays in the definitely tier — proving
+    // the tier keys off `source`, not the kind or the detail text.
+    let ast = BehavioralSignal {
+        kind: BehavioralKind::AuthCheckRemoved,
+        path: "src/auth.ts".to_string(),
+        line: 1,
+        detail: "Authentication/authorization check removed (coarse fallback)".to_string(),
+        source: BehavioralSignalSource::Ast,
+    };
+    let tiered = build_tiered(&[], &[ast], &[], &[]);
+    assert_eq!(tiered.definitely.len(), 1);
+    assert!(tiered.noise.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Reduces false positives in review signals.

This PR hardens the coarse non-AST fallback for removed behavioral signals and prevents test files from being reported as production security-boundary changes.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- Added token-based keyword matching for coarse removed behavioral signals.
- Prevented `author` / `Authority` from matching `auth`.
- Prevented `catchy` / `makeCatcher` from matching `catch`.
- Kept high-specificity auth matches such as:
  - `oauth`
  - `jwt`
  - `authentic`
  - `authoriz`
- Marked coarse fallback signals as lower-confidence hints.
- Demoted coarse fallback signals out of the `definitely-sensitive` tier.
- Skipped test files in boundary detection.
- Added regression tests for:
  - auth/error lookalike tokens
  - coarse fallback signal tiering
  - test files that look like boundaries
- Updated `CHANGELOG.md`.

## Why

`repopilot review` should be useful without being noisy.

Two false-positive cases were too easy to hit:

1. Raw fallback matching treated words like `author` as `auth`.
2. Test files such as `auth_service_test.ts` could be classified as access-control boundary changes.

Both cases made review output look more serious than it was.

## Architecture notes

- [x] No god files introduced
- [x] Coarse keyword logic lives in a focused module
- [x] Boundary detection remains separate from behavioral detection
- [x] AST-based behavioral detection is unchanged
- [x] Test movement remains handled by `boundary_missing_test`
- [x] Coarse fallback remains visible but lower confidence

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- review . --base main
cargo run -- review . --base main --format json
```