### PR TITLE
fix(js): ignore process exits in verified CLI entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- **`language.javascript.runtime-exit-risk` no longer flags `process.exit(...)`
+  in CLI command modules.** A `process.exit` inside a `commands/` module or a
+  `bin/` script is the intended exit boundary of a CLI tool — exactly what the
+  rule's own guidance ("keep process exits at a CLI boundary") asks for — not a
+  hazard buried in reusable code. The expected-entrypoint check now covers any
+  `commands/`-segment path and any `bin/` script (dropping the prior strict
+  shebang requirement), while a `process.exit` in ordinary library code still
+  fires at High. Measured on the real-repo zoo, this took the `ignite` CLI from
+  9 default-visible findings (all `src/commands/*.ts`) to 0, with the 3
+  non-command-module exits retained under `--profile strict`.
+
 - **`language.python.exception-risk` no longer surfaces `assert` and `raise
   NotImplementedError` by default.** An `assert` (commonly type-narrowing or an
   internal invariant) and `raise NotImplementedError` (the idiomatic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,20 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
-- **`language.javascript.runtime-exit-risk` no longer flags `process.exit(...)`
-  in CLI command modules.** A `process.exit` inside a `commands/` module or a
-  `bin/` script is the intended exit boundary of a CLI tool — exactly what the
-  rule's own guidance ("keep process exits at a CLI boundary") asks for — not a
-  hazard buried in reusable code. The expected-entrypoint check now covers any
-  `commands/`-segment path and any `bin/` script (dropping the prior strict
-  shebang requirement), while a `process.exit` in ordinary library code still
-  fires at High. Measured on the real-repo zoo, this took the `ignite` CLI from
-  9 default-visible findings (all `src/commands/*.ts`) to 0, with the 3
-  non-command-module exits retained under `--profile strict`.
+- **`language.javascript.runtime-exit-risk` downgrades `process.exit(...)` in a
+  CLI tool's own source instead of surfacing it as a default High.** A package
+  that declares an executable (`package.json#bin`, or a Cargo `[[bin]]`/`src/bin`
+  target) is a CLI tool, so a `process.exit` anywhere in its source is the
+  intended exit boundary the rule's own guidance asks for — not a hazard in
+  reusable code. The scanner now records, per file, whether it belongs to such a
+  package (new `cli-executable` role) and the knowledge pack **downgrades the
+  finding to Low** for that role — hidden in the default profile, still shown
+  under `--profile strict` — rather than suppressing it in the detector, so the
+  signal stays recoverable. Crucially this is keyed off the package manifest, not
+  a path: a `process.exit` in a non-CLI package's `domain/commands/` (a
+  CQRS-style command, no declared `bin`) keeps its default-visible High. Measured
+  on the real-repo zoo, this took the `ignite` CLI from 9 default-visible
+  findings to 0 (all 12 retained as Low in strict) and `changesets` from 2 to 1.
 
 - **`language.python.exception-risk` no longer surfaces `assert` and `raise
   NotImplementedError` by default.** An `assert` (commonly type-narrowing or an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,21 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Changed
 
 - **`language.javascript.runtime-exit-risk` downgrades `process.exit(...)` in a
-  CLI tool's own source instead of surfacing it as a default High.** A package
-  that declares an executable (`package.json#bin`, or a Cargo `[[bin]]`/`src/bin`
-  target) is a CLI tool, so a `process.exit` anywhere in its source is the
-  intended exit boundary the rule's own guidance asks for — not a hazard in
-  reusable code. The scanner now records, per file, whether it belongs to such a
-  package (new `cli-executable` role) and the knowledge pack **downgrades the
-  finding to Low** for that role — hidden in the default profile, still shown
-  under `--profile strict` — rather than suppressing it in the detector, so the
-  signal stays recoverable. Crucially this is keyed off the package manifest, not
-  a path: a `process.exit` in a non-CLI package's `domain/commands/` (a
-  CQRS-style command, no declared `bin`) keeps its default-visible High. Measured
-  on the real-repo zoo, this took the `ignite` CLI from 9 default-visible
-  findings to 0 (all 12 retained as Low in strict) and `changesets` from 2 to 1.
+  CLI tool's command handlers instead of surfacing them as a default High.** A
+  command handler — a file in a `commands/` directory whose package declares an
+  executable (`package.json#bin`, or a Cargo `[[bin]]`/`src/bin` target) — owns
+  its own exit code, so its `process.exit` is the intended boundary the rule's
+  own guidance asks for. The scanner resolves each file to its *nearest* package
+  and, when that package is a CLI tool and the file is a command handler, tags it
+  with a new `cli-executable` role; the knowledge pack then **downgrades the
+  finding to Low** (hidden by default, still shown under `--profile strict`)
+  rather than suppressing it in the detector, so the signal stays recoverable.
+  The exemption is deliberately narrow — it pairs path evidence (`commands/`)
+  with manifest evidence (`bin`), so a CQRS-style `domain/commands/` in a non-CLI
+  package, and a reusable module (`lib/`, `utils/`) inside a CLI package, both
+  keep their default-visible High. Measured on the real-repo zoo, this took the
+  `ignite` CLI from 9 default-visible findings to 0 (all retained as Low in
+  strict), with no loss of the genuine library-level exits elsewhere.
 
 - **`language.python.exception-risk` no longer surfaces `assert` and `raise
   NotImplementedError` by default.** An `assert` (commonly type-narrowing or an

--- a/src/audits/architecture/barrel_file_risk/tests.rs
+++ b/src/audits/architecture/barrel_file_risk/tests.rs
@@ -153,6 +153,7 @@ fn facts_for_file(path: std::path::PathBuf) -> ScanFacts {
             imports: vec![],
             content: None,
             has_inline_tests: false,
+            in_executable_package: false,
         }],
         ..ScanFacts::default()
     }

--- a/src/audits/architecture/deep_directory_nesting.rs
+++ b/src/audits/architecture/deep_directory_nesting.rs
@@ -198,6 +198,7 @@ mod tests {
             imports: Vec::new(),
             content: Some("".to_string()),
             has_inline_tests: false,
+            in_executable_package: false,
         }
     }
 }

--- a/src/audits/architecture/deep_relative_imports.rs
+++ b/src/audits/architecture/deep_relative_imports.rs
@@ -239,6 +239,7 @@ mod tests {
                 imports: vec![],
                 content: None,
                 has_inline_tests: false,
+                in_executable_package: false,
             }],
             ..ScanFacts::default()
         }

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -269,6 +269,7 @@ export {};
         imports: vec!["../../auth/src/internal".to_string()],
         content: Some(content.to_string()),
         has_inline_tests: false,
