### PR TITLE
feat(facts): add core RepoFacts skeleton

### DIFF
--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -79,12 +79,15 @@ These capabilities are the foundation for the next architecture. The goal is to
 compose and deepen them, not replace working product paths with parallel
 commands.
 
+The first internal implementation step now exists in `src/facts`: a facts-core
+skeleton with repository, file, source, confidence, and diagnostic types. It is
+not yet connected to scan, review, report output, AI context, or MCP.
+
 ## What Is Missing
 
 RepoPilot still needs a deeper fact-based platform with:
 
-- `RepoFacts`: a repository-level fact model assembled from file and scan
-  facts;
+- a populated `RepoFacts` model assembled from existing file and scan facts;
 - a first-class dependency graph with explicit core types and contracts;
 - symbol facts for definitions, references, ownership, and relationships;
 - rule capabilities that declare which facts and analysis levels a rule needs;
@@ -142,13 +145,12 @@ without creating a durable user workflow.
 
 ## Next Planned Implementation Steps
 
-1. Add a facts-core skeleton.
-2. Add a `ScanFacts -> RepoFacts` bridge.
-3. Expose facts through scan JSON and AI context, not `inspect`.
-4. Design graph v2.
-5. Add graph v2 core types.
-6. Feed graph v2 into scan, review, and AI context.
-7. Add rule capabilities metadata.
-8. Add language support tiers.
-9. Add runtime evidence ingestion.
-10. Add evaluation fixtures.
+1. Add a `ScanFacts -> RepoFacts` bridge.
+2. Expose facts through scan JSON and AI context, not `inspect`.
+3. Design graph v2.
+4. Add graph v2 core types.
+5. Feed graph v2 into scan, review, and AI context.
+6. Add rule capabilities metadata.
+7. Add language support tiers.
+8. Add runtime evidence ingestion.
+9. Add evaluation fixtures.

--- a/src/facts/confidence.rs
+++ b/src/facts/confidence.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FactConfidence {
+    Low,
+    Medium,
+    High,
+}

--- a/src/facts/diagnostic.rs
+++ b/src/facts/diagnostic.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FactDiagnostic {
+    pub code: String,
+    pub message: String,
+    pub path: Option<PathBuf>,
+}

--- a/src/facts/file.rs
+++ b/src/facts/file.rs
@@ -1,0 +1,11 @@
+use super::{FactConfidence, FactSource};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileFact {
+    pub path: PathBuf,
+    pub language: Option<String>,
+    pub non_empty_lines: usize,
+    pub source: FactSource,
+    pub confidence: FactConfidence,
+}

--- a/src/facts/mod.rs
+++ b/src/facts/mod.rs
@@ -1,0 +1,56 @@
+mod confidence;
+mod diagnostic;
+mod file;
+mod repo;
+mod source;
+
+pub use confidence::FactConfidence;
+pub use diagnostic::FactDiagnostic;
+pub use file::FileFact;
+pub use repo::RepoFacts;
+pub use source::FactSource;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn default_repo_facts_are_empty() {
+        let facts = RepoFacts::default();
+
+        assert_eq!(facts.root, PathBuf::new());
+        assert!(facts.files.is_empty());
+        assert!(facts.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn file_fact_stores_core_metadata() {
+        let fact = FileFact {
+            path: PathBuf::from("src/lib.rs"),
+            language: Some("Rust".to_string()),
+            non_empty_lines: 42,
+            source: FactSource::Ast,
+            confidence: FactConfidence::High,
+        };
+
+        assert_eq!(fact.path, PathBuf::from("src/lib.rs"));
+        assert_eq!(fact.language.as_deref(), Some("Rust"));
+        assert_eq!(fact.non_empty_lines, 42);
+        assert_eq!(fact.source, FactSource::Ast);
+        assert_eq!(fact.confidence, FactConfidence::High);
+    }
+
+    #[test]
+    fn fact_diagnostic_stores_code_message_and_path() {
+        let diagnostic = FactDiagnostic {
+            code: "facts.read_failed".to_string(),
+            message: "could not read source file".to_string(),
+            path: Some(PathBuf::from("src/missing.rs")),
+        };
+
+        assert_eq!(diagnostic.code, "facts.read_failed");
+        assert_eq!(diagnostic.message, "could not read source file");
+        assert_eq!(diagnostic.path, Some(PathBuf::from("src/missing.rs")));
+    }
+}

--- a/src/facts/repo.rs
+++ b/src/facts/repo.rs
@@ -1,0 +1,9 @@
+use super::{FactDiagnostic, FileFact};
+use std::path::PathBuf;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RepoFacts {
+    pub root: PathBuf,
+    pub files: Vec<FileFact>,
+    pub diagnostics: Vec<FactDiagnostic>,
+}

--- a/src/facts/source.rs
+++ b/src/facts/source.rs
@@ -1,0 +1,12 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FactSource {
+    Filesystem,
+    TextHeuristic,
+    Ast,
+    ImportGraph,
+    PackageManifest,
+    ConfigFile,
+    GitDiff,
+    ExternalTool,
+    Mixed,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ pub mod config;
 #[doc(hidden)]
 pub mod explain;
 #[doc(hidden)]
+pub mod facts;
+#[doc(hidden)]
 pub mod findings;
 #[doc(hidden)]
 pub mod frameworks;


### PR DESCRIPTION
## Summary

Adds the first internal facts-core skeleton for RepoPilot's future fact-based analysis platform.

This introduces lightweight internal types for repository facts, file facts, fact sources, confidence, and diagnostics. The new module is intentionally not connected to `scan`, `review`, report output, AI context, or MCP yet.

## Type of change

* [x] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added a new internal `src/facts` module.
* Added `RepoFacts` as the initial repository-level facts container.
* Added `FileFact` for basic file-level fact metadata.
* Added `FactSource` to describe where a fact came from.
* Added `FactConfidence` to describe confidence in a fact.
* Added `FactDiagnostic` for fact-collection diagnostics.
* Added focused unit tests for the new facts types.
* Exported the new facts module from the crate root as hidden/internal API.
* Updated `docs/engineering/analysis-platform-state.md` to mark the facts-core skeleton as created and adjust the next implementation steps.

## Why

RepoPilot is moving toward a deeper shared analysis platform:

```text
files
  -> facts
  -> graph
  -> rules
  -> findings
  -> risk
  -> suppressions / decisions
  -> reports / AI context / MCP
```

This PR creates the first internal foundation for that direction without changing current product behavior.

The goal is to prepare for a future `ScanFacts -> RepoFacts` bridge while keeping the current `scan`, `review`, baseline, AI context, and MCP outputs stable.

## Contract and ownership

* [x] The change stays within the new internal facts module and engineering documentation.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] No public CLI behavior changes are introduced.
* [x] No report schema changes are introduced.
* [x] No new findings or review signals are introduced.
* [x] Existing `scan::facts::ScanFacts` and `scan::facts::FileFacts` remain unchanged.
* [x] The new facts module is not yet connected to scan/review output.
* [x] No unrelated refactor or generated-file churn is included.

## Changelog

* [ ] `CHANGELOG.md` updated

Skipped because this is an internal foundation change with no user-visible CLI behavior change.

## Verification

```bash
cargo test facts
git diff --check
git status --short
```
