### PR TITLE
refactor(graph): complete import-coupling graph v2 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,21 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   (`build_coupling_graph_snapshot`), so future graph v2 consumers can reuse it.
   No user-facing behavior, finding contract, or output schema changed.
 
-- Internal: migrated `architecture.excessive-fan-out` and
-  `architecture.high-instability-hub` onto graph v2 degree counting
-  (`compute_degrees` over the shared snapshot, with instability owned by
-  `NodeDegree::instability`) instead of the v1 `compute_metrics` path. All three
-  import-coupling rules now share one graph model. Fan-in/fan-out/instability
-  values, finding IDs, severities, evidence, and thresholds are unchanged; the
-  Rust facade exemption moved to an `import_coupling::rust_facade` submodule to
-  keep each file under the 300-line limit.
+- Internal: completed the near-term graph v2 migration so the import-coupling
+  rules, review blast radius, and the AI context hot-files fallback share one
+  graph model, with every migrated output preserved and guarded by parity tests.
+  `architecture.excessive-fan-out` and `architecture.high-instability-hub` now
+  derive fan-in/fan-out/instability from a single v2-backed `coupling_file_metrics`
+  (degree counting over the shared snapshot, instability owned by
+  `NodeDegree::instability`); the AI context hot-files fallback uses the same
+  function instead of v1 `compute_metrics`. Review's importer inversion
+  (`build_importers_by_target`, feeding blast radius and boundary/tiered signals)
+  is sourced from the snapshot via a new one-hop `direct_dependents` algorithm.
+  A `graph_capabilities` helper adds bounded, internal metadata describing the
+  dependency facts a snapshot carries (no command consumes it yet). Finding IDs,
+  severities, evidence, thresholds, and review JSON are unchanged; the Rust facade
+  exemption moved to an `import_coupling::rust_facade` submodule to keep each file
+  under the 300-line limit.
 
 - Documented the gate model as one coherent two-axis story: a **finding gate**
   (`--fail-on` by severity/status, or the mutually exclusive `--fail-on-priority`

--- a/docs/engineering/dependency-graph-v2.md
+++ b/docs/engineering/dependency-graph-v2.md
@@ -24,34 +24,46 @@ findings, review blast radius, AI context, or public report schemas.
 
 Graph v2 now has internal algorithms for degree summaries, hubs, SCC-based cycle
 detection, local neighborhoods, transitive blast radius (reverse dependents of a
-changed set), directory-level dependency aggregation (cross-directory coupling),
-and compact deterministic graph summaries.
+changed set), one-hop direct dependents (the importer set per file),
+directory-level dependency aggregation (cross-directory coupling), compact
+deterministic graph summaries, and bounded capability metadata
+(`graph_capabilities`) describing which dependency facts a snapshot carries.
 
-The `architecture.circular-dependency` scan rule is the first graph-related rule
-migrated to graph v2: it now detects cycles through the v2 `GraphSnapshot` and
-SCC `find_cycles` internally, while preserving its rule ID, severity, category,
-recommendation, and evidence shape. The other import-coupling rules
-(`architecture.excessive-fan-out`, `architecture.high-instability-hub`) now also
-run on graph v2 via degree counting, so all three coupling rules share one model.
-Review and AI context do not yet consume these algorithms.
+All three import-coupling scan rules now run on graph v2. The
+`architecture.circular-dependency` rule detects cycles through the v2
+`GraphSnapshot` and SCC `find_cycles`; `architecture.excessive-fan-out` and
+`architecture.high-instability-hub` derive their per-file fan-in, fan-out, and
+instability from v2 degree counting. Review and AI context consume graph v2 too:
+review's blast radius (the per-file importer set) is sourced from the snapshot's
+one-hop `direct_dependents`, and the AI context hot-files fallback uses the same
+metrics. Each migration preserves its existing rule IDs, severities, evidence,
+and output shapes.
 
-PR #195 migrated circular dependency detection to graph v2. PR #196 extracts the
-coupling graph → `GraphSnapshot` conversion out of that rule and into shared
-graph infrastructure (`build_coupling_graph_snapshot`), so it no longer lives
-inside a single audit. The adapter is intentionally free of audit concepts (no
-severities, rule IDs, findings, recommendations, or evidence) and only produces
-file nodes and `Imports` edges with a node-id → path map. Future graph v2
-consumers — blast radius, hot files, dependency depth, review context — can reuse
-this shared conversion instead of re-encoding the coupling graph themselves.
+### Migration history
 
