### PR TITLE
feat(ai-context): add repository facts summary

### DIFF
--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -83,8 +83,9 @@ The first internal implementation steps now exist in `src/facts`: a facts-core
 skeleton, a minimal `ScanFacts -> RepoFacts` bridge, and an internal `RepoFacts`
 summary projection. The bridge currently preserves only repository root, file
 path, language, and non-empty line count. The summary provides aggregate file,
-language, line, and diagnostic counts without exposing raw facts. Neither is
-yet exposed through scan, review, report output, AI context, or MCP.
+language, line, and diagnostic counts without exposing raw facts. AI context now
+includes this summary as aggregate evidence; raw `RepoFacts` remain internal and
+are not exposed through scan JSON, review, report schemas, or MCP.
 
 ## What Is Missing
 
@@ -148,11 +149,10 @@ without creating a durable user workflow.
 
 ## Next Planned Implementation Steps
 
-1. Feed the facts summary into AI context without exposing raw `RepoFacts`.
-2. Design graph v2.
-3. Add graph v2 core types.
-4. Feed graph v2 into scan, review, and AI context.
-5. Add rule capabilities metadata.
-6. Add language support tiers.
-7. Add runtime evidence ingestion.
-8. Add evaluation fixtures.
+1. Design graph v2.
+2. Add graph v2 core types.
+3. Feed graph v2 into scan, review, and AI context.
+4. Add rule capabilities metadata.
+5. Add language support tiers.
+6. Add runtime evidence ingestion.
+7. Add evaluation fixtures.

--- a/src/commands/ai_context.rs
+++ b/src/commands/ai_context.rs
@@ -1,6 +1,8 @@
 use crate::cli::ai::AiContextOptions;
 use crate::commands::llm::{LlmCommandArgs, run_markdown_command};
-use repopilot::output::ai_context::{AiContextRenderOptions, render_with_breakdown};
+use repopilot::output::ai_context::{
+    AiContextRenderOptions, render_with_facts_summary_and_breakdown,
+};
 use std::io::IsTerminal;
 
 pub fn run(options: AiContextOptions) -> Result<(), Box<dyn std::error::Error>> {
@@ -27,14 +29,15 @@ pub fn run(options: AiContextOptions) -> Result<(), Box<dyn std::error::Error>> 
             budget,
             output,
         },
