### PR TITLE
fix(review): make dependency detection workspace-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- Made review dependency detection workspace-aware: `DependencyContext` now
+  collects local package names from Cargo `[workspace].members`, npm `workspaces`,
+  and `go.work` members, so importing one local package from another in a monorepo
+  is no longer reported as a newly added external dependency. The repo's own scoped
+  name (e.g. `@acme/core`) no longer swallows an unrelated bare `core` import, and a
+  manifest that exists but fails to parse is reported once on stderr instead of
+  silently making every import look external.
 - Hardened the AST `AuthCheckRemoved` and `ErrorHandlingRemoved` review signals to
   match only a call's callee (its `object.method` path), never its arguments or
   string literals, and to count each call once. Removing

--- a/src/review/signals/behavioral.rs
+++ b/src/review/signals/behavioral.rs
@@ -6,6 +6,7 @@
 //! Also handles path-based migration detection for newly added files.
 
 mod csharp;
+mod dependency;
 mod go;
 mod js;
 mod jvm;
@@ -21,7 +22,6 @@ use crate::review::diff::{ChangeStatus, ChangedFile};
 use crate::review::signals::content::ReviewSource;
 use serde::Serialize;
 use std::collections::BTreeSet;
-use std::fs;
 use std::path::Path;
 use tree_sitter::Node;
 
