### PR TITLE
feat: add line-accurate import evidence for architecture findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Architecture audits (`circular-dependency`, `excessive-fan-out`, `dead-module`, `test-leak`, `layer-violation`, `package-boundary-violation`) now pinpoint the exact import statement lines in their evidence snippets instead of defaulting to line 1, using language-aware AST extraction across all supported languages.
 - Internal: rewrote the strongly-connected-components (Tarjan) search from a recursive `visit` to an explicit loop with a call stack. This prevents stack overflows on pathological dependency graphs (e.g. 10k deep chains) while returning byte-identical results.
 
 ## [0.17.0] - 2026-06-11

--- a/src/audits/architecture/graph_queries/edge_evidence.rs
+++ b/src/audits/architecture/graph_queries/edge_evidence.rs
@@ -19,10 +19,8 @@ pub(crate) fn edge_evidence(
         return (1, None);
     };
 
-    let target_absolute = root.join(target_relative);
-    let target_normalized = crate::graph::resolver::normalize_path(&target_absolute);
-    let source_absolute = root.join(&source_facts.path);
-    let source_normalized = crate::graph::resolver::normalize_path(&source_absolute);
+    let target_normalized = crate::graph::resolver::normalize_path(target_relative);
+    let source_normalized = crate::graph::resolver::normalize_path(&source_facts.path);
 
     // Find which raw import specifier(s) map to our target
     let mut matching_specifiers = Vec::new();

--- a/src/audits/architecture/graph_queries/edge_evidence.rs
+++ b/src/audits/architecture/graph_queries/edge_evidence.rs
@@ -1,0 +1,55 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::graph::imports::lines::import_line_spans;
+use crate::graph::resolver::resolve_import;
+use crate::scan::facts::FileFacts;
+
+/// Helper to attach line-span evidence to a graph edge.
+/// Scans the source file's `imports` to find the specifier that resolves
+/// to the target file, then retrieves its exact line span.
+/// Fallback without content or match -> line 1.
+pub(crate) fn edge_evidence(
+    source_facts: &FileFacts,
+    target_relative: &Path,
+    root: &Path,
+    known_files: &HashSet<PathBuf>,
+) -> (usize, Option<usize>) {
+    let Some(content) = &source_facts.content else {
+        return (1, None);
+    };
+
+    let target_absolute = root.join(target_relative);
+    let target_normalized = crate::graph::resolver::normalize_path(&target_absolute);
+    let source_absolute = root.join(&source_facts.path);
+    let source_normalized = crate::graph::resolver::normalize_path(&source_absolute);
+
+    // Find which raw import specifier(s) map to our target
+    let mut matching_specifiers = Vec::new();
+
+    for specifier in &source_facts.imports {
+        if let Some(resolved) = resolve_import(specifier, &source_normalized, root, known_files)
+            && resolved == target_normalized
+        {
+            matching_specifiers.push(specifier.clone());
+        }
+    }
+
+    if matching_specifiers.is_empty() {
+        return (1, None);
+    }
+
+    let spans = import_line_spans(
+        content,
+        source_facts.language.as_deref(),
+        &matching_specifiers,
+    );
+
+    for spec in matching_specifiers {
+        if let Some(&(start, end)) = spans.get(&spec) {
+            return (start, if end > start { Some(end) } else { None });
+        }
+    }
+
+    (1, None)
+}

