### PR TITLE
refactor(graph): move coupling snapshot conversion into graph v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Internal: moved the coupling graph → graph v2 `GraphSnapshot` conversion out
+  of the `architecture.circular-dependency` audit and into a shared graph stage
+  (`build_coupling_graph_snapshot`), so future graph v2 consumers can reuse it.
+  No user-facing behavior, finding contract, or output schema changed.
+
 - Documented the gate model as one coherent two-axis story: a **finding gate**
   (`--fail-on` by severity/status, or the mutually exclusive `--fail-on-priority`
   by risk; in-diff only on `review`) and a separate, opt-in **review-signal gate**

--- a/docs/engineering/dependency-graph-v2.md
+++ b/docs/engineering/dependency-graph-v2.md
@@ -33,6 +33,17 @@ SCC `find_cycles` internally, while preserving its rule ID, severity, category,
 recommendation, and evidence shape. The remaining graph-related rules still need
 migration, and review and AI context do not yet consume these algorithms.
 
+PR #195 migrated circular dependency detection to graph v2. PR #196 extracts the
+coupling graph → `GraphSnapshot` conversion out of that rule and into shared
+graph infrastructure (`build_coupling_graph_snapshot`), so it no longer lives
+inside a single audit. The adapter is intentionally free of audit concepts (no
+severities, rule IDs, findings, recommendations, or evidence) and only produces
+file nodes and `Imports` edges with a node-id → path map. The existing v1
+`CouplingGraph` metrics (fan-in/fan-out/instability) remain available wherever
+rules still need them. Future graph v2 consumers — blast radius, hot files,
+dependency depth, review context — can reuse this shared conversion instead of
+re-encoding the coupling graph themselves.
+
 Today, `CouplingGraph`, `RepoContextGraph`, import extraction, language
 resolvers, review signals, and graph summaries provide useful behavior. Graph
 v2 should give those paths one deterministic model built from repository facts,
@@ -255,8 +266,10 @@ internal.
 
 1. Migrate remaining graph-related architecture rules to graph v2. The
    `architecture.circular-dependency` rule is the first migrated and now uses
-   graph v2 cycle detection internally; remaining graph-related rules still need
-   migration.
+   graph v2 cycle detection internally; the coupling graph → `GraphSnapshot`
+   conversion it relies on now lives in shared graph infrastructure
+   (`build_coupling_graph_snapshot`) for reuse. Remaining graph-related rules
+   still need migration.
 2. Feed graph v2 blast radius into review.
 3. Feed graph v2 hot files into AI context.
 4. Add graph capabilities metadata for rules.

