### PR TITLE
feat(graph): model workspace packages as Package nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- The dependency graph now models workspace packages as first-class `Package`
+  nodes. The builder detects npm/yarn, pnpm, Cargo, and Go (`go.work`) workspaces and records which package each file belongs to (by longest path
+  prefix), so future rules can reason about real package boundaries instead of
+  path globs. A non-workspace repository produces no package nodes and leaves
+  the graph unchanged. Internal only for now — no command consumes it yet.
+
 ### Changed
 
 - Architecture audits (`circular-dependency`, `excessive-fan-out`, `dead-module`, `test-leak`, `layer-violation`, `package-boundary-violation`) now pinpoint the exact import statement lines in their evidence snippets instead of defaulting to line 1, using language-aware AST extraction across all supported languages.

--- a/src/graph/v2/algorithms/tests.rs
+++ b/src/graph/v2/algorithms/tests.rs
@@ -31,7 +31,7 @@ fn snapshot(nodes: &[&str], edges: &[(&str, &str)]) -> GraphSnapshot {
     GraphSnapshot {
         nodes: nodes.iter().map(|value| node(value)).collect(),
         edges: edges.iter().map(|(from, to)| edge(from, to)).collect(),
-        diagnostics: Vec::new(),
+        ..Default::default()
     }
 }
 
@@ -403,7 +403,7 @@ fn directory_dependencies_ignore_non_dependency_and_external_edges() {
                 confidence: GraphEdgeConfidence::Medium,
             },
         ],
-        diagnostics: Vec::new(),
+        ..Default::default()
     };
 
     assert!(directory_dependencies(&graph).edges.is_empty());

--- a/src/graph/v2/builder/mod.rs
+++ b/src/graph/v2/builder/mod.rs
@@ -1,3 +1,4 @@
+mod packages;
 mod test_edges;
 
 use super::{
@@ -101,6 +102,13 @@ pub fn graph_snapshot_from_scan(scan: &ScanFacts) -> GraphSnapshot {
         }
     }
 