-PR #197 finishes migrating the import-coupling architecture rules onto graph v2:
-`architecture.excessive-fan-out` and `architecture.high-instability-hub` now
-derive their per-file fan-in, fan-out, and instability from graph v2 degree
-counting (`compute_degrees`) over that shared snapshot, with instability owned by
-`NodeDegree::instability`. The rule no longer calls the v1 `compute_metrics`.
-That v1 metric path stays available for the remaining non-rule consumers (e.g.
-the AI context hot-files fallback) until they migrate too; the rule findings (IDs,
-severities, evidence, thresholds) are unchanged.
+PR #195 migrated circular dependency detection to graph v2. PR #196 extracted the
+coupling graph → `GraphSnapshot` conversion into shared graph infrastructure
+(`build_coupling_graph_snapshot`): an adapter free of audit concepts (no
+severities, rule IDs, findings, recommendations, or evidence) that produces file
+nodes and `Imports` edges with a node-id → path map.
+
+PR #197 completes the near-term migration. One v2-backed metric path,
+`coupling_file_metrics` (degree counting over the shared snapshot, with
+instability owned by `NodeDegree::instability`), replaces v1 `compute_metrics` in
+both the fan-out/instability-hub rules and the AI context hot-files fallback.
+Review's importer inversion (`build_importers_by_target`, feeding blast radius and
+boundary/tiered signals) is sourced from the snapshot via the new one-hop
+`direct_dependents` algorithm. `graph_capabilities` adds bounded metadata
+describing the dependency facts a snapshot carries — internal foundation for the
+roadmap's rule-capability checks, with no command or report consumer yet. The v1
+`compute_metrics`/`RepoContextGraph` paths remain for consumers not yet migrated;
+all migrated outputs are byte-for-byte unchanged and guarded by parity tests.
+
+The largest remaining migration is the context graph subsystem
+(`RepoContextGraph` / `context_graph_summary`), which still backs the *primary* AI
+context graph projection (edit order, blast radius, high-context files). It should
+move to graph v2 only once v2 has equivalent deterministic fixtures and bounded
+behavior, as below.
 
 Today, `CouplingGraph`, `RepoContextGraph`, import extraction, language
 resolvers, review signals, and graph summaries provide useful behavior. Graph
@@ -273,12 +285,19 @@ internal.
 
 ## Implementation Steps
 
-1. Migrate remaining graph-related architecture rules to graph v2. The
-   import-coupling rules — `architecture.circular-dependency` (cycles),
-   `architecture.excessive-fan-out`, and `architecture.high-instability-hub`
-   (degrees) — are migrated and share the coupling graph → `GraphSnapshot`
-   conversion in shared graph infrastructure (`build_coupling_graph_snapshot`).
-   Other graph-related rules can migrate onto the same snapshot next.
-2. Feed graph v2 blast radius into review.
-3. Feed graph v2 hot files into AI context.
-4. Add graph capabilities metadata for rules.
+1. **Done.** Migrate the import-coupling architecture rules to graph v2 —
+   `architecture.circular-dependency` (cycles), `architecture.excessive-fan-out`,
+   and `architecture.high-instability-hub` (degrees) — sharing the coupling graph
+   → `GraphSnapshot` conversion (`build_coupling_graph_snapshot`). Other
+   graph-related rules can migrate onto the same snapshot next.
+2. **Done.** Feed graph v2 into review blast radius: the importer inversion is
+   sourced from the snapshot via one-hop `direct_dependents`, output unchanged.
+3. **Done (fallback).** Feed graph v2 into AI context hot files: the coupling
+   fallback uses `coupling_file_metrics`. The primary `context_graph_summary`
+   projection still needs migration (see below).
+4. **Done (foundation).** Add graph capability metadata (`graph_capabilities`).
+   No rule consumes it yet; wiring rules to declare required graph facts is next.
+5. Migrate the context graph subsystem (`RepoContextGraph` /
+   `context_graph_summary`) to graph v2 so the primary AI context projection and
+   review signals share one model. This is the largest remaining step and should
+   land only behind equivalent deterministic fixtures.

