### PR TITLE
fix(zoo): bind scans to the current workspace binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **Real-repo zoo scans now build and run the current workspace RepoPilot by
+  default.** `python3 scripts/zoo.py scan` invokes Cargo once, uses the
+  executable Cargo reports, and prints scanner provenance before scanning so
+  stale `target/release` or `target/debug` artifacts can no longer make the gate
+  pass silently. Explicit external binaries remain supported with `--repopilot`,
+  but they are version/report-metadata checked and require
+  `--allow-version-mismatch` for intentional cross-version runs.
+
 - **`language.javascript.runtime-exit-risk` (and other generated-file-aware
   rules) no longer flag vendored/generated bundles such as Emscripten/WASM
   glue.** An Emscripten `process.exit` shim in compiled WASM bindings is not the

--- a/scripts/zoo.py
+++ b/scripts/zoo.py
@@ -1,26 +1,10 @@
 #!/usr/bin/env python3
 """RepoPilot real-repo validation "zoo".
 
-Clones a curated set of real open-source repos (pinned to fixed commit SHAs)
-into a gitignored `.zoo/` directory, scans each with RepoPilot, and snapshots
-per-rule finding counts so we can track how the default profile behaves on real
-diversity — not just synthetic fixtures.
+Clones pinned real repositories into the gitignored `.zoo/`, scans them with the
+current workspace RepoPilot by default, and compares committed snapshots. Repo
+contents are never committed; only tests/zoo/snapshots/*.json are tracked.
 
-Repo contents are never committed; only tests/zoo/snapshots/*.json are tracked.
-
-Subcommands:
-    list          Print the manifest as a table.
-    verify-pins   Check each cloned repo HEAD matches its pinned SHA.
-    clone         Shallow-fetch each repo at its pinned SHA into .zoo/<name>/.
-    scan          Scan each cloned repo (default + strict) and write snapshots.
-    report        Aggregate snapshots into a per-rule noise-suspect table.
-
-Typical loop:
-    python3 scripts/zoo.py clone
-    python3 scripts/zoo.py scan            # writes tests/zoo/snapshots/*.json
-    python3 scripts/zoo.py report          # markdown triage table
-
-Use --bless on `scan` to (re)write committed snapshots after an intended change.
 See tests/zoo/README.md for the full workflow.
 """
 
@@ -35,6 +19,15 @@ import tomllib
 from collections import Counter
 from pathlib import Path
 from typing import Any
