### PR TITLE
docs(cli): clarify gate model and taint-lite signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,19 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   editor packaging.
 - Added a real schema `0.18` report fixture and documented report schema
   versioning independently from package versions.
+- Review now prints a one-line taint disclaimer when taint-lite signals are
+  present (console and Markdown): they trace input → sink *reachability*, a path
+  that exists, not a confirmed vulnerability.
 
 ### Changed
+
+- Documented the gate model as one coherent two-axis story: a **finding gate**
+  (`--fail-on` by severity/status, or the mutually exclusive `--fail-on-priority`
+  by risk; in-diff only on `review`) and a separate, opt-in **review-signal gate**
+  (`--fail-on-review`, config peer `[review] fail_on`). Harmonized the `scan` and
+  `review` flag help and the CLI/configuration references so the config key
+  `[review] fail_on` is no longer mistaken for the CLI `--fail-on`. No flags or
+  behavior changed — only help text and documentation.
 
 - Consolidated the AI handoff into a single `ai context` command. Its output now
   bundles repository facts, evidence, the Context Risk Graph edit order, a
@@ -85,6 +96,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   repeated method name in the function text.
 - Behavioral runtime side effects are no longer emitted from tests/fixtures,
   and removed auth/error coarse fallbacks no longer run on prose documents.
+- Corrected the taint flow module's doc comment: taint seeding is a single
+  document-order forward pass (chains like `a = src; b = a` carry through), not
+  the "iterated to a small fixpoint" the header previously claimed.
 
 ## [0.16.0] - 2026-06-08
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,8 +73,8 @@ repopilot s <PATH> [OPTIONS]
 | `--receipt` | path | — | Write a compact audit receipt JSON file with tool, git, scope, finding, language, and health metadata |
 | `--config` | path | auto-detected | Path to a `repopilot.toml` config file |
 | `--baseline` | path | — | Path to a baseline file; marks findings as new or existing |
