### PR TITLE
feat(graph): add directory dependency aggregation

### DIFF
--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -155,8 +155,8 @@ architecture direction. Its isolated internal core types and a `GraphSnapshot`
 builder now exist; the builder reuses RepoPilot's shared language-aware import
 resolvers and emits typed edges (`Imports`/`DependsOn`/`TestOf`) carrying
 provenance and a confidence tier. Deterministic internal graph algorithms cover
-degrees, hubs, SCC cycles, neighborhoods, transitive blast radius, and summaries,
-but are not yet product-facing.
+degrees, hubs, SCC cycles, neighborhoods, transitive blast radius, directory-level
+dependency aggregation, and summaries, but are not yet product-facing.
 
 1. Migrate existing graph-related architecture rules to graph v2.
 2. Feed graph v2 blast radius into review.

--- a/docs/engineering/dependency-graph-v2.md
+++ b/docs/engineering/dependency-graph-v2.md
@@ -24,8 +24,9 @@ findings, review blast radius, AI context, or public report schemas.
 
 Graph v2 now has internal algorithms for degree summaries, hubs, SCC-based cycle
 detection, local neighborhoods, transitive blast radius (reverse dependents of a
-changed set), and compact deterministic graph summaries. These algorithms are not
-yet used by public scan, review, or AI context output.
+changed set), directory-level dependency aggregation (cross-directory coupling),
+and compact deterministic graph summaries. These algorithms are not yet used by
+public scan, review, or AI context output.
 
 Today, `CouplingGraph`, `RepoContextGraph`, import extraction, language
 resolvers, review signals, and graph summaries provide useful behavior. Graph

--- a/src/graph/v2/algorithms/directory.rs
+++ b/src/graph/v2/algorithms/directory.rs
@@ -1,0 +1,69 @@
+use crate::graph::v2::{GraphNodeKind, GraphSnapshot};
+use std::collections::BTreeMap;
+
+/// A directory-level dependency: the number of file-level dependency edges that
+/// cross from one directory into another.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectoryDependency {
+    pub from: String,
+    pub to: String,
+    pub edge_count: usize,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct GraphDirectoryDependencies {
+    pub edges: Vec<DirectoryDependency>,
+}
+
+/// Projects the file-level dependency graph onto directories: each file is
+/// mapped to its parent directory and dependency edges are aggregated into
+/// directory -> directory edges with counts. Intra-directory edges (cohesion)
+/// and edges touching non-file nodes (e.g. external dependencies) are excluded,
+/// leaving the cross-directory coupling that boundary and layer analysis builds
+/// on. Output is sorted by (from, to) for determinism.
+pub fn directory_dependencies(snapshot: &GraphSnapshot) -> GraphDirectoryDependencies {
+    let directory_by_file = snapshot
+        .nodes
+        .iter()
+        .filter(|node| node.kind == GraphNodeKind::File)
+        .map(|node| (node.id.clone(), directory_of(&node.label)))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut counts: BTreeMap<(String, String), usize> = BTreeMap::new();
+    for edge in &snapshot.edges {
+        if !edge.kind.is_dependency() {
+            continue;
+        }
+        let (Some(from_dir), Some(to_dir)) = (
+            directory_by_file.get(&edge.from),
+            directory_by_file.get(&edge.to),
+        ) else {
+            continue;
+        };
+        if from_dir != to_dir {
+            *counts
+                .entry((from_dir.clone(), to_dir.clone()))
+                .or_insert(0) += 1;
+        }
+    }
+
+    let edges = counts
+        .into_iter()
+        .map(|((from, to), edge_count)| DirectoryDependency {
+            from,
+            to,
+            edge_count,
+        })
+        .collect();
+
+    GraphDirectoryDependencies { edges }
+}
+
+/// The parent directory of a repository-relative slash path, or `"."` for files
+/// at the repository root.
+fn directory_of(label: &str) -> String {
+    match label.rfind('/') {
+        Some(index) => label[..index].to_string(),
+        None => ".".to_string(),
+    }
+}

