### PR TITLE
feat(graph): add graph v2 builder and algorithms

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ adoption or CI policy.
 ## Maintainer Guides
 
 - [Analysis platform state](engineering/analysis-platform-state.md)
+- [Dependency Graph v2 design](engineering/dependency-graph-v2.md)
 - [Signal contract](engineering/signal-contract.md)
 - [Engine pipeline](engineering/engine-pipeline.md)
 - [Graph scan hardening](engineering/graph-scan-hardening.md)

--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -92,7 +92,8 @@ are not exposed through scan JSON, review, report schemas, or MCP.
 RepoPilot still needs a deeper fact-based platform with:
 
 - a richer `RepoFacts` model beyond the initial scan-facts bridge;
-- a first-class dependency graph with explicit core types and contracts;
+- a first-class dependency graph with explicit core types and contracts,
+  following the [Dependency Graph v2 design](dependency-graph-v2.md);
 - symbol facts for definitions, references, ownership, and relationships;
 - rule capabilities that declare which facts and analysis levels a rule needs;
 - language support tiers that make analysis depth and guarantees explicit;
@@ -149,10 +150,18 @@ without creating a durable user workflow.
 
 ## Next Planned Implementation Steps
 
-1. Design graph v2.
-2. Add graph v2 core types.
-3. Feed graph v2 into scan, review, and AI context.
-4. Add rule capabilities metadata.
+The [Dependency Graph v2 design](dependency-graph-v2.md) now defines the next
+architecture direction. Its isolated internal core types and a `GraphSnapshot`
+builder now exist; the builder reuses RepoPilot's shared language-aware import
+resolvers and emits typed edges (`Imports`/`DependsOn`/`TestOf`) carrying
+provenance and a confidence tier. Deterministic internal graph algorithms cover
+degrees, hubs, SCC cycles, neighborhoods, transitive blast radius, and summaries,
+but are not yet product-facing.
+
+1. Migrate existing graph-related architecture rules to graph v2.
+2. Feed graph v2 blast radius into review.
+3. Feed graph v2 hot files into AI context.
+4. Add graph capabilities metadata for rules.
 5. Add language support tiers.
 6. Add runtime evidence ingestion.
 7. Add evaluation fixtures.

--- a/docs/engineering/dependency-graph-v2.md
+++ b/docs/engineering/dependency-graph-v2.md
@@ -1,0 +1,253 @@
+# Dependency Graph v2
+
+## Purpose
+
+Dependency Graph v2 should become RepoPilot's shared dependency graph layer for
+architecture rules, blast-radius analysis, AI context, and future rule
+capabilities.
+
+Graph v2 core types now exist internally as an isolated module. They define
+nodes, edges, snapshots, and diagnostics without changing existing graph
+consumers.
+
+Graph v2 now also has an initial internal `GraphSnapshot` builder from scan
+facts. It creates file nodes, external dependency nodes, and import edges by
+reusing RepoPilot's shared language-aware import resolvers (Rust
+`crate::`/`super::`/`self::`/`mod`, TypeScript/JavaScript relative and `tsconfig`
+aliases, Python, Go, JVM). Imports that do not resolve to a scanned file become
+external dependency nodes, and unresolved relative imports record a bounded
+diagnostic. Edges carry typed kinds (`Imports` for resolved local files,
+`DependsOn` for external dependencies, `TestOf` for co-located test files),
+provenance, and a confidence tier (high for resolved files, medium for external
+packages, low for unresolved relative imports). It is not yet used by scan
+findings, review blast radius, AI context, or public report schemas.
+
+Graph v2 now has internal algorithms for degree summaries, hubs, SCC-based cycle
+detection, local neighborhoods, transitive blast radius (reverse dependents of a
+changed set), and compact deterministic graph summaries. These algorithms are not
+yet used by public scan, review, or AI context output.
+
+Today, `CouplingGraph`, `RepoContextGraph`, import extraction, language
+resolvers, review signals, and graph summaries provide useful behavior. Graph
+v2 should give those paths one deterministic model built from repository facts,
+without forcing product commands to rescan or independently reinterpret the
+same imports.
+
+## Non-Goals
+
+Graph v2 should not:
+
+- add new public CLI commands;
+- reintroduce `repopilot inspect graph`;
+- expose unstable graph internals as a public report schema;
+- replace language-specific tools such as the TypeScript compiler, Cargo, or
+  package managers;
+- attempt to become a complete semantic call graph in its first version.
+
+The graph should represent evidence RepoPilot can resolve locally and
+deterministically. It should preserve uncertainty through diagnostics and
+capability metadata rather than claim semantic completeness.
+
+## Current Problems
+
+The current import and graph implementation is not a sufficient long-term
+platform:
+
+- graph construction, context enrichment, caching, and consumers are
+  distributed across scan, graph, audit, review, risk, and output modules;
+- import resolution depth and guarantees differ by language;
+- architecture rules need shared graph facts instead of rebuilding
+  relationships independently;
+- review blast radius and AI context need the same understanding of dependency
+  direction and resolved boundaries;
+- future rule capabilities need to declare whether required graph facts are
+  available for a repository, language, or scan scope.
+
+Existing graph behavior should remain operational while graph v2 is introduced
+incrementally. The migration should avoid parallel rescans and preserve bounded
+output, cache invalidation, and changed-scan honesty.
+
+## Target Pipeline
+
+```text
+RepoFacts
+  -> import facts
+  -> GraphSnapshot
+  -> graph algorithms
+  -> rule inputs / review signals / AI context
+```
+
+`GraphSnapshot` should be built once for a command path from facts and resolver
+results. Algorithms and product consumers should operate on that snapshot
+rather than reconstructing edges.
+
+## Core Concepts
+
+The planned concepts are:
+
+- `GraphNode`: a stable identity and kind for an entity in the repository or
+  its dependency boundary;
+- `GraphEdge`: a directed, typed relationship with provenance, confidence, and
+  optional evidence;
+- `GraphSnapshot`: the immutable nodes, edges, resolver metadata, diagnostics,
+  and capability state for one analysis scope;
+- `GraphNodeKind`: the category of an entity represented by a node;
+- `GraphEdgeKind`: the meaning of a directed relationship;
+- `GraphResolver`: a language-aware component that converts import or
+  dependency facts into resolved graph relationships;
+- `GraphDiagnostic`: a bounded explanation of unresolved, ambiguous, skipped,
+  or unsupported graph evidence.
+
+Initial node kinds:
+
+```text
+File
+Directory
+Package
+Workspace
+ExternalDependency
+```
+
+Initial edge kinds:
+
+```text
+Imports
+ReExports
+DependsOn
+TestOf
+GeneratedFrom
+Configures
+```
+
+Not every kind needs to ship in the first implementation. The core model should
+allow these relationships without requiring consumers to infer their meaning
+from paths or untyped strings.
+
+Node and edge identities must be deterministic. Paths should be normalized
+relative to the repository root where possible, and external dependencies
+should use stable ecosystem-aware identities rather than local installation
+paths.
+
+## Resolver Strategy
+
+Resolver support should be explicit and capability-based. Unresolved imports
+should produce bounded diagnostics or unresolved external nodes, not invented
+edges.
+
+### JavaScript And TypeScript
+
+Initial scope:
+
+- relative imports;
+- extensionless imports;
+- index files;
+- `tsconfig` path aliases.
+
+Later scope:
+
+- package and workspace imports;
+- package export maps where deterministic local metadata is available.
+
+The resolver should not claim parity with the TypeScript compiler for every
+module mode, plugin, or generated configuration.
+
+### Rust
+
+Initial scope:
+
+- `mod`;
+- `pub mod`;
+- `use crate::`;
+- `use super::`.
+
+Later scope:
+
+- workspace crates;
+- package dependency relationships derived from Cargo metadata or manifests.
+
+The first implementation should focus on source-module relationships and avoid
+pretending to replace Cargo's complete dependency and feature resolution.
+
+### Python
+
+Initial scope:
+
+- relative imports;
+- package roots;
+- `__init__.py`.
+
+Later scope:
+
+- FastAPI and Django project roots;
+- environment-aware package resolution where inputs remain local and
+  deterministic.
+
+Python path mutation, dynamic imports, and environment-specific import hooks
+should remain explicit limitations.
+
+Other languages can continue using current import extraction until their
+resolver contract and support tier are defined. Graph v2 should not imply equal
+resolution depth across all detected languages.
+
+## Algorithm Roadmap
+
+Graph algorithms should consume `GraphSnapshot` through shared, deterministic
+implementations:
+
+```text
+cycles
+fan-in / fan-out
+hubs
+shared dependency detection
+blast radius
+layer violation support
+workspace/package boundaries
+```
+
+Algorithms must have explicit direction semantics, bounded output, stable
+ordering, and tests for disconnected nodes, unresolved edges, cycles, and
+cross-boundary relationships. Expensive derived results should be computed once
+per command path or cached against versioned graph inputs.
+
+## Product Integration
+
+Graph v2 should feed existing durable workflows:
+
+- scan findings should use shared graph facts for coupling, cycles, layer
+  boundaries, and related architecture evidence;
+- review should use the same graph direction and boundary model for blast
+  radius;
+- AI context should derive hot files, dependency context, and edit order from
+  graph v2 summaries;
+- future architecture policies should consume typed nodes and edges rather than
+  path heuristics alone;
+- future rule capabilities should declare the graph facts, resolver support,
+  and analysis scope they require.
+
+Integration should be incremental. Existing `CouplingGraph` and
+`RepoContextGraph` consumers should migrate only after graph v2 has equivalent
+deterministic fixtures and bounded behavior.
+
+## Public Surface Rule
+
+Graph v2 diagnostics should not create a new public `inspect graph` command.
+
+Use:
+
+- scan JSON;
+- review output;
+- AI context;
+- MCP tools;
+- tests;
+- internal development scripts.
+
+Any future public projection should be aggregate, bounded, versioned, and tied
+to an existing durable workflow. Raw or unstable graph internals should remain
+internal.
+
+## Implementation Steps
+
+1. Migrate existing graph-related rules to graph v2.
+2. Feed graph v2 blast radius into review.
+3. Feed graph v2 hot files into AI context.
+4. Add graph capabilities metadata for rules.

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,6 +1,7 @@
 pub mod context;
 pub mod imports;
 pub mod resolver;
