### PR TITLE
test(rules): add web framework rule fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,16 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   matches no registered rule is now a hard error rather than being silently
   skipped, and the test reports which preview/experimental rules still lack
   fixtures.
+- Internal: added true-positive/false-positive fixtures for seven previously
+  unfixtured web framework rules (`framework.js.var-declaration`,
+  `framework.js.console-log`, `framework.react.class-component`,
+  `framework.react.prop-types`, `framework.react-native.inline-style`,
+  `framework.react-native.flatlist-missing-key`,
+  `framework.rn-new-arch-incompatible-dep`). The false-positive fixtures pin the
+  known safe shapes — `var`/`console.log` in identifiers or comments,
+  `prop-types` absent from a TypeScript project, a `StyleSheet` instead of an
+  inline style, a `FlatList` with a `keyExtractor`, and a New-Architecture
+  compatible dependency — so the text-/AST-lite matchers stay honest.
 
 ### Fixed
 

--- a/tests/fixtures/rules/framework.js.console-log/expected.json
+++ b/tests/fixtures/rules/framework.js.console-log/expected.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "framework.js.console-log"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/framework.js.console-log/false_positive/package.json
+++ b/tests/fixtures/rules/framework.js.console-log/false_positive/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "express": "4.18.2"
+  }
+}

--- a/tests/fixtures/rules/framework.js.console-log/false_positive/src/server.js
+++ b/tests/fixtures/rules/framework.js.console-log/false_positive/src/server.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const logger = { log: () => {} };
+app.get('/', (req, res) => {
+  console.error('boom');
+  console.warn('careful');
+  logger.log('custom logger, not console.log');
+  // console.log('debug left in a comment') must not trigger
+  res.send('ok');
+});
+app.listen(3000);

--- a/tests/fixtures/rules/framework.js.console-log/true_positive/package.json
+++ b/tests/fixtures/rules/framework.js.console-log/true_positive/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "express": "4.18.2"
+  }
+}

--- a/tests/fixtures/rules/framework.js.console-log/true_positive/src/server.js
+++ b/tests/fixtures/rules/framework.js.console-log/true_positive/src/server.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const app = express();
+app.get('/', (req, res) => {
+  console.log('request received');
+  res.send('ok');
+});
+app.listen(3000);

--- a/tests/fixtures/rules/framework.js.var-declaration/expected.json
+++ b/tests/fixtures/rules/framework.js.var-declaration/expected.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "framework.js.var-declaration"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/framework.js.var-declaration/false_positive/package.json
+++ b/tests/fixtures/rules/framework.js.var-declaration/false_positive/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "express": "4.18.2"
+  }
+}

--- a/tests/fixtures/rules/framework.js.var-declaration/false_positive/src/server.js
+++ b/tests/fixtures/rules/framework.js.var-declaration/false_positive/src/server.js
@@ -1,0 +1,6 @@
+const express = require('express');
+const app = express();
+const handlerVar = 1;
+let activeRoutes = handlerVar;
+// var legacy = 1; a commented-out var must not trigger
+app.listen(3000);

--- a/tests/fixtures/rules/framework.js.var-declaration/true_positive/package.json
+++ b/tests/fixtures/rules/framework.js.var-declaration/true_positive/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "express": "4.18.2"
+  }
+}

--- a/tests/fixtures/rules/framework.js.var-declaration/true_positive/src/server.js
+++ b/tests/fixtures/rules/framework.js.var-declaration/true_positive/src/server.js
@@ -1,0 +1,3 @@
+const express = require('express');
+var server = express();
+server.listen(3000);

--- a/tests/fixtures/rules/framework.react-native.flatlist-missing-key/expected.json
+++ b/tests/fixtures/rules/framework.react-native.flatlist-missing-key/expected.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "framework.react-native.flatlist-missing-key"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/framework.react-native.flatlist-missing-key/false_positive/package.json
+++ b/tests/fixtures/rules/framework.react-native.flatlist-missing-key/false_positive/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.74.0"
+  }
+}

--- a/tests/fixtures/rules/framework.react-native.flatlist-missing-key/false_positive/src/List.tsx
+++ b/tests/fixtures/rules/framework.react-native.flatlist-missing-key/false_positive/src/List.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { FlatList, Text } from 'react-native';
+
+export function List({ items }) {
+  return (
+    <FlatList
+      data={items}
+      keyExtractor={(item) => item.id.toString()}
+      renderItem={({ item }) => <Text>{item.label}</Text>}
+    />
+  );
+}

--- a/tests/fixtures/rules/framework.react-native.flatlist-missing-key/true_positive/package.json
+++ b/tests/fixtures/rules/framework.react-native.flatlist-missing-key/true_positive/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.74.0"
+  }
+}