--- a/src/graph/v2/algorithms/mod.rs
+++ b/src/graph/v2/algorithms/mod.rs
@@ -1,12 +1,14 @@
 mod blast_radius;
 mod cycles;
 mod degree;
+mod directory;
 mod neighborhood;
 mod summary;
 
 pub use blast_radius::{GraphBlastRadius, blast_radius};
 pub use cycles::{GraphCycle, find_cycles};
 pub use degree::{GraphDegreeSummary, NodeDegree, compute_degrees, top_fan_in, top_fan_out};
+pub use directory::{DirectoryDependency, GraphDirectoryDependencies, directory_dependencies};
 pub use neighborhood::{GraphNeighborhood, neighborhood};
 pub use summary::{GraphV2Summary, summarize_graph};
 

--- a/src/graph/v2/algorithms/tests.rs
+++ b/src/graph/v2/algorithms/tests.rs
@@ -278,3 +278,81 @@ fn blast_radius_ignores_missing_seeds_and_terminates_on_cycles() {
     assert!(empty.seeds.is_empty());
     assert!(empty.impacted.is_empty());
 }
+
+#[test]
+fn directory_dependencies_aggregate_cross_directory_edges() {
+    let graph = snapshot(
+        &["src/a/x.rs", "src/a/y.rs", "src/b/z.rs"],
+        &[
+            ("src/a/x.rs", "src/b/z.rs"),
+            ("src/a/y.rs", "src/b/z.rs"),
+            // Intra-directory edge is cohesion, not a boundary crossing.
+            ("src/a/x.rs", "src/a/y.rs"),
+        ],
+    );
+
+    let deps = directory_dependencies(&graph);
+
+    assert_eq!(
+        deps.edges,
+        vec![DirectoryDependency {
+            from: "src/a".to_string(),
+            to: "src/b".to_string(),
+            edge_count: 2,
+        }]
+    );
+}
+
+#[test]
+fn directory_dependencies_ignore_non_dependency_and_external_edges() {
+    let external = GraphNode {
+        id: id("external:serde"),
+        kind: GraphNodeKind::ExternalDependency,
+        label: "serde".to_string(),
+        path: None,
+    };
+    let graph = GraphSnapshot {
+        nodes: vec![node("src/a/x.rs"), node("src/b/y.rs"), external],
+        edges: vec![
+            // A TestOf relationship is not a dependency.
+            GraphEdge {
+                from: id("src/a/x.rs"),
+                to: id("src/b/y.rs"),
+                kind: GraphEdgeKind::TestOf,
+                provenance: GraphEdgeProvenance::TestHeuristic,
+                confidence: GraphEdgeConfidence::High,
+            },
+            // An external dependency has no directory.
+            GraphEdge {
+                from: id("src/a/x.rs"),
+                to: id("external:serde"),
+                kind: GraphEdgeKind::DependsOn,
+                provenance: GraphEdgeProvenance::Import,
+                confidence: GraphEdgeConfidence::Medium,
+            },
+        ],
+        diagnostics: Vec::new(),
+    };
+
+    assert!(directory_dependencies(&graph).edges.is_empty());
+}
+
+#[test]
+fn directory_dependencies_handle_root_files_and_empty_graph() {
+    assert!(
+        directory_dependencies(&GraphSnapshot::default())
+            .edges
+            .is_empty()
+    );
+
+    let graph = snapshot(&["main.rs", "src/util.rs"], &[("main.rs", "src/util.rs")]);
+
+    assert_eq!(
+        directory_dependencies(&graph).edges,
+        vec![DirectoryDependency {
+            from: ".".to_string(),
+            to: "src".to_string(),
+            edge_count: 1,
+        }]
+    );
+}

--- a/src/graph/v2/edge.rs
+++ b/src/graph/v2/edge.rs
@@ -10,6 +10,16 @@ pub enum GraphEdgeKind {
     Configures,
 }
 
