### PR TITLE
fix(secret-candidate): reduce path qualifier and identifier slug noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,19 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **`security.secret-candidate` no longer misreads namespace path qualifiers as
+  hardcoded secrets, and lowercase slug-like values are strict-only Low.** A
+  `key::Rest` path qualifier (a Rust/C++ enum or type path such as
+  `Token::RecursiveSuffix`) was parsed as a `token: <secret>` assignment. Values
+  made only of lowercase words joined by `-`/`_` (for example
+  `excalidraw-oai-api-key`) are now downgraded to Low confidence instead of
+  removed, so default output hides storage identifiers while `--profile strict`
+  still retains passphrases and token-like slugs. Genuine mixed-case/digit
+  credentials stay High and default-visible. Measured on the real-repo zoo, this
+  removed ripgrep's 2 default-visible findings (`glob.rs` enum paths) and hid 1
+  excalidraw storage-key slug from default output while retaining it in strict;
+  eShopOnWeb's 7 genuine hardcoded credentials were correctly retained.
+
 - **`repopilot_scan` MCP disk caching no longer serves stale scan reports after
   agent edits.** The scan tool now bypasses the MCP session cache, keys disk
   entries from the git-root working tree, stores entries under Git-owned

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -120,20 +120,22 @@ fn detect_secret_line(line: &str, line_number: usize, path: &std::path::Path) ->
             path,
             "jwt-like token",
             mask_token_in_line(line.trim(), jwt),
+            Confidence::High,
         ));
     }
 
     let lower = line.to_ascii_lowercase();
 
-    if let Some(matched_key) = SECRET_KEYS
+    if let Some((matched_key, confidence)) = SECRET_KEYS
         .iter()
-        .find(|&&key| assigned_secret_value_for_key(line, &lower, key).is_some())
+        .find_map(|&key| assigned_secret_confidence_for_key(line, &lower, key).map(|c| (key, c)))
     {
         return Some(build_finding(
             line_number,
             path,
             matched_key,
             mask_secret_value(line.trim()),
+            confidence,
         ));
     }
 

