### PR TITLE
chore(zoo): refresh stale excalidraw and fastapi snapshots

### DIFF
--- a/tests/zoo/snapshots/excalidraw.json
+++ b/tests/zoo/snapshots/excalidraw.json
@@ -1,50 +1,53 @@
 {
-	"default": {
-		"by_priority": {
-			"P0": 5
-		},
-		"by_rule": {
-			"architecture.circular-dependency": 3,
-			"language.javascript.runtime-exit-risk": 1,
-			"security.secret-candidate": 1
-		},
-		"fingerprints": [
-			"architecture.circular-dependency:excalidraw-app/App.tsx:e575ed4f8104d3d4",
-			"architecture.circular-dependency:excalidraw-app/collab/Collab.tsx:40148bf1157fe6d3",
-			"architecture.circular-dependency:packages/common/src/index.ts:7b14cf4e6bb5e522",
-			"language.javascript.runtime-exit-risk:packages/excalidraw/subset/woff2/woff2-bindings.ts:cac7cba895f49cd1",
-			"security.secret-candidate:dev-docs/docusaurus.config.js:9fe21045a4599527"
-		],
-		"visible_total": 5
-	},
-	"framework": "react",
-	"language": "typescript",
-	"repo": "excalidraw",
-	"sha": "28a9b1711dc0625b8ab5d643dc871810ee13642f",
-	"strict": {
-		"by_rule": {
-			"architecture.barrel-file-risk": 5,
-			"architecture.circular-dependency": 3,
-			"architecture.dead-module": 62,
-			"architecture.deep-relative-imports": 9,
-			"architecture.excessive-fan-out": 23,
-			"architecture.large-file": 84,
-			"architecture.test-leak": 3,
-			"architecture.too-many-modules": 5,
-			"code-marker.fixme": 12,
-			"code-marker.hack": 1,
-			"code-marker.todo": 80,
-			"code-quality.complex-file": 13,
-			"code-quality.complex-function": 151,
-			"code-quality.deep-control-flow": 56,
-			"code-quality.long-function": 331,
-			"framework.js.var-declaration": 4,
-			"framework.react.class-component": 2,
-			"language.javascript.runtime-exit-risk": 8,
-			"security.env-file-committed": 2,
-			"security.secret-candidate": 2,
-			"testing.source-without-test": 374
-		},
-		"visible_total": 1230
-	}
+  "default": {
+    "by_priority": {
+      "P0": 8
+    },
+    "by_rule": {
+      "architecture.circular-dependency": 6,
+      "language.javascript.runtime-exit-risk": 1,
+      "security.secret-candidate": 1
+    },
+    "fingerprints": [
+      "architecture.circular-dependency:excalidraw-app/App.tsx:e575ed4f8104d3d4",
+      "architecture.circular-dependency:excalidraw-app/data/firebase.ts:5c3e800a8ebb659a",
+      "architecture.circular-dependency:packages/common/src/index.ts:7b14cf4e6bb5e522",
+      "architecture.circular-dependency:packages/element/src/Scene.ts:9cbbca234b2ff447",
+      "architecture.circular-dependency:packages/excalidraw/actions/actionHistory.tsx:5c057c5a6edef722",
+      "architecture.circular-dependency:packages/excalidraw/data/blob.ts:5c1b1535711c051e",
+      "language.javascript.runtime-exit-risk:packages/excalidraw/subset/woff2/woff2-bindings.ts:cac7cba895f49cd1",
+      "security.secret-candidate:dev-docs/docusaurus.config.js:9fe21045a4599527"
+    ],
+    "visible_total": 8
+  },
+  "framework": "react",
+  "language": "typescript",
+  "repo": "excalidraw",
+  "sha": "28a9b1711dc0625b8ab5d643dc871810ee13642f",
+  "strict": {
+    "by_rule": {
+      "architecture.barrel-file-risk": 5,
+      "architecture.circular-dependency": 6,
+      "architecture.dead-module": 62,
+      "architecture.deep-relative-imports": 9,
+      "architecture.excessive-fan-out": 23,
+      "architecture.large-file": 84,
+      "architecture.test-leak": 3,
+      "architecture.too-many-modules": 5,
+      "code-marker.fixme": 12,
+      "code-marker.hack": 1,
+      "code-marker.todo": 80,
+      "code-quality.complex-file": 13,
+      "code-quality.complex-function": 151,
+      "code-quality.deep-control-flow": 56,
+      "code-quality.long-function": 331,
+      "framework.js.var-declaration": 4,
+      "framework.react.class-component": 2,
+      "language.javascript.runtime-exit-risk": 8,
+      "security.env-file-committed": 2,
+      "security.secret-candidate": 2,
+      "testing.source-without-test": 374
+    },
+    "visible_total": 1233
+  }
 }

--- a/tests/zoo/snapshots/fastapi.json
+++ b/tests/zoo/snapshots/fastapi.json
@@ -28,8 +28,9 @@
       "code-quality.deep-control-flow": 17,
       "code-quality.long-function": 90,
       "language.python.exception-risk": 103,
+      "security.secret-candidate": 2,
       "testing.source-without-test": 36
     },
-    "visible_total": 763
+    "visible_total": 765
   }
 }


### PR DESCRIPTION
## Summary

- Refreshes the committed zoo snapshots for `excalidraw` and `fastapi` against the current main binary.
- Captures the already-landed circular-dependency and secret-candidate behavior in the baseline snapshots.
- Reformats the touched snapshot JSON to the current `zoo.py` 2-space output.

## Why

The committed snapshots were stale: they predated earlier rule changes, while the local zoo gate stayed green because it had been run with an older release binary. This PR is a baseline refresh only, with no analyzer behavior changes.

## Impact

The real-repo zoo baseline now matches current analyzer output. This PR is best merged before the two behavior-fix PRs so those reviews stay focused on code changes rather than historical baseline drift.

## Validation

- `python3 -m json.tool tests/zoo/snapshots/excalidraw.json >/dev/null`
- `python3 -m json.tool tests/zoo/snapshots/fastapi.json >/dev/null`
- `REPOPILOT_ZOO=1 cargo test --test zoo_regression`