### PR TITLE
feat(mcp): harden repopilot_scan persistent cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,15 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **`repopilot_scan` MCP disk caching no longer serves stale scan reports after
+  agent edits.** The scan tool now bypasses the MCP session cache, keys disk
+  entries from the git-root working tree, stores entries under Git-owned
+  metadata instead of the working tree, and invalidates when a changed-scope base
+  ref resolves to a different commit or when path-discovered config,
+  `.repopilot/feedback.yml`, `.repopilotignore`, or effective Git/ignore-file
+  inputs change. Corrupt cache files are ignored and recomputed, and retention
+  keeps at most 32 valid scan reports per repository cache directory.
+
 - **Scan pipelines now collapse only exact duplicate finding emissions, not stable-baseline-key collisions.** Full and changed scans aggregate repeated emissions for the same rule, file, line, snippet, and compatible metadata before risk scoring, preserving a single finding with distinct evidence. The guard deliberately ignores `Finding::id` as a dedupe identity because that id is line-insensitive and literal-normalized for baseline stability; separate occurrences such as two hardcoded secrets on different lines remain separate findings and still contribute independently to counts, hotspots, and risk overlays.
 
 - **`testing.source-without-test` no longer flags documentation example code or standard Python entrypoints.** A `docs_src/` tree (an unambiguous documentation name) is skipped wherever it appears, and a `docs/` directory is skipped at a package root (repo root or a monorepo package such as `packages/<pkg>/docs/`) — but a `docs` module *nested inside a source tree* (`src/docs/`, `lib/docs/`, `app/docs/`) stays visible, since in a document-management app that is ordinary production code. The standard Django entrypoints `manage.py`/`wsgi.py`/`asgi.py` are also exempt (the analogue of the already-skipped `__main__.py`). A bare `apps.py` is deliberately *not* skipped by name: the filename alone is not evidence of a declarative `AppConfig` stub (it can carry a `ready()` with real startup behaviour, or be an ordinary module), so skipping it would hide untested production code. Measured on the real-repo zoo, this took fastapi's strict-profile count from 389 to 36 (its `docs_src/` tutorial tree was 349 of those findings) and wagtail's from 671 to 668, with no change to any default-visible output.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -56,6 +56,39 @@ or aggregate counts must be authoritative.
 Tool failures use MCP `isError: true`. Malformed input produces JSON-RPC error
 `-32700` instead of being skipped.
 
+## `repopilot_scan` Persistent Cache
+
+`repopilot_scan` may reuse a local persistent cache for repeated scans of an
+unchanged repository state. The cache is read-only from the MCP client's
+perspective: it only stores scan reports produced by local RepoPilot analysis and
+never uploads source, telemetry, or results.
+
+Cache files are stored in Git-owned metadata, resolved with:
+
+```bash
+git rev-parse --git-path repopilot/cache/mcp-scan
+```
+
+RepoPilot disables the disk cache if that Git metadata path cannot be resolved
+safely. Full scan reports are not written under the repository working tree
+(`.repopilot/cache/mcp-scan` is not used), so users cannot accidentally commit
+cached evidence snippets.
+
+A cached `repopilot_scan` result is invalidated by RepoPilot version or cache
+schema changes, scan arguments (`profile`, `scope`, `base`, filters), the
+resolved commit for a changed-scope `base` ref, committed/staged/unstaged or
+untracked changes anywhere in the Git worktree, explicit or discovered
+`repopilot.toml` content, `.repopilot/feedback.yml`, `.repopilotignore`, parent
+`.gitignore` and `.ignore` files, `.git/info/exclude`, and the effective global
+Git ignore file. If any cache input is uncertain, RepoPilot prefers a fresh scan
+over a cache hit.
+
+The cache can be deleted safely. RepoPilot recreates it on demand. Retention is
+best effort: after a successful store, RepoPilot keeps at most 32 valid scan
+reports per repository cache directory, removes the oldest valid entries first,
+ignores cleanup errors, and leaves unrelated files in that Git-owned cache
+directory untouched.
+
 ## Resources
 
 The server exposes:
@@ -67,7 +100,11 @@ The server exposes:
 - `repopilot://last-review`: the last successful review in this session.
 
 Last-result resources appear after the corresponding tool has run. Identical
-tool calls are served from the session cache.
+non-scan tool calls are served from the in-process session cache; `repopilot_scan`
+uses the persistent cache above because its correctness depends on Git state.
+Session-cache invalidation for `repopilot_review_change`, `repopilot_context`,
+and `repopilot_explain_file` is intentionally left to the next MCP correctness
+PR.
 
 ## Prompts
 

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -11,7 +11,10 @@ mod explain_file;
 mod jsonrpc;
 mod review_change;
 mod scan;
+mod scan_cache;
 
+#[cfg(test)]
+mod session_cache_tests;
 #[cfg(test)]
 mod tests;
 
@@ -311,8 +314,9 @@ fn handle_tools_call(id: Value, params: &Value, state: &mut ServerState) -> Resp
         return Response::success(id, tool_result(name, Err(message)));
     }
 
+    let use_session_cache = name != scan::TOOL_NAME;
     let cache_key = format!("{name}:{}", arguments);