--- a/src/audits/security/secret_candidate/finding.rs
+++ b/src/audits/security/secret_candidate/finding.rs
@@ -8,6 +8,7 @@ fn build_finding(
     path: &std::path::Path,
     matched_key: &str,
     snippet: String,
+    confidence: Confidence,
 ) -> Finding {
     Finding {
         id: String::new(),
@@ -20,7 +21,7 @@ fn build_finding(
         ),
         category: FindingCategory::Security,
         severity: Severity::High,
-        confidence: Confidence::High,
+        confidence,
         evidence: vec![Evidence {
             path: path.to_path_buf(),
             line_start: line_number,

--- a/src/audits/security/secret_candidate/helpers.rs
+++ b/src/audits/security/secret_candidate/helpers.rs
@@ -1,6 +1,13 @@
 fn assigned_value_after_key(after_key: &str) -> Option<&str> {
     let trimmed = after_key.trim_start();
 
+    // `key::Rest` is a namespace/path qualifier (`Token::RecursiveSuffix`,
+    // `Self::secret`), not a `key = value` / `key: value` assignment — the text
+    // after `::` is a type or enum path, never a hardcoded secret.
+    if trimmed.starts_with("::") {
+        return None;
+    }
+
     if let Some(value) = trimmed.strip_prefix('=') {
         return Some(value.trim_start());
     }
@@ -13,7 +20,11 @@ fn assigned_value_after_key(after_key: &str) -> Option<&str> {
     Some(after_colon)
 }
 
-fn assigned_secret_value_for_key<'a>(line: &'a str, lower_line: &str, key: &str) -> Option<&'a str> {
+fn assigned_secret_confidence_for_key(
+    line: &str,
+    lower_line: &str,
+    key: &str,
+) -> Option<Confidence> {
     let mut search_start = 0;
 
     while let Some(offset) = lower_line[search_start..].find(key) {
@@ -25,10 +36,10 @@ fn assigned_secret_value_for_key<'a>(line: &'a str, lower_line: &str, key: &str)
             continue;
         }
         let after_key = &line[key_start + key.len()..];
-        if let Some(value) = assigned_value_after_key(after_key)
-            && is_secret_literal(value)
+        if let Some(confidence) =
+            assigned_value_after_key(after_key).and_then(secret_literal_confidence)
         {
-            return Some(value);
+            return Some(confidence);
         }
     }
 
@@ -66,7 +77,19 @@ fn looks_like_env_var_name(value: &str) -> bool {
             .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
 }
 
-fn is_secret_literal(value: &str) -> bool {
+// Lowercase kebab/snake slugs are often storage identifiers, but can also be
+// committed passphrases or service tokens. Keep them as low-confidence findings
+// so strict profile retains recall while default output hides the noise.
+fn is_human_readable_slug(value: &str) -> bool {
+    let has_separator = value.contains('-') || value.contains('_');
+    has_separator
+        && value
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c == '-' || c == '_')
+        && value.split(['-', '_']).all(|segment| !segment.is_empty())
+}
+
+fn secret_literal_confidence(value: &str) -> Option<Confidence> {
     let value = value.trim().trim_end_matches([',', ';']).trim();
     let unquoted = unwrap_first_quoted(value);
     let lower = unquoted.to_lowercase();
@@ -97,20 +120,24 @@ fn is_secret_literal(value: &str) -> bool {
     ];
 
     if is_placeholder || NON_SECRET_VALUES.contains(&lower.as_str()) || unquoted.len() < 8 {
-        return false;
+        return None;
     }
 
     // Low-entropy strings (repetitive English words) are not real secrets.
     // Real API keys/tokens have high character diversity (entropy > 3.0 bits/char).
     if shannon_entropy(unquoted) < 3.0 {
-        return false;
+        return None;
+    }
+
+    if is_human_readable_slug(unquoted) {
+        return Some(Confidence::Low);
     }
 
     if value.starts_with('"') || value.starts_with('\'') {
-        return true;
+        return Some(Confidence::High);
     }
 
-    is_unquoted_secret_token(unquoted)
+    is_unquoted_secret_token(unquoted).then_some(Confidence::High)
 }
 
 fn looks_like_placeholder_value(value: &str) -> bool {
@@ -295,4 +322,3 @@ fn shannon_entropy(s: &str) -> f64 {
         })
         .sum()
 }
-

--- a/tests/fixtures/rules/security.secret-candidate/expected.json
+++ b/tests/fixtures/rules/security.secret-candidate/expected.json
@@ -13,6 +13,16 @@
       "expected_rule_ids": []
     },
     {
+      "path": "false_positive_path_qualifier",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "low_confidence_slug_identifier",
+      "expected_rule_ids": [
+        "security.secret-candidate"
+      ]
+    },
+    {
       "path": "true_positive",
       "expected_rule_ids": [
         "security.secret-candidate"

--- a/tests/fixtures/rules/security.secret-candidate/false_positive_path_qualifier/src/glob.rs
+++ b/tests/fixtures/rules/security.secret-candidate/false_positive_path_qualifier/src/glob.rs
@@ -1,0 +1,16 @@
+// A Rust enum-path qualifier (`Token::RecursiveSuffix`) is not a
+// `token: <secret>` assignment — the `::` after the keyword names a type.
+// (Regression: ripgrep's glob parser was flagged here.)
+enum Token {
+    RecursivePrefix,
+    RecursiveSuffix,
+    RecursiveZeroOrMore,
+}
+
+fn classify(token: &Token) -> bool {
+    match token {
+        Token::RecursivePrefix => true,
+        Token::RecursiveSuffix => true,
+        Token::RecursiveZeroOrMore => false,
+    }
+}

--- a/tests/fixtures/rules/security.secret-candidate/low_confidence_slug_identifier/src/constants.ts
+++ b/tests/fixtures/rules/security.secret-candidate/low_confidence_slug_identifier/src/constants.ts
@@ -1,0 +1,6 @@
+// Ambiguous human-readable identifier: retained as a Low-confidence secret
+// candidate for strict analysis and hidden from default output.
+export const STORAGE_KEYS = {
+  OAI_API_KEY: "excalidraw-oai-api-key",
+  LOCAL_STATE: "excalidraw-local-state",
+};

--- a/tests/scan_visibility_cli.rs
+++ b/tests/scan_visibility_cli.rs
@@ -188,7 +188,7 @@ fn default_scan_keeps_real_secret_and_private_key_candidates() {
     let root = temp.path();
     write(
         root.join("src/config.rs"),
-        "const API_KEY: &str = \"abc123xyz987\";\n",
+        "const API_KEY: &str = \"xK9mQ2pL8rT5vN3wY7\";\n",
     );
     write(
         root.join("src/key.pem"),
@@ -196,9 +196,49 @@ fn default_scan_keeps_real_secret_and_private_key_candidates() {
     );
 
     let json = scan_json(root, &[]);
+    let secret_findings = findings_for_rule(&json, "security.secret-candidate").collect::<Vec<_>>();
 
-    assert_rule_present(&json, "security.secret-candidate");
+    assert_eq!(
+        secret_findings.len(),
+        1,
+        "mixed-case/digit high-entropy credential must remain default-visible: {json:#?}"
+    );
+    assert_eq!(secret_findings[0]["confidence"], "HIGH");
     assert_rule_present(&json, "security.private-key-candidate");
+}
+
+#[test]
+fn default_scan_hides_lowercase_slug_secrets_but_strict_keeps_them() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    write(
+        root.join("src/config.ts"),
+        "export const CONFIG = {\n\
+           OAI_API_KEY: \"excalidraw-oai-api-key\",\n\
+           password: \"correct-horse-battery-staple\",\n\
+           client_secret: \"prod-service-access-token\",\n\
+           auth_token: \"internal-service-access-token\",\n\
+         };\n",
+    );
+
+    let default = scan_json(root, &[]);
+    assert_rule_absent(&default, "security.secret-candidate");
+
+    let strict = scan_json(root, &["--profile", "strict"]);
+    let secret_findings =
+        findings_for_rule(&strict, "security.secret-candidate").collect::<Vec<_>>();
+
+    assert_eq!(
+        secret_findings.len(),
+        4,
+        "strict profile must retain lowercase passphrase/token-like slug findings: {strict:#?}"
+    );
+    assert!(
+        secret_findings
+            .iter()
+            .all(|finding| finding["confidence"] == "LOW"),
+        "slug findings should be low-confidence strict-only suggestions: {strict:#?}"
+    );
 }
 
 #[test]

--- a/tests/security_rules.rs
+++ b/tests/security_rules.rs
@@ -2,6 +2,7 @@ use repopilot::audits::security::env_file_committed::EnvFileCommittedAudit;
 use repopilot::audits::security::private_key_candidate::PrivateKeyCandidateAudit;
 use repopilot::audits::security::secret_candidate::SecretCandidateAudit;
 use repopilot::audits::traits::{FileAudit, ProjectAudit};
+use repopilot::findings::types::Confidence;
 use repopilot::scan::config::ScanConfig;
 use repopilot::scan::facts::{FileFacts, ScanFacts};
 use std::path::PathBuf;
@@ -91,6 +92,56 @@ fn secret_candidate_does_not_flag_variable_references() {
             "variable reference must not be flagged as a secret: `{line}` -> {findings:?}"
         );
     }
+}
+
+#[test]
+fn secret_candidate_does_not_flag_rust_path_qualifier() {
+    // `Token::RecursiveSuffix` is an enum-path qualifier, not a `token: <secret>`
+    // assignment — the `::` after the keyword names a type, not a credential.
+    // (Regression: ripgrep's glob parser flagged `Token::RecursiveSuffix`.)
+    for line in [
+        "                Token::RecursivePrefix\n",
+        "                | Token::RecursiveSuffix\n",
+        "    let value = Self::secret_key();\n",
+    ] {
+        let f = file("crates/globset/src/glob.rs", line);
+        let findings = SecretCandidateAudit.audit(&f, &ScanConfig::default());
+        assert!(
+            findings.is_empty(),
+            "a `::` path qualifier must not be flagged as a secret: `{line}` -> {findings:?}"
+        );
+    }
+}
+
+#[test]
+fn secret_candidate_keeps_kebab_and_snake_slugs_as_low_confidence() {
+    for line in [
+        "  OAI_API_KEY: \"excalidraw-oai-api-key\",\n",
+        "password: \"correct-horse-battery-staple\",\n",
+        "client_secret: \"prod-service-access-token\",\n",
+        "auth_token: \"internal_service_access_token\",\n",
+    ] {
+        let slug = file("packages/common/src/constants.ts", line);
+        let findings = SecretCandidateAudit.audit(&slug, &ScanConfig::default());
+        assert_eq!(
+            findings.len(),
+            1,
+            "lowercase secret-shaped slug must remain available in raw/strict findings: `{line}`"
+        );
+        assert_eq!(findings[0].confidence, Confidence::Low);
+    }
+}
+
+#[test]
+fn secret_candidate_keeps_mixed_case_credentials_high_confidence() {
+    let real = file(
+        "packages/common/src/constants.ts",
+        "  OAI_API_KEY: \"sk-Zj4Hn8Qw2Kp6Mv9Rs1Tb7\",\n",
+    );
+    let findings = SecretCandidateAudit.audit(&real, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1, "a real secret-shaped value must fire");
+    assert_eq!(findings[0].confidence, Confidence::High);
 }
 
 #[test]
@@ -269,10 +320,7 @@ fn secret_candidate_flags_high_entropy_values() {
             !findings.is_empty(),
             "high-entropy value must be flagged: `{line}`"
         );
-        assert_eq!(
-            findings[0].confidence,
-            repopilot::findings::types::Confidence::High
-        );
+        assert_eq!(findings[0].confidence, Confidence::High);
     }
 }
 
