### PR TITLE
release: prepare v0.18.0 false-positive fixes

### DIFF
--- a/.github/workflows/repopilot-pr-review.yml
+++ b/.github/workflows/repopilot-pr-review.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: RepoPilot version to run
         type: string
-        default: "0.17.0"
+        default: "0.18.0"
       fail-on-review:
         description: Review signal gate policy
         type: string
@@ -57,7 +57,7 @@ jobs:
 
       - name: Review pull request
         id: repopilot
-        uses: MykytaStel/repopilot@v0.17.0
+        uses: MykytaStel/repopilot@v0.18.0
         with:
           command: review
           version: ${{ inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,45 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-18
+
 ### Fixed
 
+- **`language.rust.panic-risk` no longer escalates a literal
+  `Regex::new("…")`/`Selector::parse("…")` to a visible High.** A regex or CSS
+  selector built from a string *literal* only fails on a malformed
+  compile-time pattern — a deterministic programmer error any test catches, not
+  a runtime panic risk from external input — yet on scraper-shaped files the
+  context-driven escalation pushed these to a **visible High**. A structural
+  syntax-tree check now skips an `unwrap`/`expect` chained onto a literal
+  `Regex::new`/`Selector::parse` (handling the multi-line
+  `Regex::new(\n    r"…",\n).unwrap()` form the previous text heuristic could
+  not see); a pattern built from a runtime value still stays a panic risk.
+- **`architecture.dead-module` no longer claims High confidence on monorepo
+  files whose importers it cannot resolve.** The "nothing imports this file"
+  safety-net only weakened its claim on unresolved *relative* imports, so a
+  workspace/monorepo whose internal imports are absolute or package-style
+  (`from app.services import x`, the `@/…` path alias, multi-crate Rust paths)
+  looked like a fully-resolved graph and every unreferenced file was reported at
+  **High**. The resolver now also records an unresolved import as graph-incomplete
+  evidence when it is a recognized alias or its leading segment names a directory
+  that actually exists in the repository — a workspace package it could not wire
+  up — while genuine third-party packages (`react`, `numpy`) stay out. With the
+  graph provably incomplete the finding drops to **Low** confidence (the prior
+  demotion silently collapsed back to High because `Medium` is the registry's
+  "use the default" sentinel), and it is suppressed entirely when an unresolved
+  import's final path or dotted segment matches the candidate file's name. On a
+  sampled monorepo this moved 61 dead-module findings from High to Low; a cleanly
+  resolved repository is unaffected and keeps High-confidence claims. Resolved
+  edges (cycles, fan-out) are unchanged — only absence claims are weakened.
+- **Rust production modules named `test_*.rs`/`*_test.rs` are no longer silently
+  dropped from the scan.** The low-signal path filter applied the singular
+  `test_`/`_test` name conventions (Python/Go/JS) to `.rs` files too, so ordinary
+  Rust modules such as `test_edges.rs` and `source_without_test.rs` were excluded
+  from every audit and from the import graph — matching the gap the refined
+  `is_test_file` already closed. For `.rs` files only the plural Rust forms
+  (`tests.rs`, `*_tests.rs`) and the `tests/` directory now mark a file as
+  low-signal; non-Rust conventions are unchanged.
 - **`security.secret-candidate` no longer flags shell expansions or
   inline-test fixtures.** A value that is a shell command substitution
   (`token="$(...)"`, backticks) or a variable expansion is a captured value,
@@ -83,6 +120,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Imports gated by `#[cfg(test)]` are kept out of the import graph entirely, so
   test-only `use` statements can no longer form phantom
   `architecture.circular-dependency` edges between production modules.
+- `architecture.deep-directory-nesting` now measures nesting depth relative to
+  the scan root, so scanning a repository by an absolute path no longer counts
+  the directories above the repository and over-reports every file as deeply
+  nested.
 
 ### Changed
 
@@ -93,32 +134,6 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   declared by the repository's own manifests. Explicit `[architecture]
   package_roots` still take priority and keep the Medium default confidence;
   with neither a workspace nor config the rule stays silent. A non-workspace repository (including RepoPilot itself) is unaffected.
-
-### Added
-
-- Added `code-quality.complex-function` (preview): a per-function cognitive-complexity rule that weights **nesting depth** rather than counting
-  branches flatly. A deeply nested handler is flagged while a wide-but-flat
-  `switch`/`match` dispatcher is not — the case where the file-level
-  `code-quality.complex-file` over-reports. Nested closures are scored
-  independently rather than folded into their enclosing function. Hidden in the
-  default profile (a strict-mode maintainability suggestion); threshold is
-  configurable via `[code_quality] complex_function_threshold` (default 15, the
-  conventional cognitive-complexity limit). `complex-file` is unchanged. Ships
-  with true-positive/false-positive fixtures.
-- The dependency graph now models workspace packages as first-class `Package` nodes. The builder detects npm/yarn, pnpm, Cargo, and Go (`go.work`) workspaces and records which package each file belongs to (by longest path
-  prefix), so future rules can reason about real package boundaries instead of
-  path globs. A non-workspace repository produces no package nodes and leaves
-  the graph unchanged. Internal only for now — no command consumes it yet.
-- Added a published [rules reference](docs/rules-reference.md) generated
-  straight from the rule registry: every rule's id, category, default
-  severity/confidence, lifecycle, signal source, recommendation, and known
-  false positives. A drift test (`tests/rules_reference_doc.rs`) re-renders it
-  in memory and fails if the committed file falls behind the code, so the
-  catalog cannot drift from what actually ships. Regenerate with
-  `REPOPILOT_BLESS=1 cargo test --test rules_reference_doc`.
-
-### Changed
-
 - Configuration discovery now walks up from the current directory to the git
   root (stopping at `.git` or the filesystem root) looking for `repopilot.toml`,
   so running RepoPilot from a subdirectory picks up the repository's config
@@ -209,12 +224,28 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Internal: documented the test-fixture families and how to add/update them in
   `tests/fixtures/README.md`.
 
-### Fixed
+### Added
 
-- `architecture.deep-directory-nesting` now measures nesting depth relative to
-  the scan root, so scanning a repository by an absolute path no longer counts
-  the directories above the repository and over-reports every file as deeply
-  nested.
+- Added `code-quality.complex-function` (preview): a per-function cognitive-complexity rule that weights **nesting depth** rather than counting
+  branches flatly. A deeply nested handler is flagged while a wide-but-flat
+  `switch`/`match` dispatcher is not — the case where the file-level
+  `code-quality.complex-file` over-reports. Nested closures are scored
+  independently rather than folded into their enclosing function. Hidden in the
+  default profile (a strict-mode maintainability suggestion); threshold is
+  configurable via `[code_quality] complex_function_threshold` (default 15, the
+  conventional cognitive-complexity limit). `complex-file` is unchanged. Ships
+  with true-positive/false-positive fixtures.
+- The dependency graph now models workspace packages as first-class `Package` nodes. The builder detects npm/yarn, pnpm, Cargo, and Go (`go.work`) workspaces and records which package each file belongs to (by longest path
+  prefix), so future rules can reason about real package boundaries instead of
+  path globs. A non-workspace repository produces no package nodes and leaves
+  the graph unchanged. Internal only for now — no command consumes it yet.
+- Added a published [rules reference](docs/rules-reference.md) generated
+  straight from the rule registry: every rule's id, category, default
+  severity/confidence, lifecycle, signal source, recommendation, and known
+  false positives. A drift test (`tests/rules_reference_doc.rs`) re-renders it
+  in memory and fails if the committed file falls behind the code, so the
+  catalog cannot drift from what actually ships. Regenerate with
+  `REPOPILOT_BLESS=1 cargo test --test rules_reference_doc`.
 
 ## [0.17.0] - 2026-06-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repopilot"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repopilot"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 description = "Local-first CLI for reviewing Git changes, security boundaries, and blast radius before merge."
 license = "MIT OR Apache-2.0"

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ inputs:
   version:
     description: "GitHub Release version to install and checksum-verify."
     required: false
-    default: "0.17.0"
+    default: "0.18.0"
   upload-sarif:
     description: "Automatically upload SARIF output to GitHub Code Scanning"
     required: false

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -108,7 +108,7 @@ Use the reusable workflow:
 ```yaml
 jobs:
   repopilot:
-    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.17.0
+    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.18.0
     with:
       fail-on-review: none
       upload-sarif: false
@@ -117,7 +117,7 @@ jobs:
 Or use the Action directly:
 
 ```yaml
-- uses: MykytaStel/repopilot@v0.17.0
+- uses: MykytaStel/repopilot@v0.18.0
   with:
     command: review
     scope: changed

--- a/docs/integrations/github-code-scanning.md
+++ b/docs/integrations/github-code-scanning.md
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   review:
-    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.17.0
+    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.18.0
     with:
       fail-on-review: definitely
       fail-on-priority: p1
@@ -42,7 +42,7 @@ This default is read-only and works for fork PRs. It does not use
 
 - name: RepoPilot review
   id: repopilot
-  uses: MykytaStel/repopilot@v0.17.0
+  uses: MykytaStel/repopilot@v0.18.0
   with:
     command: review
     scope: changed
@@ -69,7 +69,7 @@ permissions:
   security-events: write
 
 steps:
-  - uses: MykytaStel/repopilot@v0.17.0
+  - uses: MykytaStel/repopilot@v0.18.0
     with:
       command: review
       upload-sarif: "true"
@@ -97,7 +97,7 @@ permissions:
   pull-requests: write
 
 steps:
-  - uses: MykytaStel/repopilot@v0.17.0
+  - uses: MykytaStel/repopilot@v0.18.0
     with:
       command: review
       comment: "true"

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -44,7 +44,7 @@ This production file is not imported by any other project file and is not a know
 
 **Recommendation:** Remove the file if it is no longer used, or ensure it is exported in the package's public API.
 
-**Known false positives:** Dynamic imports, dependency injection, and build-tool aliases create importers the graph cannot see. When the repository contains unresolved relative imports the finding is reported at Medium confidence, and it is suppressed when an unresolved import matches the candidate file's name.
+**Known false positives:** Dynamic imports, dependency injection, and build-tool aliases create importers the graph cannot see. When the repository contains unresolved internal imports (relative paths, aliases, or workspace-package imports the resolver cannot wire up — common in monorepos) the finding is reported at Low confidence, and it is suppressed when an unresolved import matches the candidate file's name.
 
 ### `architecture.deep-directory-nesting` — Deep directory nesting detected
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repopilot",
-	"version": "0.17.0",
+	"version": "0.18.0",
 	"description": "Local-first CLI for reviewing Git changes, security boundaries, and blast radius before merge.",
 	"license": "MIT OR Apache-2.0",
 	"repository": {
@@ -29,11 +29,11 @@
 		"LICENSE"
 	],
 	"optionalDependencies": {
-		"@repopilot/darwin-arm64": "0.17.0",
-		"@repopilot/darwin-x64": "0.17.0",
-		"@repopilot/linux-arm64-gnu": "0.17.0",
-		"@repopilot/linux-x64-gnu": "0.17.0",
-		"@repopilot/win32-x64-msvc": "0.17.0"
+		"@repopilot/darwin-arm64": "0.18.0",
+		"@repopilot/darwin-x64": "0.18.0",
+		"@repopilot/linux-arm64-gnu": "0.18.0",
+		"@repopilot/linux-x64-gnu": "0.18.0",
+		"@repopilot/win32-x64-msvc": "0.18.0"
 	},
 	"keywords": [
 		"cli",

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -133,10 +133,12 @@ impl GraphQueriesAudit {
 /// package's public API surface is likely dead code.
 ///
 /// "Nothing imports this file" is an absence claim, so it is only as good as
-/// the import graph: an unresolved relative import whose final segment matches
+/// the import graph: an unresolved internal import whose final segment matches
 /// this file's name could well be the missing importer (skip entirely), and
-/// any other unresolved relative import still means the graph is incomplete
-/// (report at `Medium` instead of the registry's `High`).
+/// any other unresolved internal import still means the graph is incomplete
+/// (report at `Medium` instead of the registry's `High`). Internal imports
+/// include relative paths, recognized aliases, and bare imports that target a
+/// repository directory — the monorepo/workspace shapes the resolver misses.
 fn dead_module_finding(
     info: &NodeInfo,
     fan_in: Option<usize>,
@@ -179,14 +181,17 @@ fn dead_module_finding(
     }
 
     let mut snippet = "fan_in=0, role=Production, entrypoint=false".to_string();
+    // `Confidence::Medium` is the "unset, use the registry default" sentinel in
+    // `populate_rule_metadata`, so a contextual demotion must use `Low` to
+    // survive — otherwise the High default is restored and the demotion is lost.
     let confidence = if resolution.is_empty() {
         Confidence::High
     } else {
         snippet.push_str(&format!(
-            " ({} unresolved relative import(s) in the repository — the import graph may be incomplete)",
+            " ({} unresolved internal import(s) in the repository — the import graph may be incomplete)",
             resolution.total()
         ));
-        Confidence::Medium
+        Confidence::Low
     };
 
     let mut finding = architecture_finding(

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -93,18 +93,19 @@ fn dead_module_exempts_entrypoints_public_api_and_imported_files() {
 }
 
 #[test]
-fn dead_module_is_demoted_to_medium_when_graph_has_unresolved_imports() {
+fn dead_module_is_demoted_to_low_when_graph_has_unresolved_imports() {
     let mut resolution = ImportResolutionStats::default();
     resolution.record(Path::new("src/other.ts"), "./missing-helper");
 
     let finding = dead_module_finding(&prod("src/orphan.ts"), Some(0), &resolution)
         .expect("dead module should still be reported when the graph is merely incomplete");
 
-    assert_eq!(finding.confidence, Confidence::Medium);
+    // `Low` (not the `Medium` sentinel) so the registry keeps the demotion.
+    assert_eq!(finding.confidence, Confidence::Low);
     assert!(
         finding.evidence[0]
             .snippet
-            .contains("unresolved relative import"),
+            .contains("unresolved internal import"),
         "snippet should explain the demotion: {}",
         finding.evidence[0].snippet
     );

--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -21,9 +21,10 @@ use crate::scan::path_classification::is_low_signal_audit_path;
 
 use self::finding::build_finding;
 use self::pattern::{
-    detect_pattern, is_external_failure_path, is_infallible_render_write_result_unwrap,
-    is_infallible_render_write_start, is_report_renderer_path,
-    is_structural_infallible_render_write_unwrap, should_ignore_contextual_panic_pattern,
+    detect_pattern, is_external_failure_path, is_infallible_literal_construction_unwrap,
+    is_infallible_render_write_result_unwrap, is_infallible_render_write_start,
+    is_report_renderer_path, is_structural_infallible_render_write_unwrap,
+    should_ignore_contextual_panic_pattern,
 };
 
 const RULE_ID: &str = "language.rust.panic-risk";
@@ -77,6 +78,14 @@ impl RustPanicRiskAudit {
                     if is_report_renderer_path(&file.path)
                         && is_structural_infallible_render_write_unwrap(*node, content)
                     {
+                        continue;
+                    }
+
+                    // A literal `Regex::new("…")`/`Selector::parse("…")` only fails
+                    // on a malformed compile-time pattern — a deterministic bug, not
+                    // a runtime panic risk — so skip it structurally (handles the
+                    // multi-line form the text heuristic below cannot).
+                    if is_infallible_literal_construction_unwrap(*node, content) {
                         continue;
                     }
 

--- a/src/audits/code_quality/rust_panic_risk/pattern.rs
+++ b/src/audits/code_quality/rust_panic_risk/pattern.rs
@@ -208,6 +208,87 @@ fn is_deserialize_call(lower: &str) -> bool {
     DESERIALIZE_CALLS.iter().any(|call| lower.contains(call))
 }
 
+/// True when `node` is a `Regex::new("literal").unwrap()` /
+/// `Selector::parse("literal").expect(...)`-style call: an `unwrap`/`expect`
+/// chained directly onto a constructor that only fails on a malformed pattern,
+/// where that pattern is a **string literal**. A literal regex/selector is fixed
+/// at authoring time — if it is malformed the program fails on its first run and
+/// any test catches it, so this is a deterministic programmer error, not a
+/// runtime panic risk from external input. The escalation that made these
+/// **visible High** on scraper-shaped files is context-driven, so it is not
+/// reached by the `is_external_failure_path` guards; this structural check skips
+/// the candidate outright, and because it walks the syntax tree it also handles
+/// the multi-line `Regex::new(\n    r"…",\n).unwrap()` form that the text-based
+/// [`should_ignore_contextual_panic_pattern`] heuristic cannot see.
+pub(super) fn is_infallible_literal_construction_unwrap(
+    node: tree_sitter::Node<'_>,
+    content: &str,
+) -> bool {
+    if node.kind() != "call_expression" {
+        return false;
+    }
+    let Some(function) = node.child_by_field_name("function") else {
+        return false;
+    };
+    if function.kind() != "field_expression" {
+        return false;
+    }
+    let Some(field) = function.child_by_field_name("field") else {
+        return false;
+    };
+    let Ok(method) = field.utf8_text(content.as_bytes()) else {
+        return false;
+    };
+    // `unwrap_err`/`expect_err` assert the *Err* arm — a literal constructor that
+    // succeeds would make those panic, so they are not infallible here.
+    if method != "unwrap" && method != "expect" {
+        return false;
+    }
+    let Some(receiver) = function.child_by_field_name("value") else {
+        return false;
+    };
+    is_literal_infallible_constructor_call(receiver, content)
+}
+
+/// True when `node` is `Regex::new(<string literal>)` or
+/// `Selector::parse(<string literal>)` (path-qualified forms such as
+/// `regex::Regex::new` are accepted). A non-literal first argument means the
+/// pattern is built at runtime and can genuinely fail, so it is left as a risk.
+fn is_literal_infallible_constructor_call(node: tree_sitter::Node<'_>, content: &str) -> bool {
+    const INFALLIBLE_LITERAL_CTORS: &[&str] = &["Regex::new", "Selector::parse"];
+
+    if node.kind() != "call_expression" {
+        return false;
+    }
+    let Some(callee) = node.child_by_field_name("function") else {
+        return false;
+    };
+    let Ok(callee_text) = callee.utf8_text(content.as_bytes()) else {
+        return false;
+    };
+    let callee_text = callee_text.trim();
+    let is_known_ctor = INFALLIBLE_LITERAL_CTORS
+        .iter()
+        .any(|ctor| callee_text == *ctor || callee_text.ends_with(&format!("::{ctor}")));
+    if !is_known_ctor {
+        return false;
+    }
+
+    let Some(arguments) = node.child_by_field_name("arguments") else {
+        return false;
+    };
+    let mut cursor = arguments.walk();
+    for child in arguments.children(&mut cursor) {
+        match child.kind() {
+            "(" | ")" | "," => continue,
+            "string_literal" | "raw_string_literal" => return true,
+            // The first real argument is not a literal: the pattern is dynamic.
+            _ => return false,
+        }
+    }
+    false
+}
+
 pub(super) fn is_infallible_render_write_start(path: &std::path::Path, trimmed: &str) -> bool {
     is_report_renderer_path(path)
         && (trimmed.starts_with("writeln!(") || trimmed.starts_with("write!("))

--- a/src/audits/code_quality/rust_panic_risk/tests.rs
+++ b/src/audits/code_quality/rust_panic_risk/tests.rs
@@ -166,6 +166,64 @@ fn ignores_valid_regex_expect_in_production_code() {
 }
 
 #[test]
+fn ignores_literal_regex_new_unwrap_in_production_code() {
+    // A literal regex is infallible by construction; the `.unwrap()` form (no
+    // "valid regex" message for the text heuristic to match) must still be
+    // skipped via the structural AST check.
+    let file = facts(
+        "src/scraper/extract.rs",
+        "let re = Regex::new(r\"\\d{4}\").unwrap();",
+        false,
+    );
+
+    let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn ignores_literal_selector_parse_expect_in_production_code() {
+    let file = facts(
+        "src/scraper/extract.rs",
+        "let sel = Selector::parse(\"div.price\").expect(\"selector\");",
+        false,
+    );
+
+    let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn ignores_multiline_literal_regex_new_unwrap() {
+    let file = facts(
+        "src/scraper/extract.rs",
+        "let re = Regex::new(\n    r\"^[a-z]+$\",\n).unwrap();",
+        false,
+    );
+
+    let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn keeps_dynamic_regex_new_unwrap_as_risk() {
+    // A regex built from a runtime value can genuinely fail to compile, so it
+    // stays a panic risk — only string-literal patterns are exempt.
+    let file = facts(
+        "src/scraper/extract.rs",
+        "let re = Regex::new(&pattern).unwrap();",
+        false,
+    );
+
+    let findings = RustPanicRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert!(findings[0].title.contains("unwrap()"));
+}
+
+#[test]
 fn ignores_mutex_poison_invariant_expect() {
     let file = facts(
         "src/state.rs",

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -47,6 +47,8 @@ pub fn build_coupling_graph_with_resolution(
         .map(|file| (resolver::normalize_path(&file.path), file.path.clone()))
         .collect();
     let known_files: HashSet<PathBuf> = known_file_by_normalized.keys().cloned().collect();
+    let repo_dirs =
+        resolution_stats::repo_directory_names(facts.files.iter().map(|file| file.path.as_path()));
 
     let mut edges: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
     let mut resolution = ImportResolutionStats::default();
@@ -70,8 +72,9 @@ pub fn build_coupling_graph_with_resolution(
                 // A file importing itself carries no dependency information.
                 Some(_) => {}
                 None => {
-                    if resolution_stats::is_relative_import(raw.trim()) {
-                        resolution.record(&source, raw.trim());
+                    let raw = raw.trim();
+                    if resolution_stats::is_unresolved_internal_import(raw, &repo_dirs) {
+                        resolution.record(&source, raw);
                     }
                 }
             }
@@ -315,6 +318,43 @@ impl CycleDfs<'_, '_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::scan::facts::{FileFacts, ScanFacts};
+
+    fn py(path: &str, imports: &[&str]) -> FileFacts {
+        FileFacts {
+            path: PathBuf::from(path),
+            language: Some("Python".to_string()),
+            non_empty_lines: 0,
+            branch_count: 0,
+            imports: imports.iter().map(|value| (*value).to_string()).collect(),
+            content: None,
+            has_inline_tests: false,
+        }
+    }
+
+    #[test]
+    fn records_unresolved_workspace_import_but_not_third_party() {
+        // A monorepo package import (`app.*` where `app/` is a real directory)
+        // that the resolver cannot wire up must be recorded so dead-module's
+        // absence claim is demoted; a genuine third-party import must not be.
+        let facts = ScanFacts {
+            root_path: PathBuf::from("/repo"),
+            files: vec![py(
+                "apps/ml/app/api.py",
+                &["app.enrichment.contract", "numpy", "fastapi"],
+            )],
+            ..ScanFacts::default()
+        };
+
+        let (_graph, resolution) = build_coupling_graph_with_resolution(&facts, Path::new("/repo"));
+
+        assert_eq!(
+            resolution.total(),
+            1,
+            "only the internal workspace import should be recorded"
+        );
+        assert!(resolution.could_target_stem("contract"));
+    }
 
     fn graph_from_edges(edges: &[(&str, &str)]) -> CouplingGraph {
         let mut edge_map: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();

--- a/src/graph/resolution_stats.rs
+++ b/src/graph/resolution_stats.rs
@@ -2,67 +2,142 @@
 //! coupling graph is built.
 //!
 //! Resolved edges are proof: a cycle or fan-out claim built on them holds no
-//! matter what else failed to resolve. *Unresolved relative* imports are the
+//! matter what else failed to resolve. *Unresolved internal* imports are the
 //! opposite — they mark places where the graph is provably incomplete, which
 //! weakens absence-based claims (dead modules, fan-in-derived instability).
-//! Bare/package imports are real external dependencies and are not recorded.
+//! Genuine third-party packages (`react`, `numpy`) are real external
+//! dependencies and are not recorded; only imports that *should* have resolved
+//! to a scanned file are — relative imports, recognized local path aliases, and
+//! bare imports whose leading segment names a directory that exists in the
+//! repository (a monorepo/workspace package the resolver did not wire up).
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ImportResolutionStats {
-    /// Unresolved relative (`./`, `../`) imports keyed by the importing file.
-    pub unresolved_relative_by_source: BTreeMap<PathBuf, Vec<String>>,
+    /// Unresolved internal imports keyed by the importing file.
+    pub unresolved_internal_by_source: BTreeMap<PathBuf, Vec<String>>,
 }
 
 impl ImportResolutionStats {
     pub fn record(&mut self, source: &Path, raw_import: &str) {
-        self.unresolved_relative_by_source
+        self.unresolved_internal_by_source
             .entry(source.to_path_buf())
             .or_default()
             .push(raw_import.to_string());
     }
 
     pub fn is_empty(&self) -> bool {
-        self.unresolved_relative_by_source.is_empty()
+        self.unresolved_internal_by_source.is_empty()
     }
 
     pub fn total(&self) -> usize {
-        self.unresolved_relative_by_source
+        self.unresolved_internal_by_source
             .values()
             .map(Vec::len)
             .sum()
     }
 
-    /// True when any unresolved import's final path segment (extension
-    /// stripped) matches `stem`. Such an import could plausibly target a file
-    /// with that name, so "nothing imports it" cannot be claimed for it.
+    /// True when any unresolved import could plausibly target a file named
+    /// `stem`, so "nothing imports it" cannot be claimed for it. Both the last
+    /// path segment (`./legacy/Utils.js` → `Utils`) and the last dotted segment
+    /// (Python `app.services.foo` → `foo`) are considered, since the path/module
+    /// separator differs by language.
     pub fn could_target_stem(&self, stem: &str) -> bool {
         if stem.is_empty() {
             return false;
         }
-        self.unresolved_relative_by_source
+        self.unresolved_internal_by_source
             .values()
             .flatten()
             .any(|import| {
-                import_stem(import).is_some_and(|candidate| candidate.eq_ignore_ascii_case(stem))
+                import_target_stems(import)
+                    .iter()
+                    .any(|candidate| candidate.eq_ignore_ascii_case(stem))
             })
     }
 }
 
-fn import_stem(raw_import: &str) -> Option<&str> {
+/// Candidate file stems an import could be referring to. A path import's target
+/// is its last `/`-segment with the extension stripped; a dotted module import's
+/// target is its last `.`-segment. Both are returned because `.` doubles as a
+/// file extension and a Python/JS module separator.
+fn import_target_stems(raw_import: &str) -> Vec<String> {
     let trimmed = raw_import.trim().trim_end_matches('/');
-    let last = trimmed.rsplit(['/', '\\']).next()?;
-    let stem = last.split('.').next().unwrap_or(last);
-    if stem.is_empty() || stem == ".." {
-        return None;
+    let last_path = trimmed.rsplit(['/', '\\']).next().unwrap_or(trimmed);
+
+    let mut stems = Vec::new();
+    // Path interpretation: strip a file extension (`Button.tsx` → `Button`).
+    if let Some(head) = last_path.split('.').next()
+        && !head.is_empty()
+        && head != ".."
+    {
+        stems.push(head.to_string());
     }
-    Some(stem)
+    // Dotted-module interpretation: the final segment (`app.services.foo`→`foo`).
+    if let Some(tail) = last_path.rsplit('.').next()
+        && !tail.is_empty()
+        && tail != ".."
+        && !stems.iter().any(|s| s == tail)
+    {
+        stems.push(tail.to_string());
+    }
+    stems
 }
 
 pub(crate) fn is_relative_import(import: &str) -> bool {
     import.starts_with("./") || import.starts_with("../")
+}
+
+/// Whether an unresolved import should weaken absence claims (dead module,
+/// instability). Relative imports and recognizable local path aliases always
+/// count; a bare import counts only when its leading segment names a directory
+/// that exists in `repo_dirs` — i.e. an internal monorepo/workspace package the
+/// resolver did not wire up — which keeps genuine third-party packages out.
+pub(crate) fn is_unresolved_internal_import(import: &str, repo_dirs: &HashSet<String>) -> bool {
+    let import = import.trim();
+    if import.is_empty() {
+        return false;
+    }
+    if is_relative_import(import) {
+        return true;
+    }
+    // Common bundler/tsconfig path aliases for the project's own source root.
+    if import.starts_with("@/") || import.starts_with("~/") || import == "~" {
+        return true;
+    }
+    leading_segment(import).is_some_and(|segment| repo_dirs.contains(segment))
+}
+
+/// The first non-empty segment of an import, splitting on every path/module
+/// separator used across the supported languages (`/`, `\`, `.`, `:`). For
+/// `app.services.x` this is `app`; for Rust `other_crate::module` it is
+/// `other_crate`; for `@angular/core` it is `@angular`.
+fn leading_segment(import: &str) -> Option<&str> {
+    import
+        .split(['/', '\\', '.', ':'])
+        .find(|segment| !segment.is_empty())
+}
+
+/// Directory names that appear anywhere in the scanned file paths. Used to tell
+/// an unresolved *internal* import apart from a third-party package.
+pub(crate) fn repo_directory_names<'a, I>(paths: I) -> HashSet<String>
+where
+    I: IntoIterator<Item = &'a Path>,
+{
+    let mut dirs = HashSet::new();
+    for path in paths {
+        let mut components: Vec<&str> = path
+            .components()
+            .filter_map(|component| component.as_os_str().to_str())
+            .collect();
+        components.pop(); // Drop the file name; keep only directory segments.
+        for component in components {
+            dirs.insert(component.to_string());
+        }
+    }
+    dirs
 }
 
 #[cfg(test)]
@@ -80,7 +155,7 @@ mod tests {
 
         assert!(!stats.is_empty());
         assert_eq!(stats.total(), 3);
-        assert_eq!(stats.unresolved_relative_by_source.len(), 2);
+        assert_eq!(stats.unresolved_internal_by_source.len(), 2);
     }
 
     #[test]
@@ -95,10 +170,13 @@ mod tests {
     }
 
     #[test]
-    fn import_stem_handles_trailing_slashes_and_parent_segments() {
-        assert_eq!(import_stem("./components/"), Some("components"));
-        assert_eq!(import_stem("../.."), None);
-        assert_eq!(import_stem("./mod.rs"), Some("mod"));
+    fn could_target_stem_matches_last_dotted_module_segment() {
+        let mut stats = ImportResolutionStats::default();
+        stats.record(Path::new("apps/web/main.py"), "app.services.foo");
+
+        assert!(stats.could_target_stem("foo"));
+        assert!(stats.could_target_stem("app"));
+        assert!(!stats.could_target_stem("services"));
     }
 
     #[test]
@@ -107,5 +185,53 @@ mod tests {
         assert!(is_relative_import("../a"));
         assert!(!is_relative_import("react"));
         assert!(!is_relative_import("@scope/pkg"));
+    }
+
+    #[test]
+    fn internal_import_classifier_separates_workspace_from_third_party() {
+        let repo_dirs: HashSet<String> = ["app", "components", "ml"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+
+        // Relative and aliased imports are always internal.
+        assert!(is_unresolved_internal_import("./helper", &repo_dirs));
+        assert!(is_unresolved_internal_import(
+            "@/components/Button",
+            &repo_dirs
+        ));
+        assert!(is_unresolved_internal_import("~/lib/util", &repo_dirs));
+        // Bare imports whose leading segment is a repo directory are internal.
+        assert!(is_unresolved_internal_import("app.ml.train", &repo_dirs));
+        assert!(is_unresolved_internal_import(
+            "components/Button",
+            &repo_dirs
+        ));
+        // Genuine third-party packages stay out.
+        assert!(!is_unresolved_internal_import("react", &repo_dirs));
+        assert!(!is_unresolved_internal_import("@angular/core", &repo_dirs));
+        assert!(!is_unresolved_internal_import("numpy", &repo_dirs));
+        assert!(!is_unresolved_internal_import(
+            "django.db.models",
+            &repo_dirs
+        ));
+    }
+
+    #[test]
+    fn repo_directory_names_collects_parent_segments_only() {
+        let paths = [
+            Path::new("apps/ml/app/train.py"),
+            Path::new("apps/web/src/index.ts"),
+        ];
+        let dirs = repo_directory_names(paths);
+
+        assert!(dirs.contains("apps"));
+        assert!(dirs.contains("ml"));
+        assert!(dirs.contains("app"));
+        assert!(dirs.contains("web"));
+        assert!(dirs.contains("src"));
+        // File names are not directories.
+        assert!(!dirs.contains("train"));
+        assert!(!dirs.contains("index"));
     }
 }

--- a/src/rules/registry/architecture.rs
+++ b/src/rules/registry/architecture.rs
@@ -149,9 +149,9 @@ pub(super) static RULES: &[RuleMetadata] = &[
         category: FindingCategory::Architecture,
         default_severity: Severity::Low,
         default_confidence: Confidence::High,
-        // Demoted to Medium when the repository has unresolved relative
-        // imports (the graph is provably incomplete); suppressed entirely when
-        // an unresolved import could plausibly target the candidate file.
+        // Demoted to Low when the repository has unresolved internal imports
+        // (the graph is provably incomplete); suppressed entirely when an
+        // unresolved import could plausibly target the candidate file.
         contextual_confidence: true,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::ImportGraph,
@@ -161,7 +161,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
             "Remove the file if it is no longer used, or ensure it is exported in the package's public API.",
         ),
         false_positive_notes: Some(
-            "Dynamic imports, dependency injection, and build-tool aliases create importers the graph cannot see. When the repository contains unresolved relative imports the finding is reported at Medium confidence, and it is suppressed when an unresolved import matches the candidate file's name.",
+            "Dynamic imports, dependency injection, and build-tool aliases create importers the graph cannot see. When the repository contains unresolved internal imports (relative paths, aliases, or workspace-package imports the resolver cannot wire up — common in monorepos) the finding is reported at Low confidence, and it is suppressed when an unresolved import matches the candidate file's name.",
         ),
         ..RuleMetadata::DEFAULT
     },

--- a/src/scan/path_classification.rs
+++ b/src/scan/path_classification.rs
@@ -41,6 +41,17 @@ fn has_test_like_file_name(path: &Path) -> bool {
         .and_then(|stem| stem.to_str())
         .unwrap_or_default();
 
+    // Rust test files use the `tests/` directory (caught by the component check),
+    // `#[cfg(test)]`, or the plural `tests.rs` / `*_tests.rs` names. The singular
+    // `test_*` / `*_test` patterns are Python/Go/JS conventions that collide with
+    // ordinary Rust production modules (`test_edges.rs`, `source_without_test.rs`),
+    // matching the refined `is_test_file`. Applying them here silently dropped
+    // those production files from the scan — and thus from every audit and the
+    // import graph — so for `.rs` files only the plural Rust forms qualify.
+    if name.ends_with(".rs") {
+        return name == "tests.rs" || name.ends_with("_tests.rs");
+    }
+
     stem == "test"
         || stem == "tests"
         || stem.ends_with("_test")
@@ -79,6 +90,44 @@ mod tests {
             assert!(
                 !is_low_signal_audit_path(Path::new(path)),
                 "{path} should remain eligible for medium audits"
+            );
+        }
+    }
+
+    #[test]
+    fn rust_singular_test_name_patterns_are_production() {
+        // `test_*` / `*_test` are not Rust test conventions; these are real
+        // production modules that must still be scanned and audited.
+        for path in [
+            "src/graph/test_edges.rs",
+            "src/audits/testing/source_without_test.rs",
+        ] {
+            assert!(
+                !is_low_signal_audit_path(Path::new(path)),
+                "{path} is a Rust production module and must not be low-signal"
+            );
+        }
+    }
+
+    #[test]
+    fn rust_plural_test_modules_remain_low_signal() {
+        for path in [
+            "src/audits/foo/tests.rs",
+            "src/audits/code_quality/behavioral_tests.rs",
+        ] {
+            assert!(
+                is_low_signal_audit_path(Path::new(path)),
+                "{path} is a Rust test module and should stay low-signal"
+            );
+        }
+    }
+
+    #[test]
+    fn non_rust_singular_test_names_remain_low_signal() {
+        for path in ["pkg/user_test.go", "app/test_helpers.py"] {
+            assert!(
+                is_low_signal_audit_path(Path::new(path)),
+                "{path} follows a non-Rust test convention and should stay low-signal"
             );
         }
     }


### PR DESCRIPTION
## Summary

Prepares RepoPilot `v0.18.0` and reduces several noisy audit false positives around Rust panic-risk detection, architecture dead-module confidence, Rust test-file classification, and deep directory nesting.

## Type of change

* [ ] Feature
* [ ] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [x] CI / repository maintenance

## What changed

* Bumped RepoPilot references from `0.17.0` to `0.18.0` across Cargo, npm package metadata, GitHub Action defaults, reusable workflow examples, and docs.
* Fixed `language.rust.panic-risk` so literal `Regex::new(...)` / `Selector::parse(...)` followed by `unwrap`/`expect` is not escalated as a runtime panic risk.
* Improved `architecture.dead-module` confidence handling for incomplete import graphs in monorepos/workspaces by treating unresolved internal imports as graph-incomplete evidence.
* Fixed Rust low-signal path filtering so production modules named `test_*.rs` or `*_test.rs` are still scanned.
* Updated rule documentation and changelog entries for the new release behavior.
* Added/updated tests for panic-risk handling, unresolved internal import classification, dead-module confidence demotion, and Rust test-file path classification.

## Why

This release reduces visible false positives in real repositories, especially scraper-like Rust code and monorepo/workspace projects where import resolution can be incomplete. It makes RepoPilot’s findings safer: absence-based architecture claims are weakened when the graph is incomplete, while genuinely resolved graph findings remain unchanged.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] No unrelated refactor or generated-file churn is included

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