--- a/tests/fixtures/rules/framework.react-native.flatlist-missing-key/true_positive/src/List.tsx
+++ b/tests/fixtures/rules/framework.react-native.flatlist-missing-key/true_positive/src/List.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { FlatList, Text } from 'react-native';
+
+export function List({ items }) {
+  return (
+    <FlatList
+      data={items}
+      renderItem={({ item }) => <Text>{item.label}</Text>}
+    />
+  );
+}

--- a/tests/fixtures/rules/framework.react-native.inline-style/expected.json
+++ b/tests/fixtures/rules/framework.react-native.inline-style/expected.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "framework.react-native.inline-style"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/framework.react-native.inline-style/false_positive/package.json
+++ b/tests/fixtures/rules/framework.react-native.inline-style/false_positive/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.74.0"
+  }
+}

--- a/tests/fixtures/rules/framework.react-native.inline-style/false_positive/src/Screen.tsx
+++ b/tests/fixtures/rules/framework.react-native.inline-style/false_positive/src/Screen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: { padding: 16 },
+});
+
+export function Screen() {
+  return (
+    <View style={styles.container}>
+      <Text>Hello</Text>
+    </View>
+  );
+}

--- a/tests/fixtures/rules/framework.react-native.inline-style/true_positive/package.json
+++ b/tests/fixtures/rules/framework.react-native.inline-style/true_positive/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.74.0"
+  }
+}

--- a/tests/fixtures/rules/framework.react-native.inline-style/true_positive/src/Screen.tsx
+++ b/tests/fixtures/rules/framework.react-native.inline-style/true_positive/src/Screen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export function Screen() {
+  return (
+    <View style={{ padding: 16 }}>
+      <Text>Hello</Text>
+    </View>
+  );
+}

--- a/tests/fixtures/rules/framework.react.class-component/expected.json
+++ b/tests/fixtures/rules/framework.react.class-component/expected.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "framework.react.class-component"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/framework.react.class-component/false_positive/package.json
+++ b/tests/fixtures/rules/framework.react.class-component/false_positive/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react": "18.2.0"
+  }
+}

--- a/tests/fixtures/rules/framework.react.class-component/false_positive/src/Widget.tsx
+++ b/tests/fixtures/rules/framework.react.class-component/false_positive/src/Widget.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+// Migrated away from a class that used `extends React.Component`.
+export function Widget() {
+  return <div>hello</div>;
+}

--- a/tests/fixtures/rules/framework.react.class-component/true_positive/package.json
+++ b/tests/fixtures/rules/framework.react.class-component/true_positive/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react": "18.2.0"
+  }
+}

--- a/tests/fixtures/rules/framework.react.class-component/true_positive/src/Widget.tsx
+++ b/tests/fixtures/rules/framework.react.class-component/true_positive/src/Widget.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export class Widget extends React.Component {
+  render() {
+    return <div>hello</div>;
+  }
+}

--- a/tests/fixtures/rules/framework.react.prop-types/expected.json
+++ b/tests/fixtures/rules/framework.react.prop-types/expected.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "framework.react.prop-types"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/framework.react.prop-types/false_positive/package.json
+++ b/tests/fixtures/rules/framework.react.prop-types/false_positive/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react": "18.2.0"
+  }
+}

--- a/tests/fixtures/rules/framework.react.prop-types/false_positive/src/Card.tsx
+++ b/tests/fixtures/rules/framework.react.prop-types/false_positive/src/Card.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+interface CardProps {
+  title: string;
+}
+
+// Props are typed with a TypeScript interface, not the prop-types package.
+export function Card({ title }: CardProps) {
+  return <div>{title}</div>;
+}

--- a/tests/fixtures/rules/framework.react.prop-types/true_positive/package.json
+++ b/tests/fixtures/rules/framework.react.prop-types/true_positive/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "react": "18.2.0",
+    "prop-types": "15.8.1"
+  }
+}

--- a/tests/fixtures/rules/framework.react.prop-types/true_positive/src/Card.tsx
+++ b/tests/fixtures/rules/framework.react.prop-types/true_positive/src/Card.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export function Card({ title }) {
+  return <div>{title}</div>;
+}
+
+Card.propTypes = {
+  title: PropTypes.string,
+};

--- a/tests/fixtures/rules/framework.rn-new-arch-incompatible-dep/expected.json
+++ b/tests/fixtures/rules/framework.rn-new-arch-incompatible-dep/expected.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "path": "false_positive",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "true_positive",
+      "expected_rule_ids": [
+        "framework.rn-new-arch-incompatible-dep"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/rules/framework.rn-new-arch-incompatible-dep/false_positive/package.json
+++ b/tests/fixtures/rules/framework.rn-new-arch-incompatible-dep/false_positive/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.74.0",
+    "react-native-screens": "3.29.0"
+  }
+}

--- a/tests/fixtures/rules/framework.rn-new-arch-incompatible-dep/false_positive/src/App.tsx
+++ b/tests/fixtures/rules/framework.rn-new-arch-incompatible-dep/false_positive/src/App.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export function App() {
+  return <View />;
+}

