### PR TITLE
feat(facts): add scan bridge and repo facts summary

### DIFF
--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -79,15 +79,18 @@ These capabilities are the foundation for the next architecture. The goal is to
 compose and deepen them, not replace working product paths with parallel
 commands.
 
-The first internal implementation step now exists in `src/facts`: a facts-core
-skeleton with repository, file, source, confidence, and diagnostic types. It is
-not yet connected to scan, review, report output, AI context, or MCP.
+The first internal implementation steps now exist in `src/facts`: a facts-core
+skeleton, a minimal `ScanFacts -> RepoFacts` bridge, and an internal `RepoFacts`
+summary projection. The bridge currently preserves only repository root, file
+path, language, and non-empty line count. The summary provides aggregate file,
+language, line, and diagnostic counts without exposing raw facts. Neither is
+yet exposed through scan, review, report output, AI context, or MCP.
 
 ## What Is Missing
 
 RepoPilot still needs a deeper fact-based platform with:
 
-- a populated `RepoFacts` model assembled from existing file and scan facts;
+- a richer `RepoFacts` model beyond the initial scan-facts bridge;
 - a first-class dependency graph with explicit core types and contracts;
 - symbol facts for definitions, references, ownership, and relationships;
 - rule capabilities that declare which facts and analysis levels a rule needs;
@@ -145,12 +148,11 @@ without creating a durable user workflow.
 
 ## Next Planned Implementation Steps
 
-1. Add a `ScanFacts -> RepoFacts` bridge.
-2. Expose facts through scan JSON and AI context, not `inspect`.
-3. Design graph v2.
-4. Add graph v2 core types.
-5. Feed graph v2 into scan, review, and AI context.
-6. Add rule capabilities metadata.
-7. Add language support tiers.
-8. Add runtime evidence ingestion.
-9. Add evaluation fixtures.
+1. Feed the facts summary into AI context without exposing raw `RepoFacts`.
+2. Design graph v2.
+3. Add graph v2 core types.
+4. Feed graph v2 into scan, review, and AI context.
+5. Add rule capabilities metadata.
+6. Add language support tiers.
+7. Add runtime evidence ingestion.
+8. Add evaluation fixtures.

