### PR TITLE
fix(circular-dependency): ignore TypeScript type-only import edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,11 +78,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   module imported type-only (and never as a value — a mixed `import { type A, B }`
   or a dynamic `import()` keeps the runtime edge) is subtracted from cycle
   detection while staying a full edge for coupling, fan-out, and dead-module
-  analysis. Unlike a Python function-body
-  deferred import — which runs lazily and so is still surfaced as an
-  informational Low cycle — a purely type-only cycle is erased at compile time
-  and is suppressed outright, in the default profile and under `--profile
-  strict`. Measured on the real-repo zoo, this removed wagtail's four
+  analysis. Changed-scan file-role caches and context-graph caches are bumped so
+  upgrades do not reuse stale TS/JS graph edges from previous versions. Unlike a
+  Python function-body deferred import — which runs lazily and so is still
+  surfaced as an informational Low cycle — a purely type-only cycle is erased at
+  compile time and is suppressed outright, in the default profile and under
+  `--profile strict`. Measured on the real-repo zoo, this removed wagtail's four
   default-visible type-only cycles (its `CommentApp`/`Sidebar`/`StreamField`
   client components, 6 → 2 default; 15 → 11 strict), with the genuine Python
   cycles retained.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,21 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **`architecture.circular-dependency` no longer counts TypeScript/JavaScript
+  `import type` / `export type` imports as runtime cycle edges.** The compiler
+  erases type-only imports, so a cycle that exists solely through them is not a
+  real dependency in any sense. A module imported type-only (and never as a
+  value — a mixed `import { type A, B }` or a dynamic `import()` keeps the runtime
+  edge) is subtracted from cycle detection while staying a full edge for
+  coupling, fan-out, and dead-module analysis. Unlike a Python function-body
+  deferred import — which runs lazily and so is still surfaced as an
+  informational Low cycle — a purely type-only cycle is erased at compile time
+  and is suppressed outright, in the default profile and under `--profile
+  strict`. Measured on the real-repo zoo, this removed wagtail's four
+  default-visible type-only cycles (its `CommentApp`/`Sidebar`/`StreamField`
+  client components, 6 → 2 default; 15 → 11 strict), with the genuine Python
+  cycles retained.
+
 - **`repopilot_scan` MCP disk caching no longer serves stale scan reports after
   agent edits.** The scan tool now bypasses the MCP session cache, keys disk
   entries from the git-root working tree, stores entries under Git-owned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,12 +72,13 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Fixed
 
 - **`architecture.circular-dependency` no longer counts TypeScript/JavaScript