-    if let Some(cached) = state.cache.get(&cache_key) {
+    if use_session_cache && let Some(cached) = state.cache.get(&cache_key) {
         return Response::success(id, tool_result(name, Ok(cached.clone())));
     }
 
@@ -325,7 +329,9 @@ fn handle_tools_call(id: Value, params: &Value, state: &mut ServerState) -> Resp
     };
 
     if let Ok(text) = &outcome {
-        state.cache.insert(cache_key, text.clone());
+        if use_session_cache {
+            state.cache.insert(cache_key, text.clone());
+        }
         match name {
             scan::TOOL_NAME => state.last_scan = Some(text.clone()),
             review_change::TOOL_NAME => state.last_review = Some(text.clone()),

--- a/src/commands/mcp/scan.rs
+++ b/src/commands/mcp/scan.rs
@@ -3,6 +3,7 @@
 
 use crate::commands::product_scan::{ProductScanMode, ProductScanRequest, run_product_scan};
 use crate::commands::scan_config::ScanConfigOverrides;
+use repopilot::config::loader::discover_config_path;
 use repopilot::findings::filter::FindingFilter;
 use repopilot::findings::types::{Confidence, Severity};
 use repopilot::findings::visibility::FindingVisibilityProfile;
@@ -53,10 +54,21 @@ pub fn definition() -> Value {
 
 pub fn call(arguments: &Value) -> Result<String, String> {
     let path = PathBuf::from(arguments.get("path").and_then(Value::as_str).unwrap_or("."));
+
+    // Cross-session disk cache: a repeated scan of an unchanged tree is a hit.
+    // The key folds in the working-tree state, so any edit invalidates it.
+    let cache_key = super::scan_cache::cache_key(&path, arguments);
+    if let Some(key) = &cache_key
+        && let Some(cached) = super::scan_cache::load(&path, key)
+    {
+        return Ok(cached);
+    }
+
     let config_path = arguments
         .get("config")
         .and_then(Value::as_str)
-        .map(PathBuf::from);
+        .map(PathBuf::from)
+        .or_else(|| discover_config_path(super::scan_cache::config_search_start(&path)));
     let visibility_profile = match arguments.get("profile").and_then(Value::as_str) {
         Some("strict") => FindingVisibilityProfile::Strict,
         Some("default") | None => FindingVisibilityProfile::Default,
@@ -75,7 +87,7 @@ pub fn call(arguments: &Value) -> Result<String, String> {
 
     let filter = parse_filters(arguments)?;
     let mut scan_result = run_product_scan(ProductScanRequest {
-        path,
+        path: path.clone(),
         config_path,
         overrides: ScanConfigOverrides::default(),
         preset: None,
@@ -95,8 +107,13 @@ pub fn call(arguments: &Value) -> Result<String, String> {
         filter.apply_to_summary(&mut scan_result.summary);
     }
 
-    render_scan_summary(&scan_result.summary, OutputFormat::Json)
-        .map_err(|error| format!("render failed: {error}"))
+    let output = render_scan_summary(&scan_result.summary, OutputFormat::Json)
+        .map_err(|error| format!("render failed: {error}"))?;
+
+    if let Some(key) = &cache_key {
+        super::scan_cache::store(&path, key, &output);
+    }
+    Ok(output)
 }
 
 pub(super) fn parse_filters(arguments: &Value) -> Result<FindingFilter, String> {

--- a/src/commands/mcp/scan_cache.rs
+++ b/src/commands/mcp/scan_cache.rs
@@ -1,0 +1,228 @@
+//! Cross-session disk cache for the `repopilot_scan` tool. A repeated scan of an
+//! unchanged tree is a cache hit, so an agent's edit-rescan loop does not
+//! re-audit from scratch every session.
+//!
+//! Correctness over speed: the key includes a working-tree fingerprint, config
+//! and feedback control files, tool/schema versions, and the resolved changed
+//! scan base commit when applicable. If any required cache input is uncertain,
+//! the caller gets `None` and runs a fresh scan.
+
+mod git;
+mod storage;
+
+use repopilot::config::loader::discover_config_path;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const SCHEMA: &str = "mcp-scan-cache-v1";
+const FEEDBACK_PATH: &str = ".repopilot/feedback.yml";
+const REPOPILOT_IGNORE_FILENAME: &str = ".repopilotignore";
+
+/// The cache key for a scan call, or `None` when cache correctness cannot be
+/// established. `None` means "run a fresh scan and do not read/write disk cache."
+pub(super) fn cache_key(path: &Path, arguments: &Value) -> Option<String> {
+    cache_key_with_metadata(path, arguments, SCHEMA, env!("CARGO_PKG_VERSION"))
+}
+
+fn cache_key_with_metadata(
+    path: &Path,
+    arguments: &Value,
+    schema: &str,
+    version: &str,
+) -> Option<String> {
+    let repo_root = git::git_root(path)?;
+    storage::cache_dir(path)?;
+
+    let tree = git::working_tree_fingerprint(&repo_root)?;
+    let changed_base = changed_scope_base_blob(&repo_root, arguments)?;
+    let ignore_sources = ignore_sources_blob(path, &repo_root)?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(schema.as_bytes());
+    hasher.update(b"\nversion:");
+    hasher.update(version.as_bytes());
+    hasher.update(b"\nargs:");
+    hasher.update(canonical_json(arguments).as_bytes());
+    hasher.update(b"\nchanged-base:");
+    hasher.update(changed_base.as_bytes());
+    hasher.update(b"\nconfig:");
+    hasher.update(config_blob(path, arguments).as_bytes());
+    hasher.update(b"\nfeedback:");
+    hasher.update(path_blob(path.join(FEEDBACK_PATH)).as_bytes());
+    hasher.update(b"\nrepopilotignore:");
+    hasher.update(path_blob(repopilotignore_path(path)).as_bytes());
+    hasher.update(b"\nignore-sources:");
+    hasher.update(ignore_sources.as_bytes());
+    hasher.update(b"\ntree:");
+    hasher.update(tree.as_bytes());
+    Some(hex(&hasher.finalize()))
+}
+
+pub(super) fn load(path: &Path, key: &str) -> Option<String> {
+    storage::load(path, key)
+}
+
+/// Best-effort write: a cache failure must never break the scan.
+pub(super) fn store(path: &Path, key: &str, output: &str) {
+    storage::store(path, key, output);
+}
+
+/// Config content folded into the key so a config change invalidates the cache:
+/// the explicit `config` argument, or the same path-discovered default config the
+/// MCP scan call uses when `config` is omitted.
+fn config_blob(path: &Path, arguments: &Value) -> String {
+    let config_path = arguments
+        .get("config")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .or_else(|| discover_config_path(config_search_start(path)));
+    path_blob(config_path)
+}
+
+fn changed_scope_base_blob(repo_root: &Path, arguments: &Value) -> Option<String> {
+    if arguments.get("scope").and_then(Value::as_str) != Some("changed") {
+        return Some("scope:full-or-default\n".to_string());
+    }
+
+    let Some(base) = arguments.get("base").and_then(Value::as_str) else {
+        return Some("base:<working-tree>\n".to_string());
+    };
+    let resolved = git::resolve_commit(repo_root, base)?;
+    Some(format!("base:{base}\nresolved:{resolved}\n"))
+}
+
+pub(super) fn config_search_start(path: &Path) -> &Path {
+    if path.is_file() {
+        path.parent().unwrap_or(path)
+    } else {
+        path
+    }
+}
+
+fn repopilotignore_path(path: &Path) -> Option<PathBuf> {
+    let candidate = config_search_start(path).join(REPOPILOT_IGNORE_FILENAME);
+    candidate.is_file().then_some(candidate)
+}
+
+fn ignore_sources_blob(path: &Path, repo_root: &Path) -> Option<String> {
+    let mut paths = BTreeSet::new();
+    for parent in scan_ancestors(path, repo_root)? {
+        paths.insert(parent.join(".gitignore"));
+        paths.insert(parent.join(".ignore"));
+    }
+    if let Some(exclude) = git::git_path(repo_root, "info/exclude") {
+        paths.insert(exclude);
+    }
+    for global in global_ignore_paths(repo_root) {
+        paths.insert(global);
+    }
+
+    let mut blob = String::new();
+    for path in paths {
+        blob.push_str(&path_blob(Some(path)));
+        blob.push('\n');
+    }
+    Some(blob)
+}
+
+fn scan_ancestors(path: &Path, repo_root: &Path) -> Option<Vec<PathBuf>> {
+    let start = absolute_scan_start(path);
+    let start = start.canonicalize().unwrap_or(start);
+    let start = if start.is_file() {
+        start.parent()?.to_path_buf()
+    } else {
+        start
+    };
+    let mut ancestors = Vec::new();
+    let mut current = Some(start.as_path());
+    while let Some(dir) = current {
+        if !dir.starts_with(repo_root) {
+            return None;
+        }
+        ancestors.push(dir.to_path_buf());
+        if dir == repo_root {
+            break;
+        }
+        current = dir.parent();
+    }
+    Some(ancestors)
+}
+
+fn absolute_scan_start(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    }
+}
+
+fn global_ignore_paths(repo_root: &Path) -> Vec<PathBuf> {
+    if let Some(configured) = git::git(
+        repo_root,
+        &["config", "--path", "--get", "core.excludesFile"],
+    ) {
+        let path = PathBuf::from(configured);
+        return vec![if path.is_absolute() {
+            path
+        } else {
+            repo_root.join(path)
+        }];
+    }
+
+    fallback_global_ignore_path().into_iter().collect()
+}
+
+fn fallback_global_ignore_path() -> Option<PathBuf> {
+    if let Some(xdg) = env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty()) {
+        return Some(PathBuf::from(xdg).join("git/ignore"));
+    }
+    env::var_os("HOME").map(|home| PathBuf::from(home).join(".config/git/ignore"))
+}
+
+fn path_blob(path: impl Into<Option<PathBuf>>) -> String {
+    let Some(path) = path.into() else {
+        return "missing\n".to_string();
+    };
+    match fs::read(&path) {
+        Ok(bytes) => {
+            let mut blob = format!("path:{}\nbytes:", path.display());
+            blob.push_str(&hex(&bytes));
+            blob
+        }
+        Err(_) => format!("path:{}\nmissing\n", path.display()),
+    }
+}
+
+/// Canonical key-sorted encoding so equal arguments hash equally regardless of
+/// client key order. This is only stable key material, not a JSON renderer.
+fn canonical_json(value: &Value) -> String {
+    match value {
+        Value::Object(map) => {
+            let mut entries: Vec<_> = map.iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(b.0));
+            let inner: Vec<String> = entries
+                .into_iter()
+                .map(|(key, value)| format!("{key:?}:{}", canonical_json(value)))
+                .collect();
+            format!("{{{}}}", inner.join(","))
+        }
+        Value::Array(items) => {
+            let inner: Vec<String> = items.iter().map(canonical_json).collect();
+            format!("[{}]", inner.join(","))
+        }
+        other => other.to_string(),
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/commands/mcp/scan_cache/git.rs
+++ b/src/commands/mcp/scan_cache/git.rs
@@ -1,0 +1,164 @@
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const CACHE_DIR: &str = ".repopilot/cache";
+
+pub(super) fn working_tree_fingerprint(repo_root: &Path) -> Option<String> {
+    let head = git(repo_root, &["rev-parse", "HEAD"])?;
+    let status_args = ["status", "--porcelain=v1", "-z", "-uall"];
+    let status = git_bytes(repo_root, &status_args)?;
+    let mut entries = status_entries(&status);
+    entries.sort_by(|left, right| {
+        (&left.path, &left.status, &left.old_path).cmp(&(
+            &right.path,
+            &right.status,
+            &right.old_path,
+        ))
+    });
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"head:");
+    hasher.update(head.as_bytes());
+    hasher.update(b"\nstatus:\n");
+    for entry in entries {
+        if is_cache_path(&entry.path) {
+            continue;
+        }
+        hasher.update(b"status:");
+        hasher.update(entry.status.as_bytes());
+        hasher.update(b" ");
+        hasher.update(entry.path.as_bytes());
+        if let Some(old_path) = &entry.old_path {
+            hasher.update(b" <- ");
+            hasher.update(old_path.as_bytes());
+        }
+        hasher.update(b"\n");
+        if let Ok(bytes) = fs::read(repo_root.join(&entry.path)) {
+            hasher.update(b"file:");
+            hasher.update(entry.path.as_bytes());
+            hasher.update(b"\n");
+            hasher.update(&bytes);
+        }
+    }
+    Some(super::hex(&hasher.finalize()))
+}
+
+pub(super) fn git(path: &Path, args: &[&str]) -> Option<String> {
+    let output = git_output(path, args)?;
+    Some(String::from_utf8_lossy(&output).trim().to_string())
+}
+
+pub(super) fn git_root(path: &Path) -> Option<PathBuf> {
+    let root = git(path, &["rev-parse", "--show-toplevel"]).map(PathBuf::from)?;
+    fs::canonicalize(&root).ok().or(Some(root))
+}
+
+pub(super) fn git_dir(path: &Path) -> Option<PathBuf> {
+    let raw = git(path, &["rev-parse", "--git-dir"])?;
+    resolve_git_path(path, &raw)
+}
+
+pub(super) fn git_common_dir(path: &Path) -> Option<PathBuf> {
+    let raw = git(path, &["rev-parse", "--git-common-dir"])?;
+    resolve_git_path(path, &raw)
+}
+
+pub(super) fn git_path(path: &Path, repo_relative: &str) -> Option<PathBuf> {
+    let repo_root = git_root(path)?;
+    let raw = git(&repo_root, &["rev-parse", "--git-path", repo_relative])?;
+    Some(if Path::new(&raw).is_absolute() {
+        PathBuf::from(raw)
+    } else {
+        repo_root.join(raw)
+    })
+}
+
+pub(super) fn resolve_commit(repo_root: &Path, reference: &str) -> Option<String> {
+    let spec = format!("{reference}^{{commit}}");
+    git(
+        repo_root,
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            "--end-of-options",
+            spec.as_str(),
+        ],
+    )
+}
+
+fn git_bytes(path: &Path, args: &[&str]) -> Option<Vec<u8>> {
+    git_output(path, args)
+}
+
+fn git_output(path: &Path, args: &[&str]) -> Option<Vec<u8>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(git_command_dir(path))
+        .args(args)
+        .output()
+        .ok()?;
+    output.status.success().then_some(output.stdout)
+}
+
+fn resolve_git_path(path: &Path, raw: &str) -> Option<PathBuf> {
+    let raw = PathBuf::from(raw);
+    Some(if raw.is_absolute() {
+        raw
+    } else {
+        git_command_dir(path).join(raw)
+    })
+}
+
+fn git_command_dir(path: &Path) -> &Path {
+    if path.is_file() {
+        path.parent().unwrap_or(path)
+    } else {
+        path
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StatusEntry {
+    status: String,
+    path: String,
+    old_path: Option<String>,
+}
+
+fn status_entries(status: &[u8]) -> Vec<StatusEntry> {
+    let mut parts = status
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty());
+    let mut entries = Vec::new();
+
+    while let Some(raw) = parts.next() {
+        if raw.len() < 4 {
+            continue;
+        }
+        let status = String::from_utf8_lossy(&raw[..2]).to_string();
+        let path = String::from_utf8_lossy(&raw[3..]).replace('\\', "/");
+        let old_path = if raw[0] == b'R' || raw[0] == b'C' || raw[1] == b'R' || raw[1] == b'C' {
+            parts
+                .next()
+                .map(|path| String::from_utf8_lossy(path).replace('\\', "/"))
+        } else {
+            None
+        };
+        entries.push(StatusEntry {
+            status,
+            path,
+            old_path,
+        });
+    }
+
+    entries
+}
+
+fn is_cache_path(rel: &str) -> bool {
+    rel == CACHE_DIR
+        || rel.starts_with(&format!("{CACHE_DIR}/"))
+        || rel.ends_with(&format!("/{CACHE_DIR}"))
+        || rel.contains(&format!("/{CACHE_DIR}/"))
+}

--- a/src/commands/mcp/scan_cache/storage.rs
+++ b/src/commands/mcp/scan_cache/storage.rs
@@ -1,0 +1,139 @@
+use serde_json::Value;
+use std::cmp::Ordering;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+use std::time::SystemTime;
+
+pub(super) const MAX_VALID_ENTRIES: usize = 32;
+const CACHE_GIT_PATH: &str = "repopilot/cache/mcp-scan";
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub(super) fn load(path: &Path, key: &str) -> Option<String> {
+    let cached = fs::read_to_string(cache_file(path, key)?).ok()?;
+    valid_cached_scan(&cached).then_some(cached)
+}
+
+pub(super) fn store(path: &Path, key: &str, output: &str) {
+    let Some(dir) = cache_dir(path) else {
+        return;
+    };
+    if fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+
+    let file = dir.join(format!("{key}.json"));
+    let tmp = unique_tmp_file(&dir, key);
+    if fs::write(&tmp, output).is_err() {
+        let _ = fs::remove_file(&tmp);
+        return;
+    }
+    if fs::rename(&tmp, &file).is_ok() {
+        prune(&dir);
+    } else {
+        let _ = fs::remove_file(&tmp);
+    }
+}
+
+pub(super) fn cache_dir(path: &Path) -> Option<PathBuf> {
+    let candidate = normalize_path(super::git::git_path(path, CACHE_GIT_PATH)?);
+    let git_dir = canonical_metadata_dir(super::git::git_dir(path)?)?;
+    let common_dir = canonical_metadata_dir(super::git::git_common_dir(path)?)?;
+
+    (candidate.starts_with(&git_dir) || candidate.starts_with(&common_dir)).then_some(candidate)
+}
+
+fn cache_file(path: &Path, key: &str) -> Option<PathBuf> {
+    Some(cache_dir(path)?.join(format!("{key}.json")))
+}
+
+fn unique_tmp_file(dir: &Path, key: &str) -> PathBuf {
+    let suffix = TEMP_COUNTER.fetch_add(1, AtomicOrdering::Relaxed);
+    dir.join(format!(
+        "{}.{}.{}.json.tmp",
+        key,
+        std::process::id(),
+        suffix
+    ))
+}
+
+fn prune(dir: &Path) {
+    let mut entries = valid_entries(dir);
+    if entries.len() <= MAX_VALID_ENTRIES {
+        return;
+    }
+    entries.sort_by(|left, right| match left.modified.cmp(&right.modified) {
+        Ordering::Equal => left.path.cmp(&right.path),
+        order => order,
+    });
+
+    let remove_count = entries.len().saturating_sub(MAX_VALID_ENTRIES);
+    for entry in entries.into_iter().take(remove_count) {
+        let _ = fs::remove_file(entry.path);
+    }
+}
+
+fn valid_entries(dir: &Path) -> Vec<CacheEntry> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| cache_entry(entry.path()))
+        .collect()
+}
+
+fn cache_entry(path: PathBuf) -> Option<CacheEntry> {
+    if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+        return None;
+    }
+    let text = fs::read_to_string(&path).ok()?;
+    if !valid_cached_scan(&text) {
+        return None;
+    }
+    let modified = fs::metadata(&path)
+        .and_then(|metadata| metadata.modified())
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    Some(CacheEntry { path, modified })
+}
+
+struct CacheEntry {
+    path: PathBuf,
+    modified: SystemTime,
+}
+
+fn valid_cached_scan(text: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(text) else {
+        return false;
+    };
+    value
+        .get("schema_version")
+        .and_then(Value::as_str)
+        .is_some()
+        && value
+            .get("report")
+            .and_then(|report| report.get("kind"))
+            .and_then(Value::as_str)
+            == Some("scan")
+}
+
+fn canonical_metadata_dir(path: PathBuf) -> Option<PathBuf> {
+    fs::canonicalize(path).ok().map(normalize_path)
+}
+
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}

--- a/src/commands/mcp/scan_cache/tests.rs
+++ b/src/commands/mcp/scan_cache/tests.rs
@@ -1,0 +1,76 @@
+use super::*;
+use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+mod changed_base;
+mod invalidation;
+mod storage_tests;
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git is available");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_stdout(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git is available");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn init_repo() -> (TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path().to_path_buf();
+    git(&root, &["init", "-q"]);
+    git(&root, &["config", "user.email", "t@example.com"]);
+    git(&root, &["config", "user.name", "Test"]);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(
+        root.join("src/lib.rs"),
+        "pub fn add(a: i32, b: i32) -> i32 { a + b }\n",
+    )
+    .unwrap();
+    git(&root, &["add", "."]);
+    git(&root, &["commit", "-qm", "init"]);
+    (dir, root)
+}
+
+fn args(root: &Path) -> Value {
+    json!({ "path": root.to_str().unwrap() })
+}
+
+fn changed_args(root: &Path, base: &str) -> Value {
+    json!({ "path": root.to_str().unwrap(), "scope": "changed", "base": base })
+}
+
+fn cached_scan_probe(marker: &str) -> String {
+    json!({
+        "schema_version": "test",
+        "report": { "kind": "scan" },
+        "cache_probe": marker
+    })
+    .to_string()
+}
+
+fn cache_dir_for(root: &Path) -> PathBuf {
+    storage::cache_dir(root).expect("safe git-owned cache dir")
+}

