### PR TITLE
refactor(graph): deduplicate context metrics on graph v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   exemption moved to an `import_coupling::rust_facade` submodule to keep each file
   under the 300-line limit.
 
+- Internal: moved the Context Risk Graph summary and the risk graph-impact overlay
+  off the v1 `compute_metrics` path onto the shared v2-backed `coupling_file_metrics`,
+  and rebuilt the context summary's changed-blast-radius from the shared one-hop
+  `direct_dependents` instead of a private edge inversion. This removes the last
+  duplicate importer-inversion copy and leaves v1 `compute_metrics` out of every
+  production path (it remains only as the parity-test reference). The
+  `ContextGraphSummary` (AI context "Context Risk Graph", review CI, report schema)
+  and all risk scoring are byte-for-byte unchanged, guarded by existing and new
+  parity tests.
+
 - Documented the gate model as one coherent two-axis story: a **finding gate**
   (`--fail-on` by severity/status, or the mutually exclusive `--fail-on-priority`
   by risk; in-diff only on `review`) and a separate, opt-in **review-signal gate**

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -1,7 +1,8 @@
 use crate::audits::context::{FileRole, classify_file};
 use crate::findings::types::Finding;
+use crate::graph::v2::{build_coupling_graph_snapshot, direct_dependents};
 use crate::graph::{
-    CouplingGraph, build_coupling_graph, compute_metrics, detect_cycles_bounded,
+    CouplingGraph, build_coupling_graph, coupling_file_metrics, detect_cycles_bounded,
     without_rust_module_containment_edges,
 };
 use crate::review::diff::{ChangeStatus, ChangedFile};
@@ -174,6 +175,37 @@ mod tests {
                 .iter()
                 .any(|value| value == "risky_clusters")
         );