+
+from zoo_scanner import (
+    ScannerPreparationError,
+    ScannerProvenanceError,
+    prepare_scanner,
+    print_scanner_provenance,
+    run,
+    scan_repo,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / "tests" / "zoo" / "manifest.toml"
@@ -66,19 +59,6 @@ def load_manifest() -> list[dict[str, Any]]:
 
 def repo_path(repo: dict[str, Any]) -> Path:
     return ZOO_DIR / repo["name"]
-
-
-# ----------------------------------------------------------------------------
-# git helpers
-# ----------------------------------------------------------------------------
-def run(cmd: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        cmd,
-        cwd=str(cwd) if cwd else None,
-        text=True,
-        capture_output=True,
-        check=check,
-    )
 
 
 def head_sha(path: Path) -> str | None:
@@ -158,30 +138,6 @@ def cmd_clone(args: argparse.Namespace) -> int:
     return 0
 
 
-def find_repopilot(explicit: str | None) -> list[str]:
-    """Resolve the repopilot invocation: explicit > release > debug > cargo run."""
-    if explicit:
-        return [explicit]
-    for build in ("release", "debug"):
-        candidate = REPO_ROOT / "target" / build / "repopilot"
-        if candidate.exists():
-            return [str(candidate)]
-    return ["cargo", "run", "-q", "--release", "--manifest-path", str(REPO_ROOT / "Cargo.toml"), "--"]
-
-
-def scan_repo(bin_cmd: list[str], path: Path, profile: str) -> dict[str, Any]:
-    proc = run(
-        bin_cmd + ["scan", str(path), "--format", "json", "--profile", profile],
-        check=False,
-    )
-    if proc.returncode not in (0, 1):  # 1 == findings present / fail-on threshold
-        raise SystemExit(f"scan failed for {path} ({profile}):\n{proc.stderr.strip()}")
-    try:
-        return json.loads(proc.stdout)
-    except json.JSONDecodeError as exc:
-        raise SystemExit(f"scan produced invalid JSON for {path} ({profile}): {exc}")
-
-
 def visible_findings(report: dict[str, Any]) -> list[dict[str, Any]]:
     findings = report.get("findings")
     return [f for f in findings if isinstance(f, dict)] if isinstance(findings, list) else []
@@ -223,7 +179,20 @@ def snapshot_for(repo: dict[str, Any], default_report: dict[str, Any], strict_re
 
 def cmd_scan(args: argparse.Namespace) -> int:
     repos = select(load_manifest(), args.only)
-    bin_cmd = find_repopilot(args.repopilot)
+    try:
+        scanner = prepare_scanner(
+            REPO_ROOT,
+            args.repopilot,
+            args.allow_version_mismatch,
+        )
+    except ScannerPreparationError as exc:
+        print(f"SCANNER PREPARATION FAILED\n{exc}", file=sys.stderr)
+        return 2
+    except ScannerProvenanceError as exc:
+        print(f"SCANNER PROVENANCE FAILED\n{exc}", file=sys.stderr)
+        return 3
+
+    print_scanner_provenance(scanner)
     SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
     drift = False
     for repo in repos:
@@ -235,8 +204,8 @@ def cmd_scan(args: argparse.Namespace) -> int:
         print(f"  scanning {repo['name']} ...")
         snap = snapshot_for(
             repo,
-            scan_repo(bin_cmd, path, "default"),
-            scan_repo(bin_cmd, path, "strict"),
+            scan_repo(scanner, path, "default"),
+            scan_repo(scanner, path, "strict"),
         )
         out = SNAPSHOT_DIR / f"{repo['name']}.json"
         rendered = json.dumps(snap, indent=2, sort_keys=True) + "\n"
@@ -306,7 +275,15 @@ def main() -> int:
     p_scan = sub.add_parser("scan", help="scan repos and write/check snapshots")
     p_scan.add_argument("--only", help="comma-separated repo names")
     p_scan.add_argument("--bless", action="store_true", help="(re)write committed snapshots")
-    p_scan.add_argument("--repopilot", help="path to repopilot binary (default: target/release|debug, else cargo run)")
+    p_scan.add_argument(
+        "--repopilot",
+        help="explicit path to an external repopilot binary (default: build current workspace)",
+    )
+    p_scan.add_argument(
+        "--allow-version-mismatch",
+        action="store_true",
+        help="allow --repopilot to use a version that differs from this workspace",
+    )
     p_scan.set_defaults(func=cmd_scan)
 
     sub.add_parser("report", help="aggregate snapshots into a triage table").set_defaults(func=cmd_report)

--- a/scripts/zoo_scanner.py
+++ b/scripts/zoo_scanner.py
@@ -1,0 +1,300 @@
+"""Scanner preparation for the real-repo validation zoo."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import tempfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+WORKSPACE_PROFILE = "release"
+
+
+class ScannerPreparationError(RuntimeError):
+    pass
+
+class ScannerProvenanceError(RuntimeError):
+    pass
+
+@dataclass(frozen=True)
+class ReportIdentity:
+    repopilot_version: str
+    schema_version: str
+
+
+@dataclass(frozen=True)
+class ScannerProvenance:
+    mode: str
+    command: tuple[str, ...]
+    binary: Path
+    version: str
+    report_schema_version: str
+    workspace_version: str
+    profile: str | None = None
+    workspace_commit: str | None = None
+    workspace_dirty: bool | None = None
+    version_mismatch_allowed: bool = False
+
+def run(cmd: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+def format_cmd(cmd: list[str] | tuple[str, ...]) -> str:
+    return shlex.join(str(part) for part in cmd)
+
+def completed_diagnostic(proc: subprocess.CompletedProcess[str]) -> str:
+    outcome = "failed" if proc.returncode else "completed"
+    details = [f"command {outcome} ({proc.returncode}): {format_cmd(tuple(str(a) for a in proc.args))}"]
+    if proc.stderr.strip():
+        details.append(f"stderr:\n{proc.stderr.strip()}")
+    if proc.stdout.strip():
+        details.append(f"stdout:\n{proc.stdout.strip()}")
+    return "\n".join(details)
+
+
+def prepare_scanner(repo_root: Path, explicit: str | None, allow_version_mismatch: bool) -> ScannerProvenance:
+    workspace_version = read_workspace_version(repo_root)
+    if explicit:
+        mode = "explicit"
+        profile = None
+        binary = resolve_explicit_binary(explicit)
+    else:
+        mode = "workspace"
+        profile = WORKSPACE_PROFILE
+        binary = build_workspace_binary(repo_root)
+
+    command = (str(binary),)
+    cli_version = read_cli_version(command)
+    default_identity, strict_identity = read_report_identities(command)
+    validate_report_consistency(cli_version, default_identity, strict_identity)
+    mismatch_allowed = validate_workspace_version(
+        mode,
+        cli_version,
+        workspace_version,
+        allow_version_mismatch,
+    )
+    commit, dirty = workspace_git_state(repo_root) if mode == "workspace" else (None, None)
+    return ScannerProvenance(
+        mode=mode,
+        command=command,
+        binary=binary,
+        version=cli_version,
+        report_schema_version=default_identity.schema_version,
+        workspace_version=workspace_version,
+        profile=profile,
+        workspace_commit=commit,
+        workspace_dirty=dirty,
+        version_mismatch_allowed=mismatch_allowed,
+    )
+
+
+def print_scanner_provenance(scanner: ScannerProvenance) -> None:
+    print(f"scanner mode: {scanner.mode}")
+    if scanner.profile:
+        print(f"scanner profile: {scanner.profile}")
+    print(f"scanner binary: {scanner.binary}")
+    print(f"scanner version: {scanner.version}")
+    print(f"scanner report schema: {scanner.report_schema_version}")
+    if scanner.version_mismatch_allowed:
+        print(f"workspace version: {scanner.workspace_version} (mismatch allowed)")
+    if scanner.workspace_commit:
+        print(f"workspace commit: {scanner.workspace_commit}")
+    if scanner.workspace_dirty is not None:
+        print(f"workspace dirty: {str(scanner.workspace_dirty).lower()}")
+    print()
+
+
+def build_workspace_binary(repo_root: Path) -> Path:
+    cmd = ["cargo", "build", "--release", "--manifest-path", str(repo_root / "Cargo.toml")]
+    cmd.append("--message-format=json-render-diagnostics")
+    proc = run(cmd, cwd=repo_root, check=False)
+    if proc.returncode != 0:
+        raise ScannerPreparationError("scanner build failed\n" + completed_diagnostic(proc))
+    executable = cargo_build_executable(proc.stdout)
+    if executable is None:
+        raise ScannerPreparationError(
+            "scanner build did not report a repopilot executable\n"
+            + completed_diagnostic(proc)
+        )
+    if not executable.exists():
+        raise ScannerPreparationError(
+            f"cargo reported repopilot executable that does not exist: {executable}"
+        )
+    return executable
+
+
+def cargo_build_executable(stdout: str) -> Path | None:
+    executable: Path | None = None
+    for line in stdout.splitlines():
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if message.get("reason") != "compiler-artifact":
+            continue
+        target, kind = message.get("target"), None
+        if isinstance(target, dict):
+            kind = target.get("kind")
+        if not isinstance(target, dict) or target.get("name") != "repopilot":
+            continue
+        raw_executable = message.get("executable")
+        if isinstance(kind, list) and "bin" in kind and isinstance(raw_executable, str):
+            executable = Path(raw_executable)
+    return executable
+
+
+def resolve_explicit_binary(explicit: str) -> Path:
+    binary = Path(explicit).expanduser()
+    if not binary.is_absolute():
+        binary = (Path.cwd() / binary).resolve()
+    if not binary.exists():
+        raise ScannerPreparationError(f"explicit repopilot binary does not exist: {binary}")
+    if not os.access(binary, os.X_OK):
+        raise ScannerPreparationError(f"explicit repopilot binary is not executable: {binary}")
+    return binary
+
+
+def read_workspace_version(repo_root: Path) -> str:
+    data = tomllib.loads((repo_root / "Cargo.toml").read_text(encoding="utf-8"))
+    package = data.get("package")
+    if not isinstance(package, dict) or not isinstance(package.get("version"), str):
+        raise ScannerPreparationError("could not read package.version from Cargo.toml")
+    return package["version"]
+
+
+def read_cli_version(command: tuple[str, ...]) -> str:
+    proc = run([*command, "--version"], check=False)
+    if proc.returncode != 0:
+        raise ScannerProvenanceError("scanner version check failed\n" + completed_diagnostic(proc))
+    text = "\n".join(part.strip() for part in (proc.stdout, proc.stderr) if part.strip())
+    match = re.search(r"(?im)^repopilot\s+([^\s]+)\s*$", text)
+    if not match:
+        raise ScannerProvenanceError(
+            "scanner did not identify itself as RepoPilot via --version\n"
+            f"output:\n{text}"
+        )
+    return match.group(1)
+
+
+def read_report_identities(command: tuple[str, ...]) -> tuple[ReportIdentity, ReportIdentity]:
+    with tempfile.TemporaryDirectory(prefix="repopilot-zoo-identity-") as tmp:
+        root = Path(tmp)
+        return (
+            read_report_identity(command, root, "default"),
+            read_report_identity(command, root, "strict"),
+        )
+
+
+def read_report_identity(command: tuple[str, ...], root: Path, profile: str) -> ReportIdentity:
+    proc = run(
+        [*command, "scan", str(root), "--format", "json", "--profile", profile],
+        check=False,
+    )
+    if proc.returncode not in (0, 1):
+        raise ScannerProvenanceError(
+            f"scanner identity scan failed for {profile} profile\n"
+            + completed_diagnostic(proc)
+        )
+    try:
+        report = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise ScannerProvenanceError(
+            f"scanner identity scan produced invalid JSON for {profile} profile: {exc}"
+        ) from exc
+    return validate_report_identity(report, profile)
+
+
+def validate_report_identity(report: dict[str, Any], profile: str) -> ReportIdentity:
+    schema_version = report.get("schema_version")
+    repopilot_version = report.get("repopilot_version")
+    envelope = report.get("report")
+    if not isinstance(schema_version, str) or not isinstance(repopilot_version, str):
+        raise ScannerProvenanceError(
+            f"{profile} report is missing top-level schema/version metadata"
+        )
+    if not isinstance(envelope, dict):
+        raise ScannerProvenanceError(f"{profile} report is missing report envelope metadata")
+    if envelope.get("kind") != "scan":
+        raise ScannerProvenanceError(
+            f"{profile} report envelope kind is not 'scan': {envelope.get('kind')!r}"
+        )
+    if envelope.get("schema_version") != schema_version:
+        raise ScannerProvenanceError(
+            f"{profile} report schema mismatch: top-level {schema_version!r}, "
+            f"envelope {envelope.get('schema_version')!r}"
+        )
+    if envelope.get("repopilot_version") != repopilot_version:
+        raise ScannerProvenanceError(
+            f"{profile} report version mismatch: top-level {repopilot_version!r}, "
+            f"envelope {envelope.get('repopilot_version')!r}"
+        )
+    return ReportIdentity(repopilot_version=repopilot_version, schema_version=schema_version)
+
+
+def validate_report_consistency(
+    cli_version: str,
+    default_identity: ReportIdentity,
+    strict_identity: ReportIdentity,
+) -> None:
+    for profile, identity in (("default", default_identity), ("strict", strict_identity)):
+        if identity.repopilot_version != cli_version:
+            raise ScannerProvenanceError(
+                f"{profile} report version {identity.repopilot_version} "
+                f"does not match --version {cli_version}"
+            )
+    if default_identity.schema_version != strict_identity.schema_version:
+        raise ScannerProvenanceError(
+            "default and strict reports use different schema versions: "
+            f"{default_identity.schema_version} vs {strict_identity.schema_version}"
+        )
+
+
+def validate_workspace_version(
+    mode: str,
+    scanner_version: str,
+    workspace_version: str,
+    allow_version_mismatch: bool,
+) -> bool:
+    if scanner_version == workspace_version:
+        return False
+    if mode == "explicit" and allow_version_mismatch:
+        return True
+    hint = "\npass --allow-version-mismatch to intentionally test another version" if mode == "explicit" else ""
+    raise ScannerProvenanceError(
+        f"scanner version {scanner_version} does not match workspace Cargo.toml "
+        f"version {workspace_version}{hint}"
+    )
+
+
+def workspace_git_state(repo_root: Path) -> tuple[str | None, bool | None]:
+    commit_proc = run(["git", "rev-parse", "HEAD"], cwd=repo_root, check=False)
+    commit = commit_proc.stdout.strip() if commit_proc.returncode == 0 else None
+    status_proc = run(["git", "status", "--porcelain"], cwd=repo_root, check=False)
+    dirty = bool(status_proc.stdout.strip()) if status_proc.returncode == 0 else None
+    return commit, dirty
+
+
+def scan_repo(scanner: ScannerProvenance, path: Path, profile: str) -> dict[str, Any]:
+    proc = run(
+        [*scanner.command, "scan", str(path), "--format", "json", "--profile", profile],
+        check=False,
+    )
+    if proc.returncode not in (0, 1):
+        raise SystemExit(f"scan failed for {path} ({profile}):\n{completed_diagnostic(proc)}")
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"scan produced invalid JSON for {path} ({profile}): {exc}") from exc

--- a/tests/zoo/README.md
+++ b/tests/zoo/README.md
@@ -34,6 +34,22 @@ Other helpers: `python3 scripts/zoo.py list` (manifest table),
 `python3 scripts/zoo.py verify-pins` (clones match pins), and `--only a,b`
 on `clone`/`scan` to work a subset.
 
+`scan` builds the current workspace once with Cargo, resolves the executable
+Cargo produced, validates its version/report metadata, and then reuses that
+binary for every repo/profile scan. Existing `target/release/repopilot` or
+`target/debug/repopilot` artifacts are never selected just because they already
+exist.
+
+To intentionally compare snapshots with an external binary:
+
+```bash
+python3 scripts/zoo.py scan --repopilot /path/to/repopilot
+python3 scripts/zoo.py scan --repopilot /path/to/repopilot --allow-version-mismatch
+```
+
+External binaries are provenance-checked too. A version mismatch fails unless
+`--allow-version-mismatch` is supplied.
+
 ## As a regression gate
 
 [`tests/zoo_regression.rs`](../zoo_regression.rs) wraps `zoo.py scan` and is

--- a/tests/zoo_regression.rs
+++ b/tests/zoo_regression.rs
@@ -55,9 +55,22 @@ fn zoo_snapshots_match_committed() {
     print!("{}", String::from_utf8_lossy(&output.stdout));
     eprint!("{}", String::from_utf8_lossy(&output.stderr));
 
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let failure_kind =
+        if output.status.code() == Some(2) || stderr.contains("SCANNER PREPARATION FAILED") {
+            "scanner build/resolution failure"
+        } else if output.status.code() == Some(3) || stderr.contains("SCANNER PROVENANCE FAILED") {
+            "scanner provenance/version failure"
+        } else if stdout.contains("DRIFT vs committed snapshot") {
+            "real snapshot drift"
+        } else {
+            "zoo scan failure"
+        };
+
     assert!(
         output.status.success(),
-        "zoo snapshots drifted from committed values. Review the diff above; \
+        "zoo regression failed ({failure_kind}). Review the output above; \
          if the change is intended, re-bless with \
          `python3 scripts/zoo.py scan --bless`."
     );

--- a/tests/zoo_runner_contract.rs
+++ b/tests/zoo_runner_contract.rs
@@ -1,0 +1,294 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+struct Harness {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    bin_dir: PathBuf,
+    cargo_log: PathBuf,
+    scan_log: PathBuf,
+    stale_log: PathBuf,
+    current: PathBuf,
+    explicit: PathBuf,
+}
+
+impl Harness {
+    fn new(current_relative: &str) -> Self {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let root = temp.path().join("repo");
+        let bin_dir = root.join("fake-bin");
+        let cargo_log = root.join("cargo.log");
+        let scan_log = root.join("scan.log");
+        let stale_log = root.join("stale.log");
+        let current = root.join(current_relative);
+        let explicit = root.join("external/repopilot");
+        fs::create_dir_all(root.join("scripts")).expect("scripts dir");
+        fs::create_dir_all(root.join("tests/zoo/snapshots")).expect("snapshot dir");
+        fs::create_dir_all(root.join(".zoo/sample")).expect("zoo clone");
+        fs::create_dir_all(&bin_dir).expect("bin dir");
+        copy_script(&root, "zoo.py");
+        copy_script(&root, "zoo_scanner.py");
+        fs::write(root.join("Cargo.toml"), CARGO_TOML).expect("Cargo.toml");
+        fs::write(root.join("tests/zoo/manifest.toml"), MANIFEST).expect("manifest");
+        fs::write(root.join("tests/zoo/snapshots/sample.json"), SNAPSHOT).expect("snapshot");
+        write_executable(&bin_dir.join("cargo"), fake_cargo());
+        write_executable(&bin_dir.join("git"), fake_git());
+        write_executable(&current, fake_repopilot());
+        write_executable(&explicit, fake_repopilot());
+        write_executable(&root.join("target/release/repopilot"), stale_repopilot());
+        Self {
+            _temp: temp,
+            root,
+            bin_dir,
+            cargo_log,
+            scan_log,
+            stale_log,
+            current,
+            explicit,
+        }
+    }
+
+    fn run(&self, args: &[&str], extra_env: &[(&str, String)]) -> Output {
+        let mut cmd = Command::new("python3");
+        cmd.arg("scripts/zoo.py").args(args).current_dir(&self.root);
+        cmd.env("PATH", path_with_fake_bin(&self.bin_dir));
+        cmd.env("FAKE_CARGO_LOG", &self.cargo_log);
+        cmd.env("FAKE_SCAN_LOG", &self.scan_log);
+        cmd.env("FAKE_STALE_LOG", &self.stale_log);
+        cmd.env("FAKE_CARGO_EXECUTABLE", &self.current);
+        for (key, value) in extra_env {
+            cmd.env(key, value);
+        }
+        cmd.output().expect("run zoo.py")
+    }
+}
+
+#[test]
+fn workspace_mode_builds_once_ignores_stale_target_binary_and_keeps_snapshots() {
+    let h = Harness::new("fresh/repopilot");
+    let output = h.run(&["scan", "--only", "sample"], &[]);
+    assert_success(&output);
+    let stdout = text(&output.stdout);
+    assert_contains(&stdout, "scanner mode: workspace");
+    assert_contains(&stdout, "scanner profile: release");
+    assert_contains(&stdout, format!("scanner binary: {}", h.current.display()));
+    assert_contains(&stdout, "scanner version: 0.18.0");
+    assert_contains(
+        &stdout,
+        "workspace commit: 0123456789abcdef0123456789abcdef01234567",
+    );
+    assert_contains(&stdout, "workspace dirty: false");
+    assert!(
+        stdout.find("scanner mode: workspace")
+            < stdout.find("  scanning sample").or(Some(usize::MAX))
+    );
+    assert_contains(&stdout, "ok (default-visible: 0)");
+    assert_eq!(line_count(&h.cargo_log), 1, "cargo build should run once");
+    assert!(
+        !h.stale_log.exists(),
+        "stale target/release binary was selected"
+    );
+}
+
+#[test]
+fn explicit_repopilot_path_is_used_without_cargo_build() {
+    let h = Harness::new("fresh/repopilot");
+    let explicit = h.explicit.to_str().unwrap();
+    let output = h.run(&["scan", "--only", "sample", "--repopilot", explicit], &[]);
+    assert_success(&output);
+    let stdout = text(&output.stdout);
+    assert_contains(&stdout, "scanner mode: explicit");
+    assert_contains(&stdout, format!("scanner binary: {}", h.explicit.display()));
+    assert!(
+        !h.cargo_log.exists(),
+        "explicit mode should not invoke cargo"
+    );
+    assert!(
+        fs::read_to_string(&h.scan_log)
+            .unwrap()
+            .contains(&h.explicit.display().to_string())
+    );
+}
+
+#[test]
+fn explicit_version_mismatch_requires_opt_in() {
+    let h = Harness::new("fresh/repopilot");
+    let mismatch = [("FAKE_REPOPILOT_VERSION", "9.9.9".to_string())];
+    let explicit = h.explicit.to_str().unwrap();
+    let output = h.run(
+        &["scan", "--only", "sample", "--repopilot", explicit],
+        &mismatch,
+    );
+    assert_eq!(output.status.code(), Some(3), "{}", text(&output.stderr));
+    let stderr = text(&output.stderr);
+    assert!(stderr.contains("SCANNER PROVENANCE FAILED"), "{stderr}");
+    assert!(stderr.contains("--allow-version-mismatch"), "{stderr}");
+
+    let allowed = h.run(
+        &[
+            "scan",
+            "--only",
+            "sample",
+            "--repopilot",
+            explicit,
+            "--allow-version-mismatch",
+        ],
+        &mismatch,
+    );
+    assert_success(&allowed);
+    assert!(text(&allowed.stdout).contains("workspace version: 0.18.0 (mismatch allowed)"));
+}
+
+#[test]
+fn workspace_build_uses_cargo_reported_target_dir_and_exe_artifact() {
+    let h = Harness::new("custom-target/release/repopilot.exe");
+    let target_dir = h.root.join("custom-target");
+    let output = h.run(
+        &["scan", "--only", "sample"],
+        &[("CARGO_TARGET_DIR", target_dir.display().to_string())],
+    );
+    assert_success(&output);
+    let stdout = text(&output.stdout);
+    assert_contains(&stdout, "custom-target/release/repopilot.exe");
+    let cargo_log = fs::read_to_string(&h.cargo_log).expect("cargo log");
+    assert!(cargo_log.contains(&format!("CARGO_TARGET_DIR={}", target_dir.display())));
+}
+
+#[test]
+fn provenance_rejects_inconsistent_default_and_strict_report_metadata() {
+    let h = Harness::new("fresh/repopilot");
+    let output = h.run(
+        &["scan", "--only", "sample"],
+        &[("FAKE_STRICT_SCHEMA_VERSION", "9.99".to_string())],
+    );
+    assert_eq!(output.status.code(), Some(3), "{}", text(&output.stderr));
+    let stderr = text(&output.stderr);
+    assert!(stderr.contains("SCANNER PROVENANCE FAILED"), "{stderr}");
+    assert!(stderr.contains("different schema versions"), "{stderr}");
+    assert!(!text(&output.stdout).contains("  scanning sample"));
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+fn copy_script(root: &Path, name: &str) {
+    fs::copy(
+        repo_root().join("scripts").join(name),
+        root.join("scripts").join(name),
+    )
+    .unwrap_or_else(|err| panic!("copy {name}: {err}"));
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::create_dir_all(path.parent().expect("parent")).expect("executable parent");
+    fs::write(path, contents).expect("write executable");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod");
+    }
+}
+
+fn path_with_fake_bin(bin_dir: &Path) -> std::ffi::OsString {
+    let old_path = env::var_os("PATH").unwrap_or_default();
+    let paths = std::iter::once(bin_dir.to_path_buf()).chain(env::split_paths(&old_path));
+    env::join_paths(paths).expect("join PATH")
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        text(&output.stdout),
+        text(&output.stderr)
+    );
+}
+
+fn assert_contains(haystack: &str, needle: impl AsRef<str>) {
+    assert!(haystack.contains(needle.as_ref()), "{haystack}");
+}
+
+fn text(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn line_count(path: &Path) -> usize {
+    fs::read_to_string(path).expect("log").lines().count()
+}
+
+const CARGO_TOML: &str =
+    "[package]\nname = \"repopilot\"\nversion = \"0.18.0\"\nedition = \"2024\"\n";
+const MANIFEST: &str = "[[repo]]\nname = \"sample\"\nurl = \"https://example.invalid/sample.git\"\nsha = \"abc123\"\nlanguage = \"rust\"\n";
+const SNAPSHOT: &str = "{\n  \"default\": {\n    \"by_priority\": {},\n    \"by_rule\": {},\n    \"fingerprints\": [],\n    \"visible_total\": 0\n  },\n  \"framework\": \"\",\n  \"language\": \"rust\",\n  \"repo\": \"sample\",\n  \"sha\": \"abc123\",\n  \"strict\": {\n    \"by_rule\": {},\n    \"visible_total\": 0\n  }\n}\n";
+
+fn fake_cargo() -> &'static str {
+    r#"#!/usr/bin/env python3
+import json, os, sys
+with open(os.environ["FAKE_CARGO_LOG"], "a", encoding="utf-8") as log:
+    log.write(" ".join(sys.argv[1:]) + "|CARGO_TARGET_DIR=" + os.environ.get("CARGO_TARGET_DIR", "") + "\n")
+if len(sys.argv) > 1 and sys.argv[1] == "build":
+    print(json.dumps({
+        "reason": "compiler-artifact",
+        "target": {"kind": ["bin"], "name": "repopilot"},
+        "executable": os.environ["FAKE_CARGO_EXECUTABLE"],
+    }))
+    print(json.dumps({"reason": "build-finished", "success": True}))
+    raise SystemExit(0)
+print("unexpected cargo args: " + repr(sys.argv), file=sys.stderr)
+raise SystemExit(9)
+"#
+}
+
+fn fake_git() -> &'static str {
+    r#"#!/usr/bin/env python3
+import os, sys
+if sys.argv[1:] == ["rev-parse", "HEAD"]:
+    print("0123456789abcdef0123456789abcdef01234567")
+    raise SystemExit(0)
+if sys.argv[1:] == ["status", "--porcelain"]:
+    print(os.environ.get("FAKE_GIT_STATUS", ""), end="")
+    raise SystemExit(0)
+print("unexpected git args: " + repr(sys.argv), file=sys.stderr)
+raise SystemExit(9)
+"#
+}
+
+fn fake_repopilot() -> &'static str {
+    r#"#!/usr/bin/env python3
+import json, os, sys
+with open(os.environ["FAKE_SCAN_LOG"], "a", encoding="utf-8") as log:
+    log.write(sys.argv[0] + "|" + " ".join(sys.argv[1:]) + "\n")
+if sys.argv[1:] == ["--version"]:
+    print("repopilot " + os.environ.get("FAKE_REPOPILOT_VERSION", "0.18.0"))
+    raise SystemExit(0)
+if len(sys.argv) > 1 and sys.argv[1] == "scan":
+    profile = sys.argv[sys.argv.index("--profile") + 1]
+    version = os.environ.get("FAKE_REPOPILOT_VERSION", "0.18.0")
+    schema = os.environ.get("FAKE_REPOPILOT_SCHEMA_VERSION", "0.19")
+    if profile == "strict":
+        version = os.environ.get("FAKE_STRICT_REPOPILOT_VERSION", version)
+        schema = os.environ.get("FAKE_STRICT_SCHEMA_VERSION", schema)
+    print(json.dumps({
+        "schema_version": schema,
+        "repopilot_version": version,
+        "report": {"kind": "scan", "schema_version": schema, "repopilot_version": version},
+        "findings": [],
+    }))
+    raise SystemExit(0)
+print("unexpected repopilot args: " + repr(sys.argv), file=sys.stderr)
+raise SystemExit(9)
+"#
+}
+
+fn stale_repopilot() -> &'static str {
+    r#"#!/usr/bin/env python3
+import os, sys
+with open(os.environ["FAKE_STALE_LOG"], "a", encoding="utf-8") as log:
+    log.write("stale invoked\n")
+print("stale target binary was used", file=sys.stderr)
+raise SystemExit(88)
+"#
+}


### PR DESCRIPTION
## Summary
- Build the current workspace RepoPilot once before default zoo scans.
- Resolve the scanner executable from Cargo JSON build output instead of stale target paths.
- Add scanner provenance/version/report metadata validation.
- Keep explicit external binaries with a guarded version-mismatch opt-in.
- Add focused fake-runner regression coverage and improve opt-in zoo failure classification.

## Testing
- python3 -m py_compile scripts/zoo.py scripts/zoo_scanner.py
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --test zoo_runner_contract
- cargo test --all
- npm run release:contract
- npm run test:release-contract
- python3 scripts/zoo.py verify-pins
- python3 scripts/zoo.py scan --only ripgrep
- cargo test --test zoo_regression
- REPOPILOT_ZOO=1 cargo test --test zoo_regression

## Note
`REPOPILOT_ZOO=1 cargo test --test zoo_regression` now correctly fails on an existing `excalidraw` snapshot drift when using the current workspace binary. Snapshots were not re-blessed in this change.