-  `import type` / `export type` imports as runtime cycle edges.** The compiler
-  erases type-only imports, so a cycle that exists solely through them is not a
-  real dependency in any sense. A module imported type-only (and never as a
-  value — a mixed `import { type A, B }` or a dynamic `import()` keeps the runtime
-  edge) is subtracted from cycle detection while staying a full edge for
-  coupling, fan-out, and dead-module analysis. Unlike a Python function-body
+  type-only imports/exports as runtime cycle edges, including inline specifiers
+  like `import { type A, type B }`.** The compiler erases type-only imports, so a
+  cycle that exists solely through them is not a real dependency in any sense. A
+  module imported type-only (and never as a value — a mixed `import { type A, B }`
+  or a dynamic `import()` keeps the runtime edge) is subtracted from cycle
+  detection while staying a full edge for coupling, fan-out, and dead-module
+  analysis. Unlike a Python function-body
   deferred import — which runs lazily and so is still surfaced as an
   informational Low cycle — a purely type-only cycle is erased at compile time
   and is suppressed outright, in the default profile and under `--profile

--- a/src/audits/architecture/import_coupling/cycles.rs
+++ b/src/audits/architecture/import_coupling/cycles.rs
@@ -65,6 +65,15 @@ pub(super) fn emit_circular_dependency_findings(
             continue;
         }
 
+        // A deferred-only cycle whose members are all TypeScript/JavaScript is
+        // held together by `import type` edges, which the compiler erases — it is
+        // not a runtime cycle in any sense (unlike a Python function-body
+        // deferral, which runs lazily), so it is suppressed entirely rather than
+        // surfaced as an informational Low finding.
+        if members.iter().all(|path| is_type_erasing_language(path)) {
+            continue;
+        }
+
         // Mixed component: this SCC only exists in the full graph because a
         // deferred edge widened a component that already has an eager cycle.
         // The eager sub-cycle is reported as High; labelling the whole component
@@ -92,6 +101,16 @@ pub(super) fn emit_circular_dependency_findings(
 
 fn is_prod_cycle(members: &[PathBuf], prod_files: &HashSet<PathBuf>) -> bool {
     !members.is_empty() && members.iter().all(|path| prod_files.contains(path))
+}
+
+// A TypeScript/JavaScript file's only deferred imports are `import type` edges,
+// which the compiler erases — so a deferred-only cycle made solely of these
+// files is purely type-level and has no runtime existence.
+fn is_type_erasing_language(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs")
+    )
 }
 
 /// `component` is the full strongly-connected component (all mutually dependent

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 
 pub const CONTEXT_GRAPH_CACHE_NAME: &str = "repo_context.json";
 pub const CONTEXT_GRAPH_SCHEMA_VERSION: u32 = 4;
-pub const CONTEXT_GRAPH_RESOLVER_VERSION: &str = "context-graph-v2";
+pub const CONTEXT_GRAPH_RESOLVER_VERSION: &str = "context-graph-v3";
 pub const MAX_CONTEXT_GRAPH_CYCLES: usize = 20;
 pub const MAX_CONTEXT_GRAPH_METRICS: usize = 10;
 pub const MAX_CONTEXT_GRAPH_RISKY_CLUSTERS: usize = 20;

--- a/src/graph/imports.rs
+++ b/src/graph/imports.rs
@@ -42,10 +42,15 @@ pub(crate) fn extract_imports_from(parsed: &ParsedFile, language: Option<&str>) 
     set.into_iter().collect()
 }
 
-/// Imports that are *deferred* — present only inside a function body, never at
-/// module scope. Currently Python-only (the language whose idiom is to defer an
-/// import to break a load-time cycle). These are real edges in the coupling
-/// graph but are subtracted by cycle detection. Other languages have none.
+/// Imports that are real edges in the coupling graph but must be subtracted by
+/// cycle detection because they create no module-load dependency:
+/// - **Python**: imports deferred into a function body (the idiom for breaking a
+///   load-time cycle), present only inside a function, never at module scope.
+/// - **TypeScript/JavaScript**: `import type` / `export type` imports, which the
+///   compiler erases, so they are type-only and never run at load time.
+///
+/// These stay full edges for coupling, fan-out, and dead-module analysis; only
+/// cycle detection subtracts them. Other languages have none.
 pub(crate) fn extract_deferred_imports_from(
     parsed: &ParsedFile,
     language: Option<&str>,
@@ -53,6 +58,10 @@ pub(crate) fn extract_deferred_imports_from(
     let content = parsed.content();
     let set: HashSet<String> = match language {
         Some("Python") => from_tree(parsed, |tree| python::extract_deferred(tree, content)),
+        Some("TypeScript")
+        | Some("TypeScript React")
+        | Some("JavaScript")
+        | Some("JavaScript React") => from_tree(parsed, |tree| ts::extract_type_only(tree, content)),
         _ => return Vec::new(),
     };
     set.into_iter().collect()
@@ -114,5 +123,45 @@ mod tests {
             extract_deferred_imports_from(&ParsedFile::new(content, Some("Rust")), Some("Rust"))
                 .is_empty()
         );
+    }
+
+    fn type_only(content: &str) -> Vec<String> {
+        let mut d = extract_deferred_imports_from(
+            &ParsedFile::new(content, Some("TypeScript")),
+            Some("TypeScript"),
+        );
+        d.sort();
+        d
+    }
+
+    #[test]
+    fn ts_import_type_is_type_only_but_still_a_full_edge() {
+        let content = "import type { User } from \"./types\";\nimport { run } from \"./run\";\n";
+        // Both remain real edges for coupling / fan-out…
+        let imports = extract_imports(content, Some("TypeScript"));
+        assert!(imports.contains(&"./types".to_string()));
+        assert!(imports.contains(&"./run".to_string()));
+        // …but only the erased `import type` is subtracted from cycle detection.
+        assert_eq!(type_only(content), vec!["./types".to_string()]);
+    }
+
+    #[test]
+    fn ts_value_and_mixed_imports_are_not_type_only() {
+        // A plain value import and a mixed `{ type A, B }` both execute the module.
+        let content = "import { A } from \"./a\";\nimport { type T, b } from \"./b\";\n";
+        assert!(type_only(content).is_empty(), "{:?}", type_only(content));
+    }
+
+    #[test]
+    fn ts_export_type_reexport_is_type_only_but_value_barrel_is_not() {
+        let content = "export type { Cfg } from \"./cfg\";\nexport { thing } from \"./thing\";\n";
+        assert_eq!(type_only(content), vec!["./cfg".to_string()]);
+    }
+
+    #[test]
+    fn ts_module_imported_both_type_and_value_is_not_type_only() {
+        // The value import keeps the runtime edge, so the module is not type-only.
+        let content = "import type { T } from \"./x\";\nimport { run } from \"./x\";\n";
+        assert!(type_only(content).is_empty());
     }
 }

--- a/src/graph/imports.rs
+++ b/src/graph/imports.rs
@@ -155,6 +155,23 @@ mod tests {
     }
 
     #[test]
+    fn ts_all_inline_type_specifiers_are_type_only() {
+        let content = "import { type A, type B } from \"./types\";\n\
+             export { type C } from \"./config\";\n";
+
+        assert_eq!(
+            type_only(content),
+            vec!["./config".to_string(), "./types".to_string()]
+        );
+    }
+
+    #[test]
+    fn ts_inline_type_and_value_specifiers_keep_runtime_edge() {
+        let content = "import { type A, b } from \"./module\";\n";
+        assert!(type_only(content).is_empty());
+    }
+
+    #[test]
     fn ts_export_type_reexport_is_type_only_but_value_barrel_is_not() {
         let content = "export type { Cfg } from \"./cfg\";\nexport { thing } from \"./thing\";\n";
         assert_eq!(type_only(content), vec!["./cfg".to_string()]);

--- a/src/graph/imports/ts.rs
+++ b/src/graph/imports/ts.rs
@@ -12,13 +12,14 @@ pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
     extract_spans(tree, content).into_keys().collect()
 }
 
-/// Module paths imported *type-only* — `import type { … }` / `export type { … }`
-/// — and never imported as a value. The TypeScript compiler erases these, so they
-/// create no runtime edge and must be subtracted from cycle detection (they stay
-/// real edges for coupling/fan-out, like Python deferred imports). A module that
-/// is *also* imported as a value anywhere — including a mixed
-/// `import { type A, B }` or a dynamic `import("…")` — is a runtime edge and is
-/// excluded here.
+/// Module paths imported *type-only* — `import type { … }`, `export type { … }`,
+/// or named imports/exports whose every specifier is inline type-only
+/// (`import { type A, type B }`) — and never imported as a value. The TypeScript
+/// compiler erases these, so they create no runtime edge and must be subtracted
+/// from cycle detection (they stay real edges for coupling/fan-out, like Python
+/// deferred imports). A module that is *also* imported as a value anywhere —
+/// including a mixed `import { type A, B }`, a default/namespace import, or a
+/// dynamic `import("…")` — is a runtime edge and is excluded here.
 pub(super) fn extract_type_only(tree: &Tree, content: &str) -> HashSet<String> {
     let mut type_only: HashSet<String> = HashSet::new();
     let mut value: HashSet<String> = HashSet::new();
@@ -36,7 +37,7 @@ fn collect_type_only(
     match node.kind() {
         "import_statement" | "export_statement" => {
             if let Some(path) = module_source(node, content).filter(|path| is_candidate(path)) {
-                if statement_is_type_only(node) {
+                if statement_is_type_only(node, content) {
                     type_only.insert(path.to_string());
                 } else {
                     value.insert(path.to_string());
@@ -59,14 +60,54 @@ fn collect_type_only(
     }
 }
 
-// `import type … from` / `export type … from` carry a `type` (or `typeof`) token
-// as a *direct* child of the statement. A `type` modifier on an individual
-// specifier (`import { type A, B }`) is nested inside `import_specifier`, so a
-// direct-child check correctly treats that mixed import as a runtime edge.
-fn statement_is_type_only(node: Node<'_>) -> bool {
+fn statement_is_type_only(node: Node<'_>, content: &str) -> bool {
+    if has_direct_type_modifier(node) {
+        return true;
+    }
+
+    starts_with_named_specifiers(node, content) && all_named_specifiers_are_type_only(node)
+}
+
+fn has_direct_type_modifier(node: Node<'_>) -> bool {
     let mut cursor = node.walk();
     node.children(&mut cursor)
         .any(|child| matches!(child.kind(), "type" | "typeof"))
+}
+
+fn starts_with_named_specifiers(node: Node<'_>, content: &str) -> bool {
+    let Ok(text) = node.utf8_text(content.as_bytes()) else {
+        return false;
+    };
+    let keyword = match node.kind() {
+        "import_statement" => "import",
+        "export_statement" => "export",
+        _ => return false,
+    };
+    text.trim_start()
+        .strip_prefix(keyword)
+        .is_some_and(|rest| rest.trim_start().starts_with('{'))
+}
+
+fn all_named_specifiers_are_type_only(node: Node<'_>) -> bool {
+    let mut specifier_count = 0;
+    let mut all_type_only = true;
+    visit_named_specifiers(node, &mut |specifier| {
+        specifier_count += 1;
+        all_type_only &= has_direct_type_modifier(specifier);
+    });
+    specifier_count > 0 && all_type_only
+}
+
+fn visit_named_specifiers(node: Node<'_>, visit: &mut impl FnMut(Node<'_>)) {
+    if matches!(node.kind(), "import_specifier" | "export_specifier") {
+        visit(node);
+        return;
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit_named_specifiers(child, visit);
+    }
 }
 
 fn is_candidate(path: &str) -> bool {

--- a/src/graph/imports/ts.rs
+++ b/src/graph/imports/ts.rs
@@ -12,6 +12,62 @@ pub(super) fn extract(tree: &Tree, content: &str) -> HashSet<String> {
     extract_spans(tree, content).into_keys().collect()
 }
 
+/// Module paths imported *type-only* — `import type { … }` / `export type { … }`
+/// — and never imported as a value. The TypeScript compiler erases these, so they
+/// create no runtime edge and must be subtracted from cycle detection (they stay
+/// real edges for coupling/fan-out, like Python deferred imports). A module that
+/// is *also* imported as a value anywhere — including a mixed
+/// `import { type A, B }` or a dynamic `import("…")` — is a runtime edge and is
+/// excluded here.
+pub(super) fn extract_type_only(tree: &Tree, content: &str) -> HashSet<String> {
+    let mut type_only: HashSet<String> = HashSet::new();
+    let mut value: HashSet<String> = HashSet::new();
+    collect_type_only(tree.root_node(), content, &mut type_only, &mut value);
+    type_only.retain(|path| !value.contains(path));
+    type_only
+}
+
+fn collect_type_only(
+    node: Node<'_>,
+    content: &str,
+    type_only: &mut HashSet<String>,
+    value: &mut HashSet<String>,
+) {
+    match node.kind() {
+        "import_statement" | "export_statement" => {
+            if let Some(path) = module_source(node, content).filter(|path| is_candidate(path)) {
+                if statement_is_type_only(node) {
+                    type_only.insert(path.to_string());
+                } else {
+                    value.insert(path.to_string());
+                }
+            }
+        }
+        "call_expression" => {
+            // A dynamic `import("…")` / `require("…")` executes the module.
+            if let Some(path) = call_module_source(node, content).filter(|path| is_candidate(path)) {
+                value.insert(path.to_string());
+            }
+        }
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_type_only(child, content, type_only, value);
+    }
+}
+
+// `import type … from` / `export type … from` carry a `type` (or `typeof`) token
+// as a *direct* child of the statement. A `type` modifier on an individual
+// specifier (`import { type A, B }`) is nested inside `import_specifier`, so a
+// direct-child check correctly treats that mixed import as a runtime edge.
+fn statement_is_type_only(node: Node<'_>) -> bool {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .any(|child| matches!(child.kind(), "type" | "typeof"))
+}
+
 fn is_candidate(path: &str) -> bool {
     path.starts_with('.')
         || path.starts_with('/')

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -89,9 +89,9 @@ pub fn build_coupling_graph_with_resolution(
             }
         }
 
-        // Record the deferred (function-body) subset against the same source so
-        // cycle detection can subtract these edges. `deferred_imports ⊆ imports`,
-        // so every resolved target is already present in `edges` above.
+        // Record the non-runtime subset against the same source so cycle detection
+        // can subtract these edges. `deferred_imports ⊆ imports`, so every resolved
+        // target is already present in `edges` above.
         for raw in &file.deferred_imports {
             if let Some(target) = resolve_import(raw, &normalized_source, root, &known_files)
                 && target != normalized_source
@@ -195,10 +195,9 @@ pub fn detect_cycles_bounded(graph: &CouplingGraph, max_cycles: usize) -> Vec<Ve
     // Map each node to a stable integer index
     let index: HashMap<&PathBuf, usize> = nodes.iter().enumerate().map(|(i, p)| (*p, i)).collect();
 
-    // Adjacency list using indices. Deferred (function-body) edges are excluded:
-    // a deferred import runs only when a function is called, so it does not form a
-    // module-load cycle — counting it would resurrect the very cycle the deferral
-    // was written to break.
+    // Adjacency list using indices. Deferred/non-runtime edges are excluded:
+    // Python function-body imports run only when called, and TS/JS type-only imports
+    // are erased, so neither forms a module-load/runtime cycle.
     let adj: Vec<Vec<usize>> = nodes
         .iter()
         .map(|node| {
@@ -277,17 +276,17 @@ pub fn without_rust_module_containment_edges(graph: &CouplingGraph) -> CouplingG
 
     CouplingGraph {
         edges,
-        // Rust-only transform; the Python-only deferred edges pass through.
+        // Rust-only transform; deferred/non-runtime edges pass through.
         deferred_edges: graph.deferred_edges.clone(),
         nodes: graph.nodes.clone(),
     }
 }
 
-/// Returns a copy of `graph` with every *deferred* (Python function-body) edge
-/// removed, for cycle detection only. A deferred import runs only when a function
-/// is called, so it does not form a module-load cycle — keeping it would
-/// resurrect the very cycle the deferral was written to break. Fan-out and
-/// dead-module use the full graph, so this is applied solely to the cycle graph.
+/// Returns a copy of `graph` with every *deferred* / non-runtime edge removed,
+/// for cycle detection only. Python function-body imports run only when called,
+/// and TS/JS type-only imports are erased, so neither forms a module-load/runtime
+/// cycle. Fan-out and dead-module use the full graph, so this is applied solely to
+/// the cycle graph.
 pub fn without_deferred_edges(graph: &CouplingGraph) -> CouplingGraph {
     if graph.deferred_edges.is_empty() {
         return graph.clone();

--- a/src/scan/cache.rs
+++ b/src/scan/cache.rs
@@ -11,12 +11,15 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-/// Bump whenever the on-disk shape of a cached entry changes so stale caches
-/// are rejected instead of silently deserialized with `#[serde(default)]` gaps.
+/// Bump whenever the on-disk shape or semantics of a cached entry changes so
+/// stale caches are rejected instead of silently deserialized with
+/// `#[serde(default)]` gaps.
 /// v4 added `FileRoleEntry::deferred_imports`: a v3 cache lacks the field and
 /// would rehydrate it as `[]`, dropping deferred (function-body) imports and
 /// resurrecting the phantom cycles the deferral was meant to break.
