### PR TITLE
feat(graph): migrate circular dependency detection to graph v2

### DIFF
--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -156,9 +156,14 @@ builder now exist; the builder reuses RepoPilot's shared language-aware import
 resolvers and emits typed edges (`Imports`/`DependsOn`/`TestOf`) carrying
 provenance and a confidence tier. Deterministic internal graph algorithms cover
 degrees, hubs, SCC cycles, neighborhoods, transitive blast radius, directory-level
-dependency aggregation, and summaries, but are not yet product-facing.
+dependency aggregation, and summaries. The `architecture.circular-dependency` scan
+rule now consumes the v2 SCC cycle detection internally (the first graph-related
+rule migrated); the remaining algorithms are not yet product-facing.
 
-1. Migrate existing graph-related architecture rules to graph v2.
+1. Migrate remaining graph-related architecture rules to graph v2. The
+   `architecture.circular-dependency` rule now uses graph v2 cycle detection
+   internally (first rule migrated); remaining graph-related rules still need
+   migration.
 2. Feed graph v2 blast radius into review.
 3. Feed graph v2 hot files into AI context.
 4. Add graph capabilities metadata for rules.

--- a/docs/engineering/dependency-graph-v2.md
+++ b/docs/engineering/dependency-graph-v2.md
@@ -25,8 +25,13 @@ findings, review blast radius, AI context, or public report schemas.
 Graph v2 now has internal algorithms for degree summaries, hubs, SCC-based cycle
 detection, local neighborhoods, transitive blast radius (reverse dependents of a
 changed set), directory-level dependency aggregation (cross-directory coupling),
-and compact deterministic graph summaries. These algorithms are not yet used by
-public scan, review, or AI context output.
+and compact deterministic graph summaries.
+
+The `architecture.circular-dependency` scan rule is the first graph-related rule
+migrated to graph v2: it now detects cycles through the v2 `GraphSnapshot` and
+SCC `find_cycles` internally, while preserving its rule ID, severity, category,
+recommendation, and evidence shape. The remaining graph-related rules still need
+migration, and review and AI context do not yet consume these algorithms.
 
 Today, `CouplingGraph`, `RepoContextGraph`, import extraction, language
 resolvers, review signals, and graph summaries provide useful behavior. Graph
@@ -248,7 +253,10 @@ internal.
 
 ## Implementation Steps
 
-1. Migrate existing graph-related rules to graph v2.
+1. Migrate remaining graph-related architecture rules to graph v2. The
+   `architecture.circular-dependency` rule is the first migrated and now uses
+   graph v2 cycle detection internally; remaining graph-related rules still need
+   migration.
 2. Feed graph v2 blast radius into review.
 3. Feed graph v2 hot files into AI context.
 4. Add graph capabilities metadata for rules.

