### PR TITLE
feat: add generated rules reference and config discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,21 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   prefix), so future rules can reason about real package boundaries instead of
   path globs. A non-workspace repository produces no package nodes and leaves
   the graph unchanged. Internal only for now — no command consumes it yet.
+- Added a published [rules reference](docs/rules-reference.md) generated
+  straight from the rule registry: every rule's id, category, default
+  severity/confidence, lifecycle, signal source, recommendation, and known
+  false positives. A drift test (`tests/rules_reference_doc.rs`) re-renders it
+  in memory and fails if the committed file falls behind the code, so the
+  catalog cannot drift from what actually ships. Regenerate with
+  `REPOPILOT_BLESS=1 cargo test --test rules_reference_doc`.
 
 ### Changed
 
+- Configuration discovery now walks up from the current directory to the git
+  root (stopping at `.git` or the filesystem root) looking for `repopilot.toml`,
+  so running RepoPilot from a subdirectory picks up the repository's config
+  instead of silently using defaults. An explicit `--config <path>` still wins
+  and is never affected by discovery.
 - Architecture audits (`circular-dependency`, `excessive-fan-out`, `dead-module`, `test-leak`, `layer-violation`, `package-boundary-violation`) now pinpoint the exact import statement lines in their evidence snippets instead of defaulting to line 1, using language-aware AST extraction across all supported languages.
 - Internal: rewrote the strongly-connected-components (Tarjan) search from a recursive `visit` to an explicit loop with a call stack. This prevents stack overflows on pathological dependency graphs (e.g. 10k deep chains) while returning byte-identical results.
 - Internal: extracted the AST function-boundary walker shared by the

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ adoption or CI policy.
 ## Product Behavior
 
 - [Rulesets](rulesets.md)
