### PR TITLE
release: prepare v0.17.0

### DIFF
--- a/.github/workflows/repopilot-pr-review.yml
+++ b/.github/workflows/repopilot-pr-review.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: RepoPilot version to run
         type: string
-        default: "0.16.0"
+        default: "0.17.0"
       fail-on-review:
         description: Review signal gate policy
         type: string
@@ -57,7 +57,7 @@ jobs:
 
       - name: Review pull request
         id: repopilot
-        uses: MykytaStel/repopilot@v0.16.0
+        uses: MykytaStel/repopilot@v0.17.0
         with:
           command: review
           version: ${{ inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-11
+
 ### Added
 
 - Added four architecture rules that query the import graph.
@@ -21,8 +23,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added regression coverage and a release self-review quality gate for
   standard-library/local dependency imports, AST-confirmed recursion,
   prose-only removed-behavior text, and side effects in tests/fixtures.
-- Added stdlib Python tests for release-note extraction, version validation,
-  Cargo package allowlisting, pinned Actions, npm orchestration, and removed
+- Added stdlib Python tests for release-note extraction, version validation, Cargo package allowlisting, pinned Actions, npm orchestration, and removed
   editor packaging.
 - Added a real schema `0.18` report fixture and documented report schema
   versioning independently from package versions.
@@ -600,7 +601,8 @@ CI and AI-assisted remediation.
 - Added `compare` for diffing two JSON scan reports.
 - Added CI workflow, release workflow, distribution docs, release docs, and ruleset docs.
 
-[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/MykytaStel/repopilot/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/MykytaStel/repopilot/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/MykytaStel/repopilot/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/MykytaStel/repopilot/compare/v0.13.0...v0.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repopilot"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repopilot"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 description = "Local-first CLI for reviewing Git changes, security boundaries, and blast radius before merge."
 license = "MIT OR Apache-2.0"

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ inputs:
   version:
     description: "GitHub Release version to install and checksum-verify."
     required: false
-    default: "0.16.0"
+    default: "0.17.0"
   upload-sarif:
     description: "Automatically upload SARIF output to GitHub Code Scanning"
     required: false

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -108,7 +108,7 @@ Use the reusable workflow:
 ```yaml
 jobs:
   repopilot:
-    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.16.0
+    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.17.0
     with:
       fail-on-review: none
       upload-sarif: false
@@ -117,7 +117,7 @@ jobs:
 Or use the Action directly:
 
 ```yaml
-- uses: MykytaStel/repopilot@v0.16.0
+- uses: MykytaStel/repopilot@v0.17.0
   with:
     command: review
     scope: changed

--- a/docs/integrations/github-code-scanning.md
+++ b/docs/integrations/github-code-scanning.md
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   review:
-    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.16.0
+    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.17.0
     with:
       fail-on-review: definitely
       fail-on-priority: p1
@@ -42,7 +42,7 @@ This default is read-only and works for fork PRs. It does not use
 
 - name: RepoPilot review
   id: repopilot
-  uses: MykytaStel/repopilot@v0.16.0
+  uses: MykytaStel/repopilot@v0.17.0
   with:
     command: review
     scope: changed
@@ -69,7 +69,7 @@ permissions:
   security-events: write
 
 steps:
-  - uses: MykytaStel/repopilot@v0.16.0
+  - uses: MykytaStel/repopilot@v0.17.0
     with:
       command: review
       upload-sarif: "true"
@@ -97,7 +97,7 @@ permissions:
   pull-requests: write
 
 steps:
-  - uses: MykytaStel/repopilot@v0.16.0
+  - uses: MykytaStel/repopilot@v0.17.0
     with:
       command: review
       comment: "true"

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -11,16 +11,16 @@ repopilot scan . --format json --output repopilot-report.json
 
 ## JSON report schema
 
-JSON scan reports include explicit schema metadata. The current schema is 0.18:
+JSON scan reports include explicit schema metadata. The current schema is 0.19:
 
 ```json
 {
-  "schema_version": "0.18",
-  "repopilot_version": "0.16.0",
+  "schema_version": "0.19",
+  "repopilot_version": "0.17.0",
   "report": {
     "kind": "scan",
-    "schema_version": "0.18",
-    "repopilot_version": "0.16.0"
+    "schema_version": "0.19",
+    "repopilot_version": "0.17.0"
   },
   "root_path": ".",
   "files_analyzed": 42,
@@ -88,6 +88,7 @@ JSON scan reports include explicit schema metadata. The current schema is 0.18:
 | `scan_timings` | object | Optional engine timing metadata. `file_scan_us` remains the compatibility aggregate; newer fields break out `discovery_us`, `file_analysis_us`, `parse_us` (tree-sitter parsing within file analysis), `enrichment_us`, `risk_scoring_us`, `contract_validation_us`, and `report_finalization_us`. |
 | `local_feedback` | object | Optional summary of `.repopilot/feedback.yml` suppressions applied during this scan or review. |
 | `diagnostics` | array | Optional structured warnings/errors captured during a scan, such as workspace partial failures. |
+| `rule_false_positive_notes` | object | Optional map of rule id → registry false-positive notes for every rule that fired, so consumers can self-triage without a catalog lookup. |
 
 Diagnostics use `{ code, severity, message, path? }`. Recoverable diagnostics
 with `warning` severity are report-only and keep the scan exit code at `0`
@@ -98,9 +99,9 @@ requested report/receipt and then exits with RepoPilot runtime code `3`.
 may fix bugs without changing the report schema, while future minor releases can
 evolve the schema in a documented way.
 
-Binary `0.17.x` continues to emit schema `0.18` unless the serialized contract
-changes. Schema numbers are monotonic contract revisions, not predictions of the
-next RepoPilot package version.
+Binary `0.17.x` emits schema `0.19` unless the serialized contract changes.
+Schema numbers are monotonic contract revisions, not predictions of the next
+RepoPilot package version.
 
 ### Compatibility
 
@@ -125,7 +126,9 @@ Schema `0.16` adds context graph report and cache diagnostics. Schema `0.17`
 adds raw-vs-visible finding and signal-quality metrics so default-profile
 reports do not look clean when meaningful strict-only findings were hidden.
 Schema `0.18` adds the stable review-signal contract, suppression/gate metadata,
-and the explicit review gate result.
+and the explicit review gate result. Schema `0.19` makes the rule registry the
+single source of truth for finding severity/confidence and adds the optional
+`rule_false_positive_notes` map (additive).
 
 Migration from pre-`0.13` reports is intentionally consumer-owned:
 
@@ -135,8 +138,9 @@ Migration from pre-`0.13` reports is intentionally consumer-owned:
 | `lines_of_code` | `non_empty_lines` |
 | `skipped_files_count` | `large_files_skipped` |
 
-The current reader accepts `0.16`, `0.17`, and `0.18` scan reports during the
-transition. Baseline files follow their separate baseline schema policy.
+The current reader accepts `0.16`, `0.17`, `0.18`, and `0.19` scan reports
+during the transition. Baseline files follow their separate baseline schema
+policy.
 
 ## Baseline JSON reports
 
@@ -154,12 +158,12 @@ Example shape:
 
 ```json
 {
-  "schema_version": "0.18",
-  "repopilot_version": "0.16.0",
+  "schema_version": "0.19",
+  "repopilot_version": "0.17.0",
   "report": {
     "kind": "baseline-scan",
-    "schema_version": "0.18",
-    "repopilot_version": "0.16.0"
+    "schema_version": "0.19",
+    "repopilot_version": "0.17.0"
   },
   "root_path": ".",
   "files_analyzed": 42,
@@ -212,10 +216,10 @@ Receipt JSON is intentionally smaller than a scan report and has its own schema:
   "report": {
     "kind": "receipt",
     "schema_version": "5",
-    "repopilot_version": "0.16.0"
+    "repopilot_version": "0.17.0"
   },
   "tool": "repopilot",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "generated_at": "2026-05-16T00:00:00Z",
   "root_path": ".",
   "git": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repopilot",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"description": "Local-first CLI for reviewing Git changes, security boundaries, and blast radius before merge.",
 	"license": "MIT OR Apache-2.0",
 	"repository": {
@@ -29,11 +29,11 @@
 		"LICENSE"
 	],
 	"optionalDependencies": {
-		"@repopilot/darwin-arm64": "0.16.0",
-		"@repopilot/darwin-x64": "0.16.0",
-		"@repopilot/linux-arm64-gnu": "0.16.0",
-		"@repopilot/linux-x64-gnu": "0.16.0",
-		"@repopilot/win32-x64-msvc": "0.16.0"
+		"@repopilot/darwin-arm64": "0.17.0",
+		"@repopilot/darwin-x64": "0.17.0",
+		"@repopilot/linux-arm64-gnu": "0.17.0",
+		"@repopilot/linux-x64-gnu": "0.17.0",
+		"@repopilot/win32-x64-msvc": "0.17.0"
 	},
 	"keywords": [
 		"cli",


### PR DESCRIPTION
## Summary

This PR prepares RepoPilot `v0.17.0` for release.

It updates package versions, GitHub Action defaults, reusable workflow examples, npm optional binary dependencies, changelog links, and report documentation for the new release line.

## Type of change

- Release / repository maintenance
- Documentation
- CI / Action metadata
- Package metadata

## What changed

- Bumped Cargo package version from `0.16.0` to `0.17.0`.
- Updated `Cargo.lock` for the new package version.
- Bumped npm package version from `0.16.0` to `0.17.0`.
- Updated npm optional platform binary dependencies to `0.17.0`.
- Updated `action.yml` default version from `0.16.0` to `0.17.0`.
- Updated reusable PR review workflow default version to `0.17.0`.
- Updated docs examples from `v0.16.0` to `v0.17.0`.
- Added the `0.17.0` changelog section.
- Updated changelog compare links:
  - `Unreleased` now compares from `v0.17.0` to `HEAD`.
  - `0.17.0` compares `v0.16.0...v0.17.0`.
- Updated report documentation to describe scan report schema `0.19`.

## Why

`v0.17.0` includes the recent architecture and graph-rule work, rule-registry contract updates, graph v2 migration cleanup, and report schema changes.

This release PR keeps all public installation and integration surfaces aligned before tagging:

- Cargo/crates.io package version;
- npm package version;
- platform optional npm packages;
- GitHub Action default version;
- reusable workflow examples;
- report schema documentation;
- changelog release notes.

## Contract and compatibility

- This PR should not introduce new runtime behavior.
- CLI behavior should remain unchanged from the merged feature PRs.
- Existing report readers should continue accepting previous supported schema versions.
- Scan reports now document schema `0.19`.
- GitHub Action examples now point to `v0.17.0`.
- npm optional platform packages are expected to be published with matching `0.17.0` versions.