--- a/src/audits/architecture/import_coupling.rs
+++ b/src/audits/architecture/import_coupling.rs
@@ -1,11 +1,15 @@
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::graph::v2::{
+    GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance, GraphNode, GraphNodeId,
+    GraphNodeKind, GraphSnapshot, find_cycles,
+};
 use crate::graph::{
-    CouplingGraph, FileMetrics, build_coupling_graph, compute_metrics, detect_cycles,
+    CouplingGraph, FileMetrics, build_coupling_graph, compute_metrics,
     without_rust_module_containment_edges,
 };
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 pub struct ImportCouplingAudit;
@@ -19,8 +23,25 @@ impl ImportCouplingAudit {
     ) -> (Vec<Finding>, CouplingGraph) {
         let graph = build_coupling_graph(facts, root);
         let metrics = compute_metrics(&graph);
+
+        // Circular dependencies now run through graph v2's SCC-based cycle
+        // detection. We re-encode the existing (module-containment-stripped)
+        // coupling graph as a `GraphSnapshot` and reuse `find_cycles`; the v1
+        // graph build still feeds fan-out/instability metrics and the graph
+        // returned to the scan pipeline. Each cycle is one strongly-connected
+        // component (set of mutually dependent files).
         let cycle_graph = without_rust_module_containment_edges(&graph);
-        let cycles = detect_cycles(&cycle_graph);
+        let (cycle_snapshot, path_by_id) = coupling_graph_snapshot(&cycle_graph);
+        let cycles: Vec<Vec<PathBuf>> = find_cycles(&cycle_snapshot)
+            .into_iter()
+            .map(|cycle| {
+                cycle
+                    .node_ids
+                    .iter()
+                    .filter_map(|id| path_by_id.get(id).cloned())
+                    .collect()
+            })
+            .collect();
 
         let classifier = crate::analysis::ArchitectureClassifier::new(&config.module_mappings);
         let mut findings = Vec::new();
@@ -259,4 +280,42 @@ fn is_rust_facade_declaration(line: &str) -> bool {
 
 fn relative_path(path: &Path, root: &Path) -> PathBuf {
     path.strip_prefix(root).unwrap_or(path).to_path_buf()
+}
+
+/// Re-encodes a file-level coupling graph as a graph v2 `GraphSnapshot` so the
+/// shared v2 SCC cycle detection can run over it, returning the snapshot and a
+/// map back to file paths. Only file nodes and dependency (`Imports`) edges are
+/// produced. Kept local to this rule for now; it can move into a shared scan
+/// stage once one computes a snapshot directly.
+fn coupling_graph_snapshot(
+    graph: &CouplingGraph,
+) -> (GraphSnapshot, BTreeMap<GraphNodeId, PathBuf>) {
+    let node_id = |path: &Path| GraphNodeId::new(format!("file:{}", path.display()));
+    let mut snapshot = GraphSnapshot::new();
+    let mut path_by_id = BTreeMap::new();
+
+    for path in &graph.nodes {
+        let id = node_id(path);
+        path_by_id.insert(id.clone(), path.clone());
+        snapshot.add_node(GraphNode {
+            id,
+            kind: GraphNodeKind::File,
+            label: path.display().to_string(),
+            path: Some(path.clone()),
+        });
+    }
+
+    for (from, targets) in &graph.edges {
+        for to in targets {
+            snapshot.add_edge(GraphEdge {
+                from: node_id(from),
+                to: node_id(to),
+                kind: GraphEdgeKind::Imports,
+                provenance: GraphEdgeProvenance::Import,
+                confidence: GraphEdgeConfidence::High,
+            });
+        }
+    }
+
+    (snapshot, path_by_id)
 }

--- a/tests/coupling_audit.rs
+++ b/tests/coupling_audit.rs
@@ -193,6 +193,99 @@ fn circular_dependency_finding_is_emitted() {
         .find(|finding| finding.rule_id == "architecture.circular-dependency")
         .expect("expected circular dependency finding");
     assert_eq!(finding.severity, Severity::High);
+    // Evidence lists the cycle members with repository-relative paths.
+    assert!(!finding.evidence.is_empty());
+    let cycle_files: Vec<_> = finding
+        .evidence
+        .iter()
+        .map(|item| {
+            assert!(
+                item.path.is_relative(),
+                "evidence path should be relative, got {:?}",
+                item.path
+            );
+            item.path.as_path()
+        })
+        .collect();
+    assert!(cycle_files.contains(&Path::new("src/a.ts")));
+    assert!(cycle_files.contains(&Path::new("src/b.ts")));
+}
+
+#[test]
+fn acyclic_imports_do_not_emit_circular_dependency() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    write_file(
+        &temp,
+        "src/a.ts",
+        r#"import { b } from "./b"; export function a() { return b(); }"#,
+    );
+    write_file(
+        &temp,
+        "src/b.ts",
+        r#"import { c } from "./c"; export function b() { return c(); }"#,
+    );
+    write_file(&temp, "src/c.ts", "export function c() { return 1; }\n");
+
+    let summary = scan_path_with_config(temp.path(), &ScanConfig::default())
+        .expect("failed to scan temp project");
+
+    assert!(
+        summary
+            .artifacts
+            .findings
+            .iter()
+            .all(|finding| finding.rule_id != "architecture.circular-dependency"),
+        "acyclic import chain must not be reported as circular: {:#?}",
+        summary.artifacts.findings
+    );
+}
+
+#[test]
+fn multiple_circular_dependencies_are_each_reported() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    // Two independent 2-file cycles: a <-> b and c <-> d.
+    write_file(
+        &temp,
+        "src/a.ts",
+        r#"import { b } from "./b"; export function a() { return b(); }"#,
+    );
+    write_file(
+        &temp,
+        "src/b.ts",
+        r#"import { a } from "./a"; export function b() { return a(); }"#,
+    );
+    write_file(
+        &temp,
+        "src/c.ts",
+        r#"import { d } from "./d"; export function c() { return d(); }"#,
+    );
+    write_file(
+        &temp,
+        "src/d.ts",
+        r#"import { c } from "./c"; export function d() { return c(); }"#,
+    );
+
+    let summary = scan_path_with_config(temp.path(), &ScanConfig::default())
+        .expect("failed to scan temp project");
+
+    let circular: Vec<_> = summary
+        .artifacts
+        .findings
+        .iter()
+        .filter(|finding| finding.rule_id == "architecture.circular-dependency")
+        .collect();
+
+    // One finding per strongly-connected component.
+    assert_eq!(
+        circular.len(),
+        2,
+        "expected one finding per cycle: {circular:#?}"
+    );
+    assert!(
+        circular
+            .iter()
+            .all(|finding| finding.severity == Severity::High)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR migrates the `architecture.circular-dependency` rule to RepoPilot's graph v2 cycle detection.

Circular dependency findings now use graph v2's `GraphSnapshot` and SCC-based `find_cycles` internally, while preserving the existing rule ID, severity, category, recommendation, and evidence shape.

This is the first graph-related architecture rule migrated to graph v2.

## Type of change

- Feature
- Refactor
- Tests
- Documentation

## What changed

- Re-encoded the existing file-level coupling graph into a graph v2 `GraphSnapshot`.
- Replaced circular dependency detection with graph v2 SCC-based cycle detection.
- Preserved the existing `architecture.circular-dependency` finding contract.
- Kept v1 coupling graph metrics for fan-out, instability, and existing scan pipeline behavior.
- Added tests for:
  - circular dependency findings;
  - acyclic import chains;
  - multiple independent circular dependencies;
  - repository-relative evidence paths.
- Updated graph v2 engineering documentation.
- Updated analysis platform state documentation.

## Why

RepoPilot is gradually moving architecture analysis toward graph v2 as the shared foundation for dependency analysis, cycle detection, blast radius, hot files, and AI context.

Migrating `architecture.circular-dependency` first is a good low-risk step because it keeps the public finding contract stable while proving that graph v2 can power an existing production rule.

## Contract and ownership

- The rule ID remains `architecture.circular-dependency`.
- Severity remains `High`.
- Existing evidence shape is preserved.
- Findings continue to use repository-relative paths.
- No public JSON/SARIF/baseline contract should break.
- The v1 coupling graph is still used where needed for existing metrics.
- The graph v2 adapter is kept local to the rule for now and can be moved later into a shared scan graph stage.

## Architecture notes

- `ImportCouplingAudit` still owns import-coupling architecture findings.
- Graph v2 is introduced only for cycle detection in this PR.
- The local `coupling_graph_snapshot` adapter keeps the migration contained.
- Remaining graph-related rules can be migrated later.
- Review blast radius and AI context integration are intentionally left for follow-up PRs.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```