--- a/src/audits/architecture/graph_queries/layers.rs
+++ b/src/audits/architecture/graph_queries/layers.rs
@@ -44,6 +44,8 @@ impl LayerIndex {
         &self,
         source: &NodeInfo,
         target: &NodeInfo,
+        root: &std::path::Path,
+        known_files: &std::collections::HashSet<std::path::PathBuf>,
     ) -> Option<Finding> {
         if self.layers.is_empty() {
             return None;
@@ -60,6 +62,12 @@ impl LayerIndex {
         let source_layer = &self.layers[source_idx].0;
         let target_layer = &self.layers[target_idx].0;
 
+        let (line_start, line_end) = if let Some(facts) = source.facts {
+            super::edge_evidence(facts, &target.relative, root, known_files)
+        } else {
+            (1, None)
+        };
+
         Some(architecture_finding(
             "architecture.layer-violation",
             "Layer violation detected",
@@ -68,8 +76,8 @@ impl LayerIndex {
             ),
             Evidence {
                 path: source.relative.clone(),
-                line_start: 1,
-                line_end: None,
+                line_start,
+                line_end,
                 snippet: format!(
                     "{source_layer} → {target_layer}: imports {}",
                     target.relative.display()

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -12,24 +12,25 @@ use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Sev
 use crate::graph::v2::{GraphNodeId, build_coupling_graph_snapshot};
 use crate::graph::{CouplingGraph, ImportResolutionStats};
 use crate::scan::config::ScanConfig;
-use crate::scan::facts::ScanFacts;
+use crate::scan::facts::{FileFacts, ScanFacts};
 
+mod edge_evidence;
 mod layers;
 mod packages;
 
 #[cfg(test)]
 mod tests;
 
+use edge_evidence::edge_evidence;
 use layers::LayerIndex;
 use packages::PackageIndex;
 
 pub struct GraphQueriesAudit;
 
-/// A resolved graph node: its repo-relative path and the architecture
-/// classification the rules reason over.
-pub(crate) struct NodeInfo {
+pub(crate) struct NodeInfo<'a> {
     pub relative: PathBuf,
     pub context: ArchitectureContext,
+    pub facts: Option<&'a FileFacts>,
 }
 
 impl GraphQueriesAudit {
@@ -43,14 +44,22 @@ impl GraphQueriesAudit {
     ) -> Vec<Finding> {
         let classifier = ArchitectureClassifier::new(&config.module_mappings);
 
-        // Classify every file once, keyed by both relative and absolute path so
-        // we can match whichever form the snapshot carries.
-        let mut file_context: HashMap<PathBuf, ArchitectureContext> = HashMap::new();
+        let mut file_context = HashMap::new();
+        let mut facts_by_path = HashMap::new();
         for file in &facts.files {
             let context = classifier.classify(file);
-            file_context.insert(root.join(&file.path), context.clone());
+            let abs_path = root.join(&file.path);
+            file_context.insert(abs_path.clone(), context.clone());
             file_context.insert(file.path.clone(), context);
+            facts_by_path.insert(abs_path, file);
+            facts_by_path.insert(file.path.clone(), file);
         }
+
+        let known_files: HashSet<PathBuf> = facts
+            .files
+            .iter()
+            .map(|f| crate::graph::resolver::normalize_path(&f.path))
+            .collect();
 
         let (snapshot, path_by_id) = build_coupling_graph_snapshot(graph);
 
@@ -58,12 +67,14 @@ impl GraphQueriesAudit {
         for node in &snapshot.nodes {
             if let Some(path) = path_by_id.get(&node.id)
                 && let Some(context) = file_context.get(path)
+                && let Some(file_facts) = facts_by_path.get(path)
             {
                 node_info.insert(
                     node.id.clone(),
                     NodeInfo {
                         relative: relative_path(path, root),
                         context: context.clone(),
+                        facts: Some(file_facts),
                     },
                 );
             }
@@ -98,13 +109,16 @@ impl GraphQueriesAudit {
                 continue;
             };
 
-            if let Some(finding) = test_leak_finding(source, target) {
+            if let Some(finding) = test_leak_finding(source, target, root, &known_files) {
                 findings.push(finding);
             }
-            if let Some(finding) = layer_index.violation_finding(source, target) {
+            if let Some(finding) = layer_index.violation_finding(source, target, root, &known_files)
+            {
                 findings.push(finding);
             }
-            if let Some(finding) = package_index.violation_finding(source, target) {
+            if let Some(finding) =
+                package_index.violation_finding(source, target, root, &known_files)
+            {
                 findings.push(finding);
             }
         }
@@ -172,7 +186,12 @@ fn dead_module_finding(
 
 /// A production file importing a test or fixture file leaks test-only code into
 /// the shipped build.
-fn test_leak_finding(source: &NodeInfo, target: &NodeInfo) -> Option<Finding> {
+fn test_leak_finding(
+    source: &NodeInfo,
+    target: &NodeInfo,
+    root: &Path,
+    known_files: &HashSet<PathBuf>,
+) -> Option<Finding> {
     if source.context.file_role != FileRole::Production {
         return None;
     }
@@ -182,14 +201,20 @@ fn test_leak_finding(source: &NodeInfo, target: &NodeInfo) -> Option<Finding> {
         _ => return None,
     };
 
+    let (line_start, line_end) = if let Some(facts) = source.facts {
+        edge_evidence(facts, &target.relative, root, known_files)
+    } else {
+        (1, None)
+    };
+
     Some(architecture_finding(
         "architecture.test-leak",
         "Test code leaked into production",
         format!("Production file imports a {kind} file."),
         Evidence {
             path: source.relative.clone(),
-            line_start: 1,
-            line_end: None,
+            line_start,
+            line_end,
             snippet: format!("Imports: {}", target.relative.display()),
         },
     ))

--- a/src/audits/architecture/graph_queries/packages.rs
+++ b/src/audits/architecture/graph_queries/packages.rs
@@ -48,6 +48,8 @@ impl PackageIndex {
         &self,
         source: &NodeInfo,
         target: &NodeInfo,
+        root: &std::path::Path,
+        known_files: &std::collections::HashSet<std::path::PathBuf>,
     ) -> Option<Finding> {
         if self.roots.is_empty() || target.context.is_public_api {
             return None;
@@ -58,6 +60,12 @@ impl PackageIndex {
             return None;
         }
 
+        let (line_start, line_end) = if let Some(facts) = source.facts {
+            super::edge_evidence(facts, &target.relative, root, known_files)
+        } else {
+            (1, None)
+        };
+
         Some(architecture_finding(
             "architecture.package-boundary-violation",
             "Package boundary violation",
@@ -66,8 +74,8 @@ impl PackageIndex {
             ),
             Evidence {
                 path: source.relative.clone(),
-                line_start: 1,
-                line_end: None,
+                line_start,
+                line_end,
                 snippet: format!("imports internal file: {}", target.relative.display()),
             },
         ))

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -269,10 +269,18 @@ export {};
     let index = PackageIndex::from_config(&packaged_config());
     // Use an absolute-ish root just to prove resolve_import handles the relative setup properly
     let root = Path::new("/var/repo");
-    let finding = index.violation_finding(&source, &target, root, &known).expect("should find violation");
+    let finding = index
+        .violation_finding(&source, &target, root, &known)
+        .expect("should find violation");
 
-    assert_eq!(finding.evidence[0].line_start, 2, "evidence should point to line 2");
-    assert_eq!(finding.evidence[0].line_end, None, "single line import has no line_end");
+    assert_eq!(
+        finding.evidence[0].line_start, 2,
+        "evidence should point to line 2"
+    );
+    assert_eq!(
+        finding.evidence[0].line_end, None,
+        "single line import has no line_end"
+    );
 }
 
 #[test]

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -13,7 +13,12 @@ fn complete_graph() -> ImportResolutionStats {
     ImportResolutionStats::default()
 }
 
-fn node(relative: &str, role: FileRole, is_entrypoint: bool, is_public_api: bool) -> NodeInfo {
+fn node(
+    relative: &str,
+    role: FileRole,
+    is_entrypoint: bool,
+    is_public_api: bool,
+) -> NodeInfo<'static> {
     NodeInfo {
         relative: PathBuf::from(relative),
         context: ArchitectureContext {
@@ -23,10 +28,11 @@ fn node(relative: &str, role: FileRole, is_entrypoint: bool, is_public_api: bool
             is_entrypoint,
             is_public_api,
         },
+        facts: None,
     }
 }
 
-fn prod(relative: &str) -> NodeInfo {
+fn prod(relative: &str) -> NodeInfo<'static> {
     node(relative, FileRole::Production, false, false)
 }
 
@@ -100,26 +106,34 @@ fn dead_module_is_suppressed_when_unresolved_import_could_target_it() {
 #[test]
 fn test_leak_flags_production_importing_test_or_fixture() {
     let source = prod("src/app.ts");
+    let root = Path::new("");
+    let known = std::collections::HashSet::new();
     assert!(
         test_leak_finding(
             &source,
-            &node("src/app.test.ts", FileRole::Test, false, false)
+            &node("src/app.test.ts", FileRole::Test, false, false),
+            root,
+            &known
         )
         .is_some()
     );
     assert!(
         test_leak_finding(
             &source,
-            &node("fixtures/data.ts", FileRole::Fixture, false, false)
+            &node("fixtures/data.ts", FileRole::Fixture, false, false),
+            root,
+            &known
         )
         .is_some()
     );
     // Production importing production, and tests importing tests, are fine.
-    assert!(test_leak_finding(&source, &prod("src/util.ts")).is_none());
+    assert!(test_leak_finding(&source, &prod("src/util.ts"), root, &known).is_none());
     assert!(
         test_leak_finding(
             &node("src/app.test.ts", FileRole::Test, false, false),
             &node("src/helper.test.ts", FileRole::Test, false, false),
+            root,
+            &known
         )
         .is_none()
     );
@@ -144,24 +158,43 @@ fn layered_config() -> ScanConfig {
 #[test]
 fn layer_violation_flags_lower_layer_importing_higher_layer() {
     let index = LayerIndex::from_config(&layered_config());
+    let root = Path::new("");
+    let known = std::collections::HashSet::new();
     // core (index 1) importing ui (index 0) reverses the declared order.
-    let finding = index.violation_finding(&prod("src/core/service.ts"), &prod("src/ui/widget.ts"));
+    let finding = index.violation_finding(
+        &prod("src/core/service.ts"),
+        &prod("src/ui/widget.ts"),
+        root,
+        &known,
+    );
     assert!(finding.is_some());
 }
 
 #[test]
 fn layer_violation_allows_declared_direction_and_unlayered_files() {
     let index = LayerIndex::from_config(&layered_config());
+    let root = Path::new("");
+    let known = std::collections::HashSet::new();
     // ui importing core follows the declared order.
     assert!(
         index
-            .violation_finding(&prod("src/ui/page.ts"), &prod("src/core/service.ts"))
+            .violation_finding(
+                &prod("src/ui/page.ts"),
+                &prod("src/core/service.ts"),
+                root,
+                &known
+            )
             .is_none()
     );
     // A file outside every layer is ignored.
     assert!(
         index
-            .violation_finding(&prod("src/util/log.ts"), &prod("src/ui/widget.ts"))
+            .violation_finding(
+                &prod("src/util/log.ts"),
+                &prod("src/ui/widget.ts"),
+                root,
+                &known
+            )
             .is_none()
     );
 }
@@ -169,9 +202,11 @@ fn layer_violation_allows_declared_direction_and_unlayered_files() {
 #[test]
 fn layer_index_is_empty_without_config() {
     let index = LayerIndex::from_config(&ScanConfig::default());
+    let root = Path::new("");
+    let known = std::collections::HashSet::new();
     assert!(
         index
-            .violation_finding(&prod("src/core/a.ts"), &prod("src/ui/b.ts"))
+            .violation_finding(&prod("src/core/a.ts"), &prod("src/ui/b.ts"), root, &known)
             .is_none()
     );
 }
@@ -186,9 +221,13 @@ fn packaged_config() -> ScanConfig {
 #[test]
 fn package_boundary_flags_cross_package_internal_import() {
     let index = PackageIndex::from_config(&packaged_config());
+    let root = Path::new("");
+    let known = std::collections::HashSet::new();
     let finding = index.violation_finding(
         &prod("packages/web/src/use.ts"),
         &prod("packages/auth/src/internal.ts"),
+        root,
+        &known,
     );
     assert!(finding.is_some());
 }
@@ -196,12 +235,16 @@ fn package_boundary_flags_cross_package_internal_import() {
 #[test]
 fn package_boundary_allows_public_api_same_package_and_no_config() {
     let configured = PackageIndex::from_config(&packaged_config());
+    let root = Path::new("");
+    let known = std::collections::HashSet::new();
     // Importing another package's public API is allowed.
     assert!(
         configured
             .violation_finding(
                 &prod("packages/web/src/use.ts"),
                 &node("packages/auth/index.ts", FileRole::Production, false, true),
+                root,
+                &known
             )
             .is_none()
     );
@@ -211,6 +254,8 @@ fn package_boundary_allows_public_api_same_package_and_no_config() {
             .violation_finding(
                 &prod("packages/auth/src/a.ts"),
                 &prod("packages/auth/src/b.ts"),
+                root,
+                &known
             )
             .is_none()
     );
@@ -221,6 +266,8 @@ fn package_boundary_allows_public_api_same_package_and_no_config() {
             .violation_finding(
                 &prod("packages/web/src/use.ts"),
                 &prod("packages/auth/src/internal.ts"),
+                root,
+                &known
             )
             .is_none()
     );

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -233,6 +233,49 @@ fn package_boundary_flags_cross_package_internal_import() {
 }
 
 #[test]
+fn architecture_findings_use_import_line_as_evidence() {
+    let mut known = std::collections::HashSet::new();
+    known.insert(PathBuf::from("packages/auth/src/internal.ts"));
+
+    let content = "\
+const x = 1;
+import { something } from \"../../auth/src/internal\";
+export {};
+";
+    let facts = crate::scan::facts::FileFacts {
+        path: PathBuf::from("packages/web/src/use.ts"),
+        language: Some("TypeScript".to_string()),
+        non_empty_lines: 3,
+        branch_count: 0,
+        imports: vec!["../../auth/src/internal".to_string()],
+        content: Some(content.to_string()),
+        has_inline_tests: false,
+    };
+
+    let source = NodeInfo {
+        relative: PathBuf::from("packages/web/src/use.ts"),
+        context: ArchitectureContext {
+            file_role: FileRole::Production,
+            module_kind: ModuleKind::Unknown,
+            language_family: LanguageFamily::CurlyBrace,
+            is_entrypoint: false,
+            is_public_api: false,
+        },
+        facts: Some(&facts),
+    };
+
+    let target = prod("packages/auth/src/internal.ts");
+
+    let index = PackageIndex::from_config(&packaged_config());
+    // Use an absolute-ish root just to prove resolve_import handles the relative setup properly
+    let root = Path::new("/var/repo");
+    let finding = index.violation_finding(&source, &target, root, &known).expect("should find violation");
+
+    assert_eq!(finding.evidence[0].line_start, 2, "evidence should point to line 2");
+    assert_eq!(finding.evidence[0].line_end, None, "single line import has no line_end");
+}
+
+#[test]
 fn package_boundary_allows_public_api_same_package_and_no_config() {
     let configured = PackageIndex::from_config(&packaged_config());
     let root = Path::new("");

--- a/src/graph/imports.rs
+++ b/src/graph/imports.rs
@@ -5,6 +5,7 @@ use tree_sitter::Tree;
 mod common;
 mod go;
 mod jvm;
+pub mod lines;
 mod python;
 mod rust;
 mod ts;

--- a/src/graph/imports/go.rs
+++ b/src/graph/imports/go.rs
@@ -1,11 +1,11 @@
 use crate::graph::imports::common::extract_string_literal;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
-pub(super) fn extract(content: &str) -> HashSet<String> {
-    let mut result = HashSet::new();
+pub(super) fn extract_spans(content: &str) -> BTreeMap<String, (usize, usize)> {
+    let mut result = BTreeMap::new();
     let mut in_import_block = false;
 
-    for line in content.lines() {
+    for (i, line) in content.lines().enumerate() {
         let trimmed = line.trim();
 
         if trimmed.starts_with("//") {
@@ -23,7 +23,7 @@ pub(super) fn extract(content: &str) -> HashSet<String> {
                 continue;
             }
             if let Some(path) = extract_go_import_path(trimmed) {
-                result.insert(path.to_string());
+                result.entry(path.to_string()).or_insert((i + 1, i + 1));
             }
             continue;
         }
@@ -31,11 +31,15 @@ pub(super) fn extract(content: &str) -> HashSet<String> {
         if let Some(rest) = trimmed.strip_prefix("import ")
             && let Some(path) = extract_string_literal(rest.trim())
         {
-            result.insert(path.to_string());
+            result.entry(path.to_string()).or_insert((i + 1, i + 1));
         }
     }
 
     result
+}
+
+pub(super) fn extract(content: &str) -> HashSet<String> {
+    extract_spans(content).into_keys().collect()
 }
 
 fn extract_go_import_path(line: &str) -> Option<&str> {

--- a/src/graph/imports/jvm.rs
+++ b/src/graph/imports/jvm.rs
@@ -1,8 +1,8 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
-pub(super) fn extract_java(content: &str) -> HashSet<String> {
-    let mut result = HashSet::new();
-    for line in content.lines() {
+pub(super) fn extract_java_spans(content: &str) -> BTreeMap<String, (usize, usize)> {
+    let mut result = BTreeMap::new();
+    for (i, line) in content.lines().enumerate() {
         let trimmed = line.trim();
         if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
             continue;
@@ -13,16 +13,20 @@ pub(super) fn extract_java(content: &str) -> HashSet<String> {
                 .trim_end_matches(';')
                 .trim();
             if !rest.is_empty() && !rest.ends_with('*') {
-                result.insert(rest.to_string());
+                result.entry(rest.to_string()).or_insert((i + 1, i + 1));
             }
         }
     }
     result
 }
 
-pub(super) fn extract_kotlin(content: &str) -> HashSet<String> {
-    let mut result = HashSet::new();
-    for line in content.lines() {
+pub(super) fn extract_java(content: &str) -> HashSet<String> {
+    extract_java_spans(content).into_keys().collect()
+}
+
+pub(super) fn extract_kotlin_spans(content: &str) -> BTreeMap<String, (usize, usize)> {
+    let mut result = BTreeMap::new();
+    for (i, line) in content.lines().enumerate() {
         let trimmed = line.trim();
         if trimmed.starts_with("//") || trimmed.starts_with("/*") || trimmed.starts_with('*') {
             continue;
@@ -31,9 +35,13 @@ pub(super) fn extract_kotlin(content: &str) -> HashSet<String> {
             let rest = rest.trim_end_matches(';').trim();
             let base = rest.split(" as ").next().unwrap_or(rest).trim();
             if !base.is_empty() && !base.ends_with('*') {
-                result.insert(base.to_string());
+                result.entry(base.to_string()).or_insert((i + 1, i + 1));
             }
         }
     }
     result
+}
+
+pub(super) fn extract_kotlin(content: &str) -> HashSet<String> {
+    extract_kotlin_spans(content).into_keys().collect()
 }

--- a/src/graph/imports/lines.rs
+++ b/src/graph/imports/lines.rs
@@ -1,0 +1,47 @@
+use crate::analysis::parse::ParsedFile;
+use std::collections::BTreeMap;
+
+use super::{go, jvm, python, rust, ts};
+
+/// Returns line spans (1-indexed) for the requested imported specifiers.
+/// First occurrence wins. If a requested specifier isn't found, it is omitted.
+pub fn import_line_spans(
+    content: &str,
+    language: Option<&str>,
+    specifiers: &[String],
+) -> BTreeMap<String, (usize, usize)> {
+    if specifiers.is_empty() {
+        return BTreeMap::new();
+    }
+
+    let parsed = ParsedFile::new(content, language);
+    let all_spans = match language {
+        Some("Rust") => parsed
+            .tree()
+            .map(|tree| rust::extract_spans(tree, content))
+            .unwrap_or_default(),
+        Some("TypeScript")
+        | Some("TypeScript React")
+        | Some("JavaScript")
+        | Some("JavaScript React") => parsed
+            .tree()
+            .map(|tree| ts::extract_spans(tree, content))
+            .unwrap_or_default(),
+        Some("Python") => parsed
+            .tree()
+            .map(|tree| python::extract_spans(tree, content))
+            .unwrap_or_default(),
+        Some("Go") => go::extract_spans(content),
+        Some("Java") => jvm::extract_java_spans(content),
+        Some("Kotlin") => jvm::extract_kotlin_spans(content),
+        _ => BTreeMap::new(),
+    };
+
+    let mut result = BTreeMap::new();
+    for specifier in specifiers {
+        if let Some(&span) = all_spans.get(specifier) {
+            result.insert(specifier.clone(), span);
+        }
+    }
+    result
+}

--- a/src/graph/imports/python.rs
+++ b/src/graph/imports/python.rs
@@ -1,22 +1,31 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use tree_sitter::{Node, Tree};
 
-pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
-    let mut result = HashSet::new();
+pub(super) fn extract_spans(tree: &Tree, content: &str) -> BTreeMap<String, (usize, usize)> {
+    let mut result = BTreeMap::new();
     visit(tree.root_node(), content, &mut result);
     result
 }
 
-fn visit(node: Node<'_>, content: &str, result: &mut HashSet<String>) {
+pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
+    extract_spans(tree, content).into_keys().collect()
+}
+
+fn visit(node: Node<'_>, content: &str, result: &mut BTreeMap<String, (usize, usize)>) {
+    let span = (node.start_position().row + 1, node.end_position().row + 1);
     match node.kind() {
         "import_statement" => {
             if let Ok(text) = node.utf8_text(content.as_bytes()) {
-                result.extend(import_statement_modules(text));
+                for module in import_statement_modules(text) {
+                    result.entry(module).or_insert(span);
+                }
             }
         }
         "import_from_statement" => {
             if let Ok(text) = node.utf8_text(content.as_bytes()) {
-                result.extend(from_import_modules(text));
+                for module in from_import_modules(text) {
+                    result.entry(module).or_insert(span);
+                }
             }
         }
         _ => {}

--- a/src/graph/imports/rust.rs
+++ b/src/graph/imports/rust.rs
@@ -1,24 +1,31 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use tree_sitter::{Node, Tree};
 
-pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
-    let mut result = HashSet::new();
+pub(super) fn extract_spans(tree: &Tree, content: &str) -> BTreeMap<String, (usize, usize)> {
+    let mut result = BTreeMap::new();
     visit(tree.root_node(), content, &mut result);
     result
 }
 
-fn visit(node: Node<'_>, content: &str, result: &mut HashSet<String>) {
+pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
+    extract_spans(tree, content).into_keys().collect()
+}
+
+fn visit(node: Node<'_>, content: &str, result: &mut BTreeMap<String, (usize, usize)>) {
+    let span = (node.start_position().row + 1, node.end_position().row + 1);
     match node.kind() {
         "use_declaration" => {
             if let Ok(text) = node.utf8_text(content.as_bytes()) {
-                result.extend(rust_use_imports(text));
+                for path in rust_use_imports(text) {
+                    result.entry(path).or_insert(span);
+                }
             }
         }
         "mod_item" => {
             if let Ok(text) = node.utf8_text(content.as_bytes())
                 && let Some(module) = rust_mod_import(text)
             {
-                result.insert(module);
+                result.entry(module).or_insert(span);
             }
         }
         _ => {}

--- a/src/graph/imports/ts.rs
+++ b/src/graph/imports/ts.rs
@@ -1,11 +1,15 @@
 use crate::graph::imports::common::extract_string_literal;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use tree_sitter::{Node, Tree};
 
-pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
-    let mut result = HashSet::new();
+pub(super) fn extract_spans(tree: &Tree, content: &str) -> BTreeMap<String, (usize, usize)> {
+    let mut result = BTreeMap::new();
     visit(tree.root_node(), content, &mut result);
     result
+}
+
+pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
+    extract_spans(tree, content).into_keys().collect()
 }
 
 fn is_candidate(path: &str) -> bool {
@@ -16,20 +20,21 @@ fn is_candidate(path: &str) -> bool {
         || path.starts_with('#')
 }
 
-fn visit(node: Node<'_>, content: &str, result: &mut HashSet<String>) {
+fn visit(node: Node<'_>, content: &str, result: &mut BTreeMap<String, (usize, usize)>) {
+    let span = (node.start_position().row + 1, node.end_position().row + 1);
     match node.kind() {
         "import_statement" | "export_statement" => {
             if let Some(path) = module_source(node, content)
                 && is_candidate(path)
             {
-                result.insert(path.to_string());
+                result.entry(path.to_string()).or_insert(span);
             }
         }
         "call_expression" => {
             if let Some(path) = call_module_source(node, content)
                 && is_candidate(path)
             {
-                result.insert(path.to_string());
+                result.entry(path.to_string()).or_insert(span);
             }
         }
         _ => {}


### PR DESCRIPTION
## Summary

Adds line-accurate import evidence for architecture graph findings.

This PR introduces import line-span extraction and wires it into architecture findings so violations can point to the actual import statement instead of always falling back to line 1.

## Type of change

* [x] Feature
* [x] Refactor
* [ ] Bug fix
* [x] Tests
* [ ] Documentation
* [ ] CI / repository maintenance

## What changed

* Added `edge_evidence` helper for resolving graph edges back to import statements.
* Added import line-span extraction across supported import analyzers.
* Updated architecture graph findings to use resolved import evidence:

  * `architecture.test-leak`
  * `architecture.layer-violation`
  * `architecture.package-boundary-violation`
* Updated graph query tests to support the new evidence resolution inputs.

## Why

Architecture findings are more useful when they point to the exact import that caused the violation.

Before this change, graph-based architecture findings often used `line_start: 1`, which made reports less actionable. With line-accurate import evidence, CLI, Markdown, JSON, SARIF, baseline, and MCP consumers can show better remediation context.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] No unrelated refactor or generated-file churn is included

Affected subsystem:

* `src/graph/imports/*`
* `src/audits/architecture/graph_queries/*`

Public behavior affected:

* Architecture findings may now report more accurate `evidence.line_start` and `evidence.line_end` values for import-driven violations.
* Finding IDs and schemas remain unchanged.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
