### PR TITLE
chore: prepare v0.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-05
+
+RepoPilot 0.15 turns review from *scanning the code* into *understanding the
+change*. `repopilot review` now reads the diff itself — security boundaries,
+behavioral shifts (added network/subprocess/filesystem/SQL, removed error
+handling or auth checks), and algorithmic deltas (deeper nesting, a new nested
+loop, a function that grew or became recursive) — and presents them grouped into
+three confidence tiers, across the console, Markdown, and JSON outputs and over
+MCP to AI agents. Every signal is a structural fact, never a verdict: it flags,
+it does not prove. New `repopilot snapshot` + `review --since-snapshot` mark the
+repository before an agent or manual change and review everything since — the
+deterministic, local check an agent can run on its own edits before handing you
+the PR. Security-boundary detection now also reads file content via the shared
+syntax tree with token-aware matching. Everything new ships at `preview` and runs
+entirely locally — nothing uploaded, no AI service called.
+
 ### Added
 
 - Added true-positive and false-positive rule-evaluation fixtures so `inspect eval-rules` now covers `architecture.excessive-fan-out` (including the new Rust-facade false-positive case) and the Django and React Native framework rules (`framework.django.debug-true`, `framework.django.missing-allowed-hosts`, `framework.react-native.{architecture-mismatch, async-storage-from-core, deprecated-api, direct-state-mutation}`, `framework.rn-{navigation-compat, reanimated-compat, gesture-handler-old}`).
@@ -363,7 +379,9 @@ CI and AI-assisted remediation.
 - Added `compare` for diffing two JSON scan reports.
 - Added CI workflow, release workflow, distribution docs, release docs, and ruleset docs.
 