-        |summary, focus, budget_tokens| {
+        |summary, facts_summary, focus, budget_tokens| {
             let opts = AiContextRenderOptions {
                 focus,
                 budget_tokens,
                 no_header,
                 no_task,
             };
-            let (content, breakdown) = render_with_breakdown(summary, &opts);
+            let (content, breakdown) =
+                render_with_facts_summary_and_breakdown(summary, facts_summary, &opts);
             if should_show_breakdown {
                 breakdown.render_stderr();
             }

--- a/src/commands/llm.rs
+++ b/src/commands/llm.rs
@@ -1,9 +1,10 @@
 use crate::commands::focus::parse_focus_category;
 use crate::commands::product_scan::{
     ProductScanMode, ProductScanRequest, emit_report_only_diagnostics,
-    enforce_diagnostics_exit_policy, run_product_scan,
+    enforce_diagnostics_exit_policy, run_product_scan_with_facts_summary,
 };
 use crate::commands::scan_config::ScanConfigOverrides;
+use repopilot::facts::RepoFactsSummary;
 use repopilot::findings::filter::FindingFilter;
 use repopilot::findings::visibility::FindingVisibilityProfile;
 use repopilot::output::ai_context::{AiFocusCategory, DEFAULT_TOKEN_BUDGET};
@@ -24,12 +25,12 @@ pub fn run_markdown_command<F>(
     render: F,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    F: FnOnce(&ScanSummary, Option<AiFocusCategory>, usize) -> String,
+    F: FnOnce(&ScanSummary, Option<&RepoFactsSummary>, Option<AiFocusCategory>, usize) -> String,
 {
     let focus_category = parse_focus_category(args.focus.as_deref())?;
     let budget_tokens = args.budget.unwrap_or(DEFAULT_TOKEN_BUDGET);
 
-    let scan_result = run_product_scan(ProductScanRequest {
+    let scan_result = run_product_scan_with_facts_summary(ProductScanRequest {
         path: args.path,
         config_path: args.config,
         overrides: ScanConfigOverrides::default(),
@@ -43,7 +44,12 @@ where
     let summary = scan_result.summary;
 
     emit_report_only_diagnostics(&summary);
-    let rendered = render(&summary, focus_category, budget_tokens);
+    let rendered = render(
+        &summary,
+        scan_result.repo_facts_summary.as_ref(),
+        focus_category,
+        budget_tokens,
+    );
     write_report(&rendered, args.output.as_deref())?;
     enforce_diagnostics_exit_policy(&summary)?;
 

--- a/src/commands/product_scan.rs
+++ b/src/commands/product_scan.rs
@@ -4,12 +4,14 @@ use crate::commands::{CliExit, EXIT_RUNTIME, EXIT_USAGE};
 use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::config::model::RepoPilotConfig;
 use repopilot::config::presets::{Preset, apply_preset};
+use repopilot::facts::RepoFactsSummary;
 use repopilot::findings::feedback::apply_local_feedback;
 use repopilot::findings::filter::FindingFilter;
 use repopilot::findings::visibility::{FindingVisibilityProfile, apply_visibility_profile};
 use repopilot::review::diff::ChangedFile;
 use repopilot::scan::scanner::{
-    scan_changed_with_config, scan_path_with_config, scan_resolved_changed_with_config,
+    scan_changed_with_config, scan_path_with_config, scan_path_with_config_and_facts_summary,
+    scan_resolved_changed_with_config,
 };
 use repopilot::scan::types::ScanSummary;
 use repopilot::scan::workspace_scan::scan_workspace_with_config;
@@ -43,12 +45,26 @@ pub struct ProductScanRequest {
 
 pub struct ProductScanResult {
     pub summary: ScanSummary,
+    pub repo_facts_summary: Option<RepoFactsSummary>,
     pub repo_config: RepoPilotConfig,
     pub scan_elapsed: Duration,
 }
 
 pub fn run_product_scan(
     request: ProductScanRequest,
+) -> Result<ProductScanResult, Box<dyn std::error::Error>> {
+    run_product_scan_internal(request, false)
+}
+
+pub fn run_product_scan_with_facts_summary(
+    request: ProductScanRequest,
+) -> Result<ProductScanResult, Box<dyn std::error::Error>> {
+    run_product_scan_internal(request, true)
+}
+
+fn run_product_scan_internal(
+    request: ProductScanRequest,
+    include_repo_facts_summary: bool,
 ) -> Result<ProductScanResult, Box<dyn std::error::Error>> {
     let mut repo_config = match &request.config_path {
         Some(config_path) => load_optional_config(config_path)?,
@@ -71,10 +87,19 @@ pub fn run_product_scan(
     };
     let scan_start = Instant::now();
     let scan_result = match &request.mode {
-        ProductScanMode::Full => scan_path_with_config(&request.path, &scan_config),
-        ProductScanMode::Workspace => scan_workspace_with_config(&request.path, &scan_config),
+        ProductScanMode::Full if include_repo_facts_summary => {
+            scan_path_with_config_and_facts_summary(&request.path, &scan_config)
+                .map(|(summary, facts_summary)| (summary, Some(facts_summary)))
+        }
+        ProductScanMode::Full => {
+            scan_path_with_config(&request.path, &scan_config).map(|summary| (summary, None))
+        }
+        ProductScanMode::Workspace => {
+            scan_workspace_with_config(&request.path, &scan_config).map(|summary| (summary, None))
+        }
         ProductScanMode::Changed { since } => {
             scan_changed_with_config(&request.path, &scan_config, since.as_deref())
+                .map(|summary| (summary, None))
         }
         ProductScanMode::ResolvedChanged {
             repo_root,
@@ -86,12 +111,13 @@ pub fn run_product_scan(
             repo_root.clone(),
             changed_files.clone(),
             base_ref.as_deref(),
-        ),
+        )
+        .map(|summary| (summary, None)),
     };
     let scan_elapsed = scan_start.elapsed();
     finish_spinner(pb);
 
-    let mut summary = scan_result?;
+    let (mut summary, repo_facts_summary) = scan_result?;
 
     if !request.ignore_feedback {
         apply_local_feedback(&mut summary, &request.path)?;
@@ -105,6 +131,7 @@ pub fn run_product_scan(
 
     Ok(ProductScanResult {
         summary,
+        repo_facts_summary,
         repo_config,
         scan_elapsed,
     })

--- a/src/output/ai_context.rs
+++ b/src/output/ai_context.rs
@@ -4,9 +4,11 @@ mod guardrails;
 mod header;
 mod hotfiles;
 mod recommendations;
+mod repo_facts;
 
 pub use budget::SectionBreakdown;
 
+use crate::facts::RepoFactsSummary;
 use crate::findings::types::Finding;
 use crate::output::ai_context::budget::BreakdownSection;
 use crate::scan::types::ScanSummary;
@@ -81,7 +83,7 @@ impl AiFocusCategory {
 
 /// Render the AI context, discarding breakdown info.
 pub fn render(summary: &ScanSummary, opts: &AiContextRenderOptions) -> String {
-    let (content, _) = render_internal(summary, opts);
+    let (content, _) = render_internal(summary, None, opts);
     content
 }
 
@@ -90,11 +92,21 @@ pub fn render_with_breakdown(
     summary: &ScanSummary,
     opts: &AiContextRenderOptions,
 ) -> (String, SectionBreakdown) {
-    render_internal(summary, opts)
+    render_internal(summary, None, opts)
+}
+
+/// Render AI context with aggregate repository facts and token breakdown.
+pub fn render_with_facts_summary_and_breakdown(
+    summary: &ScanSummary,
+    facts_summary: Option<&RepoFactsSummary>,
+    opts: &AiContextRenderOptions,
+) -> (String, SectionBreakdown) {
+    render_internal(summary, facts_summary, opts)
 }
 
 fn render_internal(
     summary: &ScanSummary,
+    facts_summary: Option<&RepoFactsSummary>,
     opts: &AiContextRenderOptions,
 ) -> (String, SectionBreakdown) {
     let budget_chars = opts.budget_tokens * 4;
@@ -135,6 +147,15 @@ fn render_internal(
         header::render_header(&mut out, summary, &findings);
         sections.push(BreakdownSection {
             label: "Header".into(),
+            tokens: (out.len() - pre) / 4,
+        });
+    }
+
+    if let Some(facts_summary) = facts_summary {
+        let pre = out.len();
+        repo_facts::render_summary(&mut out, facts_summary);
+        sections.push(BreakdownSection {
+            label: "Repository Facts".into(),
             tokens: (out.len() - pre) / 4,
         });
     }

--- a/src/output/ai_context/repo_facts.rs
+++ b/src/output/ai_context/repo_facts.rs
@@ -1,0 +1,135 @@
+use crate::facts::RepoFactsSummary;
+use std::fmt::Write as FmtWrite;
+
+const MAX_LANGUAGES: usize = 5;
+
+pub(super) fn render_summary(out: &mut String, summary: &RepoFactsSummary) {
+    let _ = writeln!(out, "## Repository Facts Summary\n");
+
+    if summary.total_files == 0 {
+        let _ = writeln!(out, "- No repository file facts were collected.");
+        let _ = writeln!(out, "- Fact diagnostics: {}\n", summary.diagnostics_count);
+        return;
+    }
+
+    let _ = writeln!(out, "- Files: {}", summary.total_files);
+    let _ = writeln!(
+        out,
+        "- Files with detected language: {}",
+        summary.files_with_language
+    );
+    let _ = writeln!(out, "- Non-empty lines: {}", summary.total_non_empty_lines);
+    let _ = writeln!(out, "- Fact diagnostics: {}", summary.diagnostics_count);
+
+    if !summary.languages.is_empty() {
+        let _ = writeln!(out, "\nTop languages:");
+        for language in summary.languages.iter().take(MAX_LANGUAGES) {
+            let file_label = if language.files == 1 { "file" } else { "files" };
+            let _ = writeln!(
+                out,
+                "- {}: {} {}, {} non-empty lines",
+                language.language, language.files, file_label, language.non_empty_lines
+            );
+        }
+    }
+
+    out.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::facts::{
+        FactConfidence, FactDiagnostic, FactSource, FileFact, RepoFacts, repo_facts_from_scan,
+        summarize_repo_facts,
+    };
+    use crate::scan::facts::{FileFacts, ScanFacts};
+    use std::path::PathBuf;
+
+    #[test]
+    fn renders_empty_state_with_diagnostic_count() {
+        let mut output = String::new();
+        render_summary(
+            &mut output,
+            &RepoFactsSummary {
+                diagnostics_count: 2,
+                ..RepoFactsSummary::default()
+            },
+        );
+
+        assert!(output.contains("## Repository Facts Summary"));
+        assert!(output.contains("- No repository file facts were collected."));
+        assert!(output.contains("- Fact diagnostics: 2"));
+    }
+
+    #[test]
+    fn renders_aggregate_facts_without_raw_paths() {
+        let raw_path = PathBuf::from("/private/repo/src/lib.rs");
+        let scan = ScanFacts {
+            root_path: PathBuf::from("/private/repo"),
+            files: vec![
+                FileFacts {
+                    path: raw_path.clone(),
+                    language: Some("Rust".to_string()),
+                    non_empty_lines: 42,
+                    branch_count: 0,
+                    imports: Vec::new(),
+                    content: None,
+                    has_inline_tests: false,
+                },
+                FileFacts {
+                    path: PathBuf::from("/private/repo/README"),
+                    language: None,
+                    non_empty_lines: 8,
+                    branch_count: 0,
+                    imports: Vec::new(),
+                    content: None,
+                    has_inline_tests: false,
+                },
+            ],
+            ..ScanFacts::default()
+        };
+        let facts = repo_facts_from_scan(&scan);
+        let mut summary = summarize_repo_facts(&facts);
+        summary.diagnostics_count = 1;
+
+        let mut output = String::new();
+        render_summary(&mut output, &summary);
+
+        assert!(output.contains("## Repository Facts Summary"));
+        assert!(output.contains("- Files: 2"));
+        assert!(output.contains("- Files with detected language: 1"));
+        assert!(output.contains("- Non-empty lines: 50"));
+        assert!(output.contains("- Fact diagnostics: 1"));
+        assert!(output.contains("- Rust: 1 file, 42 non-empty lines"));
+        assert!(!output.contains(&raw_path.display().to_string()));
+    }
+
+    #[test]
+    fn limits_language_output_to_five_entries() {
+        let facts = RepoFacts {
+            files: (0..6)
+                .map(|index| FileFact {
+                    path: PathBuf::from(format!("file-{index}")),
+                    language: Some(format!("Language-{index}")),
+                    non_empty_lines: 10 - index,
+                    source: FactSource::Mixed,
+                    confidence: FactConfidence::High,
+                })
+                .collect(),
+            diagnostics: vec![FactDiagnostic {
+                code: "facts.example".to_string(),
+                message: "example".to_string(),
+                path: None,
+            }],
+            ..RepoFacts::default()
+        };
+        let summary = summarize_repo_facts(&facts);
+
+        let mut output = String::new();
+        render_summary(&mut output, &summary);
+
+        assert_eq!(output.matches("- Language-").count(), MAX_LANGUAGES);
+        assert!(!output.contains("- Language-5:"));
+    }
+}

--- a/src/scan/scanner/full.rs
+++ b/src/scan/scanner/full.rs
@@ -1,6 +1,7 @@
 use super::{collection, contract_stage};
 use crate::audits::architecture::import_coupling::ImportCouplingAudit;
 use crate::audits::pipeline::{build_file_audits, run_framework_audits, run_project_audits};
+use crate::facts::{RepoFactsSummary, repo_facts_from_scan, summarize_repo_facts};
 use crate::findings::enrichment::enrich_findings_timed;
 use crate::findings::quality::summarize_signal_quality_with_contract_violations;
 use crate::findings::types::Finding;
@@ -24,6 +25,13 @@ pub fn scan_path(path: &Path) -> io::Result<ScanSummary> {
 
 pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<ScanSummary> {
     ScanEngine::new(path, config).run()
+}
+
+pub fn scan_path_with_config_and_facts_summary(
+    path: &Path,
+    config: &ScanConfig,
+) -> io::Result<(ScanSummary, RepoFactsSummary)> {
+    ScanEngine::new(path, config).run_with_facts_summary()
 }
 
 pub struct ScanEngine<'a> {
@@ -61,6 +69,20 @@ impl<'a> ScanEngine<'a> {
     }
 
     pub fn run(self) -> io::Result<ScanSummary> {
+        self.run_internal(|_| ()).map(|(summary, ())| summary)
+    }
+
+    fn run_with_facts_summary(self) -> io::Result<(ScanSummary, RepoFactsSummary)> {
+        self.run_internal(|scan_facts| {
+            let repo_facts = repo_facts_from_scan(scan_facts);
+            summarize_repo_facts(&repo_facts)
+        })
+    }
+
+    fn run_internal<T>(
+        self,
+        build_sidecar: impl FnOnce(&ScanFacts) -> T,
+    ) -> io::Result<(ScanSummary, T)> {
         let start = Instant::now();
         let discovery_stage = self.run_discovery()?;
         let file_stage = self.run_file_analysis(discovery_stage.discovered)?;
@@ -97,13 +119,16 @@ impl<'a> ScanEngine<'a> {
             report_finalization_us: 0,
         };
 
-        Ok(self.finalize_report(
+        let sidecar = build_sidecar(&project_stage.facts);
+        let summary = self.finalize_report(
             project_stage,
             scan_duration_us,
             timings,
             contract_stage.diagnostics,
             signal_quality,
-        ))
+        );
+
+        Ok((summary, sidecar))
     }
 
     fn run_discovery(&self) -> io::Result<DiscoveryStage> {

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -12,4 +12,6 @@ mod walker;
 
 pub use changed::{scan_changed_with_config, scan_resolved_changed_with_config};
 pub use collection::{collect_scan_facts, collect_scan_facts_with_config};
-pub use full::{ScanEngine, scan_path, scan_path_with_config};
+pub use full::{
+    ScanEngine, scan_path, scan_path_with_config, scan_path_with_config_and_facts_summary,
+};

--- a/tests/ai_context_command.rs
+++ b/tests/ai_context_command.rs
@@ -52,6 +52,12 @@ fn ai_context_default_output_succeeds() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
     assert!(stdout.contains("# RepoPilot AI Context"));
+    assert!(stdout.contains("## Repository Facts Summary"));
+    assert!(stdout.contains("- Files: 2"));
+    assert!(stdout.contains("- Files with detected language: 2"));
+    assert!(stdout.contains("- Non-empty lines: 2"));
+    assert!(stdout.contains("- Fact diagnostics: 0"));
+    assert!(stdout.contains("- Rust: 2 files, 2 non-empty lines"));
     assert!(stdout.contains("Security"));
     assert!(stdout.contains("Possible secret detected"));
     assert!(stdout.contains("sk_...***"));
@@ -92,6 +98,10 @@ fn ai_context_handoff_includes_plan_rules_and_verify() {
     assert!(
         lean.contains("## Remediation Plan"),
         "plan should remain under --no-task\n{lean}"
+    );
+    assert!(
+        lean.contains("## Repository Facts Summary"),
+        "facts summary should remain under --no-task\n{lean}"
     );
 }
 


### PR DESCRIPTION
## Summary

Adds an aggregate repository facts summary to the AI context handoff.

This connects the new internal `RepoFactsSummary` projection to `repopilot ai context` while keeping raw `RepoFacts` internal. The section gives an AI/developer a compact view of repository size, language coverage, line counts, and fact diagnostics without exposing raw file-level facts or changing report schemas.

## Type of change

* [x] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added a new `Repository Facts Summary` section to AI context output.
* Rendered aggregate-only facts:

  * total files;
  * files with detected language;
  * total non-empty lines;
  * fact diagnostics count;
  * top languages.
* Limited top language output to five entries.
* Ensured raw file paths are not rendered in the facts summary.
* Kept the facts summary visible under `--no-task`, because it is evidence/context rather than task instruction.
* Added a facts-summary-aware AI context render path.
* Added a facts-summary-aware product scan path only for full AI context scans.
* Left workspace/changed/resolved-changed scan modes without facts summary for now.
* Updated AI context tests to assert the section appears in default and `--no-task` output.
* Updated engineering docs to mark AI context facts summary integration as complete.

## Why

RepoPilot is moving toward a fact-based analysis platform:

```text
files
  -> facts
  -> graph
  -> rules
  -> findings
  -> risk
  -> suppressions / decisions
  -> reports / AI context / MCP
```

The previous PRs introduced the internal facts model, the `ScanFacts -> RepoFacts` bridge, and the `RepoFactsSummary` projection. This PR is the first safe product use of that platform: AI context receives a compact aggregate summary, while raw facts remain internal.

This gives AI handoffs better repository-level evidence without expanding the public CLI surface or adding a new diagnostic command.

## Contract and ownership

* [x] The change stays within AI context rendering, product scan plumbing, tests, and engineering docs.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] No public CLI command is added.
* [x] `inspect` is not reintroduced.
* [x] Raw `RepoFacts` are not exposed.
* [x] No scan JSON, SARIF, or baseline schema changes are introduced.
* [x] No new findings or review signals are introduced.
* [x] The facts summary is aggregate-only and avoids raw file paths.
* [x] No unrelated refactor or generated-file churn is included.

## Changelog

* [ ] `CHANGELOG.md` updated

Skipped because this is an internal AI context evidence improvement with no CLI command or schema change.

## Verification

```bash
cargo test ai_context
cargo test facts
git diff --check
git status --short
```