--- a/src/commands/mcp/scan_cache/tests/changed_base.rs
+++ b/src/commands/mcp/scan_cache/tests/changed_base.rs
@@ -1,0 +1,68 @@
+use super::*;
+
+#[test]
+fn unchanged_resolved_changed_base_produces_a_cache_hit() {
+    let (_dir, root) = init_repo();
+    git(&root, &["branch", "scan-base", "HEAD"]);
+    std::fs::write(root.join("src/lib.rs"), "pub fn changed() -> i32 { 2 }\n").unwrap();
+    git(&root, &["commit", "-am", "head change", "-q"]);
+
+    let arguments = changed_args(&root, "scan-base");
+    let first = cache_key(&root, &arguments).expect("resolved base is cacheable");
+    let second = cache_key(&root, &arguments).expect("resolved base remains cacheable");
+    assert_eq!(first, second);
+
+    let cached = cached_scan_probe("changed-base-hit");
+    store(&root, &first, &cached);
+    assert_eq!(
+        super::super::super::scan::call(&arguments).unwrap(),
+        cached,
+        "unchanged named base should serve the cached report"
+    );
+}
+
+#[test]
+fn moving_the_same_named_changed_base_invalidates_the_key() {
+    let (_dir, root) = init_repo();
+    git(&root, &["branch", "scan-base", "HEAD"]);
+    std::fs::write(root.join("src/lib.rs"), "pub fn changed() -> i32 { 2 }\n").unwrap();
+    git(&root, &["commit", "-am", "head change", "-q"]);
+
+    let arguments = changed_args(&root, "scan-base");
+    let before = cache_key(&root, &arguments).expect("initial base is cacheable");
+
+    git(&root, &["branch", "-f", "scan-base", "HEAD"]);
+    let after = cache_key(&root, &arguments).expect("moved base is cacheable");
+
+    assert_ne!(
+        before, after,
+        "moving a named base ref to a new commit must invalidate"
+    );
+}
+
+#[test]
+fn unresolvable_changed_base_disables_disk_cache() {
+    let (_dir, root) = init_repo();
+    git(&root, &["branch", "scan-base", "HEAD"]);
+    std::fs::write(root.join("src/lib.rs"), "pub fn changed() -> i32 { 2 }\n").unwrap();
+    git(&root, &["commit", "-am", "head change", "-q"]);
+
+    let good_args = changed_args(&root, "scan-base");
+    let good_key = cache_key(&root, &good_args).expect("valid base is cacheable");
+    store(&root, &good_key, &cached_scan_probe("must-not-serve"));
+
+    let bad_args = changed_args(&root, "missing-base");
+    assert!(
+        cache_key(&root, &bad_args).is_none(),
+        "an unresolvable base ref must disable disk caching"
+    );
+    let outcome = super::super::super::scan::call(&bad_args);
+    assert!(
+        outcome.is_err(),
+        "the fresh scan should surface the bad ref"
+    );
+    assert!(
+        !format!("{outcome:?}").contains("must-not-serve"),
+        "an unresolvable base must not serve an existing cache entry"
+    );
+}