-pub const CACHE_SCHEMA_VERSION: u32 = 4;
+/// v5 invalidates cached file roles because `deferred_imports` now also includes
+/// TypeScript/JavaScript type-only imports and exports erased at runtime.
+pub const CACHE_SCHEMA_VERSION: u32 = 5;
 pub const CACHE_DIR: &str = ".repopilot/cache";
 const FILE_HASHES_NAME: &str = "file_hashes.json";
 const FILE_ROLES_NAME: &str = "file_roles.json";

--- a/src/scan/facts.rs
+++ b/src/scan/facts.rs
@@ -34,10 +34,11 @@ pub struct FileFacts {
     pub non_empty_lines: usize,
     pub branch_count: usize,
     pub imports: Vec<String>,
-    /// Imports present only inside a function body (Python deferred imports). A
+    /// Imports that are full coupling edges but not module-load/runtime edges for
+    /// cycle detection: Python imports present only inside a function body, plus
+    /// TypeScript/JavaScript type-only imports/exports erased by the compiler. A
     /// subset of `imports`; the coupling graph keeps them as edges but cycle
-    /// detection subtracts them, since a deferred import does not form a
-    /// module-load cycle. Empty for languages without the deferred-import idiom.
+    /// detection subtracts them. Empty for languages without such non-runtime edges.
     pub deferred_imports: Vec<String>,
     /// Source text while file audits are running. `None` means the file was skipped,
     /// binary/unreadable, or retained only as summary metadata after auditing.

--- a/tests/cache_fingerprint.rs
+++ b/tests/cache_fingerprint.rs
@@ -11,7 +11,7 @@ fn stable_hash_hex_uses_sha256() {
 
 #[test]
 fn config_fingerprint_changes_with_config_and_cache_schema_context() {
-    assert_eq!(CACHE_SCHEMA_VERSION, 4);
+    assert_eq!(CACHE_SCHEMA_VERSION, 5);
 
     let default = config_fingerprint(&ScanConfig::default());
     let changed = config_fingerprint(&ScanConfig {

--- a/tests/coupling_audit.rs
+++ b/tests/coupling_audit.rs
@@ -208,6 +208,37 @@ fn circular_dependency_finding_is_emitted() {
 }
 
 #[test]
+fn inline_type_only_cycle_does_not_emit_circular_dependency_even_in_strict() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    write_file(
+        &temp,
+        "src/a.ts",
+        r#"import { type B } from "./b"; export type A = { b?: B };"#,
+    );
+    write_file(
+        &temp,
+        "src/b.ts",
+        r#"import { type A } from "./a"; export type B = { a?: A };"#,
+    );
+
+    let config = ScanConfig {
+        include_low_signal: true,
+        ..ScanConfig::default()
+    };
+    let summary = scan_path_with_config(temp.path(), &config).expect("failed to scan temp project");
+
+    assert!(
+        summary
+            .artifacts
+            .findings
+            .iter()
+            .all(|finding| finding.rule_id != "architecture.circular-dependency"),
+        "inline type-only cycle must not be reported even in strict visibility: {:#?}",
+        summary.artifacts.findings
+    );
+}
+
+#[test]
 fn acyclic_imports_do_not_emit_circular_dependency() {
     let temp = TempDir::new().expect("failed to create temp dir");
     write_file(

--- a/tests/fixtures/rules/architecture.circular-dependency/expected.json
+++ b/tests/fixtures/rules/architecture.circular-dependency/expected.json
@@ -5,6 +5,10 @@
       "expected_rule_ids": []
     },
     {
+      "path": "false_positive_type_only",
+      "expected_rule_ids": []
+    },
+    {
       "path": "true_positive",
       "expected_rule_ids": [
         "architecture.circular-dependency"

--- a/tests/fixtures/rules/architecture.circular-dependency/false_positive_type_only/src/a.ts
+++ b/tests/fixtures/rules/architecture.circular-dependency/false_positive_type_only/src/a.ts
@@ -1,0 +1,6 @@
+// A type-only import cycle: the TypeScript compiler erases `import type`, so
+// `a` and `b` referencing each other's types creates no runtime dependency and
+// must not be reported as a circular dependency.
+import type { B } from "./b";
+
+export type A = { value: number; other: B };

--- a/tests/fixtures/rules/architecture.circular-dependency/false_positive_type_only/src/b.ts
+++ b/tests/fixtures/rules/architecture.circular-dependency/false_positive_type_only/src/b.ts
@@ -1,0 +1,3 @@
+import type { A } from "./a";
+
+export type B = { value: number; other: A };

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -60,7 +60,7 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
     assert!(cache_dir.join("repo_context.json").is_file());
     assert_eq!(
         read_json(&cache_dir.join("file_hashes.json"))["schema_version"],
-        4
+        5
     );
     assert_eq!(
         read_json(&cache_dir.join("file_hashes.json"))["entries"][0]["hash"]
@@ -179,7 +179,7 @@ fn changed_scan_invalidates_old_cache_schema() {
 
     scan_changed_json(temp.path(), &["--changed"]);
     for name in ["file_hashes.json", "file_roles.json", "findings.json"] {
-        force_cache_schema(temp.path().join(".repopilot/cache").join(name).as_path(), 1);
+        force_cache_schema(temp.path().join(".repopilot/cache").join(name).as_path(), 4);
     }
     let json = scan_changed_json(temp.path(), &["--changed"]);
 
@@ -328,12 +328,53 @@ fn changed_scan_cache_hit_preserves_deferred_imports_for_graph_patch() {
 }
 
 #[test]
+fn changed_scan_rejects_v4_cache_missing_inline_type_only_deferred_imports() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(
+        temp.path().join("src/a.ts"),
+        "import { type B } from \"./b\";\nexport type A = { b?: B };\n",
+    );
+    write(
+        temp.path().join("src/b.ts"),
+        "import { type A } from \"./a\";\nexport type B = { a?: A };\n",
+    );
+    commit_all(temp.path(), "initial");
+
+    write(
+        temp.path().join("src/a.ts"),
+        "import { type B } from \"./b\";\nexport type A = { b?: B };\nconst API_KEY = \"abc123xyz987\";\n",
+    );
+    let first_changed = scan_changed_json(temp.path(), &["--changed", "--profile", "strict"]);
+    assert_eq!(
+        first_changed["cache_telemetry"]["changed_files"][0]["cache_status"],
+        "miss"
+    );
+
+    let cache_dir = temp.path().join(".repopilot/cache");
+    for name in ["file_hashes.json", "file_roles.json", "findings.json"] {
+        force_cache_schema(cache_dir.join(name).as_path(), 4);
+    }
+    clear_file_roles_deferred_imports(&cache_dir.join("file_roles.json"));
+    force_context_graph_resolver(&cache_dir.join("repo_context.json"), "context-graph-v2");
+    clear_context_graph_deferred_imports(&cache_dir.join("repo_context.json"));
+
+    let upgraded_changed = scan_changed_json(temp.path(), &["--changed", "--profile", "strict"]);
+    assert_eq!(
+        upgraded_changed["cache_telemetry"]["changed_files"][0]["cache_status"], "miss",
+        "v4 file-role caches must be rejected after inline TS type-only semantics changed: {upgraded_changed:#?}"
+    );
+    assert_eq!(upgraded_changed["context_graph_cache"]["status"], "miss");
+    assert_rule_absent(&upgraded_changed, "architecture.circular-dependency");
+}
+
+#[test]
 fn changed_scan_rejects_pre_deferred_imports_file_roles_cache() {
     // A v3 file-roles cache predates `FileRoleEntry::deferred_imports`. With
     // `#[serde(default)]` it would rehydrate as `[]`, turn a deferred import back
     // into an eager edge, and resurrect a phantom cycle on the next cache hit.
-    // Bumping CACHE_SCHEMA_VERSION to 4 must reject it, forcing re-analysis that
-    // restores the deferred imports.
+    // The current cache schema must reject it, forcing re-analysis that restores
+    // the deferred imports.
     let temp = tempdir().expect("temp dir");
     init_repo(temp.path());
     write(temp.path().join("app/__init__.py"), "");
@@ -539,9 +580,39 @@ fn rewrite_cached_finding_title(path: &Path, title: &str) {
 fn force_cache_schema(path: &Path, schema_version: u64) {
     let mut value = read_json(path);
     value["schema_version"] = Value::Number(schema_version.into());
+    write_json(path, &value);
+}
+
+fn clear_file_roles_deferred_imports(path: &Path) {
+    let mut value = read_json(path);
+    for entry in value["entries"].as_array_mut().expect("file role entries") {
+        entry["deferred_imports"] = Value::Array(Vec::new());
+    }
+    write_json(path, &value);
+}
+
+fn force_context_graph_resolver(path: &Path, resolver_version: &str) {
+    let mut value = read_json(path);
+    value["resolver_version"] = Value::String(resolver_version.to_string());
+    write_json(path, &value);
+}
+
+fn clear_context_graph_deferred_imports(path: &Path) {
+    let mut value = read_json(path);
+    value["graph"]["deferred_edges"] = serde_json::json!({});
+    for node in value["graph"]["nodes"]
+        .as_array_mut()
+        .expect("context nodes")
+    {
+        node["deferred_imports"] = Value::Array(Vec::new());
+    }
+    write_json(path, &value);
+}
+
+fn write_json(path: &Path, value: &Value) {
     fs::write(
         path,
-        serde_json::to_string_pretty(&value).expect("render cache"),
+        serde_json::to_string_pretty(value).expect("render cache"),
     )
     .expect("write cache");
 }
@@ -573,6 +644,17 @@ fn assert_rule_present(json: &Value, rule_id: &str) {
             .flatten()
             .any(|finding| finding["rule_id"] == rule_id),
         "expected {rule_id} in findings: {json:#?}"
+    );
+}
+
+fn assert_rule_absent(json: &Value, rule_id: &str) {
+    assert!(
+        json["findings"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .all(|finding| finding["rule_id"] != rule_id),
+        "did not expect {rule_id} in findings: {json:#?}"
     );
 }
 

--- a/tests/zoo/snapshots/changesets.json
+++ b/tests/zoo/snapshots/changesets.json
@@ -8,7 +8,7 @@
       "language.javascript.runtime-exit-risk": 1
     },
     "fingerprints": [
-      "architecture.circular-dependency:packages/cli/src/commands/publish/npm-utils.ts:8a41bbd295f5f42b",
+      "architecture.circular-dependency:packages/cli/src/commands/publish/npm-utils.ts:450588cb75896a2b",
       "language.javascript.runtime-exit-risk:packages/cli/src/utils/cli-utilities.ts:272512749156ce06"
     ],
     "visible_total": 2

--- a/tests/zoo/snapshots/excalidraw.json
+++ b/tests/zoo/snapshots/excalidraw.json
@@ -1,25 +1,29 @@
 {
   "default": {
     "by_priority": {
-      "P0": 8
+      "P0": 12
     },
     "by_rule": {
-      "architecture.circular-dependency": 3,
+      "architecture.circular-dependency": 7,
       "language.javascript.runtime-exit-risk": 1,
       "security.env-file-committed": 2,
       "security.secret-candidate": 2
     },
     "fingerprints": [
       "architecture.circular-dependency:excalidraw-app/App.tsx:e575ed4f8104d3d4",
-      "architecture.circular-dependency:excalidraw-app/collab/Collab.tsx:40148bf1157fe6d3",
+      "architecture.circular-dependency:excalidraw-app/data/firebase.ts:5c3e800a8ebb659a",
       "architecture.circular-dependency:packages/common/src/index.ts:7b14cf4e6bb5e522",
+      "architecture.circular-dependency:packages/element/src/Scene.ts:9cbbca234b2ff447",
+      "architecture.circular-dependency:packages/excalidraw/actions/actionHistory.tsx:5c057c5a6edef722",
+      "architecture.circular-dependency:packages/excalidraw/data/blob.ts:5c1b1535711c051e",
+      "architecture.circular-dependency:packages/excalidraw/fonts/Cascadia/index.ts:b87f669bcfd3eae8",
       "language.javascript.runtime-exit-risk:packages/excalidraw/subset/woff2/woff2-bindings.ts:cac7cba895f49cd1",
       "security.env-file-committed:.env.development:449ca767a377cdab",
       "security.env-file-committed:.env.production:2c69a58fcc634ff5",
       "security.secret-candidate:dev-docs/docusaurus.config.js:9fe21045a4599527",
       "security.secret-candidate:packages/common/src/constants.ts:e6518a50fca8bcff"
     ],
-    "visible_total": 8
+    "visible_total": 12
   },
   "framework": "react",
   "language": "typescript",
@@ -28,7 +32,7 @@
   "strict": {
     "by_rule": {
       "architecture.barrel-file-risk": 5,
-      "architecture.circular-dependency": 3,
+      "architecture.circular-dependency": 7,
       "architecture.dead-module": 62,
       "architecture.deep-relative-imports": 9,
       "architecture.excessive-fan-out": 23,
@@ -49,6 +53,6 @@
       "security.secret-candidate": 2,
       "testing.source-without-test": 374
     },
-    "visible_total": 1230
+    "visible_total": 1234
   }
 }

--- a/tests/zoo/snapshots/wagtail.json
+++ b/tests/zoo/snapshots/wagtail.json
@@ -1,23 +1,19 @@
 {
   "default": {
     "by_priority": {
-      "P0": 6,
+      "P0": 2,
       "P1": 1
     },
     "by_rule": {
-      "architecture.circular-dependency": 6,
+      "architecture.circular-dependency": 2,
       "language.python.exception-risk": 1
     },
     "fingerprints": [
-      "architecture.circular-dependency:client/src/components/CommentApp/actions/comments.ts:bc263ed84a211b9f",
-      "architecture.circular-dependency:client/src/components/CommentApp/actions/settings.ts:a4e5faaec3531953",
-      "architecture.circular-dependency:client/src/components/Sidebar/menu/MenuItem.tsx:3fc4eb8abfacb35a",
-      "architecture.circular-dependency:client/src/components/StreamField/blocks/ActionButtons.ts:56b8c1842e7c51e8",
       "architecture.circular-dependency:wagtail/actions/publish_revision.py:0da7c5453404677e",
       "architecture.circular-dependency:wagtail/admin/views/bulk_action/__init__.py:a2ca81903a3ef0d5",
       "language.python.exception-risk:wagtail/images/models.py:b3686c8d8679d8e4"
     ],
-    "visible_total": 7
+    "visible_total": 3
   },
   "framework": "django",
   "language": "python",
@@ -25,7 +21,7 @@
   "sha": "20259838f089138e1319b51621677358b90c8268",
   "strict": {
     "by_rule": {
-      "architecture.circular-dependency": 15,
+      "architecture.circular-dependency": 11,
       "architecture.dead-module": 657,
       "architecture.deep-directory-nesting": 1019,
       "architecture.deep-relative-imports": 33,
@@ -47,6 +43,6 @@
       "language.python.exception-risk": 45,
       "testing.source-without-test": 668
     },
-    "visible_total": 3044
+    "visible_total": 3040
   }
 }

--- a/tests/zoo/snapshots/wagtail.json
+++ b/tests/zoo/snapshots/wagtail.json
@@ -37,8 +37,8 @@
       "code-marker.hack": 3,
       "code-marker.todo": 19,
       "code-quality.complex-file": 28,
-      "code-quality.complex-function": 221,
-      "code-quality.deep-control-flow": 54,
+      "code-quality.complex-function": 174,
+      "code-quality.deep-control-flow": 22,
       "code-quality.long-function": 203,
       "framework.js.console-log": 1,
       "framework.js.var-declaration": 27,
@@ -47,6 +47,6 @@
       "language.python.exception-risk": 45,
       "testing.source-without-test": 668
     },
-    "visible_total": 3123
+    "visible_total": 3044
   }
 }


### PR DESCRIPTION
## Summary

Make `architecture.circular-dependency` distinguish TypeScript/JavaScript type-only dependencies from real runtime dependency edges.

Type-only imports and exports are erased by the compiler, so cycles composed exclusively of those edges should not be reported as circular runtime dependencies.

## Type of change

* [ ] Feature
* [ ] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added AST-based detection for statement-level type-only imports and exports:

  * `import type { A } from "./module"`
  * `export type { A } from "./module"`
* Added support for inline type-only specifiers:

  * `import { type A, type B } from "./module"`
  * `export { type A } from "./module"`
* Kept mixed and runtime imports as real cycle edges:

  * `import { type A, value } from "./module"`
  * regular value imports
  * dynamic `import()` and `require()`
* Preserved type-only imports as full coupling, fan-out, and dead-module edges while subtracting them only from runtime cycle detection.
* Suppressed purely type-only TypeScript/JavaScript cycles in both default and strict profiles.
* Preserved Python deferred-import cycles as informational Low findings because those imports still execute at runtime.
* Updated the `deferred_imports` internal contract to represent all non-runtime cycle edges, including Python deferred imports and compiler-erased TypeScript/JavaScript type imports.
* Bumped the file-role cache schema from `v4` to `v5`.
* Bumped the context graph resolver version from `context-graph-v2` to `context-graph-v3`.
* Added upgrade-path coverage to ensure stale caches cannot resurrect previously cached false-positive cycles.
* Updated focused fixtures, integration coverage, changelog, and real-repository zoo snapshots.

## Why

RepoPilot previously treated TypeScript type-only dependencies as runtime imports.

This caused `architecture.circular-dependency` to report cycles that do not exist after compilation, including client-side type relationships in real repositories such as Wagtail.

The updated behavior separates:

* runtime dependency cycles that remain actionable High findings;
* Python deferred-import cycles that remain informational Low findings;
* compiler-erased TypeScript/JavaScript type-only cycles that are suppressed entirely.

The cache version bumps ensure users upgrading RepoPilot do not continue receiving stale findings from file-role or context-graph caches created by earlier versions.

## Contract and ownership

* [x] The change stays within the import graph and circular-dependency ownership boundary.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] Changed graph signals retain deterministic evidence and stable rule identity.
* [x] Noise reduction preserves runtime-cycle recall and includes false-negative guard tests.
* [x] The claimed noise reduction is backed by unit tests, integration fixtures, upgrade-path coverage, and zoo measurements.
* [x] No unrelated refactor or generated-file churn is included.

## Behavior examples

Pure type-only dependency — excluded from runtime cycle detection:

```ts
import type { User } from "./types";
import { type Config, type Options } from "./config";
```

Mixed import — remains a runtime dependency:

```ts
import { type Config, createConfig } from "./config";
```

Module imported as both type and value — remains a runtime dependency:

```ts
import type { Config } from "./config";
import { createConfig } from "./config";
```

## Zoo impact

For the Wagtail snapshot:

* default-visible circular-dependency findings: `6 → 2`;
* strict circular-dependency findings: `15 → 11`;
* four TypeScript type-only cycles were removed;
* genuine Python cycles remain reported.

## Changelog

* [x] `CHANGELOG.md` updated.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