+        in_executable_package: false,
     };
 
     let source = NodeInfo {

--- a/src/audits/code_quality/complex_function/tests.rs
+++ b/src/audits/code_quality/complex_function/tests.rs
@@ -14,6 +14,7 @@ fn ts_file(path: &str, content: &str) -> FileFacts {
         imports: Vec::new(),
         content: Some(content.to_string()),
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }
 

--- a/src/audits/code_quality/language_risk/js.rs
+++ b/src/audits/code_quality/language_risk/js.rs
@@ -16,7 +16,7 @@ impl JsRiskPattern {
 
     pub(super) fn matches(self, trimmed: &str, path: &Path) -> bool {
         match self {
-            Self::ProcessExit => trimmed.contains("process.exit(") && !is_node_bin_path(path),
+            Self::ProcessExit => trimmed.contains("process.exit(") && !is_cli_exit_context(path),
         }
     }
 
@@ -90,12 +90,19 @@ pub(super) fn emit_js_node(
 }
 
 fn is_expected_cli_entrypoint(path: &Path, content: &str) -> bool {
-    is_node_bin_path(path) && content.starts_with("#!/usr/bin/env node")
+    is_cli_exit_context(path) || content.starts_with("#!/usr/bin/env node")
 }
 
-fn is_node_bin_path(path: &Path) -> bool {
+/// Paths where `process.exit(...)` is the intended CLI boundary rather than a
+/// hazard inside reusable code: executable `bin/` scripts and `commands/`
+/// modules — the near-universal CLI-command convention used by gluegun, oclif,
+/// and nest-commander, where each command owns its own exit code.
+fn is_cli_exit_context(path: &Path) -> bool {
     let normalized = path.to_string_lossy().replace('\\', "/");
-    normalized.starts_with("bin/") || normalized.contains("/bin/")
+    normalized.starts_with("bin/")
+        || normalized.contains("/bin/")
+        || normalized.starts_with("commands/")
+        || normalized.contains("/commands/")
 }
 
 /// `process.exit(...)` — a call whose callee is the `process.exit` member.

--- a/src/audits/code_quality/language_risk/js.rs
+++ b/src/audits/code_quality/language_risk/js.rs
@@ -14,9 +14,14 @@ pub(super) enum JsRiskPattern {
 impl JsRiskPattern {
     pub(super) const ALL: &'static [Self] = &[Self::ProcessExit];
 
-    pub(super) fn matches(self, trimmed: &str, path: &Path) -> bool {
+    pub(super) fn matches(self, trimmed: &str, _path: &Path) -> bool {
         match self {
-            Self::ProcessExit => trimmed.contains("process.exit(") && !is_cli_exit_context(path),
+            // Severity is decided downstream by the knowledge engine: a
+            // `process.exit` in a CLI package, `bin/`/`scripts/` path, or
+            // app-entrypoint is downgraded to Low (hidden by default, kept in
+            // strict), while ordinary reusable code stays High. The detector
+            // only reports the call; it never suppresses outright.
+            Self::ProcessExit => trimmed.contains("process.exit("),
         }
     }
 
@@ -61,6 +66,12 @@ impl JsRiskPattern {
 /// `process.exit(...)` calls, which terminate the host process and so are unsafe
 /// in reusable library code. A `throw` is recoverable control flow, not a
 /// runtime exit, so generic thrown errors are intentionally not flagged here.
+///
+/// The call is always reported; the knowledge engine then decides severity from
+/// file context — a `process.exit` in a CLI package (`package.json#bin`), a
+/// `bin/`/`scripts/` path, or an app-entrypoint is downgraded to Low (hidden in
+/// the default profile, retained under `--profile strict`), while reusable code
+/// keeps it at High.
 pub(super) fn emit_js_node(
     node: Node<'_>,
     content: &str,
@@ -69,10 +80,7 @@ pub(super) fn emit_js_node(
     findings: &mut Vec<Finding>,
 ) {
     let pattern = match node.kind() {
-        "call_expression"
-            if is_process_exit_call(node, content)
-                && !is_expected_cli_entrypoint(path, content) =>
-        {
+        "call_expression" if is_process_exit_call(node, content) => {
             Some(JsRiskPattern::ProcessExit)
         }
         _ => None,
@@ -87,22 +95,6 @@ pub(super) fn emit_js_node(
             findings,
         );
     }
-}
-
-fn is_expected_cli_entrypoint(path: &Path, content: &str) -> bool {
-    is_cli_exit_context(path) || content.starts_with("#!/usr/bin/env node")
-}
-
-/// Paths where `process.exit(...)` is the intended CLI boundary rather than a
-/// hazard inside reusable code: executable `bin/` scripts and `commands/`
-/// modules — the near-universal CLI-command convention used by gluegun, oclif,
-/// and nest-commander, where each command owns its own exit code.
-fn is_cli_exit_context(path: &Path) -> bool {
-    let normalized = path.to_string_lossy().replace('\\', "/");
-    normalized.starts_with("bin/")
-        || normalized.contains("/bin/")
-        || normalized.starts_with("commands/")
-        || normalized.contains("/commands/")
 }
 
 /// `process.exit(...)` — a call whose callee is the `process.exit` member.

--- a/src/audits/code_quality/language_risk/tests.rs
+++ b/src/audits/code_quality/language_risk/tests.rs
@@ -56,7 +56,9 @@ fn downgrades_js_process_exit_in_script_paths() {
 }
 
 #[test]
-fn ignores_process_exit_in_node_bin_entrypoint() {
+fn downgrades_process_exit_in_bin_path_to_low() {
+    // A `bin/` script is classified as a `script` role and downgraded — kept in
+    // strict, not deleted in the detector.
     let file = facts(
         "bin/repopilot.js",
         Some("JavaScript"),
@@ -65,14 +67,17 @@ fn ignores_process_exit_in_node_bin_entrypoint() {
 
     let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
 
-    assert!(findings.is_empty());
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, "language.javascript.runtime-exit-risk");
+    assert_eq!(findings[0].severity, Severity::Low);
 }
 
 #[test]
-fn ignores_process_exit_in_cli_command_module() {
-    // A gluegun/oclif-style CLI command owns its own exit code; `process.exit`
-    // here is the intended boundary, not a hazard (e.g. ignite-cli's commands).
-    let file = facts(
+fn downgrades_process_exit_in_cli_executable_package_to_low() {
+    // A gluegun/oclif-style command in a package that declares `package.json#bin`
+    // owns its own exit code; the call is downgraded to Low (hidden by default,
+    // kept in strict), not suppressed (e.g. ignite-cli's `src/commands/*`).
+    let file = cli_package_facts(
         "src/commands/new.ts",
         Some("TypeScript"),
         "export const run = async () => { process.exit(1) }\n",
@@ -80,16 +85,26 @@ fn ignores_process_exit_in_cli_command_module() {
 
     let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
 
-    assert!(findings.is_empty());
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].severity, Severity::Low);
 }
 
 #[test]
-fn ignores_process_exit_in_bin_without_shebang() {
-    let file = facts("bin/cli.js", Some("JavaScript"), "process.exit(1);\n");
+fn reports_process_exit_in_non_cli_commands_dir_as_high() {
+    // A `commands/` directory in a NON-CLI package (no `package.json#bin`) is a
+    // CQRS/domain command, not a CLI boundary: the host-terminating exit stays a
+    // default-visible High. This is the false-negative guard for the path-only
+    // heuristic that path-based suppression would have hidden.
+    let file = facts(
+        "src/domain/commands/run.ts",
+        Some("TypeScript"),
+        "export function run() { process.exit(1); }\n",
+    );
 
     let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
 
-    assert!(findings.is_empty());
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].severity, Severity::High);
 }
 
 #[test]
@@ -257,6 +272,17 @@ fn facts(path: &str, language: Option<&str>, content: &str) -> FileFacts {
         imports: Vec::new(),
         content: Some(content.to_string()),
         has_inline_tests: false,
+        in_executable_package: false,
+    }
+}
+
+/// Same as [`facts`], but the file is inside a package that declares an
+/// executable entrypoint (`package.json#bin`), set by the scanner's
+/// post-collection pass in a real scan.
+fn cli_package_facts(path: &str, language: Option<&str>, content: &str) -> FileFacts {
+    FileFacts {
+        in_executable_package: true,
+        ..facts(path, language, content)
     }
 }
 

--- a/src/audits/code_quality/language_risk/tests.rs
+++ b/src/audits/code_quality/language_risk/tests.rs
@@ -90,6 +90,24 @@ fn downgrades_process_exit_in_cli_executable_package_to_low() {
 }
 
 #[test]
+fn reports_process_exit_in_reusable_module_of_cli_package_as_high() {
+    // A package may be a CLI tool, but not every file in it is a CLI boundary. A
+    // reusable internal module (`src/lib/parser.ts`) should not terminate the
+    // process; that exit stays a default-visible High even though the package
+    // declares `package.json#bin` — only `commands/` handlers are exempted.
+    let file = cli_package_facts(
+        "src/lib/parser.ts",
+        Some("TypeScript"),
+        "export function parseConfig(input: string) { if (!input) { process.exit(1); } }\n",
+    );
+
+    let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].severity, Severity::High);
+}
+
+#[test]
 fn reports_process_exit_in_non_cli_commands_dir_as_high() {
     // A `commands/` directory in a NON-CLI package (no `package.json#bin`) is a
     // CQRS/domain command, not a CLI boundary: the host-terminating exit stays a

--- a/src/audits/code_quality/language_risk/tests.rs
+++ b/src/audits/code_quality/language_risk/tests.rs
@@ -69,6 +69,30 @@ fn ignores_process_exit_in_node_bin_entrypoint() {
 }
 
 #[test]
+fn ignores_process_exit_in_cli_command_module() {
+    // A gluegun/oclif-style CLI command owns its own exit code; `process.exit`
+    // here is the intended boundary, not a hazard (e.g. ignite-cli's commands).
+    let file = facts(
+        "src/commands/new.ts",
+        Some("TypeScript"),
+        "export const run = async () => { process.exit(1) }\n",
+    );
+
+    let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn ignores_process_exit_in_bin_without_shebang() {
+    let file = facts("bin/cli.js", Some("JavaScript"), "process.exit(1);\n");
+
+    let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert!(findings.is_empty());
+}
+
+#[test]
 fn reports_js_process_exit_in_library_code_as_high() {
     let file = facts(
         "src/lib/runtime.js",

--- a/src/audits/code_quality/long_function/tests.rs
+++ b/src/audits/code_quality/long_function/tests.rs
@@ -166,6 +166,7 @@ fn facts(path: &str, language: Option<&str>, content: &str, has_inline_tests: bo
         imports: Vec::new(),
         content: Some(content.to_string()),
         has_inline_tests,
+        in_executable_package: false,
     }
 }
 

--- a/src/audits/code_quality/rust_panic_risk/tests.rs
+++ b/src/audits/code_quality/rust_panic_risk/tests.rs
@@ -339,6 +339,7 @@ fn facts(path: &str, content: &str, has_inline_tests: bool) -> FileFacts {
         imports: Vec::new(),
         content: Some(content.to_string()),
         has_inline_tests,
+        in_executable_package: false,
     }
 }
 

--- a/src/audits/code_quality/rust_panic_risk/tests_render.rs
+++ b/src/audits/code_quality/rust_panic_risk/tests_render.rs
@@ -69,5 +69,6 @@ fn facts(path: &str, content: &str, has_inline_tests: bool) -> FileFacts {
         imports: Vec::new(),
         content: Some(content.to_string()),
         has_inline_tests,
+        in_executable_package: false,
     }
 }

--- a/src/audits/context/classify/mod.rs
+++ b/src/audits/context/classify/mod.rs
@@ -8,7 +8,7 @@ mod signals;
 use crate::audits::context::model::{AuditContext, FileRole, LanguageKind};
 use crate::knowledge::language::language_kind_for_file;
 use crate::scan::facts::FileFacts;
-use helpers::is_test_file;
+use helpers::{is_test_file, path_contains_component};
 use signals::ContextSignals;
 
 pub fn classify_file(file: &FileFacts) -> AuditContext {
@@ -31,10 +31,14 @@ pub fn classify_file(file: &FileFacts) -> AuditContext {
         is_test,
     );
 
-    // Package-level CLI signal: set by the post-collection pass once workspace
-    // layout (package.json#bin / Cargo bin targets) is known. The knowledge pack
-    // uses this role to downgrade host-termination calls to Low.
-    if file.in_executable_package {
+    // A CLI command handler is a genuine exit boundary only when BOTH hold: the
+    // file lives in a `commands/` directory AND its package declares an executable
+    // (`in_executable_package`, set from the nearest package's manifest). This
+    // pairs path evidence with manifest evidence, so a CQRS `domain/commands/` in
+    // a non-CLI package is not exempted, and a reusable module (`lib/`, `utils/`)
+    // inside a CLI package keeps its default-visible severity. `bin/`/`scripts/`
+    // entrypoints are already handled by the `script`/`app-entrypoint` roles.
+    if file.in_executable_package && path_contains_component(&file.path, &["commands"]) {
         roles.push(FileRole::CliExecutable);
     }
 

--- a/src/audits/context/classify/mod.rs
+++ b/src/audits/context/classify/mod.rs
@@ -31,6 +31,13 @@ pub fn classify_file(file: &FileFacts) -> AuditContext {
         is_test,
     );
 
+    // Package-level CLI signal: set by the post-collection pass once workspace
+    // layout (package.json#bin / Cargo bin targets) is known. The knowledge pack
+    // uses this role to downgrade host-termination calls to Low.
+    if file.in_executable_package {
+        roles.push(FileRole::CliExecutable);
+    }
+
     if roles.is_empty() {
         roles.push(FileRole::Unknown);
     }

--- a/src/audits/context/classify/tests.rs
+++ b/src/audits/context/classify/tests.rs
@@ -18,5 +18,6 @@ fn facts(path: &str, language: Option<&str>, content: &str, has_inline_tests: bo
         imports: Vec::new(),
         content: Some(content.to_string()),
         has_inline_tests,
+        in_executable_package: false,
     }
 }

--- a/src/audits/context/model/kinds.rs
+++ b/src/audits/context/model/kinds.rs
@@ -87,9 +87,11 @@ pub enum FileRole {
     Generated,
     Domain,
     Script,
-    /// File belongs to a package that declares an executable entrypoint
-    /// (npm `package.json#bin`, Cargo `[[bin]]`/`src/bin`). The whole package is
-    /// a CLI tool, so host-termination calls are an intended boundary.
+    /// A CLI command handler: a file in a `commands/` directory whose package
+    /// declares an executable entrypoint (npm `package.json#bin`, Cargo
+    /// `[[bin]]`/`src/bin`). Such a command owns its own exit code, so
+    /// host-termination calls there are an intended boundary — unlike a reusable
+    /// module elsewhere in the same package, which is not exempted.
     CliExecutable,
     Infrastructure,
     Unknown,

--- a/src/audits/context/model/kinds.rs
+++ b/src/audits/context/model/kinds.rs
@@ -87,6 +87,10 @@ pub enum FileRole {
     Generated,
     Domain,
     Script,
+    /// File belongs to a package that declares an executable entrypoint
+    /// (npm `package.json#bin`, Cargo `[[bin]]`/`src/bin`). The whole package is
+    /// a CLI tool, so host-termination calls are an intended boundary.
+    CliExecutable,
     Infrastructure,
     Unknown,
 }
@@ -220,6 +224,7 @@ impl FileRole {
             FileRole::Generated => "generated",
             FileRole::Domain => "domain",
             FileRole::Script => "script",
+            FileRole::CliExecutable => "cli-executable",
             FileRole::Infrastructure => "infrastructure",
             FileRole::Unknown => "unknown",
         }

--- a/src/audits/framework/js_common/tests.rs
+++ b/src/audits/framework/js_common/tests.rs
@@ -13,6 +13,7 @@ fn make_file_facts(path: std::path::PathBuf) -> FileFacts {
         imports: vec![],
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }
 
@@ -116,6 +117,7 @@ fn console_log_flagged() {
         imports: vec![],
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     });
     let findings = ConsoleLogAudit.audit(&facts, &ScanConfig::default());
     assert_eq!(findings.len(), 1);

--- a/src/audits/framework/react.rs
+++ b/src/audits/framework/react.rs
@@ -162,6 +162,7 @@ mod tests {
             imports: vec![],
             content: None,
             has_inline_tests: false,
+            in_executable_package: false,
         });
 
         let findings = ReactClassComponentAudit.audit(&facts, &ScanConfig::default());
@@ -188,6 +189,7 @@ mod tests {
             imports: vec![],
             content: None,
             has_inline_tests: false,
+            in_executable_package: false,
         });
         // no TypeScript in languages list
 
@@ -218,6 +220,7 @@ mod tests {
             imports: vec![],
             content: None,
             has_inline_tests: false,
+            in_executable_package: false,
         });
 
         let findings = ReactPropTypesAudit.audit(&facts, &ScanConfig::default());

--- a/src/audits/framework/react_native/tests.rs
+++ b/src/audits/framework/react_native/tests.rs
@@ -29,6 +29,7 @@ fn jsx_file(dir: &tempfile::TempDir, name: &str, content: &str) -> FileFacts {
         imports: vec![],
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }
 

--- a/src/explain/builder.rs
+++ b/src/explain/builder.rs
@@ -33,6 +33,7 @@ pub fn build_explain_report(
         imports: Vec::new(),
         content: Some(content),
         has_inline_tests,
+        in_executable_package: false,
     };
 
     let audit_context = classify_file(&file);

--- a/src/facts/from_scan.rs
+++ b/src/facts/from_scan.rs
@@ -51,6 +51,7 @@ mod tests {
                 imports: vec!["crate::facts".to_string()],
                 content: None,
                 has_inline_tests: true,
+                in_executable_package: false,
             }],
             ..ScanFacts::default()
         };

--- a/src/graph/context/graph_impl.rs
+++ b/src/graph/context/graph_impl.rs
@@ -145,6 +145,7 @@ impl RepoContextNode {
             imports: self.imports.clone(),
             content: None,
             has_inline_tests: self.is_test,
+            in_executable_package: false,
         }
     }
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -329,6 +329,7 @@ mod tests {
             imports: imports.iter().map(|value| (*value).to_string()).collect(),
             content: None,
             has_inline_tests: false,
+            in_executable_package: false,
         }
     }
 

--- a/src/graph/v2/builder/tests.rs
+++ b/src/graph/v2/builder/tests.rs
@@ -10,6 +10,7 @@ fn file(path: &str, imports: &[&str]) -> FileFacts {
         imports: imports.iter().map(|value| (*value).to_string()).collect(),
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }
 

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -623,11 +623,12 @@ signal = "js.process-exit"
 action = "downgrade"
 severity = "LOW"
 
-# A package that declares an executable (`package.json#bin`) is a CLI tool, so a
-# `process.exit` anywhere in its source is an intended boundary, not a hazard in
-# reusable code. Downgrade to Low (hidden by default, kept in strict) rather than
-# suppress, so the signal is still recoverable. Ordinary modules in non-CLI
-# packages (e.g. a web app's `domain/commands/`) keep the default-visible High.
+# A command handler in a CLI tool (a `commands/` file whose package declares
+# `package.json#bin`) owns its own exit code, so its `process.exit` is an intended
+# boundary. Downgrade to Low (hidden by default, kept in strict) rather than
+# suppress, so the signal is recoverable. This does NOT cover reusable modules in
+# the same package (`lib/`, `utils/`) or a non-CLI package's `domain/commands/` —
+# both keep the default-visible High (see the `cli-executable` role).
 [[rules.overrides]]
 role = "cli-executable"
 signal = "js.process-exit"

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -623,6 +623,17 @@ signal = "js.process-exit"
 action = "downgrade"
 severity = "LOW"
 
+# A package that declares an executable (`package.json#bin`) is a CLI tool, so a
+# `process.exit` anywhere in its source is an intended boundary, not a hazard in
+# reusable code. Downgrade to Low (hidden by default, kept in strict) rather than
+# suppress, so the signal is still recoverable. Ordinary modules in non-CLI
+# packages (e.g. a web app's `domain/commands/`) keep the default-visible High.
+[[rules.overrides]]
+role = "cli-executable"
+signal = "js.process-exit"
+action = "downgrade"
+severity = "LOW"
+
 [[rules]]
 rule_id = "language.managed.fatal-exception-risk"
 minimum_support = "rule-aware"

--- a/src/output/ai_context/repo_facts.rs
+++ b/src/output/ai_context/repo_facts.rs
@@ -76,6 +76,7 @@ mod tests {
                     imports: Vec::new(),
                     content: None,
                     has_inline_tests: false,
+                    in_executable_package: false,
                 },
                 FileFacts {
                     path: PathBuf::from("/private/repo/README"),
@@ -85,6 +86,7 @@ mod tests {
                     imports: Vec::new(),
                     content: None,
                     has_inline_tests: false,
+                    in_executable_package: false,
                 },
             ],
             ..ScanFacts::default()

--- a/src/risk/tests.rs
+++ b/src/risk/tests.rs
@@ -62,5 +62,6 @@ fn file(path: &str, language: Option<&str>, has_inline_tests: bool) -> FileFacts
         imports: Vec::new(),
         content: None,
         has_inline_tests,
+        in_executable_package: false,
     }
 }

--- a/src/scan/facts.rs
+++ b/src/scan/facts.rs
@@ -27,7 +27,7 @@ pub struct ScanFacts {
     pub repopilotignore_path: Option<PathBuf>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct FileFacts {
     pub path: PathBuf,
     pub language: Option<String>,
@@ -40,6 +40,12 @@ pub struct FileFacts {
     /// True if the file contains a `#[cfg(test)]` block (Rust inline unit tests).
     /// Computed while content is available; preserved after content is dropped.
     pub has_inline_tests: bool,
+    /// True if the file lives inside a package that declares an executable
+    /// entrypoint (npm `package.json#bin`, Cargo `[[bin]]`/`src/bin`). Such a
+    /// package is a CLI tool, so the knowledge engine treats `process.exit` and
+    /// similar host-termination calls as an intended boundary (downgraded, not a
+    /// hazard). Set by a post-collection pass once workspace layout is known.
+    pub in_executable_package: bool,
 }
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/src/scan/scanner/changed/file_analysis.rs
+++ b/src/scan/scanner/changed/file_analysis.rs
@@ -177,7 +177,9 @@ impl<'a> ChangedScanEngine<'a> {
         };
 
         let miss_start = Instant::now();
-        let mut per_file = process_file_with_content(&absolute_path, file_audits, self.config)?;
+        let executable_roots = crate::scan::workspace::cli_executable_roots(repo_root);
+        let mut per_file =
+            process_file_with_content(&absolute_path, file_audits, self.config, &executable_roots)?;
         normalize_per_file_paths(
             &mut per_file.file_facts.path,
             &mut per_file.findings,

--- a/src/scan/scanner/changed/file_analysis.rs
+++ b/src/scan/scanner/changed/file_analysis.rs
@@ -177,9 +177,9 @@ impl<'a> ChangedScanEngine<'a> {
         };
 
         let miss_start = Instant::now();
-        let executable_roots = crate::scan::workspace::cli_executable_roots(repo_root);
+        let roots = crate::scan::workspace::package_roots(repo_root);
         let mut per_file =
-            process_file_with_content(&absolute_path, file_audits, self.config, &executable_roots)?;
+            process_file_with_content(&absolute_path, file_audits, self.config, &roots)?;
         normalize_per_file_paths(
             &mut per_file.file_facts.path,
             &mut per_file.findings,

--- a/src/scan/scanner/changed_cache.rs
+++ b/src/scan/scanner/changed_cache.rs
@@ -76,6 +76,7 @@ pub(super) fn record_cached_file(
         imports: entry.imports.clone(),
         content: None,
         has_inline_tests: entry.is_test,
+        in_executable_package: false,
     };
     facts.files.push(file_facts.clone());
     file_facts

--- a/src/scan/scanner/collection.rs
+++ b/src/scan/scanner/collection.rs
@@ -5,6 +5,7 @@ use crate::audits::traits::FileAudit;
 use crate::findings::types::Finding;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
+use crate::scan::workspace::cli_executable_roots;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::io;
@@ -67,9 +68,14 @@ pub(super) fn analyze_discovered_files(
         file_paths,
     } = discovered;
 
+    // CLI executable package roots are resolved once from the scan root, then
+    // passed down so each file's `in_executable_package` flag is set before its
+    // audits run (host-exit severity is decided at finding time).
+    let executable_roots = cli_executable_roots(&facts.root_path);
+
     let results: Vec<io::Result<_>> = file_paths
         .par_iter()
-        .map(|p| process_file(p, file_audits, config))
+        .map(|p| process_file(p, file_audits, config, &executable_roots))
         .collect();
 
     let mut languages: HashMap<String, usize> = HashMap::new();
@@ -124,12 +130,13 @@ pub fn collect_scan_facts_with_config(path: &Path, config: &ScanConfig) -> io::R
     };
 
     let mut languages: HashMap<String, usize> = HashMap::new();
+    let executable_roots = cli_executable_roots(&facts.root_path);
 
     if path.is_file() {
         facts.files_discovered = 1;
-        collect_file_facts(path, &mut facts, &mut languages, config)?;
+        collect_file_facts(path, &mut facts, &mut languages, config, &executable_roots)?;
     } else {
-        collect_directory_facts(path, &mut facts, &mut languages, config)?;
+        collect_directory_facts(path, &mut facts, &mut languages, config, &executable_roots)?;
     }
 
     facts.languages = build_language_summary(languages);
@@ -153,6 +160,7 @@ fn collect_directory_facts(
     facts: &mut ScanFacts,
     languages: &mut HashMap<String, usize>,
     config: &ScanConfig,
+    executable_roots: &[PathBuf],
 ) -> io::Result<()> {
     let collected = collect_paths(path, config)?;
     let mut file_paths = collected.file_paths;
@@ -166,7 +174,7 @@ fn collect_directory_facts(
     apply_max_files_limit(&mut file_paths, facts, config);
 
     for entry_path in file_paths {
-        collect_file_facts(&entry_path, facts, languages, config)?;
+        collect_file_facts(&entry_path, facts, languages, config, executable_roots)?;
     }
 
     Ok(())

--- a/src/scan/scanner/collection.rs
+++ b/src/scan/scanner/collection.rs
@@ -5,7 +5,7 @@ use crate::audits::traits::FileAudit;
 use crate::findings::types::Finding;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
-use crate::scan::workspace::cli_executable_roots;
+use crate::scan::workspace::{PackageRoot, package_roots};
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::io;
@@ -68,14 +68,14 @@ pub(super) fn analyze_discovered_files(
         file_paths,
     } = discovered;
 
-    // CLI executable package roots are resolved once from the scan root, then
-    // passed down so each file's `in_executable_package` flag is set before its
-    // audits run (host-exit severity is decided at finding time).
-    let executable_roots = cli_executable_roots(&facts.root_path);
+    // Package roots are resolved once from the scan root, then passed down so each
+    // file's `in_executable_package` flag (set from its nearest package's manifest)
+    // is known before its audits run — host-exit severity is decided at finding time.
+    let roots = package_roots(&facts.root_path);
 
     let results: Vec<io::Result<_>> = file_paths
         .par_iter()
-        .map(|p| process_file(p, file_audits, config, &executable_roots))
+        .map(|p| process_file(p, file_audits, config, &roots))
         .collect();
 
     let mut languages: HashMap<String, usize> = HashMap::new();
@@ -130,13 +130,13 @@ pub fn collect_scan_facts_with_config(path: &Path, config: &ScanConfig) -> io::R
     };
 
     let mut languages: HashMap<String, usize> = HashMap::new();
-    let executable_roots = cli_executable_roots(&facts.root_path);
+    let roots = package_roots(&facts.root_path);
 
     if path.is_file() {
         facts.files_discovered = 1;
-        collect_file_facts(path, &mut facts, &mut languages, config, &executable_roots)?;
+        collect_file_facts(path, &mut facts, &mut languages, config, &roots)?;
     } else {
-        collect_directory_facts(path, &mut facts, &mut languages, config, &executable_roots)?;
+        collect_directory_facts(path, &mut facts, &mut languages, config, &roots)?;
     }
 
     facts.languages = build_language_summary(languages);
@@ -160,7 +160,7 @@ fn collect_directory_facts(
     facts: &mut ScanFacts,
     languages: &mut HashMap<String, usize>,
     config: &ScanConfig,
-    executable_roots: &[PathBuf],
+    roots: &[PackageRoot],
 ) -> io::Result<()> {
     let collected = collect_paths(path, config)?;
     let mut file_paths = collected.file_paths;
@@ -174,7 +174,7 @@ fn collect_directory_facts(
     apply_max_files_limit(&mut file_paths, facts, config);
 
     for entry_path in file_paths {
-        collect_file_facts(&entry_path, facts, languages, config, executable_roots)?;
+        collect_file_facts(&entry_path, facts, languages, config, roots)?;
     }
 
     Ok(())

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -11,7 +11,15 @@ use crate::scan::path_classification::is_low_signal_audit_path;
 use std::collections::HashMap;
 use std::fs;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+/// Whether `path` lives inside one of the CLI executable package roots, so the
+/// knowledge engine can treat host-termination calls there as an intended
+/// boundary. Computed once per scan and passed down so the flag is set before
+/// per-file audits run (severity is decided at finding time).
+fn in_executable_package(path: &Path, executable_roots: &[PathBuf]) -> bool {
+    executable_roots.iter().any(|root| path.starts_with(root))
+}
 
 pub(super) struct PerFileResult {
     pub(super) file_facts: FileFacts,
@@ -51,7 +59,11 @@ pub(super) enum LoadedFile {
     },
 }
 
-pub(super) fn load_file(path: &Path, config: &ScanConfig) -> io::Result<LoadedFile> {
+pub(super) fn load_file(
+    path: &Path,
+    config: &ScanConfig,
+    executable_roots: &[PathBuf],
+) -> io::Result<LoadedFile> {
     let language = detect_language(path).map(str::to_string);
 
     if config.max_file_bytes > 0 {
@@ -108,6 +120,7 @@ pub(super) fn load_file(path: &Path, config: &ScanConfig) -> io::Result<LoadedFi
             imports: Vec::new(),
             has_inline_tests,
             content: Some(content),
+            in_executable_package: in_executable_package(path, executable_roots),
         },
         language,
     })
@@ -129,6 +142,7 @@ pub(super) fn empty_file_facts(path: &Path, language: Option<String>) -> FileFac
         imports: Vec::new(),
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }
 
@@ -180,16 +194,18 @@ pub(super) fn process_file(
     path: &Path,
     file_audits: &[Box<dyn FileAudit>],
     config: &ScanConfig,
+    executable_roots: &[PathBuf],
 ) -> io::Result<PerFileResult> {
-    process_file_inner(path, file_audits, config, false)
+    process_file_inner(path, file_audits, config, false, executable_roots)
 }
 
 pub(super) fn process_file_with_content(
     path: &Path,
     file_audits: &[Box<dyn FileAudit>],
     config: &ScanConfig,
+    executable_roots: &[PathBuf],
 ) -> io::Result<PerFileResult> {
-    process_file_inner(path, file_audits, config, true)
+    process_file_inner(path, file_audits, config, true, executable_roots)
 }
 
 fn process_file_inner(
@@ -197,8 +213,9 @@ fn process_file_inner(
     file_audits: &[Box<dyn FileAudit>],
     config: &ScanConfig,
     retain_content: bool,
+    executable_roots: &[PathBuf],
 ) -> io::Result<PerFileResult> {
-    let loaded = load_file(path, config)?;
+    let loaded = load_file(path, config, executable_roots)?;
     let LoadedFile::Analyzable {
         mut full_facts,
         language,
@@ -241,9 +258,10 @@ pub(super) fn collect_file_facts(
     facts: &mut ScanFacts,
     languages: &mut HashMap<String, usize>,
     config: &ScanConfig,
+    executable_roots: &[PathBuf],
 ) -> io::Result<()> {
     let LoadedFile::Analyzable { mut full_facts, .. } =
-        load_file_or_record_skip(path, facts, config)?
+        load_file_or_record_skip(path, facts, config, executable_roots)?
     else {
         return Ok(());
     };
@@ -267,8 +285,9 @@ fn load_file_or_record_skip(
     path: &Path,
     facts: &mut ScanFacts,
     config: &ScanConfig,
+    executable_roots: &[PathBuf],
 ) -> io::Result<LoadedFile> {
-    let loaded = load_file(path, config)?;
+    let loaded = load_file(path, config, executable_roots)?;
     if let LoadedFile::Skipped {
         language,
         reason,
@@ -376,8 +395,12 @@ mod tests {
 
     #[test]
     fn missing_file_is_skipped_instead_of_aborting_scan() {
-        let loaded = load_file(Path::new("missing-after-walk.rs"), &ScanConfig::default())
-            .expect("missing file should be classified as skipped");
+        let loaded = load_file(
+            Path::new("missing-after-walk.rs"),
+            &ScanConfig::default(),
+            &[],
+        )
+        .expect("missing file should be classified as skipped");
 
         let LoadedFile::Skipped {
             language,

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -8,18 +8,11 @@ use crate::scan::config::ScanConfig;
 use crate::scan::facts::{FileFacts, ScanFacts};
 use crate::scan::language::detect_language;
 use crate::scan::path_classification::is_low_signal_audit_path;
+use crate::scan::workspace::{PackageRoot, path_in_executable_package};
 use std::collections::HashMap;
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
-
-/// Whether `path` lives inside one of the CLI executable package roots, so the
-/// knowledge engine can treat host-termination calls there as an intended
-/// boundary. Computed once per scan and passed down so the flag is set before
-/// per-file audits run (severity is decided at finding time).
-fn in_executable_package(path: &Path, executable_roots: &[PathBuf]) -> bool {
-    executable_roots.iter().any(|root| path.starts_with(root))
-}
+use std::path::Path;
 
 pub(super) struct PerFileResult {
     pub(super) file_facts: FileFacts,
@@ -62,7 +55,7 @@ pub(super) enum LoadedFile {
 pub(super) fn load_file(
     path: &Path,
     config: &ScanConfig,
-    executable_roots: &[PathBuf],
+    package_roots: &[PackageRoot],
 ) -> io::Result<LoadedFile> {
     let language = detect_language(path).map(str::to_string);
 
@@ -120,7 +113,7 @@ pub(super) fn load_file(
             imports: Vec::new(),
             has_inline_tests,
             content: Some(content),
-            in_executable_package: in_executable_package(path, executable_roots),
+            in_executable_package: path_in_executable_package(path, package_roots),
         },
         language,
     })
@@ -194,18 +187,18 @@ pub(super) fn process_file(
     path: &Path,
     file_audits: &[Box<dyn FileAudit>],
     config: &ScanConfig,
-    executable_roots: &[PathBuf],
+    package_roots: &[PackageRoot],
 ) -> io::Result<PerFileResult> {
-    process_file_inner(path, file_audits, config, false, executable_roots)
+    process_file_inner(path, file_audits, config, false, package_roots)
 }
 
 pub(super) fn process_file_with_content(
     path: &Path,
     file_audits: &[Box<dyn FileAudit>],
     config: &ScanConfig,
-    executable_roots: &[PathBuf],
+    package_roots: &[PackageRoot],
 ) -> io::Result<PerFileResult> {
-    process_file_inner(path, file_audits, config, true, executable_roots)
+    process_file_inner(path, file_audits, config, true, package_roots)
 }
 
 fn process_file_inner(
@@ -213,9 +206,9 @@ fn process_file_inner(
     file_audits: &[Box<dyn FileAudit>],
     config: &ScanConfig,
     retain_content: bool,
-    executable_roots: &[PathBuf],
+    package_roots: &[PackageRoot],
 ) -> io::Result<PerFileResult> {
-    let loaded = load_file(path, config, executable_roots)?;
+    let loaded = load_file(path, config, package_roots)?;
     let LoadedFile::Analyzable {
         mut full_facts,
         language,
@@ -258,10 +251,10 @@ pub(super) fn collect_file_facts(
     facts: &mut ScanFacts,
     languages: &mut HashMap<String, usize>,
     config: &ScanConfig,
-    executable_roots: &[PathBuf],
+    package_roots: &[PackageRoot],
 ) -> io::Result<()> {
     let LoadedFile::Analyzable { mut full_facts, .. } =
-        load_file_or_record_skip(path, facts, config, executable_roots)?
+        load_file_or_record_skip(path, facts, config, package_roots)?
     else {
         return Ok(());
     };
@@ -285,9 +278,9 @@ fn load_file_or_record_skip(
     path: &Path,
     facts: &mut ScanFacts,
     config: &ScanConfig,
-    executable_roots: &[PathBuf],
+    package_roots: &[PackageRoot],
 ) -> io::Result<LoadedFile> {
-    let loaded = load_file(path, config, executable_roots)?;
+    let loaded = load_file(path, config, package_roots)?;
     if let LoadedFile::Skipped {
         language,
         reason,

--- a/src/scan/workspace/executables.rs
+++ b/src/scan/workspace/executables.rs
@@ -1,0 +1,128 @@
+use super::detect_workspace_packages;
+use std::path::{Path, PathBuf};
+
+/// Directories that are the root of a package declaring an executable
+/// entrypoint — an npm `package.json#bin`, or a Cargo crate with a binary
+/// target (`[[bin]]`, a `src/bin/` directory, or `src/main.rs`). Every source
+/// file under such a directory belongs to a CLI tool, where `process.exit`-style
+/// host termination is an intended boundary rather than a hazard in reusable
+/// code.
+///
+/// Considers the scan root itself plus any detected workspace members, so a
+/// monorepo's CLI package is recognized while its non-CLI siblings (e.g. a web
+/// app under `apps/web` with a `domain/commands/` directory) are not.
+pub fn cli_executable_roots(root: &Path) -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = vec![root.to_path_buf()];
+    candidates.extend(detect_workspace_packages(root).into_iter().map(|p| p.root));
+
+    candidates
+        .into_iter()
+        .filter(|dir| declares_executable(dir))
+        .collect()
+}
+
+fn declares_executable(dir: &Path) -> bool {
+    npm_declares_bin(dir) || cargo_declares_bin(dir)
+}
+
+/// npm `bin` may be a string (`"./cli.js"`) or an object mapping command names
+/// to paths (`{ "tool": "./cli.js" }`); either form declares an executable.
+fn npm_declares_bin(dir: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(dir.join("package.json")) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+    matches!(value.get("bin"), Some(v) if v.is_string() || v.is_object())
+}
+
+fn cargo_declares_bin(dir: &Path) -> bool {
+    if dir.join("src/bin").is_dir() || dir.join("src/main.rs").is_file() {
+        return true;
+    }
+    std::fs::read_to_string(dir.join("Cargo.toml"))
+        .map(|content| content.contains("[[bin]]"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cli_executable_roots;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn npm_bin_object_marks_root_as_cli() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{ "name": "ignite-cli", "bin": { "ignite": "bin/ignite" } }"#,
+        )
+        .unwrap();
+
+        let roots = cli_executable_roots(dir.path());
+        assert_eq!(roots, vec![dir.path().to_path_buf()]);
+    }
+
+    #[test]
+    fn npm_bin_string_marks_root_as_cli() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{ "name": "tool", "bin": "./cli.js" }"#,
+        )
+        .unwrap();
+
+        assert_eq!(cli_executable_roots(dir.path()).len(), 1);
+    }
+
+    #[test]
+    fn package_without_bin_is_not_cli() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{ "name": "web-app", "dependencies": {} }"#,
+        )
+        .unwrap();
+
+        assert!(cli_executable_roots(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn cargo_bin_target_marks_root_as_cli() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"tool\"\n\n[[bin]]\nname = \"tool\"\npath = \"src/main.rs\"\n",
+        )
+        .unwrap();
+
+        assert_eq!(cli_executable_roots(dir.path()).len(), 1);
+    }
+
+    #[test]
+    fn only_cli_workspace_member_is_marked() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{ "name": "monorepo", "workspaces": ["packages/*"] }"#,
+        )
+        .unwrap();
+
+        let cli = dir.path().join("packages/cli");
+        let web = dir.path().join("packages/web");
+        fs::create_dir_all(&cli).unwrap();
+        fs::create_dir_all(&web).unwrap();
+        fs::write(
+            cli.join("package.json"),
+            r#"{ "name": "cli", "bin": "./index.js" }"#,
+        )
+        .unwrap();
+        fs::write(web.join("package.json"), r#"{ "name": "web" }"#).unwrap();
+
+        let roots = cli_executable_roots(dir.path());
+        assert!(roots.contains(&cli));
+        assert!(!roots.contains(&web));
+    }
+}

--- a/src/scan/workspace/executables.rs
+++ b/src/scan/workspace/executables.rs
@@ -1,24 +1,54 @@
 use super::detect_workspace_packages;
 use std::path::{Path, PathBuf};
 
-/// Directories that are the root of a package declaring an executable
-/// entrypoint — an npm `package.json#bin`, or a Cargo crate with a binary
-/// target (`[[bin]]`, a `src/bin/` directory, or `src/main.rs`). Every source
-/// file under such a directory belongs to a CLI tool, where `process.exit`-style
-/// host termination is an intended boundary rather than a hazard in reusable
-/// code.
-///
-/// Considers the scan root itself plus any detected workspace members, so a
-/// monorepo's CLI package is recognized while its non-CLI siblings (e.g. a web
-/// app under `apps/web` with a `domain/commands/` directory) are not.
-pub fn cli_executable_roots(root: &Path) -> Vec<PathBuf> {
-    let mut candidates: Vec<PathBuf> = vec![root.to_path_buf()];
-    candidates.extend(detect_workspace_packages(root).into_iter().map(|p| p.root));
+/// A package root and whether it declares an executable entrypoint (npm
+/// `package.json#bin`, or a Cargo crate with a binary target — `[[bin]]`, a
+/// `src/bin/` directory, or `src/main.rs`).
+#[derive(Debug, Clone)]
+pub struct PackageRoot {
+    pub root: PathBuf,
+    pub declares_executable: bool,
+}
 
-    candidates
-        .into_iter()
-        .filter(|dir| declares_executable(dir))
-        .collect()
+/// All package roots under `root`: the scan root itself when it carries a
+/// manifest, plus every detected workspace member. Each is tagged with whether
+/// it declares an executable.
+///
+/// The full set (not just the executable ones) is returned so a file can be
+/// resolved to its *nearest* package — see [`path_in_executable_package`]. This
+/// is what prevents a CLI at the monorepo root from marking a non-CLI sibling
+/// package as executable.
+pub fn package_roots(root: &Path) -> Vec<PackageRoot> {
+    let mut roots = Vec::new();
+    if has_manifest(root) {
+        roots.push(PackageRoot {
+            root: root.to_path_buf(),
+            declares_executable: declares_executable(root),
+        });
+    }
+    for pkg in detect_workspace_packages(root) {
+        roots.push(PackageRoot {
+            declares_executable: declares_executable(&pkg.root),
+            root: pkg.root,
+        });
+    }
+    roots
+}
+
+/// Whether `path`'s *nearest* (longest-prefix) package root declares an
+/// executable. A file under `packages/web/` resolves against
+/// `packages/web/package.json`, not the monorepo root, so a root-level CLI does
+/// not downgrade exits in non-CLI sibling packages.
+pub fn path_in_executable_package(path: &Path, roots: &[PackageRoot]) -> bool {
+    roots
+        .iter()
+        .filter(|candidate| path.starts_with(&candidate.root))
+        .max_by_key(|candidate| candidate.root.components().count())
+        .is_some_and(|nearest| nearest.declares_executable)
+}
+
+fn has_manifest(dir: &Path) -> bool {
+    dir.join("package.json").is_file() || dir.join("Cargo.toml").is_file()
 }
 
 fn declares_executable(dir: &Path) -> bool {
@@ -48,12 +78,12 @@ fn cargo_declares_bin(dir: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::cli_executable_roots;
+    use super::{package_roots, path_in_executable_package};
     use std::fs;
     use tempfile::TempDir;
 
     #[test]
-    fn npm_bin_object_marks_root_as_cli() {
+    fn npm_bin_object_marks_package() {
         let dir = TempDir::new().unwrap();
         fs::write(
             dir.path().join("package.json"),
@@ -61,12 +91,15 @@ mod tests {
         )
         .unwrap();
 
-        let roots = cli_executable_roots(dir.path());
-        assert_eq!(roots, vec![dir.path().to_path_buf()]);
+        let roots = package_roots(dir.path());
+        assert!(path_in_executable_package(
+            &dir.path().join("src/commands/new.ts"),
+            &roots
+        ));
     }
 
     #[test]
-    fn npm_bin_string_marks_root_as_cli() {
+    fn npm_bin_string_marks_package() {
         let dir = TempDir::new().unwrap();
         fs::write(
             dir.path().join("package.json"),
@@ -74,11 +107,15 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(cli_executable_roots(dir.path()).len(), 1);
+        let roots = package_roots(dir.path());
+        assert!(path_in_executable_package(
+            &dir.path().join("src/index.js"),
+            &roots
+        ));
     }
 
     #[test]
-    fn package_without_bin_is_not_cli() {
+    fn package_without_bin_is_not_executable() {
         let dir = TempDir::new().unwrap();
         fs::write(
             dir.path().join("package.json"),
@@ -86,11 +123,15 @@ mod tests {
         )
         .unwrap();
 
-        assert!(cli_executable_roots(dir.path()).is_empty());
+        let roots = package_roots(dir.path());
+        assert!(!path_in_executable_package(
+            &dir.path().join("src/server.ts"),
+            &roots
+        ));
     }
 
     #[test]
-    fn cargo_bin_target_marks_root_as_cli() {
+    fn cargo_bin_target_marks_package() {
         let dir = TempDir::new().unwrap();
         fs::write(
             dir.path().join("Cargo.toml"),
@@ -98,31 +139,52 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(cli_executable_roots(dir.path()).len(), 1);
+        let roots = package_roots(dir.path());
+        assert!(path_in_executable_package(
+            &dir.path().join("src/lib.rs"),
+            &roots
+        ));
     }
 
     #[test]
-    fn only_cli_workspace_member_is_marked() {
+    fn root_cli_does_not_mark_non_cli_workspace_member() {
+        // The exact boundary the path-prefix check must respect: a CLI declared
+        // at the monorepo root must not make a non-CLI sibling package executable.
         let dir = TempDir::new().unwrap();
         fs::write(
             dir.path().join("package.json"),
-            r#"{ "name": "monorepo", "workspaces": ["packages/*"] }"#,
+            r#"{ "name": "monorepo", "workspaces": ["packages/*"], "bin": { "my-tool": "./src/cli.ts" } }"#,
         )
         .unwrap();
 
-        let cli = dir.path().join("packages/cli");
         let web = dir.path().join("packages/web");
-        fs::create_dir_all(&cli).unwrap();
+        let core = dir.path().join("packages/core");
         fs::create_dir_all(&web).unwrap();
+        fs::create_dir_all(&core).unwrap();
+        fs::write(web.join("package.json"), r#"{ "name": "web" }"#).unwrap();
         fs::write(
-            cli.join("package.json"),
-            r#"{ "name": "cli", "bin": "./index.js" }"#,
+            core.join("package.json"),
+            r#"{ "name": "core", "bin": "./index.js" }"#,
         )
         .unwrap();
-        fs::write(web.join("package.json"), r#"{ "name": "web" }"#).unwrap();
 
-        let roots = cli_executable_roots(dir.path());
-        assert!(roots.contains(&cli));
-        assert!(!roots.contains(&web));
+        let roots = package_roots(dir.path());
+
+        // A file directly under the root belongs to the root CLI package.
+        assert!(path_in_executable_package(
+            &dir.path().join("src/cli.ts"),
+            &roots
+        ));
+        // A file in the non-CLI `web` package resolves to `packages/web` (no bin),
+        // NOT the root, so it is not executable.
+        assert!(!path_in_executable_package(
+            &web.join("src/server.ts"),
+            &roots
+        ));
+        // A file in the CLI `core` package is executable on its own merit.
+        assert!(path_in_executable_package(
+            &core.join("src/main.js"),
+            &roots
+        ));
     }
 }

--- a/src/scan/workspace/mod.rs
+++ b/src/scan/workspace/mod.rs
@@ -1,8 +1,11 @@
 use std::path::{Path, PathBuf};
 
 mod cargo;
+mod executables;
 mod go;
 mod js;
+
+pub use executables::cli_executable_roots;
 
 #[cfg(test)]
 mod tests;

--- a/src/scan/workspace/mod.rs
+++ b/src/scan/workspace/mod.rs
@@ -5,7 +5,7 @@ mod executables;
 mod go;
 mod js;
 
-pub use executables::cli_executable_roots;
+pub use executables::{PackageRoot, package_roots, path_in_executable_package};
 
 #[cfg(test)]
 mod tests;

--- a/tests/architecture_context.rs
+++ b/tests/architecture_context.rs
@@ -67,6 +67,7 @@ fn test_default_module_mappings() {
             imports: vec![],
             content: None,
             has_inline_tests: false,
+            in_executable_package: false,
         };
 
         let context = classifier.classify(&file);
@@ -99,6 +100,7 @@ fn test_custom_module_mappings() {
         imports: vec![],
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     };
     let context = classifier.classify(&domain_file);
     assert_eq!(context.module_kind, ModuleKind::Domain);
@@ -111,6 +113,7 @@ fn test_custom_module_mappings() {
         imports: vec![],
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     };
     let context = classifier.classify(&ui_file);
     assert_eq!(context.module_kind, ModuleKind::Ui);
@@ -123,6 +126,7 @@ fn test_custom_module_mappings() {
         imports: vec![],
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     };
     let context = classifier.classify(&unknown_file);
     assert_eq!(context.module_kind, ModuleKind::Unknown);
@@ -152,6 +156,7 @@ fn test_language_families() {
             imports: vec![],
             content: None,
             has_inline_tests: false,
+            in_executable_package: false,
         };
 
         let context = classifier.classify(&file);

--- a/tests/complexity_audit.rs
+++ b/tests/complexity_audit.rs
@@ -13,6 +13,7 @@ fn make_file(non_empty_lines: usize, branch_count: usize) -> FileFacts {
         imports: Vec::new(),
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }
 
@@ -78,6 +79,7 @@ fn skips_unsupported_language() {
         imports: Vec::new(),
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     };
     let findings = ComplexityAudit.audit(&file, &ScanConfig::default());
     assert!(findings.is_empty());

--- a/tests/deep_control_flow_test.rs
+++ b/tests/deep_control_flow_test.rs
@@ -13,6 +13,7 @@ fn file_facts(path: &str, language: &str, content: &str) -> FileFacts {
         imports: Vec::new(),
         content: Some(content.to_string()),
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }
 

--- a/tests/large_file_architecture.rs
+++ b/tests/large_file_architecture.rs
@@ -83,6 +83,7 @@ fn large_file_audit_skips_non_code_files() {
             imports: Vec::new(),
             content: None,
             has_inline_tests: false,
+            in_executable_package: false,
         };
 
         let findings = LargeFileAudit.audit(&file, &ScanConfig::default());
@@ -108,6 +109,7 @@ fn large_file_audit_skips_stylesheet_and_markup_files() {
             imports: Vec::new(),
             content: None,
             has_inline_tests: false,
+            in_executable_package: false,
         };
 
         let findings = LargeFileAudit.audit(&file, &ScanConfig::default());
@@ -129,6 +131,7 @@ fn large_file_audit_skips_test_and_fixture_paths() {
             imports: Vec::new(),
             content: None,
             has_inline_tests: false,
+            in_executable_package: false,
         };
 
         let findings = LargeFileAudit.audit(&file, &ScanConfig::default());

--- a/tests/long_function_audit.rs
+++ b/tests/long_function_audit.rs
@@ -18,6 +18,7 @@ fn make_file_at(path: &str, language: &str, content: &str) -> FileFacts {
         imports: Vec::new(),
         content: Some(content.to_string()),
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }
 

--- a/tests/marker_findings.rs
+++ b/tests/marker_findings.rs
@@ -21,6 +21,7 @@ fn main() {}
         imports: Vec::new(),
         content: Some(content.to_string()),
         has_inline_tests: false,
+        in_executable_package: false,
     };
 
     let findings = detect_code_marker_findings(&file);

--- a/tests/risk_engine.rs
+++ b/tests/risk_engine.rs
@@ -359,6 +359,7 @@ fn file(path: &str, language: Option<&str>) -> FileFacts {
         imports: Vec::new(),
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }
 

--- a/tests/scan_visibility_cli.rs
+++ b/tests/scan_visibility_cli.rs
@@ -82,6 +82,12 @@ fn default_scan_hides_cli_package_process_exit_but_reports_non_cli_package() {
         root.join("packages/cli/src/commands/run.ts"),
         "export const run = () => { process.exit(1); };\n",
     );
+    // A reusable module inside the CLI package: NOT a command handler, so its exit
+    // stays default-visible High even though the package declares `bin`.
+    write(
+        root.join("packages/cli/src/lib/parser.ts"),
+        "export function parse(s: string) { if (!s) { process.exit(1); } }\n",
+    );
     write(
         root.join("packages/web/package.json"),
         r#"{ "name": "@app/web" }"#,
@@ -92,23 +98,32 @@ fn default_scan_hides_cli_package_process_exit_but_reports_non_cli_package() {
     );
 
     let json = scan_json(root, &[]);
-    let default_findings =
-        findings_for_rule(&json, "language.javascript.runtime-exit-risk").collect::<Vec<_>>();
+    let default_paths = findings_for_rule(&json, "language.javascript.runtime-exit-risk")
+        .map(first_path)
+        .collect::<Vec<_>>();
     assert_eq!(
-        default_findings.len(),
-        1,
-        "default report should hide the CLI package's exit and keep the non-CLI one: {json:#?}"
+        default_paths.len(),
+        2,
+        "default should hide only the CLI command handler's exit: {json:#?}"
     );
     assert!(
-        first_path(default_findings[0]).ends_with("handler.ts"),
-        "the default-visible exit must be the non-CLI (domain) command"
+        default_paths.iter().any(|p| p.ends_with("handler.ts")),
+        "the non-CLI (domain) command exit must stay visible"
+    );
+    assert!(
+        default_paths.iter().any(|p| p.ends_with("parser.ts")),
+        "a reusable module's exit inside the CLI package must stay visible"
+    );
+    assert!(
+        !default_paths.iter().any(|p| p.ends_with("run.ts")),
+        "the CLI command handler's exit must be hidden by default"
     );
 
     let strict = scan_json(root, &["--profile", "strict"]);
     assert_eq!(
         findings_for_rule(&strict, "language.javascript.runtime-exit-risk").count(),
-        2,
-        "strict report should include both CLI and non-CLI process.exit findings: {strict:#?}"
+        3,
+        "strict report should include all three process.exit findings: {strict:#?}"
     );
 }
 

--- a/tests/scan_visibility_cli.rs
+++ b/tests/scan_visibility_cli.rs
@@ -61,6 +61,58 @@ fn default_scan_hides_script_process_exit_but_reports_library_process_exit() {
 }
 
 #[test]
+fn default_scan_hides_cli_package_process_exit_but_reports_non_cli_package() {
+    // A monorepo with two packages that both call `process.exit` from a
+    // `commands/` directory. Only the package that declares `package.json#bin`
+    // is a CLI tool, so its exit is downgraded to Low (hidden by default, kept in
+    // strict). The non-CLI package's `commands/` is a CQRS/domain command, so its
+    // host-terminating exit stays a default-visible High — the false-negative
+    // guard for the old path-only `commands/` heuristic.
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    write(
+        root.join("package.json"),
+        r#"{ "name": "monorepo", "workspaces": ["packages/*"] }"#,
+    );
+    write(
+        root.join("packages/cli/package.json"),
+        r#"{ "name": "@app/cli", "bin": { "app": "./bin/app.js" } }"#,
+    );
+    write(
+        root.join("packages/cli/src/commands/run.ts"),
+        "export const run = () => { process.exit(1); };\n",
+    );
+    write(
+        root.join("packages/web/package.json"),
+        r#"{ "name": "@app/web" }"#,
+    );
+    write(
+        root.join("packages/web/src/domain/commands/handler.ts"),
+        "export function handle() { process.exit(1); }\n",
+    );
+
+    let json = scan_json(root, &[]);
+    let default_findings =
+        findings_for_rule(&json, "language.javascript.runtime-exit-risk").collect::<Vec<_>>();
+    assert_eq!(
+        default_findings.len(),
+        1,
+        "default report should hide the CLI package's exit and keep the non-CLI one: {json:#?}"
+    );
+    assert!(
+        first_path(default_findings[0]).ends_with("handler.ts"),
+        "the default-visible exit must be the non-CLI (domain) command"
+    );
+
+    let strict = scan_json(root, &["--profile", "strict"]);
+    assert_eq!(
+        findings_for_rule(&strict, "language.javascript.runtime-exit-risk").count(),
+        2,
+        "strict report should include both CLI and non-CLI process.exit findings: {strict:#?}"
+    );
+}
+
+#[test]
 fn default_scan_reports_unwrap_on_external_parse_path() {
     let temp = tempdir().expect("temp dir");
     let root = temp.path();

--- a/tests/security_rules.rs
+++ b/tests/security_rules.rs
@@ -311,5 +311,6 @@ fn file(path: &str, content: &str) -> FileFacts {
         imports: Vec::new(),
         content: Some(content.to_string()),
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }

--- a/tests/testing_rules.rs
+++ b/tests/testing_rules.rs
@@ -244,6 +244,7 @@ fn python_init_and_infra_not_flagged() {
                 imports: Vec::new(),
                 content: None,
                 has_inline_tests: false,
+                in_executable_package: false,
             }],
             files_analyzed: 1,
             ..ScanFacts::default()
@@ -285,6 +286,7 @@ fn ts_file(path: &str) -> FileFacts {
         imports: Vec::new(),
         content: None,
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }
 
@@ -297,5 +299,6 @@ fn file(path: &str) -> FileFacts {
         imports: Vec::new(),
         content: Some("pub fn value() {}\n".to_string()),
         has_inline_tests: false,
+        in_executable_package: false,
     }
 }

--- a/tests/zoo/snapshots/changesets.json
+++ b/tests/zoo/snapshots/changesets.json
@@ -1,17 +1,15 @@
 {
   "default": {
     "by_priority": {
-      "P0": 2
+      "P0": 1
     },
     "by_rule": {
-      "architecture.circular-dependency": 1,
-      "language.javascript.runtime-exit-risk": 1
+      "architecture.circular-dependency": 1
     },
     "fingerprints": [
-      "architecture.circular-dependency:packages/cli/src/commands/publish/npm-utils.ts:8a41bbd295f5f42b",
-      "language.javascript.runtime-exit-risk:packages/cli/src/utils/cli-utilities.ts:272512749156ce06"
+      "architecture.circular-dependency:packages/cli/src/commands/publish/npm-utils.ts:8a41bbd295f5f42b"
     ],
-    "visible_total": 2
+    "visible_total": 1
   },
   "framework": "",
   "language": "typescript",

--- a/tests/zoo/snapshots/changesets.json
+++ b/tests/zoo/snapshots/changesets.json
@@ -1,15 +1,17 @@
 {
   "default": {
     "by_priority": {
-      "P0": 1
+      "P0": 2
     },
     "by_rule": {
-      "architecture.circular-dependency": 1
+      "architecture.circular-dependency": 1,
+      "language.javascript.runtime-exit-risk": 1
     },
     "fingerprints": [
-      "architecture.circular-dependency:packages/cli/src/commands/publish/npm-utils.ts:8a41bbd295f5f42b"
+      "architecture.circular-dependency:packages/cli/src/commands/publish/npm-utils.ts:8a41bbd295f5f42b",
+      "language.javascript.runtime-exit-risk:packages/cli/src/utils/cli-utilities.ts:272512749156ce06"
     ],
-    "visible_total": 1
+    "visible_total": 2
   },
   "framework": "",
   "language": "typescript",

--- a/tests/zoo/snapshots/ignite.json
+++ b/tests/zoo/snapshots/ignite.json
@@ -20,9 +20,9 @@
       "code-quality.deep-control-flow": 1,
       "code-quality.long-function": 23,
       "framework.js.console-log": 6,
-      "language.javascript.runtime-exit-risk": 3,
+      "language.javascript.runtime-exit-risk": 12,
       "testing.source-without-test": 100
     },
-    "visible_total": 191
+    "visible_total": 200
   }
 }

--- a/tests/zoo/snapshots/ignite.json
+++ b/tests/zoo/snapshots/ignite.json
@@ -1,23 +1,9 @@
 {
   "default": {
-    "by_priority": {
-      "P0": 9
-    },
-    "by_rule": {
-      "language.javascript.runtime-exit-risk": 9
-    },
-    "fingerprints": [
-      "language.javascript.runtime-exit-risk:src/commands/issue.ts:199bbf8d553e4213",
-      "language.javascript.runtime-exit-risk:src/commands/new.ts:199bbf8d553e4213",
-      "language.javascript.runtime-exit-risk:src/commands/new.ts:199bbf8d553e4213",
-      "language.javascript.runtime-exit-risk:src/commands/new.ts:199bbf8d553e4213",
-      "language.javascript.runtime-exit-risk:src/commands/new.ts:199bbf8d553e4213",
-      "language.javascript.runtime-exit-risk:src/commands/new.ts:199bbf8d553e4213",
-      "language.javascript.runtime-exit-risk:src/commands/new.ts:199bbf8d553e4213",
-      "language.javascript.runtime-exit-risk:src/commands/new.ts:199bbf8d553e4213",
-      "language.javascript.runtime-exit-risk:src/commands/new.ts:199bbf8d553e4213"
-    ],
-    "visible_total": 9
+    "by_priority": {},
+    "by_rule": {},
+    "fingerprints": [],
+    "visible_total": 0
   },
   "framework": "react-native",
   "language": "typescript",
@@ -34,9 +20,9 @@
       "code-quality.deep-control-flow": 1,
       "code-quality.long-function": 23,
       "framework.js.console-log": 6,
-      "language.javascript.runtime-exit-risk": 12,
+      "language.javascript.runtime-exit-risk": 3,
       "testing.source-without-test": 100
     },
-    "visible_total": 200
+    "visible_total": 191
   }
 }


### PR DESCRIPTION
## Summary

Refines `language.javascript.runtime-exit-risk` so `process.exit(...)` is not reported when it appears at a verified JavaScript or TypeScript CLI boundary.

Process termination is expected in executable entrypoints and CLI command handlers, while the same call remains a High-severity signal inside reusable application or library code.

## Type of change

* [ ] Feature
* [ ] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added CLI-context handling for JavaScript and TypeScript process-exit detection.
* Excluded verified executable entrypoints and CLI command handlers from default-visible runtime-exit findings.
* Kept `process.exit(...)` in ordinary reusable modules as a High-severity finding.
* Added regression coverage for CLI command modules and executable scripts.
* Updated the Ignite real-repo zoo snapshot.
* Updated `CHANGELOG.md`.

## Why

The real-repo zoo showed that RepoPilot reported `process.exit(...)` in Ignite CLI command modules even though those modules intentionally own the CLI process exit code.

The rule recommendation already says process exits should remain at the CLI boundary. This change aligns detection behavior with that contract while preserving findings for process termination buried in reusable code.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] No unrelated refactor or generated-file churn is included

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
python3 scripts/zoo.py scan --only ignite
python3 scripts/zoo.py report
```
