### PR TITLE
fix(output): hide low-confidence heuristics from default profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- Default finding visibility is now lifecycle- and provenance-aware: low-confidence
+  and experimental heuristics stay hidden even when risk scoring ranks them
+  highly, while stable import-graph risks, validated security findings, direct
+  runtime evidence, and High-confidence manifest-backed package-boundary
+  violations remain visible. `--profile strict` still preserves the complete
+  finding set and existing finding IDs/report schemas are unchanged.
 - **Rust inline tests no longer poison file-role classification.** A file was
   treated as a *test file* whenever it carried inline tests
   (`has_inline_tests`), but in Rust a `#[cfg(test)] mod tests` block is

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ repopilot scan . \
   --fail-on new-high
 ```
 
-Default scans hide broad maintainability noise. Use `--profile strict` for the
-full audit surface.
+Default scans hide low-confidence, experimental, and broad maintainability
+suggestions. Use `--profile strict` for the full audit surface.
 
 ## AI Handoff
 

--- a/docs/trust-mode.md
+++ b/docs/trust-mode.md
@@ -21,7 +21,9 @@ repopilot scan . --include-maintainability
 
 `default` is optimized for day-to-day development and CI review. It hides broad
 maintainability and testing heuristics by policy, including long-function,
-complex-file, TODO/FIXME/HACK, and testing-gap rules.
+complex-file, TODO/FIXME/HACK, and testing-gap rules. Low-confidence findings
+and experimental rules are also strict-only by default, even when clustering or
+other risk signals rank them highly.
 
 `strict` preserves the full raw audit output. Use it for refactoring passes,
 codebase cleanup, rule development, and release-hardening audits.
@@ -47,12 +49,23 @@ The visibility layer then applies profile policy:
 
 ```text
 raw finding
+  -> confidence, lifecycle, and signal-source checks
   -> intent classification
   -> default/strict policy
   -> visible finding or hidden suggestion
 ```
 
 This keeps audit rules focused on evidence and keeps report policy centralized.
+
+The default policy favors direct evidence:
+
+- stable High/Medium-confidence security and import-graph risks remain visible
+- validated secret candidates and production runtime risks remain visible
+- High-confidence package boundaries derived from workspace manifests remain visible
+- experimental and Low-confidence findings are hidden by default
+- Preview + Medium-confidence findings require actionable AST, config,
+  manifest, import-graph, framework-detector, or diff evidence
+- framework style and convention suggestions remain strict-only
 
 ## Hidden suggestion summaries
 
@@ -129,10 +142,26 @@ A high-priority architecture/coupling issue can remain visible:
 architecture.circular-dependency -> ActionableRisk -> visible when high priority or high confidence
 ```
 
+A manifest-declared package boundary remains visible:
+
+```text
+architecture.package-boundary-violation + High confidence -> ActionableRisk -> visible
+```
+
+Convention-shaped architecture heuristics remain strict-only:
+
+```text
+architecture.barrel-file-risk -> Maintainability -> hidden
+architecture.deep-directory-nesting -> Maintainability -> hidden
+architecture.too-many-modules -> Maintainability -> hidden
+```
+
 ## Future improvements
 
-The current intent model is still rule-id aware, but visibility policy is now
-centralized and semantic. The next improvements should be:
+The intent model retains a small rule-id-aware list for convention-shaped
+maintainability and framework style rules, while lifecycle, confidence, and
+signal-source decisions come from finding provenance and registry metadata. The
+next improvements should be:
 
 - persisted hidden summaries in SARIF properties
 - `repopilot eval` fixtures for visibility behavior

--- a/src/findings/visibility/policy.rs
+++ b/src/findings/visibility/policy.rs
@@ -1,6 +1,7 @@
 use super::{FindingIntent, FindingVisibilityDecision};
 use crate::findings::types::{Confidence, Finding, FindingCategory, Severity};
 use crate::risk::RiskPriority;
+use crate::rules::{RuleLifecycle, SignalSource, lookup_rule_metadata};
 use std::path::Path;
 
 pub fn classify_visibility(finding: &Finding) -> FindingVisibilityDecision {
@@ -13,11 +14,50 @@ pub fn classify_visibility(finding: &Finding) -> FindingVisibilityDecision {
         );
     }
 