@@ -78,34 +78,20 @@ pub struct DependencyContext {
 }
 
 impl DependencyContext {
+    /// Build the set of names/prefixes that count as *local* — the repo's own
+    /// package(s) and, in a monorepo, its workspace members — so cross-package
+    /// imports are not mistaken for newly added external dependencies.
     pub fn from_repo_root(root: &Path) -> Self {
         let mut context = Self::default();
 
-        if let Ok(content) = fs::read_to_string(root.join("Cargo.toml"))
-            && let Ok(value) = toml::from_str::<toml::Value>(&content)
-            && let Some(name) = value
-                .get("package")
-                .and_then(|package| package.get("name"))
-                .and_then(toml::Value::as_str)
-        {
-            context.add_local_name(name);
+        for name in dependency::cargo_local_names(root) {
+            context.add_local_name(&name);
         }
-
-        if let Ok(content) = fs::read_to_string(root.join("package.json"))
-            && let Ok(value) = serde_json::from_str::<serde_json::Value>(&content)
-            && let Some(name) = value.get("name").and_then(serde_json::Value::as_str)
-        {
-            context.add_local_name(name);
+        for name in dependency::npm_local_names(root) {
+            context.add_local_name(&name);
         }
-
-        if let Ok(content) = fs::read_to_string(root.join("go.mod"))
-            && let Some(module) = content
-                .lines()
-                .find_map(|line| line.trim().strip_prefix("module "))
-        {
-            context
-                .local_import_prefixes
-                .insert(module.trim().to_string());
+        for prefix in dependency::go_local_prefixes(root) {
+            context.local_import_prefixes.insert(prefix);
         }
 
         context
@@ -116,13 +102,12 @@ impl DependencyContext {
         if normalized.is_empty() {
             return;
         }
+        // Match the full package name (and its `-`→`_` spelling). The bare last
+        // path segment is intentionally *not* inserted: a repo named `@acme/core`
+        // must not swallow an unrelated bare `core` import.
         self.local_package_names.insert(normalized.to_string());
         self.local_package_names
             .insert(normalized.replace('-', "_"));
-        if let Some(last) = normalized.rsplit('/').next() {
-            self.local_package_names.insert(last.to_string());
-            self.local_package_names.insert(last.replace('-', "_"));
-        }
     }
 
     pub(super) fn is_local_package(&self, name: &str) -> bool {

--- a/src/review/signals/behavioral/dependency.rs
+++ b/src/review/signals/behavioral/dependency.rs
@@ -1,0 +1,277 @@
+//! Workspace-aware discovery of *local* package names and module prefixes for
+//! [`super::DependencyContext`].
+//!
+//! Each collector reads the repo-root manifest and, when it declares a
+//! workspace, the manifests of its members — so an import of one local package
+//! from another (common in monorepos) is recognized as local rather than
+//! reported as a newly added external dependency. A manifest that exists but
+//! fails to parse is surfaced once on stderr instead of silently making every
+//! import look external.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Local Cargo package names: the root `[package].name` plus the `[package].name`
+/// of every `[workspace].members` entry.
+pub(super) fn cargo_local_names(root: &Path) -> Vec<String> {
+    let mut names = Vec::new();
+    let path = root.join("Cargo.toml");
+    let Ok(content) = fs::read_to_string(&path) else {
+        return names;
+    };
+    let value = match toml::from_str::<toml::Value>(&content) {
+        Ok(value) => value,
+        Err(err) => {
+            report_unparseable(&path, &err);
+            return names;
+        }
+    };
+
+    if let Some(name) = cargo_package_name(&value) {
+        names.push(name.to_string());
+    }
+    if let Some(members) = value
+        .get("workspace")
+        .and_then(|workspace| workspace.get("members"))
+        .and_then(toml::Value::as_array)
+    {
+        for member in members.iter().filter_map(toml::Value::as_str) {
+            for dir in expand_member(root, member) {
+                if let Ok(content) = fs::read_to_string(dir.join("Cargo.toml"))
+                    && let Ok(value) = toml::from_str::<toml::Value>(&content)
+                    && let Some(name) = cargo_package_name(&value)
+                {
+                    names.push(name.to_string());
+                }
+            }
+        }
+    }
+    names
+}
+
+fn cargo_package_name(value: &toml::Value) -> Option<&str> {
+    value.get("package")?.get("name")?.as_str()
+}
+
+/// Local npm package names: the root `name` plus the `name` of every workspace
+/// package (`"workspaces": [...]` or `"workspaces": { "packages": [...] }`).
+pub(super) fn npm_local_names(root: &Path) -> Vec<String> {
+    let mut names = Vec::new();
+    let path = root.join("package.json");
+    let Ok(content) = fs::read_to_string(&path) else {
+        return names;
+    };
+    let value = match serde_json::from_str::<serde_json::Value>(&content) {
+        Ok(value) => value,
+        Err(err) => {
+            report_unparseable(&path, &err);
+            return names;
+        }
+    };
+
+    if let Some(name) = value.get("name").and_then(serde_json::Value::as_str) {
+        names.push(name.to_string());
+    }
+    for glob in npm_workspace_globs(&value) {
+        for dir in expand_member(root, &glob) {
+            if let Ok(content) = fs::read_to_string(dir.join("package.json"))
+                && let Ok(value) = serde_json::from_str::<serde_json::Value>(&content)
+                && let Some(name) = value.get("name").and_then(serde_json::Value::as_str)
+            {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names
+}
+
+fn npm_workspace_globs(value: &serde_json::Value) -> Vec<String> {
+    let Some(workspaces) = value.get("workspaces") else {
+        return Vec::new();
+    };
+    workspaces
+        .as_array()
+        .or_else(|| {
+            workspaces
+                .get("packages")
+                .and_then(serde_json::Value::as_array)
+        })
+        .map(|globs| {
+            globs
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Local Go module import prefixes: the root `go.mod` module path plus the module
+/// path of every directory a `go.work` file `use`s.
+pub(super) fn go_local_prefixes(root: &Path) -> Vec<String> {
+    let mut prefixes = Vec::new();
+    if let Ok(content) = fs::read_to_string(root.join("go.mod"))
+        && let Some(module) = go_module(&content)
+    {
+        prefixes.push(module.to_string());
+    }
+    if let Ok(content) = fs::read_to_string(root.join("go.work")) {
+        for dir in go_work_uses(&content) {
+            if let Ok(content) = fs::read_to_string(root.join(&dir).join("go.mod"))
+                && let Some(module) = go_module(&content)
+            {
+                prefixes.push(module.to_string());
+            }
+        }
+    }
+    prefixes
+}
+
+fn go_module(content: &str) -> Option<&str> {
+    content
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("module "))
+        .map(str::trim)
+}
+
+/// Directories a `go.work` file `use`s, supporting both the single-line
+/// (`use ./dir`) and block (`use ( … )`) forms.
+fn go_work_uses(content: &str) -> Vec<String> {
+    let mut uses = Vec::new();
+    let mut in_block = false;
+    for line in content.lines() {
+        let line = line.trim();
+        if in_block {
+            if line.starts_with(')') {
+                in_block = false;
+            } else if !line.is_empty() {
+                uses.push(line.trim_matches('"').to_string());
+            }
+            continue;
+        }
+        let Some(rest) = line.strip_prefix("use") else {
+            continue;
+        };
+        let rest = rest.trim();
+        if let Some(rest) = rest.strip_prefix('(') {
+            in_block = true;
+            let rest = rest.trim();
+            if !rest.is_empty() {
+                uses.push(rest.trim_matches('"').to_string());
+            }
+        } else if !rest.is_empty() {
+            uses.push(rest.trim_matches('"').to_string());
+        }
+    }
+    uses
+}
+
+/// Resolve a workspace member entry to concrete directories. Supports an exact
+/// path or a single trailing `*`/`**` wildcard (`crates/*`) — the common cases.
+fn expand_member(root: &Path, member: &str) -> Vec<PathBuf> {
+    let member = member.trim_matches('"');
+    if let Some(parent) = member
+        .strip_suffix("/**")
+        .or_else(|| member.strip_suffix("/*"))
+    {
+        let Ok(entries) = fs::read_dir(root.join(parent)) else {
+            return Vec::new();
+        };
+        return entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.is_dir())
+            .collect();
+    }
+    vec![root.join(member)]
+}
+
+fn report_unparseable(path: &Path, err: &dyn std::fmt::Display) {
+    eprintln!(
+        "repopilot: ignoring unparseable manifest {} ({err}); its imports may look external",
+        path.display()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create dirs");
+        }
+        fs::write(path, content).expect("write file");
+    }
+
+    #[test]
+    fn cargo_workspace_members_are_local() {
+        let temp = tempfile::tempdir().expect("temp repo");
+        let root = temp.path();
+        write(
+            &root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/*\", \"tools/cli\"]\n",
+        );
+        write(
+            &root.join("crates/engine/Cargo.toml"),
+            "[package]\nname = \"acme-engine\"\nversion = \"0.1.0\"\n",
+        );
+        write(
+            &root.join("tools/cli/Cargo.toml"),
+            "[package]\nname = \"acme-cli\"\nversion = \"0.1.0\"\n",
+        );
+
+        let names = cargo_local_names(root);
+        assert!(names.contains(&"acme-engine".to_string()), "{names:?}");
+        assert!(names.contains(&"acme-cli".to_string()), "{names:?}");
+    }
+
+    #[test]
+    fn npm_workspaces_array_and_object_forms_are_local() {
+        let temp = tempfile::tempdir().expect("temp repo");
+        let root = temp.path();
+        write(
+            &root.join("package.json"),
+            "{\"name\":\"@acme/root\",\"workspaces\":[\"packages/*\"]}",
+        );
+        write(
+            &root.join("packages/ui/package.json"),
+            "{\"name\":\"@acme/ui\"}",
+        );
+        let names = npm_local_names(root);
+        assert!(names.contains(&"@acme/root".to_string()), "{names:?}");
+        assert!(names.contains(&"@acme/ui".to_string()), "{names:?}");
+    }
+
+    #[test]
+    fn go_work_modules_are_local_prefixes() {
+        let temp = tempfile::tempdir().expect("temp repo");
+        let root = temp.path();
+        write(
+            &root.join("go.mod"),
+            "module github.com/acme/app\n\ngo 1.22\n",
+        );
+        write(&root.join("go.work"), "go 1.22\n\nuse (\n\t./svc\n)\n");
+        write(
+            &root.join("svc/go.mod"),
+            "module github.com/acme/svc\n\ngo 1.22\n",
+        );
+        let prefixes = go_local_prefixes(root);
+        assert!(
+            prefixes.contains(&"github.com/acme/app".to_string()),
+            "{prefixes:?}"
+        );
+        assert!(
+            prefixes.contains(&"github.com/acme/svc".to_string()),
+            "{prefixes:?}"
+        );
+    }
+
+    #[test]
+    fn unparseable_cargo_manifest_yields_no_names() {
+        let temp = tempfile::tempdir().expect("temp repo");
+        let root = temp.path();
+        write(&root.join("Cargo.toml"), "this is not = valid = toml [[[");
+        assert!(cargo_local_names(root).is_empty());
+    }
+}

--- a/src/review/signals/behavioral_tests.rs
+++ b/src/review/signals/behavioral_tests.rs
@@ -139,6 +139,49 @@ fn standard_library_and_local_imports_are_not_dependency_signals() {
 }
 
 #[test]
+fn workspace_member_imports_are_not_dependency_signals() {
+    let temp = tempfile::tempdir().expect("temp repo");
+    let root = temp.path();
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"crates/*\"]\n",
+    )
+    .expect("write workspace manifest");
+    std::fs::create_dir_all(root.join("crates/engine")).expect("create member dir");
+    std::fs::write(
+        root.join("crates/engine/Cargo.toml"),
+        "[package]\nname = \"acme-engine\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write member manifest");
+
+    let dependencies = DependencyContext::from_repo_root(root);
+    assert!(
+        dependencies.is_local_package("acme_engine"),
+        "sibling workspace crate must be local: {dependencies:?}"
+    );
+
+    // A changed file in another member imports the sibling crate and an external one.
+    let source = ReviewSource::new(
+        "use acme_engine::run;\nuse serde::Serialize;\n".to_string(),
+        Some("Rust".to_string()),
+    );
+    let file = file_with_range("crates/cli/src/main.rs", ChangeStatus::Modified, 1, 2);
+    let deps: Vec<_> = detect_behavioral_added(&file, &source, &dependencies)
+        .into_iter()
+        .filter(|s| s.kind == BehavioralKind::DependencyImportAdded)
+        .map(|s| s.detail)
+        .collect();
+    assert!(
+        deps.iter().any(|detail| detail.contains("serde")),
+        "external crate must be flagged: {deps:?}"
+    );
+    assert!(
+        !deps.iter().any(|detail| detail.contains("acme_engine")),
+        "workspace crate must not be flagged: {deps:?}"
+    );
+}
+
+#[test]
 fn runtime_side_effects_in_test_files_are_not_review_signals() {
     let content = r#"
 use std::fs;


### PR DESCRIPTION
## Summary

This PR improves `repopilot review` dependency-import detection for monorepos and workspace-based repositories.

`DependencyContext` now collects local package/module names from:

- Cargo `[workspace].members`
- npm `workspaces`
- Go `go.work` members

This prevents imports between local workspace packages from being reported as newly added external dependencies.

## Type of change

- [ ] Feature
- [x] Refactor
- [x] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- Moved dependency-context manifest discovery into a dedicated `behavioral::dependency` module.
- Added Cargo workspace member discovery.
- Added npm workspace discovery for both array and object `workspaces` forms.
- Added Go `go.work` module-prefix discovery.
- Removed bare last-segment local-name matching.
- Kept full package names and `-` → `_` variants for local package matching.
- Added stderr diagnostics for unparseable root manifests.
- Added regression tests for workspace member imports.
- Updated `CHANGELOG.md`.

## Why

Before this change, RepoPilot only recognized the root package/module as local.

In monorepos, this could cause imports between local workspace packages to be reported as new external dependencies.

Example:

```rust
use acme_engine::run;
```

If acme-engine is a sibling Cargo workspace member, this should not be reported as DependencyImportAdded.

This PR reduces false positives and makes repopilot review more trustworthy on real-world monorepos.

It also fixes the opposite problem: a scoped package such as @acme/core should not make an unrelated bare core import look local.

## Contract and ownership

```
 The change stays inside the review behavioral-signal subsystem.
 No CLI behavior changes.
 No JSON/SARIF/report schema changes.
 No Action, MCP, baseline, or release-contract changes.
 New/changed dependency signal behavior has regression tests.
 Changelog was updated.
```

## Risk / limitations

This is intentionally a lightweight workspace resolver, not a full package-manager implementation.

## Known limitations:

- Cargo workspace exclude is not modeled yet.
- Complex glob patterns beyond exact paths and common trailing * / ** forms are not fully modeled.
- npm workspace protocol/version semantics are not modeled.
- Go go.work parsing is lightweight and does not aim to fully replace go list.

These limitations are acceptable for this PR because the goal is false-positive reduction, not full dependency graph resolution.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo test --lib review::signals::behavioral
```

Focused checks:

```
cargo test cargo_workspace_members_are_local
cargo test npm_workspaces_array_and_object_forms_are_local
cargo test go_work_modules_are_local_prefixes
cargo test workspace_member_imports_are_not_dependency_signals
```