### PR TITLE
feat(ai): add budget-aware JSON output for AI context

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,8 @@
 - [ ] The change stays within a clear subsystem or ownership boundary
 - [ ] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
 - [ ] New or changed findings/signals include deterministic evidence and tests
+- [ ] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
+- [ ] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
 - [ ] No unrelated refactor or generated-file churn is included
 
 ## Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,24 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- **`repopilot ai context --format json`** emits a structured, deterministic JSON
+  handoff — schema version, project, risk summary, repository facts,
+  focus-filtered findings, and the prioritized P0–P3 plan — so agents get the same
+  facts the Markdown brief carries without parsing Markdown, matching the JSON the
+  MCP tools already return. Markdown stays the default; JSON output never mixes in
+  the stderr token breakdown. Pinned by a golden snapshot.
+
 ### Changed
+
+- **The `repopilot_context` MCP tool now includes the repository facts summary**
+  (aggregate file, line, and language stats), matching `repopilot ai context`. The
+  tool previously rendered without facts despite documenting a fact-only brief, so
+  agents calling it received a thinner context than the CLI; they now get the same
+  aggregate stack/size picture.
+
+- **Agent-facing docs now document the false-positive/noise-reduction workflow.** MCP docs and AI-context workflow docs now call out strict-mode recall, exact duplicate aggregation, changed-scan limits, and the need for false-negative guard tests before hiding or downgrading signals.
 
 - **`language.javascript.runtime-exit-risk` downgrades `process.exit(...)` in a
   CLI tool's command handlers instead of surfacing them as a default High.** A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,20 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Added
 
 - **`repopilot ai context --format json`** emits a structured, deterministic JSON
-  handoff — schema version, project, risk summary, repository facts,
-  focus-filtered findings, and the prioritized P0–P3 plan — so agents get the same
-  facts the Markdown brief carries without parsing Markdown, matching the JSON the
-  MCP tools already return. Markdown stays the default; JSON output never mixes in
-  the stderr token breakdown. Pinned by a golden snapshot.
+  handoff so agents get the same facts the Markdown brief carries without parsing
+  Markdown, matching the JSON the MCP tools already return. Each finding includes
+  the evidence an agent needs — stable id, severity/confidence, `risk` (score,
+  priority, signals), description, recommendation, docs URL, and the full
+  `evidence` list (path, line range, snippet) — not just a title. Like the
+  Markdown brief it is **budget-aware**: findings are ordered by risk and added
+  until the serialized output reaches `--budget`, and the document reports
+  `truncated`, `findings_included/omitted`, and `plan_clusters_included` so the
+  budget is honest rather than advisory. `approx_tokens` is measured from the real
+  (pretty) output. `risk.level` is a machine token (`moderate`) alongside the
+  display `risk.label` (`🟡 MODERATE`). Markdown stays the default; `--no-header`
+  and `--no-task` apply to Markdown only (JSON is always fact-only), and JSON
+  never mixes the stderr token breakdown in. Pinned by a golden snapshot and
+  end-to-end CLI tests.
 
 ### Changed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -296,9 +296,14 @@ the MCP tools) with `--profile strict` when you need recall validation before
 deciding whether a signal should be downgraded, hidden, or kept visible.
 
 `ai context` emits Markdown by default. Pass `--format json` for a structured,
-deterministic handoff (project, risk summary, repository facts, focus-filtered
-findings, and the P0–P3 plan) — the same facts without Markdown parsing, matching
-the JSON the MCP tools return. JSON output never mixes in the stderr token breakdown.
+deterministic handoff — project, risk summary, repository facts, focus-filtered
+findings (each with stable id, `risk` score/priority/signals, description,
+recommendation, and the full `evidence` list), and the P0–P3 plan — the same facts
+without Markdown parsing, matching the JSON the MCP tools return. The JSON form is
+**budget-aware**: findings are ordered by risk and added until the output reaches
+`--budget`, and the document reports `truncated` plus included/omitted counts, so
+the budget is honest. `--no-header`/`--no-task` affect Markdown only (JSON is
+always fact-only), and JSON output never mixes in the stderr token breakdown.
 
 ### Synopsis
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -290,7 +290,15 @@ Scans the repository and formats one LLM-ready handoff as structured Markdown fo
 
 The handoff bundles a risk summary, tech stack signals, findings grouped by category with evidence snippets, the Context Risk Graph edit order, a prioritized P0–P3 remediation plan, working rules, a verification checklist, and an approximate token count. The standalone `ai plan` and `ai prompt` commands were folded into this single handoff. Pass `--no-task` to drop the agent guidance (task, rules, and verification) and emit fact-only context — the same form the MCP `context` tool returns.
 
-`ai context` emits Markdown only and does not accept `--format`.
+For false-positive work, remember that this handoff is product-facing context.
+The default profile may hide low-confidence suggestions; use `scan`/`review` (or
+the MCP tools) with `--profile strict` when you need recall validation before
+deciding whether a signal should be downgraded, hidden, or kept visible.
+
+`ai context` emits Markdown by default. Pass `--format json` for a structured,
+deterministic handoff (project, risk summary, repository facts, focus-filtered
+findings, and the P0–P3 plan) — the same facts without Markdown parsing, matching
+the JSON the MCP tools return. JSON output never mixes in the stderr token breakdown.
 
 ### Synopsis
 
@@ -312,6 +320,7 @@ repopilot ai context <PATH> [OPTIONS]
 | `--focus` | `security\|arch\|architecture\|quality\|framework\|all` | `all` | Limit output to a category |
 | `--budget` | `2k\|4k\|8k\|16k` or positive integer | `4k` | Target token budget |
 | `-o, --output` | path | stdout | Write output to a file instead of stdout |
+| `--format` | `markdown\|json` | `markdown` | Output format: human-readable Markdown, or structured JSON for agents |
 | `--no-header` | flag | — | Omit the intro header block |
 | `--no-task` | flag | — | Omit the AI task instruction preamble |
 | `--show-breakdown` | flag | — | Print a per-section token breakdown to stderr (automatic when stdout is a TTY) |
@@ -323,6 +332,7 @@ repopilot ai context .
 repopilot ai context . --focus security --budget 2k
 repopilot ai context . --output ai-context.md
 repopilot ai context . --no-task --output ai-context.md
+repopilot ai context . --format json --output ai-context.json
 ```
 
 ---

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -149,6 +149,13 @@ Keep remediation prompts scoped to one risk category or priority group. Require
 the agent to preserve unrelated behavior, add focused tests, and report any
 verification it could not run.
 
+For false-positive or noise-reduction work, ask the agent to keep strict-mode
+recall intact: downgrade or hide low-confidence/default noise rather than deleting
+signals, and require a false-negative guard test. Generic dedupe should only merge
+exact duplicate emissions (`rule_id` + file + line + snippet + compatible
+metadata); broader aggregation belongs in the specific audit that can prove
+several locations are one logical issue.
+
 For direct agent integration, run the local MCP server:
 
 ```bash

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -46,6 +46,13 @@ to `scope=changed`, `profile=default`, `fail_on_review=none`, and
 and review accept `filters.min_severity`, `filters.min_confidence`,
 `filters.min_priority`, and `filters.rules`.
 
+For agent-assisted remediation, treat default-profile tool output as the product
+view, not the full recall set. Use `profile=strict` when auditing false positives,
+validating that a downgrade remains recoverable, or checking whether hidden
+suggestions still exist. Changed-scope tools are optimized for edited files and
+cache reuse; run a full scan when repository-wide architecture/framework findings
+or aggregate counts must be authoritative.
+
 Tool failures use MCP `isError: true`. Malformed input produces JSON-RPC error
 `-32700` instead of being skipped.
 

