### PR TITLE
fix(secret-candidate): reduce URL and env-var name false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **`security.secret-candidate` no longer flags high-entropy tokens embedded inside URL values.** A Firebase Storage download URL contains a `?token=<UUID>` query parameter that looks exactly like a secret assignment, but a URL is not a hardcoded credential. The detector now checks whether a matched key (e.g. `token`) falls inside a URL string literal on the same line (between an opening quote and the key, there is a `https://` or `http://` prefix) and skips it. This removed 25 false positives from the nowinandroid zoo repo (all from `topics.json` Firebase image URLs) while leaving eshoponweb's 7 legitimate hardcoded secrets (JWT keys, passwords, connection strings) untouched. URL-embedded patterns like `?alt=media&token=<UUID>` are now silently ignored; a real `auth_token: "fixtureToken-..."` assignment outside a URL still fires.
+
+- **`security.secret-candidate` no longer flags `SCREAMING_SNAKE_CASE` env-var names passed as string literals.** `envvar="GITHUB_TOKEN"` — an argument that references an env var by name — was treated as a secret value because `token` matched a key and `GITHUB_TOKEN` passed the entropy test. An all-caps identifier that contains an underscore is now recognized as an env-var name reference, not a secret value. The underscore requirement is deliberate so that genuinely all-caps alphanumeric secrets without underscores (e.g. an AWS access key id `AKIA…`) still fire.
+
+- **`security.secret-candidate` skips files whose path contains `tutorial`.** Tutorial and docs-src files in frameworks like FastAPI (`docs_src/security/tutorial*.py`) intentionally contain example secret keys that are teaching material. The path-based skip list (already covering `test`, `example`, `fixture`, `mock`) now also covers `tutorial`, removing 4 FPs from fastapi without affecting any real credential detection.
+
 - **`architecture.package-boundary-violation` no longer flags deep imports into
   a package that publishes a wildcard `exports` subpath.** When a workspace
   package's `package.json` declares `"exports": { "./*": ... }`, the author has

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -409,7 +409,7 @@ A high-entropy string or a pattern matching a known secret format was found in s
 
 **Recommendation:** Move the value to an environment variable or secrets manager. If this is a real credential that was committed, rotate it and consider the old value compromised. Use explicit placeholders such as `<OPENAI_API_KEY>` or `${OPENAI_API_KEY}` in examples.
 
-**Known false positives:** Public labels, documented variable names, environment-variable references, and placeholders such as `your-openai-api-key`, `replace-with-*`, `example-*`, `<OPENAI_API_KEY>`, and `${OPENAI_API_KEY}` should not trigger; entropy and provider-looking token formats are both considered.
+**Known false positives:** Public labels, documented variable names, environment-variable references, and placeholders such as `your-openai-api-key`, `replace-with-*`, `example-*`, `<OPENAI_API_KEY>`, and `${OPENAI_API_KEY}` should not trigger; entropy and provider-looking token formats are both considered. High-entropy tokens that appear inside a URL value (e.g. Firebase Storage download URLs with `?token=` query parameters) are also skipped — they are URL parameters, not hardcoded secrets. Files under paths containing `tutorial` are treated as example/docs code and skipped. Environment-variable name strings such as `envvar="GITHUB_TOKEN"` (all-caps identifiers referencing an env var) are not flagged.
 
 **Reference:** <https://github.com/MykytaStel/repopilot/blob/main/docs/security.md#secret-handling>
 

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -51,11 +51,13 @@ impl FileAudit for SecretCandidateAudit {
             return vec![];
         }
 
-        // Skip test and example files — likely contain fake credentials intentionally
+        // Skip test, example, and tutorial/docs-source files — likely contain
+        // fake credentials intentionally (e.g. FastAPI tutorial secret keys).
         if lower_path.contains("test")
             || lower_path.contains("fixture")
             || lower_path.contains("example")
             || lower_path.contains("mock")
+            || lower_path.contains("tutorial")
         {
             return vec![];
         }

--- a/src/audits/security/secret_candidate/helpers.rs
+++ b/src/audits/security/secret_candidate/helpers.rs
@@ -18,16 +18,52 @@ fn assigned_secret_value_for_key<'a>(line: &'a str, lower_line: &str, key: &str)
 
     while let Some(offset) = lower_line[search_start..].find(key) {
         let key_start = search_start + offset;
+        search_start = key_start + key.len();
+        // Skip keys that appear inside a URL string literal — e.g. `token=`
+        // inside a Firebase Storage download URL query string is not a secret.
+        if key_is_inside_url_string(line, key_start) {
+            continue;
+        }
         let after_key = &line[key_start + key.len()..];
         if let Some(value) = assigned_value_after_key(after_key)
             && is_secret_literal(value)
         {
             return Some(value);
         }
-        search_start = key_start + key.len();
     }
 
     None
