### PR TITLE
fix(rust): separate inline tests from file role classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Fixed
+
+- **Rust inline tests no longer poison file-role classification.** A file was
+  treated as a *test file* whenever it carried inline tests
+  (`has_inline_tests`), but in Rust a `#[cfg(test)] mod tests` block is
+  idiomatic in ordinary production modules. This mislabeled most of the codebase
+  as test code and made every production-to-production import look like a leak:
+  on RepoPilot's own tree `architecture.test-leak` dropped from **294 findings
+  to 0**. File role is now decided purely by path/name conventions; the
+  inline-test flag stays a separate coverage signal. The singular `test_*`/
+  `*_test.rs` Rust name patterns (which are Python/Go/JS conventions and collide
+  with production modules like `test_edges.rs` and `source_without_test.rs`) no
+  longer classify a `.rs` file as a test — real Rust test files use `tests/`,
+  `#[cfg(test)]`, or the plural `*_tests.rs`/`tests.rs`.
+- **`architecture.dead-module` no longer flags non-code files.** Docs, config,
+  stylesheets, lockfiles, images, and shell scripts (Markup / Shell / Unknown
+  language families) are never "imported", so they always had `fan_in=0` and
+  were all reported as dead — on real repositories this meant every
+  `.claude/*.md`, `*.css`, `*.json`, lockfile, and image. The rule now only
+  considers languages the resolver actually wires up (Rust, TS/JS, Python, Go,
+  JVM). On three sampled multi-language repos this removed 72–86% of the
+  `dead-module` findings.
+- **`architecture.dead-module` no longer flags live modules wired with
+  `#[path = "..."] mod x;` or `include!("...")`.** The Rust import resolver now
+  follows both, so files such as `language_risk/{go,js,managed,python}.rs` and
+  the `output/*/sections/*.rs` include-targets are correctly seen as reachable.
+  Files that carry their own inline tests are also exempt from `dead-module`,
+  since their only importer is often a `#[cfg(test)]` declaration whose edge is
+  excluded from the production graph.
+- **`language.rust.panic-risk` no longer reports `panic!`/`unwrap`/`expect`
+  inside `#[cfg(test)]` blocks.** Test bodies are expected to panic; the AST
+  walk now skips `#[cfg(test)]`/`#[test]` items so only production panic risks
+  remain.
+- Imports gated by `#[cfg(test)]` are kept out of the import graph entirely, so
+  test-only `use` statements can no longer form phantom
+  `architecture.circular-dependency` edges between production modules.
+
 ### Changed
 
 - `architecture.package-boundary-violation` now **auto-enables on a detected