+    // Workspace `Package` nodes + file → package membership. Empty (no nodes,
+    // no membership) for a non-workspace root, leaving the snapshot unchanged.
+    let package_graph = packages::package_graph(&root, &known_files);
+    for (id, node) in package_graph.nodes {
+        nodes.entry(id).or_insert(node);
+    }
+
     edges.extend(test_edges::test_of_edges(&known_files));
 
     edges.sort_by(|left, right| {
@@ -127,6 +135,7 @@ pub fn graph_snapshot_from_scan(scan: &ScanFacts) -> GraphSnapshot {
         nodes: nodes.into_values().collect(),
         edges,
         diagnostics,
+        package_membership: package_graph.membership,
     }
 }
 

--- a/src/graph/v2/builder/packages.rs
+++ b/src/graph/v2/builder/packages.rs
@@ -1,0 +1,167 @@
+use super::slash_path;
+use crate::graph::resolver::normalize_path;
+use crate::graph::v2::{GraphNode, GraphNodeId, GraphNodeKind};
+use crate::scan::workspace::detect_workspace_packages;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// `Package` graph nodes for a workspace plus the file → package membership map.
+#[derive(Default)]
+pub(super) struct PackageGraph {
+    pub nodes: Vec<(GraphNodeId, GraphNode)>,
+    pub membership: BTreeMap<GraphNodeId, GraphNodeId>,
+}
+
+/// A detected workspace package, normalized for prefix matching.
+struct PackageNode {
+    id: GraphNodeId,
+    node: GraphNode,
+    root: PathBuf,
+}
+
+/// Build `Package` nodes for the workspace rooted at `repo_root` (already
+/// normalized) and map each known file node to the most specific package whose
+/// root is a path prefix of the file. Returns empty for a non-workspace root.
+pub(super) fn package_graph(
+    repo_root: &Path,
+    known_files: &BTreeMap<PathBuf, GraphNodeId>,
+) -> PackageGraph {
+    // An empty root would make manifest reads resolve against the process CWD.
+    if repo_root.as_os_str().is_empty() {
+        return PackageGraph::default();
+    }
+
+    let packages = detect_package_nodes(repo_root);
+    let membership = membership_by_longest_prefix(&packages, known_files);
+
+    PackageGraph {
+        nodes: packages
+            .into_iter()
+            .map(|package| (package.id, package.node))
+            .collect(),
+        membership,
+    }
+}
+
+fn detect_package_nodes(repo_root: &Path) -> Vec<PackageNode> {
+    let mut packages: Vec<PackageNode> = detect_workspace_packages(repo_root)
+        .into_iter()
+        .filter_map(|package| {
+            let root = normalize_path(&package.root);
+            // The repo root itself is not a sub-package; sub-package roots have a
+            // non-empty relative path.
+            let relative = root.strip_prefix(repo_root).ok()?;
+            let label = slash_path(relative);
+            if label.is_empty() {
+                return None;
+            }
+            let id = GraphNodeId::new(format!("package:{label}"));
+            Some(PackageNode {
+                node: GraphNode {
+                    id: id.clone(),
+                    kind: GraphNodeKind::Package,
+                    label: package.name,
+                    path: Some(root.clone()),
+                },
+                id,
+                root,
+            })
+        })
+        .collect();
+
+    // Deterministic, duplicate-free node order.
+    packages.sort_by(|left, right| left.id.cmp(&right.id));
+    packages.dedup_by(|left, right| left.id == right.id);
+    packages
+}
+
+fn membership_by_longest_prefix(
+    packages: &[PackageNode],
+    known_files: &BTreeMap<PathBuf, GraphNodeId>,
+) -> BTreeMap<GraphNodeId, GraphNodeId> {
+    let mut membership = BTreeMap::new();
+    if packages.is_empty() {
+        return membership;
+    }
+
+    for (file_path, file_id) in known_files {
+        let owner = packages
+            .iter()
+            .filter(|package| file_path.starts_with(&package.root))
+            .max_by_key(|package| package.root.components().count());
+        if let Some(package) = owner {
+            membership.insert(file_id.clone(), package.id.clone());
+        }
+    }
+    membership
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pkg(id: &str, root: &str) -> PackageNode {
+        let id = GraphNodeId::new(id);
+        PackageNode {
+            node: GraphNode {
+                id: id.clone(),
+                kind: GraphNodeKind::Package,
+                label: String::new(),
+                path: Some(PathBuf::from(root)),
+            },
+            id,
+            root: PathBuf::from(root),
+        }
+    }
+
+    fn files(entries: &[(&str, &str)]) -> BTreeMap<PathBuf, GraphNodeId> {
+        entries
+            .iter()
+            .map(|(path, id)| (PathBuf::from(path), GraphNodeId::new(*id)))
+            .collect()
+    }
+
+    #[test]
+    fn membership_picks_the_most_specific_package() {
+        let packages = vec![
+            pkg("package:packages/app", "/repo/packages/app"),
+            pkg("package:packages/app/plugin", "/repo/packages/app/plugin"),
+        ];
+        let known = files(&[
+            ("/repo/packages/app/src/main.ts", "file:a"),
+            ("/repo/packages/app/plugin/src/p.ts", "file:b"),
+        ]);
+
+        let membership = membership_by_longest_prefix(&packages, &known);
+
+        assert_eq!(
+            membership
+                .get(&GraphNodeId::new("file:a"))
+                .unwrap()
+                .as_str(),
+            "package:packages/app"
+        );
+        // The nested package wins over its ancestor by longest prefix.
+        assert_eq!(
+            membership
+                .get(&GraphNodeId::new("file:b"))
+                .unwrap()
+                .as_str(),
+            "package:packages/app/plugin"
+        );
+    }
+
+    #[test]
+    fn files_outside_every_package_have_no_membership() {
+        let packages = vec![pkg("package:packages/app", "/repo/packages/app")];
+        let known = files(&[("/repo/tools/script.ts", "file:x")]);
+
+        assert!(membership_by_longest_prefix(&packages, &known).is_empty());
+    }
+
+    #[test]
+    fn no_packages_means_no_membership() {
+        let known = files(&[("/repo/src/main.ts", "file:x")]);
+        assert!(membership_by_longest_prefix(&[], &known).is_empty());
+    }
+}

--- a/src/graph/v2/builder/tests.rs
+++ b/src/graph/v2/builder/tests.rs
@@ -183,3 +183,152 @@ fn test_files_link_to_their_subject_with_a_test_of_edge() {
     assert_eq!(test_of.provenance, GraphEdgeProvenance::TestHeuristic);
     assert_eq!(test_of.confidence, GraphEdgeConfidence::High);
 }
+
+// ── Workspace package nodes ─────────────────────────────────────────────────
+//
+// Package detection reads manifests from disk, so these build a real workspace
+// on a temp dir and a `ScanFacts` whose file paths live under it.
+
+use std::fs;
+use tempfile::TempDir;
+
+fn write(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn scan_under(root: &Path, relatives: &[&str]) -> ScanFacts {
+    let files = relatives
+        .iter()
+        .map(|relative| file(root.join(relative).to_string_lossy().as_ref(), &[]))
+        .collect();
+    ScanFacts {
+        root_path: root.to_path_buf(),
+        files,
+        ..ScanFacts::default()
+    }
+}
+
+fn package_nodes(snapshot: &GraphSnapshot) -> Vec<&str> {
+    snapshot
+        .nodes
+        .iter()
+        .filter(|node| node.kind == GraphNodeKind::Package)
+        .map(|node| node.id.as_str())
+        .collect()
+}
+
+#[test]
+fn npm_workspace_creates_package_nodes_and_membership() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(root, "package.json", r#"{ "workspaces": ["packages/*"] }"#);
+    write(
+        root,
+        "packages/web/package.json",
+        r#"{ "name": "@acme/web" }"#,
+    );
+    write(
+        root,
+        "packages/api/package.json",
+        r#"{ "name": "@acme/api" }"#,
+    );
+
+    let snapshot = graph_snapshot_from_scan(&scan_under(
+        root,
+        &["packages/web/src/index.ts", "packages/api/src/index.ts"],
+    ));
+
+    assert_eq!(
+        package_nodes(&snapshot),
+        vec!["package:packages/api", "package:packages/web"]
+    );
+    // The Package node label carries the manifest name for consumers.
+    let web = snapshot
+        .nodes
+        .iter()
+        .find(|node| node.id.as_str() == "package:packages/web")
+        .unwrap();
+    assert_eq!(web.label, "@acme/web");
+
+    let membership = &snapshot.package_membership;
+    assert_eq!(
+        membership
+            .get(&GraphNodeId::new("file:packages/web/src/index.ts"))
+            .unwrap()
+            .as_str(),
+        "package:packages/web"
+    );
+    assert_eq!(
+        membership
+            .get(&GraphNodeId::new("file:packages/api/src/index.ts"))
+            .unwrap()
+            .as_str(),
+        "package:packages/api"
+    );
+}
+
+#[test]
+fn cargo_workspace_creates_package_nodes() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        root,
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"crates/*\"]\n",
+    );
+    write(
+        root,
+        "crates/core/Cargo.toml",
+        "[package]\nname = \"core\"\n",
+    );
+    write(root, "crates/core/src/lib.rs", "");
+
+    let snapshot = graph_snapshot_from_scan(&scan_under(root, &["crates/core/src/lib.rs"]));
+
+    assert_eq!(package_nodes(&snapshot), vec!["package:crates/core"]);
+    assert_eq!(
+        snapshot
+            .package_membership
+            .get(&GraphNodeId::new("file:crates/core/src/lib.rs"))
+            .unwrap()
+            .as_str(),
+        "package:crates/core"
+    );
+}
+
+#[test]
+fn go_work_creates_package_nodes() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(root, "go.work", "use (\n\t./svc-a\n)\n");
+    write(root, "svc-a/go.mod", "module example.com/svc-a\n");
+    write(root, "svc-a/main.go", "package main\n");
+
+    let snapshot = graph_snapshot_from_scan(&scan_under(root, &["svc-a/main.go"]));
+
+    assert_eq!(package_nodes(&snapshot), vec!["package:svc-a"]);
+    assert_eq!(
+        snapshot
+            .package_membership
+            .get(&GraphNodeId::new("file:svc-a/main.go"))
+            .unwrap()
+            .as_str(),
+        "package:svc-a"
+    );
+}
+
+#[test]
+fn non_workspace_root_adds_no_package_nodes_or_membership() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(root, "package.json", r#"{ "name": "solo" }"#);
+
+    let snapshot = graph_snapshot_from_scan(&scan_under(root, &["src/index.ts"]));
+
+    assert!(package_nodes(&snapshot).is_empty());
+    assert!(snapshot.package_membership.is_empty());
+    // The only node is the file itself — the snapshot is unchanged by package support.
+    assert_eq!(snapshot.node_count(), 1);
+}