--- a/src/commands/mcp/scan_cache/tests/invalidation.rs
+++ b/src/commands/mcp/scan_cache/tests/invalidation.rs
@@ -1,0 +1,280 @@
+use super::*;
+
+#[test]
+fn key_is_stable_for_an_unchanged_tree() {
+    let (_dir, root) = init_repo();
+    let first = cache_key(&root, &args(&root));
+    let second = cache_key(&root, &args(&root));
+    assert!(first.is_some(), "a git repo is cacheable");
+    assert_eq!(first, second, "an unchanged tree yields a stable key");
+}
+
+#[test]
+fn non_git_path_is_never_cached() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(
+        cache_key(dir.path(), &args(dir.path())).is_none(),
+        "a non-git path must not be cached"
+    );
+}
+
+#[test]
+fn committed_staged_unstaged_and_untracked_changes_invalidate_the_key() {
+    let (_dir, root) = init_repo();
+    let before = cache_key(&root, &args(&root)).unwrap();
+
+    std::fs::write(
+        root.join("src/lib.rs"),
+        "pub fn add(a: i32, b: i32) -> i32 { a - b }\n",
+    )
+    .unwrap();
+    let unstaged = cache_key(&root, &args(&root)).unwrap();
+    assert_ne!(before, unstaged, "an unstaged edit must invalidate");
+
+    git(&root, &["add", "src/lib.rs"]);
+    let staged = cache_key(&root, &args(&root)).unwrap();
+    assert_ne!(before, staged, "a staged edit must invalidate");
+
+    git(&root, &["commit", "-qm", "change"]);
+    let committed = cache_key(&root, &args(&root)).unwrap();
+    assert_ne!(before, committed, "a commit must invalidate");
+
+    std::fs::write(root.join("src/new.rs"), "pub fn extra() {}\n").unwrap();
+    let untracked = cache_key(&root, &args(&root)).unwrap();
+    assert_ne!(committed, untracked, "an untracked file must invalidate");
+}
+
+#[test]
+fn changes_outside_subdir_scan_still_invalidate_the_key() {
+    let (_dir, root) = init_repo();
+    std::fs::write(root.join("README.md"), "initial\n").unwrap();
+    git(&root, &["add", "README.md"]);
+    git(&root, &["commit", "-qm", "add readme"]);
+
+    let subdir = root.join("src");
+    let before = cache_key(&subdir, &args(&subdir)).unwrap();
+    std::fs::write(root.join("README.md"), "changed\n").unwrap();
+    let after = cache_key(&subdir, &args(&subdir)).unwrap();
+
+    assert_ne!(
+        before, after,
+        "the cache key must fingerprint the whole Git working tree"
+    );
+}
+
+#[test]
+fn staged_rename_and_deletion_invalidate_the_key() {
+    let (_dir, root) = init_repo();
+    let before_rename = cache_key(&root, &args(&root)).unwrap();
+    git(&root, &["mv", "src/lib.rs", "src/renamed.rs"]);
+    let after_rename = cache_key(&root, &args(&root)).unwrap();
+    assert_ne!(
+        before_rename, after_rename,
+        "a staged rename must invalidate"
+    );
+
+    git(&root, &["commit", "-qm", "rename"]);
+    let before_delete = cache_key(&root, &args(&root)).unwrap();
+    git(&root, &["rm", "src/renamed.rs"]);
+    let after_delete = cache_key(&root, &args(&root)).unwrap();
+    assert_ne!(
+        before_delete, after_delete,
+        "a staged deletion must invalidate"
+    );
+}
+
+#[test]
+fn profile_and_filter_changes_invalidate_the_key() {
+    let (_dir, root) = init_repo();
+    let base = cache_key(&root, &args(&root)).unwrap();
+
+    let strict = cache_key(
+        &root,
+        &json!({ "path": root.to_str().unwrap(), "profile": "strict" }),
+    )
+    .unwrap();
+    assert_ne!(base, strict, "a profile change must invalidate");
+
+    let filtered = cache_key(
+        &root,
+        &json!({ "path": root.to_str().unwrap(), "filters": { "min_severity": "high" } }),
+    )
+    .unwrap();
+    assert_ne!(base, filtered, "a filter change must invalidate");
+}
+
+#[test]
+fn explicit_and_discovered_config_content_changes_invalidate_the_key() {
+    let (_dir, root) = init_repo();
+    let cfg_dir = tempfile::tempdir().unwrap();
+    let cfg = cfg_dir.path().join("repopilot.toml");
+    let explicit = json!({ "path": root.to_str().unwrap(), "config": cfg.to_str().unwrap() });
+
+    std::fs::write(&cfg, "[architecture]\nmax_file_lines = 300\n").unwrap();
+    let explicit_before = cache_key(&root, &explicit).unwrap();
+    std::fs::write(&cfg, "[architecture]\nmax_file_lines = 10\n").unwrap();
+    let explicit_after = cache_key(&root, &explicit).unwrap();
+    assert_ne!(
+        explicit_before, explicit_after,
+        "an explicit config edit must invalidate"
+    );
+
+    std::fs::write(root.join(".gitignore"), "repopilot.toml\n").unwrap();
+    git(&root, &["add", ".gitignore"]);
+    git(&root, &["commit", "-qm", "ignore config"]);
+    let discovered = root.join("repopilot.toml");
+    std::fs::write(&discovered, "[architecture]\nmax_file_lines = 300\n").unwrap();
+    let root_before = cache_key(&root, &args(&root)).unwrap();
+    let subdir_before = cache_key(&root.join("src"), &args(&root.join("src"))).unwrap();
+
+    std::fs::write(&discovered, "[architecture]\nmax_file_lines = 10\n").unwrap();
+    let root_after = cache_key(&root, &args(&root)).unwrap();
+    let subdir_after = cache_key(&root.join("src"), &args(&root.join("src"))).unwrap();
+    assert_ne!(root_before, root_after);
+    assert_ne!(subdir_before, subdir_after);
+}
+
+#[test]
+fn feedback_and_repopilotignore_content_changes_invalidate_the_key() {
+    let (_dir, root) = init_repo();
+    std::fs::write(
+        root.join(".gitignore"),
+        ".repopilot/feedback.yml\n.repopilotignore\n",
+    )
+    .unwrap();
+    git(&root, &["add", ".gitignore"]);
+    git(&root, &["commit", "-qm", "ignore controls"]);
+
+    let feedback = root.join(".repopilot/feedback.yml");
+    std::fs::create_dir_all(feedback.parent().unwrap()).unwrap();
+    std::fs::write(
+        &feedback,
+        "suppressions:\n  - rule_id: security.secret-candidate\n    path: src/lib.rs\n",
+    )
+    .unwrap();
+    let before_feedback = cache_key(&root, &args(&root)).unwrap();
+    std::fs::write(
+        &feedback,
+        "suppressions:\n  - rule_id: architecture.large-file\n    path: src/lib.rs\n",
+    )
+    .unwrap();
+    let after_feedback = cache_key(&root, &args(&root)).unwrap();
+    assert_ne!(before_feedback, after_feedback);
+
+    let ignore = root.join(".repopilotignore");
+    std::fs::write(&ignore, "target/\n").unwrap();
+    let before_ignore = cache_key(&root, &args(&root)).unwrap();
+    std::fs::write(&ignore, "target/\ndist/\n").unwrap();
+    let after_ignore = cache_key(&root, &args(&root)).unwrap();
+    assert_ne!(before_ignore, after_ignore);
+}
+
+#[test]
+fn parent_gitignore_change_invalidates_subdir_scan_and_never_serves_stale_cache() {
+    let (_dir, root) = init_repo();
+    std::fs::write(root.join("src/generated.rs"), "pub fn generated() {}\n").unwrap();
+    git(&root, &["add", "."]);
+    git(&root, &["commit", "-qm", "add generated"]);
+
+    let subdir = root.join("src");
+    let arguments = args(&subdir);
+    let before = cache_key(&subdir, &arguments).unwrap();
+    store(
+        &subdir,
+        &before,
+        &cached_scan_probe("stale-parent-gitignore"),
+    );
+
+    std::fs::write(root.join(".gitignore"), "/src/generated.rs\n").unwrap();
+    let after = cache_key(&subdir, &arguments).unwrap();
+    assert_ne!(
+        before, after,
+        "a parent .gitignore edit must invalidate a subdir scan"
+    );
+
+    let fresh = super::super::super::scan::call(&arguments).unwrap();
+    assert!(
+        !fresh.contains("stale-parent-gitignore"),
+        "a parent .gitignore edit must not serve the stale cache"
+    );
+}
+
+#[test]
+fn git_info_exclude_change_invalidates_subdir_scan() {
+    let (_dir, root) = init_repo();
+    std::fs::write(root.join("src/generated.rs"), "pub fn generated() {}\n").unwrap();
+    git(&root, &["add", "."]);
+    git(&root, &["commit", "-qm", "add generated"]);
+
+    let subdir = root.join("src");
+    let arguments = args(&subdir);
+    let before = cache_key(&subdir, &arguments).unwrap();
+    let exclude = git::git_path(&root, "info/exclude").expect("git exclude path");
+    std::fs::write(exclude, "/src/generated.rs\n").unwrap();
+    let after = cache_key(&subdir, &arguments).unwrap();
+
+    assert_ne!(
+        before, after,
+        ".git/info/exclude must be part of the cache key"
+    );
+}
+
+#[test]
+fn configured_global_ignore_change_invalidates_subdir_scan() {
+    let (_dir, root) = init_repo();
+    let global_dir = tempfile::tempdir().unwrap();
+    let global_ignore = global_dir.path().join("ignore");
+    std::fs::write(&global_ignore, "target/\n").unwrap();
+    git(
+        &root,
+        &[
+            "config",
+            "core.excludesFile",
+            global_ignore.to_str().unwrap(),
+        ],
+    );
+
+    let subdir = root.join("src");
+    let arguments = args(&subdir);
+    let before = cache_key(&subdir, &arguments).unwrap();
+    std::fs::write(&global_ignore, "target/\nsrc/generated.rs\n").unwrap();
+    let after = cache_key(&subdir, &arguments).unwrap();
+
+    assert_ne!(
+        before, after,
+        "the effective global Git ignore file must be part of the cache key"
+    );
+}
+
+#[test]
+fn ignored_parent_dotignore_change_invalidates_subdir_scan() {
+    let (_dir, root) = init_repo();
+    std::fs::write(root.join(".gitignore"), ".ignore\n").unwrap();
+    git(&root, &["add", ".gitignore"]);
+    git(&root, &["commit", "-qm", "ignore dotignore"]);
+
+    let subdir = root.join("src");
+    let arguments = args(&subdir);
+    std::fs::write(root.join(".ignore"), "dist/\n").unwrap();
+    let before = cache_key(&subdir, &arguments).unwrap();
+    std::fs::write(root.join(".ignore"), "dist/\nsrc/generated.rs\n").unwrap();
+    let after = cache_key(&subdir, &arguments).unwrap();
+
+    assert_ne!(
+        before, after,
+        "a parent .ignore edit must invalidate even when git status ignores it"
+    );
+}
+
+#[test]
+fn schema_and_package_version_changes_invalidate_the_key() {
+    let (_dir, root) = init_repo();
+    let arguments = args(&root);
+
+    let base = cache_key_with_metadata(&root, &arguments, "schema-a", "1.0.0").unwrap();
+    let schema = cache_key_with_metadata(&root, &arguments, "schema-b", "1.0.0").unwrap();
+    let version = cache_key_with_metadata(&root, &arguments, "schema-a", "1.0.1").unwrap();
+
+    assert_ne!(base, schema, "a cache schema change must invalidate");
+    assert_ne!(base, version, "a package version change must invalidate");
+}