-| `--fail-on` | threshold | — | Exit code 1 when findings meet this threshold (see [Thresholds](#thresholds)) |
-| `--fail-on-priority` | `p0\|p1\|p2\|p3` | — | Exit code 1 when findings meet this risk priority threshold |
+| `--fail-on` | threshold | — | Finding gate by severity/status; exit code 1 on a breach (see [Gates](#gates)) |
+| `--fail-on-priority` | `p0\|p1\|p2\|p3` | — | Finding gate by risk priority; mutually exclusive with `--fail-on` |
 | `--ignore-feedback` | flag | — | Ignore `.repopilot/feedback.yml` local suppressions |
 | `--max-file-loc` | integer | `300` | Maximum non-empty LOC before a file is flagged as large |
 | `--max-directory-modules` | integer | `20` | Maximum files per directory before flagging |
@@ -102,8 +102,8 @@ repopilot s <PATH> [OPTIONS]
 
 | Code | Meaning |
 |------|---------|
-| `0` | Success (no threshold breach) |
-| `1` | Findings exceed the `--fail-on` threshold |
+| `0` | Success (no gate breach) |
+| `1` | The finding gate (`--fail-on` / `--fail-on-priority`) was breached |
 | `2` | Invalid CLI/config/user input |
 | `3` | Runtime or environment failure |
 
@@ -193,9 +193,11 @@ When coupling data is available, review also shows **blast radius**: files that 
 
 By default, review compares the working tree against `HEAD` (staged, unstaged, and untracked changes). Pass `--base` to review a branch range for CI.
 
-`--fail-on` and `--fail-on-priority` evaluate only scan findings.
-`--fail-on-review definitely` is a separate, opt-in gate for unsuppressed,
-gate-eligible definitely-sensitive review signals.
+Review has two independent gate axes (see [Gates](#gates)): the **finding gate**
+(`--fail-on` by severity or `--fail-on-priority` by risk, scoped to in-diff
+findings) and the **review-signal gate** (`--fail-on-review definitely`, an
+opt-in gate for unsuppressed, gate-eligible definitely-sensitive review signals).
+They compose: either one failing exits non-zero.
 
 ### Synopsis
 
@@ -224,9 +226,9 @@ repopilot r [PATH] [OPTIONS]
 | `--sarif-output` | path | — | Write secondary review SARIF without a second scan |
 | `--config` | path | auto-detected | Path to a `repopilot.toml` config file |
 | `--baseline` | path | — | Path to a baseline file |
-| `--fail-on` | threshold | — | Exit code 1 when **in-diff** findings meet this threshold |
-| `--fail-on-priority` | `p0\|p1\|p2\|p3` | — | Exit code 1 when **in-diff** findings meet this risk priority threshold |
-| `--fail-on-review` | `none\|definitely` | `none` | Exit code 1 for eligible definitely-sensitive review signals |
+| `--fail-on` | threshold | — | Finding gate by severity/status on **in-diff** findings (see [Gates](#gates)) |
+| `--fail-on-priority` | `p0\|p1\|p2\|p3` | — | Finding gate by risk priority on **in-diff** findings; mutually exclusive with `--fail-on` |
+| `--fail-on-review` | `none\|definitely` | `none` | Review-signal gate; config peer `[review] fail_on` |
 | `--no-progress` | flag | — | Disable progress indicators |
 | `--ignore-feedback` | flag | — | Ignore `.repopilot/feedback.yml` local suppressions |
 | `--max-file-loc` | integer | `300` | Maximum non-empty LOC before a file is flagged as large |
@@ -444,7 +446,25 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | repopilot mcp -
 
 ---
 
-## Thresholds
+## Gates
+
+RepoPilot has two independent gate axes. Each can exit the process with code `1`;
+they compose, so a build fails if **either** trips.
+
+| Gate | Flags | Acts on | Available in |
+|------|-------|---------|--------------|
+| **Finding gate** | `--fail-on` (severity/status) **or** `--fail-on-priority` (risk) | Rule findings | `scan`, `review` |
+| **Review-signal gate** | `--fail-on-review` / config `[review] fail_on` | Review signals (behavioral/boundary/taint) | `review` |
+
+- The two finding-gate flags are **mutually exclusive** — pick severity *or*
+  priority, not both. On `review` the finding gate evaluates only **in-diff**
+  findings; on `scan` it evaluates the whole report.
+- The review-signal gate is a **different axis** from the finding gate: despite
+  the similar name, the config key `[review] fail_on` (`none`/`definitely`) is the
+  peer of `--fail-on-review`, **not** of `--fail-on`. `definitely` fails on
+  unsuppressed, gate-eligible definitely-sensitive review signals.
+
+### Finding-gate thresholds
 
 The `--fail-on` flag accepts the following values:
 
@@ -461,9 +481,10 @@ The `--fail-on` flag accepts the following values:
 
 `new-*` thresholds require a `--baseline` to distinguish new from existing findings. Without a baseline, all current findings are treated as new.
 
-For `review`, `--fail-on` evaluates only **in-diff** findings.
+`--fail-on-priority` accepts `p0`, `p1`, `p2`, or `p3` and fails on any finding at
+or above that risk priority.
 
-The `--min-severity` flag filters rendered findings before baseline or CI gate evaluation. Use it when a local report is too noisy, for example `--min-severity high` during fast review or `--workspace --min-severity medium` in monorepos.
+The `--min-severity` flag filters rendered findings before gate evaluation, and is not itself a gate. Use it when a local report is too noisy, for example `--min-severity high` during fast review or `--workspace --min-severity medium` in monorepos.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,12 +78,18 @@ default_format = "console"
 ```
 
 `[review] scope` accepts `changed` or `full`. `[review] fail_on` accepts `none`
-or `definitely`. CLI flags have higher priority:
+or `definitely` and is the **review-signal gate** — the config peer of the
+`--fail-on-review` flag, **not** of the CLI `--fail-on` finding gate (which takes
+severity/status thresholds). It fails the review on unsuppressed, gate-eligible
+definitely-sensitive review signals. CLI flags have higher priority:
 
 ```bash
 repopilot review . --scope full --profile strict
 repopilot review . --fail-on-review definitely
 ```
+
+See [CLI reference → Gates](cli.md#gates) for the full two-axis gate model
+(finding gate vs review-signal gate).
 
 ## Common CLI overrides
 

--- a/src/cli/options/review.rs
+++ b/src/cli/options/review.rs
@@ -40,15 +40,15 @@ pub struct ReviewOptions {
     #[arg(long)]
     pub baseline: Option<PathBuf>,
 
-    /// Exit with code 1 when in-diff findings meet this severity threshold
+    /// Finding gate: exit 1 when in-diff findings meet this severity threshold (excludes --fail-on-priority)
     #[arg(long, value_enum)]
     pub fail_on: Option<FailOnArg>,
 
-    /// Exit with code 1 when in-diff findings meet this risk priority threshold
+    /// Finding gate: exit 1 when in-diff findings meet this risk-priority threshold (excludes --fail-on)
     #[arg(long, value_enum)]
     pub fail_on_priority: Option<PriorityArg>,
 
-    /// Exit with code 1 when review signals breach the selected policy
+    /// Review-signal gate: exit 1 on gate-eligible definitely-sensitive signals; config peer [review] fail_on
     #[arg(long, value_enum)]
     pub fail_on_review: Option<ReviewFailOnArg>,
 

--- a/src/cli/options/scan.rs
+++ b/src/cli/options/scan.rs
@@ -55,11 +55,11 @@ pub struct ScanOptions {
     #[arg(long)]
     pub baseline: Option<PathBuf>,
 
-    /// Exit with code 1 when findings meet this severity/status threshold
+    /// Finding gate: exit 1 when findings meet this severity/status threshold (excludes --fail-on-priority)
     #[arg(long, value_enum)]
     pub fail_on: Option<FailOnArg>,
 
-    /// Exit with code 1 when findings meet this risk priority threshold
+    /// Finding gate: exit 1 when findings meet this risk-priority threshold (excludes --fail-on)
     #[arg(long, value_enum)]
     pub fail_on_priority: Option<PriorityArg>,
 

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -136,6 +136,11 @@ fn render_tiered_signals(output: &mut String, report: &ReviewReport) {
     }
     render_tier_group(output, "Maybe sensitive", &tiered.maybe, &mut remaining);
     render_tier_group(output, "Large diff / noise", &tiered.noise, &mut remaining);
+    if tiered.has_taint_signal() {
+        output.push_str(
+            "  Taint signals trace input \u{2192} sink reachability \u{2014} a path exists, not a confirmed vulnerability. Verify before acting.\n",
+        );
+    }
 }
 
 fn render_tier_group(

--- a/src/review/render/markdown.rs
+++ b/src/review/render/markdown.rs
@@ -159,6 +159,11 @@ fn render_markdown_tiered_signals(output: &mut String, report: &ReviewReport) {
     );
     render_markdown_tier(output, "Maybe sensitive", &tiered.maybe, &mut remaining);
     render_markdown_tier(output, "Large diff / noise", &tiered.noise, &mut remaining);
+    if tiered.has_taint_signal() {
+        output.push_str(
+            "> Taint signals trace input → sink reachability — a path exists, not a confirmed vulnerability. Verify before acting.\n\n",
+        );
+    }
 }
 
 fn render_markdown_tier(

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -2,7 +2,8 @@
 //!
 //! Two passes per function/module scope: seed a set of tainted local names from
 //! assignments whose right-hand side reads a [`source`](super::sources) or
-//! references an already-tainted name (iterated to a small fixpoint for chains),
+//! references an already-tainted name — the assignments are processed in a single
+//! document-order forward pass, so `a = src; b = a; c = b` chains carry through —
 //! then report each [`sink`](super::sinks) call — gated to the changed lines —
 //! whose arguments carry a tainted value. Nested functions are analyzed with a
 //! fresh map so local names do not leak between procedures.

--- a/src/review/signals/tiered.rs
+++ b/src/review/signals/tiered.rs
@@ -142,6 +142,16 @@ impl TieredSignals {
             .count()
     }
 
+    /// Whether any visible tier carries a taint-lite reachability signal. Used to
+    /// surface the "a path exists, not a confirmed vulnerability" disclaimer once
+    /// per report rather than repeating it on every taint row.
+    pub fn has_taint_signal(&self) -> bool {
+        [&self.definitely, &self.maybe, &self.noise]
+            .into_iter()
+            .flatten()
+            .any(|signal| !signal.suppressed && signal.family == SignalFamily::Taint)
+    }
+
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut ReviewSignal> {
         self.definitely
             .iter_mut()

--- a/src/review/signals/tiered_tests.rs
+++ b/src/review/signals/tiered_tests.rs
@@ -164,6 +164,21 @@ fn taint_tiers_by_sink_severity() {
 }
 
 #[test]
+fn has_taint_signal_detects_taint_family_only() {
+    let with_taint = build_tiered(&[], &[], &[], &[taint(SinkKind::Sql, "src/db.ts")], &[]);
+    assert!(with_taint.has_taint_signal());
+
+    let without_taint = build_tiered(
+        &[boundary(BoundaryCategory::AccessControl, "src/auth.ts")],
+        &[behavioral(BehavioralKind::FsWriteAdded, "src/f0.rs")],
+        &[],
+        &[],
+        &[],
+    );
+    assert!(!without_taint.has_taint_signal());
+}
+
+#[test]
 fn noise_tier_fires_only_for_a_large_diff_with_nothing_flagged() {
     let tiered = build_tiered(&[], &[], &[], &[], &large_diff(6));
     assert_eq!(tiered.noise.len(), 1);

--- a/tests/cli_stabilization.rs
+++ b/tests/cli_stabilization.rs
@@ -98,7 +98,8 @@ fn scan_and_review_help_have_flag_descriptions() {
     assert!(review_help.contains("Path to project, folder, or file to review"));
     assert!(review_help.contains("Base Git ref for branch/CI review"));
     assert!(review_help.contains("Review everything since the last `repopilot snapshot`"));
-    assert!(review_help.contains("Exit with code 1 when in-diff findings"));
+    assert!(review_help.contains("Finding gate: exit 1 when in-diff findings"));
+    assert!(review_help.contains("Review-signal gate"));
     assert!(review_help.contains("Disable progress indicators"));
 }
 


### PR DESCRIPTION
## Summary

Clarifies RepoPilot's gate model and taint-lite review wording.

This PR documents the difference between the finding gate and the review-signal gate, updates CLI help text so `scan` and `review` describe the same model consistently, and adds a one-line taint-lite disclaimer when visible taint signals are present.

No gate behavior changes in this PR.

## Type of change

* [ ] Feature
* [ ] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Documented RepoPilot's two independent gate axes:

  * finding gate: `--fail-on` / `--fail-on-priority`;
  * review-signal gate: `--fail-on-review` / config `[review] fail_on`.
* Clarified that `--fail-on` and `--fail-on-priority` are mutually exclusive finding gates.
* Clarified that `review` applies the finding gate only to in-diff findings.
* Clarified that `[review] fail_on` is the config peer of `--fail-on-review`, not of `--fail-on`.
* Updated `scan` and `review` CLI help text to use consistent gate terminology.
* Added a console and Markdown disclaimer when visible taint-lite signals are present.
* Corrected the taint flow module docs to describe the actual single document-order forward pass.
* Added/updated tests for the taint disclaimer helper and CLI help wording.

## Why

The previous wording made it too easy to confuse two different concepts:

```text
--fail-on          -> finding gate
--fail-on-review   -> review-signal gate
[review] fail_on   -> config peer of --fail-on-review
```

This PR makes that contract explicit in CLI help, CLI docs, configuration docs, and changelog.

The taint-lite disclaimer also makes review output safer and more precise: taint-lite reports reachability from input to sink, not a confirmed vulnerability.

## Contract and ownership

* [x] The change stays within CLI help text, docs, review rendering, and tests.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] No gate behavior changes are introduced.
* [x] No new findings or review signal families are introduced.
* [x] The taint-lite disclaimer is rendered only when visible taint signals exist.
* [x] No unrelated refactor or generated-file churn is included.

## Changelog

* [x] `CHANGELOG.md` updated.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