--- a/src/cli/options/ai.rs
+++ b/src/cli/options/ai.rs
@@ -38,9 +38,13 @@ pub struct AiContextOptions {
     #[arg(long, value_parser = parse_token_budget)]
     pub budget: Option<usize>,
 
-    /// Write Markdown output to a file instead of stdout
+    /// Write output to a file instead of stdout
     #[arg(short, long)]
     pub output: Option<PathBuf>,
+
+    /// Output format for the handoff: markdown (default, human-readable) or json (structured, for agents)
+    #[arg(long, value_parser = ["markdown", "json"], default_value = "markdown")]
+    pub format: String,
 
     /// Omit the intro header block
     #[arg(long)]

--- a/src/cli/options/ai.rs
+++ b/src/cli/options/ai.rs
@@ -46,11 +46,11 @@ pub struct AiContextOptions {
     #[arg(long, value_parser = ["markdown", "json"], default_value = "markdown")]
     pub format: String,
 
-    /// Omit the intro header block
+    /// Omit the intro header block (Markdown output only)
     #[arg(long)]
     pub no_header: bool,
 
-    /// Omit the AI task instruction block (the "> Instructions for AI assistant:" preamble)
+    /// Omit the AI task instruction block — the "> Instructions for AI assistant:" preamble (Markdown output only; JSON is always fact-only)
     #[arg(long)]
     pub no_task: bool,
 

--- a/src/commands/ai_context.rs
+++ b/src/commands/ai_context.rs
@@ -1,7 +1,7 @@
 use crate::cli::ai::AiContextOptions;
 use crate::commands::llm::{LlmCommandArgs, run_markdown_command};
 use repopilot::output::ai_context::{
-    AiContextRenderOptions, render_with_facts_summary_and_breakdown,
+    AiContextRenderOptions, render_json, render_with_facts_summary_and_breakdown,
 };
 use std::io::IsTerminal;
 
@@ -12,14 +12,17 @@ pub fn run(options: AiContextOptions) -> Result<(), Box<dyn std::error::Error>> 
         focus,
         budget,
         output,
+        format,
         no_header,
         no_task,
         show_breakdown,
     } = options;
 
+    let want_json = format == "json";
     // Show breakdown when explicitly requested or when stdout is a terminal
-    // (piping to pbcopy/clip suppresses it automatically).
-    let should_show_breakdown = show_breakdown || std::io::stdout().is_terminal();
+    // (piping to pbcopy/clip suppresses it automatically). JSON output stays
+    // machine-clean, so the breakdown is never mixed in.
+    let should_show_breakdown = !want_json && (show_breakdown || std::io::stdout().is_terminal());
 
     run_markdown_command(
         LlmCommandArgs {
@@ -36,6 +39,9 @@ pub fn run(options: AiContextOptions) -> Result<(), Box<dyn std::error::Error>> 
                 no_header,
                 no_task,
             };
+            if want_json {
+                return render_json(summary, facts_summary, &opts);
+            }
             let (content, breakdown) =
                 render_with_facts_summary_and_breakdown(summary, facts_summary, &opts);
             if should_show_breakdown {

--- a/src/commands/mcp/context.rs
+++ b/src/commands/mcp/context.rs
@@ -2,11 +2,15 @@
 //! repository, wrapping the same builder the `ai context` command uses.
 
 use crate::commands::focus::parse_focus_category;
-use crate::commands::product_scan::{ProductScanMode, ProductScanRequest, run_product_scan};
+use crate::commands::product_scan::{
+    ProductScanMode, ProductScanRequest, run_product_scan_with_facts_summary,
+};
 use crate::commands::scan_config::ScanConfigOverrides;
 use repopilot::findings::filter::FindingFilter;
 use repopilot::findings::visibility::FindingVisibilityProfile;
-use repopilot::output::ai_context::{AiContextRenderOptions, DEFAULT_TOKEN_BUDGET, render};
+use repopilot::output::ai_context::{
+    AiContextRenderOptions, DEFAULT_TOKEN_BUDGET, render_with_facts_summary_and_breakdown,
+};
 use serde_json::{Value, json};
 use std::path::PathBuf;
 
@@ -69,7 +73,7 @@ pub fn call(arguments: &Value) -> Result<String, String> {
         Some(other) => return Err(format!("invalid profile: {other}")),
     };
 
-    let scan_result = run_product_scan(ProductScanRequest {
+    let scan_result = run_product_scan_with_facts_summary(ProductScanRequest {
         path,
         config_path,
         overrides: ScanConfigOverrides::default(),
@@ -83,9 +87,11 @@ pub fn call(arguments: &Value) -> Result<String, String> {
     .map_err(|error| format!("scan failed: {error}"))?;
 
     // Agents that call this tool bring their own instructions, so return the
-    // fact-only context (facts, evidence, prioritized plan, edit order) — the
-    // same form `repopilot ai context --no-task` emits — and omit the human task
-    // preamble, working rules, and verification checklist.
+    // fact-only context (repository facts, evidence, prioritized plan, edit
+    // order) — the same form `repopilot ai context --no-task` emits — and omit
+    // the human task preamble, working rules, and verification checklist. The
+    // facts summary mirrors what the CLI handoff includes so agents get the same
+    // aggregate stack/size picture, not a thinner brief.
     let options = AiContextRenderOptions {
         focus,
         budget_tokens,
@@ -93,5 +99,10 @@ pub fn call(arguments: &Value) -> Result<String, String> {
         no_task: true,
     };
 
-    Ok(render(&scan_result.summary, &options))
+    let (content, _) = render_with_facts_summary_and_breakdown(
+        &scan_result.summary,
+        scan_result.repo_facts_summary.as_ref(),
+        &options,
+    );
+    Ok(content)
 }

--- a/src/output/ai_context.rs
+++ b/src/output/ai_context.rs
@@ -3,10 +3,12 @@ mod findings;
 mod guardrails;
 mod header;
 mod hotfiles;
+mod json;
 mod recommendations;
 mod repo_facts;
 
 pub use budget::SectionBreakdown;
+pub use json::{AI_CONTEXT_JSON_SCHEMA_VERSION, render_json};
 
 use crate::facts::RepoFactsSummary;
 use crate::findings::types::Finding;

--- a/src/output/ai_context/json.rs
+++ b/src/output/ai_context/json.rs
@@ -1,0 +1,179 @@
+//! JSON form of the `ai context` handoff. The default Markdown brief is for a
+//! human skimming; agents that parse structured data get the same facts without
+//! Markdown parsing — closing the asymmetry with the JSON-returning MCP tools.
+//!
+//! It mirrors the Markdown sections as data: project + risk summary, optional
+//! repository facts, focus-filtered findings, and the P0–P3 remediation plan.
+//! Deterministic (no clock/rand/net), so it can be golden-tested.
+
+use crate::facts::RepoFactsSummary;
+use crate::findings::types::{Finding, Severity};
+use crate::output::ai_context::{AiContextRenderOptions, AiFocusCategory, project_name};
+use crate::output::ai_plan::{PlanCluster, ordered_plan_clusters};
+use crate::scan::types::ScanSummary;
+use serde::Serialize;
+
+/// Bumped when the JSON shape changes in a breaking way.
+pub const AI_CONTEXT_JSON_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Serialize)]
+struct AiContextJson {
+    schema_version: u32,
+    project: String,
+    focus: &'static str,
+    budget_tokens: usize,
+    approx_tokens: usize,
+    risk: RiskJson,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    facts: Option<FactsJson>,
+    findings: Vec<FindingJson>,
+    plan: Vec<PlanCluster>,
+}
+
+#[derive(Serialize)]
+struct RiskJson {
+    level: &'static str,
+    total: usize,
+    critical: usize,
+    high: usize,
+    medium: usize,
+    low: usize,
+    info: usize,
+}
+
+#[derive(Serialize)]
+struct FactsJson {
+    total_files: usize,
+    files_with_language: usize,
+    total_non_empty_lines: usize,
+    languages: Vec<LanguageJson>,
+    diagnostics_count: usize,
+}
+
+#[derive(Serialize)]
+struct LanguageJson {
+    language: String,
+    files: usize,
+    non_empty_lines: usize,
+}
+
+#[derive(Serialize)]
+struct FindingJson {
+    rule_id: String,
+    category: &'static str,
+    severity: &'static str,
+    confidence: &'static str,
+    priority: &'static str,
+    path: String,
+    line: usize,
+    title: String,
+}
+
+/// Render the AI context handoff as pretty JSON. Deterministic and never panics:
+/// serializing this owned struct cannot realistically fail, but a failure is
+/// surfaced as an `{"error": ...}` document rather than a panic.
+pub fn render_json(
+    summary: &ScanSummary,
+    facts_summary: Option<&RepoFactsSummary>,
+    opts: &AiContextRenderOptions,
+) -> String {
+    let mut doc = build(summary, facts_summary, opts);
+    // Fill the approximate token count from the compact encoding (1 token ≈ 4
+    // chars), matching the Markdown footer's convention.
+    if let Ok(compact) = serde_json::to_string(&doc) {
+        doc.approx_tokens = compact.len() / 4;
+    }
+    serde_json::to_string_pretty(&doc).unwrap_or_else(|error| {
+        format!("{{\n  \"error\": \"ai context json serialization failed: {error}\"\n}}")
+    })
+}
+
+fn build(
+    summary: &ScanSummary,
+    facts_summary: Option<&RepoFactsSummary>,
+    opts: &AiContextRenderOptions,
+) -> AiContextJson {
+    let findings: Vec<&Finding> = summary
+        .artifacts
+        .findings
+        .iter()
+        .filter(|finding| {
+            opts.focus
+                .as_ref()
+                .is_none_or(|focus| focus.matches(&finding.category))
+        })
+        .collect();
+
+    AiContextJson {
+        schema_version: AI_CONTEXT_JSON_SCHEMA_VERSION,
+        project: project_name(summary),
+        focus: focus_label(&opts.focus),
+        budget_tokens: opts.budget_tokens,
+        approx_tokens: 0,
+        risk: risk_json(&findings),
+        facts: facts_summary.map(facts_json),
+        findings: findings
+            .iter()
+            .map(|finding| finding_json(finding))
+            .collect(),
+        plan: ordered_plan_clusters(summary, opts.focus.as_ref()),
+    }
+}
+
+fn focus_label(focus: &Option<AiFocusCategory>) -> &'static str {
+    match focus {
+        None | Some(AiFocusCategory::All) => "all",
+        Some(AiFocusCategory::Security) => "security",
+        Some(AiFocusCategory::Architecture) => "architecture",
+        Some(AiFocusCategory::Quality) => "quality",
+        Some(AiFocusCategory::Framework) => "framework",
+    }
+}
+
+fn risk_json(findings: &[&Finding]) -> RiskJson {
+    let count = |severity: Severity| findings.iter().filter(|f| f.severity == severity).count();
+    RiskJson {
+        level: super::header::risk_level(findings),
+        total: findings.len(),
+        critical: count(Severity::Critical),
+        high: count(Severity::High),
+        medium: count(Severity::Medium),
+        low: count(Severity::Low),
+        info: count(Severity::Info),
+    }
+}
+
+fn facts_json(facts: &RepoFactsSummary) -> FactsJson {
+    FactsJson {
+        total_files: facts.total_files,
+        files_with_language: facts.files_with_language,
+        total_non_empty_lines: facts.total_non_empty_lines,
+        languages: facts
+            .languages
+            .iter()
+            .take(8)
+            .map(|language| LanguageJson {
+                language: language.language.clone(),
+                files: language.files,
+                non_empty_lines: language.non_empty_lines,
+            })
+            .collect(),
+        diagnostics_count: facts.diagnostics_count,
+    }
+}
+
+fn finding_json(finding: &Finding) -> FindingJson {
+    let evidence = finding.evidence.first();
+    FindingJson {
+        rule_id: finding.rule_id.clone(),
+        category: finding.category.label(),
+        severity: finding.severity.label(),
+        confidence: finding.confidence.label(),
+        priority: finding.risk.priority.label(),
+        path: evidence
+            .map(|evidence| evidence.path.display().to_string())
+            .unwrap_or_default(),
+        line: evidence.map(|evidence| evidence.line_start).unwrap_or(0),
+        title: finding.title.clone(),
+    }
+}

--- a/src/output/ai_context/json.rs
+++ b/src/output/ai_context/json.rs
@@ -1,20 +1,28 @@
 //! JSON form of the `ai context` handoff. The default Markdown brief is for a
-//! human skimming; agents that parse structured data get the same facts without
-//! Markdown parsing — closing the asymmetry with the JSON-returning MCP tools.
+//! human skimming; agents that parse structured data get the same facts —
+//! evidence, snippets, risk, recommendation — without Markdown parsing, closing
+//! the asymmetry with the JSON-returning MCP tools.
 //!
-//! It mirrors the Markdown sections as data: project + risk summary, optional
-//! repository facts, focus-filtered findings, and the P0–P3 remediation plan.
-//! Deterministic (no clock/rand/net), so it can be golden-tested.
+//! Like the Markdown renderer it is **budget-aware**: findings are ordered by
+//! risk and added until the serialized size reaches `--budget`, and the document
+//! reports exactly what was included vs omitted. `approx_tokens` is measured from
+//! the real (pretty) output, so an agent can trust it. Deterministic (no
+//! clock/rand/net), so it can be golden-tested.
 
 use crate::facts::RepoFactsSummary;
 use crate::findings::types::{Finding, Severity};
 use crate::output::ai_context::{AiContextRenderOptions, AiFocusCategory, project_name};
 use crate::output::ai_plan::{PlanCluster, ordered_plan_clusters};
+use crate::output::finding_helpers::finding_location_key;
 use crate::scan::types::ScanSummary;
 use serde::Serialize;
 
 /// Bumped when the JSON shape changes in a breaking way.
 pub const AI_CONTEXT_JSON_SCHEMA_VERSION: u32 = 1;
+
+/// Share of the budget findings may consume before plan clusters get a turn, so
+/// a finding-heavy repo still leaves room for the prioritized plan.
+const FINDINGS_BUDGET_SHARE: usize = 70;
 
 #[derive(Serialize)]
 struct AiContextJson {
@@ -23,7 +31,13 @@ struct AiContextJson {
     focus: &'static str,
     budget_tokens: usize,
     approx_tokens: usize,
-    risk: RiskJson,
+    truncated: bool,
+    findings_total: usize,
+    findings_included: usize,
+    findings_omitted: usize,
+    plan_clusters_total: usize,
+    plan_clusters_included: usize,
+    risk: RiskSummaryJson,
     #[serde(skip_serializing_if = "Option::is_none")]
     facts: Option<FactsJson>,
     findings: Vec<FindingJson>,
@@ -31,8 +45,11 @@ struct AiContextJson {
 }
 
 #[derive(Serialize)]
-struct RiskJson {
-    level: &'static str,
+struct RiskSummaryJson {
+    /// Machine token, e.g. `moderate`.
+    level: String,
+    /// Display label, e.g. `🟡 MODERATE`.
+    label: String,
     total: usize,
     critical: usize,
     high: usize,
@@ -59,14 +76,48 @@ struct LanguageJson {
 
 #[derive(Serialize)]
 struct FindingJson {
+    id: String,
     rule_id: String,
     category: &'static str,
     severity: &'static str,
     confidence: &'static str,
-    priority: &'static str,
-    path: String,
-    line: usize,
     title: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    description: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    recommendation: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    docs_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_package: Option<String>,
+    risk: FindingRiskJson,
+    evidence: Vec<EvidenceJson>,
+}
+
+#[derive(Serialize)]
+struct FindingRiskJson {
+    score: u8,
+    priority: &'static str,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    signals: Vec<RiskSignalJson>,
+}
+
+#[derive(Serialize)]
+struct RiskSignalJson {
+    id: String,
+    label: String,
+    weight: i16,
+    reason: String,
+}
+
+#[derive(Serialize)]
+struct EvidenceJson {
+    path: String,
+    line_start: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    line_end: Option<usize>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    snippet: String,
 }
 
 /// Render the AI context handoff as pretty JSON. Deterministic and never panics:
@@ -78,10 +129,10 @@ pub fn render_json(
     opts: &AiContextRenderOptions,
 ) -> String {
     let mut doc = build(summary, facts_summary, opts);
-    // Fill the approximate token count from the compact encoding (1 token ≈ 4
-    // chars), matching the Markdown footer's convention.
-    if let Ok(compact) = serde_json::to_string(&doc) {
-        doc.approx_tokens = compact.len() / 4;
+    // Two-pass on the *pretty* encoding — the form the caller receives — so
+    // `approx_tokens` reflects the real output, not a denser compact form.
+    if let Ok(pretty) = serde_json::to_string_pretty(&doc) {
+        doc.approx_tokens = pretty.len() / 4;
     }
     serde_json::to_string_pretty(&doc).unwrap_or_else(|error| {
         format!("{{\n  \"error\": \"ai context json serialization failed: {error}\"\n}}")
@@ -93,7 +144,11 @@ fn build(
     facts_summary: Option<&RepoFactsSummary>,
     opts: &AiContextRenderOptions,
 ) -> AiContextJson {
-    let findings: Vec<&Finding> = summary
+    let budget_chars = opts.budget_tokens.saturating_mul(4);
+
+    // Focus-filtered findings, ordered by risk so truncation drops the least
+    // important first.
+    let mut ordered: Vec<&Finding> = summary
         .artifacts
         .findings
         .iter()
@@ -103,21 +158,86 @@ fn build(
                 .is_none_or(|focus| focus.matches(&finding.category))
         })
         .collect();
+    ordered.sort_by(|a, b| {
+        crate::risk::compare_findings(a, b)
+            .then_with(|| finding_location_key(a).cmp(&finding_location_key(b)))
+    });
 
-    AiContextJson {
+    let findings_total = ordered.len();
+    let plan = ordered_plan_clusters(summary, opts.focus.as_ref());
+    let plan_total = plan.len();
+
+    let mut doc = AiContextJson {
         schema_version: AI_CONTEXT_JSON_SCHEMA_VERSION,
         project: project_name(summary),
         focus: focus_label(&opts.focus),
         budget_tokens: opts.budget_tokens,
         approx_tokens: 0,
-        risk: risk_json(&findings),
+        truncated: false,
+        findings_total,
+        findings_included: 0,
+        findings_omitted: findings_total,
+        plan_clusters_total: plan_total,
+        plan_clusters_included: 0,
+        // Risk summary counts the whole focus-filtered set, not just what fits.
+        risk: risk_json(&ordered),
         facts: facts_summary.map(facts_json),
-        findings: findings
-            .iter()
-            .map(|finding| finding_json(finding))
-            .collect(),
-        plan: ordered_plan_clusters(summary, opts.focus.as_ref()),
+        findings: Vec::new(),
+        plan: Vec::new(),
+    };
+
+    // Measure the envelope (risk + facts + counts) with empty collections, then
+    // fill within the remaining budget — pretty bytes, matching the real output.
+    let base_cost = pretty_cost(&doc);
+    let mut used = base_cost;
+    let findings_ceiling =
+        base_cost + budget_chars.saturating_sub(base_cost) * FINDINGS_BUDGET_SHARE / 100;
+
+    for finding in &ordered {
+        let json = finding_json(finding);
+        let cost = pretty_cost(&json) + 4; // +array comma/indentation
+        if !doc.findings.is_empty() && used + cost > findings_ceiling {
+            break;
+        }
+        used += cost;
+        doc.findings.push(json);
     }
+
+    for cluster in plan {
+        let cost = pretty_cost(&cluster) + 4;
+        if used + cost > budget_chars {
+            break;
+        }
+        used += cost;
+        doc.plan.push(cluster);
+    }
+
+    // The per-item estimate under-counts nested array indentation, so verify
+    // against the real pretty encoding and trim until it genuinely fits — plan
+    // clusters first (derived data), then the lowest-risk findings, always
+    // keeping at least one finding for signal.
+    while pretty_cost(&doc) > budget_chars {
+        if doc.plan.pop().is_some() {
+            continue;
+        }
+        if doc.findings.len() > 1 {
+            doc.findings.pop();
+            continue;
+        }
+        break;
+    }
+
+    doc.findings_included = doc.findings.len();
+    doc.findings_omitted = findings_total.saturating_sub(doc.findings.len());
+    doc.plan_clusters_included = doc.plan.len();
+    doc.truncated = doc.findings_omitted > 0 || doc.plan_clusters_included < plan_total;
+    doc
+}
+
+fn pretty_cost<T: Serialize>(value: &T) -> usize {
+    serde_json::to_string_pretty(value)
+        .map(|rendered| rendered.len())
+        .unwrap_or(0)
 }
 
 fn focus_label(focus: &Option<AiFocusCategory>) -> &'static str {
@@ -130,10 +250,12 @@ fn focus_label(focus: &Option<AiFocusCategory>) -> &'static str {
     }
 }
 
-fn risk_json(findings: &[&Finding]) -> RiskJson {
+fn risk_json(findings: &[&Finding]) -> RiskSummaryJson {
     let count = |severity: Severity| findings.iter().filter(|f| f.severity == severity).count();
-    RiskJson {
-        level: super::header::risk_level(findings),
+    let label = super::header::risk_level(findings);
+    RiskSummaryJson {
+        level: machine_level(label),
+        label: label.to_string(),
         total: findings.len(),
         critical: count(Severity::Critical),
         high: count(Severity::High),
@@ -141,6 +263,15 @@ fn risk_json(findings: &[&Finding]) -> RiskJson {
         low: count(Severity::Low),
         info: count(Severity::Info),
     }
+}
+
+/// `🟡 MODERATE` -> `moderate`. The label is always `<emoji> WORD`.
+fn machine_level(label: &str) -> String {
+    label
+        .split_whitespace()
+        .last()
+        .unwrap_or("clean")
+        .to_ascii_lowercase()
 }
 
 fn facts_json(facts: &RepoFactsSummary) -> FactsJson {
@@ -151,7 +282,7 @@ fn facts_json(facts: &RepoFactsSummary) -> FactsJson {
         languages: facts
             .languages
             .iter()
-            .take(8)
+            .take(super::repo_facts::MAX_LANGUAGES)
             .map(|language| LanguageJson {
                 language: language.language.clone(),
                 files: language.files,
@@ -163,17 +294,44 @@ fn facts_json(facts: &RepoFactsSummary) -> FactsJson {
 }
 
 fn finding_json(finding: &Finding) -> FindingJson {
-    let evidence = finding.evidence.first();
     FindingJson {
+        id: finding.id.clone(),
         rule_id: finding.rule_id.clone(),
         category: finding.category.label(),
         severity: finding.severity.label(),
         confidence: finding.confidence.label(),
-        priority: finding.risk.priority.label(),
-        path: evidence
-            .map(|evidence| evidence.path.display().to_string())
-            .unwrap_or_default(),
-        line: evidence.map(|evidence| evidence.line_start).unwrap_or(0),
         title: finding.title.clone(),
+        description: finding.description.clone(),
+        recommendation: finding.recommendation_or_default().to_string(),
+        docs_url: finding.docs_url.clone(),
+        workspace_package: finding.workspace_package.clone(),
+        risk: FindingRiskJson {
+            score: finding.risk.score,
+            priority: finding.risk.priority.label(),
+            signals: finding
+                .risk
+                .signals
+                .iter()
+                .map(|signal| RiskSignalJson {
+                    id: signal.id.clone(),
+                    label: signal.label.clone(),
+                    weight: signal.weight,
+                    reason: signal.reason.clone(),
+                })
+                .collect(),
+        },
+        evidence: finding
+            .evidence
+            .iter()
+            .map(|evidence| EvidenceJson {
+                path: evidence.path.display().to_string(),
+                line_start: evidence.line_start,
+                line_end: evidence.line_end,
+                snippet: evidence.snippet.clone(),
+            })
+            .collect(),
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/output/ai_context/json/tests.rs
+++ b/src/output/ai_context/json/tests.rs
@@ -1,0 +1,139 @@
+use super::*;
+use crate::findings::types::{Evidence, FindingCategory};
+use crate::scan::types::{ScanArtifacts, ScanMetadata, ScanSummary};
+use std::path::PathBuf;
+
+fn finding(index: usize, severity: Severity) -> Finding {
+    Finding {
+        id: format!("rule.example:src/file_{index}.rs:1"),
+        rule_id: "rule.example".to_string(),
+        title: format!("Example finding {index}"),
+        description: "A reasonably long description so each finding carries real \
+            weight in the budget accounting and truncation is exercised."
+            .to_string(),
+        category: FindingCategory::Security,
+        severity,
+        evidence: vec![Evidence {
+            path: PathBuf::from(format!("src/file_{index}.rs")),
+            line_start: 1,
+            line_end: Some(2),
+            snippet: "let secret = \"abcdefghijklmnopqrstuvwxyz0123456789\";".to_string(),
+        }],
+        ..Default::default()
+    }
+}
+
+fn summary_with(findings: Vec<Finding>) -> ScanSummary {
+    ScanSummary {
+        metadata: ScanMetadata {
+            root_path: PathBuf::from("repo"),
+            ..Default::default()
+        },
+        metrics: Default::default(),
+        artifacts: ScanArtifacts {
+            findings,
+            ..Default::default()
+        },
+    }
+}
+
+fn parse(json: &str) -> serde_json::Value {
+    serde_json::from_str(json).expect("ai context json is valid")
+}
+
+#[test]
+fn budget_truncates_low_risk_findings_and_reports_counts() {
+    let findings = (0..40)
+        .map(|index| finding(index, Severity::High))
+        .collect();
+    let summary = summary_with(findings);
+    // A budget that fits several enriched findings but nowhere near all 40.
+    let budget = 600;
+    let opts = AiContextRenderOptions {
+        focus: None,
+        budget_tokens: budget,
+        no_header: false,
+        no_task: false,
+    };
+
+    let value = parse(&render_json(&summary, None, &opts));
+
+    assert_eq!(value["findings_total"], 40);
+    let included = value["findings_included"].as_u64().expect("included count");
+    assert!(
+        (1..40).contains(&included),
+        "should include some but not all findings: {included}"
+    );
+    assert_eq!(
+        included + value["findings_omitted"].as_u64().expect("omitted count"),
+        40,
+        "included + omitted must equal total"
+    );
+    assert_eq!(value["truncated"], true);
+    assert_eq!(
+        value["findings"].as_array().expect("findings").len() as u64,
+        included
+    );
+
+    // approx_tokens is measured from the real (pretty) output and the trim loop
+    // keeps it within budget (the only exception is the one-finding signal floor).
+    let approx = value["approx_tokens"].as_u64().expect("approx_tokens");
+    assert!(
+        approx <= budget as u64,
+        "approx_tokens {approx} should stay within the {budget}-token budget"
+    );
+}
+
+#[test]
+fn small_repo_is_not_truncated_and_carries_full_evidence() {
+    let summary = summary_with(vec![finding(0, Severity::High)]);
+    let opts = AiContextRenderOptions {
+        focus: None,
+        budget_tokens: 4096,
+        no_header: false,
+        no_task: false,
+    };
+
+    let value = parse(&render_json(&summary, None, &opts));
+
+    assert_eq!(value["truncated"], false);
+    assert_eq!(value["findings_total"], 1);
+    assert_eq!(value["findings_included"], 1);
+
+    let finding = &value["findings"][0];
+    assert_eq!(finding["rule_id"], "rule.example");
+    assert!(finding["risk"]["score"].is_number(), "risk score present");
+    assert!(
+        finding["evidence"][0]["snippet"]
+            .as_str()
+            .expect("snippet")
+            .contains("secret"),
+        "evidence snippet is included"
+    );
+    assert!(
+        finding["recommendation"].is_string(),
+        "recommendation present"
+    );
+}
+
+#[test]
+fn risk_level_exposes_machine_token_and_display_label() {
+    let summary = summary_with(vec![finding(0, Severity::High)]);
+    let value = parse(&render_json(
+        &summary,
+        None,
+        &AiContextRenderOptions::default(),
+    ));
+
+    let level = value["risk"]["level"].as_str().expect("level");
+    let label = value["risk"]["label"].as_str().expect("label");
+    assert_eq!(
+        level,
+        level.to_ascii_lowercase(),
+        "level is a machine token"
+    );
+    assert!(
+        label.to_uppercase().contains(&level.to_uppercase()),
+        "display label `{label}` should carry the machine level `{level}`"
+    );
+}

--- a/src/output/ai_context/repo_facts.rs
+++ b/src/output/ai_context/repo_facts.rs
@@ -1,7 +1,7 @@
 use crate::facts::RepoFactsSummary;
 use std::fmt::Write as FmtWrite;
 
-const MAX_LANGUAGES: usize = 5;
+pub(super) const MAX_LANGUAGES: usize = 5;
 
 pub(super) fn render_summary(out: &mut String, summary: &RepoFactsSummary) {
     let _ = writeln!(out, "## Repository Facts Summary\n");

--- a/src/output/ai_plan.rs
+++ b/src/output/ai_plan.rs
@@ -6,9 +6,11 @@
 use crate::findings::types::{Finding, FindingCategory, Severity};
 use crate::output::ai_context::AiFocusCategory;
 use crate::output::finding_helpers::{
-    RuleCluster, category_rank, clusters_by_rule_scope, example_locations, finding_recommendation,
+    RuleCluster, category_rank, clusters_by_rule_scope, example_locations, finding_location,
+    finding_recommendation,
 };
 use crate::scan::types::ScanSummary;
+use serde::Serialize;
 use std::fmt::Write as FmtWrite;
 
 /// Renders the prioritized P0–P3 remediation clusters for embedding in the
@@ -63,6 +65,61 @@ pub(crate) fn render_plan_section(
             break;
         }
     }
+}
+
+/// Serializable view of one prioritized plan cluster, for `ai context --format
+/// json`. Mirrors what `render_cluster_plan` emits as Markdown.
+#[derive(Serialize)]
+pub(crate) struct PlanCluster {
+    pub(crate) priority: &'static str,
+    pub(crate) title: String,
+    pub(crate) rule_id: String,
+    pub(crate) severity: &'static str,
+    pub(crate) max_score: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) scope: Option<String>,
+    pub(crate) finding_count: usize,
+    pub(crate) examples: Vec<String>,
+    pub(crate) recommendation: String,
+}
+
+/// The ordered P0–P3 plan clusters as data — same ordering and priority labels
+/// as the Markdown `render_plan_section`, but structured for the JSON handoff.
+pub(crate) fn ordered_plan_clusters(
+    summary: &ScanSummary,
+    focus: Option<&AiFocusCategory>,
+) -> Vec<PlanCluster> {
+    let findings: Vec<&Finding> = summary
+        .artifacts
+        .findings
+        .iter()
+        .filter(|finding| focus.is_none_or(|focus| focus.matches(&finding.category)))
+        .collect();
+    let mut clusters = clusters_by_rule_scope(&findings);
+    sort_ai_plan_clusters(&mut clusters);
+
+    clusters
+        .iter()
+        .map(|cluster| {
+            let first = cluster.findings[0];
+            PlanCluster {
+                priority: priority_label(cluster_priority(cluster)),
+                title: cluster.title.clone(),
+                rule_id: cluster.rule_id.to_string(),
+                severity: cluster.severity.label(),
+                max_score: cluster.max_score,
+                scope: cluster.scope.clone().filter(|scope| scope != "."),
+                finding_count: cluster.findings.len(),
+                examples: cluster
+                    .findings
+                    .iter()
+                    .filter_map(|finding| finding_location(finding))
+                    .take(3)
+                    .collect(),
+                recommendation: finding_recommendation(first).to_string(),
+            }
+        })
+        .collect()
 }
 
 include!("ai_plan/cluster.rs");

--- a/tests/ai_context_command.rs
+++ b/tests/ai_context_command.rs
@@ -181,6 +181,121 @@ fn ai_context_uses_default_product_visibility() {
 }
 
 #[test]
+fn ai_context_json_format_is_structured_facts_aware_and_clean() {
+    let temp = tempdir().expect("failed to create temp dir");
+    write_sample_project(temp.path());
+
+    let output = repopilot()
+        .args(["ai", "context", ".", "--format", "json", "--budget", "2k"])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot ai context");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    // stdout is pure JSON — no Markdown leaks in.
+    assert!(
+        !stdout.contains("# RepoPilot AI Context"),
+        "markdown leaked:\n{stdout}"
+    );
+
+    let doc: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    assert_eq!(doc["schema_version"], 1);
+    // Phase: facts come through the real CLI path (the golden passes None).
+    assert_eq!(
+        doc["facts"]["total_files"], 2,
+        "facts present from the CLI: {doc}"
+    );
+
+    // A finding carries the structured evidence an agent needs, not just a title.
+    let findings = doc["findings"].as_array().expect("findings array");
+    let secret = findings
+        .iter()
+        .find(|finding| finding["rule_id"] == "security.secret-candidate")
+        .expect("secret finding present");
+    assert!(secret["risk"]["score"].is_number(), "risk score present");
+    assert!(
+        secret["evidence"][0]["path"].is_string(),
+        "evidence locations present: {secret}"
+    );
+    assert!(
+        secret["recommendation"].is_string(),
+        "recommendation present"
+    );
+
+    // Budget is real: either the estimate fits, or the doc is explicitly truncated.
+    let approx = doc["approx_tokens"].as_u64().expect("approx_tokens");
+    let truncated = doc["truncated"].as_bool().expect("truncated flag");
+    assert!(
+        approx <= 2048 || truncated,
+        "budget ignored: approx={approx} truncated={truncated}"
+    );
+}
+
+#[test]
+fn ai_context_json_focus_filters_and_writes_output_file() {
+    let temp = tempdir().expect("failed to create temp dir");
+    write_sample_project(temp.path());
+
+    // --focus security: every emitted finding is in the security category.
+    let focused = repopilot()
+        .args([
+            "ai", "context", ".", "--focus", "security", "--format", "json",
+        ])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot ai context");
+    assert!(focused.status.success());
+    let doc: serde_json::Value =
+        serde_json::from_str(&String::from_utf8(focused.stdout).expect("utf-8")).expect("json");
+    assert_eq!(doc["focus"], "security");
+    assert!(
+        doc["findings"]
+            .as_array()
+            .expect("findings")
+            .iter()
+            .all(|finding| finding["category"] == "security"),
+        "focus did not filter: {doc}"
+    );
+
+    // --output writes a valid JSON file and leaves stdout empty.
+    let path = temp.path().join("ai-context.json");
+    let written = repopilot()
+        .args(["ai", "context", ".", "--format", "json", "--output"])
+        .arg(&path)
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot ai context");
+    assert!(written.status.success());
+    assert!(
+        written.stdout.is_empty(),
+        "stdout should be empty when writing a file"
+    );
+    let contents = fs::read_to_string(&path).expect("failed to read JSON output file");
+    let _: serde_json::Value = serde_json::from_str(&contents).expect("output file is valid JSON");
+}
+
+#[test]
+fn ai_context_json_does_not_emit_breakdown_to_stderr() {
+    let temp = tempdir().expect("failed to create temp dir");
+    write_sample_project(temp.path());
+
+    let output = repopilot()
+        .args(["ai", "context", ".", "--format", "json", "--show-breakdown"])
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run repopilot ai context");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(
+        !stderr.contains("tokens"),
+        "JSON output must not print the Markdown token breakdown to stderr: {stderr}"
+    );
+}
+
+#[test]
 fn ai_context_rejects_unknown_focus() {
     let temp = tempdir().expect("failed to create temp dir");
     fs::write(temp.path().join("lib.rs"), "fn main() {}\n").expect("failed to write file");

--- a/tests/ai_context_golden.rs
+++ b/tests/ai_context_golden.rs
@@ -15,7 +15,7 @@
 
 use repopilot::findings::visibility::{FindingVisibilityProfile, apply_visibility_profile};
 use repopilot::output::ai_context::{
-    AiContextRenderOptions, AiFocusCategory, DEFAULT_TOKEN_BUDGET, render,
+    AiContextRenderOptions, AiFocusCategory, DEFAULT_TOKEN_BUDGET, render, render_json,
 };
 use repopilot::scan::config::ScanConfig;
 use repopilot::scan::scanner::scan_path_with_config;
@@ -64,6 +64,23 @@ fn ai_context_security_focus_brief_stays_stable() {
         "ai-context-focus-security.md",
         render_variant(Some(AiFocusCategory::Security)),
     );
+}
+
+fn render_json_variant(focus: Option<AiFocusCategory>) -> String {
+    let options = AiContextRenderOptions {
+        focus,
+        budget_tokens: DEFAULT_TOKEN_BUDGET,
+        no_header: false,
+        no_task: false,
+    };
+    render_json(&scanned_summary(), None, &options)
+}
+
+#[test]
+fn ai_context_json_brief_stays_stable() {
+    // The JSON form is deterministic (no version/cache/wall-clock fields), so the
+    // golden is the raw output; `normalize` is a no-op here.
+    assert_golden("ai-context.json", render_json_variant(None));
 }
 
 fn assert_golden(name: &str, actual: String) {

--- a/tests/fixtures/golden/ai-context.json
+++ b/tests/fixtures/golden/ai-context.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "project": "ai-context-sample",
+  "focus": "all",
+  "budget_tokens": 4096,
+  "approx_tokens": 379,
+  "risk": {
+    "level": "🟡 MODERATE",
+    "total": 2,
+    "critical": 0,
+    "high": 2,
+    "medium": 0,
+    "low": 0,
+    "info": 0
+  },
+  "findings": [
+    {
+      "rule_id": "framework.django.debug-true",
+      "category": "security",
+      "severity": "HIGH",
+      "confidence": "HIGH",
+      "priority": "P1",
+      "path": "tests/fixtures/projects/ai-context-sample/config/settings.py",
+      "line": 1,
+      "title": "DEBUG = True in Django settings"
+    },
+    {
+      "rule_id": "framework.django.missing-allowed-hosts",
+      "category": "security",
+      "severity": "HIGH",
+      "confidence": "HIGH",
+      "priority": "P1",
+      "path": "tests/fixtures/projects/ai-context-sample/config/settings.py",
+      "line": 2,
+      "title": "ALLOWED_HOSTS is empty in Django settings"
+    }
+  ],
+  "plan": [
+    {
+      "priority": "P0 - Immediate risk",
+      "title": "DEBUG = True in Django settings",
+      "rule_id": "framework.django.debug-true",
+      "severity": "HIGH",
+      "max_score": 75,
+      "scope": "tests/fixtures",
+      "finding_count": 1,
+      "examples": [
+        "tests/fixtures/projects/ai-context-sample/config/settings.py:1"
+      ],
+      "recommendation": "Set DEBUG = False for deployed environments and load debug mode only from local development configuration."
+    },
+    {
+      "priority": "P0 - Immediate risk",
+      "title": "ALLOWED_HOSTS is empty in Django settings",
+      "rule_id": "framework.django.missing-allowed-hosts",
+      "severity": "HIGH",
+      "max_score": 75,
+      "scope": "tests/fixtures",
+      "finding_count": 1,
+      "examples": [
+        "tests/fixtures/projects/ai-context-sample/config/settings.py:2"
+      ],
+      "recommendation": "Set ALLOWED_HOSTS to the explicit domain names and IP addresses the service should accept."
+    }
+  ]
+}

--- a/tests/fixtures/golden/ai-context.json
+++ b/tests/fixtures/golden/ai-context.json
@@ -3,9 +3,16 @@
   "project": "ai-context-sample",
   "focus": "all",
   "budget_tokens": 4096,
-  "approx_tokens": 379,
+  "approx_tokens": 1252,
+  "truncated": false,
+  "findings_total": 2,
+  "findings_included": 2,
+  "findings_omitted": 0,
+  "plan_clusters_total": 2,
+  "plan_clusters_included": 2,
   "risk": {
-    "level": "🟡 MODERATE",
+    "level": "moderate",
+    "label": "🟡 MODERATE",
     "total": 2,
     "critical": 0,
     "high": 2,
@@ -15,24 +22,100 @@
   },
   "findings": [
     {
+      "id": "framework.django.debug-true:config/settings.py:38dfbcdbb0337940",
       "rule_id": "framework.django.debug-true",
       "category": "security",
       "severity": "HIGH",
       "confidence": "HIGH",
-      "priority": "P1",
-      "path": "tests/fixtures/projects/ai-context-sample/config/settings.py",
-      "line": 1,
-      "title": "DEBUG = True in Django settings"
+      "title": "DEBUG = True in Django settings",
+      "description": "Django's `DEBUG = True` mode exposes detailed error pages with stack traces, local variables, and settings values to anyone who triggers an exception. This setting must be `False` in any environment reachable from the internet.",
+      "recommendation": "Set DEBUG = False for deployed environments and load debug mode only from local development configuration.",
+      "docs_url": "https://docs.djangoproject.com/en/stable/ref/settings/#debug",
+      "risk": {
+        "score": 75,
+        "priority": "P1",
+        "signals": [
+          {
+            "id": "severity.high",
+            "label": "severity",
+            "weight": 75,
+            "reason": "high severity finding"
+          },
+          {
+            "id": "confidence.high",
+            "label": "confidence",
+            "weight": 8,
+            "reason": "high confidence signal"
+          },
+          {
+            "id": "category.security",
+            "label": "security",
+            "weight": 12,
+            "reason": "security findings are prioritized"
+          },
+          {
+            "id": "role.test",
+            "label": "visibility",
+            "weight": -20,
+            "reason": "test code often accepts patterns that would be risky in production"
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "path": "tests/fixtures/projects/ai-context-sample/config/settings.py",
+          "line_start": 1,
+          "snippet": "DEBUG = True"
+        }
+      ]
     },
     {
+      "id": "framework.django.missing-allowed-hosts:config/settings.py:03cedf4ca18ad316",
       "rule_id": "framework.django.missing-allowed-hosts",
       "category": "security",
       "severity": "HIGH",
       "confidence": "HIGH",
-      "priority": "P1",
-      "path": "tests/fixtures/projects/ai-context-sample/config/settings.py",
-      "line": 2,
-      "title": "ALLOWED_HOSTS is empty in Django settings"
+      "title": "ALLOWED_HOSTS is empty in Django settings",
+      "description": "`ALLOWED_HOSTS = []` permits any host header when `DEBUG = False`, making the application vulnerable to HTTP Host header attacks. Set `ALLOWED_HOSTS` to the explicit domain names and IPs this service accepts.",
+      "recommendation": "Set ALLOWED_HOSTS to the explicit domain names and IP addresses the service should accept.",
+      "docs_url": "https://docs.djangoproject.com/en/stable/ref/settings/#allowed-hosts",
+      "risk": {
+        "score": 75,
+        "priority": "P1",
+        "signals": [
+          {
+            "id": "severity.high",
+            "label": "severity",
+            "weight": 75,
+            "reason": "high severity finding"
+          },
+          {
+            "id": "confidence.high",
+            "label": "confidence",
+            "weight": 8,
+            "reason": "high confidence signal"
+          },
+          {
+            "id": "category.security",
+            "label": "security",
+            "weight": 12,
+            "reason": "security findings are prioritized"
+          },
+          {
+            "id": "role.test",
+            "label": "visibility",
+            "weight": -20,
+            "reason": "test code often accepts patterns that would be risky in production"
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "path": "tests/fixtures/projects/ai-context-sample/config/settings.py",
+          "line_start": 2,
+          "snippet": "ALLOWED_HOSTS = []"
+        }
+      ]
     }
   ],
   "plan": [

--- a/tests/mcp_cli.rs
+++ b/tests/mcp_cli.rs
@@ -113,6 +113,38 @@ fn mcp_server_initializes_lists_tools_and_runs_scan_locally() {
 }
 
 #[test]
+fn mcp_context_tool_includes_repository_facts() {
+    // Phase 1: the context tool wraps the facts-aware renderer (like the CLI),
+    // so an agent gets the aggregate stack/size picture, not a thinner brief.
+    let temp = tempfile::tempdir().expect("temp dir");
+    fs::create_dir_all(temp.path().join("src")).expect("src dir");
+    fs::write(
+        temp.path().join("src/lib.rs"),
+        "pub fn live() -> i32 {\n    1\n}\n",
+    )
+    .expect("source file");
+
+    let responses = run_mcp(
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}"#,
+            r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"repopilot_context","arguments":{"path":"."}}}"#,
+        ],
+        temp.path(),
+    );
+
+    let result = &responses[1]["result"];
+    assert_eq!(result["isError"], false, "context should succeed");
+    assert!(
+        responses[1]
+            .to_string()
+            .contains("Repository Facts Summary"),
+        "context tool should include the repository facts section: {}",
+        responses[1]
+    );
+}
+
+#[test]
 fn mcp_server_reports_unknown_tool_as_in_band_error() {
     let temp = tempfile::tempdir().expect("temp dir");
 


### PR DESCRIPTION
## Summary

Adds a structured JSON output format to `repopilot ai context` for reliable agent and tool integration.

The new format contains repository facts, risk summaries, findings with complete evidence, and a prioritized remediation plan without requiring agents to parse Markdown.

JSON output is deterministic, focus-aware, and constrained by the requested token budget. Markdown remains the default format.

This PR also aligns the `repopilot_context` MCP tool with the CLI by including the repository facts summary.

## Type of change

* [x] Feature
* [x] Refactor
* [x] Tests
* [x] Documentation
* [ ] Bug fix
* [ ] CI / repository maintenance

## What changed

* Added `--format markdown|json` to `repopilot ai context`.
* Kept Markdown as the default output format.
* Added a versioned JSON contract with:

  * schema version;
  * project and focus metadata;
  * requested and approximate token counts;
  * truncation metadata;
  * complete risk summary;
  * repository facts;
  * structured findings;
  * prioritized P0–P3 remediation plan.
* Added complete finding information for agents:

  * stable finding ID;
  * rule ID;
  * category;
  * severity and confidence;
  * title and description;
  * recommendation;
  * documentation URL;
  * workspace package;
  * risk score, priority, and signals;
  * full evidence list with paths, line ranges, and snippets.
* Added budget-aware JSON rendering.
* Sorted findings by risk before budget truncation.
* Reserved part of the available budget for remediation plan clusters.
* Added included and omitted counts for findings and plan clusters.
* Calculated `approx_tokens` from the real pretty-printed JSON output.
* Added separate machine-readable and display risk levels.
* Kept JSON output free from Markdown token-breakdown messages.
* Documented `--no-header` and `--no-task` as Markdown-only options.
* Updated `repopilot_context` MCP output to include repository facts.
* Shared the same top-language limit between Markdown and JSON.
* Added golden, unit, CLI, and MCP integration tests.
* Updated AI workflow and MCP documentation.
* Updated the pull request template with false-positive validation requirements.
* Updated `CHANGELOG.md`.

## Why

`repopilot ai context` previously emitted only Markdown.

Markdown works well for human review and direct prompting, but agents and external tools need a stable structured contract. Parsing Markdown introduces unnecessary ambiguity and makes it harder to reliably consume evidence, risk scores, repository facts, and remediation priorities.

The JSON format provides the same core handoff as structured data:

```text
Repository facts
→ Risk summary
→ Prioritized findings with evidence
→ P0–P3 remediation plan
```

It also prevents large repositories from producing unexpectedly large agent payloads by enforcing the requested token budget and explicitly reporting omitted content.

## Usage

Markdown remains the default:

```bash
repopilot ai context .
```

Generate structured JSON:

```bash
repopilot ai context . --format json
```

Limit the context to security findings:

```bash
repopilot ai context . --format json --focus security
```

Use a smaller token budget:

```bash
repopilot ai context . --format json --budget 2k
```

Write the result to a file:

```bash
repopilot ai context . --format json --output ai-context.json
```

## JSON contract

The top-level output includes:

```json
{
  "schema_version": 1,
  "project": "example",
  "focus": "all",
  "budget_tokens": 4096,
  "approx_tokens": 1920,
  "truncated": false,
  "findings_total": 8,
  "findings_included": 8,
  "findings_omitted": 0,
  "plan_clusters_total": 4,
  "plan_clusters_included": 4,
  "risk": {},
  "facts": {},
  "findings": [],
  "plan": []
}
```

Each finding contains the information required for implementation and verification:

```json
{
  "id": "security.secret-candidate:src/config.ts:...",
  "rule_id": "security.secret-candidate",
  "category": "security",
  "severity": "HIGH",
  "confidence": "HIGH",
  "title": "Possible secret detected",
  "description": "A credential-like value is stored in source code.",
  "recommendation": "Move the secret to an environment variable or secret manager.",
  "risk": {
    "score": 95,
    "priority": "P0",
    "signals": []
  },
  "evidence": [
    {
      "path": "src/config.ts",
      "line_start": 12,
      "line_end": 12,
      "snippet": "export const API_KEY = ..."
    }
  ]
}
```

## Budget behaviour

JSON rendering follows these rules:

1. Focus-filtered findings are sorted by risk.
2. The document envelope and repository facts are measured first.
3. Findings receive a bounded share of the remaining budget.
4. Remediation plan clusters use the remaining space.
5. The final pretty JSON is measured again.
6. Lower-priority content is removed until the document fits the target budget.

The output reports whether it was truncated and how many findings or plan clusters were omitted.

At least one finding may be retained as a signal even when an unusually small custom budget cannot contain the full document.

## Risk representation

Risk level now has two representations:

```json
{
  "level": "moderate",
  "label": "🟡 MODERATE"
}
```

* `level` is intended for machines.
* `label` preserves the human-readable display value.

## MCP alignment

The `repopilot_context` MCP tool now uses the facts-aware context renderer.

Agents calling MCP receive the same aggregate repository information available through the CLI:

* total files;
* files with a detected language;
* non-empty lines;
* top languages;
* fact diagnostics.

The MCP tool remains fact-only and does not include the CLI task instructions or verification guidance.

## CLI behaviour

* Markdown remains the default.
* `--format json` emits machine-readable JSON.
* `--focus` applies to JSON findings and plan clusters.
* `--budget` limits structured output.
* `--output` writes valid JSON to a file and leaves stdout empty.
* `--show-breakdown` does not add Markdown breakdown output to JSON stderr.
* `--no-header` and `--no-task` apply only to Markdown because JSON is always fact-only.

## Tests

Added coverage for:

* deterministic JSON golden output;
* token-budget truncation;
* included and omitted counts;
* complete evidence and recommendation fields;
* risk machine token and display label;
* real CLI `--format json` execution;
* repository facts through the CLI path;
* focus filtering;
* JSON file output;
* clean stdout and stderr behaviour;
* MCP repository facts integration.

## Contract and ownership

* [x] The change stays within the AI context, AI plan, and MCP context boundaries
* [x] Markdown remains backward compatible and stays the default
* [x] The JSON contract is explicitly versioned
* [x] JSON output is deterministic
* [x] Token-budget behaviour is tested
* [x] Focus filtering is applied consistently
* [x] Findings contain deterministic evidence and remediation context
* [x] CLI and MCP behaviour were covered by integration tests
* [x] No unrelated generated-file churn is included

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh

repopilot ai context . --format json
repopilot ai context . --format json --focus security --budget 2k
repopilot ai context . --format json --output ai-context.json
```