+    }
+
+    #[test]
+    fn summary_changed_blast_radius_lists_direct_importers() {
+        // a.rs and b.rs both import shared.rs; changing shared.rs reaches both,
+        // sourced through the shared graph v2 one-hop dependents.
+        let shared = PathBuf::from("src/shared.rs");
+        let a = PathBuf::from("src/a.rs");
+        let b = PathBuf::from("src/b.rs");
+        let mut edges = BTreeMap::new();
+        edges.insert(a.clone(), BTreeSet::from([shared.clone()]));
+        edges.insert(b.clone(), BTreeSet::from([shared.clone()]));
+
+        let graph = RepoContextGraph {
+            root_path: PathBuf::from("."),
+            nodes: vec![node(&a), node(&b), node(&shared)],
+            edges,
+            detected_frameworks: Vec::new(),
+            framework_projects: Vec::new(),
+            react_native: None,
+        };
+        let changed = vec![ChangedFile {
+            path: shared.clone(),
+            status: ChangeStatus::Modified,
+            ranges: Vec::new(),
+            hunks: Vec::new(),
+        }];
+
+        let summary = summarize_context_graph(&graph, &[], &changed);
+
+        assert_eq!(summary.changed_blast_radius, vec![a, b]);
     }
 
     fn node(path: &Path) -> RepoContextNode {

--- a/src/graph/context/summary.rs
+++ b/src/graph/context/summary.rs
@@ -6,7 +6,7 @@ pub fn summarize_context_graph(
     changed_files: &[ChangedFile],
 ) -> ContextGraphSummary {
     let coupling_graph = graph.coupling_graph();
-    let mut metrics = compute_metrics(&coupling_graph);
+    let mut metrics = coupling_file_metrics(&coupling_graph);
     let node_by_path = graph
         .nodes
         .iter()
@@ -113,15 +113,21 @@ fn changed_blast_radius(
         .iter()
         .map(|file| file.path.clone())
         .collect::<HashSet<_>>();
-    let mut importers_by_target: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
-    for (source, targets) in &graph.edges {
-        for target in targets {
-            importers_by_target
-                .entry(target.clone())
-                .or_default()
-                .insert(source.clone());
-        }
-    }
+    // Invert the dependency edges through the shared graph v2 one-hop
+    // `direct_dependents`, then key the importer sets back by repository path so
+    // the lookup below is unchanged.
+    let (snapshot, path_by_id) = build_coupling_graph_snapshot(graph);
+    let importers_by_target: BTreeMap<PathBuf, BTreeSet<PathBuf>> = direct_dependents(&snapshot)
+        .into_iter()
+        .filter_map(|(target_id, source_ids)| {
+            let target = path_by_id.get(&target_id)?.clone();
+            let sources = source_ids
+                .iter()
+                .filter_map(|id| path_by_id.get(id).cloned())
+                .collect::<BTreeSet<_>>();
+            Some((target, sources))
+        })
+        .collect();
 
     let mut impacted = BTreeSet::new();
     for path in &changed {

--- a/src/risk/overlays/support.rs
+++ b/src/risk/overlays/support.rs
@@ -3,7 +3,7 @@
 //! normalization they share.
 
 use crate::findings::types::{Finding, Severity};
-use crate::graph::{CouplingGraph, compute_metrics};
+use crate::graph::{CouplingGraph, coupling_file_metrics};
 use crate::risk::model::GraphImpact;
 use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path};
@@ -24,7 +24,7 @@ pub(super) fn workspace_hotspots(findings: &[Finding]) -> HashSet<String> {
 }
 
 pub(super) fn graph_impacts(graph: &CouplingGraph) -> HashMap<String, GraphImpact> {
-    compute_metrics(graph)
+    coupling_file_metrics(graph)
         .into_iter()
         .filter_map(|metric| {
             let impact = if metric.fan_in >= 3 || metric.fan_out >= 8 {


### PR DESCRIPTION
## Summary

This PR removes the remaining duplicated context/risk coupling-metric paths and routes them through the shared graph v2-backed `coupling_file_metrics` helper.

After the previous graph v2 migration PRs moved import-coupling rules, review dependency signals, and AI context hot-file fallback onto graph v2-backed data, this PR updates the remaining context summary and risk graph-impact overlay consumers to use the same shared coupling metric path.

## Type of change

- Refactor
- Architecture
- Tests
- Documentation

## What changed

- Updated Context Risk Graph summary metrics to use `coupling_file_metrics`.
- Updated changed blast radius computation to use graph v2 `direct_dependents`.
- Removed the private importer-inversion path from context summary logic.
- Updated risk graph-impact overlay metrics to use `coupling_file_metrics`.
- Kept v1 `compute_metrics` out of production metric consumers.
- Left v1 `compute_metrics` available as a parity-test/reference path.
- Added/updated tests for changed blast radius behavior.
- Updated CHANGELOG with the context metrics deduplication note.

## Why

RepoPilot is consolidating graph-derived architecture, review, risk, and AI-context signals around graph v2.

Before this change, some context/risk paths still duplicated importer inversion or consumed v1 coupling metrics directly. That made the graph layer harder to reason about and increased the chance that different report surfaces could drift over time.

This PR keeps those consumers on one shared graph-backed metric path.

## Contract

This PR should not change public behavior.

The following should remain stable:

- Context Risk Graph output shape;
- review CI/report schema compatibility;
- risk scoring behavior;
- AI context output shape;
- JSON/SARIF/baseline compatibility;
- existing architecture finding contracts.

The goal is implementation deduplication, not new findings or new report sections.

## Architecture notes

- Graph v2 owns direct dependent lookup.
- `coupling_file_metrics` is the shared compatibility bridge for per-file coupling metrics.
- Context summary code consumes graph-derived facts instead of owning importer inversion.
- Risk overlays consume shared graph metrics instead of calling v1 `compute_metrics`.
- No new CLI commands or user-facing output sections are introduced.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo test context
cargo test graph
cargo test risk
cargo run -- scan .
cargo run -- review .
cargo run -- scan . --format json --output report.json
npm run release:contract
./scripts/smoke-product.sh
```