### PR TITLE
refactor(graph): migrate coupling degree rules to graph v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   (`build_coupling_graph_snapshot`), so future graph v2 consumers can reuse it.
   No user-facing behavior, finding contract, or output schema changed.
 
+- Internal: migrated `architecture.excessive-fan-out` and
+  `architecture.high-instability-hub` onto graph v2 degree counting
+  (`compute_degrees` over the shared snapshot, with instability owned by
+  `NodeDegree::instability`) instead of the v1 `compute_metrics` path. All three
+  import-coupling rules now share one graph model. Fan-in/fan-out/instability
+  values, finding IDs, severities, evidence, and thresholds are unchanged; the
+  Rust facade exemption moved to an `import_coupling::rust_facade` submodule to
+  keep each file under the 300-line limit.
+
 - Documented the gate model as one coherent two-axis story: a **finding gate**
   (`--fail-on` by severity/status, or the mutually exclusive `--fail-on-priority`
   by risk; in-diff only on `review`) and a separate, opt-in **review-signal gate**

--- a/docs/engineering/dependency-graph-v2.md
+++ b/docs/engineering/dependency-graph-v2.md
@@ -30,19 +30,28 @@ and compact deterministic graph summaries.
 The `architecture.circular-dependency` scan rule is the first graph-related rule
 migrated to graph v2: it now detects cycles through the v2 `GraphSnapshot` and
 SCC `find_cycles` internally, while preserving its rule ID, severity, category,
-recommendation, and evidence shape. The remaining graph-related rules still need
-migration, and review and AI context do not yet consume these algorithms.
+recommendation, and evidence shape. The other import-coupling rules
+(`architecture.excessive-fan-out`, `architecture.high-instability-hub`) now also
+run on graph v2 via degree counting, so all three coupling rules share one model.
+Review and AI context do not yet consume these algorithms.
 
 PR #195 migrated circular dependency detection to graph v2. PR #196 extracts the
 coupling graph → `GraphSnapshot` conversion out of that rule and into shared
 graph infrastructure (`build_coupling_graph_snapshot`), so it no longer lives
 inside a single audit. The adapter is intentionally free of audit concepts (no
 severities, rule IDs, findings, recommendations, or evidence) and only produces
-file nodes and `Imports` edges with a node-id → path map. The existing v1
-`CouplingGraph` metrics (fan-in/fan-out/instability) remain available wherever
-rules still need them. Future graph v2 consumers — blast radius, hot files,
-dependency depth, review context — can reuse this shared conversion instead of
-re-encoding the coupling graph themselves.
+file nodes and `Imports` edges with a node-id → path map. Future graph v2
+consumers — blast radius, hot files, dependency depth, review context — can reuse
+this shared conversion instead of re-encoding the coupling graph themselves.
+
+PR #197 finishes migrating the import-coupling architecture rules onto graph v2:
+`architecture.excessive-fan-out` and `architecture.high-instability-hub` now
+derive their per-file fan-in, fan-out, and instability from graph v2 degree
+counting (`compute_degrees`) over that shared snapshot, with instability owned by
+`NodeDegree::instability`. The rule no longer calls the v1 `compute_metrics`.
+That v1 metric path stays available for the remaining non-rule consumers (e.g.
+the AI context hot-files fallback) until they migrate too; the rule findings (IDs,
+severities, evidence, thresholds) are unchanged.
 
 Today, `CouplingGraph`, `RepoContextGraph`, import extraction, language
 resolvers, review signals, and graph summaries provide useful behavior. Graph
@@ -265,11 +274,11 @@ internal.
 ## Implementation Steps
 
 1. Migrate remaining graph-related architecture rules to graph v2. The
-   `architecture.circular-dependency` rule is the first migrated and now uses
-   graph v2 cycle detection internally; the coupling graph → `GraphSnapshot`
-   conversion it relies on now lives in shared graph infrastructure
-   (`build_coupling_graph_snapshot`) for reuse. Remaining graph-related rules
-   still need migration.
+   import-coupling rules — `architecture.circular-dependency` (cycles),
+   `architecture.excessive-fan-out`, and `architecture.high-instability-hub`
+   (degrees) — are migrated and share the coupling graph → `GraphSnapshot`
+   conversion in shared graph infrastructure (`build_coupling_graph_snapshot`).
+   Other graph-related rules can migrate onto the same snapshot next.
 2. Feed graph v2 blast radius into review.
 3. Feed graph v2 hot files into AI context.
 4. Add graph capabilities metadata for rules.

