### PR TITLE
docs(architecture): document analysis platform state

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ adoption or CI policy.
 
 ## Maintainer Guides
 
+- [Analysis platform state](engineering/analysis-platform-state.md)
 - [Signal contract](engineering/signal-contract.md)
 - [Engine pipeline](engineering/engine-pipeline.md)
 - [Graph scan hardening](engineering/graph-scan-hardening.md)

--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -1,0 +1,154 @@
+# Analysis Platform State
+
+RepoPilot is converging on a smaller public CLI backed by a deeper, shared
+analysis platform. New analysis capabilities should strengthen existing user
+workflows rather than create additional public diagnostic commands.
+
+## Current Product Surface
+
+The active public commands are:
+
+```text
+scan
+review
+baseline
+cache
+snapshot
+ai context
+init
+mcp
+```
+
+The following legacy or diagnostic commands have been removed from the public
+surface:
+
+```text
+ai plan
+ai prompt
+compare
+doctor
+inspect
+```
+
+RepoPilot should avoid adding public diagnostic commands unless a diagnostic
+becomes a durable user workflow with a stable product contract. Internal
+analysis data should normally be exposed through existing reports, AI context,
+MCP tools, tests, or development scripts.
+
+## Current Analysis Stack
+
+The current engine already has layers that move repository contents toward
+reviewable findings:
+
+```text
+filesystem scan
+-> file facts / scan facts
+-> tree-sitter parsing
+-> import extraction
+-> framework detection
+-> audits / rules
+-> findings
+-> risk scoring
+-> baseline / feedback / suppressions
+-> review signals
+-> AI context handoff
+-> MCP tools
+```
+
+These layers are useful but do not yet form one complete, first-class fact and
+dependency model. Some capabilities remain distributed across scan, graph,
+rule, review, and reporting code.
+
+## What Already Exists
+
+RepoPilot already provides:
+
+- `ScanFacts` and `FileFacts` as structured scan inputs;
+- shared parse-once tree-sitter parsing;
+- import extraction and graph-related logic;
+- rule metadata and a rule lifecycle;
+- a finding contract with evidence, confidence, severity, provenance, and risk;
+- explainable risk scoring;
+- local feedback and suppressions;
+- review signals for boundary, behavioral, algorithmic, taint-lite, and blast
+  radius concerns;
+- an AI context handoff through `repopilot ai context`;
+- MCP access to local analysis tools.
+
+These capabilities are the foundation for the next architecture. The goal is to
+compose and deepen them, not replace working product paths with parallel
+commands.
+
+## What Is Missing
+
+RepoPilot still needs a deeper fact-based platform with:
+
+- `RepoFacts`: a repository-level fact model assembled from file and scan
+  facts;
+- a first-class dependency graph with explicit core types and contracts;
+- symbol facts for definitions, references, ownership, and relationships;
+- rule capabilities that declare which facts and analysis levels a rule needs;
+- language support tiers that make analysis depth and guarantees explicit;
+- runtime evidence ingestion that can enrich static facts without making
+  analysis nondeterministic;
+- a suppression decision model that records why findings are retained, hidden,
+  or accepted;
+- evaluation fixtures that measure fact, graph, rule, and finding quality.
+
+## Target Architecture
+
+The target pipeline is:
+
+```text
+files
+  -> facts
+  -> graph
+  -> rules
+  -> findings
+  -> risk
+  -> suppressions / decisions
+  -> reports / AI context / MCP
+```
+
+Facts and graph data should be computed through shared engine paths. Rules
+should declare their requirements, findings should retain evidence and
+provenance, and all product outputs should consume the same decisions rather
+than reimplementing analysis.
+
+## Rule For Future Diagnostics
+
+Do not add public diagnostic commands by default.
+
+Prefer:
+
+- scan JSON;
+- review output;
+- AI context sections;
+- MCP tools;
+- tests;
+- internal development scripts.
+
+Avoid public commands such as:
+
+```text
+repopilot inspect facts
+repopilot inspect graph
+repopilot inspect rules
+```
+
+`inspect` was intentionally removed from the public CLI surface. Reintroducing
+it for internal architecture visibility would expand the product contract
+without creating a durable user workflow.
+
+## Next Planned Implementation Steps
+
+1. Add a facts-core skeleton.
+2. Add a `ScanFacts -> RepoFacts` bridge.
+3. Expose facts through scan JSON and AI context, not `inspect`.
+4. Design graph v2.
+5. Add graph v2 core types.
+6. Feed graph v2 into scan, review, and AI context.
+7. Add rule capabilities metadata.
+8. Add language support tiers.
+9. Add runtime evidence ingestion.
+10. Add evaluation fixtures.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,6 +19,8 @@ LLM integration enters `0.17`.
 
 ## Next
 
+- move toward a fact-based analysis platform without adding new public
+  diagnostic commands;
 - collect adoption evidence through reproducible reports, issues, and user
   feedback;
 - improve first-run examples from observed user failures;


### PR DESCRIPTION
## Summary

Adds an engineering document that captures RepoPilot's current analysis platform state and the next architecture direction.

This documents the product surface after the recent CLI cleanup and explains how future analysis work should evolve without reintroducing public diagnostic commands like `inspect`.

## Type of change

* [ ] Feature
* [ ] Refactor
* [ ] Bug fix
* [ ] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added `docs/engineering/analysis-platform-state.md`.
* Documented the active public command surface:

```text
scan
review
baseline
cache
snapshot
ai context
init
mcp
```

* Documented removed legacy/diagnostic command surfaces:

```text
ai plan
ai prompt
compare
doctor
inspect
```

* Captured the current analysis stack from filesystem scan through facts, parsing, imports, rules, findings, risk, review signals, AI context, and MCP.
* Documented what already exists and what is still missing for a deeper fact-based platform.
* Added the target architecture:

```text
files
  -> facts
  -> graph
  -> rules
  -> findings
  -> risk
  -> suppressions / decisions
  -> reports / AI context / MCP
```

* Added guidance that future diagnostics should use scan JSON, review output, AI context, MCP tools, tests, or internal dev scripts instead of new public diagnostic commands.
* Linked the new engineering document from `docs/README.md`.
* Added a short roadmap note about moving toward a fact-based analysis platform without adding new public diagnostics.

## Why

Recent PRs intentionally reduced RepoPilot's public CLI surface by removing overlapping or diagnostic commands.

This PR records the new direction before deeper architecture work begins, so the next implementation steps can focus on shared analysis foundations instead of expanding the public command surface again.

The next architecture work should deepen the engine through:

```text
RepoFacts
Graph v2
Rule capabilities
Language support tiers
Runtime evidence
Evaluation fixtures
```

without bringing back `inspect facts`, `inspect graph`, or similar public diagnostic commands.

## Contract and ownership

* [x] The change stays within engineering documentation and roadmap documentation.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] No public CLI behavior changes are introduced.
* [x] No new findings or review signals are introduced.
* [x] No unrelated refactor or generated-file churn is included.

## Changelog

* [ ] `CHANGELOG.md` updated

Skipped because this is an internal engineering documentation update with no user-visible CLI behavior change.

## Verification

```bash
git diff --check
git status --short
```
