### PR TITLE
feat(review): treat numeric and boolean coercions as taint neutralizers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ dist/
 .repopilot-patches/
 
 docs/demos/*.tape
+docs/demos/*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Changed
 
 - `repopilot review` taint-lite now clears taint when a tracked local is reassigned to a clean value (`x = req.query.id; x = "static"; …`), removing false positives at later sinks. Compound assignment (`x += …`) still keeps taint because it combines with the prior value. Detection stays intra-procedural and at `preview`.
+- `repopilot review` taint-lite now treats numeric/boolean coercions (`Number`, `parseInt`, `parseFloat`, `int`, `float`, `bool`, `strconv.Atoi`, …) as neutralizing: a request value coerced to a number/bool before a SQL/exec/filesystem/network sink is no longer flagged, while an un-coerced sibling in the same expression still is. Context-specific sanitizers (shell quoting, URL/HTML encoding) are intentionally not yet recognized.
 
 ## [0.16.0] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Changed
+
+- `repopilot review` taint-lite now clears taint when a tracked local is reassigned to a clean value (`x = req.query.id; x = "static"; …`), removing false positives at later sinks. Compound assignment (`x += …`) still keeps taint because it combines with the prior value. Detection stays intra-procedural and at `preview`.
+
 ## [0.16.0] - 2026-06-07
 
 RepoPilot 0.16 makes change review the fast, low-noise default and turns the

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -139,7 +139,15 @@ fn is_augmenting(node: Node<'_>, lang: TaintLang) -> bool {
                 node.children(&mut cursor).any(|child| {
                     matches!(
                         child.kind(),
-                        "+=" | "-=" | "*=" | "/=" | "%=" | "&=" | "|=" | "^=" | "<<=" | ">>="
+                        "+=" | "-="
+                            | "*="
+                            | "/="
+                            | "%="
+                            | "&="
+                            | "|="
+                            | "^="
+                            | "<<="
+                            | ">>="
                             | "&^="
                     )
                 })
@@ -211,6 +219,10 @@ fn node_mentions_tainted(
     tainted: &HashMap<String, SourceKind>,
 ) -> Option<SourceKind> {
     if lang.is_flow_scope(node) {
+        return None;
+    }
+    // A sanitizer/coercion call neutralizes whatever it wraps; do not descend.
+    if super::sanitizers::is_sanitizer_call(node, content, lang) {
         return None;
     }
     if node.kind() == "identifier" {

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -21,10 +21,6 @@ use crate::review::signals::behavioral::truncate_str;
 use std::collections::HashMap;
 use tree_sitter::Node;
 
-/// Maximum seeding passes — enough for realistic `a = src; b = a; c = b` chains
-/// without unbounded work on pathological inputs.
-const MAX_SEED_PASSES: usize = 4;
-
 pub(super) fn detect(
     root: Node<'_>,
     content: &str,
@@ -67,42 +63,61 @@ fn detect_nested_scopes(
 // ── Seeding ─────────────────────────────────────────────────────────────────
 
 fn seed_tainted(root: Node<'_>, content: &str, lang: TaintLang) -> HashMap<String, SourceKind> {
-    let mut assignments: Vec<(Vec<String>, Node<'_>)> = Vec::new();
+    let mut assignments: Vec<Assignment<'_>> = Vec::new();
     collect_assignments(root, lang, content, &mut assignments);
+    // Process in document order so a later reassignment overrides an earlier one;
+    // a single forward pass then resolves `a = src; b = a; c = b` chains.
+    assignments.sort_by_key(|assignment| assignment.rhs.start_byte());
 
     let mut tainted: HashMap<String, SourceKind> = HashMap::new();
-    for _ in 0..MAX_SEED_PASSES {
-        let mut changed = false;
-        for (names, rhs) in &assignments {
-            let Some(kind) = node_has_source(*rhs, content, lang)
-                .or_else(|| node_mentions_tainted(*rhs, content, lang, &tainted))
-            else {
-                continue;
-            };
-            for name in names {
-                if tainted.insert(name.clone(), kind).is_none() {
-                    changed = true;
+    for assignment in &assignments {
+        match node_has_source(assignment.rhs, content, lang)
+            .or_else(|| node_mentions_tainted(assignment.rhs, content, lang, &tainted))
+        {
+            // A tainted/source value sets (or re-sets) taint for each target name.
+            Some(kind) => {
+                for name in &assignment.names {
+                    tainted.insert(name.clone(), kind);
                 }
             }
-        }
-        if !changed {
-            break;
+            // A clean reassignment clears taint — `x = req.query.id; x = "safe"`.
+            // Compound assignment (`x += …`) combines with the old value, so it
+            // never clears.
+            None if !assignment.augmenting => {
+                for name in &assignment.names {
+                    tainted.remove(name);
+                }
+            }
+            None => {}
         }
     }
     tainted
+}
+
+/// One assignment found in a scope: the local names it targets, its value node,
+/// and whether it is a compound assignment (`+=`, …) that combines with the old
+/// value rather than replacing it.
+struct Assignment<'a> {
+    names: Vec<String>,
+    rhs: Node<'a>,
+    augmenting: bool,
 }
 
 fn collect_assignments<'a>(
     node: Node<'a>,
     lang: TaintLang,
     content: &str,
-    out: &mut Vec<(Vec<String>, Node<'a>)>,
+    out: &mut Vec<Assignment<'a>>,
 ) {
     if let Some((lhs, rhs)) = assignment_parts(node, lang) {
         let mut names = Vec::new();
         collect_lhs_names(lhs, content, &mut names);
         if !names.is_empty() {
-            out.push((names, rhs));
+            out.push(Assignment {
+                names,
+                rhs,
+                augmenting: is_augmenting(node, lang),
+            });
         }
     }
     let mut cursor = node.walk();
@@ -110,6 +125,30 @@ fn collect_assignments<'a>(
         if !lang.is_flow_scope(child) {
             collect_assignments(child, lang, content, out);
         }
+    }
+}
+
+/// Whether `node` is a compound assignment that combines with the existing value
+/// (`x += …`), as opposed to a plain replacement (`x = …`, `x := …`).
+fn is_augmenting(node: Node<'_>, lang: TaintLang) -> bool {
+    match lang {
+        TaintLang::Python => node.kind() == "augmented_assignment",
+        TaintLang::Go => {
+            node.kind() == "assignment_statement" && {
+                let mut cursor = node.walk();
+                node.children(&mut cursor).any(|child| {
+                    matches!(
+                        child.kind(),
+                        "+=" | "-=" | "*=" | "/=" | "%=" | "&=" | "|=" | "^=" | "<<=" | ">>="
+                            | "&^="
+                    )
+                })
+            }
+        }
+        // tree-sitter-javascript models `x += …` as a distinct
+        // `augmented_assignment_expression` node that `assignment_parts` does not
+        // collect, so anything collected here is a plain `=`.
+        TaintLang::Js => false,
     }
 }
 

--- a/src/review/signals/taint/mod.rs
+++ b/src/review/signals/taint/mod.rs
@@ -22,6 +22,7 @@
 
 mod ast;
 mod flow;
+mod sanitizers;
 mod sinks;
 mod sources;
 #[cfg(test)]

--- a/src/review/signals/taint/sanitizers.rs
+++ b/src/review/signals/taint/sanitizers.rs
@@ -1,0 +1,52 @@
+//! Coercion recognition for taint-lite.
+//!
+//! A value that reaches a sink only through a numeric/boolean **type coercion** —
+//! `Number(req.query.id)`, `parseInt(...)`, `int(...)`, `strconv.Atoi(...)`, … —
+//! cannot carry an injection into *any* sink: the result is a non-string
+//! primitive. The source/tainted-name walkers in [`super::sources`] and
+//! [`super::flow`] treat such a call as an opaque, clean subtree and do not
+//! descend into its arguments. Pruning is subtree-local, so `Number(a) + b` still
+//! flags `b`.
+//!
+//! Only universally-neutralizing coercions are recognized here, deliberately.
+//! Context-specific sanitizers (shell quoting like `shlex.quote`, URL encoding
+//! like `encodeURIComponent`, HTML escaping like `escape`) only neutralize for
+//! *their* sink and would cause false negatives if applied to SQL/exec/fs
+//! universally — recognizing them per-sink is a documented follow-up.
+
+use super::TaintLang;
+use tree_sitter::Node;
+
+const JS_COERCIONS: &[&str] = &["Number", "parseInt", "parseFloat", "BigInt", "Boolean"];
+
+const PY_COERCIONS: &[&str] = &["int", "float", "bool"];
+
+const GO_COERCIONS: &[&str] = &[
+    "strconv.Atoi",
+    "strconv.ParseInt",
+    "strconv.ParseFloat",
+    "strconv.ParseBool",
+];
+
+/// Whether `node` is a call to a numeric/boolean coercion that universally
+/// neutralizes its argument, so the walkers should not descend into it.
+pub(super) fn is_sanitizer_call(node: Node<'_>, content: &str, lang: TaintLang) -> bool {
+    let is_call = match lang {
+        TaintLang::Js | TaintLang::Go => node.kind() == "call_expression",
+        TaintLang::Python => node.kind() == "call",
+    };
+    if !is_call {
+        return false;
+    }
+    let Some(callee) = node.child_by_field_name("function") else {
+        return false;
+    };
+    let text = callee.utf8_text(content.as_bytes()).unwrap_or("").trim();
+
+    let coercions = match lang {
+        TaintLang::Js => JS_COERCIONS,
+        TaintLang::Python => PY_COERCIONS,
+        TaintLang::Go => GO_COERCIONS,
+    };
+    coercions.contains(&text)
+}

--- a/src/review/signals/taint/sources.rs
+++ b/src/review/signals/taint/sources.rs
@@ -104,6 +104,10 @@ fn node_has_patterns(node: Node<'_>, content: &str, lang: TaintLang, patterns: &
     if lang.is_flow_scope(node) {
         return false;
     }
+    // A sanitizer/coercion call neutralizes whatever it wraps; do not descend.
+    if super::sanitizers::is_sanitizer_call(node, content, lang) {
+        return false;
+    }
 
     let is_access = match lang {
         TaintLang::Js => node.kind() == "member_expression",

--- a/src/review/signals/taint/tests.rs
+++ b/src/review/signals/taint/tests.rs
@@ -171,6 +171,37 @@ function runsQuery(id: string) {
     assert!(signals.is_empty());
 }
 
+#[test]
+fn js_clean_reassignment_clears_taint() {
+    // `id` is tainted, then overwritten with a constant before the sink.
+    let signals = run(
+        "src/handler.ts",
+        "TypeScript",
+        r#"
+let id = req.query.id;
+id = "static";
+db.query("SELECT * FROM t WHERE id = " + id);
+"#,
+    );
+    assert!(signals.is_empty(), "a clean reassignment must clear taint");
+}
+
+#[test]
+fn js_reassignment_to_a_source_starts_tainting() {
+    // The reverse: clean first, then reassigned from a request field.
+    let signals = run(
+        "src/handler.ts",
+        "TypeScript",
+        r#"
+let id = "static";
+id = req.query.id;
+db.query("SELECT * FROM t WHERE id = " + id);
+"#,
+    );
+    assert_eq!(signals.len(), 1);
+    assert_eq!(signals[0].sink, SinkKind::Sql);
+}
+
 // ── Python ────────────────────────────────────────────────────────────────────
 
 #[test]
@@ -264,6 +295,22 @@ open(path, mode="w")
     );
     assert_eq!(signals.len(), 1);
     assert_eq!(signals[0].sink, SinkKind::FsWrite);
+}
+
+#[test]
+fn python_compound_assignment_keeps_taint() {
+    // `q += " more"` combines with the tainted value, so taint must NOT clear.
+    let signals = run(
+        "src/views.py",
+        "Python",
+        r#"
+q = request.args.get("id")
+q += " ORDER BY 1"
+cursor.execute("SELECT * FROM t WHERE id = " + q)
+"#,
+    );
+    assert_eq!(signals.len(), 1);
+    assert_eq!(signals[0].sink, SinkKind::Sql);
 }
 
 // ── Go ────────────────────────────────────────────────────────────────────────

--- a/src/review/signals/taint/tests.rs
+++ b/src/review/signals/taint/tests.rs
@@ -368,6 +368,81 @@ func handler(r *Request) {
     assert!(signals.is_empty());
 }
 
+// ── Coercion / sanitizers ──────────────────────────────────────────────────────
+
+#[test]
+fn js_numeric_coercion_clears_taint() {
+    let signals = run(
+        "src/handler.ts",
+        "TypeScript",
+        r#"
+const id = Number(req.query.id);
+db.query("SELECT * FROM t WHERE id = " + id);
+"#,
+    );
+    assert!(
+        signals.is_empty(),
+        "Number(...) coercion neutralizes injection"
+    );
+}
+
+#[test]
+fn js_parseint_coercion_into_exec_is_not_flagged() {
+    let signals = run(
+        "src/handler.ts",
+        "TypeScript",
+        r#"
+const n = parseInt(req.query.n, 10);
+exec("kill " + n);
+"#,
+    );
+    assert!(signals.is_empty());
+}
+
+#[test]
+fn js_partial_coercion_still_flags_the_raw_part() {
+    // Number(a) is neutralized, but b is still raw — pruning is subtree-local.
+    let signals = run(
+        "src/handler.ts",
+        "TypeScript",
+        r#"
+const a = req.query.a;
+const b = req.query.b;
+db.query("SELECT * FROM t WHERE a = " + Number(a) + " AND b = " + b);
+"#,
+    );
+    assert_eq!(signals.len(), 1);
+    assert_eq!(signals[0].sink, SinkKind::Sql);
+}
+
+#[test]
+fn python_int_coercion_clears_taint() {
+    let signals = run(
+        "src/views.py",
+        "Python",
+        "uid = int(request.args.get(\"id\"))\ncursor.execute(f\"SELECT * FROM t WHERE id = {uid}\")\n",
+    );
+    assert!(signals.is_empty());
+}
+
+#[test]
+fn go_strconv_atoi_clears_taint() {
+    let signals = run(
+        "src/handler.go",
+        "Go",
+        r#"
+package main
+
+func handler(r *Request, db *DB) {
+	id, _ := strconv.Atoi(r.URL.Query().Get("id"))
+	rows, _ := db.Query(fmt.Sprintf("SELECT * FROM t WHERE id = %d", id))
+	_ = rows
+}
+"#,
+    );
+    assert!(signals.is_empty());
+}
+
 // ── Scope guards ──────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

This PR improves `repopilot review` taint-lite by recognizing simple numeric and boolean coercions as taint-neutralizing operations.

Examples:

```
const id = Number(req.query.id);
db.query("SELECT * FROM users WHERE id = " + id);
uid = int(request.args.get("id"))
cursor.execute(f"SELECT * FROM users WHERE id = {uid}")
```

Before this change, taint-lite could still treat the coerced value as user-controlled string input and report a finding. Now numeric/boolean coercion calls are treated as clean subtrees, reducing false positives for injection-style sinks.

## Type of change

- [x] Feature
- [x] Bug fix
- [x] Tests
- [x] Documentation

## What changed

- Added a focused sanitizers module for taint-lite coercion recognition.
- Recognized numeric/boolean coercions for:
- JavaScript / TypeScript: Number, parseInt, parseFloat, BigInt, Boolean
- Python: int, float, bool
- Go: strconv.Atoi, strconv.ParseInt, strconv.ParseFloat, strconv.ParseBool
- Updated source detection so request/source patterns inside recognized coercion calls are not treated as tainted.
- Updated flow detection so tainted local names wrapped by recognized coercion calls are not reported at sinks.
- Kept pruning subtree-local, so mixed expressions still flag raw uncoerced values.
- Added regression tests for JS/TS, Python, and Go coercion behavior.
- Updated CHANGELOG.md.

## Why

This reduces false positives in repopilot review when user input is converted into a numeric or boolean primitive before reaching SQL, exec, filesystem, or network sinks.

The detector remains intentionally lightweight and conservative. This is not a full sanitizer framework and does not attempt context-specific escaping yet.

## Architecture notes

- The new logic is isolated inside review::signals::taint.
- No CLI flags, report schema, or public output format changes.
- No scanner/audit/report responsibility mixing.
- The coercion whitelist is intentionally small and language-specific.
- Context-specific sanitizers such as shell quoting, URL encoding, or HTML escaping are intentionally left as follow-up work.

## Limitations

- This is still preview-level taint-lite, not a full data-flow engine.
- It does not model custom validators.
- It does not model context-specific sanitizers yet.
- It does not prove semantic correctness of the coercion result.
- It only treats a small whitelist of numeric/boolean coercions as neutralizing.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- review --help
```