### PR TITLE
fix(dead-module): recognize build scripts and frontend entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,19 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **`architecture.dead-module` no longer flags Cargo build scripts or
+  React/Vite entrypoints.** Entrypoint detection is consulted by the import
+  graph after per-file content has been dropped, so it must work from the
+  filename alone — but the content-only `fn main()` check meant a `build.rs`
+  (`fn main()` present, content unavailable) was reported as a dead module, and
+  every `src/main.tsx`/`index.tsx` Vite/React entry was treated as ordinary
+  importable code. `is_app_entrypoint` now recognises `build.rs` and the
+  `.tsx`/`.jsx` entry filenames by name, independent of content.
 - **`language.rust.panic-risk` no longer escalates a poisoned-mutex unwrap to
   High just because the lock is named `db`.** A `Mutex`/`RwLock` field called
   `db`/`conn`/`pool` (`self.db.lock().unwrap()`) matched the external-failure
   keyword list (`db.`, `conn.`, `pool.`) and was reported as a **visible High**
-  finding in the default profile, even though a lock acquisition is an
-  in-process invariant, not an external I/O or database call. A `.lock()` unwrap
+  finding in the default profile, even though a lock acquisition is an in-process invariant, not an external I/O or database call. A `.lock()` unwrap
   is now treated as the ordinary (Medium, hidden-by-default) panic risk it is;
   real external-failure unwraps (`.parse()`, `fs::`, query/request paths) still
   escalate to High and stay visible.

--- a/src/audits/context/classify/helpers.rs
+++ b/src/audits/context/classify/helpers.rs
@@ -153,6 +153,7 @@ pub fn is_app_entrypoint(path: &Path, content: &str, language: LanguageKind) -> 
     matches!(
         file_name.as_str(),
         "main.rs"
+            | "build.rs"
             | "main.go"
             | "main.py"
             | "app.py"
@@ -161,8 +162,12 @@ pub fn is_app_entrypoint(path: &Path, content: &str, language: LanguageKind) -> 
             | "main.kt"
             | "index.ts"
             | "index.js"
+            | "index.tsx"
+            | "index.jsx"
             | "main.ts"
             | "main.js"
+            | "main.tsx"
+            | "main.jsx"
     ) || (language == LanguageKind::Python && content.contains("if __name__ == \"__main__\""))
         || (language == LanguageKind::Go && content.contains("func main("))
         || (language == LanguageKind::Rust && content.contains("fn main("))
@@ -170,8 +175,39 @@ pub fn is_app_entrypoint(path: &Path, content: &str, language: LanguageKind) -> 
 
 #[cfg(test)]
 mod tests {
-    use super::{is_test_file, path_contains_component};
+    use super::{is_app_entrypoint, is_test_file, path_contains_component};
+    use crate::audits::context::model::LanguageKind;
     use std::path::Path;
+
+    #[test]
+    fn entrypoints_recognized_by_filename_without_content() {
+        // The import graph classifies nodes after per-file content has been
+        // dropped, so entrypoint detection must work from the filename alone —
+        // otherwise a Cargo build script (`fn main()` but content unavailable)
+        // is wrongly reported as a dead module, and every Vite/React
+        // `src/main.tsx` is treated as ordinary importable code.
+        assert!(is_app_entrypoint(
+            Path::new("build.rs"),
+            "",
+            LanguageKind::Rust
+        ));
+        assert!(is_app_entrypoint(
+            Path::new("src/main.tsx"),
+            "",
+            LanguageKind::TypeScript
+        ));
+        assert!(is_app_entrypoint(
+            Path::new("src/index.tsx"),
+            "",
+            LanguageKind::TypeScript
+        ));
+        // A regular library module is still not an entrypoint.
+        assert!(!is_app_entrypoint(
+            Path::new("src/state.rs"),
+            "",
+            LanguageKind::Rust
+        ));
+    }
 
     #[test]
     fn path_component_matching_handles_windows_separators() {

--- a/tests/fixtures/rules/architecture.dead-module/false_positive/build.rs
+++ b/tests/fixtures/rules/architecture.dead-module/false_positive/build.rs
@@ -1,0 +1,6 @@
+// A Cargo build script is a legitimate entrypoint: it is compiled and run by
+// Cargo, never imported by another module, so its fan-in is always zero. It
+// must not be reported as a dead module.
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+}


### PR DESCRIPTION
## Summary

This PR fixes a false positive in `architecture.dead-module` where valid application entrypoints could be reported as dead modules.

Entrypoint detection is used after per-file content may no longer be available, so it must recognize common entrypoint files by filename alone. This change adds filename-based detection for Cargo build scripts and React/Vite frontend entrypoints.

## Type of change

- Bug fix
- Tests
- Changelog

## What changed

- Updated `is_app_entrypoint` to recognize `build.rs` by filename.
- Updated `is_app_entrypoint` to recognize frontend entrypoint filenames:
  - `index.tsx`
  - `index.jsx`
  - `main.tsx`
  - `main.jsx`
- Kept existing entrypoint detection for:
  - Rust `main.rs`
  - Go `main.go`
  - Python `app.py` / `main.py`
  - Java/Kotlin main-like files
  - JS/TS `index.ts`, `index.js`, `main.ts`, `main.js`
  - content-based `fn main`, `func main`, and Python `__main__`
- Added unit coverage proving filename-only entrypoint detection works without content.
- Added a false-positive fixture for Cargo `build.rs`.
- Updated `CHANGELOG.md`.

## Why

`architecture.dead-module` depends on import graph fan-in. That is useful for finding truly unreachable production modules, but entrypoints are naturally not imported by other modules.

A Cargo `build.rs` script is compiled and run by Cargo, not imported as a normal module. React/Vite entrypoints such as `src/main.tsx` and `src/index.tsx` are loaded by the bundler/runtime, not necessarily imported by application code.

Before this change, those files could appear as zero-fan-in production files and be incorrectly reported as dead modules.

## Contract and ownership

- Rule ID remains unchanged: `architecture.dead-module`.
- Existing dead-module behavior remains unchanged for ordinary production modules.
- Entrypoint classification remains owned by context classification helpers.
- Graph query rules consume entrypoint classification and do not own framework-specific entrypoint detection.
- No CLI, JSON, SARIF, baseline, Action, MCP, or report schema change is intended.
- This is a false-positive reduction only.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo test entrypoints_recognized_by_filename_without_content
cargo test rule_eval_fixture_coverage

npm run release:contract
./scripts/smoke-product.sh
```