### PR TITLE
test(rules): enforce aggregate fixture coverage gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   `testing.source-without-test`), pinning their behaviour under the rule
   quality gate. The fixture harness now scans with `detect_missing_tests`
   enabled (matching a real default scan) so the testing audits are exercisable.
+- Internal: the rule fixture coverage test now evaluates the whole registry in
+  one aggregate gate (`evaluate_rule_fixtures(None, …)`) instead of only the
+  rules listed in manual category arrays, so a fixture can no longer fall
+  outside the harness by being left off a list. A fixture directory whose name
+  matches no registered rule is now a hard error rather than being silently
+  skipped, and the test reports which preview/experimental rules still lack
+  fixtures.
 
 ### Fixed
 

--- a/src/rules/eval/fixtures.rs
+++ b/src/rules/eval/fixtures.rs
@@ -41,6 +41,7 @@ pub fn evaluate_rule_fixtures(
     }
 
     let fixture_dirs = discover_rule_fixture_dirs(&fixture_root)?;
+    ensure_fixture_dirs_are_known_rules(&fixture_dirs)?;
     let rule_ids = rule_ids_to_evaluate(only_rule, &fixture_dirs);
 
     let mut report = RuleEvaluationReport::default();
@@ -73,6 +74,34 @@ fn discover_rule_fixture_dirs(
     }
 
     Ok(fixture_dirs)
+}
+
+/// A fixture directory's name *is* its rule id. A directory that matches no
+/// registered rule (a typo, a renamed rule, a stray folder) would otherwise be
+/// evaluated with no quality gate — `apply_rule_quality_gate` returns early when
+/// `lookup_rule_metadata` is `None` — and silently contribute nothing. Reject it
+/// loudly instead so coverage can never rot unnoticed.
+fn ensure_fixture_dirs_are_known_rules(
+    fixture_dirs: &BTreeMap<String, PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let unknown: Vec<&str> = fixture_dirs
+        .keys()
+        .map(String::as_str)
+        .filter(|name| lookup_rule_metadata(name).is_none())
+        .collect();
+
+    if unknown.is_empty() {
+        return Ok(());
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!(
+            "rule fixture directories do not match any registered rule id: {}",
+            unknown.join(", ")
+        ),
+    )
+    .into())
 }
 
 fn rule_ids_to_evaluate(

--- a/tests/rule_eval_fixture_coverage.rs
+++ b/tests/rule_eval_fixture_coverage.rs
@@ -1,7 +1,11 @@
+use std::collections::BTreeSet;
+use std::fs;
 use std::path::Path;
 
 use repopilot::rules::eval::fixtures::evaluate_rule_fixtures;
 use repopilot::rules::eval::{RuleEvaluationReport, RuleEvaluationRuleReport};
+use repopilot::rules::{RuleLifecycle, all_rule_metadata};
+use tempfile::tempdir;
 
 // Test taxonomy for this file:
 //
@@ -158,6 +162,108 @@ fn given_heuristic_rule_fixtures_when_eval_rules_runs_then_quality_gates_pass() 
         let rule_report = first_rule_report(rule_id, &report);
         assert_rule_fixture_coverage_is_clean(rule_id, rule_report);
     }