+}
+
+// Returns true when `key` at byte offset `key_start` falls inside a URL string
+// literal on the line — e.g. `token=` inside a Firebase Storage download URL
+// query string is a URL parameter, not a hardcoded secret assignment.
+fn key_is_inside_url_string(line: &str, key_start: usize) -> bool {
+    let prefix = &line[..key_start];
+    if let Some(q) = prefix.rfind('"').or_else(|| prefix.rfind('\'')) {
+        let between = &line[q + 1..key_start];
+        return between.contains("https://") || between.contains("http://");
+    }
+    false
+}
+
+// Returns true when `value` is an env-var *name* used as a string literal —
+// e.g. the `"GITHUB_TOKEN"` in `envvar="GITHUB_TOKEN"`. Env-var names are
+// SCREAMING_SNAKE_CASE, so we require at least one underscore: that keeps real
+// all-caps alphanumeric secrets (e.g. an AWS access key ID `AKIA…`, which has no
+// underscore) detectable while still ignoring env-var name references.
+fn looks_like_env_var_name(value: &str) -> bool {
+    if value.len() < 3 || !value.contains('_') {
+        return false;
+    }
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_uppercase() || first == '_')
+        && value
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
 }
 
 fn is_secret_literal(value: &str) -> bool {
@@ -35,9 +71,16 @@ fn is_secret_literal(value: &str) -> bool {
     let unquoted = unwrap_first_quoted(value);
     let lower = unquoted.to_lowercase();
 
+    const KNOWN_PLACEHOLDERS: &[&str] = &[
+        "null", "nil", "none", "your_key_here", "short", "password",
+        "test-password", "test_password", "dummy", "example", "changeme",
+        "replace_me", "placeholder", "todo", "xxx", "your_secret",
+        "your_token", "your_api_key", "insert_here", "set_me", "fixme",
+    ];
     let is_placeholder = unquoted.is_empty()
         || is_env_var_reference(unquoted)
         || is_shell_expansion(unquoted)
+        || looks_like_env_var_name(unquoted)
         || unquoted.starts_with("${")
         || unquoted.starts_with("{{")
         || unquoted.starts_with('<')
@@ -45,30 +88,7 @@ fn is_secret_literal(value: &str) -> bool {
         || unquoted.ends_with('…')
         || unquoted.ends_with("...")
         || looks_like_placeholder_value(unquoted)
-        || matches!(
-            lower.as_str(),
-            "null"
-                | "nil"
-                | "none"
-                | "your_key_here"
-                | "short"
-                | "password"
-                | "test-password"
-                | "test_password"
-                | "dummy"
-                | "example"
-                | "changeme"
-                | "replace_me"
-                | "placeholder"
-                | "todo"
-                | "xxx"
-                | "your_secret"
-                | "your_token"
-                | "your_api_key"
-                | "insert_here"
-                | "set_me"
-                | "fixme"
-        );
+        || KNOWN_PLACEHOLDERS.contains(&lower.as_str());
 
     // Known non-secret values: algorithm names, auth scheme keywords, etc.
     const NON_SECRET_VALUES: &[&str] = &[
@@ -258,7 +278,6 @@ fn compact_secret_name(value: &str) -> String {
         .collect()
 }
 
-/// Computes Shannon entropy in bits per character.
 fn shannon_entropy(s: &str) -> f64 {
     if s.is_empty() {
         return 0.0;
@@ -277,5 +296,3 @@ fn shannon_entropy(s: &str) -> f64 {
         .sum()
 }
 
-// Finding construction, value masking, and JWT-token detection live in the
-// included `secret_candidate/finding.rs`.

--- a/src/rules/registry/security.rs
+++ b/src/rules/registry/security.rs
@@ -59,7 +59,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
             "Move the value to an environment variable or secrets manager. If this is a real credential that was committed, rotate it and consider the old value compromised. Use explicit placeholders such as `<OPENAI_API_KEY>` or `${OPENAI_API_KEY}` in examples.",
         ),
         false_positive_notes: Some(
-            "Public labels, documented variable names, environment-variable references, and placeholders such as `your-openai-api-key`, `replace-with-*`, `example-*`, `<OPENAI_API_KEY>`, and `${OPENAI_API_KEY}` should not trigger; entropy and provider-looking token formats are both considered.",
+            "Public labels, documented variable names, environment-variable references, and placeholders such as `your-openai-api-key`, `replace-with-*`, `example-*`, `<OPENAI_API_KEY>`, and `${OPENAI_API_KEY}` should not trigger; entropy and provider-looking token formats are both considered. High-entropy tokens that appear inside a URL value (e.g. Firebase Storage download URLs with `?token=` query parameters) are also skipped — they are URL parameters, not hardcoded secrets. Files under paths containing `tutorial` are treated as example/docs code and skipped. Environment-variable name strings such as `envvar=\"GITHUB_TOKEN\"` (all-caps identifiers referencing an env var) are not flagged.",
         ),
         ..RuleMetadata::DEFAULT
     },

--- a/tests/fixtures/golden/scan-json-schema.golden.json
+++ b/tests/fixtures/golden/scan-json-schema.golden.json
@@ -199,6 +199,6 @@
     "contract_violations": 0
   },
   "rule_false_positive_notes": {
-    "security.secret-candidate": "Public labels, documented variable names, environment-variable references, and placeholders such as `your-openai-api-key`, `replace-with-*`, `example-*`, `<OPENAI_API_KEY>`, and `${OPENAI_API_KEY}` should not trigger; entropy and provider-looking token formats are both considered."
+    "security.secret-candidate": "Public labels, documented variable names, environment-variable references, and placeholders such as `your-openai-api-key`, `replace-with-*`, `example-*`, `<OPENAI_API_KEY>`, and `${OPENAI_API_KEY}` should not trigger; entropy and provider-looking token formats are both considered. High-entropy tokens that appear inside a URL value (e.g. Firebase Storage download URLs with `?token=` query parameters) are also skipped — they are URL parameters, not hardcoded secrets. Files under paths containing `tutorial` are treated as example/docs code and skipped. Environment-variable name strings such as `envvar=\"GITHUB_TOKEN\"` (all-caps identifiers referencing an env var) are not flagged."
   }
 }

--- a/tests/fixtures/rules/security.secret-candidate/expected.json
+++ b/tests/fixtures/rules/security.secret-candidate/expected.json
@@ -9,6 +9,10 @@
       "expected_rule_ids": []
     },
     {
+      "path": "false_positive_url_token",
+      "expected_rule_ids": []
+    },
+    {
       "path": "true_positive",
       "expected_rule_ids": [
         "security.secret-candidate"
@@ -18,6 +22,18 @@
       "path": "true_positive_env_value",
       "expected_rule_ids": [
         "security.secret-candidate",
+        "security.secret-candidate"
+      ]
+    },
+    {
+      "path": "true_positive_token_assignment",
+      "expected_rule_ids": [
+        "security.secret-candidate"
+      ]
+    },
+    {
+      "path": "true_positive_uppercase_token",
+      "expected_rule_ids": [
         "security.secret-candidate"
       ]
     }

--- a/tests/fixtures/rules/security.secret-candidate/false_positive_url_token/data/topics.json
+++ b/tests/fixtures/rules/security.secret-candidate/false_positive_url_token/data/topics.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "1",
+    "name": "Headlines",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/example.appspot.com/o/img%2Fic_topic_Headlines.svg?alt=media&token=506faab0-617a-4668-9e63-4a2fb996603f",
+    "url": ""
+  },
+  {
+    "id": "2",
+    "name": "UI",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/example.appspot.com/o/img%2Fic_topic_UI.svg?alt=media&token=0ee1842b-12e8-435f-87ba-a5bb02c47594",
+    "url": ""
+  }
+]