--- a/src/audits/architecture/import_coupling.rs
+++ b/src/audits/architecture/import_coupling.rs
@@ -1,11 +1,12 @@
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
-use crate::graph::v2::{build_coupling_graph_snapshot, compute_degrees, find_cycles};
+use crate::graph::v2::{build_coupling_graph_snapshot, find_cycles};
 use crate::graph::{
-    CouplingGraph, FileMetrics, build_coupling_graph, without_rust_module_containment_edges,
+    CouplingGraph, FileMetrics, build_coupling_graph, coupling_file_metrics,
+    without_rust_module_containment_edges,
 };
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 mod rust_facade;
@@ -22,7 +23,7 @@ impl ImportCouplingAudit {
         root: &Path,
     ) -> (Vec<Finding>, CouplingGraph) {
         let graph = build_coupling_graph(facts, root);
-        let metrics = coupling_metrics(&graph);
+        let metrics = coupling_file_metrics(&graph);
 
         // Circular dependencies now run through graph v2's SCC-based cycle
         // detection. We re-encode the existing (module-containment-stripped)
@@ -215,29 +216,4 @@ fn circular_dependency_finding(cycle: &[PathBuf], root: &Path) -> Finding {
 
 fn relative_path(path: &Path, root: &Path) -> PathBuf {
     path.strip_prefix(root).unwrap_or(path).to_path_buf()
-}
-
-/// Per-file coupling metrics (fan-in, fan-out, instability) for the fan-out and
-/// instability-hub findings, derived from graph v2 degrees over the shared
-/// snapshot. Path-ordered to preserve the v1 `compute_metrics` contract.
-fn coupling_metrics(graph: &CouplingGraph) -> Vec<FileMetrics> {
-    let (snapshot, path_by_id) = build_coupling_graph_snapshot(graph);
-    let mut metrics: BTreeMap<PathBuf, FileMetrics> = BTreeMap::new();
-
-    for degree in compute_degrees(&snapshot).nodes {
-        let Some(path) = path_by_id.get(&degree.node_id) else {
-            continue;
-        };
-        metrics.insert(
-            path.clone(),
-            FileMetrics {
-                path: path.clone(),
-                fan_in: degree.fan_in,
-                fan_out: degree.fan_out,
-                instability: degree.instability(),
-            },
-        );
-    }
-
-    metrics.into_values().collect()
 }

--- a/src/graph/coupling_metrics.rs
+++ b/src/graph/coupling_metrics.rs
@@ -1,0 +1,108 @@
+//! Graph v2-backed per-file coupling metrics.
+//!
+//! [`coupling_file_metrics`] is the drop-in successor to the v1 [`compute_metrics`]
+//! path: it derives fan-in, fan-out, and instability from graph v2 degree
+//! counting over the shared `GraphSnapshot`, returning identical values in the
+//! same repository-path order. Consumers (the import-coupling rules and the AI
+//! context hot-files fallback) use this so they share one graph model.
+//!
+//! [`compute_metrics`]: super::compute_metrics
+
+use super::{CouplingGraph, FileMetrics};
+use crate::graph::v2::{build_coupling_graph_snapshot, compute_degrees};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+/// Per-file fan-in, fan-out, and instability for a coupling graph, computed via
+/// graph v2 degrees. One entry per file, ordered by repository-relative path.
+pub fn coupling_file_metrics(graph: &CouplingGraph) -> Vec<FileMetrics> {
+    let (snapshot, path_by_id) = build_coupling_graph_snapshot(graph);
+    let mut metrics: BTreeMap<PathBuf, FileMetrics> = BTreeMap::new();
+
+    for degree in compute_degrees(&snapshot).nodes {
+        let Some(path) = path_by_id.get(&degree.node_id) else {
+            continue;
+        };
+        metrics.insert(
+            path.clone(),
+            FileMetrics {
+                path: path.clone(),
+                fan_in: degree.fan_in,
+                fan_out: degree.fan_out,
+                instability: degree.instability(),
+            },
+        );
+    }
+
+    metrics.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::compute_metrics;
+    use std::collections::BTreeSet;
+
+    fn coupling_graph(edges: &[(&str, &str)]) -> CouplingGraph {
+        let mut edge_map: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
+        let mut nodes: BTreeSet<PathBuf> = BTreeSet::new();
+
+        for (src, dst) in edges {
+            let src = PathBuf::from(src);
+            let dst = PathBuf::from(dst);
+            nodes.insert(src.clone());
+            nodes.insert(dst.clone());
+            edge_map.entry(src).or_default().insert(dst);
+        }
+
+        CouplingGraph {
+            edges: edge_map,
+            nodes,
+        }
+    }
+
+    /// The v2-backed metrics must reproduce the v1 contract exactly: same files,
+    /// same order, same fan-in/fan-out/instability bits.
+    #[test]
+    fn matches_v1_compute_metrics() {
+        let graph = coupling_graph(&[
+            ("a.rs", "b.rs"),
+            ("a.rs", "c.rs"),
+            ("b.rs", "c.rs"),
+            ("c.rs", "a.rs"),
+            ("src/lib.rs", "src/util.rs"),
+        ]);
+
+        let v2 = coupling_file_metrics(&graph);
+        let v1 = compute_metrics(&graph);
+
+        let key = |metrics: &[FileMetrics]| {
+            metrics
+                .iter()
+                .map(|metric| {
+                    (
+                        metric.path.clone(),
+                        metric.fan_in,
+                        metric.fan_out,
+                        metric.instability.to_bits(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(key(&v2), key(&v1));
+    }
+
+    #[test]
+    fn covers_isolated_targets_with_zero_instability() {
+        let metrics = coupling_file_metrics(&coupling_graph(&[("a.rs", "b.rs")]));
+        let b = metrics
+            .iter()
+            .find(|metric| metric.path == std::path::Path::new("b.rs"))
+            .expect("imported file is present");
+
+        assert_eq!(b.fan_in, 1);
+        assert_eq!(b.fan_out, 0);
+        assert_eq!(b.instability, 0.0);
+    }
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -3,6 +3,9 @@ pub mod imports;
 pub mod resolver;
 pub mod v2;
 
+mod coupling_metrics;
+
+pub use coupling_metrics::coupling_file_metrics;
 pub use imports::extract_imports;
 pub use resolver::resolve_import;
 

--- a/src/graph/v2/algorithms/blast_radius.rs
+++ b/src/graph/v2/algorithms/blast_radius.rs
@@ -1,6 +1,6 @@
 use super::topology;
 use crate::graph::v2::{GraphNodeId, GraphSnapshot};
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 /// The transitive dependents of a set of changed nodes: every node that can
 /// reach a seed by following dependency edges (i.e. the importers, directly or
@@ -44,4 +44,30 @@ pub fn blast_radius(snapshot: &GraphSnapshot, seeds: &[GraphNodeId]) -> GraphBla
         seeds: present_seeds.into_iter().collect(),
         impacted,
     }
+}
+
+/// Direct (one-hop) dependents of every node: each node mapped to the nodes that
+/// depend on it through an incoming dependency edge — its importer set. This is
+/// the non-transitive counterpart to [`blast_radius`], used where a consumer
+/// needs "who imports this file directly" rather than the full reachable set.
+/// Every node is present; nodes with no dependents map to an empty set.
+pub fn direct_dependents(snapshot: &GraphSnapshot) -> BTreeMap<GraphNodeId, BTreeSet<GraphNodeId>> {
+    let topology = topology(snapshot);
+    let mut dependents = topology
+        .node_ids
+        .iter()
+        .cloned()
+        .map(|id| (id, BTreeSet::new()))
+        .collect::<BTreeMap<GraphNodeId, BTreeSet<GraphNodeId>>>();
+
+    for edge in &topology.edges {
+        if edge.kind.is_dependency() {
+            dependents
+                .get_mut(&edge.to)
+                .expect("validated target node")
+                .insert(edge.from.clone());
+        }
+    }
+
+    dependents
 }

--- a/src/graph/v2/algorithms/mod.rs
+++ b/src/graph/v2/algorithms/mod.rs
@@ -5,7 +5,7 @@ mod directory;
 mod neighborhood;
 mod summary;
 
-pub use blast_radius::{GraphBlastRadius, blast_radius};
+pub use blast_radius::{GraphBlastRadius, blast_radius, direct_dependents};
 pub use cycles::{GraphCycle, find_cycles};
 pub use degree::{GraphDegreeSummary, NodeDegree, compute_degrees, top_fan_in, top_fan_out};
 pub use directory::{DirectoryDependency, GraphDirectoryDependencies, directory_dependencies};

--- a/src/graph/v2/algorithms/tests.rs
+++ b/src/graph/v2/algorithms/tests.rs
@@ -74,6 +74,24 @@ fn degrees_count_each_exact_edge_once() {
 }
 
 #[test]
+fn direct_dependents_lists_one_hop_importers_only() {
+    // a -> b -> c and a -> c. c is imported directly by a and b; b only by a;
+    // a by nobody. Dependents are one hop, never transitive.
+    let graph = snapshot(&["a", "b", "c"], &[("a", "b"), ("b", "c"), ("a", "c")]);
+    let dependents = direct_dependents(&graph);
+    let importers = |center: &str| {
+        dependents[&id(center)]
+            .iter()
+            .map(|node| node.as_str().to_string())
+            .collect::<Vec<_>>()
+    };
+
+    assert_eq!(importers("c"), vec!["a", "b"]);
+    assert_eq!(importers("b"), vec!["a"]);
+    assert!(importers("a").is_empty());
+}
+
+#[test]
 fn node_degree_instability_matches_coupling_formula() {
     let isolated = NodeDegree {
         node_id: id("a"),

--- a/src/graph/v2/capabilities.rs
+++ b/src/graph/v2/capabilities.rs
@@ -1,0 +1,154 @@
+//! Graph v2 capability metadata.
+//!
+//! [`graph_capabilities`] reports, for one `GraphSnapshot`, which dependency
+//! facts the graph actually carries — counts of file vs external nodes and of
+//! dependency edges by confidence tier. The roadmap calls for rules to declare
+//! whether the graph evidence they need is available for a repository or scope;
+//! this is the bounded, deterministic foundation for that check. It is internal
+//! and has no command or report consumer yet — it does not add a public surface.
+
+use super::{GraphEdgeConfidence, GraphNodeKind, GraphSnapshot};
+
+/// What dependency facts a snapshot provides. All counts are over dependency
+/// edges only (`Imports`/`ReExports`/`DependsOn`); structural edges such as
+/// `TestOf` are excluded.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GraphCapabilities {
+    /// File nodes resolved within the repository.
+    pub file_nodes: usize,
+    /// External dependency nodes (packages we do not resolve to a scanned file).
+    pub external_nodes: usize,
+    /// Dependency edges resolved to a scanned file (high confidence).
+    pub resolved_dependency_edges: usize,
+    /// Dependency edges to an external package we cannot resolve locally (medium).
+    pub external_dependency_edges: usize,
+    /// Local imports that looked relative but resolved to nothing (low).
+    pub unresolved_local_edges: usize,
+    /// Bounded diagnostics recorded while building the snapshot.
+    pub diagnostics: usize,
+}
+
+impl GraphCapabilities {
+    /// Whether the snapshot carries any resolved file-to-file dependency edges —
+    /// the minimum for cycle, degree, and blast-radius analysis to mean anything.
+    pub fn supports_dependency_analysis(&self) -> bool {
+        self.resolved_dependency_edges > 0
+    }
+}
+
+/// Derive [`GraphCapabilities`] from a snapshot. Deterministic and bounded by the
+/// snapshot's own size.
+pub fn graph_capabilities(snapshot: &GraphSnapshot) -> GraphCapabilities {
+    let mut capabilities = GraphCapabilities {
+        diagnostics: snapshot.diagnostics.len(),
+        ..GraphCapabilities::default()
+    };
+
+    for node in &snapshot.nodes {
+        match node.kind {
+            GraphNodeKind::File => capabilities.file_nodes += 1,
+            GraphNodeKind::ExternalDependency => capabilities.external_nodes += 1,
+            _ => {}
+        }
+    }
+
+    for edge in &snapshot.edges {
+        if !edge.kind.is_dependency() {
+            continue;
+        }
+        match edge.confidence {
+            GraphEdgeConfidence::High => capabilities.resolved_dependency_edges += 1,
+            GraphEdgeConfidence::Medium => capabilities.external_dependency_edges += 1,
+            GraphEdgeConfidence::Low => capabilities.unresolved_local_edges += 1,
+        }
+    }
+
+    capabilities
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::v2::{
+        GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance, GraphNode, GraphNodeId,
+        GraphNodeKind, GraphSnapshot,
+    };
+
+    fn file(id: &str) -> GraphNode {
+        GraphNode {
+            id: GraphNodeId::new(format!("file:{id}")),
+            kind: GraphNodeKind::File,
+            label: id.to_string(),
+            path: None,
+        }
+    }
+
+    fn external(name: &str) -> GraphNode {
+        GraphNode {
+            id: GraphNodeId::new(format!("external:{name}")),
+            kind: GraphNodeKind::ExternalDependency,
+            label: name.to_string(),
+            path: None,
+        }
+    }
+
+    fn edge(
+        from: &str,
+        to: &str,
+        kind: GraphEdgeKind,
+        confidence: GraphEdgeConfidence,
+    ) -> GraphEdge {
+        GraphEdge {
+            from: GraphNodeId::new(from),
+            to: GraphNodeId::new(to),
+            kind,
+            provenance: GraphEdgeProvenance::Import,
+            confidence,
+        }
+    }
+
+    #[test]
+    fn empty_snapshot_supports_nothing() {
+        let capabilities = graph_capabilities(&GraphSnapshot::new());
+
+        assert_eq!(capabilities, GraphCapabilities::default());
+        assert!(!capabilities.supports_dependency_analysis());
+    }
+
+    #[test]
+    fn counts_nodes_and_dependency_edges_by_confidence() {
+        let mut snapshot = GraphSnapshot::new();
+        snapshot.add_node(file("a.rs"));
+        snapshot.add_node(file("b.rs"));
+        snapshot.add_node(external("serde"));
+        // Resolved local import, external package dependency, and a structural
+        // test edge that must be ignored.
+        snapshot.add_edge(edge(
+            "file:a.rs",
+            "file:b.rs",
+            GraphEdgeKind::Imports,
+            GraphEdgeConfidence::High,
+        ));
+        snapshot.add_edge(edge(
+            "file:a.rs",
+            "external:serde",
+            GraphEdgeKind::DependsOn,
+            GraphEdgeConfidence::Medium,
+        ));
+        snapshot.add_edge(edge(
+            "file:b.rs",
+            "file:a.rs",
+            GraphEdgeKind::TestOf,
+            GraphEdgeConfidence::High,
+        ));
+
+        let capabilities = graph_capabilities(&snapshot);
+
+        assert_eq!(capabilities.file_nodes, 2);
+        assert_eq!(capabilities.external_nodes, 1);
+        assert_eq!(capabilities.resolved_dependency_edges, 1);
+        assert_eq!(capabilities.external_dependency_edges, 1);
+        assert_eq!(capabilities.unresolved_local_edges, 0);
+        assert!(capabilities.supports_dependency_analysis());
+    }
+}

--- a/src/graph/v2/coupling_snapshot.rs
+++ b/src/graph/v2/coupling_snapshot.rs
@@ -3,13 +3,15 @@ use super::{
     GraphNodeKind, GraphSnapshot,
 };
 use crate::scan::types::CouplingGraph;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 /// Re-encodes a file-level [`CouplingGraph`] as a graph v2 [`GraphSnapshot`] so
 /// shared v2 algorithms (e.g. SCC cycle detection) can run over it, returning
 /// the snapshot alongside a map from node id back to file path. Only file nodes
-/// and dependency (`Imports`) edges are produced.
+/// and dependency (`Imports`) edges are produced. Every edge endpoint becomes a
+/// node even if the graph's `nodes` set omits it, so no edge is silently dropped
+/// by snapshot validation (a well-formed `CouplingGraph` already lists them).
 ///
 /// This is the shared bridge between the v1 coupling graph and graph v2. It is
 /// deliberately free of audit concepts (no severities, rule ids, findings, or
@@ -22,7 +24,13 @@ pub fn build_coupling_graph_snapshot(
     let mut snapshot = GraphSnapshot::new();
     let mut path_by_id = BTreeMap::new();
 
-    for path in &graph.nodes {
+    let mut paths: BTreeSet<&PathBuf> = graph.nodes.iter().collect();
+    for (from, targets) in &graph.edges {
+        paths.insert(from);
+        paths.extend(targets);
+    }
+
+    for path in paths {
         let id = node_id(path);
         path_by_id.insert(id.clone(), path.clone());
         snapshot.add_node(GraphNode {
@@ -117,6 +125,30 @@ mod tests {
     }
 
     #[test]
+    fn edge_endpoints_missing_from_nodes_still_become_nodes() {
+        // A coupling graph whose `nodes` set omits the edge endpoints (as some
+        // callers build it from edges alone) must still keep every edge: the
+        // endpoints are materialized as nodes so snapshot validation never drops
+        // the relationship.
+        let graph = CouplingGraph {
+            edges: BTreeMap::from([(
+                PathBuf::from("a.rs"),
+                BTreeSet::from([PathBuf::from("b.rs")]),
+            )]),
+            nodes: BTreeSet::new(),
+        };
+
+        let (snapshot, path_by_id) = build_coupling_graph_snapshot(&graph);
+
+        assert_eq!(snapshot.node_count(), 2);
+        assert_eq!(snapshot.edge_count(), 1);
+        assert_eq!(path_by_id.len(), 2);
+        // The dependents query sees the edge rather than dropping it.
+        let dependents = crate::graph::v2::direct_dependents(&snapshot);
+        assert_eq!(dependents[&node_id("b.rs")].len(), 1);
+    }
+
+    #[test]
     fn simple_cycle_is_representable() {
         // a.rs -> b.rs and b.rs -> a.rs form one strongly-connected component.
         let graph = coupling_graph(&[("a.rs", "b.rs"), ("b.rs", "a.rs")]);
@@ -140,38 +172,6 @@ mod tests {
 
         assert_eq!(first.edge_count(), 1);
         assert_eq!(first, second);
-    }
-
-    #[test]
-    fn degrees_over_snapshot_match_v1_coupling_metrics() {
-        // The fan-out / instability-hub rules migrated off v1 `compute_metrics`
-        // onto graph v2 degrees; this pins that the snapshot + degree counting
-        // reproduces the v1 fan-in/fan-out/instability contract per file.
-        use crate::graph::compute_metrics;
-        use crate::graph::v2::compute_degrees;
-
-        let graph = coupling_graph(&[
-            ("a.rs", "b.rs"),
-            ("a.rs", "c.rs"),
-            ("b.rs", "c.rs"),
-            ("c.rs", "a.rs"),
-        ]);
-
-        let (snapshot, path_by_id) = build_coupling_graph_snapshot(&graph);
-        let degrees = compute_degrees(&snapshot);
-        let v1 = compute_metrics(&graph);
-
-        assert_eq!(degrees.nodes.len(), v1.len());
-        for metric in &v1 {
-            let degree = degrees
-                .nodes
-                .iter()
-                .find(|degree| path_by_id.get(&degree.node_id) == Some(&metric.path))
-                .expect("every v1 metric maps to a graph v2 degree");
-            assert_eq!(degree.fan_in, metric.fan_in);
-            assert_eq!(degree.fan_out, metric.fan_out);
-            assert_eq!(degree.instability().to_bits(), metric.instability.to_bits());
-        }
     }
 
     #[test]

--- a/src/graph/v2/mod.rs
+++ b/src/graph/v2/mod.rs
@@ -1,5 +1,6 @@
 mod algorithms;
 mod builder;
+mod capabilities;
 mod coupling_snapshot;
 mod diagnostic;
 mod edge;
@@ -9,10 +10,11 @@ mod snapshot;
 pub use algorithms::{
     DirectoryDependency, GraphBlastRadius, GraphCycle, GraphDegreeSummary,
     GraphDirectoryDependencies, GraphNeighborhood, GraphV2Summary, NodeDegree, blast_radius,
-    compute_degrees, directory_dependencies, find_cycles, neighborhood, summarize_graph,
-    top_fan_in, top_fan_out,
+    compute_degrees, direct_dependents, directory_dependencies, find_cycles, neighborhood,
+    summarize_graph, top_fan_in, top_fan_out,
 };
 pub use builder::graph_snapshot_from_scan;
+pub use capabilities::{GraphCapabilities, graph_capabilities};
 pub use coupling_snapshot::build_coupling_graph_snapshot;
 pub use diagnostic::GraphDiagnostic;
 pub use edge::{GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance};

--- a/src/output/ai_context/hotfiles.rs
+++ b/src/output/ai_context/hotfiles.rs
@@ -1,5 +1,5 @@
-use crate::graph::compute_metrics;
 use crate::graph::context::{ContextGraphFileMetric, ContextGraphSummary};
+use crate::graph::coupling_file_metrics;
 use crate::scan::types::ScanSummary;
 use std::fmt::Write as FmtWrite;
 
@@ -14,7 +14,7 @@ pub(super) fn render_hot_files(out: &mut String, summary: &ScanSummary) {
         None => return,
     };
 
-    let mut metrics = compute_metrics(graph);
+    let mut metrics = coupling_file_metrics(graph);
     metrics.retain(|m| m.fan_in > 0);
     if metrics.is_empty() {
         return;

--- a/src/review/signals/composites.rs
+++ b/src/review/signals/composites.rs
@@ -7,6 +7,7 @@
 
 use super::BoundarySignal;
 use crate::audits::context::classify::helpers::is_test_file;
+use crate::graph::v2::{build_coupling_graph_snapshot, direct_dependents};
 use crate::review::diff::ChangedFile;
 use crate::review::paths::normalized_review_path;
 use crate::scan::types::CouplingGraph;
@@ -14,21 +15,34 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 /// Invert the coupling graph: map each imported file to the set of files that
-/// import it, with paths normalized relative to the repo root.
+/// import it, with paths normalized relative to the repo root. Sources the
+/// importer relation from the shared graph v2 `GraphSnapshot` (one-hop
+/// `direct_dependents`) so review shares the same graph model as the rules;
+/// targets with no importers are omitted, matching the previous edge inversion.
 pub fn build_importers_by_target(
     graph: &CouplingGraph,
     repo_root: &Path,
 ) -> BTreeMap<PathBuf, BTreeSet<PathBuf>> {
+    let (snapshot, path_by_id) = build_coupling_graph_snapshot(graph);
     let mut importers: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
-    for (source, targets) in &graph.edges {
-        let source = normalized_review_path(source, repo_root);
-        for target in targets {
-            importers
-                .entry(normalized_review_path(target, repo_root))
-                .or_default()
-                .insert(source.clone());
+
+    for (target_id, source_ids) in direct_dependents(&snapshot) {
+        if source_ids.is_empty() {
+            continue;
+        }
+        let Some(target) = path_by_id.get(&target_id) else {
+            continue;
+        };
+        let entry = importers
+            .entry(normalized_review_path(target, repo_root))
+            .or_default();
+        for source_id in &source_ids {
+            if let Some(source) = path_by_id.get(source_id) {
+                entry.insert(normalized_review_path(source, repo_root));
+            }
         }
     }
+
     importers
 }
 
@@ -66,4 +80,46 @@ pub fn missing_test_for_code_boundary(
         .iter()
         .any(|signal| signal.category.is_code_boundary())
         && !any_test_changed(changed_files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn coupling_graph(edges: &[(&str, &str)]) -> CouplingGraph {
+        let mut edge_map: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
+        let mut nodes: BTreeSet<PathBuf> = BTreeSet::new();
+        for (src, dst) in edges {
+            let src = PathBuf::from(src);
+            let dst = PathBuf::from(dst);
+            nodes.insert(src.clone());
+            nodes.insert(dst.clone());
+            edge_map.entry(src).or_default().insert(dst);
+        }
+        CouplingGraph {
+            edges: edge_map,
+            nodes,
+        }
+    }
+
+    #[test]
+    fn importers_by_target_inverts_edges_with_normalized_paths() {
+        // a imports b and c; b imports c. c is imported by {a, b}, b by {a},
+        // and a (no importers) is absent from the map.
+        let root = Path::new("/repo");
+        let graph = coupling_graph(&[("a.rs", "b.rs"), ("a.rs", "c.rs"), ("b.rs", "c.rs")]);
+
+        let importers = build_importers_by_target(&graph, root);
+
+        let norm = |path: &str| normalized_review_path(Path::new(path), root);
+        assert_eq!(
+            importers.get(&norm("c.rs")),
+            Some(&BTreeSet::from([norm("a.rs"), norm("b.rs")]))
+        );
+        assert_eq!(
+            importers.get(&norm("b.rs")),
+            Some(&BTreeSet::from([norm("a.rs")]))
+        );
+        assert!(!importers.contains_key(&norm("a.rs")));
+    }
 }


### PR DESCRIPTION
## Summary

This PR completes the near-term graph v2 migration for RepoPilot's import-coupling architecture analysis.

After PR #195 moved circular dependency detection to graph v2 and PR #196 extracted the shared coupling snapshot adapter, this PR moves the remaining coupling metric consumers onto the same graph v2-backed path.

This includes architecture rules, review dependency signals, and the remaining AI context hot-file fallback that still consumed legacy coupling metrics.

## Type of change

- Refactor
- Architecture
- Tests
- Documentation

## What changed

- Added a shared graph v2-backed `coupling_file_metrics` helper.
- Replaced direct v1 `compute_metrics` usage in import-coupling rule paths.
- Kept `architecture.circular-dependency` on graph v2 SCC cycle detection.
- Kept `architecture.excessive-fan-out` and `architecture.high-instability-hub` on graph v2 degree counting.
- Added one-hop direct dependent lookup through graph v2.
- Updated review dependency signal wiring to use graph v2-backed importer relationships.
- Updated AI context hot-file fallback to use graph v2-backed coupling metrics.
- Added graph capability metadata foundation.
- Added parity tests to ensure graph v2 metrics preserve the previous v1 behavior.
- Updated graph v2 engineering documentation.
- Updated CHANGELOG.

## Why

RepoPilot is consolidating dependency analysis around graph v2.

Before this change, import-coupling analysis still had several graph paths:

- circular dependency detection used graph v2;
- fan-in / fan-out / instability rules were migrated gradually;
- review dependency signals had their own importer lookup path;
- AI context hot-file fallback still depended on legacy coupling metrics.

This PR reduces that split by moving the coupling rule family, review dependency signals, and remaining AI context hot-file fallback toward one shared graph model.

## Contract

This PR should not change public behavior.

The following must remain stable:

- rule IDs;
- severities;
- categories;
- thresholds;
- evidence shape;
- recommendations;
- repository-relative paths;
- JSON output shape;
- SARIF output shape;
- baseline compatibility;
- review output compatibility;
- AI context output shape, except for equivalent graph-backed ordering/metric improvements.

## Architecture notes

- Graph v2 owns degree counting and direct dependent lookup.
- `coupling_file_metrics` acts as the shared compatibility bridge for existing per-file coupling metrics.
- Architecture audits still own finding generation.
- Review signals consume graph-derived dependency facts but do not own graph conversion.
- AI context hot-file fallback consumes graph-backed metrics but does not own graph logic.
- Graph capability metadata is added as infrastructure for future reporting.
- No new user-facing commands are introduced.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo test coupling_file_metrics
cargo test coupling_snapshot
cargo test graph
cargo test review
cargo run -- scan .
cargo run -- scan . --format json --output report.json
cargo run -- review .