--- a/src/audits/architecture/import_coupling.rs
+++ b/src/audits/architecture/import_coupling.rs
@@ -1,15 +1,12 @@
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
-use crate::graph::v2::{
-    GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance, GraphNode, GraphNodeId,
-    GraphNodeKind, GraphSnapshot, find_cycles,
-};
+use crate::graph::v2::{build_coupling_graph_snapshot, find_cycles};
 use crate::graph::{
     CouplingGraph, FileMetrics, build_coupling_graph, compute_metrics,
     without_rust_module_containment_edges,
 };
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 pub struct ImportCouplingAudit;
@@ -26,12 +23,12 @@ impl ImportCouplingAudit {
 
         // Circular dependencies now run through graph v2's SCC-based cycle
         // detection. We re-encode the existing (module-containment-stripped)
-        // coupling graph as a `GraphSnapshot` and reuse `find_cycles`; the v1
-        // graph build still feeds fan-out/instability metrics and the graph
-        // returned to the scan pipeline. Each cycle is one strongly-connected
-        // component (set of mutually dependent files).
+        // coupling graph as a `GraphSnapshot` via the shared graph adapter and
+        // reuse `find_cycles`; the v1 graph build still feeds fan-out/instability
+        // metrics and the graph returned to the scan pipeline. Each cycle is one
+        // strongly-connected component (set of mutually dependent files).
         let cycle_graph = without_rust_module_containment_edges(&graph);
-        let (cycle_snapshot, path_by_id) = coupling_graph_snapshot(&cycle_graph);
+        let (cycle_snapshot, path_by_id) = build_coupling_graph_snapshot(&cycle_graph);
         let cycles: Vec<Vec<PathBuf>> = find_cycles(&cycle_snapshot)
             .into_iter()
             .map(|cycle| {
@@ -280,42 +277,4 @@ fn is_rust_facade_declaration(line: &str) -> bool {
 
 fn relative_path(path: &Path, root: &Path) -> PathBuf {
     path.strip_prefix(root).unwrap_or(path).to_path_buf()
-}
-
-/// Re-encodes a file-level coupling graph as a graph v2 `GraphSnapshot` so the
-/// shared v2 SCC cycle detection can run over it, returning the snapshot and a
-/// map back to file paths. Only file nodes and dependency (`Imports`) edges are
-/// produced. Kept local to this rule for now; it can move into a shared scan
-/// stage once one computes a snapshot directly.
-fn coupling_graph_snapshot(
-    graph: &CouplingGraph,
-) -> (GraphSnapshot, BTreeMap<GraphNodeId, PathBuf>) {
-    let node_id = |path: &Path| GraphNodeId::new(format!("file:{}", path.display()));
-    let mut snapshot = GraphSnapshot::new();
-    let mut path_by_id = BTreeMap::new();
-
-    for path in &graph.nodes {
-        let id = node_id(path);
-        path_by_id.insert(id.clone(), path.clone());
-        snapshot.add_node(GraphNode {
-            id,
-            kind: GraphNodeKind::File,
-            label: path.display().to_string(),
-            path: Some(path.clone()),
-        });
-    }
-
-    for (from, targets) in &graph.edges {
-        for to in targets {
-            snapshot.add_edge(GraphEdge {
-                from: node_id(from),
-                to: node_id(to),
-                kind: GraphEdgeKind::Imports,
-                provenance: GraphEdgeProvenance::Import,
-                confidence: GraphEdgeConfidence::High,
-            });
-        }
-    }
-
-    (snapshot, path_by_id)
 }

--- a/src/graph/v2/coupling_snapshot.rs
+++ b/src/graph/v2/coupling_snapshot.rs
@@ -1,0 +1,160 @@
+use super::{
+    GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance, GraphNode, GraphNodeId,
+    GraphNodeKind, GraphSnapshot,
+};
+use crate::scan::types::CouplingGraph;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Re-encodes a file-level [`CouplingGraph`] as a graph v2 [`GraphSnapshot`] so
+/// shared v2 algorithms (e.g. SCC cycle detection) can run over it, returning
+/// the snapshot alongside a map from node id back to file path. Only file nodes
+/// and dependency (`Imports`) edges are produced.
+///
+/// This is the shared bridge between the v1 coupling graph and graph v2. It is
+/// deliberately free of audit concepts (no severities, rule ids, findings, or
+/// evidence), so any future graph v2 consumer can reuse it without depending on
+/// a particular rule.
+pub fn build_coupling_graph_snapshot(
+    graph: &CouplingGraph,
+) -> (GraphSnapshot, BTreeMap<GraphNodeId, PathBuf>) {
+    let node_id = |path: &Path| GraphNodeId::new(format!("file:{}", path.display()));
+    let mut snapshot = GraphSnapshot::new();
+    let mut path_by_id = BTreeMap::new();
+
+    for path in &graph.nodes {
+        let id = node_id(path);
+        path_by_id.insert(id.clone(), path.clone());
+        snapshot.add_node(GraphNode {
+            id,
+            kind: GraphNodeKind::File,
+            label: path.display().to_string(),
+            path: Some(path.clone()),
+        });
+    }
+
+    for (from, targets) in &graph.edges {
+        for to in targets {
+            snapshot.add_edge(GraphEdge {
+                from: node_id(from),
+                to: node_id(to),
+                kind: GraphEdgeKind::Imports,
+                provenance: GraphEdgeProvenance::Import,
+                confidence: GraphEdgeConfidence::High,
+            });
+        }
+    }
+
+    (snapshot, path_by_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::v2::find_cycles;
+    use std::collections::BTreeSet;
+
+    fn node_id(path: &str) -> GraphNodeId {
+        GraphNodeId::new(format!("file:{path}"))
+    }
+
+    fn coupling_graph(edges: &[(&str, &str)]) -> CouplingGraph {
+        let mut edge_map: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
+        let mut nodes: BTreeSet<PathBuf> = BTreeSet::new();
+
+        for (src, dst) in edges {
+            let src = PathBuf::from(src);
+            let dst = PathBuf::from(dst);
+            nodes.insert(src.clone());
+            nodes.insert(dst.clone());
+            edge_map.entry(src).or_default().insert(dst);
+        }
+
+        CouplingGraph {
+            edges: edge_map,
+            nodes,
+        }
+    }
+
+    #[test]
+    fn empty_coupling_graph_produces_empty_snapshot() {
+        let graph = CouplingGraph {
+            edges: BTreeMap::new(),
+            nodes: BTreeSet::new(),
+        };
+
+        let (snapshot, path_by_id) = build_coupling_graph_snapshot(&graph);
+
+        assert_eq!(snapshot.node_count(), 0);
+        assert_eq!(snapshot.edge_count(), 0);
+        assert_eq!(snapshot.diagnostic_count(), 0);
+        assert!(path_by_id.is_empty());
+    }
+
+    #[test]
+    fn single_directional_edge_is_preserved() {
+        let graph = coupling_graph(&[("src/a.rs", "src/b.rs")]);
+
+        let (snapshot, path_by_id) = build_coupling_graph_snapshot(&graph);
+
+        assert_eq!(snapshot.node_count(), 2);
+        assert_eq!(snapshot.edge_count(), 1);
+        let edge = &snapshot.edges[0];
+        assert_eq!(edge.from, node_id("src/a.rs"));
+        assert_eq!(edge.to, node_id("src/b.rs"));
+        assert_eq!(edge.kind, GraphEdgeKind::Imports);
+        // Direction is not symmetric: no reverse edge is synthesised.
+        assert!(
+            !snapshot
+                .edges
+                .iter()
+                .any(|edge| edge.from == node_id("src/b.rs"))
+        );
+        assert_eq!(
+            path_by_id.get(&node_id("src/a.rs")),
+            Some(&PathBuf::from("src/a.rs"))
+        );
+    }
+
+    #[test]
+    fn simple_cycle_is_representable() {
+        // a.rs -> b.rs and b.rs -> a.rs form one strongly-connected component.
+        let graph = coupling_graph(&[("a.rs", "b.rs"), ("b.rs", "a.rs")]);
+
+        let (snapshot, _) = build_coupling_graph_snapshot(&graph);
+        let cycles = find_cycles(&snapshot);
+
+        assert_eq!(snapshot.edge_count(), 2);
+        assert_eq!(cycles.len(), 1);
+        assert_eq!(cycles[0].node_ids.len(), 2);
+    }
+
+    #[test]
+    fn duplicate_edges_collapse_to_stable_output() {
+        // The same edge supplied twice still yields exactly one edge, and the
+        // conversion is deterministic across repeated builds.
+        let graph = coupling_graph(&[("a.rs", "b.rs"), ("a.rs", "b.rs")]);
+
+        let (first, _) = build_coupling_graph_snapshot(&graph);
+        let (second, _) = build_coupling_graph_snapshot(&graph);
+
+        assert_eq!(first.edge_count(), 1);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn node_ids_and_labels_use_repository_relative_paths() {
+        let graph = coupling_graph(&[("src/a.rs", "src/nested/b.rs")]);
+
+        let (snapshot, _) = build_coupling_graph_snapshot(&graph);
+
+        let a = snapshot
+            .nodes
+            .iter()
+            .find(|node| node.path.as_deref() == Some(Path::new("src/a.rs")))
+            .expect("a.rs node should exist");
+        assert_eq!(a.id, node_id("src/a.rs"));
+        assert_eq!(a.label, "src/a.rs");
+        assert_eq!(a.kind, GraphNodeKind::File);
+    }
+}

--- a/src/graph/v2/mod.rs
+++ b/src/graph/v2/mod.rs
@@ -1,5 +1,6 @@
 mod algorithms;
 mod builder;
+mod coupling_snapshot;
 mod diagnostic;
 mod edge;
 mod node;
@@ -12,6 +13,7 @@ pub use algorithms::{
     top_fan_in, top_fan_out,
 };
 pub use builder::graph_snapshot_from_scan;
+pub use coupling_snapshot::build_coupling_graph_snapshot;
 pub use diagnostic::GraphDiagnostic;
 pub use edge::{GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance};
 pub use node::{GraphNode, GraphNodeId, GraphNodeKind};


### PR DESCRIPTION
## Summary

This PR extracts the coupling graph → graph v2 `GraphSnapshot` conversion from the circular dependency/import coupling audit into shared graph v2 infrastructure.

PR #195 migrated `architecture.circular-dependency` to graph v2 SCC-based cycle detection. This PR follows up by moving the temporary local adapter out of the audit and into `src/graph/v2/coupling_snapshot.rs`, so future graph v2 consumers can reuse the same conversion path.

## Type of change

- Refactor
- Architecture
- Tests
- Documentation

## What changed

- Added shared `build_coupling_graph_snapshot` helper under graph v2.
- Moved coupling graph → `GraphSnapshot` conversion out of `ImportCouplingAudit`.
- Updated `architecture.circular-dependency` logic to consume the shared graph v2 adapter.
- Preserved the existing v1 coupling graph metrics path for fan-out, instability, and scan pipeline behavior.
- Added focused tests for:
  - empty coupling graphs;
  - single directional edges;
  - simple cycles;
  - duplicate edge stability;
  - repository-relative node IDs and labels.
- Updated graph v2 engineering docs.
- Updated CHANGELOG with the internal graph infrastructure change.

## Why

RepoPilot is gradually moving architecture analysis toward graph v2.

The circular dependency rule was the first graph-related rule migrated to graph v2. Keeping the coupling graph conversion inside that rule would make future graph v2 features duplicate the same adapter logic.

This PR creates a shared bridge between the existing v1 coupling graph and graph v2, preparing the codebase for future work such as:

- blast radius analysis;
- graph hot files;
- dependency depth metrics;
- review context;
- vibe/harden/prompt graph context;
- graph capabilities metadata.

## Contract

This PR should not change public behavior.

The following must remain stable:

- `architecture.circular-dependency` rule ID;
- severity;
- category;
- recommendation;
- evidence shape;
- repository-relative paths;
- JSON output shape;
- SARIF output shape;
- baseline compatibility.

## Architecture notes

- Graph conversion now belongs to graph v2 infrastructure.
- Audit code consumes graph data instead of owning graph conversion.
- The shared adapter is intentionally free of audit concepts:
  - no severity;
  - no rule IDs;
  - no findings;
  - no recommendations;
  - no evidence formatting.
- `ImportCouplingAudit` remains responsible only for turning graph results into architecture findings.
- No new user-facing findings are introduced.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
```