+}
+
+// The category tests above are a readable, well-labelled subset. This is the
+// real gate: the engine autodiscovers *every* fixture directory and adds
+// *every* Stable rule, so nothing can fall outside the harness by being left
+// off a manual array. All Stable rules ship fixtures today, and the 16
+// unfixtured rules are Preview/Experimental (which the gate does not bind), so
+// this passes on a clean tree and only fails on a genuine regression: a Stable
+// rule without fixtures, a promoted rule, or a broken fixture.
+#[test]
+fn every_fixture_dir_and_stable_rule_clears_the_quality_gate() {
+    let report =
+        evaluate_rule_fixtures(None, None).expect("aggregate fixture evaluation should succeed");
+
+    let stable_count = all_rule_metadata()
+        .filter(|meta| meta.lifecycle == RuleLifecycle::Stable)
+        .count();
+    assert!(
+        report.rules_evaluated >= stable_count,
+        "expected every Stable rule ({stable_count}) to be evaluated, got {}",
+        report.rules_evaluated
+    );
+
+    let failing: Vec<String> = report
+        .rules
+        .iter()
+        .filter(|rule| rule.quality_gate_failures > 0)
+        .map(|rule| {
+            format!(
+                "  - {} ({} gate failures)",
+                rule.rule_id, rule.quality_gate_failures
+            )
+        })
+        .collect();
+    assert!(
+        failing.is_empty(),
+        "rules failed the fixture quality gate (a Stable rule needs true- and \
+false-positive fixtures, documented false-positive notes, and clean findings):\n{}",
+        failing.join("\n")
+    );
+
+    assert_eq!(
+        report.missing_findings, 0,
+        "fixtures are missing expected findings: {report:#?}"
+    );
+    assert_eq!(
+        report.unexpected_findings, 0,
+        "fixtures produced unexpected findings: {report:#?}"
+    );
+    assert_eq!(
+        report.contract_violations, 0,
+        "fixtures produced finding contract violations: {report:#?}"
+    );
+    assert_eq!(
+        report.stable_id_failures, 0,
+        "fixtures produced unstable/duplicate finding IDs: {report:#?}"
+    );
+
+    report_preview_coverage_gap(&report);
+}
+
+// A fixture directory named after a rule that does not exist (a typo or a
+// renamed rule) used to be scanned but never gated, silently contributing
+// nothing. It must now be a hard error so coverage cannot rot unnoticed.
+#[test]
+fn fixture_directory_for_unknown_rule_is_rejected() {
+    let temp = tempdir().expect("temp dir");
+    let junk = temp.path().join("architecture.not-a-real-rule");
+    fs::create_dir_all(&junk).expect("create junk fixture dir");
+    fs::write(junk.join("expected.json"), "{\"fixtures\":[]}").expect("write expected.json");
+
+    let error = evaluate_rule_fixtures(None, Some(temp.path()))
+        .expect_err("a fixture directory with no matching rule id must be rejected");
+    assert!(
+        error.to_string().contains("architecture.not-a-real-rule"),
+        "error should name the offending directory: {error}"
+    );
+}
+
+// Coverage visibility: Preview/Experimental rules without fixtures are allowed
+// (the gate only binds Stable rules), but we surface the gap so promoting a
+// rule to Stable without fixtures is a deliberate, visible decision.
+fn report_preview_coverage_gap(report: &RuleEvaluationReport) {
+    let fixtured: BTreeSet<&str> = report
+        .rules
+        .iter()
+        .filter(|rule| rule.fixtures_total > 0)
+        .map(|rule| rule.rule_id.as_str())
+        .collect();
+
+    let mut uncovered: Vec<&str> = all_rule_metadata()
+        .filter(|meta| meta.lifecycle != RuleLifecycle::Stable)
+        .map(|meta| meta.rule_id)
+        .filter(|rule_id| !fixtured.contains(rule_id))
+        .collect();
+    uncovered.sort_unstable();
+
+    eprintln!(
+        "fixture coverage: {} preview/experimental rule(s) without fixtures \
+(allowed, not gated): {uncovered:?}",
+        uncovered.len()
+    );
 }
 
 fn rule_fixture_root() -> std::path::PathBuf {


### PR DESCRIPTION
## Summary

Strengthens the rule fixture quality gate.

This PR adds an aggregate fixture coverage gate that evaluates all discovered rule fixture directories and all Stable rules, instead of relying only on manually maintained category arrays.

It also rejects fixture directories whose names do not match any registered rule id, so typos, renamed rules, or stray fixture folders cannot silently bypass the rule quality gate.

## Type of change

* [ ] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Tests
* [ ] Documentation
* [x] CI / repository maintenance

## What changed

* Added validation for rule fixture directory names.
* Fixture directories with unknown rule ids now produce a hard error.
* Added an aggregate fixture quality gate:

  * discovers every fixture directory,
  * includes every Stable rule from the registry,
  * fails if any evaluated rule has fixture quality-gate failures,
  * fails on missing expected findings,
  * fails on unexpected findings,
  * fails on finding contract violations,
  * fails on unstable or duplicate finding ids.
* Added a regression test proving unknown fixture directories are rejected.
* Added preview/experimental fixture coverage reporting as visible, non-gated debt.
* Updated `CHANGELOG.md`.

## Why

Rule fixture coverage should not depend only on manual lists.

Manual category arrays are readable, but they are easy to forget when rules are added, renamed, promoted, or moved. That can let fixtures fall outside the harness or let Stable rules ship without proper fixture coverage.

This PR makes the aggregate gate the real source of truth:

* every fixture directory must point to a real rule,
* every Stable rule must clear the quality gate,
* Preview and Experimental coverage gaps stay visible without blocking CI.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] No unrelated refactor or generated-file churn is included

Affected subsystem:

* rule fixture evaluation
* rule quality gate tests
* fixture coverage policy

Public behavior affected:

* No user-facing CLI behavior change.
* Internal test behavior is stricter:

  * unknown rule fixture directories now fail,
  * Stable rules are now covered by the aggregate fixture gate,
  * Preview/Experimental fixture gaps are reported but not gated.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash id="8z2nzj"
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