--- a/src/audits/architecture/import_coupling.rs
+++ b/src/audits/architecture/import_coupling.rs
@@ -1,13 +1,16 @@
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
-use crate::graph::v2::{build_coupling_graph_snapshot, find_cycles};
+use crate::graph::v2::{build_coupling_graph_snapshot, compute_degrees, find_cycles};
 use crate::graph::{
-    CouplingGraph, FileMetrics, build_coupling_graph, compute_metrics,
-    without_rust_module_containment_edges,
+    CouplingGraph, FileMetrics, build_coupling_graph, without_rust_module_containment_edges,
 };
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+
+mod rust_facade;
+
+use rust_facade::is_pure_rust_facade;
 
 pub struct ImportCouplingAudit;
 
@@ -19,14 +22,14 @@ impl ImportCouplingAudit {
         root: &Path,
     ) -> (Vec<Finding>, CouplingGraph) {
         let graph = build_coupling_graph(facts, root);
-        let metrics = compute_metrics(&graph);
+        let metrics = coupling_metrics(&graph);
 
         // Circular dependencies now run through graph v2's SCC-based cycle
         // detection. We re-encode the existing (module-containment-stripped)
         // coupling graph as a `GraphSnapshot` via the shared graph adapter and
-        // reuse `find_cycles`; the v1 graph build still feeds fan-out/instability
-        // metrics and the graph returned to the scan pipeline. Each cycle is one
-        // strongly-connected component (set of mutually dependent files).
+        // reuse `find_cycles`. The v1 coupling graph is still built and returned
+        // to the scan pipeline. Each cycle is one strongly-connected component
+        // (set of mutually dependent files).
         let cycle_graph = without_rust_module_containment_edges(&graph);
         let (cycle_snapshot, path_by_id) = build_coupling_graph_snapshot(&cycle_graph);
         let cycles: Vec<Vec<PathBuf>> = find_cycles(&cycle_snapshot)
@@ -210,71 +213,31 @@ fn circular_dependency_finding(cycle: &[PathBuf], root: &Path) -> Finding {
     }
 }
 
-fn is_pure_rust_facade(metric: &FileMetrics, facts: &ScanFacts, root: &Path) -> bool {
-    let Some(file) = facts
-        .files
-        .iter()
-        .find(|file| file.path == metric.path || root.join(&file.path) == metric.path)
-    else {
-        return false;
-    };
-
-    if file.language.as_deref() != Some("Rust") || !is_rust_facade_filename(&file.path) {
-        return false;
-    }
-
-    let content = file
-        .content
-        .clone()
-        .or_else(|| std::fs::read_to_string(root.join(&file.path)).ok())
-        .or_else(|| std::fs::read_to_string(&file.path).ok());
-    let Some(content) = content else {
-        return false;
-    };
-
-    let mut saw_facade_declaration = false;
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty()
-            || trimmed.starts_with("//")
-            || trimmed.starts_with("#[")
-            || trimmed.starts_with("//!")
-            || trimmed.starts_with("///")
-        {
-            continue;
-        }
-
-        if is_rust_facade_declaration(trimmed) {
-            saw_facade_declaration = true;
-            continue;
-        }
-
-        return false;
-    }
-
-    saw_facade_declaration
-}
-
-fn is_rust_facade_filename(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| matches!(name, "lib.rs" | "mod.rs"))
-}
-
-fn is_rust_facade_declaration(line: &str) -> bool {
-    let line = line.strip_suffix(';').unwrap_or(line).trim();
-    let line = line
-        .strip_prefix("pub(crate) ")
-        .or_else(|| line.strip_prefix("pub(super) "))
-        .or_else(|| line.strip_prefix("pub "))
-        .unwrap_or(line);
-
-    line.starts_with("mod ")
-        || line.starts_with("use ")
-        || line.starts_with("extern crate ")
-        || line.starts_with("pub use ")
-}
-
 fn relative_path(path: &Path, root: &Path) -> PathBuf {
     path.strip_prefix(root).unwrap_or(path).to_path_buf()
+}
+
+/// Per-file coupling metrics (fan-in, fan-out, instability) for the fan-out and
+/// instability-hub findings, derived from graph v2 degrees over the shared
+/// snapshot. Path-ordered to preserve the v1 `compute_metrics` contract.
+fn coupling_metrics(graph: &CouplingGraph) -> Vec<FileMetrics> {
+    let (snapshot, path_by_id) = build_coupling_graph_snapshot(graph);
+    let mut metrics: BTreeMap<PathBuf, FileMetrics> = BTreeMap::new();
+
+    for degree in compute_degrees(&snapshot).nodes {
+        let Some(path) = path_by_id.get(&degree.node_id) else {
+            continue;
+        };
+        metrics.insert(
+            path.clone(),
+            FileMetrics {
+                path: path.clone(),
+                fan_in: degree.fan_in,
+                fan_out: degree.fan_out,
+                instability: degree.instability(),
+            },
+        );
+    }
+
+    metrics.into_values().collect()
 }