--- a/src/commands/mcp/scan_cache/tests/storage_tests.rs
+++ b/src/commands/mcp/scan_cache/tests/storage_tests.rs
@@ -1,0 +1,184 @@
+use super::*;
+use serde_json::Value;
+use std::sync::Arc;
+
+#[test]
+fn cache_files_are_git_owned_not_worktree_and_do_not_dirty_status() {
+    let (_dir, root) = init_repo();
+    let before_status = git_stdout(&root, &["status", "--porcelain", "--", "."]);
+    let key = cache_key(&root, &args(&root)).unwrap();
+
+    store(&root, &key, &cached_scan_probe("git-owned"));
+
+    let cache_dir = cache_dir_for(&root);
+    assert!(
+        !cache_dir.starts_with(root.join(".repopilot")),
+        "cache dir must not be the repository working-tree RepoPilot dir"
+    );
+    assert!(cache_dir.join(format!("{key}.json")).is_file());
+    assert!(!root.join(".repopilot/cache/mcp-scan").exists());
+    assert_eq!(
+        before_status,
+        git_stdout(&root, &["status", "--porcelain", "--", "."]),
+        "writing cache files must not alter git status"
+    );
+}
+
+#[test]
+fn root_and_subdir_scans_share_the_same_git_owned_cache_area() {
+    let (_dir, root) = init_repo();
+    let subdir = root.join("src");
+
+    assert_eq!(cache_dir_for(&root), cache_dir_for(&subdir));
+
+    let arguments = args(&subdir);
+    let key = cache_key(&subdir, &arguments).unwrap();
+    let cached = cached_scan_probe("subdir-hit");
+    store(&subdir, &key, &cached);
+
+    assert_eq!(cache_key(&subdir, &arguments).unwrap(), key);
+    assert_eq!(load(&subdir, &key).unwrap(), cached);
+    assert!(!subdir.join(".repopilot/cache/mcp-scan").exists());
+}
+
+#[test]
+fn worktree_git_file_uses_git_metadata_or_disables_cache() {
+    let (dir, root) = init_repo();
+    let linked = dir.path().join("linked-worktree");
+    git(
+        &root,
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "linked-worktree",
+            linked.to_str().unwrap(),
+            "HEAD",
+        ],
+    );
+    assert!(
+        linked.join(".git").is_file(),
+        "linked worktree should use a .git file"
+    );
+
+    let arguments = args(&linked);
+    let Some(key) = cache_key(&linked, &arguments) else {
+        return;
+    };
+    let cache_dir = cache_dir_for(&linked);
+    assert!(!cache_dir.starts_with(linked.join(".repopilot")));
+
+    store(&linked, &key, &cached_scan_probe("worktree"));
+    assert!(load(&linked, &key).is_some());
+}
+
+#[test]
+fn corrupt_cache_entry_is_ignored() {
+    let (_dir, root) = init_repo();
+    let arguments = args(&root);
+    let key = cache_key(&root, &arguments).expect("git repo is cacheable");
+
+    store(&root, &key, "{not-json");
+    let fresh = super::super::super::scan::call(&arguments).unwrap();
+
+    assert_ne!(
+        fresh, "{not-json",
+        "corrupt cache content must not be served"
+    );
+    assert!(fresh.contains("schema_version"));
+}
+
+#[test]
+fn retention_keeps_at_most_32_valid_scan_entries_and_preserves_unrelated_files() {
+    let (_dir, root) = init_repo();
+    let cache_dir = cache_dir_for(&root);
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    let unrelated = cache_dir.join("notes.txt");
+    let invalid = cache_dir.join("invalid.json");
+    let tmp = cache_dir.join("leftover.json.tmp");
+    std::fs::write(&unrelated, "keep me").unwrap();
+    std::fs::write(&invalid, "{not-json").unwrap();
+    std::fs::write(&tmp, "partial").unwrap();
+
+    for index in 0..40 {
+        store(
+            &root,
+            &format!("{index:064x}"),
+            &cached_scan_probe(&format!("entry-{index}")),
+        );
+    }
+
+    assert!(
+        valid_scan_entry_count(&cache_dir) <= storage::MAX_VALID_ENTRIES,
+        "retention should cap valid scan entries"
+    );
+    assert!(unrelated.exists(), "unrelated files must not be pruned");
+    assert!(
+        invalid.exists(),
+        "invalid JSON is ignored, not treated as cache"
+    );
+    assert!(
+        tmp.exists(),
+        "temporary-looking unrelated files are preserved"
+    );
+    assert!(
+        load(&root, &format!("{:064x}", 0)).is_none(),
+        "oldest valid entries should be pruned first"
+    );
+    assert!(
+        load(&root, &format!("{:064x}", 39)).is_some(),
+        "newer valid entries should be retained"
+    );
+}
+
+#[test]
+fn concurrent_writers_use_unique_temp_files_and_leave_valid_json() {
+    let (_dir, root) = init_repo();
+    let key = cache_key(&root, &args(&root)).unwrap();
+    let root = Arc::new(root);
+
+    let mut handles = Vec::new();
+    for index in 0..8 {
+        let root = Arc::clone(&root);
+        let key = key.clone();
+        handles.push(std::thread::spawn(move || {
+            store(&root, &key, &cached_scan_probe(&format!("writer-{index}")));
+        }));
+    }
+    for handle in handles {
+        handle.join().expect("writer thread");
+    }
+
+    let cached = load(&root, &key).expect("one writer should win");
+    let parsed: Value = serde_json::from_str(&cached).expect("cached report is valid JSON");
+    assert_eq!(parsed["report"]["kind"], "scan");
+    assert!(
+        std::fs::read_dir(cache_dir_for(&root))
+            .unwrap()
+            .filter_map(Result::ok)
+            .all(|entry| entry.path().extension().and_then(|ext| ext.to_str()) != Some("tmp")),
+        "unique temp files should not leave partial cache files"
+    );
+}
+
+fn valid_scan_entry_count(cache_dir: &std::path::Path) -> usize {
+    std::fs::read_dir(cache_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json"))
+        .filter(|entry| {
+            std::fs::read_to_string(entry.path())
+                .ok()
+                .and_then(|text| serde_json::from_str::<Value>(&text).ok())
+                .and_then(|value| {
+                    value
+                        .get("report")?
+                        .get("kind")?
+                        .as_str()
+                        .map(str::to_owned)
+                })
+                == Some("scan".to_string())
+        })
+        .count()
+}

--- a/src/commands/mcp/session_cache_tests.rs
+++ b/src/commands/mcp/session_cache_tests.rs
@@ -1,0 +1,78 @@
+use super::{ServerState, handle_tools_call, scan};
+use serde_json::{Value, json};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git is available");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn tool_text(response: super::jsonrpc::Response) -> String {
+    response
+        .result
+        .expect("response result")
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|content| content.first())
+        .and_then(|content| content.get("text"))
+        .and_then(Value::as_str)
+        .expect("tool text")
+        .to_string()
+}
+
+#[test]
+fn scan_tool_does_not_return_same_session_cache_after_an_edit() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let root = temp.path();
+    git(root, &["init", "-q"]);
+    git(root, &["config", "user.email", "t@example.com"]);
+    git(root, &["config", "user.name", "Test"]);
+    fs::create_dir_all(root.join("src")).expect("src");
+    fs::write(root.join("src/lib.rs"), "pub fn live() -> i32 { 1 }\n").expect("source");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-qm", "init"]);
+
+    let mut state = ServerState {
+        root: root.canonicalize().expect("canonical root"),
+        initialized: true,
+        negotiated: true,
+        ..ServerState::default()
+    };
+    let params = json!({
+        "name": scan::TOOL_NAME,
+        "arguments": {
+            "path": ".",
+            "profile": "strict",
+            "filters": { "rules": ["security.secret-candidate"] }
+        }
+    });
+
+    let first = tool_text(handle_tools_call(json!(1), &params, &mut state));
+    assert!(
+        !first.contains("security.secret-candidate"),
+        "fixture should start without a secret finding"
+    );
+
+    fs::write(
+        root.join("src/config.ts"),
+        "export const API_KEY = \"abc123xyz987\";\n",
+    )
+    .expect("secret fixture");
+    let second = tool_text(handle_tools_call(json!(2), &params, &mut state));
+
+    assert!(
+        second.contains("security.secret-candidate"),
+        "the second scan must observe edits made in the same MCP session"
+    );
+}