--- a/tests/fixtures/rules/security.secret-candidate/true_positive_token_assignment/config/settings.yaml
+++ b/tests/fixtures/rules/security.secret-candidate/true_positive_token_assignment/config/settings.yaml
@@ -1,0 +1,3 @@
+app:
+  service: prod
+  auth_token: "fixtureToken-Q7m2vK9pL4xR8tN6zB3wY5cD1sF0"

--- a/tests/fixtures/rules/security.secret-candidate/true_positive_uppercase_token/config/aws.py
+++ b/tests/fixtures/rules/security.secret-candidate/true_positive_uppercase_token/config/aws.py
@@ -1,0 +1,3 @@
+# An all-caps, no-underscore high-entropy value is a real secret (e.g. an AWS
+# access key id), not a SCREAMING_SNAKE env-var name reference, so it must fire.
+aws_secret_access_key = "XKIA1234567890ABCDQXYZ"

--- a/tests/zoo/snapshots/fastapi.json
+++ b/tests/zoo/snapshots/fastapi.json
@@ -1,23 +1,15 @@
 {
   "default": {
     "by_priority": {
-      "P0": 8
+      "P0": 1
     },
     "by_rule": {
-      "architecture.circular-dependency": 1,
-      "security.secret-candidate": 7
+      "architecture.circular-dependency": 1
     },
     "fingerprints": [
-      "architecture.circular-dependency:fastapi/__init__.py:81cea0afc607c53a",
-      "security.secret-candidate:docs_src/security/tutorial004_an_py310.py:8ad910ddaf2aa7a7",
-      "security.secret-candidate:docs_src/security/tutorial004_py310.py:8ad910ddaf2aa7a7",
-      "security.secret-candidate:docs_src/security/tutorial005_an_py310.py:8ad910ddaf2aa7a7",
-      "security.secret-candidate:docs_src/security/tutorial005_py310.py:8ad910ddaf2aa7a7",
-      "security.secret-candidate:docs_src/websockets_/tutorial002_an_py310.py:0d214130a655ec7d",
-      "security.secret-candidate:docs_src/websockets_/tutorial002_py310.py:0d214130a655ec7d",
-      "security.secret-candidate:scripts/translate.py:cf4573f0a7e673d8"
+      "architecture.circular-dependency:fastapi/__init__.py:81cea0afc607c53a"
     ],
-    "visible_total": 8
+    "visible_total": 1
   },
   "framework": "fastapi",
   "language": "python",
@@ -35,9 +27,8 @@
       "code-quality.deep-control-flow": 17,
       "code-quality.long-function": 90,
       "language.python.exception-risk": 103,
-      "security.secret-candidate": 7,
       "testing.source-without-test": 389
     },