--- a/src/audits/architecture/import_coupling/rust_facade.rs
+++ b/src/audits/architecture/import_coupling/rust_facade.rs
@@ -1,0 +1,73 @@
+//! Rust facade detection for the excessive-fan-out rule. A `lib.rs`/`mod.rs`
+//! whose body is only `mod`/`use`/`pub use`/`extern crate` declarations is an
+//! intentional re-export barrel, not change-amplifying coupling, so it is
+//! exempt from the fan-out finding.
+
+use crate::graph::FileMetrics;
+use crate::scan::facts::ScanFacts;
+use std::path::Path;
+
+pub(super) fn is_pure_rust_facade(metric: &FileMetrics, facts: &ScanFacts, root: &Path) -> bool {
+    let Some(file) = facts
+        .files
+        .iter()
+        .find(|file| file.path == metric.path || root.join(&file.path) == metric.path)
+    else {
+        return false;
+    };
+
+    if file.language.as_deref() != Some("Rust") || !is_rust_facade_filename(&file.path) {
+        return false;
+    }
+
+    let content = file
+        .content
+        .clone()
+        .or_else(|| std::fs::read_to_string(root.join(&file.path)).ok())
+        .or_else(|| std::fs::read_to_string(&file.path).ok());
+    let Some(content) = content else {
+        return false;
+    };
+
+    let mut saw_facade_declaration = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with("//")
+            || trimmed.starts_with("#[")
+            || trimmed.starts_with("//!")
+            || trimmed.starts_with("///")
+        {
+            continue;
+        }
+
+        if is_rust_facade_declaration(trimmed) {
+            saw_facade_declaration = true;
+            continue;
+        }
+
+        return false;
+    }
+
+    saw_facade_declaration
+}
+
+fn is_rust_facade_filename(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| matches!(name, "lib.rs" | "mod.rs"))
+}
+
+fn is_rust_facade_declaration(line: &str) -> bool {
+    let line = line.strip_suffix(';').unwrap_or(line).trim();
+    let line = line
+        .strip_prefix("pub(crate) ")
+        .or_else(|| line.strip_prefix("pub(super) "))
+        .or_else(|| line.strip_prefix("pub "))
+        .unwrap_or(line);
+
+    line.starts_with("mod ")
+        || line.starts_with("use ")
+        || line.starts_with("extern crate ")
+        || line.starts_with("pub use ")
+}

--- a/src/graph/v2/algorithms/degree.rs
+++ b/src/graph/v2/algorithms/degree.rs
@@ -14,6 +14,20 @@ pub struct NodeDegree {
     pub fan_out: usize,
 }
 