+- [Rules reference](rules-reference.md)
 - [Trust mode](trust-mode.md)
 - [Risk engine](risk-engine.md)
 - [Knowledge engine](knowledge-engine.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,28 +4,35 @@ RepoPilot is a review-first, local CLI for maintainers and coding agents. The
 product should help answer: what changed, which boundaries moved, and how far
 the change reaches before merge.
 
-## Now: 0.17
+## Now: 0.18 — evidence you can click
 
-- reduce false positives in behavioral, algorithmic, and taint-lite signals;
-- keep self-scan and review-quality gates free of accepted local suppressions;
-- make release inputs, Actions, tools, and official channel publication
-  deterministic;
-- keep CLI help, docs, Action, and MCP aligned around change review;
-- preserve JSON/SARIF, Action output, and MCP compatibility while signals remain
-  at preview.
+- point architecture findings at the real import line instead of `line 1`, so a
+  cycle or boundary violation lands on the code that caused it;
+- model detected workspaces (npm/yarn, pnpm, Cargo, `go.work`) as first-class
+  `Package` nodes, and auto-enable `architecture.package-boundary-violation` on
+  them without configuration;
+- score complexity per function (`code-quality.complex-function`, preview) by
+  nesting depth rather than counting branches flatly across a whole file;
+- grow the trust surface: a before/after review golden harness, fixtures for the
+  previously unpinned heuristic rules, a registry-generated
+  [rules reference](rules-reference.md), and config discovery that walks up to
+  the git root;
+- preserve JSON/SARIF, Action output, baseline, and MCP compatibility while new
+  signals stay at preview.
 
 No new rule family, distribution channel, hosted service, telemetry, or implicit
-LLM integration enters `0.17`.
+LLM integration enters `0.18`. The JSON schema stays at `0.19`.
 
-## Next
+## Next: 0.19
 
-- move toward a fact-based analysis platform without adding new public
-  diagnostic commands;
+- demote `code-quality.complex-file` now that the per-function rule covers the
+  honest cases (removal lands in `0.20`);
+- open a deprecation window for explicit `[architecture] package_roots` once
+  workspace auto-detection has field data;
+- back the remaining unfixtured heuristic rules with true/false-positive
+  fixtures and broaden the review golden matrix;
 - collect adoption evidence through reproducible reports, issues, and user
-  feedback;
-- improve first-run examples from observed user failures;
-- publish a compatibility and deprecation window for the smallest `1.0`
-  command/schema surface.
+  feedback, and improve first-run examples from observed failures.
 
 ## Later
 

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -1,0 +1,674 @@
+# RepoPilot Rules Reference
+
+<!-- @generated from the rule registry — do not edit by hand. -->
+<!-- Regenerate with `REPOPILOT_BLESS=1 cargo test --test rules_reference_doc`. -->
+
+RepoPilot ships 52 rules across 5 categories. Every finding traces back to one of these rules. Severity and confidence below are the registry defaults: context (audit tiers, knowledge packs) may lower them, or raise them up to a rule's declared ceiling, but never past it.
+
+## Architecture
+
+### `architecture.barrel-file-risk` — Risky barrel file detected
+
+- **Severity:** LOW
+- **Confidence:** LOW
+- **Lifecycle:** experimental
+- **Signal source:** text-heuristic
+
+An index file re-exports many modules or relies heavily on wildcard exports. Large barrel files can become unstable module hubs and make dependency boundaries harder to understand.
+
+**Recommendation:** Split the barrel into smaller feature-level entrypoints or replace wildcard exports with explicit, stable public APIs.
+
+### `architecture.circular-dependency` — Circular import dependency detected
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** stable
+- **Signal source:** import-graph
+
+Two or more files import each other, forming a cycle. Circular dependencies make build order undefined, complicate testing, and prevent dead-code elimination.
+
+**Recommendation:** Extract the shared logic into a third module that both files can import without creating a cycle.
+
+**Known false positives:** Generated, fixture, and test-only import cycles should stay out of default scans; production source cycles are treated as actionable.
+
+**Reference:** <https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture>
+
+### `architecture.dead-module` — Dead module detected
+
+- **Severity:** LOW
+- **Confidence:** HIGH
+- **Lifecycle:** experimental
+- **Signal source:** import-graph
+
+This production file is not imported by any other project file and is not a known entrypoint. It may be dead code.
+
+**Recommendation:** Remove the file if it is no longer used, or ensure it is exported in the package's public API.
+
+**Known false positives:** Dynamic imports, dependency injection, and build-tool aliases create importers the graph cannot see. When the repository contains unresolved relative imports the finding is reported at Medium confidence, and it is suppressed when an unresolved import matches the candidate file's name.
+
+### `architecture.deep-directory-nesting` — Deep directory nesting detected
+
+- **Severity:** LOW
+- **Confidence:** MEDIUM
+- **Lifecycle:** experimental
+- **Signal source:** text-heuristic
+
+A file is nested deeply within the directory structure. Deep directory nesting makes the codebase harder to navigate, import from, and maintain.
+
+**Recommendation:** Simplify the directory structure or introduce path aliases to flatten the file layout. Adjust the max depth threshold using scan config.
+
+### `architecture.deep-relative-imports` — Deep relative import found
+
+- **Severity:** LOW
+- **Confidence:** MEDIUM
+- **Lifecycle:** preview
+- **Signal source:** text-heuristic
+
+A source file imports across three or more parent directories. Deep relative imports are fragile during refactors and often indicate missing module boundaries or aliases.
+
+**Recommendation:** Introduce a stable module boundary, path alias, or facade module instead of importing through multiple parent directories.
+
+### `architecture.excessive-fan-out` — File imports too many project-internal modules
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** stable
+- **Signal source:** import-graph
+
+This file depends on an unusually large number of other internal modules, making it a fragile integration point that breaks whenever any dependency changes.
+
+**Recommendation:** Introduce an abstraction layer or facade to reduce the number of direct imports. Consider splitting responsibilities across multiple files.
+
+**Known false positives:** Aggregator entrypoints can be acceptable when intentionally reviewed; default thresholds should be raised locally only after that decision.
+
+**Reference:** <https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture>
+
+### `architecture.high-instability-hub` — High-instability hub: high fan-in and high fan-out
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** stable
+- **Signal source:** import-graph
+
+This file is both widely imported (high fan-in) and depends on many other modules (high fan-out). Changes here ripple across the codebase with no stable upstream to absorb them.
+
+**Recommendation:** Separate the stable, widely-imported interface from the volatile implementation details to reduce coupling.
+
+**Known false positives:** Framework entrypoints and generated hubs can be expected; production modules with high fan-in and fan-out should be reviewed. When the repository contains unresolved relative imports, fan-in is a lower bound and the finding is reported at Medium confidence.
+
+**Reference:** <https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture>
+
+### `architecture.large-file` — File exceeds recommended size
+
+- **Severity:** MEDIUM
+- **Confidence:** MEDIUM
+- **Lifecycle:** experimental
+- **Signal source:** text-heuristic
+
+This file has more lines of code than the configured threshold. Large files accumulate responsibilities over time and make navigation and testing harder.
+
+**Recommendation:** Split the file into smaller, focused modules. Use repopilot.toml `max_file_loc` to adjust the threshold.
+
+### `architecture.layer-violation` — Layer violation detected
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** experimental
+- **Signal source:** import-graph
+
+A module imports another module from a higher layer than its own, against the order declared in `[[architecture.layers]]`. Opt-in: emits nothing unless layers are configured.
+
+**Recommendation:** Invert the dependency using an interface, or move the shared logic into a layer at or below the importer.
+
+### `architecture.package-boundary-violation` — Package boundary violation
+
+- **Severity:** MEDIUM
+- **Confidence:** MEDIUM
+- **Lifecycle:** experimental
+- **Signal source:** import-graph
+
+A file imports a private module from another package instead of using its public API. Auto-enabled on a detected npm/pnpm/Cargo/Go workspace; can also be driven explicitly with `[architecture] package_roots`.
+
+**Recommendation:** Import from the package's public barrel file (e.g. index.ts, mod.rs) instead of reaching into its internal implementation.
+
+**Known false positives:** Public entry files (index.ts/js/tsx/jsx, mod.rs, lib.rs) are exempt, as are imports within the same package. Intentional deep imports in a private monorepo can be suppressed via feedback or by not configuring package boundaries. Workspace-detected boundaries report at High confidence; configured `package_roots` globs report at the Medium default.
+
+### `architecture.test-leak` — Test code leaked into production
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** experimental
+- **Signal source:** import-graph
+
+A production module imports a test or fixture module.
+
+**Recommendation:** Remove the test dependency from production code or extract the shared logic into a production utility.
+
+### `architecture.too-many-modules` — Directory contains too many modules
+
+- **Severity:** MEDIUM
+- **Confidence:** MEDIUM
+- **Lifecycle:** experimental
+- **Signal source:** text-heuristic
+
+A directory contains more files than the configured threshold, suggesting it may need to be broken into sub-packages.
+
+**Recommendation:** Group related files into sub-directories. Adjust `max_directory_modules` in repopilot.toml if the current threshold is too strict.
+
+## Code quality
+
+### `code-marker.fixme` — FIXME marker found
+
+- **Severity:** MEDIUM
+- **Confidence:** LOW
+- **Lifecycle:** experimental
+- **Signal source:** text-heuristic
+
+A FIXME comment marks known broken or problematic code that has not yet been addressed.
+
+**Recommendation:** Fix the issue or file a bug report and reference its number in the comment.
+
+### `code-marker.hack` — HACK marker found
+
+- **Severity:** MEDIUM
+- **Confidence:** LOW
+- **Lifecycle:** experimental
+- **Signal source:** text-heuristic
+
+A HACK comment marks a workaround that bypasses a proper solution. Hacks tend to become permanent and break under refactoring.
+
+**Recommendation:** Document why the hack exists and create a tracked issue to replace it with a proper implementation.
+
+### `code-marker.todo` — TODO marker found
+
+- **Severity:** LOW
+- **Confidence:** LOW
+- **Lifecycle:** experimental
+- **Signal source:** text-heuristic
+
+A TODO comment marks unfinished work. Unresolved TODOs accumulate as technical debt if not tracked in an issue tracker.
+
+**Recommendation:** Convert the TODO into a tracked issue and reference the issue number in the comment, or resolve it immediately.
+
+### `code-quality.complex-file` — File has high cyclomatic complexity
+
+- **Severity:** MEDIUM
+- **Confidence:** MEDIUM
+- **Lifecycle:** preview
+- **Signal source:** text-heuristic
+
+The file's branch count density exceeds the complexity threshold, indicating too many execution paths. High complexity increases the defect rate and testing burden.
+
+**Recommendation:** Extract conditionals into well-named helper functions. Prefer early returns to deeply nested if/else chains.
+
+### `code-quality.complex-function` — Function has high cognitive complexity
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+A function's control flow is deeply nested or branch-heavy, measured by a cognitive-complexity score that weights nesting depth rather than counting branches flatly. Deeply nested logic is disproportionately hard to read, test, and change.
+
+**Recommendation:** Reduce nesting: extract nested blocks into well-named helper functions and prefer early returns/guard clauses over deep if/else and loop nesting.
+
+**Known false positives:** A wide but flat dispatcher (a large switch/match with shallow arms) scores low by design, so it is not flagged. Nested closures/callbacks are scored independently rather than folded into their enclosing function. Cross-reference: `code-quality.complex-file` counts branches per file and does not weight nesting.
+
+### `code-quality.deep-control-flow` — Deep control flow nesting detected
+
+- **Severity:** LOW
+- **Confidence:** MEDIUM
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+A source file contains deeply nested control flow blocks (if, loops, match, try). High nesting depth makes code hard to read, maintain, and test.
+
+**Recommendation:** Extract nested blocks into separate helper functions or simplify the control flow.
+
+### `code-quality.long-function` — Function body exceeds recommended length
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+A function is longer than the configured line threshold. Long functions are harder to test, understand, and safely refactor.
+
+**Recommendation:** Break the function into smaller, single-purpose helpers. Aim for functions that fit on a single screen.
+
+**Known false positives:** Parseable languages (Rust, TypeScript/JavaScript, Python) measure real function spans from the syntax tree. Languages without a tree-sitter grammar (Go, Java, C#, Kotlin) fall back to a line/brace heuristic and are reported with text-heuristic provenance.
+
+### `language.go.panic-exit-risk` — Risky Go panic or process exit usage
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+Go panic and process-exit operations can terminate the program abruptly. Their risk depends on whether the file is test code, CLI boundary code, library code, or domain code.
+
+**Recommendation:** Return errors from reusable code and reserve panic/log.Fatal/os.Exit for narrow process boundaries where callers cannot recover.
+
+**Known false positives:** `panic`, `log.Fatal`/`log.Fatalf`, and `os.Exit` calls are matched from the parsed syntax tree, so the same text inside comments or string literals is not flagged. A line heuristic with text-heuristic provenance is used only when the file fails to parse.
+
+### `language.javascript.runtime-exit-risk` — Risky JavaScript runtime exit or library throw
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+Process exits and generic thrown errors have different risk at a CLI boundary than in reusable browser, Node, or package code.
+
+**Recommendation:** Prefer returning typed errors, rejecting promises with actionable context, or centralising CLI exit handling at the entrypoint.
+
+**Known false positives:** `process.exit` calls and `throw new Error(...)` are matched from the parsed syntax tree, so the same text inside comments or string literals is not flagged. A line heuristic with text-heuristic provenance is used only when the file fails to parse.
+
+### `language.managed.fatal-exception-risk` — Risky JVM or .NET fatal exception placeholder
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+Generic fatal exceptions and not-implemented placeholders in Java, Kotlin, or C# domain/library code can become runtime failures that callers cannot handle precisely.
+
+**Recommendation:** Replace placeholders with implemented behaviour and use domain-specific exception or result types where callers need to recover.
+
+**Known false positives:** Fatal exceptions and placeholder throw/TODO structures are matched from the parsed syntax tree, so the same text inside comments or string literals is not flagged. A line scanner with text-heuristic provenance is used only when the file fails to parse.
+
+### `language.python.exception-risk` — Risky Python exception or assertion pattern
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+Broad exception handlers, production asserts, and NotImplementedError placeholders can hide failures or ship incomplete behaviour. Their severity depends on test, script, and domain context.
+
+**Recommendation:** Catch specific exceptions, use explicit runtime validation, and replace placeholders before production release.
+
+**Known false positives:** Matches come from the parsed syntax tree (bare `except` clauses, `assert` statements, and `NotImplementedError`), so the same tokens inside comments or string literals are not flagged. A line heuristic with text-heuristic provenance is used only when the file fails to parse.
+
+### `language.rust.panic-risk` — Risky Rust panic or unwrap usage
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+Rust panic-style operations such as unwrap(), expect(), panic!, todo!, and unimplemented! can be risky in reusable production code. Their severity depends on whether the code is test code, CLI boundary code, library code, or domain code.
+
+**Recommendation:** Use context-aware error handling. Prefer Result, ?, typed errors, validation, or explicit fallback behavior in production and library code.
+
+**Known false positives:** `unwrap`/`expect`/`unwrap_err`/`expect_err` calls and `panic!`/`todo!`/`unimplemented!` macros are matched from the parsed syntax tree, so the same tokens inside comments or string literals (including multi-line raw strings) are not flagged, and infallible `write!`/`writeln!` result unwraps in report renderers are recognized structurally. Severity context (test/CLI/library/domain) and external-input escalation remain heuristic. A line scanner with text-heuristic provenance is used only when the file fails to parse.
+
+## Testing
+
+### `testing.missing-test-folder` — No test directory found in project
+
+- **Severity:** MEDIUM
+- **Confidence:** MEDIUM
+- **Lifecycle:** experimental
+- **Signal source:** text-heuristic
+
+The project has no recognisable test directory (tests/, __tests__, spec/). Without tests, correctness can only be verified manually.
+
+**Recommendation:** Create a test directory and add at least smoke tests for the core logic.
+
+### `testing.source-without-test` — Source file has no corresponding test file
+
+- **Severity:** LOW
+- **Confidence:** LOW
+- **Lifecycle:** experimental
+- **Signal source:** text-heuristic
+
+A source file has no matching test file. Untested code is more likely to regress during refactoring.
+
+**Recommendation:** Add a test file alongside the source file, or co-locate tests within the same file following the project's testing conventions.
+
+## Security
+
+### `framework.django.debug-true` — DEBUG = True in Django settings
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** config-file
+
+Django DEBUG mode exposes detailed error pages with stack traces, local variables, and settings values.
+
+**Recommendation:** Set DEBUG = False for deployed environments and load debug mode only from local development configuration.
+
+**Reference:** <https://docs.djangoproject.com/en/stable/ref/settings/#debug>
+
+### `framework.django.missing-allowed-hosts` — ALLOWED_HOSTS is empty in Django settings
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** config-file
+
+An empty ALLOWED_HOSTS setting leaves deployed Django services exposed to unsafe Host header handling.
+
+**Recommendation:** Set ALLOWED_HOSTS to the explicit domain names and IP addresses the service should accept.
+
+**Reference:** <https://docs.djangoproject.com/en/stable/ref/settings/#allowed-hosts>
+
+### `framework.django.raw-sql-query` — Raw SQL with string formatting detected
+
+- **Severity:** MEDIUM
+- **Confidence:** MEDIUM
+- **Lifecycle:** preview
+- **Signal source:** text-heuristic
+
+String formatting inside cursor.execute can turn user-controlled values into SQL injection risk.
+
+**Recommendation:** Pass query parameters separately, for example cursor.execute(sql, [param]), so the database driver escapes values safely.
+
+**Reference:** <https://docs.djangoproject.com/en/stable/topics/db/sql/#passing-parameters-into-raw>
+
+### `security.env-file-committed` — Environment file committed to version control
+
+- **Severity:** CRITICAL
+- **Confidence:** HIGH
+- **Lifecycle:** stable
+- **Signal source:** config-file
+
+A .env file containing environment variables has been committed. These files frequently contain secrets, API keys, or credentials that should never enter version control.
+
+**Recommendation:** Add .env (and .env.*) to .gitignore, rotate any exposed credentials immediately, and use a secrets manager or CI environment variables instead.
+
+**Known false positives:** Local example environment files should use sample names such as .env.example; committed .env variants are treated as sensitive by default.
+
+**Reference:** <https://12factor.net/config>
+
+### `security.private-key-candidate` — Possible private key in source file
+
+- **Severity:** CRITICAL
+- **Confidence:** HIGH
+- **Lifecycle:** stable
+- **Signal source:** text-heuristic
+
+A PEM-encoded private key block was found in a source file. Committed private keys can be extracted from git history even after deletion.
+
+**Recommendation:** Remove the key from the file immediately, rotate the key pair, and purge the git history using git-filter-repo or BFG Repo Cleaner.
+
+**Known false positives:** Documentation examples and placeholder PEM blocks should live in docs or fixture paths and should not contain real key material.
+
+**Reference:** <https://github.com/MykytaStel/repopilot/blob/main/docs/security.md#reporting-a-security-issue>
+
+### `security.secret-candidate` — Possible hardcoded secret or API key
+
+- **Severity:** HIGH
+- **Confidence:** MEDIUM
+- **Lifecycle:** preview
+- **Signal source:** text-heuristic
+
+A high-entropy string or a pattern matching a known secret format was found in source code. Hardcoded secrets are exposed to everyone with repository access.
+
+**Recommendation:** Move the value to an environment variable or secrets manager. If this is a real credential that was committed, rotate it and consider the old value compromised. Use explicit placeholders such as `<OPENAI_API_KEY>` or `${OPENAI_API_KEY}` in examples.
+
+**Known false positives:** Public labels, documented variable names, environment-variable references, and placeholders such as `your-openai-api-key`, `replace-with-*`, `example-*`, `<OPENAI_API_KEY>`, and `${OPENAI_API_KEY}` should not trigger; entropy and provider-looking token formats are both considered.
+
+**Reference:** <https://github.com/MykytaStel/repopilot/blob/main/docs/security.md#secret-handling>
+
+## Framework
+
+### `framework.js.console-log` — console.log call left in source
+
+- **Severity:** LOW
+- **Confidence:** LOW
+- **Lifecycle:** experimental
+- **Signal source:** ast
+
+A console.log statement was found outside of test files. Debug logging left in production code leaks information and adds noise.
+
+**Recommendation:** Remove the console.log call or replace it with a structured logger that respects log levels.
+
+### `framework.js.var-declaration` — var declaration in JavaScript/TypeScript file
+
+- **Severity:** LOW
+- **Confidence:** MEDIUM
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+`var` has function scope and is hoisted, which can produce subtle bugs. Modern JavaScript uses `const` and `let` instead.
+
+**Recommendation:** Replace `var` with `const` for values that do not change, or `let` for variables that are reassigned.
+
+**Reference:** <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var>
+
+### `framework.react-native.architecture-mismatch` — React Native New Architecture settings differ by platform
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** framework-detector
+
+Android, iOS, or Expo configuration disagree about React Native New Architecture. Mismatched platforms produce inconsistent runtime behavior.
+
+**Recommendation:** Align newArchEnabled across android/gradle.properties, ios/Podfile.properties.json, and app.json.
+
+**Reference:** <https://reactnative.dev/docs/new-architecture-intro>
+
+### `framework.react-native.async-storage-from-core` — AsyncStorage imported from 'react-native' core
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+AsyncStorage was removed from react-native core in v0.60 and throws a runtime error on modern versions.
+
+**Recommendation:** Replace with `import AsyncStorage from '@react-native-async-storage/async-storage'`.
+
+**Reference:** <https://react-native-async-storage.github.io/async-storage/docs/install>
+
+### `framework.react-native.codegen-missing` — React Native Codegen config is missing
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** framework-detector
+
+The project uses Turbo Native Modules or Fabric components but package.json does not define codegenConfig.
+
+**Recommendation:** Add codegenConfig to package.json so React Native can generate native interfaces consistently.
+
+**Reference:** <https://reactnative.dev/docs/the-new-architecture/codegen>
+
+### `framework.react-native.deprecated-api` — Deprecated React Native API
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+A React Native API removed from core is in use. Replace with the community package equivalent.
+
+**Recommendation:** Replace the deprecated API with its @react-native-community package equivalent.
+
+**Reference:** <https://reactnative.dev/docs/out-of-tree-platforms>
+
+### `framework.react-native.direct-state-mutation` — Direct mutation of this.state detected
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+Directly assigning to this.state bypasses React change detection; the component will not re-render.
+
+**Recommendation:** Use this.setState({ key: value }) in class components or the useState setter in function components.
+
+**Reference:** <https://react.dev/reference/react/Component#setstate>
+
+### `framework.react-native.flatlist-missing-key` — FlatList is missing keyExtractor
+
+- **Severity:** LOW
+- **Confidence:** MEDIUM
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+A FlatList without keyExtractor falls back to array index keys, breaking list reconciliation when items are reordered or removed.
+
+**Recommendation:** Add keyExtractor={(item) => item.id.toString()} or an equivalent unique key.
+
+**Reference:** <https://reactnative.dev/docs/flatlist#keyextractor>
+
+### `framework.react-native.hermes-disabled` — Hermes JavaScript engine is disabled
+
+- **Severity:** LOW
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** framework-detector
+
+Hermes is explicitly disabled. Hermes reduces startup time by 2-3x and is the default engine since React Native 0.70.
+
+**Recommendation:** Remove the hermes_enabled: false / enableHermes: false flag to enable Hermes.
+
+**Reference:** <https://reactnative.dev/docs/hermes>
+
+### `framework.react-native.hermes-mismatch` — Hermes settings differ between Android and iOS
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** framework-detector
+
+Hermes is configured differently across platforms, causing platform-specific runtime and performance behavior.
+
+**Recommendation:** Align Hermes settings so both Android and iOS use the same JS engine.
+
+**Reference:** <https://reactnative.dev/docs/hermes>
+
+### `framework.react-native.inline-style` — Inline style object in JSX
+
+- **Severity:** MEDIUM
+- **Confidence:** MEDIUM
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+Inline style objects create a new object on every render, defeating memoization in React.memo and PureComponent children.
+
+**Recommendation:** Extract styles into a StyleSheet.create call outside the component.
+
+**Reference:** <https://reactnative.dev/docs/stylesheet>
+
+### `framework.react-native.old-architecture` — React Native New Architecture is not enabled
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** framework-detector
+
+The project does not have newArchEnabled set. The New Architecture eliminates the async JS bridge and is required by an increasing number of libraries.
+
+**Recommendation:** Set `"newArchEnabled": true` in app.json or react-native.config.js.
+
+**Reference:** <https://reactnative.dev/docs/new-architecture-intro>
+
+### `framework.react-native.old-react-navigation` — React Navigation v4 (unscoped package) detected
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** dependency-manifest
+
+react-navigation (v4) is no longer maintained and is incompatible with React Native 0.70+.
+
+**Recommendation:** Migrate to @react-navigation/native v5/v6 following the official migration guide.
+
+**Reference:** <https://reactnavigation.org/docs/getting-started>
+
+### `framework.react.class-component` — React class component in use
+
+- **Severity:** LOW
+- **Confidence:** MEDIUM
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+Class components are the legacy React API. Function components with hooks are now the recommended approach and are better supported by the React compiler.
+
+**Recommendation:** Migrate the class component to a function component using hooks (useState, useEffect, etc.).
+
+**Reference:** <https://react.dev/reference/react/Component>
+
+### `framework.react.prop-types` — PropTypes runtime type checking in use
+
+- **Severity:** LOW
+- **Confidence:** MEDIUM
+- **Lifecycle:** preview
+- **Signal source:** ast
+
+PropTypes adds runtime overhead and was removed from React 19. TypeScript or Flow provide better static type checking without runtime cost.
+
+**Recommendation:** Replace PropTypes with TypeScript prop type annotations and remove the prop-types package.
+
+**Reference:** <https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes>
+
+### `framework.rn-async-storage-legacy` — Deprecated @react-native-community/async-storage in use
+
+- **Severity:** MEDIUM
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** dependency-manifest
+
+`@react-native-community/async-storage` is unmaintained. The actively maintained fork is `@react-native-async-storage/async-storage`.
+
+**Recommendation:** Run: `npm remove @react-native-community/async-storage && npm install @react-native-async-storage/async-storage`.
+
+**Reference:** <https://react-native-async-storage.github.io/async-storage/docs/install>
+
+### `framework.rn-gesture-handler-old` — react-native-gesture-handler v1 incompatible with React Native version
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** dependency-manifest
+
+`react-native-gesture-handler` v1 does not support React Native ≥0.72. Gesture responder internals changed in 0.72.
+
+**Recommendation:** Upgrade to `react-native-gesture-handler` v2+: `npm install react-native-gesture-handler@latest`.
+
+**Reference:** <https://docs.swmansion.com/react-native-gesture-handler/docs/installation>
+
+### `framework.rn-navigation-compat` — React Navigation version incompatible with React Native version
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** dependency-manifest
+
+The installed version of `@react-navigation/native` is not compatible with the React Native version in use.
+
+**Recommendation:** Upgrade to `@react-navigation/native` v6 or later: `npm install @react-navigation/native@latest`.
+
+**Reference:** <https://reactnavigation.org/docs/getting-started>
+
+### `framework.rn-new-arch-incompatible-dep` — Dependency does not support React Native New Architecture
+
+- **Severity:** MEDIUM
+- **Confidence:** MEDIUM
+- **Lifecycle:** preview
+- **Signal source:** dependency-manifest
+
+A dependency in use has no New Architecture (TurboModules / Fabric) support and will break when the New Architecture is enabled.
+
+**Recommendation:** Check the library's GitHub issues for a New Architecture migration path, or find an actively-maintained alternative.
+
+**Reference:** <https://reactnative.dev/docs/new-architecture-intro>
+
+### `framework.rn-reanimated-compat` — react-native-reanimated version incompatible with React Native version
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** dependency-manifest
+
+`react-native-reanimated` v2 is not compatible with React Native ≥0.73. v3 introduced breaking changes to the worklet runtime.
+
+**Recommendation:** Upgrade to `react-native-reanimated` v3+: `npm install react-native-reanimated@latest`.
+
+**Reference:** <https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation>

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -5,7 +5,32 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 pub fn load_default_config() -> Result<RepoPilotConfig, ConfigError> {
-    load_optional_config(Path::new(CONFIG_FILE_NAME))
+    let start = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    match discover_config_path(&start) {
+        Some(path) => load_optional_config(&path),
+        None => Ok(RepoPilotConfig::default()),
+    }
+}
+
+/// Walks from `start_dir` up to the enclosing git root looking for
+/// `repopilot.toml`, returning the first match. The search stops at the
+/// directory that holds `.git` (inclusive — a config beside `.git` is still
+/// found) or at the filesystem root, so it never escapes the repository. An
+/// explicit `--config <path>` bypasses discovery entirely.
+pub fn discover_config_path(start_dir: &Path) -> Option<PathBuf> {
+    let mut dir = start_dir;
+    loop {
+        let candidate = dir.join(CONFIG_FILE_NAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        // `.git` may be a directory (normal clone) or a file (worktree /
+        // submodule), so test existence rather than file type.
+        if dir.join(".git").exists() {
+            return None;
+        }
+        dir = dir.parent()?;
+    }
 }
 
 pub fn load_optional_config(path: &Path) -> Result<RepoPilotConfig, ConfigError> {

--- a/src/output/html/escape.rs
+++ b/src/output/html/escape.rs
@@ -4,3 +4,59 @@ pub(super) fn escape_html(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::escape_html;
+
+    #[test]
+    fn neutralizes_script_tags() {
+        let escaped = escape_html("<script>alert('x')</script>");
+        assert_eq!(
+            escaped, "&lt;script&gt;alert('x')&lt;/script&gt;",
+            "angle brackets must be escaped so a snippet cannot open a tag"
+        );
+        assert!(!escaped.contains('<'));
+        assert!(!escaped.contains('>'));
+    }
+
+    #[test]
+    fn neutralizes_attribute_injection() {
+        // A snippet rendered inside `title="..."` must not be able to close the
+        // attribute and inject a new one.
+        let escaped = escape_html(r#"" onmouseover="steal()"#);
+        assert_eq!(escaped, "&quot; onmouseover=&quot;steal()");
+        assert!(!escaped.contains('"'));
+    }
+
+    #[test]
+    fn escapes_ampersand_before_entities_to_avoid_double_encoding() {
+        // `&` is replaced first, so a literal `&lt;` in source becomes
+        // `&amp;lt;` (the entity is shown verbatim) rather than `&lt;`.
+        assert_eq!(escape_html("a & b"), "a &amp; b");
+        assert_eq!(escape_html("&lt;"), "&amp;lt;");
+    }
+
+    #[test]
+    fn leaves_plain_text_untouched() {
+        let snippet = "let total = sum(items); // ok";
+        assert_eq!(escape_html(snippet), snippet);
+    }
+
+    #[test]
+    fn round_trips_a_realistic_code_snippet() {
+        let snippet = r#"const html = `<div class="x">${user}</div>`;"#;
+        let escaped = escape_html(snippet);
+        assert_eq!(
+            escaped,
+            r#"const html = `&lt;div class=&quot;x&quot;&gt;${user}&lt;/div&gt;`;"#
+        );
+        // None of the four HTML-significant characters survive unescaped.
+        for dangerous in ['<', '>', '"'] {
+            assert!(
+                !escaped.contains(dangerous),
+                "{dangerous:?} leaked through escaping"
+            );
+        }
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -2,10 +2,12 @@ pub mod catalog;
 pub mod eval;
 pub mod lifecycle;
 pub mod metadata;
+pub mod reference;
 pub mod registry;
 pub mod source;
 
 pub use lifecycle::RuleLifecycle;
 pub use metadata::RuleMetadata;
+pub use reference::render_rules_reference_markdown;
 pub use registry::{all_rule_metadata, lookup_rule_metadata};
 pub use source::SignalSource;

--- a/src/rules/reference.rs
+++ b/src/rules/reference.rs
@@ -1,0 +1,142 @@
+//! Renders the human-readable rules reference (`docs/rules-reference.md`) from
+//! the rule registry, so the published catalog can never drift from the code
+//! that actually emits findings. The drift check lives in
+//! `tests/rules_reference_doc.rs`; regenerate with
+//! `REPOPILOT_BLESS=1 cargo test --test rules_reference_doc`.
+
+use crate::findings::types::FindingCategory;
+use crate::rules::all_rule_metadata;
+use crate::rules::metadata::RuleMetadata;
+use std::fmt::Write;
+
+/// Category render order. Every registered rule belongs to exactly one of these,
+/// so a new `FindingCategory` variant fails the registry's own coverage tests
+/// before it can silently drop out of this reference.
+const CATEGORY_ORDER: &[FindingCategory] = &[
+    FindingCategory::Architecture,
+    FindingCategory::CodeQuality,
+    FindingCategory::Testing,
+    FindingCategory::Security,
+    FindingCategory::Framework,
+];
+
+const GENERATED_BANNER: &str = "<!-- @generated from the rule registry — do not edit by hand. -->\n<!-- Regenerate with `REPOPILOT_BLESS=1 cargo test --test rules_reference_doc`. -->";
+
+/// Deterministic Markdown for the full rule catalog: grouped by category, rules
+/// sorted by id within each group, defaults pulled straight from the registry.
+pub fn render_rules_reference_markdown() -> String {
+    let mut rules: Vec<&'static RuleMetadata> = all_rule_metadata().collect();
+    rules.sort_by(|a, b| a.rule_id.cmp(b.rule_id));
+
+    let category_count = CATEGORY_ORDER
+        .iter()
+        .filter(|category| rules.iter().any(|rule| rule.category == **category))
+        .count();
+
+    let mut out = String::new();
+    let _ = writeln!(out, "# RepoPilot Rules Reference\n");
+    let _ = writeln!(out, "{GENERATED_BANNER}\n");
+    let _ = writeln!(
+        out,
+        "RepoPilot ships {} rules across {} categories. Every finding traces back \
+to one of these rules. Severity and confidence below are the registry defaults: \
+context (audit tiers, knowledge packs) may lower them, or raise them up to a \
+rule's declared ceiling, but never past it.\n",
+        rules.len(),
+        category_count
+    );
+
+    for category in CATEGORY_ORDER {
+        let in_category: Vec<&RuleMetadata> = rules
+            .iter()
+            .copied()
+            .filter(|rule| rule.category == *category)
+            .collect();
+        if in_category.is_empty() {
+            continue;
+        }
+
+        let _ = writeln!(out, "## {}\n", category_title(category));
+        for rule in in_category {
+            render_rule(&mut out, rule);
+        }
+    }
+
+    // Exactly one trailing newline keeps the golden stable across editors.
+    while out.ends_with("\n\n") {
+        out.pop();
+    }
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+fn render_rule(out: &mut String, rule: &RuleMetadata) {
+    let _ = writeln!(out, "### `{}` — {}\n", rule.rule_id, rule.title);
+    let _ = writeln!(out, "- **Severity:** {}", rule.default_severity.label());
+    let _ = writeln!(out, "- **Confidence:** {}", rule.default_confidence.label());
+    let _ = writeln!(out, "- **Lifecycle:** {}", rule.lifecycle.label());
+    let _ = writeln!(out, "- **Signal source:** {}\n", rule.signal_source.label());
+
+    let description = rule.description.trim();
+    if !description.is_empty() {
+        let _ = writeln!(out, "{description}\n");
+    }
+
+    if let Some(recommendation) = non_empty(rule.recommendation) {
+        let _ = writeln!(out, "**Recommendation:** {recommendation}\n");
+    }
+    if let Some(notes) = non_empty(rule.false_positive_notes) {
+        let _ = writeln!(out, "**Known false positives:** {notes}\n");
+    }
+    if let Some(url) = non_empty(rule.docs_url) {
+        let _ = writeln!(out, "**Reference:** <{url}>\n");
+    }
+}
+
+fn non_empty(value: Option<&'static str>) -> Option<&'static str> {
+    value.map(str::trim).filter(|text| !text.is_empty())
+}
+
+fn category_title(category: &FindingCategory) -> &'static str {
+    match category {
+        FindingCategory::Architecture => "Architecture",
+        FindingCategory::CodeQuality => "Code quality",
+        FindingCategory::Testing => "Testing",
+        FindingCategory::Security => "Security",
+        FindingCategory::Framework => "Framework",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_lists_every_registered_rule() {
+        let markdown = render_rules_reference_markdown();
+        for rule in all_rule_metadata() {
+            assert!(
+                markdown.contains(&format!("### `{}`", rule.rule_id)),
+                "rules reference is missing {}",
+                rule.rule_id
+            );
+        }
+    }
+
+    #[test]
+    fn reference_is_deterministic() {
+        assert_eq!(
+            render_rules_reference_markdown(),
+            render_rules_reference_markdown()
+        );
+    }
+
+    #[test]
+    fn reference_has_one_trailing_newline() {
+        let markdown = render_rules_reference_markdown();
+        assert!(markdown.ends_with('\n'));
+        assert!(!markdown.ends_with("\n\n"));
+    }
+}

--- a/tests/config_loader.rs
+++ b/tests/config_loader.rs
@@ -1,8 +1,10 @@
-use repopilot::config::loader::{load_optional_config, parse_config};
+use repopilot::config::loader::{discover_config_path, load_optional_config, parse_config};
 use repopilot::config::model::RepoPilotConfig;
 use repopilot::output::OutputFormat;
 use std::fs;
 use tempfile::tempdir;
+
+const CONFIG_FILE_NAME: &str = "repopilot.toml";
 
 #[test]
 fn missing_config_returns_defaults() {
@@ -94,6 +96,65 @@ fn scan_max_file_bytes_is_parsed() {
 
     assert_eq!(config.scan.max_file_bytes, 12345);
     assert_eq!(config.to_scan_config().max_file_bytes, 12345);
+}
+
+#[test]
+fn discover_finds_config_in_start_dir() {
+    let temp = tempdir().expect("temp dir");
+    let dir = temp.path();
+    fs::write(dir.join(CONFIG_FILE_NAME), "[scan]\nignore = []\n").expect("write config");
+
+    assert_eq!(
+        discover_config_path(dir),
+        Some(dir.join(CONFIG_FILE_NAME)),
+        "config beside the start dir should be discovered"
+    );
+}
+
+#[test]
+fn discover_walks_up_to_an_ancestor_config() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    // `.git` bounds the upward walk so the test never escapes the temp tree.
+    fs::create_dir_all(root.join(".git")).expect("git marker");
+    fs::write(root.join(CONFIG_FILE_NAME), "[scan]\nignore = []\n").expect("write config");
+    let nested = root.join("packages/app/src");
+    fs::create_dir_all(&nested).expect("nested dirs");
+
+    assert_eq!(
+        discover_config_path(&nested),
+        Some(root.join(CONFIG_FILE_NAME)),
+        "a config at the repo root should be found from a nested subdir"
+    );
+}
+
+#[test]
+fn discover_stops_at_git_root_and_does_not_escape_the_repo() {
+    let temp = tempdir().expect("temp dir");
+    let outer = temp.path();
+    // Config sits *above* the git root and must stay invisible.
+    fs::write(outer.join(CONFIG_FILE_NAME), "[scan]\nignore = []\n").expect("write outer config");
+    let repo = outer.join("repo");
+    fs::create_dir_all(repo.join(".git")).expect("git marker");
+    let nested = repo.join("src");
+    fs::create_dir_all(&nested).expect("nested dirs");
+
+    assert_eq!(
+        discover_config_path(&nested),
+        None,
+        "discovery must stop at the git root, ignoring configs outside the repo"
+    );
+}
+
+#[test]
+fn discover_returns_none_when_no_config_exists() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    fs::create_dir_all(root.join(".git")).expect("git marker");
+    let nested = root.join("a/b");
+    fs::create_dir_all(&nested).expect("nested dirs");
+
+    assert_eq!(discover_config_path(&nested), None);
 }
 
 #[test]

--- a/tests/rules_reference_doc.rs
+++ b/tests/rules_reference_doc.rs
@@ -1,0 +1,41 @@
+//! Drift guard for the published rules catalog.
+//!
+//! `docs/rules-reference.md` is generated from the rule registry
+//! (`render_rules_reference_markdown`). This test re-renders it in memory and
+//! compares against the committed file so the docs can never fall behind the
+//! code that emits findings. It runs under the ordinary `cargo test --all`
+//! gate, so CI and `verify-release.sh` catch drift without any extra scripts.
+//!
+//! Regenerate after a registry change with:
+//!   `REPOPILOT_BLESS=1 cargo test --test rules_reference_doc`
+
+use repopilot::rules::render_rules_reference_markdown;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn rules_reference_doc_matches_registry() {
+    let rendered = render_rules_reference_markdown();
+    let path = doc_path();
+
+    if std::env::var_os("REPOPILOT_BLESS").is_some() {
+        fs::write(&path, &rendered).expect("failed to write docs/rules-reference.md");
+        return;
+    }
+
+    let committed = fs::read_to_string(&path)
+        .expect("docs/rules-reference.md is missing; run `REPOPILOT_BLESS=1 cargo test --test rules_reference_doc`")
+        .replace("\r\n", "\n");
+
+    assert_eq!(
+        rendered, committed,
+        "docs/rules-reference.md is out of date with the rule registry; \
+regenerate with `REPOPILOT_BLESS=1 cargo test --test rules_reference_doc`"
+    );
+}
+
+fn doc_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("docs")
+        .join("rules-reference.md")
+}


### PR DESCRIPTION
## Summary

Adds a generated rules reference and improves default configuration discovery.

This PR publishes `docs/rules-reference.md`, generated directly from the rule registry, and adds a drift test so the committed documentation cannot fall behind the rules that actually ship.

It also improves config discovery: when no explicit `--config <path>` is passed, RepoPilot now walks up from the current directory to the git root looking for `repopilot.toml`. This allows running RepoPilot from a repository subdirectory while still picking up the root config.

## Type of change

* [x] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added `docs/rules-reference.md`.
* Added `src/rules/reference.rs` to render the rules reference from the registry.
* Added `tests/rules_reference_doc.rs` as a drift guard for the generated documentation.
* Re-exported `render_rules_reference_markdown`.
* Updated docs navigation to include the rules reference.
* Updated README/roadmap language for the 0.18 trust surface.
* Updated config discovery to search upward from the current directory to the git root.
* Preserved explicit `--config <path>` behavior.
* Added config discovery tests:

  * config in current directory
  * config in ancestor repo root
  * no config found
  * config outside git root is ignored
* Added HTML escaping regression tests.
* Updated `CHANGELOG.md`.

## Why

Open-source users need a clear, stable, and trustworthy view of what RepoPilot actually checks.

Before this change, the rule catalog lived mostly in code and scattered docs. A generated reference makes the rules easier to audit, link, and review. The drift test keeps the public documentation aligned with the rule registry.

Config discovery also improves real usage: users often run CLI commands from inside `apps/*`, `packages/*`, or `src/*`. RepoPilot should still find the repository-level `repopilot.toml` instead of silently falling back to defaults.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] No unrelated refactor or generated-file churn is included

Affected subsystem:

* docs/rules reference
* rule registry documentation rendering
* config loading/discovery
* docs navigation
* release documentation

Public behavior affected:

* `docs/rules-reference.md` is now published as the generated rule catalog.
* `cargo test --test rules_reference_doc` now checks that the committed rules reference matches the registry.
* `REPOPILOT_BLESS=1 cargo test --test rules_reference_doc` regenerates the rules reference.
* Default config loading now discovers `repopilot.toml` by walking upward from the current directory to the git root.
* Explicit `--config <path>` still takes priority and bypasses discovery.

Known limitation:

* Discovery starts from the current working directory. It does not yet discover config relative to an arbitrary scan target path when RepoPilot is invoked from outside that repository.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