--- a/src/analysis/path_classifier.rs
+++ b/src/analysis/path_classifier.rs
@@ -74,7 +74,7 @@ impl ArchitectureClassifier {
             FileRole::Fixture
         } else if path_contains_component(&file.path, &["doc", "docs"]) {
             FileRole::Documentation
-        } else if is_test_file(&file.path, file.has_inline_tests) {
+        } else if is_test_file(&file.path) {
             FileRole::Test
         } else {
             FileRole::Production

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -8,7 +8,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use crate::analysis::{ArchitectureClassifier, ArchitectureContext, FileRole};
+use crate::analysis::{ArchitectureClassifier, ArchitectureContext, FileRole, LanguageFamily};
 use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use crate::graph::v2::{GraphNodeId, build_coupling_graph_snapshot};
 use crate::graph::{CouplingGraph, ImportResolutionStats};
@@ -143,10 +143,28 @@ fn dead_module_finding(
     resolution: &ImportResolutionStats,
 ) -> Option<Finding> {
     let ctx = &info.context;
+    // "Dead module" only means something for files that participate in the
+    // import graph. Docs, config, stylesheets, lockfiles, images, and shell
+    // scripts (Markup / Shell / Unknown families) are never "imported", so they
+    // always have fan_in=0 and would otherwise all be flagged — e.g. every
+    // `.claude/*.md`, `*.css`, `*.json`, or lockfile in a repo. Restrict to
+    // languages the resolver actually wires up.
+    let is_importable_code = matches!(
+        ctx.language_family,
+        LanguageFamily::CurlyBrace | LanguageFamily::Python | LanguageFamily::Go
+    );
+    // A file that carries its own tests is exercised by the suite, and its only
+    // importer is often a `#[cfg(test)] mod ...;` declaration, whose edge is
+    // intentionally excluded from the production import graph. Treating such a
+    // file as dead would be a false positive (e.g. a `proptests.rs` reached
+    // only under `cfg(test)`), so exempt files with inline tests.
+    let has_inline_tests = info.facts.is_some_and(|facts| facts.has_inline_tests);
     if ctx.file_role != FileRole::Production
+        || !is_importable_code
         || ctx.is_entrypoint
         || ctx.is_public_api
         || fan_in.unwrap_or(0) != 0
+        || has_inline_tests
     {
         return None;
     }

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -45,6 +45,24 @@ fn dead_module_flags_unreferenced_production_file() {
 }
 
 #[test]
+fn dead_module_ignores_non_code_files() {
+    // Docs / config / stylesheets are never "imported", so they always have
+    // fan_in=0 and must not be reported as dead modules.
+    let markup = NodeInfo {
+        relative: PathBuf::from(".claude/agents/reviewer.md"),
+        context: ArchitectureContext {
+            file_role: FileRole::Production,
+            module_kind: ModuleKind::Unknown,
+            language_family: LanguageFamily::Markup,
+            is_entrypoint: false,
+            is_public_api: false,
+        },
+        facts: None,
+    };
+    assert!(dead_module_finding(&markup, Some(0), &complete_graph()).is_none());
+}
+
+#[test]
 fn dead_module_exempts_entrypoints_public_api_and_imported_files() {
     let resolution = complete_graph();
     assert!(

--- a/src/audits/code_quality/rust_panic_risk/ast.rs
+++ b/src/audits/code_quality/rust_panic_risk/ast.rs
@@ -30,6 +30,14 @@ fn visit<'a>(
         return;
     }
 
+    // Skip `#[cfg(test)]` / `#[test]` items entirely: a `panic!`/`unwrap` inside
+    // a test body is expected and is not a production panic risk. Inline test
+    // modules are idiomatic in Rust, so this must be checked per-item rather
+    // than relying on the whole file's role.
+    if is_test_gated(node, content) {
+        return;
+    }
+
     if in_macro_args
         && (kind == "identifier" || kind == "field_identifier")
         && let Ok(text) = node.utf8_text(content.as_bytes())
@@ -151,4 +159,30 @@ fn is_followed_by_paren(node: Node<'_>, content: &str) -> bool {
         }
     }
     false
+}
+
+/// True when `node` is preceded by a `#[cfg(test)]` or `#[test]` outer
+/// attribute. tree-sitter-rust emits outer attributes as `attribute_item`
+/// siblings immediately before the item they annotate, so walk back over the
+/// contiguous run of attributes and stop at the first non-attribute sibling.
+fn is_test_gated(node: Node<'_>, content: &str) -> bool {
+    let mut prev = node.prev_sibling();
+    while let Some(sibling) = prev {
+        if sibling.kind() != "attribute_item" {
+            return false;
+        }
+        if let Ok(text) = sibling.utf8_text(content.as_bytes())
+            && attr_is_test(text)
+        {
+            return true;
+        }
+        prev = sibling.prev_sibling();
+    }
+    false
+}
+
+/// Recognizes `#[cfg(test)]` and `#[test]` once whitespace is removed.
+fn attr_is_test(attr: &str) -> bool {
+    let compact: String = attr.chars().filter(|c| !c.is_whitespace()).collect();
+    compact.contains("cfg(test)") || compact == "#[test]"
 }

--- a/src/audits/code_quality/rust_panic_risk/tests.rs
+++ b/src/audits/code_quality/rust_panic_risk/tests.rs
@@ -236,6 +236,32 @@ fn facts(path: &str, content: &str, has_inline_tests: bool) -> FileFacts {
 }
 
 #[test]
+fn ignores_unwrap_inside_inline_cfg_test_module() {
+    // `unwrap()`/`panic!` inside an inline `#[cfg(test)]` block of a production
+    // file is test code, not a production panic risk: only the production
+    // `unwrap()` on the first line should be reported.
+    let file = facts(
+        "src/domain/parser.rs",
+        "fn run() { let v = parse().unwrap(); }\n\
+         #[cfg(test)]\n\
+         mod tests {\n\
+             #[test]\n\
+             fn works() { let v = parse().unwrap(); }\n\
+         }\n",
+        true,
+    );
+
+    let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(
+        findings.len(),
+        1,
+        "only the production unwrap should report"
+    );
+    assert_eq!(findings[0].evidence[0].line_start, 1);
+}
+
+#[test]
 fn falls_back_to_line_scanner_when_no_parsed_tree() {
     use crate::analysis::parse::ParsedFile;
     use crate::rules::SignalSource;

--- a/src/audits/context/classify/helpers.rs
+++ b/src/audits/context/classify/helpers.rs
@@ -33,11 +33,18 @@ pub fn is_js_or_ts(language: LanguageKind) -> bool {
     )
 }
 
-pub fn is_test_file(path: &Path, has_inline_tests: bool) -> bool {
-    if has_inline_tests {
-        return true;
-    }
-
+/// Classifies a file as a *test file* purely by its path and name conventions.
+///
+/// Whether a file *contains* inline tests (Rust `#[cfg(test)] mod tests`, a
+/// Python doctest, etc.) is a separate fact carried by
+/// `FileFacts::has_inline_tests` and must NOT promote the file to a test role:
+/// a production module that happens to carry an inline `#[cfg(test)]` block
+/// still ships its production code and is imported as production. Conflating
+/// the two made every Rust file with inline tests look like a test file, which
+/// turned ordinary production-to-production imports into false
+/// `architecture.test-leak` findings. The role is the file's purpose, decided
+/// by location/name; the inline-test flag is an orthogonal coverage signal.
+pub fn is_test_file(path: &Path) -> bool {
     let path_text = path.to_string_lossy().to_lowercase();
     let file_name = path
         .file_name()
@@ -63,17 +70,27 @@ pub fn is_test_file(path: &Path, has_inline_tests: bool) -> bool {
         || file_name.ends_with(".spec.tsx")
         || file_name.ends_with(".spec.js")
         || file_name.ends_with(".spec.jsx")
-        || file_name.ends_with("_test.rs")
-        || file_name.ends_with("_tests.rs")
         || file_name.ends_with("_test.go")
         || file_name.ends_with("_test.py")
-        || file_name.starts_with("test_")
         || file_name.ends_with("test.java")
         || file_name.ends_with("tests.java")
         || file_name.ends_with("test.kt")
         || file_name.ends_with("tests.kt")
         || file_name.ends_with("test.cs")
         || file_name.ends_with("tests.cs")
+        // The `test_` prefix is a Python / JS test convention. It is NOT a Rust
+        // one (Rust uses `tests/`, `#[cfg(test)]`, or plural `_tests.rs`), where
+        // it instead collides with production modules like `test_edges.rs`.
+        || (file_name.starts_with("test_") && !file_name.ends_with(".rs"))
+        // Rust test modules carry no path component (a sibling `tests.rs` /
+        // `tests_render.rs` / `*_tests.rs` pulled in via `#[cfg(test)] mod ...;`).
+        // Only the *plural* forms are used for Rust test files; the singular
+        // `*_test.rs` collides with production names (e.g. `source_without_test.rs`),
+        // so it is deliberately omitted — real `*_test.rs` integration tests live
+        // under `tests/` and are already matched by the path checks above.
+        || file_name == "tests.rs"
+        || file_name.ends_with("_tests.rs")
+        || file_name.starts_with("tests_")
 }
 
 pub fn is_config_file(path: &Path) -> bool {
@@ -170,14 +187,23 @@ mod tests {
 
     #[test]
     fn test_classification_covers_rust_test_modules_and_fixtures() {
-        assert!(is_test_file(Path::new("src/behavioral_tests.rs"), false));
-        assert!(is_test_file(
-            Path::new("tests/fixtures/runtime/client.rs"),
-            false
-        ));
-        assert!(is_test_file(
-            Path::new(r"fixtures\runtime\client.rs"),
-            false
-        ));
+        assert!(is_test_file(Path::new("src/behavioral_tests.rs")));
+        assert!(is_test_file(Path::new("tests/fixtures/runtime/client.rs")));
+        assert!(is_test_file(Path::new(r"fixtures\runtime\client.rs")));
+        // Sibling Rust test modules pulled in via `#[cfg(test)] mod ...;`.
+        assert!(is_test_file(Path::new("src/audits/foo/tests.rs")));
+        assert!(is_test_file(Path::new(
+            "src/audits/code_quality/rust_panic_risk/tests_render.rs"
+        )));
+    }
+
+    #[test]
+    fn inline_tests_do_not_make_a_production_file_a_test_file() {
+        // A production module with an inline `#[cfg(test)] mod tests` block is
+        // still production: its role must not depend on carrying inline tests.
+        assert!(!is_test_file(Path::new(
+            "src/audits/code_quality/complexity.rs"
+        )));
+        assert!(!is_test_file(Path::new("src/scan/cache.rs")));
     }
 }

--- a/src/audits/context/classify/mod.rs
+++ b/src/audits/context/classify/mod.rs
@@ -14,7 +14,7 @@ use signals::ContextSignals;
 pub fn classify_file(file: &FileFacts) -> AuditContext {
     let content = file.content.as_deref().unwrap_or("");
     let language = classify_language(file);
-    let is_test = is_test_file(&file.path, file.has_inline_tests);
+    let is_test = is_test_file(&file.path);
     let signals = ContextSignals::detect(&file.path, language, content);
 
     let mut frameworks = Vec::new();

--- a/src/audits/context/classify/tests/group_1.rs
+++ b/src/audits/context/classify/tests/group_1.rs
@@ -97,7 +97,11 @@ fn classifies_dotnet_service() {
 
 
 #[test]
-fn classifies_rust_inline_test_file() {
+fn inline_tests_do_not_make_a_production_file_a_test() {
+    // A production module that carries an inline `#[cfg(test)] mod tests` block
+    // is still production. The inline-test fact (`has_inline_tests = true`) must
+    // not promote its role, or every Rust file becomes a "test file" and
+    // ordinary production imports look like test leaks.
     let file = facts(
         "src/domain/user.rs",
         Some("Rust"),
@@ -108,9 +112,27 @@ fn classifies_rust_inline_test_file() {
     let context = classify_file(&file);
 
     assert_eq!(context.language, LanguageKind::Rust);
-    assert!(context.has_role(FileRole::RustTest));
-    assert!(context.has_role(FileRole::Test));
+    assert!(!context.has_role(FileRole::Test));
+    assert!(!context.has_role(FileRole::RustTest));
+    assert!(!context.is_test);
     assert!(context.has_runtime(RuntimeKind::RustLibrary));
+}
+
+#[test]
+fn classifies_named_rust_test_module_as_test() {
+    // A file that is a test module by name is still a test file even with the
+    // inline-test shortcut gone.
+    let file = facts(
+        "src/audits/foo/tests.rs",
+        Some("Rust"),
+        "#[test]\nfn works() {}\n",
+        true,
+    );
+
+    let context = classify_file(&file);
+
+    assert!(context.has_role(FileRole::Test));
+    assert!(context.has_role(FileRole::RustTest));
     assert!(context.is_test);
 }
 

--- a/src/graph/imports/rust.rs
+++ b/src/graph/imports/rust.rs
@@ -12,6 +12,16 @@ pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
 }
 
 fn visit(node: Node<'_>, content: &str, result: &mut BTreeMap<String, (usize, usize)>) {
+    // Imports gated by `#[cfg(test)]` (the ubiquitous inline `mod tests`, or a
+    // `#[cfg(test)] use ...;`) are compiled out of release builds, so they are
+    // not production dependencies. Skipping the whole subtree keeps them out of
+    // the import graph, which otherwise reads `#[cfg(test)] mod tests;` as a
+    // production file importing a test file (false `architecture.test-leak`)
+    // and lets test-only `use` edges form phantom cycles.
+    if is_test_gated(node, content) {
+        return;
+    }
+
     let span = (node.start_position().row + 1, node.end_position().row + 1);
     match node.kind() {
         "use_declaration" => {
@@ -22,10 +32,26 @@ fn visit(node: Node<'_>, content: &str, result: &mut BTreeMap<String, (usize, us
             }
         }
         "mod_item" => {
-            if let Ok(text) = node.utf8_text(content.as_bytes())
+            // `#[path = "..."] mod x;` points the module at a file resolved
+            // relative to the current file's directory, so the plain
+            // `mod::name` resolution would miss it. The attribute is a sibling
+            // node preceding the `mod_item`, so look there first.
+            if let Some(path) = mod_path_attr(node, content) {
+                result.entry(format!("relfile::{path}")).or_insert(span);
+            } else if let Ok(text) = node.utf8_text(content.as_bytes())
                 && let Some(module) = rust_mod_import(text)
             {
                 result.entry(module).or_insert(span);
+            }
+        }
+        "macro_invocation" => {
+            // `include!("rel/path.rs")` textually pulls another file into this
+            // module; treat it as an edge so the included file is not seen as
+            // dead code. The path is relative to the current file's directory.
+            if let Ok(text) = node.utf8_text(content.as_bytes())
+                && let Some(path) = rust_include_path(text)
+            {
+                result.entry(format!("relfile::{path}")).or_insert(span);
             }
         }
         _ => {}
@@ -42,6 +68,82 @@ fn rust_mod_import(stmt: &str) -> Option<String> {
     let rest = effective.strip_prefix("mod ")?;
     let name = rest.trim().trim_end_matches(';').trim();
     (!name.is_empty() && !name.contains('{') && !name.contains(' ')).then(|| format!("mod::{name}"))
+}
+
+/// Reads the `#[path = "..."]` value from the outer attributes preceding a
+/// `mod` item. tree-sitter-rust emits outer attributes as sibling
+/// `attribute_item` nodes that precede the item, so we walk back over them.
+fn mod_path_attr(mod_item: Node<'_>, content: &str) -> Option<String> {
+    let mut prev = mod_item.prev_sibling();
+    while let Some(node) = prev {
+        if node.kind() != "attribute_item" {
+            break;
+        }
+        if let Ok(text) = node.utf8_text(content.as_bytes())
+            && let Some(path) = rust_mod_path_attr(text)
+        {
+            return Some(path);
+        }
+        prev = node.prev_sibling();
+    }
+    None
+}
+
+/// Extracts the file path from a single `#[path = "..."]` attribute's text.
+fn rust_mod_path_attr(stmt: &str) -> Option<String> {
+    let mut s = stmt.trim_start();
+    while let Some(rest) = s.strip_prefix("#[") {
+        let close = rest.find(']')?;
+        let attr = rest[..close].trim();
+        if let Some(value) = attr.strip_prefix("path") {
+            let value = value.trim_start().strip_prefix('=')?.trim();
+            return first_string_literal(value);
+        }
+        s = rest[close + 1..].trim_start();
+    }
+    None
+}
+
+/// Extracts the included file path from an `include!("...")` macro invocation.
+/// `include_str!`/`include_bytes!` are intentionally not matched: they embed
+/// data, not module code, so they should not create dead-code edges.
+fn rust_include_path(stmt: &str) -> Option<String> {
+    let rest = stmt.trim_start().strip_prefix("include")?;
+    let rest = rest.trim_start().strip_prefix('!')?;
+    first_string_literal(rest)
+}
+
+/// Returns the contents of the first double-quoted string literal in `input`.
+fn first_string_literal(input: &str) -> Option<String> {
+    let open = input.find('"')?;
+    let rest = &input[open + 1..];
+    let close = rest.find('"')?;
+    Some(rest[..close].to_string())
+}
+
+/// True when `node` is annotated with a `#[cfg(test)]` or `#[test]` outer
+/// attribute. tree-sitter-rust emits outer attributes as `attribute_item`
+/// siblings preceding the item, so walk back over the contiguous run of them.
+fn is_test_gated(node: Node<'_>, content: &str) -> bool {
+    let mut prev = node.prev_sibling();
+    while let Some(sibling) = prev {
+        if sibling.kind() != "attribute_item" {
+            return false;
+        }
+        if let Ok(text) = sibling.utf8_text(content.as_bytes())
+            && attr_is_test(text)
+        {
+            return true;
+        }
+        prev = sibling.prev_sibling();
+    }
+    false
+}
+
+/// Recognizes `#[cfg(test)]` and `#[test]` once whitespace is removed.
+fn attr_is_test(attr: &str) -> bool {
+    let compact: String = attr.chars().filter(|c| !c.is_whitespace()).collect();
+    compact.contains("cfg(test)") || compact == "#[test]"
 }
 
 fn strip_rust_outer_attributes(mut s: &str) -> &str {
@@ -183,5 +285,42 @@ fn join_rust_path(prefix: &str, item: &str) -> String {
         prefix.trim_end_matches("::").to_string()
     } else {
         format!("{}::{}", prefix.trim_end_matches("::"), item)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::parse::{ParseLanguage, parse};
+
+    fn imports(src: &str) -> HashSet<String> {
+        let tree = parse(src, ParseLanguage::Rust).expect("rust parses");
+        extract(&tree, src)
+    }
+
+    #[test]
+    fn path_attribute_points_mod_at_a_relative_file() {
+        let got = imports("#[path = \"go.rs\"]\nmod go;\n");
+        assert!(got.contains("relfile::go.rs"), "{got:?}");
+        // The plain name-based edge must not also fire for a `#[path]` mod.
+        assert!(!got.contains("mod::go"), "{got:?}");
+    }
+
+    #[test]
+    fn include_macro_creates_a_relative_file_edge() {
+        let got = imports("include!(\"sections/header.rs\");\n");
+        assert!(got.contains("relfile::sections/header.rs"), "{got:?}");
+    }
+
+    #[test]
+    fn include_str_is_not_a_module_edge() {
+        let got = imports("const D: &str = include_str!(\"data.txt\");\n");
+        assert!(got.iter().all(|i| !i.starts_with("relfile::")), "{got:?}");
+    }
+
+    #[test]
+    fn plain_mod_declaration_still_resolves_by_name() {
+        let got = imports("mod pattern;\n");
+        assert!(got.contains("mod::pattern"), "{got:?}");
     }
 }

--- a/src/graph/resolver/rust.rs
+++ b/src/graph/resolver/rust.rs
@@ -21,6 +21,16 @@ pub(super) fn resolve_rust(
         );
     }
 
+    // `#[path = "..."] mod x;` and `include!("...")` both resolve relative to
+    // the directory of the file that declares them.
+    if let Some(rel) = raw.strip_prefix("relfile::") {
+        let base = from_file
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| root.to_path_buf());
+        return probe(&[base.join(rel)], known_files);
+    }
+
     if let Some(rest) = raw.strip_prefix("crate::") {
         let src_root = root.join("src");
         return resolve_rust_module_path(&src_root, rest, known_files);

--- a/src/knowledge/loader.rs
+++ b/src/knowledge/loader.rs
@@ -31,8 +31,10 @@ pub fn active_knowledge() -> &'static KnowledgeBase {
 
 pub fn bundled_knowledge() -> &'static KnowledgeBase {
     KNOWLEDGE.get_or_init(|| {
-        load_from_source(CORE_PACK_SOURCE)
-            .unwrap_or_else(|error| panic!("bundled knowledge pack is invalid: {error}"))
+        // The pack is embedded at compile time, so a parse failure here is a
+        // build defect rather than a runtime risk. `expect` fails fast and
+        // reports the error through its `Debug` impl.
+        load_from_source(CORE_PACK_SOURCE).expect("bundled knowledge pack is invalid")
     })
 }
 

--- a/src/review/signals/algorithmic.rs
+++ b/src/review/signals/algorithmic.rs
@@ -69,7 +69,7 @@ pub fn detect_algorithmic(
 ) -> Vec<AlgorithmicSignal> {
     let mut signals = Vec::new();
 
-    if crate::audits::context::classify::helpers::is_test_file(&file.path, false) {
+    if crate::audits::context::classify::helpers::is_test_file(&file.path) {
         return signals;
     }
 

--- a/src/review/signals/algorithmic_tests.rs
+++ b/src/review/signals/algorithmic_tests.rs
@@ -149,7 +149,7 @@ fn skips_test_files() {
     let post = source(
         "fn helper() {\n    for i in 0..3 {\n        for j in 0..3 {\n            let _ = i + j;\n        }\n    }\n}\n",
     );
-    let file = changed("src/calc_test.rs");
+    let file = changed("src/calc_tests.rs");
     let signals = detect_algorithmic(&file, None, Some(&post));
     assert!(signals.is_empty(), "{signals:?}");
 }

--- a/src/review/signals/behavioral.rs
+++ b/src/review/signals/behavioral.rs
@@ -133,7 +133,7 @@ pub fn detect_behavioral_added(
 ) -> Vec<BehavioralSignal> {
     let mut signals = Vec::new();
 
-    if crate::audits::context::classify::helpers::is_test_file(&file.path, false) {
+    if crate::audits::context::classify::helpers::is_test_file(&file.path) {
         return signals;
     }
 

--- a/src/review/signals/behavioral/removed.rs
+++ b/src/review/signals/behavioral/removed.rs
@@ -16,7 +16,7 @@ pub fn detect_behavioral_removed(
     let path_str = file.path_string();
 
     // 1. Check TestDeletedOrEmptied
-    let is_test = crate::audits::context::classify::helpers::is_test_file(&file.path, false);
+    let is_test = crate::audits::context::classify::helpers::is_test_file(&file.path);
     if is_test {
         if file.status == ChangeStatus::Deleted {
             signals.push(BehavioralSignal {

--- a/src/review/signals/composites.rs
+++ b/src/review/signals/composites.rs
@@ -65,9 +65,7 @@ pub fn enrich_blast_radius(
 
 /// Whether any changed file is a test file.
 pub fn any_test_changed(changed_files: &[ChangedFile]) -> bool {
-    changed_files
-        .iter()
-        .any(|file| is_test_file(&file.path, false))
+    changed_files.iter().any(|file| is_test_file(&file.path))
 }
 
 /// True when a *code* boundary (auth / request-trust) changed but no test file

--- a/src/review/signals/mod.rs
+++ b/src/review/signals/mod.rs
@@ -115,7 +115,7 @@ pub fn detect_boundary_signals(
 
     let mut signals: Vec<BoundarySignal> = changed_files
         .iter()
-        .filter(|file| !is_test_file(&file.path, false))
+        .filter(|file| !is_test_file(&file.path))
         .filter_map(|file| {
             let path = file.path_string();
             let mut category = classify::classify_boundary(&path, custom.as_ref());

--- a/src/review/signals/taint/mod.rs
+++ b/src/review/signals/taint/mod.rs
@@ -93,7 +93,7 @@ pub struct TaintSignal {
 /// Returns at most one signal per (sink line, sink kind) so nested AST matches do
 /// not double-report. Skips test files and any language without a grammar here.
 pub fn detect_taint(file: &ChangedFile, post_source: Option<&ReviewSource>) -> Vec<TaintSignal> {
-    if crate::audits::context::classify::helpers::is_test_file(&file.path, false) {
+    if crate::audits::context::classify::helpers::is_test_file(&file.path) {
         return Vec::new();
     }
     let Some(post) = post_source else {


### PR DESCRIPTION
## Summary

Fixes Rust inline-test false positives across file classification, architecture graph findings, dead-module detection, and Rust panic-risk detection.

Rust commonly keeps tests inside production modules using `#[cfg(test)] mod tests`. RepoPilot previously treated any file with inline tests as a test file, which caused production Rust modules to be misclassified and made ordinary production imports look like `architecture.test-leak`.

This PR separates file role from inline test presence.

## Type of change

* [ ] Feature
* [ ] Refactor
* [x] Bug fix
* [x] Tests
* [ ] Documentation
* [ ] CI / repository maintenance

## What changed

* Changed file-role classification so test files are identified by path/name conventions only.
* Stopped using `FileFacts::has_inline_tests` to classify a file as test code.
* Updated Rust test file naming rules:

  * `tests/` paths remain test files.
  * `tests.rs`, `tests_*.rs`, and `*_tests.rs` remain Rust test modules.
  * singular `*_test.rs` and `test_*.rs` are no longer treated as Rust test files outside test paths.
* Updated architecture context classification tests.
* Updated review signal call sites to use the new `is_test_file(path)` signature.
* Updated `architecture.dead-module` to skip non-importable/non-code files.
* Updated `architecture.dead-module` to avoid reporting files with inline tests as dead modules.
* Updated Rust import extraction to skip `#[cfg(test)]` / `#[test]` imports.
* Added Rust import edges for:

  * `#[path = "..."] mod x;`
  * `include!("...")`
* Updated Rust import resolution to resolve `relfile::...` edges relative to the importing file.
* Updated `language.rust.panic-risk` to skip `panic!`, `unwrap`, and `expect` inside `#[cfg(test)]` / `#[test]` items.
* Added regression tests for inline-test classification, Rust panic-risk, non-code dead modules, `#[path]`, and `include!`.

## Why

Rust inline tests are production-file-local tests, not a file-role signal.

Before this change, a production Rust module with `#[cfg(test)] mod tests` could be classified as a test file. That caused several false-positive chains:

* production imports looked like test leaks,
* test-only imports could create phantom import graph edges,
* files included through Rust `#[path]` or `include!` could look dead,
* panic-risk reported expected `unwrap` / `panic!` usage inside tests,
* non-code files with no importers were treated as dead modules.

This PR makes those signals closer to Rust’s real compilation model.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] No unrelated refactor or generated-file churn is included

Affected subsystem:

* file role classification
* architecture graph queries
* Rust import extraction/resolution
* `architecture.test-leak`
* `architecture.dead-module`
* `language.rust.panic-risk`
* review signal test-file filtering

Public behavior affected:

* Rust files with inline tests are no longer classified as test files solely because they contain inline tests.
* `architecture.test-leak` should produce fewer false positives on Rust projects.
* `architecture.dead-module` should no longer report docs/config/stylesheets/lockfiles/images/shell/unknown files as dead modules.
* `architecture.dead-module` may report fewer findings for Rust files that have inline tests.
* Rust test-only imports are excluded from the production import graph.
* Rust `#[path = "..."] mod x;` and `include!("...")` now contribute import edges.
* `language.rust.panic-risk` no longer reports panic/unwrap/expect inside Rust test items.
* No JSON/SARIF schema changes.

Known tradeoff:

* A production Rust module with inline tests and no production importers may no longer be reported by `architecture.dead-module`. This avoids noisy false positives, but can hide some genuinely unused production modules. A follow-up can refine this into a lower-confidence finding instead of a full suppression.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