@@ -290,10 +338,7 @@ fn secret_candidate_flags_provider_looking_values_after_placeholder_filtering() 
             !findings.is_empty(),
             "provider-looking value must still be flagged: `{line}`"
         );
-        assert_eq!(
-            findings[0].confidence,
-            repopilot::findings::types::Confidence::High
-        );
+        assert_eq!(findings[0].confidence, Confidence::High);
         assert!(
             !findings[0].evidence[0]
                 .snippet

--- a/tests/zoo/snapshots/excalidraw.json
+++ b/tests/zoo/snapshots/excalidraw.json
@@ -1,13 +1,13 @@
 {
   "default": {
     "by_priority": {
-      "P0": 8
+      "P0": 7
     },
     "by_rule": {
       "architecture.circular-dependency": 3,
       "language.javascript.runtime-exit-risk": 1,
       "security.env-file-committed": 2,
-      "security.secret-candidate": 2
+      "security.secret-candidate": 1
     },
     "fingerprints": [
       "architecture.circular-dependency:excalidraw-app/App.tsx:e575ed4f8104d3d4",
@@ -16,10 +16,9 @@
       "language.javascript.runtime-exit-risk:packages/excalidraw/subset/woff2/woff2-bindings.ts:cac7cba895f49cd1",
       "security.env-file-committed:.env.development:449ca767a377cdab",
       "security.env-file-committed:.env.production:2c69a58fcc634ff5",
-      "security.secret-candidate:dev-docs/docusaurus.config.js:9fe21045a4599527",
-      "security.secret-candidate:packages/common/src/constants.ts:e6518a50fca8bcff"
+      "security.secret-candidate:dev-docs/docusaurus.config.js:9fe21045a4599527"
     ],
-    "visible_total": 8
+    "visible_total": 7
   },
   "framework": "react",
   "language": "typescript",

--- a/tests/zoo/snapshots/ripgrep.json
+++ b/tests/zoo/snapshots/ripgrep.json
@@ -1,21 +1,18 @@
 {
   "default": {
     "by_priority": {
-      "P0": 6
+      "P0": 4
     },
     "by_rule": {
-      "language.rust.panic-risk": 4,
-      "security.secret-candidate": 2
+      "language.rust.panic-risk": 4
     },
     "fingerprints": [
       "language.rust.panic-risk:crates/ignore/src/dir.rs:29a9cdea010a693a",
       "language.rust.panic-risk:crates/matcher/src/lib.rs:d86c9a3b5e601a78",
       "language.rust.panic-risk:crates/matcher/src/lib.rs:d86c9a3b5e601a78",
-      "language.rust.panic-risk:crates/printer/src/json.rs:a67956c2e99a577d",
-      "security.secret-candidate:crates/globset/src/glob.rs:89e9fb0d9e899eaa",
-      "security.secret-candidate:crates/globset/src/glob.rs:c8d14f43284e4d64"
+      "language.rust.panic-risk:crates/printer/src/json.rs:a67956c2e99a577d"
     ],
-    "visible_total": 6
+    "visible_total": 4
   },
   "framework": "",
   "language": "rust",
@@ -31,9 +28,8 @@
       "code-quality.deep-control-flow": 3,
       "code-quality.long-function": 59,
       "language.rust.panic-risk": 97,
-      "security.secret-candidate": 2,
       "testing.source-without-test": 27
     },
-    "visible_total": 256
+    "visible_total": 254
   }
 }


