### PR TITLE
feat(arch): auto-enable package-boundary rule on detected workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,21 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Changed
+
+- `architecture.package-boundary-violation` now **auto-enables on a detected
+  workspace** — npm/yarn, pnpm, Cargo, or Go (`go.work`). Each workspace package
+  is treated as a boundary, so reaching into another package's internals
+  (anything but its `index.ts`/`mod.rs`/`lib.rs` public entry) is flagged
+  without any configuration, at **High** confidence because the boundary is
+  declared by the repository's own manifests. Explicit `[architecture]
+  package_roots` still take priority and keep the Medium default confidence;
+  with neither a workspace nor config the rule stays silent. A non-workspace
+  repository (including RepoPilot itself) is unaffected.
+
 ### Added
 
-- The dependency graph now models workspace packages as first-class `Package`
-  nodes. The builder detects npm/yarn, pnpm, Cargo, and Go (`go.work`) workspaces and records which package each file belongs to (by longest path
+- The dependency graph now models workspace packages as first-class `Package` nodes. The builder detects npm/yarn, pnpm, Cargo, and Go (`go.work`) workspaces and records which package each file belongs to (by longest path
   prefix), so future rules can reason about real package boundaries instead of
   path globs. A non-workspace repository produces no package nodes and leaves
   the graph unchanged. Internal only for now — no command consumes it yet.

--- a/docs/architecture-antipatterns.md
+++ b/docs/architecture-antipatterns.md
@@ -37,6 +37,10 @@ from broad architecture structure heuristics.
 | `architecture.import-coupling` | Is a file coupled to too many internal modules? | Should prefer source code over generated/test corpora. |
 | `architecture.deep-relative-imports` | Are imports crossing too many directory levels? | Should focus on maintainability of production imports. |
 | `architecture.barrel-file-risk` | Is a barrel file hiding coupling or unstable public boundaries? | Should explain why the barrel is risky, not merely that it exists. |
+| `architecture.dead-module` | Is a production file imported by nothing and not an entrypoint? | Demoted/suppressed when unresolved imports make the graph incomplete. |
+| `architecture.test-leak` | Does production code import a test or fixture file? | On by default; evidence cites the import line. |
+| `architecture.layer-violation` | Does a module import against the declared layer order? | Strictly opt-in via `[[architecture.layers]]`. |
+| `architecture.package-boundary-violation` | Does one package reach into another's internals instead of its public API? | Auto-enabled on a detected workspace (manifest boundaries → High confidence); also configurable via `[architecture] package_roots` (→ Medium). |
 
 ## Visibility guidance
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,8 +121,16 @@ is silent.
 
 `architecture.package-boundary-violation` flags one package reaching into
 another package's internals instead of importing its public API (`index.ts`,
-`mod.rs`, `lib.rs`). Declare the roots whose immediate children are independent
-packages:
+`mod.rs`, `lib.rs`).
+
+The rule **auto-enables on a detected workspace** — npm/yarn (`workspaces`),
+pnpm (`pnpm-workspace.yaml`), Cargo (`[workspace] members`), or Go (`go.work`).
+Each workspace package becomes a boundary, and violations are reported at
+**High** confidence because the boundary is declared by the repository's own
+manifests. Nothing needs to be configured.
+
+To define boundaries explicitly (for example in a repo that is not a recognized
+workspace), declare the roots whose immediate children are independent packages:
 
 ```toml
 [architecture]
@@ -131,8 +139,10 @@ package_roots = ["packages/*", "apps/*"]
 
 With `packages/*`, anything under `packages/auth/` belongs to package
 `packages/auth`; an import from `packages/web/...` into `packages/auth/src/...`
-is flagged, while importing `packages/auth/index.ts` is not. With no
-`package_roots` the rule is silent.
+is flagged, while importing `packages/auth/index.ts` is not. Configured
+`package_roots` take priority over workspace detection and report at the default
+Medium confidence. With neither a workspace nor `package_roots`, the rule is
+silent.
 
 ## Per-rule control
 

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -1,8 +1,9 @@
 //! Whole-repo architecture rules that query the import graph: dead modules,
 //! test leaks into production, declared-layer violations, and package-boundary