+impl GraphEdgeKind {
+    /// Whether this edge represents a build/runtime dependency, as opposed to a
+    /// structural or auxiliary relationship (e.g. `TestOf`, `Configures`).
+    /// Dependency algorithms (coupling, layering, blast radius) should consider
+    /// only these kinds.
+    pub fn is_dependency(self) -> bool {
+        matches!(self, Self::Imports | Self::ReExports | Self::DependsOn)
+    }
+}
+
 /// Where an edge's evidence came from. Lets consumers weigh how an edge was
 /// derived without re-deriving it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/graph/v2/mod.rs
+++ b/src/graph/v2/mod.rs
@@ -6,8 +6,9 @@ mod node;
 mod snapshot;
 
 pub use algorithms::{
-    GraphBlastRadius, GraphCycle, GraphDegreeSummary, GraphNeighborhood, GraphV2Summary,
-    NodeDegree, blast_radius, compute_degrees, find_cycles, neighborhood, summarize_graph,
+    DirectoryDependency, GraphBlastRadius, GraphCycle, GraphDegreeSummary,
+    GraphDirectoryDependencies, GraphNeighborhood, GraphV2Summary, NodeDegree, blast_radius,
+    compute_degrees, directory_dependencies, find_cycles, neighborhood, summarize_graph,
     top_fan_in, top_fan_out,
 };
 pub use builder::graph_snapshot_from_scan;


### PR DESCRIPTION
## Summary

Adds directory-level dependency aggregation to Dependency Graph v2.

This projects file-level dependency edges onto parent directories so RepoPilot can reason about cross-directory coupling without exposing graph internals publicly. The new aggregation is internal and not yet connected to scan, review, AI context, or public report schemas.

## Type of change

* [x] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added `directory_dependencies()` for graph v2.
* Added `DirectoryDependency` and `GraphDirectoryDependencies`.
* Aggregates file-level dependency edges into `directory -> directory` edges with counts.
* Excludes intra-directory edges so the output focuses on cross-directory coupling.
* Ignores non-dependency edge kinds such as `TestOf` and `Configures`.
* Ignores external dependency edges because external nodes do not belong to repository directories.
* Added `GraphEdgeKind::is_dependency()` to centralize dependency-edge semantics.
* Exported the new directory aggregation API from graph v2.
* Added focused tests for:

  * cross-directory aggregation;
  * ignoring non-dependency/external edges;
  * root-level files;
  * empty graphs.
* Updated graph v2 engineering docs and analysis platform state docs.

## Why

Graph v2 already provides file-level graph structure and algorithms. The next useful architecture layer is directory-level coupling:

```text
file imports
  -> file-level graph edges
  -> directory-level dependency aggregation
  -> future boundary/layer/coupling rules
```

This is needed before migrating more architecture analysis to graph v2 because many maintainability problems are not only file-level problems. They are often directory, feature, package, or layer boundary problems.

This PR adds that internal projection while keeping the public product surface unchanged.

## Contract and ownership

* [x] The change stays within internal graph v2 algorithms, graph docs, and focused tests.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] No public CLI command is added.
* [x] `inspect graph` is not reintroduced.
* [x] No public scan/review/AI context behavior changes are introduced.
* [x] No JSON/SARIF/baseline/report schema changes are introduced.
* [x] No existing graph-related rules are migrated in this PR.
* [x] No Mermaid rendering is added.
* [x] Directory aggregation is deterministic and tested.
* [x] No unrelated refactor or generated-file churn is included.

## Not included in this PR

* No architecture finding migration yet.
* No layer policy engine.
* No feature/package boundary model.
* No graph output in public reports.
* No AI context graph section.
* No public graph diagnostics command.

## Changelog

* [ ] `CHANGELOG.md` updated

Skipped because this is an internal graph foundation change with no public CLI behavior or schema change.

## Verification

```bash
cargo test graph
git diff --check
git status --short
```