-[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/MykytaStel/repopilot/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/MykytaStel/repopilot/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/MykytaStel/repopilot/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/MykytaStel/repopilot/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/MykytaStel/repopilot/compare/v0.10.0...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repopilot"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repopilot"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Local-first CLI for repository audit, architecture risk detection, baseline tracking, and CI-friendly code review."

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![GitHub Stars](https://img.shields.io/github/stars/MykytaStel/repopilot?style=social)](https://github.com/MykytaStel/repopilot)
 
 **See what your AI agent — or you — just changed, before you merge.**
-
 RepoPilot is a fast, local-first Rust CLI that reviews a Git change and flags when it crossed a **security boundary** — the parts of your repo that decide *who can do what* (auth, sessions, permissions, CORS) and *how it ships* (CI, Dockerfiles, dependencies, committed `.env`) — then shows how far each changed file reaches. It's deterministic, runs entirely on your machine, and plugs into your AI coding agent over [MCP](#use-with-ai-agents-mcp). Nothing is uploaded.
 
 ```text
@@ -57,6 +56,8 @@ Security boundary changed [preview]:
 
 Boundary categories: **access control**, **request trust**, **deploy surface**, **supply chain**, **secret config**. Tune or disable them in `repopilot.toml` under `[security_boundary]` (ships at `preview`).
 
+Beyond boundaries, `repopilot review` also flags **behavioral** changes (added network/subprocess/filesystem/SQL, removed error handling or auth checks) and **algorithmic** changes (deeper nesting, a new nested loop, a function that grew or became recursive), grouped into three confidence tiers and reported as structural facts — never verdicts (ships at `preview`). To review a whole agent run, take a marker first: `repopilot snapshot`, let the agent edit, then `repopilot review --since-snapshot` covers every commit and uncommitted change since.
+
 Full audit, a CI gate that fails only on *new* risk, and a local brief for an assistant:
 
 ```bash
@@ -86,7 +87,7 @@ claude mcp add repopilot -- repopilot mcp
 
 It runs over stdio (JSON-RPC, no network, no AI calls) and exposes four tools:
 
-- `repopilot_review_change` — audit the current Git changes: in-diff vs out-of-diff findings, security-boundary signals, and blast radius (structured JSON).
+- `repopilot_review_change` — audit the current Git changes: in-diff vs out-of-diff findings, tiered review signals (security-boundary, behavioral, and algorithmic changes grouped by confidence), and blast radius (structured JSON).
 - `repopilot_scan` — full repository audit as JSON.
 - `repopilot_context` — a budgeted, AI-ready Markdown brief of the repo.
 - `repopilot_explain_file` — how a single file is classified and which rules apply.
@@ -97,7 +98,7 @@ More: [docs/mcp.md](docs/mcp.md).
 
 | Capability | What it does |
 |---|---|
-| **Review a change** | findings on changed lines, blast radius, and security-boundary signals — for you or your agent (`review`, MCP) |
+| **Review a change** | changed-line findings, blast radius, and tiered boundary/behavioral/algorithmic signals — including before/after an agent edit via `snapshot` + `review --since-snapshot` (`review`, MCP) |
 | Full scan | repo-wide, evidence-ranked findings — secrets, runtime footguns, architecture — quiet by default ([trust mode](docs/trust-mode.md)) |
 | Baseline + CI gate | accept current debt as a baseline; fail CI only on newly introduced risk |
 | Reports | Console, Markdown, JSON, [SARIF](docs/integrations/github-code-scanning.md), HTML, receipts |

--- a/action.yml
+++ b/action.yml
@@ -80,9 +80,9 @@ inputs:
     required: false
     default: ""
   version:
-    description: "npm version tag to install. Pin this for reproducible CI (e.g. 0.13.0)."
+    description: "npm version tag to install. Pin this for reproducible CI (e.g. 0.15.0)."
     required: false
-    default: "0.13.0"
+    default: "0.15.0"
   upload-sarif:
     description: "Automatically upload SARIF output to GitHub Code Scanning"
     required: false

--- a/docs/integrations/github-code-scanning.md
+++ b/docs/integrations/github-code-scanning.md
@@ -95,7 +95,7 @@ jobs:
 
       - name: Run RepoPilot
         id: repopilot
-        uses: MykytaStel/repopilot@v0.14.0
+        uses: MykytaStel/repopilot@v0.15.0
         with:
           command: scan
           baseline: .repopilot/baseline.json
@@ -115,7 +115,7 @@ For review-only gates, use `command: review` without `receipt`:
 
 ```yaml
       - name: RepoPilot review gate
-        uses: MykytaStel/repopilot@v0.14.0
+        uses: MykytaStel/repopilot@v0.15.0
         with:
           command: review
           base: origin/main
@@ -129,7 +129,7 @@ action without SARIF upload:
 
 ```yaml
       - name: RepoPilot doctor
-        uses: MykytaStel/repopilot@v0.14.0
+        uses: MykytaStel/repopilot@v0.15.0
         with:
           command: doctor
           format: markdown
@@ -137,7 +137,7 @@ action without SARIF upload:
           upload-sarif: "false"
 
       - name: RepoPilot focused scan
-        uses: MykytaStel/repopilot@v0.14.0
+        uses: MykytaStel/repopilot@v0.15.0
         with:
           command: scan
           rule: language.rust.panic-risk

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -16,11 +16,11 @@ JSON scan reports include explicit schema metadata. The current schema is 0.17:
 ```json
 {
   "schema_version": "0.17",
-  "repopilot_version": "0.14.0",
+  "repopilot_version": "0.15.0",
   "report": {
     "kind": "scan",
     "schema_version": "0.17",
-    "repopilot_version": "0.14.0"
+    "repopilot_version": "0.15.0"
   },
   "root_path": ".",
   "files_analyzed": 42,
@@ -140,11 +140,11 @@ Example shape:
 ```json
 {
   "schema_version": "0.17",
-  "repopilot_version": "0.14.0",
+  "repopilot_version": "0.15.0",
   "report": {
     "kind": "baseline-scan",
     "schema_version": "0.17",
-    "repopilot_version": "0.14.0"
+    "repopilot_version": "0.15.0"
   },
   "root_path": ".",
   "files_analyzed": 42,
@@ -192,10 +192,10 @@ Receipt JSON is intentionally smaller than a scan report and has its own schema:
   "report": {
     "kind": "receipt",
     "schema_version": "5",
-    "repopilot_version": "0.14.0"
+    "repopilot_version": "0.15.0"
   },
   "tool": "repopilot",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "generated_at": "2026-05-16T00:00:00Z",
   "root_path": ".",
   "git": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repopilot",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"description": "Local-first CLI for repository audit, architecture risk detection, baseline tracking, and CI-friendly code review.",
 	"license": "MIT OR Apache-2.0",
 	"repository": {
@@ -26,11 +26,11 @@
 		"LICENSE"
 	],
 	"optionalDependencies": {
-		"@repopilot/darwin-arm64": "0.14.0",
-		"@repopilot/darwin-x64": "0.14.0",
-		"@repopilot/linux-arm64-gnu": "0.14.0",
-		"@repopilot/linux-x64-gnu": "0.14.0",
-		"@repopilot/win32-x64-msvc": "0.14.0"
+		"@repopilot/darwin-arm64": "0.15.0",
+		"@repopilot/darwin-x64": "0.15.0",
+		"@repopilot/linux-arm64-gnu": "0.15.0",
+		"@repopilot/linux-x64-gnu": "0.15.0",
+		"@repopilot/win32-x64-msvc": "0.15.0"
 	},
 	"keywords": [
 		"cli",


### PR DESCRIPTION
## Summary

Prepares the RepoPilot `v0.15.0` release.

This release turns `repopilot review` from a changed-line scanner into a richer change-review workflow with tiered review signals, behavioral/algorithmic change detection, snapshot-based review, and updated documentation for AI-assisted usage.

## Type of change

- [ ] Feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [x] CI / repository maintenance

## What changed

- Bumped RepoPilot version from `0.14.0` to `0.15.0` in:
  - `Cargo.toml`
  - `Cargo.lock`
  - `package.json`
  - npm optional platform package versions
  - `action.yml`
- Finalized the `CHANGELOG.md` entry for `0.15.0`.
- Updated changelog compare links:
  - `Unreleased` now compares from `v0.15.0`
  - added `v0.14.0...v0.15.0`
  - restored the missing `v0.13.0...v0.14.0` link
- Updated README copy for:
  - tiered review signals
  - behavioral and algorithmic change signals
  - `repopilot snapshot`
  - `repopilot review --since-snapshot`
  - MCP review signal output
- Updated GitHub Code Scanning examples to use `MykytaStel/repopilot@v0.15.0`.
- Updated report docs examples to show `repopilot_version: 0.15.0`.

## Release highlights

RepoPilot `0.15.0` adds the strongest review workflow so far:

- tiered review signals grouped by confidence
- security-boundary, behavioral, and algorithmic change signals
- snapshot-based review for AI-agent/manual edits
- richer MCP review output for agents
- stronger documentation around review-before-merge workflows

The release message remains:

> See what your AI agent — or you — just changed, before you merge.

## Architecture notes

- [x] No product code changes in this release PR
- [x] Version bumps are consistent across Rust, npm, and GitHub Action surfaces
- [x] Changelog links point to the correct release ranges
- [x] README/docs describe the new 0.15 review workflow
- [x] Report schema version remains unchanged
- [x] Release PR is limited to versioning and documentation

## Changelog

- [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo package --list
cargo publish --dry-run
npm pack --dry-run
cargo run -- --version
cargo run -- review . --base main
cargo run -- review . --base main --format json
cargo run -- review . --base main --format markdown
```