--- a/src/graph/v2/snapshot.rs
+++ b/src/graph/v2/snapshot.rs
@@ -1,10 +1,16 @@
-use super::{GraphDiagnostic, GraphEdge, GraphNode};
+use super::{GraphDiagnostic, GraphEdge, GraphNode, GraphNodeId};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct GraphSnapshot {
     pub nodes: Vec<GraphNode>,
     pub edges: Vec<GraphEdge>,
     pub diagnostics: Vec<GraphDiagnostic>,
+    /// File node id → the workspace `Package` node it belongs to, by longest
+    /// path prefix. Empty when the root is not a workspace. Carried alongside
+    /// the nodes (rather than as `Contains` edges) because consumers look up
+    /// membership by file, not by traversal.
+    pub package_membership: BTreeMap<GraphNodeId, GraphNodeId>,
 }
 
 impl GraphSnapshot {

--- a/src/scan/workspace/cargo.rs
+++ b/src/scan/workspace/cargo.rs
@@ -1,0 +1,72 @@
+use super::WorkspacePackage;
+use std::path::Path;
+
+pub(super) fn from_cargo_workspace(root: &Path) -> Vec<WorkspacePackage> {
+    let content = match std::fs::read_to_string(root.join("Cargo.toml")) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let value: toml::Value = match toml::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    let members = value
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    if members.is_empty() {
+        return Vec::new();
+    }
+
+    let mut packages = Vec::new();
+    for member in &members {
+        let trimmed = member.trim_end_matches('/');
+        if trimmed.contains('*') {
+            let prefix = trimmed.trim_end_matches("/*").trim_end_matches("/**");
+            let base = root.join(prefix);
+            let Ok(entries) = std::fs::read_dir(&base) else {
+                continue;
+            };
+            for entry in entries.filter_map(Result::ok) {
+                let path = entry.path();
+                if path.is_dir()
+                    && path.join("Cargo.toml").is_file()
+                    && let Some(name) = package_name_from_path(&path)
+                {
+                    packages.push(WorkspacePackage { name, root: path });
+                }
+            }
+        } else {
+            let path = root.join(trimmed);
+            if path.join("Cargo.toml").is_file()
+                && let Some(name) = package_name_from_path(&path)
+            {
+                packages.push(WorkspacePackage { name, root: path });
+            }
+        }
+    }
+    packages
+}
+
+fn package_name_from_path(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path.join("Cargo.toml")).ok()?;
+    let value: toml::Value = toml::from_str(&content).ok()?;
+    value
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(str::to_string)
+        .or_else(|| {
+            path.file_name()
+                .and_then(|n| n.to_str())
+                .map(str::to_string)
+        })
+}

