### PR TITLE
fix(architecture): lead circular dependency findings with minimal cycle evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Added
 
 - Added four architecture rules that query the import graph.
-  `architecture.dead-module` (production files nothing imports that are not entrypoints or public API) and `architecture.test-leak` (production code
-  importing a test or fixture file) are on by default.
+  `architecture.dead-module` (production files nothing imports that are not entrypoints or public API) and `architecture.test-leak` (production code importing a test or fixture file) are on by default.
   `architecture.layer-violation` and `architecture.package-boundary-violation`
   are **strictly opt-in** and emit nothing until you declare structure: ordered
   `[[architecture.layers]]` (a module may import layers at or below its own,
@@ -35,6 +34,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- `architecture.circular-dependency` findings now lead with the **minimal cycle**
+  within a strongly-connected component (e.g. `a -> b -> c -> a`) and carry the
+  component size as context, instead of repeating the entire component into every
+  evidence snippet. Evidence now points at the files in the shortest cycle only,
+  so a large tangled component yields one actionable loop rather than a wall.
 - The rule registry is now the single source of truth for finding severity and
   confidence. `populate_rule_metadata` applies each rule's registry default
   (an audit may only lower severity, or raise it up to a declared ceiling), so

--- a/src/audits/architecture/import_coupling.rs
+++ b/src/audits/architecture/import_coupling.rs
@@ -1,5 +1,5 @@
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
-use crate::graph::v2::{build_coupling_graph_snapshot, find_cycles};
+use crate::graph::v2::{build_coupling_graph_snapshot, find_cycles, shortest_cycle};
 use crate::graph::{
     CouplingGraph, FileMetrics, build_coupling_graph, coupling_file_metrics,
     without_rust_module_containment_edges,
@@ -33,16 +33,7 @@ impl ImportCouplingAudit {
         // (set of mutually dependent files).
         let cycle_graph = without_rust_module_containment_edges(&graph);
         let (cycle_snapshot, path_by_id) = build_coupling_graph_snapshot(&cycle_graph);
-        let cycles: Vec<Vec<PathBuf>> = find_cycles(&cycle_snapshot)
-            .into_iter()
-            .map(|cycle| {
-                cycle
-                    .node_ids
-                    .iter()
-                    .filter_map(|id| path_by_id.get(id).cloned())
-                    .collect()
-            })
-            .collect();
+        let cycles = find_cycles(&cycle_snapshot);
 
         let classifier = crate::analysis::ArchitectureClassifier::new(&config.module_mappings);
         let mut findings = Vec::new();
@@ -94,15 +85,26 @@ impl ImportCouplingAudit {
         }
 
         let mut seen_cycles = BTreeSet::new();
-        for cycle in cycles {
-            let is_prod_cycle = cycle.iter().all(|path| prod_files.contains(path));
+        for cycle in &cycles {
+            let members: Vec<PathBuf> = cycle
+                .node_ids
+                .iter()
+                .filter_map(|id| path_by_id.get(id).cloned())
+                .collect();
+
+            let is_prod_cycle =
+                !members.is_empty() && members.iter().all(|path| prod_files.contains(path));
 
             if !is_prod_cycle {
                 continue;
             }
 
-            if seen_cycles.insert(cycle.clone()) {
-                findings.push(circular_dependency_finding(&cycle, root));
+            if seen_cycles.insert(members.clone()) {
+                let shortest: Vec<PathBuf> = shortest_cycle(&cycle_snapshot, cycle)
+                    .iter()
+                    .filter_map(|id| path_by_id.get(id).cloned())
+                    .collect();
+                findings.push(circular_dependency_finding(&members, &shortest, root));
             }
         }
 
@@ -206,21 +208,56 @@ fn high_instability_hub_finding(
     }
 }
 
-fn circular_dependency_finding(cycle: &[PathBuf], root: &Path) -> Finding {
-    let relative_cycle: Vec<PathBuf> = cycle.iter().map(|path| relative_path(path, root)).collect();
-    let cycle_path = relative_cycle
+/// `component` is the full strongly-connected component (all mutually dependent
+/// files); `shortest` is the minimal cycle within it, as a closed path
+/// (`a -> b -> a`). The finding leads with the actionable minimal cycle and
+/// carries the component size as context, instead of repeating the whole
+/// component into every evidence snippet.
+fn circular_dependency_finding(
+    component: &[PathBuf],
+    shortest: &[PathBuf],
+    root: &Path,
+) -> Finding {
+    let component_size = component.len();
+
+    // The closed path repeats its first node at the end; the distinct files are
+    // everything but that trailing repeat.
+    let closed: Vec<PathBuf> = if shortest.len() >= 2 {
+        shortest
+            .iter()
+            .map(|path| relative_path(path, root))
+            .collect()
+    } else {
+        component
+            .iter()
+            .map(|path| relative_path(path, root))
+            .collect()
+    };
+    let cycle_path = closed
         .iter()
         .map(|path| path.display().to_string())
         .collect::<Vec<_>>()
         .join(" -> ");
-    let file_count = relative_cycle.len();
-    let evidence = relative_cycle
+    let distinct: Vec<&PathBuf> = closed.iter().take(closed.len().saturating_sub(1)).collect();
+    let distinct = if distinct.is_empty() {
+        closed.iter().collect()
+    } else {
+        distinct
+    };
+
+    let context = if component_size > distinct.len() {
+        format!(" Part of a strongly-connected component of {component_size} files.")
+    } else {
+        String::new()
+    };
+
+    let evidence = distinct
         .iter()
         .map(|path| Evidence {
-            path: path.clone(),
+            path: (*path).clone(),
             line_start: 1,
             line_end: None,
-            snippet: format!("Cycle ({file_count} files): {cycle_path}."),
+            snippet: format!("Cycle: {cycle_path}.{context}"),
         })
         .collect();
 
@@ -229,9 +266,7 @@ fn circular_dependency_finding(cycle: &[PathBuf], root: &Path) -> Finding {
         rule_id: "architecture.circular-dependency".to_string(),
         recommendation: Finding::recommendation_for_rule_id("architecture.circular-dependency"),
         title: "Circular dependency detected".to_string(),
-        description: format!(
-            "A circular dependency was detected across {file_count} project files."
-        ),
+        description: format!("A circular dependency was detected: {cycle_path}.{context}"),
         category: FindingCategory::Architecture,
         severity: Severity::High,
         confidence: Default::default(),

--- a/src/graph/v2/algorithms/cycles.rs
+++ b/src/graph/v2/algorithms/cycles.rs
@@ -1,10 +1,94 @@
 use super::topology;
 use crate::graph::v2::{GraphNodeId, GraphSnapshot};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GraphCycle {
     pub node_ids: Vec<GraphNodeId>,
+}
+
+/// Cap on how many start nodes the shortest-cycle search tries, bounding cost on
+/// pathologically large strongly-connected components. Members are sorted, so
+/// the search stays deterministic.
+const MAX_SHORTEST_CYCLE_STARTS: usize = 64;
+
+/// The shortest directed cycle within a strongly-connected component, returned
+/// as a closed path (e.g. `a -> b -> a` is `[a, b, a]`). Useful as the
+/// actionable headline for an `architecture.circular-dependency` finding when
+/// the full component is too large to read. Falls back to the (sorted) member
+/// list if no cycle can be reconstructed.
+pub fn shortest_cycle(snapshot: &GraphSnapshot, cycle: &GraphCycle) -> Vec<GraphNodeId> {
+    let members = &cycle.node_ids;
+    let index_by_id: BTreeMap<&GraphNodeId, usize> = members
+        .iter()
+        .enumerate()
+        .map(|(index, id)| (id, index))
+        .collect();
+
+    let mut adjacency = vec![Vec::new(); members.len()];
+    for edge in &snapshot.edges {
+        if let (Some(&from), Some(&to)) = (index_by_id.get(&edge.from), index_by_id.get(&edge.to)) {
+            adjacency[from].push(to);
+        }
+    }
+    for targets in &mut adjacency {
+        targets.sort_unstable();
+        targets.dedup();
+    }
+
+    let mut best: Option<Vec<usize>> = None;
+    for start in 0..members.len().min(MAX_SHORTEST_CYCLE_STARTS) {
+        if let Some(path) = shortest_cycle_from(start, &adjacency)
+            && best
+                .as_ref()
+                .is_none_or(|current| path.len() < current.len())
+        {
+            best = Some(path);
+        }
+    }
+
+    match best {
+        Some(path) => path
+            .into_iter()
+            .map(|index| members[index].clone())
+            .collect(),
+        None => members.clone(),
+    }
+}
+
+/// Breadth-first search for the shortest cycle returning to `start`, as a closed
+/// path of node indices `[start, ..., start]`.
+fn shortest_cycle_from(start: usize, adjacency: &[Vec<usize>]) -> Option<Vec<usize>> {
+    let mut parent = vec![usize::MAX; adjacency.len()];
+    let mut visited = vec![false; adjacency.len()];
+    visited[start] = true;
+    let mut queue = VecDeque::from([start]);
+
+    while let Some(node) = queue.pop_front() {
+        for &next in &adjacency[node] {
+            if next == start {
+                let mut chain = Vec::new();
+                let mut current = node;
+                while current != start {
+                    chain.push(current);
+                    current = parent[current];
+                }
+                chain.reverse();
+                let mut path = Vec::with_capacity(chain.len() + 2);
+                path.push(start);
+                path.extend(chain);
+                path.push(start);
+                return Some(path);
+            }
+            if !visited[next] {
+                visited[next] = true;
+                parent[next] = node;
+                queue.push_back(next);
+            }
+        }
+    }
+
+    None
 }
 
 pub fn find_cycles(snapshot: &GraphSnapshot) -> Vec<GraphCycle> {

--- a/src/graph/v2/algorithms/mod.rs
+++ b/src/graph/v2/algorithms/mod.rs
@@ -6,7 +6,7 @@ mod neighborhood;
 mod summary;
 
 pub use blast_radius::{GraphBlastRadius, blast_radius, direct_dependents};
-pub use cycles::{GraphCycle, find_cycles};
+pub use cycles::{GraphCycle, find_cycles, shortest_cycle};
 pub use degree::{GraphDegreeSummary, NodeDegree, compute_degrees, top_fan_in, top_fan_out};
 pub use directory::{DirectoryDependency, GraphDirectoryDependencies, directory_dependencies};
 pub use neighborhood::{GraphNeighborhood, neighborhood};

--- a/src/graph/v2/algorithms/tests.rs
+++ b/src/graph/v2/algorithms/tests.rs
@@ -194,6 +194,37 @@ fn multiple_cycles_sort_by_size_then_first_node() {
 }
 
 #[test]
+fn shortest_cycle_returns_the_minimal_loop_within_a_large_component() {
+    // One strongly-connected component: a long ring a->b->c->d->a plus a short
+    // back-edge c->a, so the minimal cycle is a->b->c->a.
+    let graph = snapshot(
+        &["a", "b", "c", "d"],
+        &[("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("c", "a")],
+    );
+    let component = &find_cycles(&graph)[0];
+
+    let minimal = shortest_cycle(&graph, component);
+
+    assert_eq!(minimal, vec![id("a"), id("b"), id("c"), id("a")]);
+    assert!(minimal.len() < component.node_ids.len() + 1);
+}
+
+#[test]
+fn shortest_cycle_handles_two_node_loops_and_self_loops() {
+    let two = snapshot(&["a", "b"], &[("a", "b"), ("b", "a")]);
+    assert_eq!(
+        shortest_cycle(&two, &find_cycles(&two)[0]),
+        vec![id("a"), id("b"), id("a")]
+    );
+
+    let loop_back = snapshot(&["a"], &[("a", "a")]);
+    assert_eq!(
+        shortest_cycle(&loop_back, &find_cycles(&loop_back)[0]),
+        vec![id("a"), id("a")]
+    );
+}
+
+#[test]
 fn neighborhood_depth_zero_returns_only_center() {
     let graph = snapshot(&["a", "b"], &[("a", "b")]);
 

--- a/src/graph/v2/mod.rs
+++ b/src/graph/v2/mod.rs
@@ -11,7 +11,7 @@ pub use algorithms::{
     DirectoryDependency, GraphBlastRadius, GraphCycle, GraphDegreeSummary,
     GraphDirectoryDependencies, GraphNeighborhood, GraphV2Summary, NodeDegree, blast_radius,
     compute_degrees, direct_dependents, directory_dependencies, find_cycles, neighborhood,
-    summarize_graph, top_fan_in, top_fan_out,
+    shortest_cycle, summarize_graph, top_fan_in, top_fan_out,
 };
 pub use builder::graph_snapshot_from_scan;
 pub use capabilities::{GraphCapabilities, graph_capabilities};

--- a/tests/coupling_audit.rs
+++ b/tests/coupling_audit.rs
@@ -285,6 +285,73 @@ fn multiple_circular_dependencies_are_each_reported() {
 }
 
 #[test]
+fn circular_dependency_finding_leads_with_the_minimal_cycle() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    // One 4-file component {a,b,c,d}; the minimal cycle is a -> b -> c -> a,
+    // with d reachable through the c -> d -> a shortcut.
+    write_file(
+        &temp,
+        "src/a.ts",
+        r#"import { b } from "./b"; export function a() { return b(); }"#,
+    );
+    write_file(
+        &temp,
+        "src/b.ts",
+        r#"import { c } from "./c"; export function b() { return c(); }"#,
+    );
+    write_file(
+        &temp,
+        "src/c.ts",
+        r#"import { a } from "./a"; import { d } from "./d"; export function c() { return a() + d(); }"#,
+    );
+    write_file(
+        &temp,
+        "src/d.ts",
+        r#"import { a } from "./a"; export function d() { return a(); }"#,
+    );
+
+    let summary = scan_path_with_config(temp.path(), &ScanConfig::default())
+        .expect("failed to scan temp project");
+
+    let circular: Vec<_> = summary
+        .artifacts
+        .findings
+        .iter()
+        .filter(|finding| finding.rule_id == "architecture.circular-dependency")
+        .collect();
+    assert_eq!(circular.len(), 1, "expected one finding per component");
+    let finding = circular[0];
+
+    // The headline is the minimal cycle, not the whole component.
+    assert!(
+        finding
+            .description
+            .contains("src/a.ts -> src/b.ts -> src/c.ts -> src/a.ts"),
+        "description should lead with the minimal cycle, got: {}",
+        finding.description
+    );
+    // Component size is carried as context.
+    assert!(
+        finding
+            .description
+            .contains("strongly-connected component of 4 files"),
+        "description should report component size, got: {}",
+        finding.description
+    );
+    // Evidence covers only the minimal cycle's distinct files (a, b, c) — not d.
+    let evidence_paths: Vec<_> = finding
+        .evidence
+        .iter()
+        .map(|item| item.path.as_path())
+        .collect();
+    assert_eq!(evidence_paths.len(), 3, "evidence: {evidence_paths:?}");
+    assert!(evidence_paths.contains(&Path::new("src/a.ts")));
+    assert!(evidence_paths.contains(&Path::new("src/b.ts")));
+    assert!(evidence_paths.contains(&Path::new("src/c.ts")));
+    assert!(!evidence_paths.contains(&Path::new("src/d.ts")));
+}
+
+#[test]
 fn isolated_files_do_not_emit_coupling_findings() {
     let temp = TempDir::new().expect("failed to create temp dir");
     write_file(&temp, "src/a.ts", "export function a() { return 1; }\n");


### PR DESCRIPTION
## Summary

This PR improves `architecture.circular-dependency` findings by leading with the shortest actionable cycle inside a strongly-connected component.

Previously, large circular dependency components could produce noisy evidence that repeated the entire component. Now the finding highlights a minimal closed cycle such as `a -> b -> c -> a` and keeps the full component size as context.

## Type of change

- Bug fix
- Refactor
- Tests
- Documentation

## What changed

- Added `shortest_cycle` to graph v2 cycle algorithms.
- Uses BFS to find a minimal closed directed cycle inside a detected strongly-connected component.
- Updated `architecture.circular-dependency` findings to lead with the minimal cycle.
- Keeps the full component size as context when the component is larger than the displayed cycle.
- Reduces evidence noise for large tangled dependency components.
- Exports `shortest_cycle` from graph v2 algorithm modules.
- Added graph algorithm tests for:
  - minimal loop selection inside a larger component;
  - two-node cycles;
  - self-loops.
- Added coupling audit regression coverage to ensure circular dependency findings show the minimal cycle first.

## Why

Circular dependency findings should be actionable.

A large strongly-connected component can contain many files, but the developer usually needs one concrete loop to start untangling the dependency problem. Showing the shortest cycle first makes the finding easier to read, easier to fix, and more useful in reports, review output, and AI context.

## Contract and ownership

- The rule ID remains `architecture.circular-dependency`.
- Severity remains unchanged.
- Category remains unchanged.
- The finding still reports circular dependencies from the import coupling graph.
- Graph v2 owns cycle algorithms.
- Architecture audit code owns finding construction and evidence formatting.
- No new CLI command is introduced.
- JSON/SARIF/baseline compatibility should remain stable except for improved finding description/evidence text.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo test shortest_cycle
cargo test coupling_audit
cargo run -- scan .
cargo run -- scan . --format json --output report.json
npm run release:contract
./scripts/smoke-product.sh
```