### PR TITLE
fix(architecture): account for unresolved imports in graph rule confidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   `architecture.dead-module` (production files nothing imports that are not entrypoints or public API) and `architecture.test-leak` (production code importing a test or fixture file) are on by default.
   `architecture.layer-violation` and `architecture.package-boundary-violation`
   are **strictly opt-in** and emit nothing until you declare structure: ordered
-  `[[architecture.layers]]` (a module may import layers at or below its own,
-  never above) and `[architecture] package_roots` (e.g. `packages/*`, flagging
+  `[[architecture.layers]]` (a module may import layers at or below its own, never above) and `[architecture] package_roots` (e.g. `packages/*`, flagging
   imports that reach into another package's internals instead of its public
   API). Each rule ships with true-positive and false-positive fixtures; all
   four are `experimental`.
 - Added per-rule configuration: `[rules] disable` drops a rule's findings and
-  `[rules.severity_overrides]` sets an absolute severity per rule. Unknown rule
-  ids and invalid severities are surfaced as report diagnostics, not applied.
+  `[rules.severity_overrides]` sets an absolute severity per rule. Unknown rule ids and invalid severities are surfaced as report diagnostics, not applied.
 - Added regression coverage and a release self-review quality gate for
   standard-library/local dependency imports, AST-confirmed recursion,
   prose-only removed-behavior text, and side effects in tests/fixtures.
@@ -33,6 +31,20 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   that exists, not a confirmed vulnerability.
 
 ### Changed
+
+- Graph rules built on *absence* claims now reflect import-resolution quality
+  in their confidence. The coupling graph build records unresolved relative
+  (`./`, `../`) imports; when any exist, `architecture.dead-module` and
+  `architecture.high-instability-hub` are reported at `Medium` confidence
+  instead of `High`, with the evidence snippet stating how many unresolved
+  imports make the graph incomplete (fan-in is then a lower bound).
+  `architecture.dead-module` is suppressed entirely when an unresolved import's
+  final segment matches the candidate file's name — that import is a plausible
+  importer. Edge-existence proofs (`architecture.circular-dependency`,
+  `architecture.excessive-fan-out`, test-leak/layer/package rules) are
+  unaffected: unresolved imports cannot invalidate a resolved edge. Both
+  demoted rules are declared `contextual_confidence` in the registry, and their
+  false-positive notes document the demotion.
 
 - `architecture.circular-dependency` findings now lead with the **minimal cycle**
   within a strongly-connected component (e.g. `a -> b -> c -> a`) and carry the

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -8,9 +8,9 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::analysis::{ArchitectureClassifier, ArchitectureContext, FileRole};
-use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
-use crate::graph::CouplingGraph;
+use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use crate::graph::v2::{GraphNodeId, build_coupling_graph_snapshot};
+use crate::graph::{CouplingGraph, ImportResolutionStats};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
 
@@ -38,6 +38,7 @@ impl GraphQueriesAudit {
         facts: &ScanFacts,
         config: &ScanConfig,
         graph: &CouplingGraph,
+        resolution: &ImportResolutionStats,
         root: &Path,
     ) -> Vec<Finding> {
         let classifier = ArchitectureClassifier::new(&config.module_mappings);
@@ -77,7 +78,8 @@ impl GraphQueriesAudit {
 
         for node in &snapshot.nodes {
             if let Some(info) = node_info.get(&node.id)
-                && let Some(finding) = dead_module_finding(info, fan_in.get(&node.id).copied())
+                && let Some(finding) =
+                    dead_module_finding(info, fan_in.get(&node.id).copied(), resolution)
             {
                 findings.push(finding);
             }
@@ -113,7 +115,17 @@ impl GraphQueriesAudit {
 
 /// A production file that nothing imports and that is not an entrypoint or a
 /// package's public API surface is likely dead code.
-fn dead_module_finding(info: &NodeInfo, fan_in: Option<usize>) -> Option<Finding> {
+///
+/// "Nothing imports this file" is an absence claim, so it is only as good as
+/// the import graph: an unresolved relative import whose final segment matches
+/// this file's name could well be the missing importer (skip entirely), and
+/// any other unresolved relative import still means the graph is incomplete
+/// (report at `Medium` instead of the registry's `High`).
+fn dead_module_finding(
+    info: &NodeInfo,
+    fan_in: Option<usize>,
+    resolution: &ImportResolutionStats,
+) -> Option<Finding> {
     let ctx = &info.context;
     if ctx.file_role != FileRole::Production
         || ctx.is_entrypoint
@@ -123,7 +135,27 @@ fn dead_module_finding(info: &NodeInfo, fan_in: Option<usize>) -> Option<Finding
         return None;
     }
 
-    Some(architecture_finding(
+    let stem = info
+        .relative
+        .file_stem()
+        .map(|stem| stem.to_string_lossy())
+        .unwrap_or_default();
+    if resolution.could_target_stem(&stem) {
+        return None;
+    }
+
+    let mut snippet = "fan_in=0, role=Production, entrypoint=false".to_string();
+    let confidence = if resolution.is_empty() {
+        Confidence::High
+    } else {
+        snippet.push_str(&format!(
+            " ({} unresolved relative import(s) in the repository — the import graph may be incomplete)",
+            resolution.total()
+        ));
+        Confidence::Medium
+    };
+
+    let mut finding = architecture_finding(
         "architecture.dead-module",
         "Dead module detected",
         "This production file is not imported by any other project file and is not a known entrypoint.".to_string(),
@@ -131,9 +163,11 @@ fn dead_module_finding(info: &NodeInfo, fan_in: Option<usize>) -> Option<Finding
             path: info.relative.clone(),
             line_start: 1,
             line_end: None,
-            snippet: "fan_in=0, role=Production, entrypoint=false".to_string(),
+            snippet,
         },
-    ))
+    );
+    finding.confidence = confidence;
+    Some(finding)
 }
 
 /// A production file importing a test or fixture file leaks test-only code into

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -1,11 +1,17 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::analysis::{ArchitectureContext, FileRole, LanguageFamily, ModuleKind};
+use crate::findings::types::Confidence;
+use crate::graph::ImportResolutionStats;
 use crate::scan::config::{LayerSpec, ScanConfig};
 
 use super::layers::LayerIndex;
 use super::packages::PackageIndex;
 use super::{NodeInfo, dead_module_finding, test_leak_finding};
+
+fn complete_graph() -> ImportResolutionStats {
+    ImportResolutionStats::default()
+}
 
 fn node(relative: &str, role: FileRole, is_entrypoint: bool, is_public_api: bool) -> NodeInfo {
     NodeInfo {
@@ -27,32 +33,67 @@ fn prod(relative: &str) -> NodeInfo {
 #[test]
 fn dead_module_flags_unreferenced_production_file() {
     let info = prod("src/orphan.ts");
-    assert!(dead_module_finding(&info, Some(0)).is_some());
+    let finding = dead_module_finding(&info, Some(0), &complete_graph());
+    let finding = finding.expect("unreferenced production file should be flagged");
+    assert_eq!(finding.confidence, Confidence::High);
 }
 
 #[test]
 fn dead_module_exempts_entrypoints_public_api_and_imported_files() {
+    let resolution = complete_graph();
     assert!(
         dead_module_finding(
             &node("src/main.rs", FileRole::Production, true, false),
-            Some(0)
+            Some(0),
+            &resolution
         )
         .is_none()
     );
     assert!(
         dead_module_finding(
             &node("src/lib.rs", FileRole::Production, false, true),
-            Some(0)
+            Some(0),
+            &resolution
         )
         .is_none()
     );
-    assert!(dead_module_finding(&prod("src/used.ts"), Some(2)).is_none());
+    assert!(dead_module_finding(&prod("src/used.ts"), Some(2), &resolution).is_none());
     assert!(
         dead_module_finding(
             &node("src/foo.test.ts", FileRole::Test, false, false),
-            Some(0)
+            Some(0),
+            &resolution
         )
         .is_none()
+    );
+}
+
+#[test]
+fn dead_module_is_demoted_to_medium_when_graph_has_unresolved_imports() {
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record(Path::new("src/other.ts"), "./missing-helper");
+
+    let finding = dead_module_finding(&prod("src/orphan.ts"), Some(0), &resolution)
+        .expect("dead module should still be reported when the graph is merely incomplete");
+
+    assert_eq!(finding.confidence, Confidence::Medium);
+    assert!(
+        finding.evidence[0]
+            .snippet
+            .contains("unresolved relative import"),
+        "snippet should explain the demotion: {}",
+        finding.evidence[0].snippet
+    );
+}
+
+#[test]
+fn dead_module_is_suppressed_when_unresolved_import_could_target_it() {
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record(Path::new("src/other.ts"), "../legacy/orphan");
+
+    assert!(
+        dead_module_finding(&prod("src/orphan.ts"), Some(0), &resolution).is_none(),
+        "an unresolved import matching the candidate's name is a plausible importer"
     );
 }
 

--- a/src/audits/architecture/import_coupling.rs
+++ b/src/audits/architecture/import_coupling.rs
@@ -1,8 +1,8 @@
-use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
+use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use crate::graph::v2::{build_coupling_graph_snapshot, find_cycles, shortest_cycle};
 use crate::graph::{
-    CouplingGraph, FileMetrics, build_coupling_graph, coupling_file_metrics,
-    without_rust_module_containment_edges,
+    CouplingGraph, FileMetrics, ImportResolutionStats, build_coupling_graph_with_resolution,
+    coupling_file_metrics, without_rust_module_containment_edges,
 };
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
@@ -10,6 +10,9 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 mod rust_facade;
+
+#[cfg(test)]
+mod tests;
 
 use rust_facade::is_pure_rust_facade;
 
@@ -21,8 +24,8 @@ impl ImportCouplingAudit {
         facts: &ScanFacts,
         config: &ScanConfig,
         root: &Path,
-    ) -> (Vec<Finding>, CouplingGraph) {
-        let graph = build_coupling_graph(facts, root);
+    ) -> (Vec<Finding>, CouplingGraph, ImportResolutionStats) {
+        let (graph, resolution) = build_coupling_graph_with_resolution(facts, root);
         let metrics = coupling_file_metrics(&graph);
 
         // Circular dependencies now run through graph v2's SCC-based cycle
@@ -80,6 +83,7 @@ impl ImportCouplingAudit {
                     config.instability_hub_min_fan_in,
                     config.instability_hub_min_instability_pct,
                     file_facts,
+                    &resolution,
                 ));
             }
         }
@@ -108,7 +112,7 @@ impl ImportCouplingAudit {
             }
         }
 
-        (findings, graph)
+        (findings, graph, resolution)
     }
 }
 
@@ -165,6 +169,7 @@ fn high_instability_hub_finding(
     min_fan_in: usize,
     min_instability_pct: usize,
     file_facts: Option<&crate::scan::facts::FileFacts>,
+    resolution: &ImportResolutionStats,
 ) -> Finding {
     let path = relative_path(&metric.path, root);
 
@@ -175,6 +180,19 @@ fn high_instability_hub_finding(
         metric.fan_out,
         instability_pct
     );
+
+    // Instability is derived from fan-in; every unresolved relative import in
+    // the repository is a potential missing importer of this file, so the
+    // measured fan-in is a lower bound and the instability claim is weaker.
+    let confidence = if resolution.is_empty() {
+        Confidence::High
+    } else {
+        snippet.push_str(&format!(
+            "\n{} unresolved relative import(s) in the repository — fan-in may be undercounted.",
+            resolution.total()
+        ));
+        Confidence::Medium
+    };
 
     if let Some(facts) = file_facts
         && !facts.imports.is_empty()
@@ -194,7 +212,7 @@ fn high_instability_hub_finding(
         ),
         category: FindingCategory::Architecture,
         severity: Severity::High,
-        confidence: Default::default(),
+        confidence,
         evidence: vec![Evidence {
             path: path.clone(),
             line_start: 1,

--- a/src/audits/architecture/import_coupling/tests.rs
+++ b/src/audits/architecture/import_coupling/tests.rs
@@ -1,0 +1,51 @@
+use std::path::{Path, PathBuf};
+
+use super::high_instability_hub_finding;
+use crate::findings::types::Confidence;
+use crate::graph::{FileMetrics, ImportResolutionStats};
+
+fn hub_metric() -> FileMetrics {
+    FileMetrics {
+        path: PathBuf::from("src/hub.ts"),
+        fan_in: 6,
+        fan_out: 14,
+        instability: 0.7,
+    }
+}
+
+#[test]
+fn hub_confidence_is_high_when_graph_is_complete() {
+    let finding = high_instability_hub_finding(
+        &hub_metric(),
+        Path::new(""),
+        70,
+        5,
+        70,
+        None,
+        &ImportResolutionStats::default(),
+    );
+
+    assert_eq!(finding.confidence, Confidence::High);
+    assert!(
+        !finding.evidence[0].snippet.contains("unresolved"),
+        "no demotion note expected for a complete graph"
+    );
+}
+
+#[test]
+fn hub_confidence_is_demoted_when_unresolved_imports_exist() {
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record(Path::new("src/a.ts"), "./missing");
+
+    let finding =
+        high_instability_hub_finding(&hub_metric(), Path::new(""), 70, 5, 70, None, &resolution);
+
+    assert_eq!(finding.confidence, Confidence::Medium);
+    assert!(
+        finding.evidence[0]
+            .snippet
+            .contains("fan-in may be undercounted"),
+        "snippet should explain the demotion: {}",
+        finding.evidence[0].snippet
+    );
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -4,9 +4,11 @@ pub mod resolver;
 pub mod v2;
 
 mod coupling_metrics;
+mod resolution_stats;
 
 pub use coupling_metrics::coupling_file_metrics;
 pub use imports::extract_imports;
+pub use resolution_stats::ImportResolutionStats;
 pub use resolver::resolve_import;
 
 use crate::scan::facts::ScanFacts;
@@ -28,6 +30,17 @@ pub struct FileMetrics {
 // ── Graph construction ────────────────────────────────────────────────────────
 
 pub fn build_coupling_graph(facts: &ScanFacts, root: &Path) -> CouplingGraph {
+    build_coupling_graph_with_resolution(facts, root).0
+}
+
+/// Builds the coupling graph and, alongside it, the imports the resolver could
+/// not map to scanned files. The graph carries only proven edges; the stats
+/// tell absence-based consumers (dead modules, fan-in metrics) where the graph
+/// is provably incomplete.
+pub fn build_coupling_graph_with_resolution(
+    facts: &ScanFacts,
+    root: &Path,
+) -> (CouplingGraph, ImportResolutionStats) {
     let known_file_by_normalized: HashMap<PathBuf, PathBuf> = facts
         .files
         .iter()
@@ -36,6 +49,7 @@ pub fn build_coupling_graph(facts: &ScanFacts, root: &Path) -> CouplingGraph {
     let known_files: HashSet<PathBuf> = known_file_by_normalized.keys().cloned().collect();
 
     let mut edges: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
+    let mut resolution = ImportResolutionStats::default();
 
     for file in &facts.files {
         let source = file.path.clone();
@@ -44,15 +58,22 @@ pub fn build_coupling_graph(facts: &ScanFacts, root: &Path) -> CouplingGraph {
         let outgoing = edges.entry(source.clone()).or_default();
 
         for raw in &file.imports {
-            if let Some(target) = resolve_import(raw, &normalized_source, root, &known_files)
-                && target != normalized_source
-            {
-                outgoing.insert(
-                    known_file_by_normalized
-                        .get(&target)
-                        .cloned()
-                        .unwrap_or(target),
-                );
+            match resolve_import(raw, &normalized_source, root, &known_files) {
+                Some(target) if target != normalized_source => {
+                    outgoing.insert(
+                        known_file_by_normalized
+                            .get(&target)
+                            .cloned()
+                            .unwrap_or(target),
+                    );
+                }
+                // A file importing itself carries no dependency information.
+                Some(_) => {}
+                None => {
+                    if resolution_stats::is_relative_import(raw.trim()) {
+                        resolution.record(&source, raw.trim());
+                    }
+                }
             }
         }
     }
@@ -63,7 +84,7 @@ pub fn build_coupling_graph(facts: &ScanFacts, root: &Path) -> CouplingGraph {
         nodes.extend(targets.iter().cloned());
     }
 
-    CouplingGraph { edges, nodes }
+    (CouplingGraph { edges, nodes }, resolution)
 }
 
 // ── Metrics ───────────────────────────────────────────────────────────────────

--- a/src/graph/resolution_stats.rs
+++ b/src/graph/resolution_stats.rs
@@ -1,0 +1,111 @@
+//! Tracks imports the resolver could not map to scanned files while the
+//! coupling graph is built.
+//!
+//! Resolved edges are proof: a cycle or fan-out claim built on them holds no
+//! matter what else failed to resolve. *Unresolved relative* imports are the
+//! opposite — they mark places where the graph is provably incomplete, which
+//! weakens absence-based claims (dead modules, fan-in-derived instability).
+//! Bare/package imports are real external dependencies and are not recorded.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ImportResolutionStats {
+    /// Unresolved relative (`./`, `../`) imports keyed by the importing file.
+    pub unresolved_relative_by_source: BTreeMap<PathBuf, Vec<String>>,
+}
+
+impl ImportResolutionStats {
+    pub fn record(&mut self, source: &Path, raw_import: &str) {
+        self.unresolved_relative_by_source
+            .entry(source.to_path_buf())
+            .or_default()
+            .push(raw_import.to_string());
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.unresolved_relative_by_source.is_empty()
+    }
+
+    pub fn total(&self) -> usize {
+        self.unresolved_relative_by_source
+            .values()
+            .map(Vec::len)
+            .sum()
+    }
+
+    /// True when any unresolved import's final path segment (extension
+    /// stripped) matches `stem`. Such an import could plausibly target a file
+    /// with that name, so "nothing imports it" cannot be claimed for it.
+    pub fn could_target_stem(&self, stem: &str) -> bool {
+        if stem.is_empty() {
+            return false;
+        }
+        self.unresolved_relative_by_source
+            .values()
+            .flatten()
+            .any(|import| {
+                import_stem(import).is_some_and(|candidate| candidate.eq_ignore_ascii_case(stem))
+            })
+    }
+}
+
+fn import_stem(raw_import: &str) -> Option<&str> {
+    let trimmed = raw_import.trim().trim_end_matches('/');
+    let last = trimmed.rsplit(['/', '\\']).next()?;
+    let stem = last.split('.').next().unwrap_or(last);
+    if stem.is_empty() || stem == ".." {
+        return None;
+    }
+    Some(stem)
+}
+
+pub(crate) fn is_relative_import(import: &str) -> bool {
+    import.starts_with("./") || import.starts_with("../")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_and_counts_unresolved_imports_per_source() {
+        let mut stats = ImportResolutionStats::default();
+        assert!(stats.is_empty());
+
+        stats.record(Path::new("src/a.ts"), "./missing");
+        stats.record(Path::new("src/a.ts"), "../gone/helper");
+        stats.record(Path::new("src/b.ts"), "./missing");
+
+        assert!(!stats.is_empty());
+        assert_eq!(stats.total(), 3);
+        assert_eq!(stats.unresolved_relative_by_source.len(), 2);
+    }
+
+    #[test]
+    fn could_target_stem_matches_final_segment_without_extension() {
+        let mut stats = ImportResolutionStats::default();
+        stats.record(Path::new("src/a.ts"), "../legacy/Utils.js");
+
+        assert!(stats.could_target_stem("utils"));
+        assert!(stats.could_target_stem("Utils"));
+        assert!(!stats.could_target_stem("legacy"));
+        assert!(!stats.could_target_stem(""));
+    }
+
+    #[test]
+    fn import_stem_handles_trailing_slashes_and_parent_segments() {
+        assert_eq!(import_stem("./components/"), Some("components"));
+        assert_eq!(import_stem("../.."), None);
+        assert_eq!(import_stem("./mod.rs"), Some("mod"));
+    }
+
+    #[test]
+    fn relative_import_detection_matches_dot_prefixes_only() {
+        assert!(is_relative_import("./a"));
+        assert!(is_relative_import("../a"));
+        assert!(!is_relative_import("react"));
+        assert!(!is_relative_import("@scope/pkg"));
+    }
+}

--- a/src/graph/v2/builder/mod.rs
+++ b/src/graph/v2/builder/mod.rs
@@ -4,6 +4,7 @@ use super::{
     GraphDiagnostic, GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance, GraphNode,
     GraphNodeId, GraphNodeKind, GraphSnapshot,
 };
+use crate::graph::resolution_stats::is_relative_import;
 use crate::graph::resolve_import;
 use crate::graph::resolver::normalize_path;
 use crate::scan::facts::ScanFacts;
@@ -146,10 +147,6 @@ fn slash_path(path: &Path) -> String {
 
 fn normalize_import(raw_import: &str) -> String {
     raw_import.trim().replace('\\', "/")
-}
-
-fn is_relative_import(import: &str) -> bool {
-    import.starts_with("./") || import.starts_with("../")
 }
 
 fn external_node_id(import: &str, nodes: &mut BTreeMap<GraphNodeId, GraphNode>) -> GraphNodeId {

--- a/src/rules/registry/architecture.rs
+++ b/src/rules/registry/architecture.rs
@@ -126,6 +126,9 @@ pub(super) static RULES: &[RuleMetadata] = &[
         category: FindingCategory::Architecture,
         default_severity: Severity::High,
         default_confidence: Confidence::High,
+        // Demoted to Medium when the repository has unresolved relative
+        // imports: fan-in is then a lower bound and instability is overstated.
+        contextual_confidence: true,
         lifecycle: RuleLifecycle::Stable,
         signal_source: SignalSource::ImportGraph,
         docs_url: Some(
@@ -136,7 +139,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
             "Separate the stable, widely-imported interface from the volatile implementation details to reduce coupling.",
         ),
         false_positive_notes: Some(
-            "Framework entrypoints and generated hubs can be expected; production modules with high fan-in and fan-out should be reviewed.",
+            "Framework entrypoints and generated hubs can be expected; production modules with high fan-in and fan-out should be reviewed. When the repository contains unresolved relative imports, fan-in is a lower bound and the finding is reported at Medium confidence.",
         ),
         ..RuleMetadata::DEFAULT
     },
@@ -146,12 +149,19 @@ pub(super) static RULES: &[RuleMetadata] = &[
         category: FindingCategory::Architecture,
         default_severity: Severity::Low,
         default_confidence: Confidence::High,
+        // Demoted to Medium when the repository has unresolved relative
+        // imports (the graph is provably incomplete); suppressed entirely when
+        // an unresolved import could plausibly target the candidate file.
+        contextual_confidence: true,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::ImportGraph,
         docs_url: None,
         description: "This production file is not imported by any other project file and is not a known entrypoint. It may be dead code.",
         recommendation: Some(
             "Remove the file if it is no longer used, or ensure it is exported in the package's public API.",
+        ),
+        false_positive_notes: Some(
+            "Dynamic imports, dependency injection, and build-tool aliases create importers the graph cannot see. When the repository contains unresolved relative imports the finding is reported at Medium confidence, and it is suppressed when an unresolved import matches the candidate file's name.",
         ),
         ..RuleMetadata::DEFAULT
     },

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -82,7 +82,7 @@ impl<'a> ChangedScanEngine<'a> {
             &file_stage.graph_patch_files,
         )?;
         let project_start = Instant::now();
-        let ((project_findings, framework_findings), (coupling_findings, _)) = rayon::join(
+        let ((project_findings, framework_findings), (coupling_findings, _, _)) = rayon::join(
             || {
                 rayon::join(
                     || run_project_audits(&repo_stage.repo_context, self.config),

--- a/src/scan/scanner/full.rs
+++ b/src/scan/scanner/full.rs
@@ -196,20 +196,23 @@ impl<'a> ScanEngine<'a> {
         mut findings: Vec<Finding>,
     ) -> ProjectAnalysisStage {
         let start = Instant::now();
-        let ((project_findings, framework_findings), (coupling_findings, coupling_graph)) =
-            rayon::join(
-                || {
-                    rayon::join(
-                        || run_project_audits(&facts, self.config),
-                        || run_framework_audits(&facts, self.config),
-                    )
-                },
-                || ImportCouplingAudit.audit_with_graph(&facts, self.config, self.path),
-            );
+        let (
+            (project_findings, framework_findings),
+            (coupling_findings, coupling_graph, resolution),
+        ) = rayon::join(
+            || {
+                rayon::join(
+                    || run_project_audits(&facts, self.config),
+                    || run_framework_audits(&facts, self.config),
+                )
+            },
+            || ImportCouplingAudit.audit_with_graph(&facts, self.config, self.path),
+        );
         let query_findings = crate::audits::architecture::graph_queries::GraphQueriesAudit.audit(
             &facts,
             self.config,
             &coupling_graph,
+            &resolution,
             self.path,
         );
 


### PR DESCRIPTION
## Summary

This PR makes graph-based architecture findings reflect import-resolution quality.

The coupling graph builder now records unresolved relative imports through `ImportResolutionStats`. Absence-based rules that depend on a complete import graph now lower their confidence when unresolved relative imports exist.

This prevents RepoPilot from overclaiming findings such as “nothing imports this file” when the graph may be incomplete.

## Type of change

- Bug fix
- Refactor
- Tests
- Rule registry update
- Documentation

## What changed

- Added `ImportResolutionStats` for unresolved relative import tracking.
- Updated coupling graph construction to return both:
  - the resolved `CouplingGraph`;
  - import-resolution quality metadata.
- Updated `ImportCouplingAudit` to use `build_coupling_graph_with_resolution`.
- Updated graph query audits to receive import-resolution stats.
- Demoted `architecture.dead-module` from `High` to `Medium` confidence when unresolved relative imports exist.
- Suppressed `architecture.dead-module` when an unresolved import plausibly targets the candidate file.
- Demoted `architecture.high-instability-hub` from `High` to `Medium` confidence when unresolved relative imports exist.
- Added evidence snippets explaining confidence demotion.
- Kept edge-existence rules unaffected:
  - `architecture.circular-dependency`
  - `architecture.excessive-fan-out`
  - `architecture.test-leak`
  - `architecture.layer-violation`
  - `architecture.package-boundary-violation`
- Marked affected rules as `contextual_confidence` in the registry.
- Added/updated tests for dead-module suppression and confidence demotion.
- Added/updated tests for high-instability confidence demotion.
- Updated CHANGELOG.

## Why

Some graph rules prove that an edge exists. Those findings remain valid even if other imports failed to resolve.

Other graph rules are based on absence claims, for example:

- “nothing imports this file”;
- “fan-in is low enough that instability is high”.

Those claims are only as strong as the completeness of the import graph. If RepoPilot failed to resolve relative imports, fan-in may be undercounted.

This PR makes RepoPilot more honest and reduces false positives by lowering confidence when the graph is known to be incomplete.

## Contract and ownership

- Import resolution quality belongs to the graph/coupling build layer.
- Architecture audits consume resolution stats but do not own import resolution.
- Rule registry owns contextual confidence metadata.
- Existing rule IDs remain stable.
- Existing severities remain stable.
- Edge-existence findings remain unaffected.
- No new CLI command is introduced.
- JSON/SARIF/baseline compatibility should remain stable except for confidence and evidence text changes on affected findings.

## Affected rules

### `architecture.dead-module`

This rule is an absence-based claim.

If the graph is complete, it can still report `High` confidence.

If unresolved relative imports exist, it reports `Medium` confidence because fan-in may be undercounted.

If an unresolved import plausibly targets the candidate file, the finding is suppressed.

### `architecture.high-instability-hub`

This rule depends on fan-in/fan-out metrics.

If unresolved relative imports exist, fan-in may be undercounted, so the rule reports `Medium` confidence instead of `High`.

### Unaffected rules

Rules that prove existing resolved edges are not weakened by unresolved imports:

- circular dependencies;
- excessive fan-out;
- test leaks;
- layer violations;
- package boundary violations.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo test graph_queries
cargo test import_coupling
cargo test resolution_stats

cargo run -- scan .
cargo run -- scan . --format json --output report.json

npm run release:contract
./scripts/smoke-product.sh
```