### PR TITLE
fix(panic-risk): stop escalating serde serialization unwraps to High

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,20 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   React/Vite entrypoints.** Entrypoint detection is consulted by the import
   graph after per-file content has been dropped, so it must work from the
   filename alone — but the content-only `fn main()` check meant a `build.rs`
-  (`fn main()` present, content unavailable) was reported as a dead module, and
-  every `src/main.tsx`/`index.tsx` Vite/React entry was treated as ordinary
+  (`fn main()` present, content unavailable) was reported as a dead module, and every `src/main.tsx`/`index.tsx` Vite/React entry was treated as ordinary
   importable code. `is_app_entrypoint` now recognises `build.rs` and the
   `.tsx`/`.jsx` entry filenames by name, independent of content.
+- **`language.rust.panic-risk` no longer escalates a serde *serialization*
+  unwrap to High.** `serde_json::to_string(&value).unwrap()` (and `to_value`,
+  `to_vec`, `to_writer`, and the YAML/TOML equivalents) serializes an owned,
+  in-memory value — an in-process, effectively-infallible operation — yet the
+  `serde_json`/`json` external-failure signals escalated it to a **visible
+  High** in the default profile, the same way a genuine parse of untrusted
+  input is. On real services that persist structured data this was the dominant
+  panic-risk false positive. A serialization unwrap is now the ordinary
+  (Medium, hidden-by-default) panic risk; *deserialization*
+  (`from_str`/`from_slice`/`from_reader`/`from_value`) still escalates to High
+  and stays visible.
 - **`language.rust.panic-risk` no longer escalates a poisoned-mutex unwrap to
   High just because the lock is named `db`.** A `Mutex`/`RwLock` field called
   `db`/`conn`/`pool` (`self.db.lock().unwrap()`) matched the external-failure

--- a/src/audits/code_quality/rust_panic_risk/pattern.rs
+++ b/src/audits/code_quality/rust_panic_risk/pattern.rs
@@ -131,6 +131,18 @@ pub(super) fn is_external_failure_path(pattern: RustPanicPattern, sanitized: &st
         return false;
     }
 