--- a/tests/fixtures/rules/framework.rn-new-arch-incompatible-dep/true_positive/package.json
+++ b/tests/fixtures/rules/framework.rn-new-arch-incompatible-dep/true_positive/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.74.0",
+    "react-native-svg": "13.0.0"
+  }
+}

--- a/tests/fixtures/rules/framework.rn-new-arch-incompatible-dep/true_positive/src/App.tsx
+++ b/tests/fixtures/rules/framework.rn-new-arch-incompatible-dep/true_positive/src/App.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export function App() {
+  return <View />;
+}

--- a/tests/rule_eval_fixture_coverage.rs
+++ b/tests/rule_eval_fixture_coverage.rs
@@ -68,6 +68,23 @@ const HEURISTIC_RULES_WITH_FIXTURES: &[&str] = &[
     "testing.source-without-test",
 ];
 
+// Web/JS/React/React Native framework rules. All Preview/Experimental, so the
+// quality gate does not bind them — but pinning true- and false-positive
+// fixtures keeps their text-/AST-lite matching honest: `var` inside an
+// identifier or comment, `console.log` inside a comment or behind a sibling
+// API, `prop-types` only in a TypeScript project, inline styles vs a
+// `StyleSheet`, a `FlatList` with/without `keyExtractor`, and New-Arch
+// (in)compatible dependencies.
+const WEB_FRAMEWORK_RULES_WITH_FIXTURES: &[&str] = &[
+    "framework.js.var-declaration",
+    "framework.js.console-log",
+    "framework.react.class-component",
+    "framework.react.prop-types",
+    "framework.react-native.inline-style",
+    "framework.react-native.flatlist-missing-key",
+    "framework.rn-new-arch-incompatible-dep",
+];
+
 #[test]
 fn given_security_rule_fixtures_when_eval_rules_runs_then_quality_gates_pass() {
     // Given
@@ -154,6 +171,22 @@ fn given_heuristic_rule_fixtures_when_eval_rules_runs_then_quality_gates_pass() 
     let fixture_root = rule_fixture_root();
 
     for rule_id in HEURISTIC_RULES_WITH_FIXTURES {
+        // When
+        let report = evaluate_rule(rule_id, &fixture_root);
+
+        // Then
+        assert_single_rule_report(rule_id, &report);
+        let rule_report = first_rule_report(rule_id, &report);
+        assert_rule_fixture_coverage_is_clean(rule_id, rule_report);
+    }
+}
+
+#[test]
+fn given_web_framework_rule_fixtures_when_eval_rules_runs_then_coverage_is_clean() {
+    // Given
+    let fixture_root = rule_fixture_root();
+
+    for rule_id in WEB_FRAMEWORK_RULES_WITH_FIXTURES {
         // When
         let report = evaluate_rule(rule_id, &fixture_root);
 


### PR DESCRIPTION
## Summary

Adds true-positive and false-positive fixtures for seven JS, React, and React Native framework rules.

Covered rules:

* `framework.js.var-declaration`
* `framework.js.console-log`
* `framework.react.class-component`
* `framework.react.prop-types`
* `framework.react-native.inline-style`
* `framework.react-native.flatlist-missing-key`
* `framework.rn-new-arch-incompatible-dep`

These rules are Preview/Experimental, so they are not bound by the Stable aggregate gate yet, but this PR pins their expected behavior under the rule fixture quality gate.

## Type of change

* [ ] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Tests
* [ ] Documentation
* [ ] CI / repository maintenance

## What changed

* Added true-positive and false-positive fixtures for JS framework rules.
* Added true-positive and false-positive fixtures for React framework rules.
* Added true-positive and false-positive fixtures for React Native framework rules.
* Added `WEB_FRAMEWORK_RULES_WITH_FIXTURES` to `tests/rule_eval_fixture_coverage.rs`.
* Added a dedicated fixture coverage test for web framework rules.
* Updated `CHANGELOG.md`.

## Why

These rules use lightweight text or AST-lite matching, which makes false-positive coverage especially important.

The fixtures pin known safe and unsafe shapes:

* `var` as a real declaration vs `var` inside identifiers or comments,
* `console.log` as a real debug statement vs comments/custom logger usage,
* React class components vs functional components,
* `prop-types` usage vs TypeScript interface props,
* React Native inline styles vs `StyleSheet`,
* `FlatList` without `keyExtractor` vs `FlatList` with `keyExtractor`,
* New Architecture incompatible dependency vs compatible dependency.

This keeps framework rules honest while they remain Preview/Experimental.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] No unrelated refactor or generated-file churn is included

Affected subsystem:

* rule fixture coverage
* JS framework rules
* React framework rules
* React Native framework rules

Public behavior affected:

* No user-facing CLI behavior change.
* No finding IDs or output schemas changed.
* This only adds regression coverage for existing framework rules.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