+impl NodeDegree {
+    /// instability = fan_out / (fan_in + fan_out); 0.0 when the node has no
+    /// edges. Owns the derived coupling metric in graph v2 so rules no longer
+    /// recompute it from the v1 graph.
+    pub fn instability(&self) -> f32 {
+        let total = self.fan_in + self.fan_out;
+        if total == 0 {
+            0.0
+        } else {
+            self.fan_out as f32 / total as f32
+        }
+    }
+}
+
 pub fn compute_degrees(snapshot: &GraphSnapshot) -> GraphDegreeSummary {
     let topology = topology(snapshot);
     let mut degrees = topology

--- a/src/graph/v2/algorithms/tests.rs
+++ b/src/graph/v2/algorithms/tests.rs
@@ -74,6 +74,29 @@ fn degrees_count_each_exact_edge_once() {
 }
 
 #[test]
+fn node_degree_instability_matches_coupling_formula() {
+    let isolated = NodeDegree {
+        node_id: id("a"),
+        fan_in: 0,
+        fan_out: 0,
+    };
+    let pure_source = NodeDegree {
+        node_id: id("b"),
+        fan_in: 0,
+        fan_out: 3,
+    };
+    let mixed = NodeDegree {
+        node_id: id("c"),
+        fan_in: 1,
+        fan_out: 3,
+    };
+
+    assert_eq!(isolated.instability().to_bits(), 0.0_f32.to_bits());
+    assert_eq!(pure_source.instability().to_bits(), 1.0_f32.to_bits());
+    assert_eq!(mixed.instability().to_bits(), 0.75_f32.to_bits());
+}
+
+#[test]
 fn hub_helpers_apply_rankings_limits_and_zero_filtering() {
     let graph = snapshot(
         &["a", "b", "c", "d", "z"],

--- a/src/graph/v2/coupling_snapshot.rs
+++ b/src/graph/v2/coupling_snapshot.rs
@@ -143,6 +143,38 @@ mod tests {
     }
 
     #[test]
+    fn degrees_over_snapshot_match_v1_coupling_metrics() {
+        // The fan-out / instability-hub rules migrated off v1 `compute_metrics`
+        // onto graph v2 degrees; this pins that the snapshot + degree counting
+        // reproduces the v1 fan-in/fan-out/instability contract per file.
+        use crate::graph::compute_metrics;
+        use crate::graph::v2::compute_degrees;
+
+        let graph = coupling_graph(&[
+            ("a.rs", "b.rs"),
+            ("a.rs", "c.rs"),
+            ("b.rs", "c.rs"),
+            ("c.rs", "a.rs"),
+        ]);
+
+        let (snapshot, path_by_id) = build_coupling_graph_snapshot(&graph);
+        let degrees = compute_degrees(&snapshot);
+        let v1 = compute_metrics(&graph);
+
+        assert_eq!(degrees.nodes.len(), v1.len());
+        for metric in &v1 {
+            let degree = degrees
+                .nodes
+                .iter()
+                .find(|degree| path_by_id.get(&degree.node_id) == Some(&metric.path))
+                .expect("every v1 metric maps to a graph v2 degree");
+            assert_eq!(degree.fan_in, metric.fan_in);
+            assert_eq!(degree.fan_out, metric.fan_out);
+            assert_eq!(degree.instability().to_bits(), metric.instability.to_bits());
+        }
+    }
+
+    #[test]
     fn node_ids_and_labels_use_repository_relative_paths() {
         let graph = coupling_graph(&[("src/a.rs", "src/nested/b.rs")]);
 


### PR DESCRIPTION
## Summary

This PR finishes migrating RepoPilot's import-coupling architecture rules onto graph v2.

After PR #195 moved circular dependency detection to graph v2 and PR #196 extracted the shared coupling graph snapshot adapter, this PR moves the remaining import-coupling degree-based rules to graph v2 degree counting:

- `architecture.excessive-fan-out`
- `architecture.high-instability-hub`

The rules now derive fan-in, fan-out, and instability from `compute_degrees` over the shared graph v2 snapshot instead of using the v1 `compute_metrics` path directly.

## Type of change

- Refactor
- Architecture
- Tests
- Documentation

## What changed

- Migrated `architecture.excessive-fan-out` to graph v2 degree counting.
- Migrated `architecture.high-instability-hub` to graph v2 degree counting.
- Added `NodeDegree::instability()` so graph v2 owns the instability calculation.
- Kept `architecture.circular-dependency` on graph v2 cycle detection.
- Kept all three import-coupling rules on the shared coupling graph snapshot.
- Removed direct `compute_metrics` usage from the import-coupling architecture rule path.
- Preserved the existing v1 `CouplingGraph` return path for the scan pipeline.
- Moved Rust facade detection into `import_coupling::rust_facade` to keep the main audit module smaller.
- Added regression tests to confirm graph v2 degree metrics match the previous v1 coupling metrics.
- Updated graph v2 engineering documentation.
- Updated CHANGELOG.

## Why

RepoPilot is consolidating architecture analysis around graph v2.

The circular dependency rule already uses graph v2 for SCC-based cycle detection. This PR moves the remaining import-coupling architecture rules onto the same graph model, so the coupling rule family no longer mixes graph v1 metrics and graph v2 algorithms internally.

This makes the architecture layer easier to reason about and prepares the graph subsystem for future review and report integrations.

## Contract

This PR should not change public behavior.

The following must remain stable:

- rule IDs;
- severities;
- categories;
- thresholds;
- evidence shape;
- recommendations;
- repository-relative paths;
- JSON output shape;
- SARIF output shape;
- baseline compatibility.

The migrated rules are implementation changes, not new findings.

## Architecture notes

- Graph v2 now owns degree counting for import-coupling rules.
- `NodeDegree::instability()` owns the derived instability formula.
- Import-coupling findings remain owned by the architecture audit.
- The graph layer does not know about findings, severities, rule IDs, or recommendations.
- Rust facade detection is isolated in a focused submodule.
- No new user-facing report sections are introduced.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo test coupling_snapshot
cargo test coupling
cargo test graph
cargo run -- scan .
cargo run -- scan . --format json --output report.json
```