+    // Serializing an owned, in-memory value to JSON/YAML/TOML
+    // (`serde_json::to_string(&x)`, `to_value`, `to_vec`, `to_writer`, ...) is an
+    // in-process, effectively-infallible operation, not the parsing of untrusted
+    // external input that the `serde_json`/`json` signals below are meant to
+    // catch. Without this guard a serialization unwrap is escalated to a visible
+    // High the same way a genuine deserialization is — the dominant panic-risk
+    // false positive on services that persist structured data. Deserialization
+    // (`from_str`/`from_slice`/`from_reader`/`from_value`) is left to escalate.
+    if is_serialize_call(&lower) && !is_deserialize_call(&lower) {
+        return false;
+    }
+
     const EXTERNAL_SIGNALS: &[&str] = &[
         ".parse(",
         ".parse::<",
@@ -171,6 +183,29 @@ pub(super) fn is_external_failure_path(pattern: RustPanicPattern, sanitized: &st
     ];
 
     EXTERNAL_SIGNALS.iter().any(|signal| lower.contains(signal))
+}
+
+/// True when the (lowercased) line invokes a serde serialization free function
+/// (`serde_json::to_string`, `serde_yaml::to_vec`, ...). Anchored on the `::to_`
+/// form so an ordinary infallible method call (`value.to_string()`) is ignored.
+fn is_serialize_call(lower: &str) -> bool {
+    const SERIALIZE_CALLS: &[&str] = &[
+        "::to_string(",
+        "::to_string_pretty(",
+        "::to_value(",
+        "::to_vec(",
+        "::to_vec_pretty(",
+        "::to_writer(",
+        "::to_writer_pretty(",
+    ];
+    SERIALIZE_CALLS.iter().any(|call| lower.contains(call))
+}
+
+/// True when the line parses external bytes back into a value, which genuinely
+/// fails on malformed input and so remains an external-failure path.
+fn is_deserialize_call(lower: &str) -> bool {
+    const DESERIALIZE_CALLS: &[&str] = &["from_str", "from_slice", "from_reader", "from_value"];
+    DESERIALIZE_CALLS.iter().any(|call| lower.contains(call))
 }
 
 pub(super) fn is_infallible_render_write_start(path: &std::path::Path, trimmed: &str) -> bool {

--- a/src/audits/code_quality/rust_panic_risk/tests.rs
+++ b/src/audits/code_quality/rust_panic_risk/tests.rs
@@ -195,6 +195,39 @@ fn mutex_lock_unwrap_named_db_is_not_escalated_to_high() {
 }
 
 #[test]
+fn serde_json_serialization_unwrap_is_not_escalated_to_high() {
+    // `serde_json::to_string(&value).unwrap()` serializes an owned, in-memory
+    // value to JSON — an in-process, effectively-infallible operation. The
+    // `serde_json`/`json` external signals must not escalate it to a visible
+    // High the way a genuine deserialization is.
+    for line in [
+        "changes: Some(serde_json::to_string(&changes).unwrap()),",
+        "before.insert(id.clone(), serde_json::to_value(&snapshot).unwrap());",
+    ] {
+        let file = facts("src/analysis/merge_service.rs", line, false);
+        let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+        assert_eq!(findings.len(), 1, "{line}");
+        assert_eq!(findings[0].severity, Severity::Medium, "{line}");
+    }
+}
+
+#[test]
+fn serde_json_deserialization_unwrap_stays_high() {
+    // Parsing untrusted external bytes back into a value genuinely fails on
+    // malformed input, so it remains a visible High external-failure path.
+    let file = facts(
+        "src/api/handler.rs",
+        "let parsed: Payload = serde_json::from_str(&body).unwrap();",
+        false,
+    );
+
+    let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].severity, Severity::High);
+}
+
+#[test]
 fn upgrades_external_parse_unwrap_to_high() {
     let file = facts(
         "src/domain/parser.rs",

--- a/tests/scan_visibility_cli.rs
+++ b/tests/scan_visibility_cli.rs
@@ -99,6 +99,23 @@ fn default_scan_hides_mutex_lock_unwrap_named_db() {
 }
 
 #[test]
+fn default_scan_hides_serde_serialization_unwrap() {
+    // `serde_json::to_string(&value).unwrap()` serializes an owned value to
+    // JSON — effectively infallible and in-process. It must not surface as a
+    // visible HIGH the way a genuine `serde_json::from_str` deserialization does.
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    write(
+        root.join("src/store.rs"),
+        "pub fn dump(v: &Vec<u32>) -> String { serde_json::to_string(v).unwrap() }\n",
+    );
+
+    let json = scan_json(root, &[]);
+
+    assert_rule_absent(&json, "language.rust.panic-risk");
+}
+
+#[test]
 fn default_scan_keeps_real_secret_and_private_key_candidates() {
     let temp = tempdir().expect("temp dir");
     let root = temp.path();


### PR DESCRIPTION
## Summary

This PR fixes a Rust panic-risk false positive where serde serialization unwraps were escalated to visible High findings.

Calls such as `serde_json::to_string(&value).unwrap()` serialize an owned, in-memory value. They are not the same risk class as deserializing untrusted input with `serde_json::from_str(...).unwrap()`.

Serialization unwraps now remain ordinary Medium panic-risk findings and stay hidden by default, while real deserialization unwraps still escalate to High.

## Type of change

- Bug fix
- Tests
- Changelog

## What changed

- Updated Rust panic-risk external-failure classification.
- Added a guard for serde-style serialization calls:
  - `to_string`
  - `to_string_pretty`
  - `to_value`
  - `to_vec`
  - `to_vec_pretty`
  - `to_writer`
  - `to_writer_pretty`
- Kept serde-style deserialization calls classified as external-failure paths:
  - `from_str`
  - `from_slice`
  - `from_reader`
  - `from_value`
- Added unit coverage for serde JSON serialization unwraps.
- Added unit coverage to ensure serde JSON deserialization unwraps still escalate to High.
- Added CLI visibility coverage to ensure default scan output hides serde serialization unwrap findings.
- Updated `CHANGELOG.md`.

## Why

RepoPilot should not treat in-memory serialization as the same risk class as parsing external input.

Before this change, code like this could be escalated to a visible High finding:

```rust
let body = serde_json::to_string(&value).unwrap();
```

That is noisy for services that persist or emit structured data. The panic risk still exists, but it is not the same as unwrapping a parse operation over malformed or untrusted input.

This PR improves signal quality by keeping serialization unwraps at Medium severity and hidden by default, while preserving High severity for real deserialization boundaries.

## Contract and ownership

- Rule ID remains unchanged: language.rust.panic-risk.
- Serialization unwraps remain detectable as Medium panic-risk findings.
- Default visibility no longer surfaces serde serialization unwraps.
- Deserialization unwraps still escalate to High.
- Existing parse/request/query/fs unwrap behavior remains unchanged.
- No CLI, JSON, SARIF, baseline, Action, MCP, or report schema change is intended.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

cargo test rust_panic_risk
cargo test scan_visibility_cli

npm run release:contract
./scripts/smoke-product.sh
```