### PR TITLE
fix(secret-candidate): treat Algolia DocSearch apiKey as strict-only Low

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,17 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **`security.secret-candidate` treats an Algolia DocSearch `apiKey` as a
+  Low-confidence (strict-only) finding instead of a default-visible secret.** The
+  frontend search widget is configured with Algolia's **search-only** API key,
+  which is public by design — it ships in the browser bundle — so flagging it as a
+  committed secret is noise. A DocSearch block is identified by its signature trio
+  (`algolia` + `appId` + `indexName`); only the `apiKey` field in such a file is
+  downgraded, so a real credential elsewhere in the same config still flags High,
+  and the value remains visible under `--profile strict`. Measured on the
+  real-repo zoo, this removed excalidraw's default-visible Docusaurus search-key
+  finding while retaining strict-profile review.
+
 - **`language.managed.fatal-exception-risk` no longer surfaces placeholder/fatal
   throws in build-tooling or test-support modules by default.** A `TODO()` or
   `throw` in a Gradle convention plugin (`build-logic/` / `buildSrc/`) fails the

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -66,10 +66,10 @@ impl FileAudit for SecretCandidateAudit {
         // not shipped credentials, so skip those lines (the file-path test skip
         // above only catches whole test files).
         let gated_test_lines = rust_cfg_test_lines(file);
+        let content = file.content.as_deref().unwrap_or("");
+        let algolia_public_key_lines = algolia_public_api_key_lines(content);
 
-        file.content
-            .as_deref()
-            .unwrap_or("")
+        content
             .lines()
             .enumerate()
             .filter_map(|(index, line)| {
@@ -77,7 +77,13 @@ impl FileAudit for SecretCandidateAudit {
                 if gated_test_lines.contains(&line_number) {
                     return None;
                 }
-                detect_secret_line(line, line_number, &file.path).and_then(|finding| {
+                detect_secret_line(
+                    line,
+                    line_number,
+                    &file.path,
+                    algolia_public_key_lines.contains(&line_number),
+                )
+                .and_then(|finding| {
                     apply_file_decision("security.secret-candidate", file, finding, None)
                 })
             })
@@ -115,7 +121,12 @@ fn is_lock_file(path: &std::path::Path) -> bool {
     )
 }
 
-fn detect_secret_line(line: &str, line_number: usize, path: &std::path::Path) -> Option<Finding> {
+fn detect_secret_line(
+    line: &str,
+    line_number: usize,
+    path: &std::path::Path,
+    algolia_public_key_line: bool,
+) -> Option<Finding> {
     // Skip PEM headers — PrivateKeyCandidateAudit handles these (avoids double-reporting)
     if line.trim_start().starts_with("-----BEGIN") {
         return None;
@@ -137,6 +148,14 @@ fn detect_secret_line(line: &str, line_number: usize, path: &std::path::Path) ->
         .iter()
         .find_map(|&key| assigned_secret_confidence_for_key(line, &lower, key).map(|c| (key, c)))
     {
+        // An `apiKey` in an Algolia DocSearch config is the published search-only
+        // key (public by design); keep it as a Low finding so strict still
+        // surfaces the committed value while the default profile stays clean.
+        let confidence = if algolia_public_key_line && is_algolia_public_key(matched_key) {
+            Confidence::Low
+        } else {
+            confidence
+        };
         return Some(build_finding(
             line_number,
             path,

--- a/src/audits/security/secret_candidate/parsing.rs
+++ b/src/audits/security/secret_candidate/parsing.rs
@@ -28,6 +28,73 @@ fn is_shell_expansion(value: &str) -> bool {
     value.starts_with("$(") || value.starts_with('`') || value.contains("$(")
 }
 
+/// Lines carrying the public search-only `apiKey` inside an Algolia DocSearch
+/// config block. The signature trio keeps the downgrade scoped to that widget,
+/// so unrelated `apiKey` credentials elsewhere in the file stay High.
+fn algolia_public_api_key_lines(content: &str) -> HashSet<usize> {
+    let lines: Vec<_> = content.lines().collect();
+    let mut public_key_lines = HashSet::new();
+    let mut index = 0;
+
+    while index < lines.len() {
+        if !lines[index].to_ascii_lowercase().contains("algolia") {
+            index += 1;
+            continue;
+        }
+
+        let end = algolia_config_block_end(&lines, index);
+        let block = lines[index..=end].join("\n").to_ascii_lowercase();
+        if block.contains("appid") && block.contains("indexname") {
+            for (offset, line) in lines[index..=end].iter().enumerate() {
+                let lower = line.to_ascii_lowercase();
+                if ["apikey", "api_key"]
+                    .iter()
+                    .any(|key| assigned_secret_confidence_for_key(line, &lower, key).is_some())
+                {
+                    public_key_lines.insert(index + offset + 1);
+                }
+            }
+        }
+
+        index = end + 1;
+    }
+
+    public_key_lines
+}
+
+fn algolia_config_block_end(lines: &[&str], start: usize) -> usize {
+    let mut depth = 0;
+    let mut opened = false;
+    let mut in_block_comment = false;
+
+    for (index, line) in lines
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(80)
+    {
+        let sanitized = sanitize_c_style(line, &mut in_block_comment);
+        let opens = sanitized.matches('{').count() as i32;
+        let closes = sanitized.matches('}').count() as i32;
+
+        opened |= opens > 0;
+        depth += opens - closes;
+
+        if opened && depth <= 0 {
+            return index;
+        }
+    }
+
+    start
+}
+
+/// True when `matched_key` is the public-facing Algolia search key field. Only
+/// the `apiKey` family is the published search-only key; other secret keys in the
+/// same file are unaffected.
+fn is_algolia_public_key(matched_key: &str) -> bool {
+    matches!(matched_key, "apikey" | "api_key")
+}
+
 /// The 1-based line numbers that fall inside a `#[cfg(test)]`/`#[test]`-gated
 /// item in a Rust source file.
 ///

--- a/tests/fixtures/rules/security.secret-candidate/expected.json
+++ b/tests/fixtures/rules/security.secret-candidate/expected.json
@@ -23,6 +23,12 @@
       ]
     },
     {
+      "path": "low_confidence_algolia_search_key",
+      "expected_rule_ids": [
+        "security.secret-candidate"
+      ]
+    },
+    {
       "path": "true_positive",
       "expected_rule_ids": [
         "security.secret-candidate"

--- a/tests/fixtures/rules/security.secret-candidate/low_confidence_algolia_search_key/docusaurus.config.js
+++ b/tests/fixtures/rules/security.secret-candidate/low_confidence_algolia_search_key/docusaurus.config.js
@@ -1,0 +1,12 @@
+// Algolia DocSearch widget config: the `apiKey` is the public, search-only key
+// (it ships in the browser bundle), so it is retained only as a Low-confidence
+// candidate for strict analysis and hidden from default output.
+module.exports = {
+  themeConfig: {
+    algolia: {
+      appId: "8FEAOD28DI",
+      apiKey: "4b07cca33ff2d2919bc95ff98f148e9e",
+      indexName: "excalidraw",
+    },
+  },
+};

--- a/tests/security_rules.rs
+++ b/tests/security_rules.rs
@@ -133,6 +133,61 @@ fn secret_candidate_keeps_kebab_and_snake_slugs_as_low_confidence() {
 }
 
 #[test]
+fn secret_candidate_treats_algolia_docsearch_key_as_low() {
+    // The Algolia DocSearch widget config carries the public, search-only API key
+    // (it ships in the browser bundle), so the `apiKey` here is not a committed
+    // secret — but keep it Low so strict still surfaces the value.
+    let config = file(
+        "dev-docs/docusaurus.config.js",
+        "      algolia: {\n        appId: \"8FEAOD28DI\",\n        apiKey: \"4b07cca33ff2d2919bc95ff98f148e9e\",\n        indexName: \"excalidraw\",\n      },\n",
+    );
+    let findings = SecretCandidateAudit.audit(&config, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1, "Algolia search key still fires (strict)");
+    assert_eq!(findings[0].confidence, Confidence::Low);
+}
+
+#[test]
+fn secret_candidate_keeps_real_secret_high_in_algolia_config_file() {
+    // The Algolia downgrade is scoped to the `apiKey` field — a real credential
+    // elsewhere in the same config file must still flag as High.
+    let config = file(
+        "dev-docs/docusaurus.config.js",
+        "      algolia: { appId: \"8FEAOD28DI\", apiKey: \"4b07cca33ff2d2919bc95ff98f148e9e\", indexName: \"excalidraw\" },\n      client_secret: \"sk-Zj4Hn8Qw2Kp6Mv9Rs1Tb7\",\n",
+    );
+    let findings = SecretCandidateAudit.audit(&config, &ScanConfig::default());
+
+    let high: Vec<_> = findings
+        .iter()
+        .filter(|f| f.confidence == Confidence::High)
+        .collect();
+    assert_eq!(
+        high.len(),
+        1,
+        "the real client_secret must stay High even in an Algolia config file: {findings:?}"
+    );
+}
+
+#[test]
+fn secret_candidate_keeps_unrelated_api_key_high_in_algolia_config_file() {
+    let config = file(
+        "dev-docs/docusaurus.config.js",
+        "      algolia: { appId: \"8FEAOD28DI\", apiKey: \"4b07cca33ff2d2919bc95ff98f148e9e\", indexName: \"excalidraw\" },\n      stripe: { apiKey: \"sk_live_Zj4Hn8Qw2Kp6Mv9Rs1Tb7\" },\n",
+    );
+    let findings = SecretCandidateAudit.audit(&config, &ScanConfig::default());
+
+    let high: Vec<_> = findings
+        .iter()
+        .filter(|f| f.confidence == Confidence::High)
+        .collect();
+    assert_eq!(
+        high.len(),
+        1,
+        "only the Algolia apiKey should be downgraded: {findings:?}"
+    );
+}
+
+#[test]
 fn secret_candidate_keeps_mixed_case_credentials_high_confidence() {
     let real = file(
         "packages/common/src/constants.ts",


### PR DESCRIPTION
## Summary

- Downgrades the `apiKey` inside an Algolia DocSearch config to Low confidence so it is hidden by the default profile and still available under `--profile strict`.
- Keeps the downgrade scoped to the Algolia block signature (`algolia` + `appId` + `indexName`) so unrelated `apiKey` credentials in the same file still flag High.
- Adds rule fixtures and regression tests for the Low downgrade and the High-confidence guard.

## Why

Algolia DocSearch uses a public search-only API key that ships in the browser bundle by design. Treating that field as a default-visible committed secret produces false-positive noise while still being useful context in strict analysis.

## Impact

Default scans stop surfacing the Docusaurus DocSearch key as a secret candidate. Strict scans still retain the value as a Low-confidence finding, and real credentials elsewhere in the file remain High.

## Validation

- `cargo test --test security_rules secret_candidate`
- `cargo test --test rule_eval_fixture_coverage given_security_rule_fixtures_when_eval_rules_runs_then_quality_gates_pass`