--- a/src/scan/workspace/go.rs
+++ b/src/scan/workspace/go.rs
@@ -1,0 +1,76 @@
+use super::WorkspacePackage;
+use std::path::Path;
+
+/// Go multi-module workspace: each directory a `go.work` file `use`s and that
+/// carries its own `go.mod` is a workspace package. The package name is the
+/// module path declared in that `go.mod` (falling back to the directory name).
+///
+/// (`src/review/signals/behavioral/dependency.rs` has a parallel `go.work`
+/// reader tuned to import-prefix resolution; the two are kept separate because
+/// they consume the file for different purposes.)
+pub(super) fn from_go_workspace(root: &Path) -> Vec<WorkspacePackage> {
+    let content = match std::fs::read_to_string(root.join("go.work")) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut packages = Vec::new();
+    for dir in go_work_uses(&content) {
+        let package_root = root.join(&dir);
+        if !package_root.join("go.mod").is_file() {
+            continue;
+        }
+        let name = go_module_name(&package_root).unwrap_or_else(|| {
+            package_root
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned()
+        });
+        packages.push(WorkspacePackage {
+            name,
+            root: package_root,
+        });
+    }
+    packages
+}
+
+/// Directories a `go.work` file `use`s, supporting both the single-line
+/// (`use ./dir`) and block (`use ( … )`) forms.
+fn go_work_uses(content: &str) -> Vec<String> {
+    let mut uses = Vec::new();
+    let mut in_block = false;
+    for line in content.lines() {
+        let line = line.trim();
+        if in_block {
+            if line.starts_with(')') {
+                in_block = false;
+            } else if !line.is_empty() {
+                uses.push(line.trim_matches('"').to_string());
+            }
+            continue;
+        }
+        let Some(rest) = line.strip_prefix("use") else {
+            continue;
+        };
+        let rest = rest.trim();
+        if let Some(rest) = rest.strip_prefix('(') {
+            in_block = true;
+            let rest = rest.trim();
+            if !rest.is_empty() {
+                uses.push(rest.trim_matches('"').to_string());
+            }
+        } else if !rest.is_empty() {
+            uses.push(rest.trim_matches('"').to_string());
+        }
+    }
+    uses
+}
+
+fn go_module_name(package_root: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(package_root.join("go.mod")).ok()?;
+    content
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("module "))
+        .map(|module| module.trim().to_string())
+}