-//! violations. The layer and package rules are strictly opt-in — they emit
-//! nothing unless the user declares `[[architecture.layers]]` or
-//! `[architecture] package_roots`.
+//! violations. Layer violations are strictly opt-in (`[[architecture.layers]]`).
+//! Package-boundary violations auto-enable on a detected npm/pnpm/Cargo/Go
+//! workspace and can also be driven explicitly by `[architecture] package_roots`;
+//! with neither a workspace nor config the rule is silent.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -97,7 +98,8 @@ impl GraphQueriesAudit {
         }
 
         let layer_index = LayerIndex::from_config(config);
-        let package_index = PackageIndex::from_config(config);
+        let detected_packages = crate::scan::workspace::detect_workspace_packages(root);
+        let package_index = PackageIndex::new(config, &detected_packages, root);
 
         let mut reported_edges = HashSet::new();
         for edge in &snapshot.edges {

--- a/src/audits/architecture/graph_queries/packages.rs
+++ b/src/audits/architecture/graph_queries/packages.rs
@@ -1,54 +1,99 @@
-//! Opt-in `architecture.package-boundary-violation`: a file reaching into
-//! another package's internals instead of going through its public API. A
-//! "package" is an immediate child of a declared root glob (`packages/*`), or a
-//! declared directory itself. With no `[architecture] package_roots` configured
-//! the rule is silent.
+//! `architecture.package-boundary-violation`: a file reaching into another
+//! package's internals instead of going through its public API.
 //!
-//! This is the lightweight, path-based form. Promoting workspace packages to
-//! first-class graph nodes is tracked separately (roadmap PR-F).
+//! Packages come from one of two sources, in priority order:
+//!
+//! 1. **Explicit** `[architecture] package_roots` globs (`packages/*`, or a bare
+//!    directory). Findings carry the registry-default confidence.
+//! 2. **Detected** npm/pnpm/Cargo/Go workspaces, used when no `package_roots`
+//!    are configured. The rule auto-enables on a workspace, and findings are
+//!    raised to `High` confidence because the boundary is declared by the
+//!    repository's own manifests.
+//!
+//! With neither source the rule is silent.
 
-use crate::findings::types::{Evidence, Finding};
+use std::path::Path;
+
+use crate::findings::types::{Confidence, Evidence, Finding};
 use crate::scan::config::ScanConfig;
+use crate::scan::workspace::WorkspacePackage;
 
 use super::{NodeInfo, architecture_finding};
 
 pub(crate) struct PackageIndex {
+    /// Either glob patterns (`packages/*`) or bare package roots (`packages/auth`).
     roots: Vec<String>,
+    /// True when `roots` were derived from workspace manifests rather than
+    /// configured globs; such findings are reported at `High` confidence.
+    manifest_backed: bool,
 }
 
 impl PackageIndex {
-    pub(crate) fn from_config(config: &ScanConfig) -> Self {
+    /// Configured `package_roots` win (preserving the explicit, pre-0.18
+    /// behavior); otherwise detected workspace packages drive the rule.
+    pub(crate) fn new(
+        config: &ScanConfig,
+        detected: &[WorkspacePackage],
+        repo_root: &Path,
+    ) -> Self {
+        if !config.package_roots.is_empty() {
+            return Self {
+                roots: config.package_roots.clone(),
+                manifest_backed: false,
+            };
+        }
+
+        let roots = detected
+            .iter()
+            .filter_map(|package| {
+                let relative = package.root.strip_prefix(repo_root).ok()?;
+                let relative = relative.to_string_lossy().replace('\\', "/");
+                (!relative.is_empty()).then_some(relative)
+            })
+            .collect();
+
         Self {
-            roots: config.package_roots.clone(),
+            roots,
+            manifest_backed: true,
         }
     }
 
-    /// The package a file belongs to, or `None` if it is outside every declared
-    /// root. `packages/*` maps `packages/auth/src/x.ts` to `packages/auth`; a
-    /// bare `libs/core` maps anything under it to `libs/core`.
+    /// The package a file belongs to, or `None` if it is outside every root.
+    /// `packages/*` maps `packages/auth/src/x.ts` to `packages/auth`; a bare
+    /// `libs/core` maps anything under it to `libs/core`. The most specific
+    /// (longest) match wins so nested packages are attributed correctly.
     fn package_of(&self, info: &NodeInfo) -> Option<String> {
         let rel = info.relative.to_string_lossy().replace('\\', "/");
+        let mut best: Option<String> = None;
         for pattern in &self.roots {
-            if let Some(base) = pattern.strip_suffix("/*") {
+            let candidate = if let Some(base) = pattern.strip_suffix("/*") {
                 let prefix = format!("{base}/");
-                if let Some(rest) = rel.strip_prefix(&prefix) {
-                    let first = rest.split('/').next().unwrap_or("");
-                    if !first.is_empty() {
-                        return Some(format!("{base}/{first}"));
-                    }
-                }
+                rel.strip_prefix(&prefix)
+                    .and_then(|rest| rest.split('/').next())
+                    .filter(|first| !first.is_empty())
+                    .map(|first| format!("{base}/{first}"))
             } else if rel == *pattern || rel.starts_with(&format!("{pattern}/")) {
-                return Some(pattern.clone());
+                Some(pattern.clone())
+            } else {
+                None
+            };
+
+            if let Some(candidate) = candidate
+                && best
+                    .as_ref()
+                    .is_none_or(|current| candidate.len() > current.len())
+            {
+                best = Some(candidate);
             }
         }
-        None
+        best
     }
 
     pub(crate) fn violation_finding(
         &self,
         source: &NodeInfo,
         target: &NodeInfo,
-        root: &std::path::Path,
+        root: &Path,
         known_files: &std::collections::HashSet<std::path::PathBuf>,
     ) -> Option<Finding> {
         if self.roots.is_empty() || target.context.is_public_api {
@@ -66,7 +111,7 @@ impl PackageIndex {
             (1, None)
         };
 
-        Some(architecture_finding(
+        let mut finding = architecture_finding(
             "architecture.package-boundary-violation",
             "Package boundary violation",
             format!(
@@ -78,6 +123,18 @@ impl PackageIndex {
                 line_end,
                 snippet: format!("imports internal file: {}", target.relative.display()),
             },
-        ))
+        );
+
+        // A manifest-declared boundary is a fact about the repository, not a
+        // heuristic guess, so it earns the registry's confidence ceiling.
+        if self.manifest_backed {
+            finding.confidence = Confidence::High;
+        }
+        Some(finding)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_config(config: &ScanConfig) -> Self {
+        Self::new(config, &[], Path::new(""))
     }
 }

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -323,3 +323,103 @@ fn package_boundary_allows_public_api_same_package_and_no_config() {
             .is_none()
     );
 }
+
+fn detected(repo_root: &Path, rel_roots: &[&str]) -> Vec<crate::scan::workspace::WorkspacePackage> {
+    rel_roots
+        .iter()
+        .map(|rel| crate::scan::workspace::WorkspacePackage {
+            name: rel.to_string(),
+            root: repo_root.join(rel),
+        })
+        .collect()
+}
+
+#[test]
+fn detected_workspace_auto_enables_package_boundary_at_high_confidence() {
+    let repo_root = Path::new("/repo");
+    let packages = detected(repo_root, &["packages/web", "packages/auth"]);
+    // No `package_roots` config: detection drives the rule.
+    let index = PackageIndex::new(&ScanConfig::default(), &packages, repo_root);
+    let known = std::collections::HashSet::new();
+
+    let finding = index
+        .violation_finding(
+            &prod("packages/web/src/use.ts"),
+            &prod("packages/auth/src/internal.ts"),
+            repo_root,
+            &known,
+        )
+        .expect("cross-package internal import on a workspace should be flagged");
+    // Manifest-declared boundaries are reported at the High ceiling.
+    assert_eq!(finding.confidence, Confidence::High);
+}
+
+#[test]
+fn detected_workspace_respects_public_api_and_same_package() {
+    let repo_root = Path::new("/repo");
+    let packages = detected(repo_root, &["packages/web", "packages/auth"]);
+    let index = PackageIndex::new(&ScanConfig::default(), &packages, repo_root);
+    let known = std::collections::HashSet::new();
+
+    // Public entry of another package is allowed.
+    assert!(
+        index
+            .violation_finding(
+                &prod("packages/web/src/use.ts"),
+                &node("packages/auth/index.ts", FileRole::Production, false, true),
+                repo_root,
+                &known,
+            )
+            .is_none()
+    );
+    // Same package is allowed.
+    assert!(
+        index
+            .violation_finding(
+                &prod("packages/auth/src/a.ts"),
+                &prod("packages/auth/src/b.ts"),
+                repo_root,
+                &known,
+            )
+            .is_none()
+    );
+}
+
+#[test]
+fn configured_package_roots_win_over_detection() {
+    // When `package_roots` is set, detection is ignored and findings keep the
+    // registry-default (Medium) confidence rather than the manifest High.
+    let repo_root = Path::new("/repo");
+    let index = PackageIndex::new(
+        &packaged_config(),
+        &detected(repo_root, &["unrelated/pkg"]),
+        repo_root,
+    );
+    let known = std::collections::HashSet::new();
+
+    let finding = index
+        .violation_finding(
+            &prod("packages/web/src/use.ts"),
+            &prod("packages/auth/src/internal.ts"),
+            repo_root,
+            &known,
+        )
+        .expect("glob-configured boundary should still flag");
+    assert_eq!(finding.confidence, Confidence::Medium);
+}
+
+#[test]
+fn no_workspace_and_no_config_is_silent() {
+    let index = PackageIndex::new(&ScanConfig::default(), &[], Path::new("/repo"));
+    let known = std::collections::HashSet::new();
+    assert!(
+        index
+            .violation_finding(
+                &prod("packages/web/src/use.ts"),
+                &prod("packages/auth/src/internal.ts"),
+                Path::new("/repo"),
+                &known,
+            )
+            .is_none()
+    );
+}

--- a/src/rules/registry/architecture.rs
+++ b/src/rules/registry/architecture.rs
@@ -202,13 +202,21 @@ pub(super) static RULES: &[RuleMetadata] = &[
         title: "Package boundary violation",
         category: FindingCategory::Architecture,
         default_severity: Severity::Medium,
-        default_confidence: Confidence::High,
+        // Glob-driven (`package_roots`) findings keep the Medium default;
+        // manifest-driven findings on a detected workspace are raised to the
+        // High ceiling because the boundary is declared by the repo itself.
+        default_confidence: Confidence::Medium,
+        max_confidence: Confidence::High,
+        contextual_confidence: true,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::ImportGraph,
         docs_url: None,
-        description: "A file imports a private module from another package/feature instead of using its public API. Opt-in: emits nothing unless `[architecture] package_roots` is configured.",
+        description: "A file imports a private module from another package instead of using its public API. Auto-enabled on a detected npm/pnpm/Cargo/Go workspace; can also be driven explicitly with `[architecture] package_roots`.",
         recommendation: Some(
             "Import from the package's public barrel file (e.g. index.ts, mod.rs) instead of reaching into its internal implementation.",
+        ),
+        false_positive_notes: Some(
+            "Public entry files (index.ts/js/tsx/jsx, mod.rs, lib.rs) are exempt, as are imports within the same package. Intentional deep imports in a private monorepo can be suppressed via feedback or by not configuring package boundaries. Workspace-detected boundaries report at High confidence; configured `package_roots` globs report at the Medium default.",
         ),
         ..RuleMetadata::DEFAULT
     },

--- a/tests/fixtures/rules/architecture.package-boundary-violation/expected.json
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/expected.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "architecture.package-boundary-violation"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/package.json
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fp-monorepo",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/packages/a/package.json
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/packages/a/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@acme/a",
+  "version": "1.0.0"
+}

--- a/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/packages/a/src/app.ts
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/packages/a/src/app.ts
@@ -1,0 +1,6 @@
+// Imports @acme/b through its public entry — allowed.
+import { greet } from "../../b";
+
+export function run(): string {
+  return greet();
+}

--- a/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/packages/b/index.ts
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/packages/b/index.ts
@@ -1,0 +1,2 @@
+// @acme/b's public API surface.
+export { greet } from "./src/internal";

--- a/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/packages/b/package.json
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/packages/b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@acme/b",
+  "version": "1.0.0"
+}

--- a/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/packages/b/src/internal.ts
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/false_positive/packages/b/src/internal.ts
@@ -1,0 +1,3 @@
+export function greet(): string {
+  return "hello";
+}

--- a/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/package.json
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "tp-monorepo",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/packages/a/package.json
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/packages/a/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@acme/a",
+  "version": "1.0.0"
+}

--- a/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/packages/a/src/app.ts
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/packages/a/src/app.ts
@@ -1,0 +1,6 @@
+// Reaches past @acme/b's public API into its internals — a boundary violation.
+import { secret } from "../../b/src/internal";
+
+export function run(): string {
+  return secret();
+}

--- a/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/packages/b/index.ts
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/packages/b/index.ts
@@ -1,0 +1,2 @@
+// @acme/b's public API surface.
+export { greet } from "./src/internal";

--- a/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/packages/b/package.json
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/packages/b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@acme/b",
+  "version": "1.0.0"
+}

--- a/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/packages/b/src/internal.ts
+++ b/tests/fixtures/rules/architecture.package-boundary-violation/true_positive/packages/b/src/internal.ts
@@ -1,0 +1,7 @@
+export function greet(): string {
+  return "hello";
+}
+
+export function secret(): string {
+  return "internal-only";
+}

--- a/tests/rule_eval_fixture_coverage.rs
+++ b/tests/rule_eval_fixture_coverage.rs
@@ -26,6 +26,7 @@ const IMPORT_GRAPH_RULES_WITH_FIXTURES: &[&str] = &[
     "architecture.high-instability-hub",
     "architecture.dead-module",
     "architecture.test-leak",
+    "architecture.package-boundary-violation",
 ];
 
 const RUNTIME_RULES_WITH_FIXTURES: &[&str] = &[


### PR DESCRIPTION
## Summary

Auto-enables `architecture.package-boundary-violation` when RepoPilot detects a workspace.

The package-boundary rule can now use workspace manifests as package boundary evidence. If a repository has npm/yarn workspaces, pnpm workspaces, Cargo workspace members, or Go `go.work`, each detected workspace package is treated as a package boundary.

Explicit `[architecture] package_roots` still take priority and preserve the existing behavior.

## Type of change

* [x] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Auto-enable `architecture.package-boundary-violation` for detected workspaces.
* Use detected workspace package roots when `[architecture] package_roots` is not configured.
* Preserve explicit `package_roots` priority over workspace detection.
* Raise manifest-backed package-boundary findings to `High` confidence.
* Keep the rule silent when neither workspace detection nor explicit config is available.
* Update architecture rule documentation and changelog.
* Add regression tests for:

  * detected workspace auto-enable
  * public API imports
  * same-package imports
  * explicit config priority
  * no-workspace/no-config silent behavior

## Why

Package-boundary detection should work out of the box for real monorepos.

Before this change, users had to manually configure `[architecture] package_roots` even when the repository already declared package boundaries through workspace manifests. RepoPilot can now use those manifests as deterministic architecture evidence.

This makes package-boundary findings more useful while keeping explicit config available for custom layouts.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] No unrelated refactor or generated-file churn is included

Affected subsystem:

* `src/audits/architecture/graph_queries/*`
* workspace-backed architecture rule behavior
* architecture rule documentation
* changelog

Public behavior affected:

* Workspace repositories can now receive `architecture.package-boundary-violation` findings without explicit `[architecture] package_roots`.
* Explicit `[architecture] package_roots` still take priority.
* Non-workspace repositories remain unaffected.
* With neither workspace detection nor config, the rule stays silent.

Release note:

* This is a user-visible default behavior change for workspace repositories, so it should go into the next minor release rather than a patch-only release.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