--- a/tests/mcp_cli.rs
+++ b/tests/mcp_cli.rs
@@ -6,7 +6,7 @@
 use serde_json::Value;
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 /// Runs `repopilot mcp` over `requests` (one JSON-RPC message each) and returns
@@ -249,4 +249,91 @@ fn mcp_server_cancels_background_tool_calls() {
         .find(|message| message["id"] == 9)
         .expect("cancelled response");
     assert_eq!(cancelled["error"]["code"], -32800);
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let ok = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git available")
+        .status
+        .success();
+    assert!(ok, "git {args:?} failed");
+}
+
+fn git_path(root: &Path, path: &str) -> PathBuf {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "--git-path", path])
+        .output()
+        .expect("git available");
+    assert!(output.status.success(), "git rev-parse --git-path failed");
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        root.join(path)
+    }
+}
+
+#[test]
+fn mcp_scan_cache_persists_across_sessions_and_invalidates_on_edit() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let root = temp.path();
+    git(root, &["init", "-q"]);
+    git(root, &["config", "user.email", "t@example.com"]);
+    git(root, &["config", "user.name", "Test"]);
+    fs::create_dir_all(root.join("src")).expect("src");
+    fs::write(root.join("src/lib.rs"), "pub fn live() -> i32 { 1 }\n").expect("source");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-qm", "init"]);
+
+    let scan = [
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}"#,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"repopilot_scan","arguments":{"path":"."}}}"#,
+    ];
+
+    // Session 1 writes the disk cache.
+    let first = run_mcp(&scan, root);
+    assert_eq!(first[1]["result"]["isError"], false, "scan should succeed");
+    let cache_dir = git_path(root, "repopilot/cache/mcp-scan");
+    let cache_file = fs::read_dir(&cache_dir)
+        .expect("cache dir created")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .expect("a cache entry was written");
+
+    // Overwrite the cache with a sentinel: a NEW process scanning the unchanged
+    // tree must read it back — proving a cross-session disk hit.
+    fs::write(
+        &cache_file,
+        r#"{"schema_version":"test","report":{"kind":"scan"},"sentinel":"cached-across-sessions"}"#,
+    )
+    .expect("overwrite cache");
+    let hit = run_mcp(&scan, root);
+    assert!(
+        hit[1].to_string().contains("cached-across-sessions"),
+        "a second session must serve the disk cache: {}",
+        hit[1]
+    );
+
+    // Editing a file changes the working-tree fingerprint → miss → a real scan,
+    // never the stale sentinel.
+    fs::write(root.join("src/lib.rs"), "pub fn changed() -> i32 { 2 }\n").expect("edit");
+    let miss = run_mcp(&scan, root);
+    let text = miss[1].to_string();
+    assert!(
+        !text.contains("cached-across-sessions"),
+        "an edit must invalidate the cache"
+    );
+    assert!(
+        text.contains("schema_version"),
+        "a miss returns a real scan report"
+    );
 }