--- a/src/scan/workspace/js.rs
+++ b/src/scan/workspace/js.rs
@@ -1,31 +1,7 @@
-use std::path::{Path, PathBuf};
+use super::{WorkspacePackage, child_dirs};
+use std::path::Path;
 
-#[derive(Debug, Clone)]
-pub struct WorkspacePackage {
-    pub name: String,
-    pub root: PathBuf,
-}
-
-/// Detect workspace packages under `root`.
-///
-/// Checks (in order): npm/yarn workspaces (`package.json`), pnpm workspaces
-/// (`pnpm-workspace.yaml`), Cargo workspace (`Cargo.toml`). Returns the first
-/// non-empty list found. Returns an empty vec when the root is not a workspace.
-pub fn detect_workspace_packages(root: &Path) -> Vec<WorkspacePackage> {
-    let npm = from_npm_workspaces(root);
-    if !npm.is_empty() {
-        return npm;
-    }
-
-    let pnpm = from_pnpm_workspaces(root);
-    if !pnpm.is_empty() {
-        return pnpm;
-    }
-
-    from_cargo_workspace(root)
-}
-
-fn from_npm_workspaces(root: &Path) -> Vec<WorkspacePackage> {
+pub(super) fn from_npm_workspaces(root: &Path) -> Vec<WorkspacePackage> {
     let content = match std::fs::read_to_string(root.join("package.json")) {
         Ok(c) => c,
         Err(_) => return Vec::new(),
@@ -39,7 +15,7 @@ fn from_npm_workspaces(root: &Path) -> Vec<WorkspacePackage> {
     packages_from_patterns(root, &patterns)
 }
 
-fn from_pnpm_workspaces(root: &Path) -> Vec<WorkspacePackage> {
+pub(super) fn from_pnpm_workspaces(root: &Path) -> Vec<WorkspacePackage> {
     let content = match std::fs::read_to_string(root.join("pnpm-workspace.yaml")) {
         Ok(c) => c,
         Err(_) => return Vec::new(),
@@ -47,76 +23,6 @@ fn from_pnpm_workspaces(root: &Path) -> Vec<WorkspacePackage> {
 
     let patterns = parse_pnpm_packages_yaml(&content);
     packages_from_patterns(root, &patterns)
-}
-
-fn from_cargo_workspace(root: &Path) -> Vec<WorkspacePackage> {
-    let content = match std::fs::read_to_string(root.join("Cargo.toml")) {
-        Ok(c) => c,
-        Err(_) => return Vec::new(),
-    };
-    let value: toml::Value = match toml::from_str(&content) {
-        Ok(v) => v,
-        Err(_) => return Vec::new(),
-    };
-
-    let members = value
-        .get("workspace")
-        .and_then(|w| w.get("members"))
-        .and_then(|m| m.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(str::to_string))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-
-    if members.is_empty() {
-        return Vec::new();
-    }
-
-    let mut packages = Vec::new();
-    for member in &members {
-        let trimmed = member.trim_end_matches('/');
-        if trimmed.contains('*') {
-            let prefix = trimmed.trim_end_matches("/*").trim_end_matches("/**");
-            let base = root.join(prefix);
-            let Ok(entries) = std::fs::read_dir(&base) else {
-                continue;
-            };
-            for entry in entries.filter_map(Result::ok) {
-                let path = entry.path();
-                if path.is_dir()
-                    && path.join("Cargo.toml").is_file()
-                    && let Some(name) = package_name_from_path(&path)
-                {
-                    packages.push(WorkspacePackage { name, root: path });
-                }
-            }
-        } else {
-            let path = root.join(trimmed);
-            if path.join("Cargo.toml").is_file()
-                && let Some(name) = package_name_from_path(&path)
-            {
-                packages.push(WorkspacePackage { name, root: path });
-            }
-        }
-    }
-    packages
-}
-
-fn package_name_from_path(path: &Path) -> Option<String> {
-    let content = std::fs::read_to_string(path.join("Cargo.toml")).ok()?;
-    let value: toml::Value = toml::from_str(&content).ok()?;
-    value
-        .get("package")
-        .and_then(|p| p.get("name"))
-        .and_then(|n| n.as_str())
-        .map(str::to_string)
-        .or_else(|| {
-            path.file_name()
-                .and_then(|n| n.to_str())
-                .map(str::to_string)
-        })
 }
 
 fn workspace_glob_patterns(value: &serde_json::Value) -> Vec<String> {
@@ -203,15 +109,4 @@ fn npm_package_name(path: &Path) -> Option<String> {
         .get("name")
         .and_then(|n| n.as_str())
         .map(str::to_string)
-}
-
-fn child_dirs(path: &Path) -> Vec<PathBuf> {
-    let Ok(entries) = std::fs::read_dir(path) else {
-        return Vec::new();
-    };
-    entries
-        .filter_map(Result::ok)
-        .map(|e| e.path())
-        .filter(|p| p.is_dir())
-        .collect()
 }

--- a/src/scan/workspace/mod.rs
+++ b/src/scan/workspace/mod.rs
@@ -1,0 +1,52 @@
+use std::path::{Path, PathBuf};
+
+mod cargo;
+mod go;
+mod js;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug, Clone)]
+pub struct WorkspacePackage {
+    pub name: String,
+    pub root: PathBuf,
+}
+
+/// Detect workspace packages under `root`.
+///
+/// Checks (in order): npm/yarn workspaces (`package.json`), pnpm workspaces
+/// (`pnpm-workspace.yaml`), Cargo workspace (`Cargo.toml`), Go multi-module
+/// workspace (`go.work`). Returns the first non-empty list found. Returns an
+/// empty vec when the root is not a workspace.
+pub fn detect_workspace_packages(root: &Path) -> Vec<WorkspacePackage> {
+    let npm = js::from_npm_workspaces(root);
+    if !npm.is_empty() {
+        return npm;
+    }
+
+    let pnpm = js::from_pnpm_workspaces(root);
+    if !pnpm.is_empty() {
+        return pnpm;
+    }
+
+    let cargo = cargo::from_cargo_workspace(root);
+    if !cargo.is_empty() {
+        return cargo;
+    }
+
+    go::from_go_workspace(root)
+}
+
+/// Directories directly under `path`. Shared by the manifest parsers that
+/// expand `dir/*` globs.
+pub(super) fn child_dirs(path: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect()
+}

--- a/src/scan/workspace/tests.rs
+++ b/src/scan/workspace/tests.rs
@@ -1,0 +1,109 @@
+use super::detect_workspace_packages;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn write(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn names(root: &Path) -> Vec<String> {
+    let mut names: Vec<String> = detect_workspace_packages(root)
+        .into_iter()
+        .map(|pkg| pkg.name)
+        .collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn detects_npm_workspace_globs() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(root, "package.json", r#"{ "workspaces": ["packages/*"] }"#);
+    write(
+        root,
+        "packages/web/package.json",
+        r#"{ "name": "@acme/web" }"#,
+    );
+    write(
+        root,
+        "packages/api/package.json",
+        r#"{ "name": "@acme/api" }"#,
+    );
+
+    assert_eq!(names(root), vec!["@acme/api", "@acme/web"]);
+}
+
+#[test]
+fn detects_cargo_workspace_members() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        root,
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"crates/core\", \"crates/cli\"]\n",
+    );
+    write(
+        root,
+        "crates/core/Cargo.toml",
+        "[package]\nname = \"core\"\n",
+    );
+    write(root, "crates/cli/Cargo.toml", "[package]\nname = \"cli\"\n");
+
+    assert_eq!(names(root), vec!["cli", "core"]);
+}
+
+#[test]
+fn detects_go_work_use_directories() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        root,
+        "go.work",
+        "go 1.22\n\nuse (\n\t./svc-a\n\t./svc-b\n)\n",
+    );
+    write(
+        root,
+        "svc-a/go.mod",
+        "module example.com/svc-a\n\ngo 1.22\n",
+    );
+    write(
+        root,
+        "svc-b/go.mod",
+        "module example.com/svc-b\n\ngo 1.22\n",
+    );
+
+    assert_eq!(names(root), vec!["example.com/svc-a", "example.com/svc-b"]);
+}
+
+#[test]
+fn detects_single_line_go_work_use() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(root, "go.work", "go 1.22\n\nuse ./service\n");
+    write(root, "service/go.mod", "module example.com/service\n");
+
+    assert_eq!(names(root), vec!["example.com/service"]);
+}
+
+#[test]
+fn go_work_use_without_go_mod_is_skipped() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(root, "go.work", "use ./not-a-module\n");
+    fs::create_dir_all(root.join("not-a-module")).unwrap();
+
+    assert!(detect_workspace_packages(root).is_empty());
+}
+
+#[test]
+fn non_workspace_root_has_no_packages() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    write(root, "package.json", r#"{ "name": "solo" }"#);
+
+    assert!(detect_workspace_packages(root).is_empty());
+}


### PR DESCRIPTION
## Summary

Adds workspace package modeling to graph v2.

The graph builder now detects workspace packages and emits first-class `Package` nodes. It also records file-to-package membership on the graph snapshot using longest path-prefix matching.

This is an internal graph foundation for future architecture rules, especially package-boundary analysis. No runtime command consumes this package membership yet.

## Type of change

* [x] Feature
* [x] Refactor
* [ ] Bug fix
* [x] Tests
* [ ] Documentation
* [ ] CI / repository maintenance

## What changed

* Split workspace detection into dedicated modules:

  * `workspace/js`
  * `workspace/cargo`
  * `workspace/go`
* Added Go `go.work` workspace detection.
* Added graph v2 `Package` nodes for detected workspace packages.
* Added `GraphSnapshot.package_membership` for file → package ownership.
* Added longest-prefix package membership resolution.
* Added regression coverage for:

  * npm/yarn workspaces
  * Cargo workspaces
  * Go `go.work`
  * nested package ownership
  * files outside packages
  * non-workspace repositories

## Why

RepoPilot needs a stronger package model before package-boundary rules can become truly architecture-aware.

Before this change, package-boundary reasoning had to rely mostly on path patterns. With workspace packages represented in the graph, future rules can reason from detected package ownership instead of only matching globs.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] No unrelated refactor or generated-file churn is included

Affected subsystem:

* `src/scan/workspace/*`
* `src/graph/v2/*`

Public behavior affected:

* Graph v2 snapshots can now include `Package` nodes for workspace repositories.
* Graph v2 snapshots now carry `package_membership`.
* Non-workspace repositories continue to produce no package nodes and no package membership.
* No CLI-facing architecture rule consumes this data yet.

Known limitation:

* Workspace detection currently returns the first detected ecosystem in priority order: npm/yarn, pnpm, Cargo, then Go. Mixed polyglot workspaces can be handled in a follow-up by merging all detected ecosystems and deduplicating by package root.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