### PR DESCRIPTION
## Summary

Reduce false positives in `security.secret-candidate` without removing ambiguous secret-shaped values from strict analysis.

## Type of change

* [ ] Feature
* [ ] Refactor
* [x] Bug fix
* [x] Tests
* [ ] Documentation
* [ ] CI / repository maintenance

## What changed

* Stop parsing Rust/C++ namespace and type paths such as `Token::RecursiveSuffix` and `Self::secret_key()` as `token: <value>` assignments.
* Classify lowercase kebab/snake identifier values such as `excalidraw-oai-api-key` as low-confidence candidates instead of high-confidence default-visible secrets.
* Preserve slug-shaped candidates in strict profile so lowercase passphrases and service tokens are not silently discarded.
* Add focused false-positive fixtures and false-negative regression tests.
* Update real-repository zoo snapshots for ripgrep and excalidraw while retaining eShopOnWeb’s genuine hardcoded credentials.

## Why

The line-based detector previously treated `key::Rest` namespace syntax as a colon assignment. This produced false positives for enum and type paths in Rust code.

It also treated human-readable storage identifiers such as:

```ts
OAI_API_KEY: "excalidraw-oai-api-key"
```

as high-confidence secrets.

These identifier-shaped values should not pollute normal default reports, but completely removing every lowercase kebab/snake value would hide real hardcoded passphrases such as:

```yaml
password: "correct-horse-battery-staple"
```

The updated classification therefore keeps ambiguous slug-shaped values as low-confidence strict-mode evidence instead of deleting them from the analysis pipeline.

## Contract and ownership

* [x] The change stays within the `security.secret-candidate` detector and finding-classification boundary.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] Changed findings retain deterministic evidence and stable rule identity.
* [x] Noise reduction preserves strict-mode recall and includes false-negative guards.
* [x] Zoo changes are backed by focused fixtures and measured snapshot updates.
* [x] No unrelated refactor or generated-file churn is included.

## Changelog

* [x] `CHANGELOG.md` updated.

## Zoo impact

Default-visible findings:

* ripgrep: `6 → 4`
* excalidraw: `8 → 7`
* eShopOnWeb: all 7 genuine credential findings retained

Strict profile continues to retain ambiguous slug-shaped candidates as low-confidence suggestions.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