### PR DESCRIPTION
## Summary

- Add a local persistent cache for `repopilot_scan` that prefers a fresh scan over any uncertain cache hit.
- Key cache entries by RepoPilot/cache schema version, scan arguments, whole Git working-tree state, explicit/discovered config, `.repopilot/feedback.yml`, `.repopilotignore`, scanner-visible ignore sources, and the resolved commit SHA for changed-scope `base` refs.
- Include parent `.gitignore` and `.ignore` files, `.git/info/exclude`, and the effective Git global ignore file in the key so subdirectory scans cannot reuse stale reports when ignore inputs outside the scan path change.
- Store full scan reports in Git-owned metadata from `git rev-parse --git-path repopilot/cache/mcp-scan`, not under the repository working tree.
- Keep writes atomic with per-process unique temp files and prune to at most 32 valid scan reports per repository cache directory.
- Document cache location, invalidation, safe deletion, retention, and the remaining non-scan MCP session-cache follow-up.

## Why

Agents commonly run `repopilot_scan` repeatedly while editing. Cross-session reuse avoids re-auditing unchanged repositories, but stale scan reports are worse than slow scans. This PR tightens the cache around Git truth and scanner inputs: moving a named base ref, changing any dirty/untracked Git worktree state, changing config/feedback/ignore controls, changing scanner-visible Git ignore sources, or encountering an unsafe cache directory disables reuse or invalidates the key.

## Contract

- Local-first: no source, telemetry, or cache report leaves the machine.
- Read-only MCP surface: no write-capable MCP tools are added; cache writes are internal performance state only.
- Deterministic scan output: cached output is byte-identical to a prior local scan report, and uncertain cache state falls back to a fresh scan.
- Storage safety: full reports are stored in Git metadata, never `.repopilot/cache/mcp-scan` in the working tree; cache files can be deleted safely.
- Correctness-first invalidation: subdirectory scans fingerprint the whole Git working tree and hash scanner-visible ignore inputs even when those files live outside the scan path.
- Scope stays narrow: no scan sessions, scan IDs, resource templates, pagination, impact analysis, verification tools, or scanner per-file cache redesign. Session-cache invalidation for `repopilot_review_change`, `repopilot_context`, and `repopilot_explain_file` is intentionally left to the next MCP correctness PR.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