+    if finding.confidence == Confidence::Low {
+        return FindingVisibilityDecision::hidden(
+            intent,
+            "low-confidence findings are strict-mode suggestions by default",
+        );
+    }
+
     if finding.severity <= Severity::Low {
         return FindingVisibilityDecision::hidden(
             intent,
             "low-severity findings are strict-mode suggestions by default",
         );
+    }
+
+    if is_manifest_backed_package_boundary(finding) {
+        return FindingVisibilityDecision::visible(
+            FindingIntent::ActionableRisk,
+            "manifest-backed package boundary violation",
+        );
+    }
+
+    match rule_lifecycle(finding) {
+        RuleLifecycle::Experimental => {
+            return FindingVisibilityDecision::hidden(
+                intent,
+                "experimental rules are strict-mode suggestions by default",
+            );
+        }
+        RuleLifecycle::Deprecated => {
+            return FindingVisibilityDecision::hidden(
+                intent,
+                "deprecated rules are hidden in the default profile",
+            );
+        }
+        RuleLifecycle::Preview
+            if finding.confidence == Confidence::Medium
+                && !is_evidence_backed_actionable(finding, intent) =>
+        {
+            return FindingVisibilityDecision::hidden(
+                intent,
+                "medium-confidence preview finding lacks direct actionable evidence",
+            );
+        }
+        RuleLifecycle::Preview | RuleLifecycle::Stable => {}
     }
 
     match intent {
@@ -79,13 +119,20 @@ fn runtime_visibility(finding: &Finding) -> FindingVisibilityDecision {
 }
 
 fn actionable_visibility(finding: &Finding) -> FindingVisibilityDecision {
-    if is_import_graph_rule(&finding.rule_id)
-        && finding.risk.priority.is_at_least(RiskPriority::P2)
-        && finding.confidence != Confidence::Low
+    if is_import_graph_rule(&finding.rule_id) && finding.risk.priority.is_at_least(RiskPriority::P2)
     {
         return FindingVisibilityDecision::visible(
             FindingIntent::ActionableRisk,
             "stable import-graph architecture risk",
+        );
+    }
+
+    if is_evidence_backed_actionable(finding, FindingIntent::ActionableRisk)
+        && finding.severity >= Severity::Medium
+    {
+        return FindingVisibilityDecision::visible(
+            FindingIntent::ActionableRisk,
+            "evidence-backed actionable risk",
         );
     }
 
@@ -147,6 +194,16 @@ fn classify_intent(finding: &Finding) -> FindingIntent {
         return FindingIntent::ActionableRisk;
     }
 
+    if finding.category == FindingCategory::Framework {
+        if is_framework_style_rule(&finding.rule_id) {
+            return FindingIntent::Maintainability;
+        }
+
+        if is_direct_evidence_source(signal_source(finding)) {
+            return FindingIntent::ActionableRisk;
+        }
+    }
+
     if is_maintainability_rule(&finding.rule_id) {
         return FindingIntent::Maintainability;
     }
@@ -197,6 +254,20 @@ fn is_import_graph_rule(rule_id: &str) -> bool {
     )
 }
 
+fn is_framework_style_rule(rule_id: &str) -> bool {
+    matches!(
+        rule_id,
+        "framework.js.var-declaration"
+            | "framework.js.console-log"
+            | "framework.react.class-component"
+            | "framework.react.prop-types"
+            | "framework.react-native.inline-style"
+            | "framework.react-native.flatlist-missing-key"
+            | "framework.react-native.old-architecture"
+            | "framework.react-native.hermes-disabled"
+    )
+}
+
 fn is_strict_only_heuristic_rule(rule_id: &str) -> bool {
     matches!(
         rule_id,
@@ -216,6 +287,48 @@ fn is_strict_only_heuristic_rule(rule_id: &str) -> bool {
             | "code-quality.cyclomatic-complexity"
             | "code-quality.deep-control-flow"
     )
+}
+
+fn is_evidence_backed_actionable(finding: &Finding, intent: FindingIntent) -> bool {
+    matches!(
+        intent,
+        FindingIntent::SecurityRisk | FindingIntent::RuntimeRisk | FindingIntent::ActionableRisk
+    ) && is_direct_evidence_source(signal_source(finding))
+}
+
+fn is_direct_evidence_source(source: SignalSource) -> bool {
+    matches!(
+        source,
+        SignalSource::Ast
+            | SignalSource::ConfigFile
+            | SignalSource::DependencyManifest
+            | SignalSource::ImportGraph
+            | SignalSource::FrameworkDetector
+            | SignalSource::GitDiff
+    )
+}
+
+fn rule_lifecycle(finding: &Finding) -> RuleLifecycle {
+    lookup_rule_metadata(&finding.rule_id)
+        .map(|metadata| metadata.lifecycle)
+        .unwrap_or(finding.provenance.rule_lifecycle)
+}
+
+fn signal_source(finding: &Finding) -> SignalSource {
+    if finding.provenance.detector != "unknown" {
+        return finding.provenance.signal_source;
+    }
+
+    lookup_rule_metadata(&finding.rule_id)
+        .map(|metadata| metadata.signal_source)
+        .unwrap_or(finding.provenance.signal_source)
+}
+
+fn is_manifest_backed_package_boundary(finding: &Finding) -> bool {
+    finding.rule_id == "architecture.package-boundary-violation"
+        && finding.confidence == Confidence::High
+        && signal_source(finding) == SignalSource::ImportGraph
+        && !finding.evidence.is_empty()
 }
 
 fn is_validated_secret_leak(finding: &Finding) -> bool {

--- a/src/findings/visibility/profile_tests.rs
+++ b/src/findings/visibility/profile_tests.rs
@@ -6,13 +6,15 @@ use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::scan::types::{ScanArtifacts, ScanMetadata, ScanMetrics};
 
 fn finding(rule_id: &str, category: FindingCategory, severity: Severity) -> Finding {
-    Finding {
+    let mut finding = Finding {
         rule_id: rule_id.to_string(),
         category,
         severity,
         confidence: Confidence::High,
         ..Default::default()
-    }
+    };
+    finding.populate_rule_metadata();
+    finding
 }
 
 #[test]
@@ -141,4 +143,33 @@ fn strict_profile_keeps_all_findings_and_clears_hidden_breakdown() {
     assert_eq!(summary.metrics.hidden_suggestions_count, 0);
     assert!(summary.artifacts.hidden_suggestions.is_empty());
     assert_eq!(summary.artifacts.findings.len(), 2);
+}
+
+#[test]
+fn strict_profile_preserves_heuristic_finding_ids() {
+    let expected_ids = [
+        "architecture.barrel-file-risk",
+        "architecture.deep-directory-nesting",
+        "architecture.too-many-modules",
+    ];
+    let mut summary = ScanSummary {
+        artifacts: ScanArtifacts {
+            findings: expected_ids
+                .iter()
+                .map(|rule_id| finding(rule_id, FindingCategory::Architecture, Severity::Medium))
+                .collect(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    apply_visibility_profile(&mut summary, FindingVisibilityProfile::Strict);
+
+    let actual_ids = summary
+        .artifacts
+        .findings
+        .iter()
+        .map(|finding| finding.rule_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(actual_ids, expected_ids);
 }

--- a/src/findings/visibility/tests.rs
+++ b/src/findings/visibility/tests.rs
@@ -4,13 +4,15 @@ use crate::risk::{RiskAssessment, RiskPriority};
 use std::path::PathBuf;
 
 fn finding(rule_id: &str, category: FindingCategory, severity: Severity) -> Finding {
-    Finding {
+    let mut finding = Finding {
         rule_id: rule_id.to_string(),
         category,
         severity,
         confidence: Confidence::High,
         ..Default::default()
-    }
+    };
+    finding.populate_rule_metadata();
+    finding
 }
 
 fn finding_with_path(
@@ -86,6 +88,54 @@ fn default_profile_hides_deep_relative_imports() {
 }
 
 #[test]
+fn default_profile_hides_low_confidence_barrel_file_risk() {
+    let finding = finding(
+        "architecture.barrel-file-risk",
+        FindingCategory::Architecture,
+        Severity::Low,
+    );
+
+    let decision = classify_visibility(&finding);
+
+    assert_eq!(finding.confidence, Confidence::Low);
+    assert_eq!(decision.intent, FindingIntent::Maintainability);
+    assert!(!decision.visible_by_default);
+}
+
+#[test]
+fn default_profile_hides_deep_directory_nesting() {
+    let finding = finding(
+        "architecture.deep-directory-nesting",
+        FindingCategory::Architecture,
+        Severity::Low,
+    );
+
+    let decision = classify_visibility(&finding);
+
+    assert_eq!(decision.intent, FindingIntent::Maintainability);
+    assert!(!decision.visible_by_default);
+}
+
+#[test]
+fn default_profile_hides_too_many_modules_even_at_high_priority() {
+    let finding = finding_with_priority(
+        "architecture.too-many-modules",
+        FindingCategory::Architecture,
+        Severity::Medium,
+        RiskPriority::P1,
+    );
+
+    let decision = classify_visibility(&finding);
+
+    assert_eq!(decision.intent, FindingIntent::Maintainability);
+    assert!(!decision.visible_by_default);
+    assert_eq!(
+        decision.reason,
+        "experimental rules are strict-mode suggestions by default"
+    );
+}
+
+#[test]
 fn default_profile_hides_high_priority_broad_maintainability_heuristics() {
     let finding = finding_with_priority(
         "code-quality.long-function",
@@ -116,6 +166,48 @@ fn default_profile_keeps_stable_import_graph_architecture_risks() {
 }
 
 #[test]
+fn default_profile_keeps_manifest_backed_package_boundary_violations() {
+    let mut finding = finding(
+        "architecture.package-boundary-violation",
+        FindingCategory::Architecture,
+        Severity::Medium,
+    );
+    finding.evidence = vec![Evidence {
+        path: PathBuf::from("packages/app/src/main.ts"),
+        line_start: 3,
+        line_end: None,
+        snippet: "imports internal file: packages/core/src/private.ts".to_string(),
+    }];
+
+    let decision = classify_visibility(&finding);
+
+    assert_eq!(finding.confidence, Confidence::High);
+    assert_eq!(decision.intent, FindingIntent::ActionableRisk);
+    assert!(decision.visible_by_default);
+}
+
+#[test]
+fn default_profile_hides_configured_package_boundary_violations() {
+    let mut finding = finding(
+        "architecture.package-boundary-violation",
+        FindingCategory::Architecture,
+        Severity::Medium,
+    );
+    finding.confidence = Confidence::Medium;
+    finding.evidence = vec![Evidence {
+        path: PathBuf::from("packages/app/src/main.ts"),
+        line_start: 3,
+        line_end: None,
+        snippet: "imports internal file: packages/core/src/private.ts".to_string(),
+    }];
+
+    let decision = classify_visibility(&finding);
+
+    assert_eq!(decision.intent, FindingIntent::Informational);
+    assert!(!decision.visible_by_default);
+}
+
+#[test]
 fn default_profile_keeps_validated_secret_candidates() {
     let finding = finding(
         "security.secret-candidate",
@@ -126,6 +218,48 @@ fn default_profile_keeps_validated_secret_candidates() {
     let decision = classify_visibility(&finding);
 
     assert_eq!(decision.intent, FindingIntent::SecurityRisk);
+    assert!(decision.visible_by_default);
+}
+
+#[test]
+fn default_profile_keeps_stable_security_findings() {
+    let finding = finding(
+        "security.env-file-committed",
+        FindingCategory::Security,
+        Severity::Critical,
+    );
+
+    let decision = classify_visibility(&finding);
+
+    assert_eq!(decision.intent, FindingIntent::SecurityRisk);
+    assert!(decision.visible_by_default);
+}
+
+#[test]
+fn default_profile_hides_framework_style_rules() {
+    let finding = finding(
+        "framework.react-native.old-architecture",
+        FindingCategory::Framework,
+        Severity::Medium,
+    );
+
+    let decision = classify_visibility(&finding);
+
+    assert_eq!(decision.intent, FindingIntent::Maintainability);
+    assert!(!decision.visible_by_default);
+}
+
+#[test]
+fn default_profile_keeps_manifest_backed_framework_risks() {
+    let finding = finding(
+        "framework.react-native.old-react-navigation",
+        FindingCategory::Framework,
+        Severity::Medium,
+    );
+
+    let decision = classify_visibility(&finding);
+
+    assert_eq!(decision.intent, FindingIntent::ActionableRisk);
     assert!(decision.visible_by_default);
 }
 


### PR DESCRIPTION
## Summary

Makes default finding visibility lifecycle-, confidence-, and provenance-aware.

Default output now hides low-confidence, experimental, and broad heuristic findings instead of presenting them as hard problems. Strict mode still preserves the full audit surface, so advanced users can inspect the complete set of findings when needed.

## Type of change

* [ ] Feature
* [ ] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Updated finding visibility policy to hide low-confidence findings by default.
* Hid Experimental and Deprecated rules from the default profile.
* Hid Preview + Medium-confidence findings unless they have direct actionable evidence.
* Kept validated secrets and private key candidates visible.
* Kept stable security findings visible.
* Kept stable import-graph architecture risks visible.
* Kept High-confidence package-boundary violations with evidence visible.
* Treated framework style rules as maintainability suggestions.
* Preserved heuristic findings in strict mode.
* Added regression tests for default vs strict visibility behavior.
* Updated `docs/trust-mode.md`, README wording, and changelog.

## Why

RepoPilot should optimize default output for trust, not maximum finding count.

Some rules are useful during deep audits, but noisy in day-to-day usage because they depend on project conventions. Showing low-confidence heuristics as default findings can mislead users and make the tool feel less trustworthy.

This change keeps strong, evidence-backed findings visible while moving noisy suggestions to strict mode.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] No unrelated refactor or generated-file churn is included

Affected subsystem:

* finding visibility policy
* default/strict profile behavior
* hidden suggestion summaries
* trust-mode documentation

Public behavior affected:

* Default scan output may show fewer low-confidence or heuristic findings.
* Strict profile still preserves the complete finding set.
* Finding IDs are unchanged.
* JSON/SARIF/report schemas are unchanged.
* Hidden suggestions remain available through the existing hidden suggestion summary path.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
