### PR TITLE
fix(panic-risk): avoid High severity for mutex lock unwraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **`language.rust.panic-risk` no longer escalates a poisoned-mutex unwrap to
+  High just because the lock is named `db`.** A `Mutex`/`RwLock` field called
+  `db`/`conn`/`pool` (`self.db.lock().unwrap()`) matched the external-failure
+  keyword list (`db.`, `conn.`, `pool.`) and was reported as a **visible High**
+  finding in the default profile, even though a lock acquisition is an
+  in-process invariant, not an external I/O or database call. A `.lock()` unwrap
+  is now treated as the ordinary (Medium, hidden-by-default) panic risk it is;
+  real external-failure unwraps (`.parse()`, `fs::`, query/request paths) still
+  escalate to High and stay visible.
 - Default finding visibility is now lifecycle- and provenance-aware: low-confidence
-  and experimental heuristics stay hidden even when risk scoring ranks them
-  highly, while stable import-graph risks, validated security findings, direct
+  and experimental heuristics stay hidden even when risk scoring ranks them highly, while stable import-graph risks, validated security findings, direct
   runtime evidence, and High-confidence manifest-backed package-boundary
   violations remain visible. `--profile strict` still preserves the complete
   finding set and existing finding IDs/report schemas are unchanged.

--- a/src/audits/code_quality/rust_panic_risk/pattern.rs
+++ b/src/audits/code_quality/rust_panic_risk/pattern.rs
@@ -121,6 +121,16 @@ pub(super) fn is_external_failure_path(pattern: RustPanicPattern, sanitized: &st
     }
 
     let lower = sanitized.to_lowercase();
+
+    // A lock acquisition that unwraps (`Mutex::lock().unwrap()`,
+    // `RwLock::write().unwrap()`) is a poisoned-lock panic — an in-process
+    // invariant, not an external I/O or database failure. Without this guard a
+    // field named `db`/`conn`/`pool` (`self.db.lock().unwrap()`) would match the
+    // `db.`/`conn.`/`pool.` substrings below and be escalated to High.
+    if lower.contains(".lock()") {
+        return false;
+    }
+
     const EXTERNAL_SIGNALS: &[&str] = &[
         ".parse(",
         ".parse::<",

--- a/src/audits/code_quality/rust_panic_risk/tests.rs
+++ b/src/audits/code_quality/rust_panic_risk/tests.rs
@@ -179,6 +179,22 @@ fn ignores_mutex_poison_invariant_expect() {
 }
 
 #[test]
+fn mutex_lock_unwrap_named_db_is_not_escalated_to_high() {
+    // `self.db.lock().unwrap()` is a poisoned-mutex panic, not an external
+    // database failure. The `db.` substring must not escalate it to High.
+    let file = facts(
+        "src/state.rs",
+        "let mut guard = self.db.lock().unwrap();",
+        false,
+    );
+
+    let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].severity, Severity::Medium);
+}
+
+#[test]
 fn upgrades_external_parse_unwrap_to_high() {
     let file = facts(
         "src/domain/parser.rs",

--- a/tests/scan_visibility_cli.rs
+++ b/tests/scan_visibility_cli.rs
@@ -81,6 +81,24 @@ fn default_scan_reports_unwrap_on_external_parse_path() {
 }
 
 #[test]
+fn default_scan_hides_mutex_lock_unwrap_named_db() {
+    // A `Mutex` field named `db` is common; `self.db.lock().unwrap()` is a
+    // poisoned-lock panic, not an external database failure, so it must not
+    // surface as a visible HIGH finding the way an external parse unwrap does.
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    write(
+        root.join("src/state.rs"),
+        "pub struct App { db: std::sync::Mutex<u32> }\n\
+         impl App { pub fn bump(&self) { let mut g = self.db.lock().unwrap(); *g += 1; } }\n",
+    );
+
+    let json = scan_json(root, &[]);
+
+    assert_rule_absent(&json, "language.rust.panic-risk");
+}
+
+#[test]
 fn default_scan_keeps_real_secret_and_private_key_candidates() {
     let temp = tempdir().expect("temp dir");
     let root = temp.path();


### PR DESCRIPTION
## Summary

This PR fixes a Rust panic-risk false positive where `Mutex::lock().unwrap()` on a field named `db`, `conn`, or `pool` could be escalated to a visible High finding.

A poisoned mutex unwrap is an in-process invariant panic, not an external I/O, database, request, or parsing failure. It should remain the ordinary Medium panic-risk finding and stay hidden by default.

## Type of change

- Bug fix
- Tests
- Changelog

## What changed

- Updated Rust panic-risk external-failure classification.
- Prevented `.lock().unwrap()` from matching external failure keywords such as:
  - `db.`
  - `conn.`
  - `pool.`
- Kept real external unwraps, such as parse/query/request/fs paths, eligible for High severity.
- Added unit coverage for `self.db.lock().unwrap()`.
- Added CLI visibility coverage to ensure default scan output hides the mutex lock unwrap finding.
- Updated `CHANGELOG.md`.

## Why

RepoPilot should not overreport ordinary Rust synchronization invariants as visible High-risk findings.

Before this change, code like this could be treated as an external database-like failure because the receiver path contained `db.`:

```rust
let mut guard = self.db.lock().unwrap();
```

That is misleading. The panic risk is still real, but it is not the same class of risk as unwrapping a parse, request, query, filesystem, or other external boundary operation.

This PR improves signal quality by keeping poisoned mutex unwraps at Medium severity and hidden by default.

## Contract and ownership

- Rule ID remains unchanged: language.rust.panic-risk.
- Existing external-failure unwrap behavior remains unchanged.
- Real parse/query/request/fs unwraps can still escalate to High.
- Mutex lock unwraps remain detectable as Medium panic-risk findings.
- Default visibility no longer surfaces this false positive.
- No CLI, JSON, SARIF, baseline, Action, MCP, or report schema change is intended.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo test rust_panic_risk
cargo test scan_visibility_cli

npm run release:contract
./scripts/smoke-product.sh
```