+pub mod v2;
 
 pub use imports::extract_imports;
 pub use resolver::resolve_import;

--- a/src/graph/v2/algorithms/blast_radius.rs
+++ b/src/graph/v2/algorithms/blast_radius.rs
@@ -1,0 +1,47 @@
+use super::topology;
+use crate::graph::v2::{GraphNodeId, GraphSnapshot};
+use std::collections::{BTreeSet, VecDeque};
+
+/// The transitive dependents of a set of changed nodes: every node that can
+/// reach a seed by following dependency edges (i.e. the importers, directly or
+/// transitively). This is the blast radius of a change to the seeds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphBlastRadius {
+    /// Provided seeds that exist in the snapshot, sorted and deduplicated.
+    pub seeds: Vec<GraphNodeId>,
+    /// Transitive dependents of the seeds, sorted, excluding the seeds.
+    pub impacted: Vec<GraphNodeId>,
+}
+
+/// Walks dependency edges in reverse (`incoming`) from every seed, so the result
+/// is "what is affected if these nodes change". Seeds missing from the snapshot
+/// are ignored; cycles terminate because nodes are visited at most once.
+pub fn blast_radius(snapshot: &GraphSnapshot, seeds: &[GraphNodeId]) -> GraphBlastRadius {
+    let topology = topology(snapshot);
+    let present_seeds = seeds
+        .iter()
+        .filter(|seed| topology.node_set.contains(seed))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let mut visited = present_seeds.clone();
+    let mut queue = present_seeds.iter().cloned().collect::<VecDeque<_>>();
+
+    while let Some(node) = queue.pop_front() {
+        for dependent in &topology.incoming[&node] {
+            if visited.insert(dependent.clone()) {
+                queue.push_back(dependent.clone());
+            }
+        }
+    }
+
+    let impacted = visited
+        .into_iter()
+        .filter(|node| !present_seeds.contains(node))
+        .collect::<Vec<_>>();
+
+    GraphBlastRadius {
+        seeds: present_seeds.into_iter().collect(),
+        impacted,
+    }
+}

--- a/src/graph/v2/algorithms/cycles.rs
+++ b/src/graph/v2/algorithms/cycles.rs
@@ -1,0 +1,124 @@
+use super::topology;
+use crate::graph::v2::{GraphNodeId, GraphSnapshot};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphCycle {
+    pub node_ids: Vec<GraphNodeId>,
+}
+
+pub fn find_cycles(snapshot: &GraphSnapshot) -> Vec<GraphCycle> {
+    let topology = topology(snapshot);
+    let index_by_id = topology
+        .node_ids
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(index, id)| (id, index))
+        .collect::<BTreeMap<_, _>>();
+    let adjacency = topology
+        .node_ids
+        .iter()
+        .map(|id| {
+            topology.outgoing[id]
+                .iter()
+                .filter_map(|target| index_by_id.get(target).copied())
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut tarjan = Tarjan::new(&adjacency);
+
+    for node in 0..topology.node_ids.len() {
+        if tarjan.indices[node].is_none() {
+            tarjan.visit(node);
+        }
+    }
+
+    let mut cycles = tarjan
+        .components
+        .into_iter()
+        .filter(|component| {
+            component.len() > 1
+                || component
+                    .first()
+                    .is_some_and(|node| adjacency[*node].contains(node))
+        })
+        .map(|component| {
+            let mut node_ids = component
+                .into_iter()
+                .map(|node| topology.node_ids[node].clone())
+                .collect::<Vec<_>>();
+            node_ids.sort();
+            GraphCycle { node_ids }
+        })
+        .collect::<Vec<_>>();
+
+    cycles.sort_by(|left, right| {
+        right
+            .node_ids
+            .len()
+            .cmp(&left.node_ids.len())
+            .then_with(|| left.node_ids.first().cmp(&right.node_ids.first()))
+            .then_with(|| left.node_ids.cmp(&right.node_ids))
+    });
+    cycles
+}
+
+struct Tarjan<'a> {
+    adjacency: &'a [Vec<usize>],
+    next_index: usize,
+    indices: Vec<Option<usize>>,
+    lowlink: Vec<usize>,
+    stack: Vec<usize>,
+    on_stack: Vec<bool>,
+    components: Vec<Vec<usize>>,
+}
+
+impl<'a> Tarjan<'a> {
+    fn new(adjacency: &'a [Vec<usize>]) -> Self {
+        let node_count = adjacency.len();
+        Self {
+            adjacency,
+            next_index: 0,
+            indices: vec![None; node_count],
+            lowlink: vec![0; node_count],
+            stack: Vec::new(),
+            on_stack: vec![false; node_count],
+            components: Vec::new(),
+        }
+    }
+
+    fn visit(&mut self, node: usize) {
+        let index = self.next_index;
+        self.next_index += 1;
+        self.indices[node] = Some(index);
+        self.lowlink[node] = index;
+        self.stack.push(node);
+        self.on_stack[node] = true;
+
+        for &neighbor in &self.adjacency[node] {
+            if self.indices[neighbor].is_none() {
+                self.visit(neighbor);
+                self.lowlink[node] = self.lowlink[node].min(self.lowlink[neighbor]);
+            } else if self.on_stack[neighbor] {
+                self.lowlink[node] = self.lowlink[node]
+                    .min(self.indices[neighbor].expect("visited neighbor has an index"));
+            }
+        }
+
+        if self.lowlink[node] != index {
+            return;
+        }
+
+        let mut component = Vec::new();
+        loop {
+            let member = self.stack.pop().expect("current SCC contains its root");
+            self.on_stack[member] = false;
+            component.push(member);
+            if member == node {
+                break;
+            }
+        }
+        self.components.push(component);
+    }
+}