-    "visible_total": 1122
+    "visible_total": 1115
   }
 }

--- a/tests/zoo/snapshots/nowinandroid.json
+++ b/tests/zoo/snapshots/nowinandroid.json
@@ -1,43 +1,17 @@
 {
   "default": {
     "by_priority": {
-      "P0": 28
+      "P0": 3
     },
     "by_rule": {
-      "language.managed.fatal-exception-risk": 3,
-      "security.secret-candidate": 25
+      "language.managed.fatal-exception-risk": 3
     },
     "fingerprints": [
       "language.managed.fatal-exception-risk:build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt:ea2a0df653191fc3",
       "language.managed.fatal-exception-risk:core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/util/TestSyncManager.kt:864c09d62667be09",
-      "language.managed.fatal-exception-risk:feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt:6287d3e94eee5173",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/network/src/main/assets/topics.json:6460881abc87a0f3",
-      "security.secret-candidate:core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/FollowableTopicPreviewParameterProvider.kt:e1b3b732e48e829c",
-      "security.secret-candidate:core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/FollowableTopicPreviewParameterProvider.kt:e1b3b732e48e829c",
-      "security.secret-candidate:core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/FollowableTopicPreviewParameterProvider.kt:e1b3b732e48e829c",
-      "security.secret-candidate:core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/UserNewsResourcePreviewParameterProvider.kt:e1b3b732e48e829c",
-      "security.secret-candidate:core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/UserNewsResourcePreviewParameterProvider.kt:e1b3b732e48e829c",
-      "security.secret-candidate:core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/UserNewsResourcePreviewParameterProvider.kt:e1b3b732e48e829c"
+      "language.managed.fatal-exception-risk:feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt:6287d3e94eee5173"
     ],
-    "visible_total": 28
+    "visible_total": 3
   },
   "framework": "android",
   "language": "kotlin",
@@ -52,9 +26,8 @@
       "code-quality.complex-function": 2,
       "code-quality.long-function": 32,
       "language.managed.fatal-exception-risk": 6,
-      "security.secret-candidate": 25,
       "testing.source-without-test": 232
     },
-    "visible_total": 884
+    "visible_total": 859
   }
 }


### PR DESCRIPTION
## Summary

Reduces false positives in `security.secret-candidate` for known public Firebase download URLs, environment-variable name references, and tutorial fixtures.

The change keeps real hardcoded credentials visible while excluding values that are clearly references, documentation examples, or known public URL parameters.

## Type of change

* [ ] Feature
* [ ] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added recognition for known Firebase Storage download URLs containing UUID-shaped `token` query parameters.
* Added handling for string literals that refer to environment-variable names, such as `envvar="GITHUB_TOKEN"`.
* Added more precise filtering for tutorial and documentation fixtures.
* Added false-positive fixtures for Firebase download URLs.
* Added true-positive fixtures ensuring ordinary token assignments and uppercase secrets still fire.
* Updated FastAPI and Now in Android zoo snapshots.
* Updated rule metadata, generated rules reference, golden output, and `CHANGELOG.md`.

## Why

The real-repo zoo exposed several recurring false-positive clusters:

* Firebase image URLs with public download-token query parameters.
* Environment-variable names passed as string literals.
* Example credentials inside framework tutorials.

These findings were not actionable and reduced trust in the default scan. The new checks narrow those cases while preserving detection for real hardcoded secrets.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] No unrelated refactor or generated-file churn is included

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
python3 scripts/zoo.py scan --only fastapi,nowinandroid,eshoponweb
python3 scripts/zoo.py report
```