--- a/src/facts/from_scan.rs
+++ b/src/facts/from_scan.rs
@@ -1,0 +1,69 @@
+use super::{FactConfidence, FactSource, FileFact, RepoFacts};
+use crate::scan::facts::ScanFacts;
+
+pub fn repo_facts_from_scan(scan: &ScanFacts) -> RepoFacts {
+    let files = scan
+        .files
+        .iter()
+        .map(|file| FileFact {
+            path: file.path.clone(),
+            language: file.language.clone(),
+            non_empty_lines: file.non_empty_lines,
+            // Scan facts combine filesystem metadata with detected and analyzed facts.
+            source: FactSource::Mixed,
+            confidence: FactConfidence::High,
+        })
+        .collect();
+
+    RepoFacts {
+        root: scan.root_path.clone(),
+        files,
+        diagnostics: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::facts::FileFacts;
+    use std::path::PathBuf;
+
+    #[test]
+    fn empty_scan_facts_convert_to_empty_repo_facts() {
+        let scan = ScanFacts::default();
+
+        let facts = repo_facts_from_scan(&scan);
+
+        assert_eq!(facts.root, PathBuf::new());
+        assert!(facts.files.is_empty());
+        assert!(facts.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn bridge_preserves_supported_file_facts_without_content() {
+        let scan = ScanFacts {
+            root_path: PathBuf::from("/repo"),
+            files: vec![FileFacts {
+                path: PathBuf::from("/repo/src/lib.rs"),
+                language: Some("Rust".to_string()),
+                non_empty_lines: 42,
+                branch_count: 3,
+                imports: vec!["crate::facts".to_string()],
+                content: None,
+                has_inline_tests: true,
+            }],
+            ..ScanFacts::default()
+        };
+
+        let facts = repo_facts_from_scan(&scan);
+
+        assert_eq!(facts.root, PathBuf::from("/repo"));
+        assert_eq!(facts.files.len(), 1);
+        assert_eq!(facts.files[0].path, PathBuf::from("/repo/src/lib.rs"));
+        assert_eq!(facts.files[0].language.as_deref(), Some("Rust"));
+        assert_eq!(facts.files[0].non_empty_lines, 42);
+        assert_eq!(facts.files[0].source, FactSource::Mixed);
+        assert_eq!(facts.files[0].confidence, FactConfidence::High);
+        assert!(facts.diagnostics.is_empty());
+    }
+}

--- a/src/facts/mod.rs
+++ b/src/facts/mod.rs
@@ -1,14 +1,18 @@
 mod confidence;
 mod diagnostic;
 mod file;
+mod from_scan;
 mod repo;
 mod source;
+mod summary;
 
 pub use confidence::FactConfidence;
 pub use diagnostic::FactDiagnostic;
 pub use file::FileFact;
+pub use from_scan::repo_facts_from_scan;
 pub use repo::RepoFacts;
 pub use source::FactSource;
+pub use summary::{LanguageSummary, RepoFactsSummary, summarize_repo_facts};
 
 #[cfg(test)]
 mod tests {

--- a/src/facts/summary.rs
+++ b/src/facts/summary.rs
@@ -1,0 +1,144 @@
+use super::RepoFacts;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RepoFactsSummary {
+    pub total_files: usize,
+    pub files_with_language: usize,
+    pub total_non_empty_lines: usize,
+    pub languages: Vec<LanguageSummary>,
+    pub diagnostics_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageSummary {
+    pub language: String,
+    pub files: usize,
+    pub non_empty_lines: usize,
+}
+
+pub fn summarize_repo_facts(facts: &RepoFacts) -> RepoFactsSummary {
+    let mut language_totals = BTreeMap::<String, (usize, usize)>::new();
+
+    for file in &facts.files {
+        if let Some(language) = &file.language {
+            let totals = language_totals.entry(language.clone()).or_default();
+            totals.0 += 1;
+            totals.1 += file.non_empty_lines;
+        }
+    }
+
+    let mut languages = language_totals
+        .into_iter()
+        .map(|(language, (files, non_empty_lines))| LanguageSummary {
+            language,
+            files,
+            non_empty_lines,
+        })
+        .collect::<Vec<_>>();
+
+    languages.sort_by(|left, right| {
+        right
+            .files
+            .cmp(&left.files)
+            .then_with(|| right.non_empty_lines.cmp(&left.non_empty_lines))
+            .then_with(|| left.language.cmp(&right.language))
+    });
+
+    RepoFactsSummary {
+        total_files: facts.files.len(),
+        files_with_language: facts
+            .files
+            .iter()
+            .filter(|file| file.language.is_some())
+            .count(),
+        total_non_empty_lines: facts.files.iter().map(|file| file.non_empty_lines).sum(),
+        languages,
+        diagnostics_count: facts.diagnostics.len(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::facts::{FactConfidence, FactDiagnostic, FactSource, FileFact};
+    use std::path::PathBuf;
+
+    fn file(path: &str, language: Option<&str>, non_empty_lines: usize) -> FileFact {
+        FileFact {
+            path: PathBuf::from(path),
+            language: language.map(str::to_string),
+            non_empty_lines,
+            source: FactSource::Mixed,
+            confidence: FactConfidence::High,
+        }
+    }
+
+    #[test]
+    fn empty_repo_facts_have_an_empty_summary() {
+        assert_eq!(
+            summarize_repo_facts(&RepoFacts::default()),
+            RepoFactsSummary::default()
+        );
+    }
+
+    #[test]
+    fn summary_counts_groups_and_sorts_facts_deterministically() {
+        let facts = RepoFacts {
+            root: PathBuf::from("/repo"),
+            files: vec![
+                file("src/lib.rs", Some("Rust"), 30),
+                file("src/main.rs", Some("Rust"), 20),
+                file("app.py", Some("Python"), 40),
+                file("test.py", Some("Python"), 5),
+                file("main.go", Some("Go"), 100),
+                file("Main.java", Some("Java"), 100),
+                file("LICENSE", None, 7),
+            ],
+            diagnostics: vec![
+                FactDiagnostic {
+                    code: "facts.first".to_string(),
+                    message: "first diagnostic".to_string(),
+                    path: None,
+                },
+                FactDiagnostic {
+                    code: "facts.second".to_string(),
+                    message: "second diagnostic".to_string(),
+                    path: Some(PathBuf::from("src/lib.rs")),
+                },
+            ],
+        };
+
+        let summary = summarize_repo_facts(&facts);
+
+        assert_eq!(summary.total_files, 7);
+        assert_eq!(summary.files_with_language, 6);
+        assert_eq!(summary.total_non_empty_lines, 302);
+        assert_eq!(summary.diagnostics_count, 2);
+        assert_eq!(
+            summary.languages,
+            vec![
+                LanguageSummary {
+                    language: "Rust".to_string(),
+                    files: 2,
+                    non_empty_lines: 50,
+                },
+                LanguageSummary {
+                    language: "Python".to_string(),
+                    files: 2,
+                    non_empty_lines: 45,
+                },
+                LanguageSummary {
+                    language: "Go".to_string(),
+                    files: 1,
+                    non_empty_lines: 100,
+                },
+                LanguageSummary {
+                    language: "Java".to_string(),
+                    files: 1,
+                    non_empty_lines: 100,
+                },
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the first internal bridge from existing scan facts into the new facts-core model and introduces a safe summary projection for `RepoFacts`.

This keeps `RepoFacts` internal while providing a small aggregate view that can later feed AI context, reports, or MCP without exposing raw repository facts as a public contract.

## Type of change

* [x] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added `repo_facts_from_scan()` to convert existing `scan::facts::ScanFacts` into the new `facts::RepoFacts`.
* Preserved only the currently supported bridge fields:

  * repository root;
  * file path;
  * file language;
  * non-empty line count.
* Marked bridged scan facts as `FactSource::Mixed` and `FactConfidence::High`.
* Added `RepoFactsSummary` as an internal aggregate projection.
* Added `LanguageSummary` for deterministic per-language file and line counts.
* Added `summarize_repo_facts()` to compute:

  * total file count;
  * files with language;
  * total non-empty lines;
  * language summaries;
  * diagnostics count.
* Added focused tests for the scan bridge and summary projection.
* Updated `docs/engineering/analysis-platform-state.md` to mark the bridge and summary projection as existing internal steps.

## Why

RepoPilot is moving toward a fact-based analysis platform:

```text
files
  -> facts
  -> graph
  -> rules
  -> findings
  -> risk
  -> suppressions / decisions
  -> reports / AI context / MCP
```

The existing `ScanFacts` model already contains useful scan-level information, but the new `RepoFacts` model is intended to become the shared internal platform for future graph, rule capability, AI context, and report work.

This PR creates a minimal bridge without changing current product behavior.

The summary projection is intentionally small and aggregate-only. It gives future outputs a safe way to consume fact information without exposing raw `RepoFacts` directly.

## Contract and ownership

* [x] The change stays within the internal facts module and engineering documentation.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] No public CLI behavior changes are introduced.
* [x] No report schema changes are introduced.
* [x] No new findings or review signals are introduced.
* [x] Existing `scan::facts::ScanFacts` and `scan::facts::FileFacts` remain unchanged.
* [x] Raw `RepoFacts` are not exposed through public output.
* [x] No `inspect` command or public diagnostics command is reintroduced.
* [x] No unrelated refactor or generated-file churn is included.

## Changelog

* [ ] `CHANGELOG.md` updated

Skipped because this is an internal foundation change with no user-visible CLI behavior change.

## Verification

```bash
cargo test facts
git diff --check
git status --short
```