--- a/src/graph/v2/algorithms/degree.rs
+++ b/src/graph/v2/algorithms/degree.rs
@@ -1,0 +1,92 @@
+use super::topology;
+use crate::graph::v2::{GraphNodeId, GraphSnapshot};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct GraphDegreeSummary {
+    pub nodes: Vec<NodeDegree>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeDegree {
+    pub node_id: GraphNodeId,
+    pub fan_in: usize,
+    pub fan_out: usize,
+}
+
+pub fn compute_degrees(snapshot: &GraphSnapshot) -> GraphDegreeSummary {
+    let topology = topology(snapshot);
+    let mut degrees = topology
+        .node_ids
+        .into_iter()
+        .map(|node_id| {
+            (
+                node_id.clone(),
+                NodeDegree {
+                    node_id,
+                    fan_in: 0,
+                    fan_out: 0,
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    for edge in topology.edges {
+        degrees
+            .get_mut(&edge.from)
+            .expect("validated source node")
+            .fan_out += 1;
+        degrees
+            .get_mut(&edge.to)
+            .expect("validated target node")
+            .fan_in += 1;
+    }
+
+    GraphDegreeSummary {
+        nodes: degrees.into_values().collect(),
+    }
+}
+
+pub fn top_fan_in(summary: &GraphDegreeSummary, limit: usize) -> Vec<NodeDegree> {
+    if limit == 0 {
+        return Vec::new();
+    }
+
+    let mut nodes = summary
+        .nodes
+        .iter()
+        .filter(|node| node.fan_in > 0)
+        .cloned()
+        .collect::<Vec<_>>();
+    nodes.sort_by(|left, right| {
+        right
+            .fan_in
+            .cmp(&left.fan_in)
+            .then_with(|| right.fan_out.cmp(&left.fan_out))
+            .then_with(|| left.node_id.cmp(&right.node_id))
+    });
+    nodes.truncate(limit);
+    nodes
+}
+
+pub fn top_fan_out(summary: &GraphDegreeSummary, limit: usize) -> Vec<NodeDegree> {
+    if limit == 0 {
+        return Vec::new();
+    }
+
+    let mut nodes = summary
+        .nodes
+        .iter()
+        .filter(|node| node.fan_out > 0)
+        .cloned()
+        .collect::<Vec<_>>();
+    nodes.sort_by(|left, right| {
+        right
+            .fan_out
+            .cmp(&left.fan_out)
+            .then_with(|| right.fan_in.cmp(&left.fan_in))
+            .then_with(|| left.node_id.cmp(&right.node_id))
+    });
+    nodes.truncate(limit);
+    nodes
+}

--- a/src/graph/v2/algorithms/mod.rs
+++ b/src/graph/v2/algorithms/mod.rs
@@ -1,0 +1,81 @@
+mod blast_radius;
+mod cycles;
+mod degree;
+mod neighborhood;
+mod summary;
+
+pub use blast_radius::{GraphBlastRadius, blast_radius};
+pub use cycles::{GraphCycle, find_cycles};
+pub use degree::{GraphDegreeSummary, NodeDegree, compute_degrees, top_fan_in, top_fan_out};
+pub use neighborhood::{GraphNeighborhood, neighborhood};
+pub use summary::{GraphV2Summary, summarize_graph};
+
+use super::{GraphEdgeKind, GraphNodeId, GraphSnapshot};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct EdgeKey {
+    from: GraphNodeId,
+    to: GraphNodeId,
+    kind: GraphEdgeKind,
+}
+
+struct GraphTopology {
+    node_ids: Vec<GraphNodeId>,
+    node_set: BTreeSet<GraphNodeId>,
+    edges: Vec<EdgeKey>,
+    outgoing: BTreeMap<GraphNodeId, BTreeSet<GraphNodeId>>,
+    incoming: BTreeMap<GraphNodeId, BTreeSet<GraphNodeId>>,
+}
+
+fn topology(snapshot: &GraphSnapshot) -> GraphTopology {
+    let node_set = snapshot
+        .nodes
+        .iter()
+        .map(|node| node.id.clone())
+        .collect::<BTreeSet<_>>();
+    let node_ids = node_set.iter().cloned().collect::<Vec<_>>();
+    let edges = snapshot
+        .edges
+        .iter()
+        // Algorithms operate only on nodes present in the snapshot. Dangling
+        // endpoints are ignored until graph validation owns that diagnostic.
+        .filter(|edge| node_set.contains(&edge.from) && node_set.contains(&edge.to))
+        .map(|edge| EdgeKey {
+            from: edge.from.clone(),
+            to: edge.to.clone(),
+            kind: edge.kind,
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    let mut outgoing = node_ids
+        .iter()
+        .cloned()
+        .map(|id| (id, BTreeSet::new()))
+        .collect::<BTreeMap<_, _>>();
+    let mut incoming = outgoing.clone();
+
+    for edge in &edges {
+        outgoing
+            .get_mut(&edge.from)
+            .expect("validated source node")
+            .insert(edge.to.clone());
+        incoming
+            .get_mut(&edge.to)
+            .expect("validated target node")
+            .insert(edge.from.clone());
+    }
+
+    GraphTopology {
+        node_ids,
+        node_set,
+        edges,
+        outgoing,
+        incoming,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/graph/v2/algorithms/neighborhood.rs
+++ b/src/graph/v2/algorithms/neighborhood.rs
@@ -1,0 +1,57 @@
+use super::topology;
+use crate::graph::v2::{GraphNodeId, GraphSnapshot};
+use std::collections::{BTreeSet, VecDeque};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphNeighborhood {
+    pub center: GraphNodeId,
+    pub node_ids: Vec<GraphNodeId>,
+    pub edge_count: usize,
+}
+
+pub fn neighborhood(
+    snapshot: &GraphSnapshot,
+    center: &GraphNodeId,
+    depth: usize,
+) -> GraphNeighborhood {
+    let topology = topology(snapshot);
+    if !topology.node_set.contains(center) {
+        return GraphNeighborhood {
+            center: center.clone(),
+            node_ids: Vec::new(),
+            edge_count: 0,
+        };
+    }
+
+    let mut visited = BTreeSet::from([center.clone()]);
+    let mut queue = VecDeque::from([(center.clone(), 0usize)]);
+
+    while let Some((node, distance)) = queue.pop_front() {
+        if distance >= depth {
+            continue;
+        }
+
+        let neighbors = topology.outgoing[&node]
+            .iter()
+            .chain(topology.incoming[&node].iter())
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        for neighbor in neighbors {
+            if visited.insert(neighbor.clone()) {
+                queue.push_back((neighbor, distance + 1));
+            }
+        }
+    }
+
+    let edge_count = topology
+        .edges
+        .iter()
+        .filter(|edge| visited.contains(&edge.from) && visited.contains(&edge.to))
+        .count();
+
+    GraphNeighborhood {
+        center: center.clone(),
+        node_ids: visited.into_iter().collect(),
+        edge_count,
+    }
+}

--- a/src/graph/v2/algorithms/summary.rs
+++ b/src/graph/v2/algorithms/summary.rs
@@ -1,0 +1,27 @@
+use super::{compute_degrees, find_cycles, top_fan_in, top_fan_out, topology};
+use crate::graph::v2::{GraphSnapshot, NodeDegree};
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct GraphV2Summary {
+    pub node_count: usize,
+    pub edge_count: usize,
+    pub diagnostic_count: usize,
+    pub cycle_count: usize,
+    pub top_fan_in: Vec<NodeDegree>,
+    pub top_fan_out: Vec<NodeDegree>,
+}
+
+pub fn summarize_graph(snapshot: &GraphSnapshot, hub_limit: usize) -> GraphV2Summary {
+    let topology = topology(snapshot);
+    let degrees = compute_degrees(snapshot);
+    let cycles = find_cycles(snapshot);
+
+    GraphV2Summary {
+        node_count: topology.node_ids.len(),
+        edge_count: topology.edges.len(),
+        diagnostic_count: snapshot.diagnostics.len(),
+        cycle_count: cycles.len(),
+        top_fan_in: top_fan_in(&degrees, hub_limit),
+        top_fan_out: top_fan_out(&degrees, hub_limit),
+    }
+}

--- a/src/graph/v2/algorithms/tests.rs
+++ b/src/graph/v2/algorithms/tests.rs
@@ -1,0 +1,280 @@
+use super::*;
+use crate::graph::v2::{
+    GraphDiagnostic, GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance, GraphNode,
+    GraphNodeId, GraphNodeKind, GraphSnapshot,
+};
+
+fn id(value: &str) -> GraphNodeId {
+    GraphNodeId::new(value)
+}
+
+fn node(value: &str) -> GraphNode {
+    GraphNode {
+        id: id(value),
+        kind: GraphNodeKind::File,
+        label: value.to_string(),
+        path: None,
+    }
+}
+
+fn edge(from: &str, to: &str) -> GraphEdge {
+    GraphEdge {
+        from: id(from),
+        to: id(to),
+        kind: GraphEdgeKind::Imports,
+        provenance: GraphEdgeProvenance::Import,
+        confidence: GraphEdgeConfidence::High,
+    }
+}
+
+fn snapshot(nodes: &[&str], edges: &[(&str, &str)]) -> GraphSnapshot {
+    GraphSnapshot {
+        nodes: nodes.iter().map(|value| node(value)).collect(),
+        edges: edges.iter().map(|(from, to)| edge(from, to)).collect(),
+        diagnostics: Vec::new(),
+    }
+}
+
+fn degree<'a>(summary: &'a GraphDegreeSummary, node_id: &str) -> &'a NodeDegree {
+    summary
+        .nodes
+        .iter()
+        .find(|degree| degree.node_id.as_str() == node_id)
+        .expect("node degree should exist")
+}
+
+#[test]
+fn empty_and_disconnected_graphs_have_deterministic_degree_summaries() {
+    assert!(compute_degrees(&GraphSnapshot::default()).nodes.is_empty());
+
+    let summary = compute_degrees(&snapshot(&["b", "a"], &[]));
+
+    assert_eq!(
+        summary
+            .nodes
+            .iter()
+            .map(|degree| degree.node_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a", "b"]
+    );
+    assert!(summary.nodes.iter().all(|node| node.fan_in == 0));
+    assert!(summary.nodes.iter().all(|node| node.fan_out == 0));
+}
+
+#[test]
+fn degrees_count_each_exact_edge_once() {
+    let graph = snapshot(&["a", "b"], &[("a", "b"), ("a", "b")]);
+
+    let summary = compute_degrees(&graph);
+
+    assert_eq!(degree(&summary, "a").fan_out, 1);
+    assert_eq!(degree(&summary, "a").fan_in, 0);
+    assert_eq!(degree(&summary, "b").fan_in, 1);
+    assert_eq!(degree(&summary, "b").fan_out, 0);
+}
+
+#[test]
+fn hub_helpers_apply_rankings_limits_and_zero_filtering() {
+    let graph = snapshot(
+        &["a", "b", "c", "d", "z"],
+        &[("a", "c"), ("a", "d"), ("b", "c"), ("b", "d")],
+    );
+    let summary = compute_degrees(&graph);
+
+    assert_eq!(
+        top_fan_in(&summary, 2)
+            .iter()
+            .map(|node| node.node_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["c", "d"]
+    );
+    assert_eq!(
+        top_fan_out(&summary, 2)
+            .iter()
+            .map(|node| node.node_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a", "b"]
+    );
+    assert!(top_fan_in(&summary, 0).is_empty());
+    assert!(top_fan_out(&summary, 0).is_empty());
+    assert!(
+        top_fan_in(&summary, usize::MAX)
+            .iter()
+            .all(|node| node.node_id.as_str() != "z")
+    );
+}
+
+#[test]
+fn acyclic_graph_has_no_cycles() {
+    assert!(find_cycles(&snapshot(&["a", "b", "c"], &[("a", "b"), ("b", "c")])).is_empty());
+}
+
+#[test]
+fn tarjan_groups_directed_cycle_and_self_loop() {
+    let graph = snapshot(
+        &["a", "b", "c", "d"],
+        &[("a", "b"), ("b", "c"), ("c", "a"), ("d", "d"), ("d", "d")],
+    );
+
+    let cycles = find_cycles(&graph);
+
+    assert_eq!(
+        cycles,
+        vec![
+            GraphCycle {
+                node_ids: vec![id("a"), id("b"), id("c")],
+            },
+            GraphCycle {
+                node_ids: vec![id("d")],
+            },
+        ]
+    );
+}
+
+#[test]
+fn multiple_cycles_sort_by_size_then_first_node() {
+    let graph = snapshot(
+        &["a", "b", "c", "d", "e", "f"],
+        &[
+            ("a", "b"),
+            ("b", "a"),
+            ("c", "d"),
+            ("d", "e"),
+            ("e", "c"),
+            ("f", "f"),
+        ],
+    );
+
+    let cycles = find_cycles(&graph);
+
+    assert_eq!(cycles[0].node_ids, vec![id("c"), id("d"), id("e")]);
+    assert_eq!(cycles[1].node_ids, vec![id("a"), id("b")]);
+    assert_eq!(cycles[2].node_ids, vec![id("f")]);
+}
+
+#[test]
+fn neighborhood_depth_zero_returns_only_center() {
+    let graph = snapshot(&["a", "b"], &[("a", "b")]);
+
+    let result = neighborhood(&graph, &id("a"), 0);
+
+    assert_eq!(result.node_ids, vec![id("a")]);
+    assert_eq!(result.edge_count, 0);
+}
+
+#[test]
+fn neighborhood_traverses_incoming_and_outgoing_edges() {
+    let graph = snapshot(&["a", "b", "c", "d"], &[("a", "b"), ("b", "c"), ("d", "b")]);
+
+    let depth_one = neighborhood(&graph, &id("b"), 1);
+    let depth_two = neighborhood(&graph, &id("b"), 2);
+
+    assert_eq!(depth_one.node_ids, vec![id("a"), id("b"), id("c"), id("d")]);
+    assert_eq!(depth_one.edge_count, 3);
+    assert_eq!(depth_two, depth_one);
+}
+
+#[test]
+fn neighborhood_depth_two_expands_one_more_step_and_sorts_nodes() {
+    let graph = snapshot(&["a", "b", "c", "d"], &[("a", "b"), ("b", "c"), ("c", "d")]);
+
+    assert_eq!(
+        neighborhood(&graph, &id("a"), 1).node_ids,
+        vec![id("a"), id("b")]
+    );
+    assert_eq!(
+        neighborhood(&graph, &id("a"), 2).node_ids,
+        vec![id("a"), id("b"), id("c")]
+    );
+}
+
+#[test]
+fn missing_neighborhood_center_returns_empty_result() {
+    let result = neighborhood(&snapshot(&["a"], &[]), &id("missing"), 2);
+
+    assert_eq!(result.center, id("missing"));
+    assert!(result.node_ids.is_empty());
+    assert_eq!(result.edge_count, 0);
+}
+
+#[test]
+fn dangling_edges_are_ignored_by_algorithms() {
+    let graph = snapshot(&["a"], &[("a", "missing")]);
+
+    assert_eq!(
+        compute_degrees(&graph).nodes,
+        vec![NodeDegree {
+            node_id: id("a"),
+            fan_in: 0,
+            fan_out: 0,
+        }]
+    );
+    assert!(find_cycles(&graph).is_empty());
+    assert_eq!(neighborhood(&graph, &id("a"), 1).node_ids, vec![id("a")]);
+}
+
+#[test]
+fn graph_summary_counts_effective_graph_and_respects_hub_limit() {
+    let mut graph = snapshot(
+        &["a", "b", "c"],
+        &[("a", "b"), ("a", "b"), ("b", "a"), ("c", "a")],
+    );
+    graph.diagnostics.push(GraphDiagnostic {
+        code: "graph.example".to_string(),
+        message: "example".to_string(),
+        path: None,
+    });
+
+    let summary = summarize_graph(&graph, 1);
+
+    assert_eq!(summary.node_count, 3);
+    assert_eq!(summary.edge_count, 3);
+    assert_eq!(summary.diagnostic_count, 1);
+    assert_eq!(summary.cycle_count, 1);
+    assert_eq!(summary.top_fan_in.len(), 1);
+    assert_eq!(summary.top_fan_out.len(), 1);
+}
+
+#[test]
+fn graph_summary_is_independent_of_node_and_edge_order() {
+    let first = snapshot(&["a", "b", "c"], &[("a", "b"), ("b", "c"), ("c", "a")]);
+    let second = snapshot(&["c", "a", "b"], &[("c", "a"), ("a", "b"), ("b", "c")]);
+
+    assert_eq!(summarize_graph(&first, 3), summarize_graph(&second, 3));
+}
+
+#[test]
+fn blast_radius_collects_transitive_dependents_of_a_seed() {
+    // a -> b -> c and d -> b, so changing `c` impacts b (imports c) and the
+    // transitive importers a and d.
+    let graph = snapshot(&["a", "b", "c", "d"], &[("a", "b"), ("b", "c"), ("d", "b")]);
+
+    let radius = blast_radius(&graph, &[id("c")]);
+
+    assert_eq!(radius.seeds, vec![id("c")]);
+    assert_eq!(radius.impacted, vec![id("a"), id("b"), id("d")]);
+}
+
+#[test]
+fn blast_radius_unions_multiple_seeds_and_excludes_them() {
+    let graph = snapshot(&["a", "b", "c", "d"], &[("a", "b"), ("b", "c"), ("d", "b")]);
+
+    let radius = blast_radius(&graph, &[id("c"), id("d")]);
+
+    assert_eq!(radius.seeds, vec![id("c"), id("d")]);
+    assert_eq!(radius.impacted, vec![id("a"), id("b")]);
+}
+
+#[test]
+fn blast_radius_ignores_missing_seeds_and_terminates_on_cycles() {
+    let graph = snapshot(&["a", "b"], &[("a", "b"), ("b", "a")]);
+
+    let radius = blast_radius(&graph, &[id("a"), id("missing")]);
+
+    assert_eq!(radius.seeds, vec![id("a")]);
+    assert_eq!(radius.impacted, vec![id("b")]);
+
+    let empty = blast_radius(&graph, &[id("missing")]);
+    assert!(empty.seeds.is_empty());
+    assert!(empty.impacted.is_empty());
+}

--- a/src/graph/v2/builder/mod.rs
+++ b/src/graph/v2/builder/mod.rs
@@ -1,0 +1,167 @@
+mod test_edges;
+
+use super::{
+    GraphDiagnostic, GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance, GraphNode,
+    GraphNodeId, GraphNodeKind, GraphSnapshot,
+};
+use crate::graph::resolve_import;
+use crate::graph::resolver::normalize_path;
+use crate::scan::facts::ScanFacts;
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+
+pub fn graph_snapshot_from_scan(scan: &ScanFacts) -> GraphSnapshot {
+    let root = normalize_path(&scan.root_path);
+    let mut files = scan
+        .files
+        .iter()
+        .map(|file| {
+            let path = normalize_path(&file.path);
+            let relative_path = repository_relative_path(&root, &path);
+            let label = slash_path(&relative_path);
+            let id = GraphNodeId::new(format!("file:{label}"));
+            (id, label, path, &file.imports)
+        })
+        .collect::<Vec<_>>();
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let known_files = files
+        .iter()
+        .map(|(id, _, path, _)| (path.clone(), id.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let known_paths = known_files.keys().cloned().collect::<HashSet<_>>();
+    let mut nodes = files
+        .iter()
+        .map(|(id, label, path, _)| {
+            (
+                id.clone(),
+                GraphNode {
+                    id: id.clone(),
+                    kind: GraphNodeKind::File,
+                    label: label.clone(),
+                    path: Some(path.clone()),
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut edges = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    for (source_id, _, source_path, imports) in files {
+        for raw_import in imports {
+            let raw_import = raw_import.trim();
+            if raw_import.is_empty() {
+                continue;
+            }
+
+            let (target_id, kind, confidence) =
+                match resolve_import(raw_import, &source_path, &root, &known_paths) {
+                    // A file importing itself carries no dependency information.
+                    Some(resolved) if resolved == source_path => continue,
+                    Some(resolved) => (
+                        known_files
+                            .get(&resolved)
+                            .cloned()
+                            .expect("resolver only returns scanned file paths"),
+                        GraphEdgeKind::Imports,
+                        GraphEdgeConfidence::High,
+                    ),
+                    None => {
+                        // The shared resolver is authoritative: an unresolved
+                        // relative import is a genuine local gap worth surfacing,
+                        // while a bare/package import is a real external dependency.
+                        let confidence = if is_relative_import(raw_import) {
+                            diagnostics.push(GraphDiagnostic {
+                            code: "graph-v2.unresolved-import".to_string(),
+                            message: format!(
+                                "Relative import `{raw_import}` did not resolve to a scanned file"
+                            ),
+                            path: Some(source_path.clone()),
+                        });
+                            GraphEdgeConfidence::Low
+                        } else {
+                            GraphEdgeConfidence::Medium
+                        };
+                        (
+                            external_node_id(&normalize_import(raw_import), &mut nodes),
+                            GraphEdgeKind::DependsOn,
+                            confidence,
+                        )
+                    }
+                };
+
+            edges.push(GraphEdge {
+                from: source_id.clone(),
+                to: target_id,
+                kind,
+                provenance: GraphEdgeProvenance::Import,
+                confidence,
+            });
+        }
+    }
+
+    edges.extend(test_edges::test_of_edges(&known_files));
+
+    edges.sort_by(|left, right| {
+        left.from
+            .cmp(&right.from)
+            .then_with(|| left.to.cmp(&right.to))
+            .then_with(|| left.kind.cmp(&right.kind))
+    });
+    // Collapse duplicate relationships by identity, keeping one edge per
+    // (from, to, kind) regardless of how many imports produced it.
+    edges.dedup_by(|left, right| {
+        left.from == right.from && left.to == right.to && left.kind == right.kind
+    });
+
+    diagnostics.sort_by(|left, right| {
+        left.code
+            .cmp(&right.code)
+            .then_with(|| left.path.cmp(&right.path))
+            .then_with(|| left.message.cmp(&right.message))
+    });
+    diagnostics.dedup();
+
+    GraphSnapshot {
+        nodes: nodes.into_values().collect(),
+        edges,
+        diagnostics,
+    }
+}
+
+fn repository_relative_path(root: &Path, path: &Path) -> PathBuf {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    if !relative.as_os_str().is_empty() {
+        return relative.to_path_buf();
+    }
+
+    path.file_name()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("unknown"))
+}
+
+fn slash_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn normalize_import(raw_import: &str) -> String {
+    raw_import.trim().replace('\\', "/")
+}
+
+fn is_relative_import(import: &str) -> bool {
+    import.starts_with("./") || import.starts_with("../")
+}
+
+fn external_node_id(import: &str, nodes: &mut BTreeMap<GraphNodeId, GraphNode>) -> GraphNodeId {
+    let id = GraphNodeId::new(format!("external:{import}"));
+    nodes.entry(id.clone()).or_insert_with(|| GraphNode {
+        id: id.clone(),
+        kind: GraphNodeKind::ExternalDependency,
+        label: import.to_string(),
+        path: None,
+    });
+    id
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/graph/v2/builder/test_edges.rs
+++ b/src/graph/v2/builder/test_edges.rs
@@ -1,0 +1,134 @@
+use crate::graph::v2::{
+    GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance, GraphNodeId,
+};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Adds `TestOf` edges from co-located test files to the file they exercise,
+/// using conservative naming conventions. An edge is only emitted when the
+/// inferred subject is itself a scanned file, so unknown subjects are skipped.
+pub(super) fn test_of_edges(known_files: &BTreeMap<PathBuf, GraphNodeId>) -> Vec<GraphEdge> {
+    known_files
+        .iter()
+        .filter_map(|(path, test_id)| {
+            let subject_path = test_subject_path(path)?;
+            let subject_id = known_files.get(&subject_path)?;
+            Some(GraphEdge {
+                from: test_id.clone(),
+                to: subject_id.clone(),
+                kind: GraphEdgeKind::TestOf,
+                provenance: GraphEdgeProvenance::TestHeuristic,
+                confidence: GraphEdgeConfidence::High,
+            })
+        })
+        .collect()
+}
+
+/// The sibling file a test file most likely exercises, or `None` when the name
+/// does not match a known test convention.
+fn test_subject_path(path: &Path) -> Option<PathBuf> {
+    let file_name = path.file_name()?.to_str()?;
+    let subject = test_subject_file_name(file_name)?;
+    Some(path.with_file_name(subject))
+}
+
+fn test_subject_file_name(file_name: &str) -> Option<String> {
+    // `foo.test.ts` / `foo.spec.tsx` -> `foo.ts` / `foo.tsx` (JS/TS family).
+    for marker in [".test.", ".spec."] {
+        if let Some(index) = file_name.find(marker) {
+            let stem = &file_name[..index];
+            let extension = &file_name[index + marker.len()..];
+            if !stem.is_empty()
+                && matches!(
+                    extension,
+                    "ts" | "tsx" | "js" | "jsx" | "mts" | "cts" | "mjs" | "cjs"
+                )
+            {
+                return Some(format!("{stem}.{extension}"));
+            }
+        }
+    }
+
+    // `name_test.go` -> `name.go`, `name_test.py` -> `name.py`.
+    for suffix in ["_test.go", "_test.py"] {
+        if let Some(stem) = file_name.strip_suffix(suffix)
+            && !stem.is_empty()
+        {
+            let extension = &suffix["_test.".len()..];
+            return Some(format!("{stem}.{extension}"));
+        }
+    }
+
+    // `test_name.py` -> `name.py` (pytest convention).
+    if let Some(rest) = file_name.strip_prefix("test_")
+        && rest.ends_with(".py")
+        && rest.len() > ".py".len()
+    {
+        return Some(rest.to_string());
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_common_test_naming_conventions() {
+        assert_eq!(
+            test_subject_file_name("math.test.ts").as_deref(),
+            Some("math.ts")
+        );
+        assert_eq!(
+            test_subject_file_name("api.spec.tsx").as_deref(),
+            Some("api.tsx")
+        );
+        assert_eq!(
+            test_subject_file_name("server_test.go").as_deref(),
+            Some("server.go")
+        );
+        assert_eq!(
+            test_subject_file_name("client_test.py").as_deref(),
+            Some("client.py")
+        );
+        assert_eq!(
+            test_subject_file_name("test_client.py").as_deref(),
+            Some("client.py")
+        );
+    }
+
+    #[test]
+    fn ignores_non_test_and_malformed_names() {
+        assert_eq!(test_subject_file_name("math.ts"), None);
+        assert_eq!(test_subject_file_name(".test.ts"), None);
+        assert_eq!(test_subject_file_name("_test.go"), None);
+        assert_eq!(test_subject_file_name("test_.py"), None);
+        assert_eq!(test_subject_file_name("math.test.rs"), None);
+    }
+
+    #[test]
+    fn emits_edge_only_when_subject_is_a_known_file() {
+        let mut known = BTreeMap::new();
+        known.insert(
+            PathBuf::from("/repo/src/math.ts"),
+            GraphNodeId::new("file:src/math.ts"),
+        );
+        known.insert(
+            PathBuf::from("/repo/src/math.test.ts"),
+            GraphNodeId::new("file:src/math.test.ts"),
+        );
+        // A test file whose subject was not scanned produces no edge.
+        known.insert(
+            PathBuf::from("/repo/src/orphan.test.ts"),
+            GraphNodeId::new("file:src/orphan.test.ts"),
+        );
+
+        let edges = test_of_edges(&known);
+
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].from.as_str(), "file:src/math.test.ts");
+        assert_eq!(edges[0].to.as_str(), "file:src/math.ts");
+        assert_eq!(edges[0].kind, GraphEdgeKind::TestOf);
+    }
+}

--- a/src/graph/v2/builder/tests.rs
+++ b/src/graph/v2/builder/tests.rs
@@ -1,0 +1,185 @@
+use super::*;
+use crate::scan::facts::FileFacts;
+
+fn file(path: &str, imports: &[&str]) -> FileFacts {
+    FileFacts {
+        path: PathBuf::from(path),
+        language: None,
+        non_empty_lines: 0,
+        branch_count: 0,
+        imports: imports.iter().map(|value| (*value).to_string()).collect(),
+        content: None,
+        has_inline_tests: false,
+    }
+}
+
+fn scan(files: Vec<FileFacts>) -> ScanFacts {
+    ScanFacts {
+        root_path: PathBuf::from("/repo"),
+        files,
+        ..ScanFacts::default()
+    }
+}
+
+#[test]
+fn empty_scan_creates_empty_snapshot() {
+    assert_eq!(
+        graph_snapshot_from_scan(&ScanFacts::default()),
+        GraphSnapshot::default()
+    );
+}
+
+#[test]
+fn file_nodes_use_relative_stable_ids_and_keep_path_metadata() {
+    let snapshot = graph_snapshot_from_scan(&scan(vec![file("/repo/src/main.rs", &[])]));
+
+    assert_eq!(snapshot.node_count(), 1);
+    assert_eq!(snapshot.nodes[0].id.as_str(), "file:src/main.rs");
+    assert_eq!(snapshot.nodes[0].label, "src/main.rs");
+    assert_eq!(
+        snapshot.nodes[0].path.as_deref(),
+        Some(Path::new("/repo/src/main.rs"))
+    );
+    assert!(!snapshot.nodes[0].id.as_str().contains("/repo"));
+}
+
+#[test]
+fn relative_import_resolves_common_extension_and_deduplicates_edges() {
+    let snapshot = graph_snapshot_from_scan(&scan(vec![
+        file("/repo/src/main.ts", &["./util", "./util", "./components"]),
+        file("/repo/src/util.ts", &[]),
+        file("/repo/src/components/index.ts", &[]),
+    ]));
+
+    assert_eq!(snapshot.node_count(), 3);
+    assert_eq!(snapshot.edge_count(), 2);
+    assert_eq!(snapshot.edges[0].from.as_str(), "file:src/main.ts");
+    assert_eq!(
+        snapshot.edges[0].to.as_str(),
+        "file:src/components/index.ts"
+    );
+    // A resolved local import is a high-confidence `Imports` edge.
+    assert_eq!(snapshot.edges[0].kind, GraphEdgeKind::Imports);
+    assert_eq!(snapshot.edges[0].provenance, GraphEdgeProvenance::Import);
+    assert_eq!(snapshot.edges[0].confidence, GraphEdgeConfidence::High);
+    assert_eq!(snapshot.edges[1].to.as_str(), "file:src/util.ts");
+}
+
+#[test]
+fn package_and_unresolved_relative_imports_create_external_nodes() {
+    let snapshot = graph_snapshot_from_scan(&scan(vec![file(
+        "/repo/src/main.ts",
+        &["react", "./missing"],
+    )]));
+
+    assert_eq!(snapshot.node_count(), 3);
+    assert_eq!(snapshot.edge_count(), 2);
+    assert!(
+        snapshot
+            .nodes
+            .iter()
+            .any(|node| node.id.as_str() == "external:react"
+                && node.kind == GraphNodeKind::ExternalDependency
+                && node.path.is_none())
+    );
+
+    // A bare package import is a medium-confidence external dependency.
+    let react = snapshot
+        .edges
+        .iter()
+        .find(|edge| edge.to.as_str() == "external:react")
+        .expect("external package edge");
+    assert_eq!(react.kind, GraphEdgeKind::DependsOn);
+    assert_eq!(react.confidence, GraphEdgeConfidence::Medium);
+
+    // An unresolved relative import is low confidence and also diagnosed.
+    let missing = snapshot
+        .edges
+        .iter()
+        .find(|edge| edge.to.as_str() == "external:./missing")
+        .expect("unresolved relative import edge");
+    assert_eq!(missing.kind, GraphEdgeKind::DependsOn);
+    assert_eq!(missing.confidence, GraphEdgeConfidence::Low);
+    assert_eq!(snapshot.diagnostic_count(), 1);
+    assert_eq!(snapshot.diagnostics[0].code, "graph-v2.unresolved-import");
+}
+
+#[test]
+fn snapshot_order_is_independent_of_file_and_import_order() {
+    let first = graph_snapshot_from_scan(&scan(vec![
+        file("/repo/src/b.ts", &["react", "./a"]),
+        file("/repo/src/a.ts", &[]),
+    ]));
+    let second = graph_snapshot_from_scan(&scan(vec![
+        file("/repo/src/a.ts", &[]),
+        file("/repo/src/b.ts", &["./a", "react"]),
+    ]));
+
+    assert_eq!(first, second);
+}
+
+#[test]
+fn relative_import_resolves_deterministically_via_shared_resolver() {
+    // With both `util.js` and `util.ts` present, the shared TypeScript
+    // resolver probes extensions in a fixed order and picks `util.ts`, so
+    // there is no ambiguity and no diagnostic.
+    let snapshot = graph_snapshot_from_scan(&scan(vec![
+        file("/repo/src/main.ts", &["./util"]),
+        file("/repo/src/util.js", &[]),
+        file("/repo/src/util.ts", &[]),
+    ]));
+
+    assert_eq!(snapshot.edge_count(), 1);
+    assert_eq!(snapshot.diagnostic_count(), 0);
+    assert_eq!(snapshot.edges[0].to.as_str(), "file:src/util.ts");
+}
+
+#[test]
+fn rust_crate_import_resolves_to_local_module() {
+    let snapshot = graph_snapshot_from_scan(&scan(vec![
+        file("/repo/src/lib.rs", &["crate::foo"]),
+        file("/repo/src/foo.rs", &[]),
+    ]));
+
+    assert_eq!(snapshot.edge_count(), 1);
+    assert_eq!(snapshot.edges[0].from.as_str(), "file:src/lib.rs");
+    assert_eq!(snapshot.edges[0].to.as_str(), "file:src/foo.rs");
+    // `crate::` now resolves to a real file node instead of `external:`.
+    assert!(
+        snapshot
+            .nodes
+            .iter()
+            .all(|node| node.kind != GraphNodeKind::ExternalDependency)
+    );
+}
+
+#[test]
+fn rust_super_import_resolves_to_parent_module() {
+    let snapshot = graph_snapshot_from_scan(&scan(vec![
+        file("/repo/src/app/handler.rs", &["super::config"]),
+        file("/repo/src/app/config.rs", &[]),
+    ]));
+
+    assert_eq!(snapshot.edge_count(), 1);
+    assert_eq!(snapshot.edges[0].from.as_str(), "file:src/app/handler.rs");
+    assert_eq!(snapshot.edges[0].to.as_str(), "file:src/app/config.rs");
+}
+
+#[test]
+fn test_files_link_to_their_subject_with_a_test_of_edge() {
+    let snapshot = graph_snapshot_from_scan(&scan(vec![
+        file("/repo/src/math.ts", &[]),
+        file("/repo/src/math.test.ts", &["./math"]),
+    ]));
+
+    // The TestOf edge is emitted alongside the import edge between the pair.
+    let test_of = snapshot
+        .edges
+        .iter()
+        .find(|edge| edge.kind == GraphEdgeKind::TestOf)
+        .expect("test-of edge");
+    assert_eq!(test_of.from.as_str(), "file:src/math.test.ts");
+    assert_eq!(test_of.to.as_str(), "file:src/math.ts");
+    assert_eq!(test_of.provenance, GraphEdgeProvenance::TestHeuristic);
+    assert_eq!(test_of.confidence, GraphEdgeConfidence::High);
+}

--- a/src/graph/v2/diagnostic.rs
+++ b/src/graph/v2/diagnostic.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphDiagnostic {
+    pub code: String,
+    pub message: String,
+    pub path: Option<PathBuf>,
+}

--- a/src/graph/v2/edge.rs
+++ b/src/graph/v2/edge.rs
@@ -1,0 +1,41 @@
+use super::GraphNodeId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum GraphEdgeKind {
+    Imports,
+    ReExports,
+    DependsOn,
+    TestOf,
+    GeneratedFrom,
+    Configures,
+}
+
+/// Where an edge's evidence came from. Lets consumers weigh how an edge was
+/// derived without re-deriving it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum GraphEdgeProvenance {
+    /// Derived from an extracted import or module declaration.
+    Import,
+    /// Inferred from a test-file naming convention.
+    TestHeuristic,
+}
+
+/// How strongly graph v2 trusts that an edge reflects a real relationship.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum GraphEdgeConfidence {
+    /// The relationship was resolved to a concrete scanned file.
+    High,
+    /// A well-formed external dependency we cannot resolve to a scanned file.
+    Medium,
+    /// An import that looked local but did not resolve to any scanned file.
+    Low,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphEdge {
+    pub from: GraphNodeId,
+    pub to: GraphNodeId,
+    pub kind: GraphEdgeKind,
+    pub provenance: GraphEdgeProvenance,
+    pub confidence: GraphEdgeConfidence,
+}

--- a/src/graph/v2/mod.rs
+++ b/src/graph/v2/mod.rs
@@ -1,0 +1,88 @@
+mod algorithms;
+mod builder;
+mod diagnostic;
+mod edge;
+mod node;
+mod snapshot;
+
+pub use algorithms::{
+    GraphBlastRadius, GraphCycle, GraphDegreeSummary, GraphNeighborhood, GraphV2Summary,
+    NodeDegree, blast_radius, compute_degrees, find_cycles, neighborhood, summarize_graph,
+    top_fan_in, top_fan_out,
+};
+pub use builder::graph_snapshot_from_scan;
+pub use diagnostic::GraphDiagnostic;
+pub use edge::{GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance};
+pub use node::{GraphNode, GraphNodeId, GraphNodeKind};
+pub use snapshot::GraphSnapshot;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn node_id_stores_value_and_sorts_deterministically() {
+        let first = GraphNodeId::new("file:src/a.rs");
+        let second = GraphNodeId::new("file:src/b.rs");
+        let mut ids = [second, first.clone()];
+
+        ids.sort();
+
+        assert_eq!(first.as_str(), "file:src/a.rs");
+        assert_eq!(ids[0], first);
+    }
+
+    #[test]
+    fn new_snapshot_is_empty() {
+        let snapshot = GraphSnapshot::new();
+
+        assert_eq!(snapshot.node_count(), 0);
+        assert_eq!(snapshot.edge_count(), 0);
+        assert_eq!(snapshot.diagnostic_count(), 0);
+    }
+
+    #[test]
+    fn snapshot_adds_nodes_edges_and_diagnostics() {
+        let source_id = GraphNodeId::new("file:src/lib.rs");
+        let target_id = GraphNodeId::new("external:serde");
+        let mut snapshot = GraphSnapshot::new();
+
+        snapshot.add_node(GraphNode {
+            id: source_id.clone(),
+            kind: GraphNodeKind::File,
+            label: "src/lib.rs".to_string(),
+            path: Some(PathBuf::from("src/lib.rs")),
+        });
+        snapshot.add_node(GraphNode {
+            id: target_id.clone(),
+            kind: GraphNodeKind::ExternalDependency,
+            label: "serde".to_string(),
+            path: None,
+        });
+        snapshot.add_edge(GraphEdge {
+            from: source_id.clone(),
+            to: target_id.clone(),
+            kind: GraphEdgeKind::DependsOn,
+            provenance: GraphEdgeProvenance::Import,
+            confidence: GraphEdgeConfidence::High,
+        });
+        snapshot.add_diagnostic(GraphDiagnostic {
+            code: "graph.unresolved-import".to_string(),
+            message: "could not resolve one import".to_string(),
+            path: Some(PathBuf::from("src/lib.rs")),
+        });
+
+        assert_eq!(snapshot.node_count(), 2);
+        assert_eq!(snapshot.edge_count(), 1);
+        assert_eq!(snapshot.diagnostic_count(), 1);
+        assert_eq!(
+            snapshot.nodes[0].path.as_deref(),
+            Some(std::path::Path::new("src/lib.rs"))
+        );
+        assert!(snapshot.nodes[1].path.is_none());
+        assert_eq!(snapshot.edges[0].from, source_id);
+        assert_eq!(snapshot.edges[0].to, target_id);
+        assert_eq!(snapshot.edges[0].kind, GraphEdgeKind::DependsOn);
+    }
+}

--- a/src/graph/v2/node.rs
+++ b/src/graph/v2/node.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GraphNodeId(String);
+
+impl GraphNodeId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GraphNodeKind {
+    File,
+    Directory,
+    Package,
+    Workspace,
+    ExternalDependency,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphNode {
+    pub id: GraphNodeId,
+    pub kind: GraphNodeKind,
+    pub label: String,
+    pub path: Option<PathBuf>,
+}

--- a/src/graph/v2/snapshot.rs
+++ b/src/graph/v2/snapshot.rs
@@ -1,0 +1,38 @@
+use super::{GraphDiagnostic, GraphEdge, GraphNode};
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct GraphSnapshot {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+    pub diagnostics: Vec<GraphDiagnostic>,
+}
+
+impl GraphSnapshot {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn edge_count(&self) -> usize {
+        self.edges.len()
+    }
+
+    pub fn diagnostic_count(&self) -> usize {
+        self.diagnostics.len()
+    }
+
+    pub fn add_node(&mut self, node: GraphNode) {
+        self.nodes.push(node);
+    }
+
+    pub fn add_edge(&mut self, edge: GraphEdge) {
+        self.edges.push(edge);
+    }
+
+    pub fn add_diagnostic(&mut self, diagnostic: GraphDiagnostic) {
+        self.diagnostics.push(diagnostic);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the first usable internal Dependency Graph v2 foundation.

This PR introduces the internal graph v2 builder and deterministic graph algorithms. It turns graph v2 from isolated core types into a usable internal graph model that can later power architecture rules, review blast radius, AI context hot files, and rule capability metadata.

The graph remains internal and is not exposed through new CLI commands or public report schemas.

## Type of change

* [x] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added / expanded the Dependency Graph v2 engineering design document.
* Linked the graph v2 design from the docs index.
* Added an internal `GraphSnapshot` builder from scan/import facts.
* Added typed graph edges for dependency relationships.
* Added edge provenance and confidence metadata.
* Added bounded graph diagnostics for unresolved or uncertain graph evidence.
* Added deterministic graph algorithms for:

  * degree summaries;
  * fan-in / fan-out hubs;
  * SCC-based cycle detection;
  * local neighborhoods;
  * transitive blast radius;
  * compact graph summaries.
* Added focused graph tests for builder behavior and algorithms.
* Updated `analysis-platform-state.md` to mark graph v2 builder and algorithms as internal foundations that are not yet product-facing.

## Why

RepoPilot is moving toward a shared internal analysis pipeline:

```text
files
  -> facts
  -> graph
  -> rules
  -> findings
  -> risk
  -> suppressions / decisions
  -> reports / AI context / MCP
```

The facts layer now exists and already feeds AI context through an aggregate repository facts summary. The next required layer is a first-class dependency graph that can be computed once and reused by architecture rules, review signals, risk scoring, and AI context.

This PR creates that internal graph foundation without changing public CLI behavior.

## Contract and ownership

* [x] The change stays within the internal graph v2 module, graph documentation, and focused tests.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] No new public CLI command is added.
* [x] `inspect graph` is not reintroduced.
* [x] No public scan/review/AI context behavior changes are introduced.
* [x] No JSON/SARIF/baseline/report schema changes are introduced.
* [x] Existing graph-related architecture rules are not migrated yet.
* [x] Graph v2 algorithms are deterministic and tested.
* [x] No unrelated refactor or generated-file churn is included.

## Not included in this PR

* No migration of existing graph-related findings to graph v2.
* No graph v2 output in public scan/review reports.
* No graph v2 hot-files section in AI context.
* No Mermaid rendering.
* No new public diagnostic command.
* No claim that graph v2 is complete semantic dependency analysis.

## Changelog

* [ ] `CHANGELOG.md` updated

Skipped because this is an internal graph foundation change with no public CLI behavior or schema change.

## Verification

```bash
cargo test graph
git diff --check
git status --short
```
