### PR TITLE
fix(fatal-exception-risk): downgrade build-tooling and test-support t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,11 +77,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   build by design, and one in a dedicated test-double module (a `testing` source
   tree such as `core/testing/`, which lives under `src/main` so it is not a test
   file) is test plumbing — neither is the runtime hazard the rule targets. Two
-  new file roles, `build-tooling` and a language-agnostic extension of
-  `test-support` (previously Rust-filename only), tag these modules; the
-  knowledge pack downgrades the finding to Low for both — hidden by default, kept
-  under `--profile strict` — while the file keeps its production role for every
-  other rule. Genuine unfinished application code (e.g. a
+  file roles, `build-tooling` and a managed-language `test-support` extension
+  (previously Rust-filename only), tag these modules; the knowledge pack
+  downgrades the finding to Low for both — hidden by default, kept under
+  `--profile strict` — while the file keeps its production role for every other
+  rule. Changed-scan file-role caches are bumped so upgrades do not reuse stale
+  role classifications. Genuine unfinished application code (e.g. a
   `TopicUiState.Error -> TODO()` in a feature screen) stays default-visible.
   Measured on the real-repo zoo, this took the nowinandroid Android app from 3
   default-visible findings to 1, with all signals retained in strict.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,21 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **`language.managed.fatal-exception-risk` no longer surfaces placeholder/fatal
+  throws in build-tooling or test-support modules by default.** A `TODO()` or
+  `throw` in a Gradle convention plugin (`build-logic/` / `buildSrc/`) fails the
+  build by design, and one in a dedicated test-double module (a `testing` source
+  tree such as `core/testing/`, which lives under `src/main` so it is not a test
+  file) is test plumbing — neither is the runtime hazard the rule targets. Two
+  new file roles, `build-tooling` and a language-agnostic extension of
+  `test-support` (previously Rust-filename only), tag these modules; the
+  knowledge pack downgrades the finding to Low for both — hidden by default, kept
+  under `--profile strict` — while the file keeps its production role for every
+  other rule. Genuine unfinished application code (e.g. a
+  `TopicUiState.Error -> TODO()` in a feature screen) stays default-visible.
+  Measured on the real-repo zoo, this took the nowinandroid Android app from 3
+  default-visible findings to 1, with all signals retained in strict.
+
 - **`repopilot_scan` MCP disk caching no longer serves stale scan reports after
   agent edits.** The scan tool now bypasses the MCP session cache, keys disk
   entries from the git-root working tree, stores entries under Git-owned

--- a/src/audits/code_quality/language_risk/tests.rs
+++ b/src/audits/code_quality/language_risk/tests.rs
@@ -155,6 +155,85 @@ fn reports_csharp_not_implemented_placeholder() {
 }
 
 #[test]
+fn downgrades_kotlin_todo_in_build_logic_to_low() {
+    let file = facts(
+        "build-logic/convention/src/main/kotlin/Plugin.kt",
+        Some("Kotlin"),
+        "fun configure(): Unit = TODO()",
+    );
+
+    let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, "language.managed.fatal-exception-risk");
+    assert_eq!(findings[0].severity, Severity::Low);
+}
+
+#[test]
+fn downgrades_kotlin_todo_in_gradle_testing_module_to_low() {
+    let file = facts(
+        "core/testing/src/main/kotlin/com/app/core/testing/FakeSync.kt",
+        Some("Kotlin"),
+        "class FakeSync { fun sync(): Unit = TODO() }",
+    );
+
+    let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, "language.managed.fatal-exception-risk");
+    assert_eq!(findings[0].severity, Severity::Low);
+}
+
+// A test-support module under a `models/`/`domain/` package carries both the
+// `test-support` and `domain` roles. Overrides apply in order, so the
+// `test-support` downgrade must follow the `domain` upgrade — otherwise the
+// placeholder is re-upgraded to High and becomes default-visible again.
+#[test]
+fn test_support_role_wins_over_domain_role_for_managed_fatal_risk() {
+    let file = facts(
+        "core/testing/src/main/kotlin/com/app/models/FakeUser.kt",
+        Some("Kotlin"),
+        "class FakeUser { fun create(): Unit = TODO() }",
+    );
+
+    let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, "language.managed.fatal-exception-risk");
+    assert_eq!(findings[0].severity, Severity::Low);
+}
+
+#[test]
+fn kotlin_todo_in_feature_application_code_stays_high() {
+    let file = facts(
+        "feature/topic/impl/src/main/kotlin/com/app/feature/topic/TopicScreen.kt",
+        Some("Kotlin"),
+        "fun TopicScreen(state: State): Unit = TODO()",
+    );
+
+    let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, "language.managed.fatal-exception-risk");
+    assert_eq!(findings[0].severity, Severity::High);
+}
+
+#[test]
+fn kotlin_todo_in_testing_package_namespace_stays_high() {
+    let file = facts(
+        "feature/topic/impl/src/main/kotlin/com/app/testing/TopicScreen.kt",
+        Some("Kotlin"),
+        "fun TopicScreen(state: State): Unit = TODO()",
+    );
+
+    let findings = LanguageRiskAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].rule_id, "language.managed.fatal-exception-risk");
+    assert_eq!(findings[0].severity, Severity::High);
+}
+
+#[test]
 fn ignores_functional_iterator_style_without_risky_pattern() {
     let file = facts(
         "src/domain/users.ts",

--- a/src/audits/context/classify/helpers.rs
+++ b/src/audits/context/classify/helpers.rs
@@ -121,22 +121,36 @@ pub fn is_test_support_file(path: &Path) -> bool {
     )
 }
 
-/// True for a *test-support module directory* — a source tree dedicated to test
-/// doubles and helpers shared across modules, conventionally a `testing` module
-/// (e.g. `core/testing/…` in a Gradle/Android multi-module build). Unlike a test
-/// file it lives under a production source set (`src/main`), so it keeps its
-/// production role but also earns `FileRole::TestSupport` so opted-in rules can
-/// treat its placeholder/assertion throws as test plumbing. Language-agnostic
-/// companion to the Rust filename allow list in [`is_test_support_file`].
-pub fn is_test_support_dir(path: &Path) -> bool {
-    path_contains_component(path, &["testing", "testsupport", "testfixtures"])
+/// True for a managed-language *test-support module directory* — a source tree
+/// dedicated to test doubles and helpers shared across modules. This is limited
+/// to Gradle/source-set shapes that indicate a whole helper module/source set,
+/// such as `core/testing/src/main/...`, `core/testsupport/src/main/...`, or
+/// `module/src/testFixtures/...`; a package namespace component like
+/// `app/src/main/kotlin/com/example/testing/...` is ordinary production code.
+pub fn is_managed_test_support_path(path: &Path) -> bool {
+    let components = normalized_components(path);
+
+    components.windows(3).any(|window| {
+        matches!(window[0].as_str(), "testing" | "testsupport")
+            && window[1] == "src"
+            && window[2] == "main"
+    }) || components
+        .windows(2)
+        .any(|window| window[0] == "src" && window[1] == "testfixtures")
 }
 
 /// True for *build-tooling* sources — Gradle convention plugins and build logic
 /// under `build-logic/` or `buildSrc/`. These configure the build and never ship
 /// in the application, so a `throw`/`TODO()` there fails the build by design.
 pub fn is_build_tooling_path(path: &Path) -> bool {
-    path_contains_component(path, &["build-logic", "buildSrc"])
+    path_contains_component(path, &["build-logic", "buildsrc"])
+}
+
+fn normalized_components(path: &Path) -> Vec<String> {
+    path.to_string_lossy()
+        .split(['/', '\\'])
+        .map(normalize)
+        .collect()
 }
 
 pub fn is_config_file(path: &Path) -> bool {

--- a/src/audits/context/classify/helpers.rs
+++ b/src/audits/context/classify/helpers.rs
@@ -121,6 +121,24 @@ pub fn is_test_support_file(path: &Path) -> bool {
     )
 }
 
+/// True for a *test-support module directory* — a source tree dedicated to test
+/// doubles and helpers shared across modules, conventionally a `testing` module
+/// (e.g. `core/testing/…` in a Gradle/Android multi-module build). Unlike a test
+/// file it lives under a production source set (`src/main`), so it keeps its
+/// production role but also earns `FileRole::TestSupport` so opted-in rules can
+/// treat its placeholder/assertion throws as test plumbing. Language-agnostic
+/// companion to the Rust filename allow list in [`is_test_support_file`].
+pub fn is_test_support_dir(path: &Path) -> bool {
+    path_contains_component(path, &["testing", "testsupport", "testfixtures"])
+}
+
+/// True for *build-tooling* sources — Gradle convention plugins and build logic
+/// under `build-logic/` or `buildSrc/`. These configure the build and never ship
+/// in the application, so a `throw`/`TODO()` there fails the build by design.
+pub fn is_build_tooling_path(path: &Path) -> bool {
+    path_contains_component(path, &["build-logic", "buildSrc"])
+}
+
 pub fn is_config_file(path: &Path) -> bool {
     let file_name = path
         .file_name()

--- a/src/audits/context/classify/roles.rs
+++ b/src/audits/context/classify/roles.rs
@@ -3,7 +3,7 @@ use super::frameworks::{
 };
 use super::helpers::{
     is_app_entrypoint, is_build_tooling_path, is_config_file, is_generated_file, is_js_or_ts,
-    is_test_support_dir, is_test_support_file, path_contains_component, push_unique,
+    is_managed_test_support_path, is_test_support_file, path_contains_component, push_unique,
 };
 use super::signals::ContextSignals;
 use crate::audits::context::model::{FileRole, FrameworkKind, LanguageKind};
@@ -62,9 +62,17 @@ fn classify_static_roles(
     // Test-support modules keep their production role but also carry this marker
     // so opted-in rules (`rust.panic-risk`, `managed.fatal-exception-risk`) treat
     // their assertion/placeholder throws as non-production without affecting any
-    // other rule. Rust uses a filename allow list; other ecosystems use a
-    // dedicated `testing` source module (e.g. `core/testing/` in Gradle/Android).
-    if (language == LanguageKind::Rust && is_test_support_file(path)) || is_test_support_dir(path) {
+    // other rule. Rust uses a filename allow list; managed languages use dedicated
+    // Gradle/source-set shapes (not arbitrary `testing` package namespaces).
+    if language == LanguageKind::Rust && is_test_support_file(path) {
+        push_unique(roles, FileRole::TestSupport);
+    }
+
+    if matches!(
+        language,
+        LanguageKind::Java | LanguageKind::Kotlin | LanguageKind::CSharp
+    ) && is_managed_test_support_path(path)
+    {
         push_unique(roles, FileRole::TestSupport);
     }
 

--- a/src/audits/context/classify/roles.rs
+++ b/src/audits/context/classify/roles.rs
@@ -2,8 +2,8 @@ use super::frameworks::{
     is_dotnet_controller, is_dotnet_service, is_react_component_file, is_react_hook_file,
 };
 use super::helpers::{
-    is_app_entrypoint, is_config_file, is_generated_file, is_js_or_ts, is_test_support_file,
-    path_contains_component, push_unique,
+    is_app_entrypoint, is_build_tooling_path, is_config_file, is_generated_file, is_js_or_ts,
+    is_test_support_dir, is_test_support_file, path_contains_component, push_unique,
 };
 use super::signals::ContextSignals;
 use crate::audits::context::model::{FileRole, FrameworkKind, LanguageKind};
@@ -60,10 +60,19 @@ fn classify_static_roles(
     }
 
     // Test-support modules keep their production role but also carry this marker
-    // so `rust.panic-risk` can treat their assertion `panic!`/`unwrap` calls as
-    // non-production without affecting any other rule.
-    if language == LanguageKind::Rust && is_test_support_file(path) {
+    // so opted-in rules (`rust.panic-risk`, `managed.fatal-exception-risk`) treat
+    // their assertion/placeholder throws as non-production without affecting any
+    // other rule. Rust uses a filename allow list; other ecosystems use a
+    // dedicated `testing` source module (e.g. `core/testing/` in Gradle/Android).
+    if (language == LanguageKind::Rust && is_test_support_file(path)) || is_test_support_dir(path) {
         push_unique(roles, FileRole::TestSupport);
+    }
+
+    // Build-tooling sources (Gradle convention plugins under `build-logic/` /
+    // `buildSrc/`) configure the build and never ship, so opted-in rules treat
+    // their build-failing throws as intended rather than runtime risk.
+    if is_build_tooling_path(path) {
+        push_unique(roles, FileRole::BuildTooling);
     }
 }
 

--- a/src/audits/context/classify/tests/group_3.rs
+++ b/src/audits/context/classify/tests/group_3.rs
@@ -18,7 +18,6 @@ fn classifies_infrastructure_files_as_declarative_context() {
     assert!(!context.is_production_code());
 }
 
-
 #[test]
 fn classifies_ci_workflow_yaml_as_infrastructure_context() {
     let file = facts(
@@ -38,7 +37,6 @@ fn classifies_ci_workflow_yaml_as_infrastructure_context() {
     assert!(!context.is_production_code());
 }
 
-
 #[test]
 fn classifies_docker_compose_file_as_infrastructure_context() {
     let file = facts(
@@ -54,7 +52,6 @@ fn classifies_docker_compose_file_as_infrastructure_context() {
     assert!(context.has_runtime(RuntimeKind::Infrastructure));
     assert!(context.has_paradigm(ProgrammingParadigm::Declarative));
 }
-
 
 #[test]
 fn classifies_json_as_declarative_but_not_infrastructure_by_default() {
@@ -72,7 +69,6 @@ fn classifies_json_as_declarative_but_not_infrastructure_by_default() {
     assert!(!context.has_role(FileRole::Infrastructure));
     assert!(!context.has_runtime(RuntimeKind::Infrastructure));
 }
-
 
 #[test]
 fn classifies_generic_yaml_toml_as_declarative_but_not_infrastructure_by_default() {
@@ -99,7 +95,6 @@ fn classifies_generic_yaml_toml_as_declarative_but_not_infrastructure_by_default
     }
 }
 
-
 #[test]
 fn classifies_helm_path_yaml_as_infrastructure_context() {
     let file = facts(
@@ -115,7 +110,6 @@ fn classifies_helm_path_yaml_as_infrastructure_context() {
     assert!(context.has_runtime(RuntimeKind::Infrastructure));
     assert!(context.has_paradigm(ProgrammingParadigm::Declarative));
 }
-
 
 #[test]
 fn classifies_gradle_testing_module_as_test_support() {
@@ -150,6 +144,77 @@ fn classifies_build_logic_as_build_tooling() {
     let context = classify_file(&file);
 
     assert!(context.has_role(FileRole::BuildTooling));
+    assert!(!context.has_role(FileRole::TestSupport));
+}
+
+#[test]
+fn classifies_gradle_build_src_as_build_tooling() {
+    let file = facts(
+        "buildSrc/src/main/kotlin/com/app/BuildPlugin.kt",
+        Some("Kotlin"),
+        "fun configure(): Unit = TODO()",
+        false,
+    );
+
+    let context = classify_file(&file);
+
+    assert!(context.has_role(FileRole::BuildTooling));
+    assert!(!context.has_role(FileRole::TestSupport));
+}
+
+#[test]
+fn classifies_gradle_test_fixtures_source_set_as_test_support() {
+    let file = facts(
+        "core/model/src/testFixtures/kotlin/com/app/FakeUser.kt",
+        Some("Kotlin"),
+        "class FakeUser",
+        false,
+    );
+
+    let context = classify_file(&file);
+
+    assert!(context.has_role(FileRole::TestSupport));
+}
+
+#[test]
+fn runtime_package_named_testing_is_not_test_support() {
+    let file = facts(
+        "app/src/main/kotlin/com/example/testing/RuntimeValidator.kt",
+        Some("Kotlin"),
+        "class RuntimeValidator { fun validate(): Unit = TODO() }",
+        false,
+    );
+
+    let context = classify_file(&file);
+
+    assert!(!context.has_role(FileRole::TestSupport));
+}
+
+#[test]
+fn rust_testing_directory_is_not_implicitly_test_support() {
+    let file = facts(
+        "src/testing/runtime.rs",
+        Some("Rust"),
+        "pub fn validate() { panic!(\"bad\") }",
+        false,
+    );
+
+    let context = classify_file(&file);
+
+    assert!(!context.has_role(FileRole::TestSupport));
+}
+
+#[test]
+fn feature_testing_directory_is_not_test_support_without_gradle_source_set() {
+    let file = facts(
+        "feature/testing/ProductionService.kt",
+        Some("Kotlin"),
+        "class ProductionService { fun run(): Unit = TODO() }",
+        false,
+    );
+
+    let context = classify_file(&file);
+
     assert!(!context.has_role(FileRole::TestSupport));
 }
 

--- a/src/audits/context/classify/tests/group_3.rs
+++ b/src/audits/context/classify/tests/group_3.rs
@@ -118,6 +118,58 @@ fn classifies_helm_path_yaml_as_infrastructure_context() {
 
 
 #[test]
+fn classifies_gradle_testing_module_as_test_support() {
+    // `core/testing/` holds test doubles under a production source set (`src/main`),
+    // so it is not a test file but earns the TestSupport marker for opted-in rules.
+    let file = facts(
+        "core/testing/src/main/kotlin/com/app/core/testing/util/TestSyncManager.kt",
+        Some("Kotlin"),
+        "class TestSyncManager : SyncManager {\n  override fun requestSync(): Unit = TODO()\n}\n",
+        false,
+    );
+
+    let context = classify_file(&file);
+
+    assert!(context.has_role(FileRole::TestSupport));
+    assert!(
+        !context.has_role(FileRole::Test),
+        "a src/main module is not a test file"
+    );
+    assert!(!context.has_role(FileRole::BuildTooling));
+}
+
+#[test]
+fn classifies_build_logic_as_build_tooling() {
+    let file = facts(
+        "build-logic/convention/src/main/kotlin/com/app/KotlinAndroid.kt",
+        Some("Kotlin"),
+        "internal fun configure() {\n  when (x) { else -> TODO(\"Unsupported\") }\n}\n",
+        false,
+    );
+
+    let context = classify_file(&file);
+
+    assert!(context.has_role(FileRole::BuildTooling));
+    assert!(!context.has_role(FileRole::TestSupport));
+}
+
+#[test]
+fn classifies_feature_screen_as_plain_production_code() {
+    // Real app UI carries neither marker, so its `TODO()` stays default-visible.
+    let file = facts(
+        "feature/topic/impl/src/main/kotlin/com/app/feature/topic/TopicScreen.kt",
+        Some("Kotlin"),
+        "fun TopicScreen(state: TopicUiState) {\n  when (state) { is Error -> TODO() }\n}\n",
+        false,
+    );
+
+    let context = classify_file(&file);
+
+    assert!(!context.has_role(FileRole::TestSupport));
+    assert!(!context.has_role(FileRole::BuildTooling));
+}
+
+#[test]
 fn classifies_elixir_as_functional_first_context() {
     let file = facts(
         "lib/pipeline.ex",

--- a/src/audits/context/model/kinds.rs
+++ b/src/audits/context/model/kinds.rs
@@ -87,10 +87,10 @@ pub enum FileRole {
     Generated,
     Domain,
     Script,
-    /// A Rust test-support module (`testutil.rs`, `test_utils.rs`, …): a
-    /// production file whose `panic!`/`unwrap` calls are test assertion plumbing.
-    /// Carried *alongside* the file's production role so only opted-in rules
-    /// (currently `rust.panic-risk`) treat it specially.
+    /// A test-support module: Rust filename allow-list helpers (`testutil.rs`,
+    /// `test_utils.rs`, …) or managed-language Gradle/source-set helper modules
+    /// (`core/testing/src/main/...`, `src/testFixtures/...`). Carried *alongside*
+    /// the file's production role so only opted-in rules treat it specially.
     TestSupport,
     /// A CLI command handler: a file in a `commands/` directory whose package
     /// declares an executable entrypoint (npm `package.json#bin`, Cargo

--- a/src/audits/context/model/kinds.rs
+++ b/src/audits/context/model/kinds.rs
@@ -98,6 +98,12 @@ pub enum FileRole {
     /// host-termination calls there are an intended boundary — unlike a reusable
     /// module elsewhere in the same package, which is not exempted.
     CliExecutable,
+    /// A build-tooling module: a Gradle convention plugin or build script under
+    /// `build-logic/` / `buildSrc/`. It configures the build, never ships in the
+    /// app, so a `throw`/`TODO()` there fails the build by design rather than at
+    /// runtime. Carried alongside the production role so only opted-in rules
+    /// treat it specially.
+    BuildTooling,
     Infrastructure,
     Unknown,
 }
@@ -233,6 +239,7 @@ impl FileRole {
             FileRole::Script => "script",
             FileRole::TestSupport => "test-support",
             FileRole::CliExecutable => "cli-executable",
+            FileRole::BuildTooling => "build-tooling",
             FileRole::Infrastructure => "infrastructure",
             FileRole::Unknown => "unknown",
         }

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -677,6 +677,22 @@ role = "test"
 action = "downgrade"
 severity = "LOW"
 
+# A test-support module (a `testing` source tree such as `core/testing/`) holds
+# test doubles whose `TODO()`/`throw` placeholders are test plumbing, and a
+# build-tooling module (`build-logic/`, `buildSrc/`) fails the build by design.
+# Both keep their production role but downgrade to Low here (hidden by default,
+# kept under `--profile strict`) rather than being deleted; real app code such as
+# an unfinished `TopicUiState.Error -> TODO()` stays default-visible.
+[[rules.overrides]]
+role = "test-support"
+action = "downgrade"
+severity = "LOW"
+
+[[rules.overrides]]
+role = "build-tooling"
+action = "downgrade"
+severity = "LOW"
+
 [[rules.overrides]]
 role = "domain"
 action = "upgrade"

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -677,12 +677,21 @@ role = "test"
 action = "downgrade"
 severity = "LOW"
 
+[[rules.overrides]]
+role = "domain"
+action = "upgrade"
+severity = "HIGH"
+
 # A test-support module (a `testing` source tree such as `core/testing/`) holds
 # test doubles whose `TODO()`/`throw` placeholders are test plumbing, and a
 # build-tooling module (`build-logic/`, `buildSrc/`) fails the build by design.
 # Both keep their production role but downgrade to Low here (hidden by default,
 # kept under `--profile strict`) rather than being deleted; real app code such as
-# an unfinished `TopicUiState.Error -> TODO()` stays default-visible.
+# an unfinished `TopicUiState.Error -> TODO()` stays default-visible. Placed last
+# so the downgrade wins over the `domain` upgrade above: a test-support module
+# under a `models/`/`domain/` package (e.g. `core/testing/.../models/FakeUser.kt`)
+# also carries the `domain` role, and overrides apply in order — the later match
+# wins — so these must follow the upgrade to stay hidden by default.
 [[rules.overrides]]
 role = "test-support"
 action = "downgrade"
@@ -692,11 +701,6 @@ severity = "LOW"
 role = "build-tooling"
 action = "downgrade"
 severity = "LOW"
-
-[[rules.overrides]]
-role = "domain"
-action = "upgrade"
-severity = "HIGH"
 
 [[rules]]
 rule_id = "code-quality.long-function"

--- a/src/scan/cache.rs
+++ b/src/scan/cache.rs
@@ -19,7 +19,9 @@ use std::time::UNIX_EPOCH;
 /// resurrecting the phantom cycles the deferral was meant to break.
 /// v5 invalidates cached file roles because `deferred_imports` now also includes
 /// TypeScript/JavaScript type-only imports and exports erased at runtime.
-pub const CACHE_SCHEMA_VERSION: u32 = 5;
+/// v6 invalidates cached file roles because classification now adds build-tooling
+/// and managed test-support roles.
+pub const CACHE_SCHEMA_VERSION: u32 = 6;
 pub const CACHE_DIR: &str = ".repopilot/cache";
 const FILE_HASHES_NAME: &str = "file_hashes.json";
 const FILE_ROLES_NAME: &str = "file_roles.json";

--- a/tests/cache_fingerprint.rs
+++ b/tests/cache_fingerprint.rs
@@ -11,7 +11,7 @@ fn stable_hash_hex_uses_sha256() {
 
 #[test]
 fn config_fingerprint_changes_with_config_and_cache_schema_context() {
-    assert_eq!(CACHE_SCHEMA_VERSION, 5);
+    assert_eq!(CACHE_SCHEMA_VERSION, 6);
 
     let default = config_fingerprint(&ScanConfig::default());
     let changed = config_fingerprint(&ScanConfig {

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -60,7 +60,7 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
     assert!(cache_dir.join("repo_context.json").is_file());
     assert_eq!(
         read_json(&cache_dir.join("file_hashes.json"))["schema_version"],
-        5
+        6
     );
     assert_eq!(
         read_json(&cache_dir.join("file_hashes.json"))["entries"][0]["hash"]
@@ -179,7 +179,7 @@ fn changed_scan_invalidates_old_cache_schema() {
 
     scan_changed_json(temp.path(), &["--changed"]);
     for name in ["file_hashes.json", "file_roles.json", "findings.json"] {
-        force_cache_schema(temp.path().join(".repopilot/cache").join(name).as_path(), 4);
+        force_cache_schema(temp.path().join(".repopilot/cache").join(name).as_path(), 5);
     }
     let json = scan_changed_json(temp.path(), &["--changed"]);
 
@@ -188,6 +188,55 @@ fn changed_scan_invalidates_old_cache_schema() {
     assert_eq!(
         json["cache_telemetry"]["changed_files"][0]["cache_reason"],
         "missing-cache-entry"
+    );
+}
+
+#[test]
+fn changed_scan_rejects_v5_cache_missing_build_tooling_roles() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(
+        temp.path()
+            .join("buildSrc/src/main/kotlin/com/app/BuildPlugin.kt"),
+        "fun configure() = Unit\n",
+    );
+    commit_all(temp.path(), "initial");
+    write(
+        temp.path()
+            .join("buildSrc/src/main/kotlin/com/app/BuildPlugin.kt"),
+        "fun configure(): Unit = TODO()\n",
+    );
+
+    let first_changed = scan_changed_json(temp.path(), &["--changed", "--profile", "strict"]);
+    assert_eq!(
+        first_changed["cache_telemetry"]["changed_files"][0]["cache_status"],
+        "miss"
+    );
+    assert_eq!(
+        finding_for_rule(&first_changed, "language.managed.fatal-exception-risk")["severity"],
+        "LOW"
+    );
+
+    let cache_dir = temp.path().join(".repopilot/cache");
+    for name in ["file_hashes.json", "file_roles.json", "findings.json"] {
+        force_cache_schema(cache_dir.join(name).as_path(), 5);
+    }
+    remove_cached_role(&cache_dir.join("file_roles.json"), "build-tooling");
+    set_cached_rule_severity(
+        &cache_dir.join("findings.json"),
+        "language.managed.fatal-exception-risk",
+        "HIGH",
+    );
+
+    let upgraded_changed = scan_changed_json(temp.path(), &["--changed", "--profile", "strict"]);
+    assert_eq!(
+        upgraded_changed["cache_telemetry"]["changed_files"][0]["cache_status"], "miss",
+        "v5 file-role caches must be rejected after role classification changed: {upgraded_changed:#?}"
+    );
+    assert_eq!(
+        finding_for_rule(&upgraded_changed, "language.managed.fatal-exception-risk")["severity"],
+        "LOW",
+        "re-analysis must restore build-tooling downgrade: {upgraded_changed:#?}"
     );
 }
 
@@ -591,6 +640,28 @@ fn clear_file_roles_deferred_imports(path: &Path) {
     write_json(path, &value);
 }
 
+fn remove_cached_role(path: &Path, role: &str) {
+    let mut value = read_json(path);
+    for entry in value["entries"].as_array_mut().expect("file role entries") {
+        if let Some(roles) = entry["roles"].as_array_mut() {
+            roles.retain(|value| value.as_str() != Some(role));
+        }
+    }
+    write_json(path, &value);
+}
+
+fn set_cached_rule_severity(path: &Path, rule_id: &str, severity: &str) {
+    let mut value = read_json(path);
+    for entry in value["entries"].as_array_mut().expect("finding entries") {
+        for finding in entry["findings"].as_array_mut().expect("findings") {
+            if finding["rule_id"] == rule_id {
+                finding["severity"] = Value::String(severity.to_string());
+            }
+        }
+    }
+    write_json(path, &value);
+}
+
 fn force_context_graph_resolver(path: &Path, resolver_version: &str) {
     let mut value = read_json(path);
     value["resolver_version"] = Value::String(resolver_version.to_string());
@@ -645,6 +716,15 @@ fn assert_rule_present(json: &Value, rule_id: &str) {
             .any(|finding| finding["rule_id"] == rule_id),
         "expected {rule_id} in findings: {json:#?}"
     );
+}
+
+fn finding_for_rule<'a>(json: &'a Value, rule_id: &str) -> &'a Value {
+    json["findings"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|finding| finding["rule_id"] == rule_id)
+        .unwrap_or_else(|| panic!("expected {rule_id} in findings: {json:#?}"))
 }
 
 fn assert_rule_absent(json: &Value, rule_id: &str) {

--- a/tests/scan_visibility_cli.rs
+++ b/tests/scan_visibility_cli.rs
@@ -128,6 +128,42 @@ fn default_scan_hides_cli_package_process_exit_but_reports_non_cli_package() {
 }
 
 #[test]
+fn default_scan_hides_managed_placeholders_in_build_tooling_and_test_support() {
+    let temp = tempdir().expect("temp dir");
+    let root = temp.path();
+    write(
+        root.join("buildSrc/src/main/kotlin/com/app/BuildPlugin.kt"),
+        "fun configure(): Unit = TODO()\n",
+    );
+    write(
+        root.join("core/testing/src/main/kotlin/com/app/FakeSync.kt"),
+        "class FakeSync { fun sync(): Unit = TODO() }\n",
+    );
+    write(
+        root.join("feature/topic/impl/src/main/kotlin/com/app/testing/TopicScreen.kt"),
+        "fun TopicScreen(state: State): Unit = TODO()\n",
+    );
+
+    let default = scan_json(root, &[]);
+    let default_paths = findings_for_rule(&default, "language.managed.fatal-exception-risk")
+        .map(first_path)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        default_paths.len(),
+        1,
+        "default should hide build-tooling/test-support placeholders only: {default:#?}"
+    );
+    assert!(default_paths[0].ends_with("TopicScreen.kt"));
+
+    let strict = scan_json(root, &["--profile", "strict"]);
+    assert_eq!(
+        findings_for_rule(&strict, "language.managed.fatal-exception-risk").count(),
+        3,
+        "strict should retain Low build-tooling/test-support findings: {strict:#?}"
+    );
+}
+
+#[test]
 fn default_scan_reports_unwrap_on_external_parse_path() {
     let temp = tempdir().expect("temp dir");
     let root = temp.path();

--- a/tests/zoo/snapshots/nowinandroid.json
+++ b/tests/zoo/snapshots/nowinandroid.json
@@ -1,17 +1,15 @@
 {
   "default": {
     "by_priority": {
-      "P0": 3
+      "P0": 1
     },
     "by_rule": {
-      "language.managed.fatal-exception-risk": 3
+      "language.managed.fatal-exception-risk": 1
     },
     "fingerprints": [
-      "language.managed.fatal-exception-risk:build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt:ea2a0df653191fc3",
-      "language.managed.fatal-exception-risk:core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/util/TestSyncManager.kt:864c09d62667be09",
       "language.managed.fatal-exception-risk:feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt:6287d3e94eee5173"
     ],
-    "visible_total": 3
+    "visible_total": 1
   },
   "framework": "android",
   "language": "kotlin",


### PR DESCRIPTION
## Summary

Reduce false-positive `language.managed.fatal-exception-risk` findings in Gradle build tooling and dedicated managed-language test-support modules.

Placeholder and fatal throws in these contexts are not application runtime hazards:

* Gradle convention plugins fail the build by design.
* Dedicated test-support modules contain fakes, test doubles, and helper implementations used by tests.

These findings are now downgraded to `Low`, which hides them from the default profile while preserving them under `--profile strict`.

## Type of change

* [ ] Feature
* [x] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added the `build-tooling` file role for files under:

  * `build-logic/`
  * `buildSrc/`
* Extended the existing `test-support` role to managed-language source trees with explicit module/source-set structures:

  * `testing/src/main/...`
  * `testsupport/src/main/...`
  * `src/testFixtures/...`
* Limited the directory-based test-support classification to:

  * Java
  * Kotlin
  * C#
* Preserved the existing Rust filename-based test-support allowlist.
* Avoided classifying arbitrary package namespaces such as:

  * `app/src/main/kotlin/com/example/testing/...`
  * `feature/testing/...`
  * Rust `src/testing/...`
* Added knowledge-pack overrides that downgrade managed fatal-exception findings to `Low` for:

  * `test-support`
  * `build-tooling`
* Kept real application placeholders and fatal throws at their existing severity.
* Ensured the test-support and build-tooling downgrades take precedence when a file also carries another role such as `domain`.
* Bumped the changed-scan cache schema from `v5` to `v6` so older cached file-role classifications are not reused.
* Added focused classifier, rule-level, visibility, cache-upgrade, and zoo regression coverage.
* Updated the changelog and Now in Android zoo snapshot.

## Why

`language.managed.fatal-exception-risk` previously treated every managed-language `TODO()` or fatal throw as an application runtime risk.

This created noisy default findings in two common non-runtime contexts:

### Gradle build tooling

Files under `build-logic/` and `buildSrc/` configure the build. A placeholder or fatal throw there stops the build rather than failing an end-user application at runtime.

### Dedicated test-support modules

Projects often place reusable test doubles in production source sets, for example:

```text
core/testing/src/main/kotlin/...
```

These files are not test files by path, but their placeholders are test plumbing rather than unfinished production behavior.

The new roles allow only the managed fatal-exception rule to treat these contexts differently. Files retain their normal production roles for all other rules.

## Behavior

### Build tooling

```kotlin
// buildSrc/src/main/kotlin/BuildPlugin.kt
fun configure(): Unit = TODO()
```

Result:

* default profile: hidden;
* strict profile: retained as `Low`.

### Dedicated test-support module

```kotlin
// core/testing/src/main/kotlin/FakeSync.kt
class FakeSync {
    fun sync(): Unit = TODO()
}
```

Result:

* default profile: hidden;
* strict profile: retained as `Low`.

### Real application code

```kotlin
// feature/topic/impl/src/main/kotlin/TopicScreen.kt
fun TopicScreen(state: State): Unit = TODO()
```

Result:

* remains default-visible at `High`.

### Package namespace guard

```text
app/src/main/kotlin/com/example/testing/RuntimeValidator.kt
```

A package component named `testing` alone does not make a file test support. Fatal placeholders remain default-visible.

## Contract and ownership

* [x] The change stays within context classification and managed fatal-exception rule ownership.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] Findings retain stable rule IDs and deterministic evidence.
* [x] Noise reduction preserves strict-profile visibility.
* [x] False-negative guards cover ordinary application paths and package namespaces.
* [x] Multi-role override precedence is covered.
* [x] Cache upgrade behavior is covered.
* [x] Zoo impact is measured.
* [x] No unrelated generated-file churn is included.

## Cache compatibility

The file-role cache schema is bumped from `v5` to `v6`.

This forces changed scans to reclassify files after introducing:

* `build-tooling`;
* managed-language directory-based `test-support`.

Without the schema bump, users upgrading RepoPilot could continue receiving stale `High` findings from cached role classifications.

## Zoo impact

For the Now in Android snapshot:

* default-visible `language.managed.fatal-exception-risk` findings: `3 → 1`;
* build tooling finding: downgraded and hidden by default;
* test-support finding: downgraded and hidden by default;
* genuine feature application placeholder: remains visible;
* all signals remain available under the strict profile.

## Changelog

* [x] `CHANGELOG.md` updated.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```
