### PR TITLE
fix(review): reduce taint-lite false positives on clean reassignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ dist/
 .repopilot-patches/
 
 docs/demos/*.tape
+docs/demos/*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Changed
+
+- `repopilot review` taint-lite now clears taint when a tracked local is reassigned to a clean value (`x = req.query.id; x = "static"; …`), removing false positives at later sinks. Compound assignment (`x += …`) still keeps taint because it combines with the prior value. Detection stays intra-procedural and at `preview`.
+
 ## [0.16.0] - 2026-06-07
 
 RepoPilot 0.16 makes change review the fast, low-noise default and turns the

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -21,10 +21,6 @@ use crate::review::signals::behavioral::truncate_str;
 use std::collections::HashMap;
 use tree_sitter::Node;
 
-/// Maximum seeding passes — enough for realistic `a = src; b = a; c = b` chains
-/// without unbounded work on pathological inputs.
-const MAX_SEED_PASSES: usize = 4;
-
 pub(super) fn detect(
     root: Node<'_>,
     content: &str,
@@ -67,42 +63,61 @@ fn detect_nested_scopes(
 // ── Seeding ─────────────────────────────────────────────────────────────────
 
 fn seed_tainted(root: Node<'_>, content: &str, lang: TaintLang) -> HashMap<String, SourceKind> {
-    let mut assignments: Vec<(Vec<String>, Node<'_>)> = Vec::new();
+    let mut assignments: Vec<Assignment<'_>> = Vec::new();
     collect_assignments(root, lang, content, &mut assignments);
+    // Process in document order so a later reassignment overrides an earlier one;
+    // a single forward pass then resolves `a = src; b = a; c = b` chains.
+    assignments.sort_by_key(|assignment| assignment.rhs.start_byte());
 
     let mut tainted: HashMap<String, SourceKind> = HashMap::new();
-    for _ in 0..MAX_SEED_PASSES {
-        let mut changed = false;
-        for (names, rhs) in &assignments {
-            let Some(kind) = node_has_source(*rhs, content, lang)
-                .or_else(|| node_mentions_tainted(*rhs, content, lang, &tainted))
-            else {
-                continue;
-            };
-            for name in names {
-                if tainted.insert(name.clone(), kind).is_none() {
-                    changed = true;
+    for assignment in &assignments {
+        match node_has_source(assignment.rhs, content, lang)
+            .or_else(|| node_mentions_tainted(assignment.rhs, content, lang, &tainted))
+        {
+            // A tainted/source value sets (or re-sets) taint for each target name.
+            Some(kind) => {
+                for name in &assignment.names {
+                    tainted.insert(name.clone(), kind);
                 }
             }
-        }
-        if !changed {
-            break;
+            // A clean reassignment clears taint — `x = req.query.id; x = "safe"`.
+            // Compound assignment (`x += …`) combines with the old value, so it
+            // never clears.
+            None if !assignment.augmenting => {
+                for name in &assignment.names {
+                    tainted.remove(name);
+                }
+            }
+            None => {}
         }
     }
     tainted
+}
+
+/// One assignment found in a scope: the local names it targets, its value node,
+/// and whether it is a compound assignment (`+=`, …) that combines with the old
+/// value rather than replacing it.
+struct Assignment<'a> {
+    names: Vec<String>,
+    rhs: Node<'a>,
+    augmenting: bool,
 }
 
 fn collect_assignments<'a>(
     node: Node<'a>,
     lang: TaintLang,
     content: &str,
-    out: &mut Vec<(Vec<String>, Node<'a>)>,
+    out: &mut Vec<Assignment<'a>>,
 ) {
     if let Some((lhs, rhs)) = assignment_parts(node, lang) {
         let mut names = Vec::new();
         collect_lhs_names(lhs, content, &mut names);
         if !names.is_empty() {
-            out.push((names, rhs));
+            out.push(Assignment {
+                names,
+                rhs,
+                augmenting: is_augmenting(node, lang),
+            });
         }
     }
     let mut cursor = node.walk();
@@ -110,6 +125,38 @@ fn collect_assignments<'a>(
         if !lang.is_flow_scope(child) {
             collect_assignments(child, lang, content, out);
         }
+    }
+}
+
+/// Whether `node` is a compound assignment that combines with the existing value
+/// (`x += …`), as opposed to a plain replacement (`x = …`, `x := …`).
+fn is_augmenting(node: Node<'_>, lang: TaintLang) -> bool {
+    match lang {
+        TaintLang::Python => node.kind() == "augmented_assignment",
+        TaintLang::Go => {
+            node.kind() == "assignment_statement" && {
+                let mut cursor = node.walk();
+                node.children(&mut cursor).any(|child| {
+                    matches!(
+                        child.kind(),
+                        "+=" | "-="
+                            | "*="
+                            | "/="
+                            | "%="
+                            | "&="
+                            | "|="
+                            | "^="
+                            | "<<="
+                            | ">>="
+                            | "&^="
+                    )
+                })
+            }
+        }
+        // tree-sitter-javascript models `x += …` as a distinct
+        // `augmented_assignment_expression` node that `assignment_parts` does not
+        // collect, so anything collected here is a plain `=`.
+        TaintLang::Js => false,
     }
 }
 

--- a/src/review/signals/taint/tests.rs
+++ b/src/review/signals/taint/tests.rs
@@ -171,6 +171,37 @@ function runsQuery(id: string) {
     assert!(signals.is_empty());
 }
 
+#[test]
+fn js_clean_reassignment_clears_taint() {
+    // `id` is tainted, then overwritten with a constant before the sink.
+    let signals = run(
+        "src/handler.ts",
+        "TypeScript",
+        r#"
+let id = req.query.id;
+id = "static";
+db.query("SELECT * FROM t WHERE id = " + id);
+"#,
+    );
+    assert!(signals.is_empty(), "a clean reassignment must clear taint");
+}
+
+#[test]
+fn js_reassignment_to_a_source_starts_tainting() {
+    // The reverse: clean first, then reassigned from a request field.
+    let signals = run(
+        "src/handler.ts",
+        "TypeScript",
+        r#"
+let id = "static";
+id = req.query.id;
+db.query("SELECT * FROM t WHERE id = " + id);
+"#,
+    );
+    assert_eq!(signals.len(), 1);
+    assert_eq!(signals[0].sink, SinkKind::Sql);
+}
+
 // ── Python ────────────────────────────────────────────────────────────────────
 
 #[test]
@@ -264,6 +295,22 @@ open(path, mode="w")
     );
     assert_eq!(signals.len(), 1);
     assert_eq!(signals[0].sink, SinkKind::FsWrite);
+}
+
+#[test]
+fn python_compound_assignment_keeps_taint() {
+    // `q += " more"` combines with the tainted value, so taint must NOT clear.
+    let signals = run(
+        "src/views.py",
+        "Python",
+        r#"
+q = request.args.get("id")
+q += " ORDER BY 1"
+cursor.execute("SELECT * FROM t WHERE id = " + q)
+"#,
+    );
+    assert_eq!(signals.len(), 1);
+    assert_eq!(signals[0].sink, SinkKind::Sql);
 }
 
 // ── Go ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR improves `repopilot review` taint-lite behavior by clearing tracked local taint when a variable is reassigned to a clean value.

Example:

```
let id = req.query.id;
id = "static";
db.query("SELECT * FROM t WHERE id = " + id);
```

Before this change, id could remain treated as tainted even after the clean reassignment. Now plain clean reassignment removes the local taint and avoids a false positive at the later sink.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation / changelog

## What changed

- Reworked taint-lite assignment tracking to store assignment metadata instead of only (names, rhs).
- Added Assignment { names, rhs, augmenting } so the detector can distinguish plain reassignment from compound assignment.
- Clean plain reassignment now removes taint from the tracked local name.
- Compound assignment keeps taint because it combines with the previous value.
- Added regression coverage for:
- JavaScript/TypeScript clean reassignment clearing taint.
- JavaScript/TypeScript reassignment from a source starting taint again.
- Python compound assignment preserving taint.
- Updated CHANGELOG.md.
- Added generated demo logs to .gitignore.

## Why

This reduces false positives in repopilot review when tainted input is overwritten with a safe value before reaching a sink.

The goal is still conservative, local, preview-level taint detection — not a full data-flow engine.

## Architecture notes

- Keeps taint-lite inside the existing review::signals::taint module.
- Does not introduce new public CLI flags or report schema changes.
- Keeps the detector intra-procedural.
- Keeps nested scopes isolated from parent taint state.
- Avoids introducing a new large/god file.
- Maintains the existing preview-level scope of the taint signal.

## Limitations

- This is still a lightweight intra-procedural analysis.
- It does not model sanitizers.
- It does not track inter-procedural flow through function calls, return values, or arguments.
- It only reasons about simple local assignment chains.

## Verification
```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- review --help
```