### PR TITLE
feat(zoo): add labeled precision expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **The real-repo zoo now records human-reviewed dispositions for findings.** A
+  new tracked `tests/zoo/expectations/<repo>.toml` layer (one versioned file per
+  manifest repo) sits alongside the generated snapshots: snapshots answer *what
+  RepoPilot emitted*, expectations answer *how a human reviewed it*. Every
+  default-visible finding must be exhaustively labeled `actionable`,
+  `valid-but-accepted`, or `false-positive` with a non-empty reason; selected
+  strict findings act as `selective` recall anchors that fail if they disappear.
+  `python3 scripts/zoo.py scan` now validates labels and reports snapshot drift
+  and expectation failures (unlabeled / stale / duplicate / invalid / ambiguous /
+  missing-anchor / known-false-positive) on separate channels; `triage` prints
+  unlabeled findings with evidence and a copy-paste `REVIEW_REQUIRED` skeleton
+  (never guessing a disposition); `report` adds a reviewed signal-quality summary
+  (actionable/accepted/false-positive totals, a reviewed precision *proxy*, and an
+  actionability rate). The matcher disambiguates findings that share a stable id
+  via line, so distinct occurrences are never merged. Labels never suppress
+  analyzer output — `false-positive` is surfaced as calibration debt, not a
+  suppression — and `--bless` never writes human labels. Hermetic
+  `zoo_expectations_contract` test covers the pure parse/match/render helpers; the
+  real zoo stays opt-in behind `REPOPILOT_ZOO=1`.
+
 - **`repopilot ai context --format json`** emits a structured, deterministic JSON
   handoff so agents get the same facts the Markdown brief carries without parsing
   Markdown, matching the JSON the MCP tools already return. Each finding includes

--- a/scripts/zoo.py
+++ b/scripts/zoo.py
@@ -20,6 +20,8 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+import zoo_expectations as ze
+import zoo_triage as zt
 from zoo_scanner import (
     ScannerPreparationError,
     ScannerProvenanceError,
@@ -32,6 +34,7 @@ from zoo_scanner import (
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / "tests" / "zoo" / "manifest.toml"
 SNAPSHOT_DIR = REPO_ROOT / "tests" / "zoo" / "snapshots"
+EXPECTATION_DIR = REPO_ROOT / "tests" / "zoo" / "expectations"
 ZOO_DIR = REPO_ROOT / ".zoo"
 
 # Default-visible volume above this on a single repo flags a rule as a
@@ -177,6 +180,10 @@ def snapshot_for(repo: dict[str, Any], default_report: dict[str, Any], strict_re
     }
 
 
+def expectation_path(repo_name: str) -> Path:
+    return EXPECTATION_DIR / f"{repo_name}.toml"
+
+
 def cmd_scan(args: argparse.Namespace) -> int:
     repos = select(load_manifest(), args.only)
     try:
@@ -195,6 +202,7 @@ def cmd_scan(args: argparse.Namespace) -> int:
     print_scanner_provenance(scanner)
     SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
     drift = False
+    live: dict[str, tuple[list[Any], list[Any]]] = {}
     for repo in repos:
         path = repo_path(repo)
         if not path.exists():
@@ -202,11 +210,13 @@ def cmd_scan(args: argparse.Namespace) -> int:
             drift = True
             continue
         print(f"  scanning {repo['name']} ...")
-        snap = snapshot_for(
-            repo,
-            scan_repo(scanner, path, "default"),
-            scan_repo(scanner, path, "strict"),
+        default_report = scan_repo(scanner, path, "default")
+        strict_report = scan_repo(scanner, path, "strict")
+        live[repo["name"]] = (
+            ze.parse_live_findings(default_report, path, "default"),
+            ze.parse_live_findings(strict_report, path, "strict"),
         )
+        snap = snapshot_for(repo, default_report, strict_report)
         out = SNAPSHOT_DIR / f"{repo['name']}.json"
         rendered = json.dumps(snap, indent=2, sort_keys=True) + "\n"
         if args.bless or not out.exists():
@@ -219,7 +229,57 @@ def cmd_scan(args: argparse.Namespace) -> int:
                 print(f"    DRIFT vs committed snapshot {out.relative_to(REPO_ROOT)} (re-run with --bless to accept)")
             else:
                 print(f"    ok (default-visible: {snap['default']['visible_total']})")
-    return 1 if drift and not args.bless else 0
+
+    exp_diags = validate_expectations(repos, live)
+    print_expectation_diagnostics(exp_diags)
+    expectation_failed = any(ze.is_failure(d.kind) for d in exp_diags)
+    snapshot_failed = drift and not args.bless
+    return 1 if snapshot_failed or expectation_failed else 0
+
+
+def validate_expectations(
+    selected: list[dict[str, Any]],
+    live: dict[str, tuple[list[Any], list[Any]]],
+) -> list[ze.Diagnostic]:
+    """Parse + match expectation files for the selected repos against live findings."""
+    if not EXPECTATION_DIR.exists():
+        print("  no expectations directory; skipping expectation validation")
+        return []
+    manifest_names = [r["name"] for r in load_manifest()]
+    present_stems = [p.stem for p in EXPECTATION_DIR.glob("*.toml")]
+    required = [r["name"] for r in selected]
+    diags = list(ze.coverage_diagnostics(required, manifest_names, present_stems))
+    present = set(present_stems)
+    for repo in selected:
+        name = repo["name"]
+        if name not in present:
+            continue  # MISSING EXPECTATION FILE already reported by coverage_diagnostics
+        expectation, pdiags = ze.parse_expectation_file(expectation_path(name), name)
+        diags += pdiags
+        if expectation is None or name not in live:
+            continue
+        default_lives, strict_lives = live[name]
+        mdiags, _review = ze.match_repo(name, expectation, default_lives, strict_lives)
+        diags += mdiags
+    return diags
+
+
+def print_expectation_diagnostics(diags: list[ze.Diagnostic]) -> None:
+    if not diags:
+        print("\nexpectations: every default-visible finding labeled; strict anchors intact")
+        return
+    by_kind: dict[str, list[ze.Diagnostic]] = {}
+    for diag in diags:
+        by_kind.setdefault(diag.kind, []).append(diag)
+    print("\n== expectation review ==")
+    for kind in ze.DIAGNOSTIC_ORDER:
+        items = by_kind.get(kind)
+        if not items:
+            continue
+        tag = "FAIL" if ze.is_failure(kind) else "info"
+        print(f"\n[{tag}] {kind} ({len(items)})")
+        for diag in sorted(items, key=lambda d: (d.repo, d.message)):
+            print(f"  - {diag.repo}: {diag.message}")
 
 
 def cmd_report(_args: argparse.Namespace) -> int:
@@ -246,6 +306,122 @@ def cmd_report(_args: argparse.Namespace) -> int:
         print(f"\n## Noise suspects (>= {NOISE_SUSPECT_PER_REPO} default-visible on one repo)")
         for line in suspects:
             print(f"  - {line}")
+    report_reviewed_quality(snaps)
+    return 0
+
+
+def report_reviewed_quality(snaps: list[Path]) -> None:
+    """Reviewed signal-quality summary derived from committed snapshots + labels.
+
+    This reads only committed data (no clones): default-visible totals come from
+    snapshots, dispositions from expectation files. Live-only checks (stale /
+    missing anchor) are validated by `scan`; here a labeled vs snapshot-total
+    mismatch is surfaced as a coverage gap to re-run `scan`.
+    """
+    totals = ze.RepoReview(repo="(all)")
+    by_rule: Counter[str] = Counter()
+    per_repo: list[tuple[str, ze.RepoReview]] = []
+    coverage_gaps: list[str] = []
+    fp_lines: list[str] = []
+    for path in snaps:
+        snap = json.loads(path.read_text(encoding="utf-8"))
+        repo = snap["repo"]
+        review = ze.RepoReview(repo=repo, default_total=snap["default"]["visible_total"])
+        expectation, _ = ze.parse_expectation_file(expectation_path(repo), repo)
+        if expectation is not None:
+            for finding in expectation.findings:
+                if finding.profile == "strict":
+                    review.strict_anchors += 1
+                    continue
+                review.labeled += 1
+                by_rule[finding.rule_id] += 1
+                if finding.disposition == "actionable":
+                    review.actionable += 1
+                elif finding.disposition == "valid-but-accepted":
+                    review.valid_but_accepted += 1
+                elif finding.disposition == "false-positive":
+                    review.false_positive += 1
+                    fp_lines.append(f"{repo}: {finding.rule_id} @ {finding.path} — {finding.reason}")
+        review.unlabeled = max(0, review.default_total - review.labeled)
+        if review.labeled != review.default_total:
+            coverage_gaps.append(
+                f"{repo}: {review.labeled} labeled vs {review.default_total} default-visible (run `scan`)"
+            )
+        per_repo.append((repo, review))
+        for attr in ("default_total", "labeled", "unlabeled", "actionable", "valid_but_accepted", "false_positive", "strict_anchors"):
+            setattr(totals, attr, getattr(totals, attr) + getattr(review, attr))
+
+    reviewed = totals.actionable + totals.valid_but_accepted + totals.false_positive
+    print("\n# Reviewed signal quality (snapshots x labels)\n")
+    print(f"default-visible findings : {totals.default_total}")
+    print(f"labeled default findings : {totals.labeled}")
+    print(f"unlabeled default        : {totals.unlabeled}")
+    print(f"  actionable             : {totals.actionable}")
+    print(f"  valid-but-accepted     : {totals.valid_but_accepted}")
+    print(f"  false-positive         : {totals.false_positive}")
+    print(f"strict recall anchors    : {totals.strict_anchors}")
+    if reviewed:
+        proxy = (totals.actionable + totals.valid_but_accepted) / reviewed
+        rate = totals.actionable / reviewed
+        print(f"reviewed precision proxy : {proxy:.2f}  ((actionable+accepted)/reviewed; not measured precision)")
+        print(f"actionability rate       : {rate:.2f}  (actionable/reviewed)")
+
+    print("\n## Labeled default by rule")
+    for rule, count in sorted(by_rule.items()):
+        print(f"  {rule:46} {count:>4}")
+    print("\n## By repository (default_total / labeled / actionable / accepted / false-positive / strict-anchors)")
+    for repo, review in per_repo:
+        print(
+            f"  {repo:18} {review.default_total:>3} / {review.labeled:>3} / {review.actionable:>3} / "
+            f"{review.valid_but_accepted:>3} / {review.false_positive:>3} / {review.strict_anchors:>3}"
+        )
+    if coverage_gaps:
+        print("\n## Coverage gaps (labeled != snapshot default-visible)")
+        for line in coverage_gaps:
+            print(f"  - {line}")
+    if fp_lines:
+        print(f"\n## KNOWN FALSE POSITIVES ({len(fp_lines)}) — calibration debt, reported not suppressed")
+        for line in fp_lines:
+            print(f"  - {line}")
+
+
+def cmd_triage(args: argparse.Namespace) -> int:
+    repos = select(load_manifest(), args.only)
+    try:
+        scanner = prepare_scanner(REPO_ROOT, args.repopilot, args.allow_version_mismatch)
+    except ScannerPreparationError as exc:
+        print(f"SCANNER PREPARATION FAILED\n{exc}", file=sys.stderr)
+        return 2
+    except ScannerProvenanceError as exc:
+        print(f"SCANNER PROVENANCE FAILED\n{exc}", file=sys.stderr)
+        return 3
+
+    print_scanner_provenance(scanner)
+    any_unlabeled = False
+    for repo in repos:
+        path = repo_path(repo)
+        if not path.exists():
+            print(f"  {repo['name']}: NOT CLONED (run `zoo.py clone`), skip")
+            continue
+        default_lives = ze.parse_live_findings(scan_repo(scanner, path, "default"), path, "default")
+        expectation, _ = ze.parse_expectation_file(expectation_path(repo["name"]), repo["name"])
+        unlabeled = ze.unlabeled_default(expectation, default_lives)
+        if not unlabeled:
+            continue
+        any_unlabeled = True
+        print(f"\n===== {repo['name']}: {len(unlabeled)} unlabeled default finding(s) =====\n")
+        for live in unlabeled:
+            print(zt.render_triage_entry(repo["name"], live))
+        if args.write:
+            out = expectation_path(repo["name"])
+            if out.exists():
+                print(f"  (expectation file {out.name} exists; paste the skeleton(s) above and label them)")
+            else:
+                EXPECTATION_DIR.mkdir(parents=True, exist_ok=True)
+                out.write_text(zt.skeleton_file_text(repo["name"], unlabeled), encoding="utf-8")
+                print(f"  wrote REVIEW skeleton {out.relative_to(REPO_ROOT)} (every disposition is REVIEW_REQUIRED)")
+    if not any_unlabeled:
+        print("\nno unlabeled default findings — every default-visible finding is labeled")
     return 0
 
 
@@ -285,6 +461,21 @@ def main() -> int:
         help="allow --repopilot to use a version that differs from this workspace",
     )
     p_scan.set_defaults(func=cmd_scan)
+
+    p_triage = sub.add_parser("triage", help="print unlabeled default findings + TOML skeletons")
+    p_triage.add_argument("--only", help="comma-separated repo names")
+    p_triage.add_argument(
+        "--write",
+        action="store_true",
+        help="write a REVIEW_REQUIRED skeleton file for repos that have none (never guesses a disposition)",
+    )
+    p_triage.add_argument("--repopilot", help="explicit path to an external repopilot binary")
+    p_triage.add_argument(
+        "--allow-version-mismatch",
+        action="store_true",
+        help="allow --repopilot to use a version that differs from this workspace",
+    )
+    p_triage.set_defaults(func=cmd_triage)
 
     sub.add_parser("report", help="aggregate snapshots into a triage table").set_defaults(func=cmd_report)
 

--- a/scripts/zoo_expectations.py
+++ b/scripts/zoo_expectations.py
@@ -1,0 +1,458 @@
+"""Reviewed precision expectations for the real-repo validation zoo.
+
+Snapshots (`tests/zoo/snapshots/*.json`) answer *what RepoPilot emitted*.
+Expectations (`tests/zoo/expectations/*.toml`) answer *how a human reviewed those
+emissions*. This module is the pure parse + match + render layer: it has no
+network access, no scanner knowledge, and never mutates analyzer output. It is
+driven by `scripts/zoo.py` (live findings) and exercised directly by the Rust
+`zoo_expectations_contract` integration test (synthetic findings).
+
+Policy:
+  * default profile is *exhaustive*  — every default-visible live finding must
+    map to exactly one expectation, and every default expectation must map to
+    exactly one live finding;
+  * strict profile is *selective*    — listed strict expectations are recall
+    anchors that must each still match exactly one live finding; unlisted strict
+    findings are allowed.
+
+Labels never suppress findings. `false-positive` is a reviewed disposition that
+is reported prominently but does not fail the gate or hide the finding.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+DISPOSITIONS = ("actionable", "valid-but-accepted", "false-positive")
+PROFILES = ("default", "strict")
+COVERAGE = ("exhaustive", "selective")
+
+# Optional, never-required metadata fields a reviewer may attach to an entry.
+OPTIONAL_FINDING_KEYS = ("line", "line_end", "issue", "notes", "reviewed_by", "expires")
+REQUIRED_FINDING_KEYS = ("profile", "finding_id", "rule_id", "path", "disposition", "reason")
+ALLOWED_FINDING_KEYS = set(REQUIRED_FINDING_KEYS) | set(OPTIONAL_FINDING_KEYS)
+
+# Diagnostic kinds. Every kind except KNOWN_FALSE_POSITIVE fails the zoo gate.
+# SNAPSHOT_DRIFT lives in zoo.py (it compares emitted output, not labels) and is
+# reported separately, but the label is defined here so renderers agree.
+SNAPSHOT_DRIFT = "SNAPSHOT DRIFT"
+UNLABELED_DEFAULT_FINDING = "UNLABELED DEFAULT FINDING"
+STALE_EXPECTATION = "STALE EXPECTATION"
+DUPLICATE_EXPECTATION = "DUPLICATE EXPECTATION"
+INVALID_EXPECTATION = "INVALID EXPECTATION"
+AMBIGUOUS_EXPECTATION = "AMBIGUOUS EXPECTATION"
+MISSING_STRICT_RECALL_ANCHOR = "MISSING STRICT RECALL ANCHOR"
+MISSING_EXPECTATION_FILE = "MISSING EXPECTATION FILE"
+UNKNOWN_EXPECTATION_FILE = "UNKNOWN EXPECTATION FILE"
+KNOWN_FALSE_POSITIVE = "KNOWN FALSE POSITIVE"
+
+# Order used when grouping diagnostics for output (most urgent first).
+DIAGNOSTIC_ORDER = (
+    SNAPSHOT_DRIFT,
+    UNLABELED_DEFAULT_FINDING,
+    STALE_EXPECTATION,
+    DUPLICATE_EXPECTATION,
+    AMBIGUOUS_EXPECTATION,
+    INVALID_EXPECTATION,
+    MISSING_EXPECTATION_FILE,
+    UNKNOWN_EXPECTATION_FILE,
+    MISSING_STRICT_RECALL_ANCHOR,
+    KNOWN_FALSE_POSITIVE,
+)
+
+
+def is_failure(kind: str) -> bool:
+    """Every diagnostic except a reviewed known-false-positive fails the gate."""
+    return kind != KNOWN_FALSE_POSITIVE
+
+
+# ----------------------------------------------------------------------------
+# Records
+# ----------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ExpectationFinding:
+    profile: str
+    finding_id: str
+    rule_id: str
+    path: str
+    disposition: str
+    reason: str
+    line: int | None = None
+    line_end: int | None = None
+    issue: str | None = None
+    notes: str | None = None
+    reviewed_by: str | None = None
+    expires: str | None = None
+    index: int = 0  # 1-based position in file, for diagnostics
+
+    def identity(self) -> tuple[str, str, str, str, int | None, int | None]:
+        return (self.profile, self.finding_id, self.rule_id, self.path, self.line, self.line_end)
+
+
+@dataclass(frozen=True)
+class Expectation:
+    repo: str
+    schema_version: int
+    default_coverage: str
+    strict_coverage: str
+    findings: tuple[ExpectationFinding, ...]
+    source: str
+
+
+@dataclass(frozen=True)
+class LiveFinding:
+    profile: str
+    id: str
+    rule_id: str
+    path: str
+    line: int | None
+    line_end: int | None
+    severity: str
+    confidence: str
+    priority: str
+    title: str
+    snippet: str
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    kind: str
+    repo: str
+    message: str
+
+
+@dataclass
+class RepoReview:
+    """Aggregated, snapshot-free review of one repo's labeled default findings."""
+
+    repo: str
+    default_total: int = 0
+    labeled: int = 0
+    unlabeled: int = 0
+    actionable: int = 0
+    valid_but_accepted: int = 0
+    false_positive: int = 0
+    strict_anchors: int = 0
+    by_rule: dict[str, int] = field(default_factory=dict)
+
+
+# ----------------------------------------------------------------------------
+# Parse + structural validation
+# ----------------------------------------------------------------------------
+def parse_expectation_text(text: str, repo: str, source: str) -> tuple[Expectation | None, list[Diagnostic]]:
+    """Parse + structurally validate one expectation file's TOML text.
+
+    Returns (expectation_or_None, diagnostics). When the file is unparseable or
+    its header is invalid the expectation is None and matching must be skipped;
+    individual malformed `[[finding]]` entries are dropped with an INVALID
+    diagnostic while the remaining valid entries are kept.
+    """
+    diags: list[Diagnostic] = []
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        return None, [Diagnostic(INVALID_EXPECTATION, repo, f"{source}: TOML parse error: {exc}")]
+
+    schema = data.get("schema_version")
+    if schema != SCHEMA_VERSION:
+        diags.append(
+            Diagnostic(
+                INVALID_EXPECTATION,
+                repo,
+                f"{source}: unsupported schema_version {schema!r} (expected {SCHEMA_VERSION})",
+            )
+        )
+        return None, diags
+
+    declared_repo = data.get("repo")
+    if declared_repo != repo:
+        diags.append(
+            Diagnostic(
+                INVALID_EXPECTATION,
+                repo,
+                f"{source}: repo field {declared_repo!r} does not match filename repo {repo!r}",
+            )
+        )
+        return None, diags
+
+    default_coverage = data.get("default_coverage", "exhaustive")
+    strict_coverage = data.get("strict_coverage", "selective")
+    for label, value in (("default_coverage", default_coverage), ("strict_coverage", strict_coverage)):
+        if value not in COVERAGE:
+            diags.append(Diagnostic(INVALID_EXPECTATION, repo, f"{source}: {label} {value!r} not in {COVERAGE}"))
+            return None, diags
+
+    raw_findings = data.get("finding", [])
+    if not isinstance(raw_findings, list):
+        return None, [Diagnostic(INVALID_EXPECTATION, repo, f"{source}: [[finding]] must be an array of tables")]
+
+    findings: list[ExpectationFinding] = []
+    seen: dict[tuple, int] = {}
+    for position, raw in enumerate(raw_findings, start=1):
+        parsed, entry_diags = _parse_finding(raw, repo, source, position)
+        diags.extend(entry_diags)
+        if parsed is None:
+            continue
+        key = parsed.identity()
+        if key in seen:
+            diags.append(
+                Diagnostic(
+                    DUPLICATE_EXPECTATION,
+                    repo,
+                    f"{source}: entry #{position} duplicates entry #{seen[key]} ({parsed.finding_id} @ {parsed.path})",
+                )
+            )
+            continue
+        seen[key] = position
+        findings.append(parsed)
+
+    expectation = Expectation(
+        repo=repo,
+        schema_version=SCHEMA_VERSION,
+        default_coverage=default_coverage,
+        strict_coverage=strict_coverage,
+        findings=tuple(findings),
+        source=source,
+    )
+    return expectation, diags
+
+
+def coverage_diagnostics(
+    required_names: list[str], manifest_names: list[str], present_stems: list[str]
+) -> list[Diagnostic]:
+    """Every required repo must have a file; every file must map to a manifest repo."""
+    diags: list[Diagnostic] = []
+    present = set(present_stems)
+    manifest = set(manifest_names)
+    for name in required_names:
+        if name not in present:
+            diags.append(Diagnostic(MISSING_EXPECTATION_FILE, name, f"no {name}.toml in expectations dir"))
+    for stem in sorted(present):
+        if stem not in manifest:
+            diags.append(Diagnostic(UNKNOWN_EXPECTATION_FILE, stem, f"{stem}.toml has no matching manifest [[repo]]"))
+    return diags
+
+
+def parse_expectation_file(path: Path, repo: str) -> tuple[Expectation | None, list[Diagnostic]]:
+    source = path.name
+    if not path.exists():
+        return None, [Diagnostic(MISSING_EXPECTATION_FILE, repo, f"no expectation file at {source}")]
+    return parse_expectation_text(path.read_text(encoding="utf-8"), repo, source)
+
+
+def _parse_finding(
+    raw: Any, repo: str, source: str, position: int
+) -> tuple[ExpectationFinding | None, list[Diagnostic]]:
+    where = f"{source}: entry #{position}"
+    if not isinstance(raw, dict):
+        return None, [Diagnostic(INVALID_EXPECTATION, repo, f"{where} is not a table")]
+
+    unknown = set(raw) - ALLOWED_FINDING_KEYS
+    if unknown:
+        return None, [Diagnostic(INVALID_EXPECTATION, repo, f"{where} has unknown field(s): {', '.join(sorted(unknown))}")]
+
+    def fail(msg: str) -> tuple[None, list[Diagnostic]]:
+        return None, [Diagnostic(INVALID_EXPECTATION, repo, f"{where} {msg}")]
+
+    profile = raw.get("profile")
+    if profile not in PROFILES:
+        return fail(f"has unknown profile {profile!r} (expected one of {PROFILES})")
+
+    for key in ("finding_id", "rule_id", "path"):
+        value = raw.get(key)
+        if not isinstance(value, str) or not value.strip():
+            return fail(f"is missing a non-empty {key}")
+
+    disposition = raw.get("disposition")
+    if disposition not in DISPOSITIONS:
+        return fail(f"has unknown disposition {disposition!r} (expected one of {DISPOSITIONS})")
+
+    reason = raw.get("reason")
+    if not isinstance(reason, str) or not reason.strip():
+        return fail("has an empty reason")
+
+    line = raw.get("line")
+    line_end = raw.get("line_end")
+    for key, value in (("line", line), ("line_end", line_end)):
+        if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+            return fail(f"has a non-integer {key} {value!r}")
+
+    return (
+        ExpectationFinding(
+            profile=profile,
+            finding_id=raw["finding_id"],
+            rule_id=raw["rule_id"],
+            path=raw["path"],
+            disposition=disposition,
+            reason=reason,
+            line=line,
+            line_end=line_end,
+            issue=raw.get("issue"),
+            notes=raw.get("notes"),
+            reviewed_by=raw.get("reviewed_by"),
+            expires=raw.get("expires"),
+            index=position,
+        ),
+        [],
+    )
+
+
+# ----------------------------------------------------------------------------
+# Live findings
+# ----------------------------------------------------------------------------
+def parse_live_findings(report: dict[str, Any], clone_dir: str | Path, profile: str) -> list[LiveFinding]:
+    raw = report.get("findings")
+    findings = [f for f in raw if isinstance(f, dict)] if isinstance(raw, list) else []
+    return [_live_from_dict(f, clone_dir, profile) for f in findings]
+
+
+def _live_from_dict(finding: dict[str, Any], clone_dir: str | Path, profile: str) -> LiveFinding:
+    evidence = finding.get("evidence")
+    first = evidence[0] if isinstance(evidence, list) and evidence and isinstance(evidence[0], dict) else {}
+    risk = finding.get("risk")
+    priority = risk.get("priority") if isinstance(risk, dict) else None
+    return LiveFinding(
+        profile=profile,
+        id=str(finding.get("id", "")),
+        rule_id=str(finding.get("rule_id", "")),
+        path=relative_path(first.get("path", ""), clone_dir),
+        line=first.get("line_start") if isinstance(first.get("line_start"), int) else None,
+        line_end=first.get("line_end") if isinstance(first.get("line_end"), int) else None,
+        severity=str(finding.get("severity", "")),
+        confidence=str(finding.get("confidence", "")),
+        priority=str(priority) if isinstance(priority, str) else "unknown",
+        title=str(finding.get("title", "")),
+        snippet=str(first.get("snippet", "")),
+    )
+
+
+def relative_path(path: str, clone_dir: str | Path) -> str:
+    """Normalize an evidence path to a clone-relative path.
+
+    File-based findings carry an absolute path under the clone dir; graph
+    findings (cycles) already carry a relative path. Both must collapse to the
+    same machine-independent relative form the finding `id` encodes.
+    """
+    text = str(path)
+    root = str(clone_dir).rstrip("/")
+    if root and text.startswith(root + "/"):
+        text = text[len(root) + 1 :]
+    return text.lstrip("./") if text.startswith("./") else text
+
+
+# ----------------------------------------------------------------------------
+# Matching
+# ----------------------------------------------------------------------------
+def _matches(exp: ExpectationFinding, live: LiveFinding) -> bool:
+    if exp.finding_id != live.id or exp.rule_id != live.rule_id or exp.path != live.path:
+        return False
+    if exp.line is not None and exp.line != live.line:
+        return False
+    if exp.line_end is not None and exp.line_end != live.line_end:
+        return False
+    return True
+
+
+def match_repo(
+    repo: str,
+    expectation: Expectation,
+    default_live: list[LiveFinding],
+    strict_live: list[LiveFinding],
+) -> tuple[list[Diagnostic], RepoReview]:
+    """Match one repo's expectations against its live default + strict findings."""
+    diags: list[Diagnostic] = []
+    review = RepoReview(repo=repo, default_total=len(default_live))
+
+    default_exps = [f for f in expectation.findings if f.profile == "default"]
+    strict_exps = [f for f in expectation.findings if f.profile == "strict"]
+    review.strict_anchors = len(strict_exps)
+
+    diags += _match_profile(repo, default_exps, default_live, "default", exhaustive=True, review=review)
+    diags += _match_profile(repo, strict_exps, strict_live, "strict", exhaustive=False, review=review)
+    return diags, review
+
+
+def _match_profile(
+    repo: str,
+    exps: list[ExpectationFinding],
+    live: list[LiveFinding],
+    profile: str,
+    exhaustive: bool,
+    review: RepoReview,
+) -> list[Diagnostic]:
+    diags: list[Diagnostic] = []
+    exp_matches = {id(e): [lf for lf in live if _matches(e, lf)] for e in exps}
+    live_matches = {idx: [e for e in exps if _matches(e, lf)] for idx, lf in enumerate(live)}
+
+    for exp in exps:
+        matched = exp_matches[id(exp)]
+        if len(matched) == 0:
+            kind = STALE_EXPECTATION if exhaustive else MISSING_STRICT_RECALL_ANCHOR
+            diags.append(Diagnostic(kind, repo, _describe_exp(exp)))
+        elif len(matched) > 1:
+            diags.append(
+                Diagnostic(
+                    AMBIGUOUS_EXPECTATION,
+                    repo,
+                    f"{profile} expectation matches {len(matched)} live findings; add `line` to disambiguate: {_describe_exp(exp)}",
+                )
+            )
+        else:
+            _count_disposition(exp, matched[0], repo, diags, review)
+
+    for idx, lf in enumerate(live):
+        matched = live_matches[idx]
+        if len(matched) > 1:
+            diags.append(
+                Diagnostic(
+                    DUPLICATE_EXPECTATION,
+                    repo,
+                    f"{len(matched)} {profile} expectations match one live finding: {_describe_live(lf)}",
+                )
+            )
+        elif len(matched) == 0 and exhaustive:
+            diags.append(Diagnostic(UNLABELED_DEFAULT_FINDING, repo, _describe_live(lf)))
+
+    return diags
+
+
+def _count_disposition(
+    exp: ExpectationFinding, live: LiveFinding, repo: str, diags: list[Diagnostic], review: RepoReview
+) -> None:
+    if exp.profile == "default":
+        review.labeled += 1
+        review.by_rule[exp.rule_id] = review.by_rule.get(exp.rule_id, 0) + 1
+        if exp.disposition == "actionable":
+            review.actionable += 1
+        elif exp.disposition == "valid-but-accepted":
+            review.valid_but_accepted += 1
+        elif exp.disposition == "false-positive":
+            review.false_positive += 1
+    if exp.disposition == "false-positive":
+        diags.append(
+            Diagnostic(
+                KNOWN_FALSE_POSITIVE,
+                repo,
+                f"{exp.profile} {_describe_live(live)} — reviewed false positive: {exp.reason}",
+            )
+        )
+
+
+def _describe_exp(exp: ExpectationFinding) -> str:
+    suffix = f" line {exp.line}" if exp.line is not None else ""
+    return f"{exp.rule_id} @ {exp.path}{suffix} (id {exp.finding_id})"
+
+
+def _describe_live(live: LiveFinding) -> str:
+    suffix = f" line {live.line}" if live.line is not None else ""
+    return f"{live.rule_id} @ {live.path}{suffix} (id {live.id})"
+
+
+def unlabeled_default(expectation: Expectation | None, default_live: list[LiveFinding]) -> list[LiveFinding]:
+    exps = [f for f in expectation.findings if f.profile == "default"] if expectation else []
+    return [lf for lf in default_live if not any(_matches(e, lf) for e in exps)]

--- a/scripts/zoo_triage.py
+++ b/scripts/zoo_triage.py
@@ -1,0 +1,64 @@
+"""Triage rendering for the zoo expectation layer.
+
+CLI-facing rendering kept separate from parsing/matching (`zoo_expectations.py`):
+it turns an unlabeled live finding into human-readable evidence plus a copy-paste
+TOML skeleton. It NEVER decides a disposition — every generated entry carries the
+non-valid placeholder `REVIEW_REQUIRED`, which expectation validation rejects, so
+a maintainer must consciously classify each finding.
+"""
+
+from __future__ import annotations
+
+from zoo_expectations import SCHEMA_VERSION, LiveFinding
+
+REVIEW_REQUIRED = "REVIEW_REQUIRED"
+
+
+def triage_skeleton(live: LiveFinding) -> str:
+    lines = [
+        "[[finding]]",
+        f'profile = "{live.profile}"',
+        f'finding_id = "{live.id}"',
+        f'rule_id = "{live.rule_id}"',
+        f'path = "{live.path}"',
+    ]
+    if live.line is not None:
+        lines.append(f"line = {live.line}")
+    lines.append(f'disposition = "{REVIEW_REQUIRED}"  # actionable | valid-but-accepted | false-positive')
+    lines.append('reason = ""')
+    return "\n".join(lines)
+
+
+def render_triage_entry(repo: str, live: LiveFinding) -> str:
+    line = f"{live.line}" if live.line is not None else "?"
+    snippet = live.snippet.replace("\n", "\\n")
+    if len(snippet) > 160:
+        snippet = snippet[:160] + "…"
+    header = [
+        f"repo:        {repo}",
+        f"profile:     {live.profile}",
+        f"finding_id:  {live.id}",
+        f"rule_id:     {live.rule_id}",
+        f"priority:    {live.priority}",
+        f"severity:    {live.severity}",
+        f"confidence:  {live.confidence}",
+        f"path:line:   {live.path}:{line}",
+        f"title:       {live.title}",
+        f"evidence:    {snippet}",
+    ]
+    return "\n".join(header) + "\n\n" + triage_skeleton(live) + "\n"
+
+
+def skeleton_file_text(repo: str, lives: list[LiveFinding]) -> str:
+    head = [
+        f"schema_version = {SCHEMA_VERSION}",
+        f'repo = "{repo}"',
+        'default_coverage = "exhaustive"',
+        'strict_coverage = "selective"',
+        "",
+        "# Auto-generated REVIEW skeleton. Replace every REVIEW_REQUIRED disposition",
+        "# and fill each reason before validation will pass.",
+        "",
+    ]
+    blocks = [triage_skeleton(lf) for lf in lives]
+    return "\n".join(head) + ("\n\n".join(blocks) + "\n" if blocks else "")

--- a/tests/zoo/README.md
+++ b/tests/zoo/README.md
@@ -11,10 +11,25 @@ and hunt false positives" loop that produced the 0.18 increment fixes.
 ## What's tracked vs. ignored
 
 - **Tracked (committed):** [`manifest.toml`](manifest.toml) (repos + pinned
-  SHAs) and `snapshots/*.json` (per-repo default-visible finding counts +
-  fingerprints, and strict counts). These are small.
+  SHAs), `snapshots/*.json` (per-repo default-visible finding counts +
+  fingerprints, and strict counts), and `expectations/*.toml` (per-repo
+  human-reviewed dispositions). These are small.
 - **Ignored:** the actual repo checkouts live in `/.zoo/` (gitignored) and are
   **never committed**. They are cloned on demand.
+
+## Snapshots vs. expectations
+
+Two separate layers, deliberately kept apart:
+
+| Layer | File | Answers | Written by |
+|-------|------|---------|------------|
+| **Snapshot** | `snapshots/<repo>.json` | *What did RepoPilot emit?* (counts + fingerprints) | the scanner (`scan`, `--bless`) |
+| **Expectation** | `expectations/<repo>.toml` | *How did a human review those emissions?* | a human reviewer |
+
+A green snapshot means "the output did not change." A green expectation set
+additionally means "every default-visible finding was reviewed and classified."
+**Labels never change analyzer output.** `--bless` rewrites snapshots; it
+**never** touches expectation files.
 
 ## The loop
 
@@ -22,17 +37,75 @@ and hunt false positives" loop that produced the 0.18 increment fixes.
 # 1. Clone every repo at its pinned SHA into .zoo/ (shallow, network).
 python3 scripts/zoo.py clone
 
-# 2. Scan each repo (default + strict) and compare to committed snapshots.
-python3 scripts/zoo.py scan          # exits non-zero on drift
-python3 scripts/zoo.py scan --bless  # accept changes -> rewrites snapshots
+# 2. Scan: compare snapshots AND validate labels (drift + expectations report
+#    on separate channels). Exits non-zero on either.
+python3 scripts/zoo.py scan
+python3 scripts/zoo.py scan --bless   # accept snapshot drift only (not labels)
 
-# 3. Aggregate into a per-rule triage table (drives false-positive work).
+# 3. Triage: print unlabeled default findings + a copy-paste TOML skeleton.
+python3 scripts/zoo.py triage
+python3 scripts/zoo.py triage --only excalidraw
+
+# 4. Assign a human disposition: paste the skeleton into expectations/<repo>.toml
+#    and replace REVIEW_REQUIRED + the empty reason. Re-run `scan` to validate.
+
+# 5. Report: per-rule table + reviewed signal-quality summary.
 python3 scripts/zoo.py report
 ```
 
 Other helpers: `python3 scripts/zoo.py list` (manifest table),
 `python3 scripts/zoo.py verify-pins` (clones match pins), and `--only a,b`
-on `clone`/`scan` to work a subset.
+on `clone`/`scan`/`triage` to work a subset. `triage --write` creates a
+REVIEW_REQUIRED skeleton file only for a repo that has none — it never guesses a
+disposition and never overwrites existing labels.
+
+## Dispositions
+
+Every expectation entry carries a closed-enum `disposition` and a non-empty
+human `reason`:
+
+- **`actionable`** — a real risk or design issue the rule intends to surface.
+- **`valid-but-accepted`** — correctly detected structural fact, but the upstream
+  repo intentionally accepts it (a design trade-off). Not a detector false
+  positive; just less actionable for that repo.
+- **`false-positive`** — does not represent the rule's claimed condition, or
+  lacks the context to justify default visibility. This is **calibration debt**:
+  it is reported prominently but, in this PR, does **not** fail the gate and is
+  **never** turned into a suppression.
+
+Optional fields: `line`, `line_end` (required to disambiguate two findings that
+share a stable id), plus free-form `issue`, `notes`, `reviewed_by`, `expires`.
+
+## Default exhaustive vs. strict selective
+
+- **Default profile is exhaustive.** Every default-visible live finding must map
+  to exactly one expectation and vice-versa. Unlabeled findings, stale
+  expectations, duplicates, malformed entries, and rule/path mismatches all fail.
+- **Strict profile is selective.** Strict output can run to hundreds of broad
+  findings, so only listed strict expectations are checked — each must still match
+  exactly one live finding (a *recall anchor*). Unlisted strict findings are
+  allowed. Anchors pin intentionally downgraded signals (e.g. the public Algolia
+  DocSearch key, a test-support panic, a CLI command-handler `process.exit`, a
+  Python `assert`) so a downgrade can never silently become a full suppression.
+
+## Common tasks
+
+- **Add a new repo:** follow "Adding or bumping a repo" below, then
+  `triage --only <name>` and create `expectations/<name>.toml` (required even when
+  the repo has zero default findings).
+- **Update a pin:** bump the `sha`, re-clone with `--force`, `scan --bless`, then
+  reconcile labels — new/changed findings show as unlabeled (`triage`), removed
+  findings show as stale expectations to delete.
+- **A new default finding appeared:** `scan` fails with `UNLABELED DEFAULT
+  FINDING`; run `triage`, classify it, add the entry.
+- **Remove a stale expectation:** `scan` fails with `STALE EXPECTATION`; delete
+  the entry whose finding no longer exists.
+- **Why `false-positive` is not a suppression:** expectations describe current
+  behavior; they do not change what the analyzer emits. A false positive stays
+  visible and is surfaced as calibration debt to be fixed in the rule, not hidden.
+- **Why `--bless` never updates labels:** snapshots and human review are separate
+  concerns. Re-blessing accepts a *measured* output change; a human must still
+  review what changed.
 
 `scan` builds the current workspace once with Cargo, resolves the executable
 Cargo produced, validates its version/report metadata, and then reuses that

--- a/tests/zoo/expectations/changesets.toml
+++ b/tests/zoo/expectations/changesets.toml
@@ -1,0 +1,20 @@
+schema_version = 1
+repo = "changesets"
+default_coverage = "exhaustive"
+strict_coverage = "selective"
+
+[[finding]]
+profile = "default"
+finding_id = "language.javascript.runtime-exit-risk:packages/cli/src/utils/cli-utilities.ts:272512749156ce06"
+rule_id = "language.javascript.runtime-exit-risk"
+path = "packages/cli/src/utils/cli-utilities.ts"
+disposition = "actionable"
+reason = "process.exit lives in a shared CLI utility module (not a command entrypoint), so it can terminate the host process unexpectedly; the rule intentionally keeps this High outside commands/."
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.circular-dependency:packages/cli/src/commands/publish/npm-utils.ts:450588cb75896a2b"
+rule_id = "architecture.circular-dependency"
+path = "packages/cli/src/commands/publish/npm-utils.ts"
+disposition = "actionable"
+reason = "Real two-node eager import cycle between npm-utils.ts and publishPackages.ts inside the publish command."

--- a/tests/zoo/expectations/cobra.toml
+++ b/tests/zoo/expectations/cobra.toml
@@ -1,0 +1,8 @@
+schema_version = 1
+repo = "cobra"
+default_coverage = "exhaustive"
+strict_coverage = "selective"
+
+# cobra emits no default-visible findings at the pinned SHA. The file is still
+# required so the zoo gate proves the empty default profile was reviewed, not
+# merely un-scanned.

--- a/tests/zoo/expectations/eshoponweb.toml
+++ b/tests/zoo/expectations/eshoponweb.toml
@@ -1,0 +1,71 @@
+schema_version = 1
+repo = "eshoponweb"
+default_coverage = "exhaustive"
+strict_coverage = "selective"
+
+# eShopOnWeb is a Microsoft reference/sample application. Every default secret is
+# a correctly detected hardcoded credential the app intentionally ships for local
+# demo/Docker use — a real structural fact, accepted by upstream, not a detector
+# false positive.
+
+[[finding]]
+profile = "default"
+finding_id = "security.secret-candidate:docker-compose.yml:51c0493bf3025959"
+rule_id = "security.secret-candidate"
+path = "docker-compose.yml"
+disposition = "valid-but-accepted"
+reason = "Hardcoded SA_PASSWORD in docker-compose; intentional demo credential for the sample app's local SQL Server container."
+
+[[finding]]
+profile = "default"
+finding_id = "security.secret-candidate:src/ApplicationCore/Constants/AuthorizationConstants.cs:a9ec5b53067db7ff"
+rule_id = "security.secret-candidate"
+path = "src/ApplicationCore/Constants/AuthorizationConstants.cs"
+disposition = "valid-but-accepted"
+reason = "Hardcoded JWT_SECRET_KEY constant; demo signing key shipped by the reference app, not a production secret."
+
+[[finding]]
+profile = "default"
+finding_id = "security.secret-candidate:src/ApplicationCore/Constants/AuthorizationConstants.cs:5a72f55e73b3db87"
+rule_id = "security.secret-candidate"
+path = "src/ApplicationCore/Constants/AuthorizationConstants.cs"
+disposition = "valid-but-accepted"
+reason = "Hardcoded DEFAULT_PASSWORD constant used to seed sample accounts; intentional demo credential."
+
+# appsettings.Docker.json: one stable id at two distinct lines (Catalog + Identity
+# connection strings) -> both occurrences are disambiguated by line.
+[[finding]]
+profile = "default"
+finding_id = "security.secret-candidate:src/PublicApi/appsettings.Docker.json:01d78fc0be373598"
+rule_id = "security.secret-candidate"
+path = "src/PublicApi/appsettings.Docker.json"
+line = 3
+disposition = "valid-but-accepted"
+reason = "CatalogConnection string with an embedded demo password for the Docker SQL container (PublicApi)."
+
+[[finding]]
+profile = "default"
+finding_id = "security.secret-candidate:src/PublicApi/appsettings.Docker.json:01d78fc0be373598"
+rule_id = "security.secret-candidate"
+path = "src/PublicApi/appsettings.Docker.json"
+line = 4
+disposition = "valid-but-accepted"
+reason = "IdentityConnection string with an embedded demo password for the Docker SQL container (PublicApi)."
+
+[[finding]]
+profile = "default"
+finding_id = "security.secret-candidate:src/Web/appsettings.Docker.json:01d78fc0be373598"
+rule_id = "security.secret-candidate"
+path = "src/Web/appsettings.Docker.json"
+line = 3
+disposition = "valid-but-accepted"
+reason = "CatalogConnection string with an embedded demo password for the Docker SQL container (Web)."
+
+[[finding]]
+profile = "default"
+finding_id = "security.secret-candidate:src/Web/appsettings.Docker.json:01d78fc0be373598"
+rule_id = "security.secret-candidate"
+path = "src/Web/appsettings.Docker.json"
+line = 4
+disposition = "valid-but-accepted"
+reason = "IdentityConnection string with an embedded demo password for the Docker SQL container (Web)."

--- a/tests/zoo/expectations/excalidraw.toml
+++ b/tests/zoo/expectations/excalidraw.toml
@@ -1,0 +1,64 @@
+schema_version = 1
+repo = "excalidraw"
+default_coverage = "exhaustive"
+strict_coverage = "selective"
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.circular-dependency:excalidraw-app/App.tsx:e575ed4f8104d3d4"
+rule_id = "architecture.circular-dependency"
+path = "excalidraw-app/App.tsx"
+disposition = "actionable"
+reason = "Two-node eager cycle between the app entry and App.tsx (App.tsx <-> index.tsx); a real load-order coupling at the application root."
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.circular-dependency:packages/common/src/index.ts:7b14cf4e6bb5e522"
+rule_id = "architecture.circular-dependency"
+path = "packages/common/src/index.ts"
+disposition = "valid-but-accepted"
+reason = "Barrel re-export cycle (common/src/index.ts <-> queue.ts); idiomatic package-index aggregation in a TS monorepo."
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.circular-dependency:packages/excalidraw/actions/actionHistory.tsx:5c057c5a6edef722"
+rule_id = "architecture.circular-dependency"
+path = "packages/excalidraw/actions/actionHistory.tsx"
+disposition = "actionable"
+reason = "Mutual dependency between actions/actionHistory.tsx and components/App.tsx inside a 100-file strongly-connected component; a genuine architectural tangle."
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.circular-dependency:excalidraw-app/data/firebase.ts:5c3e800a8ebb659a"
+rule_id = "architecture.circular-dependency"
+path = "excalidraw-app/data/firebase.ts"
+disposition = "valid-but-accepted"
+reason = "Barrel re-export cycle (data/firebase.ts <-> data/index.ts); idiomatic package-index aggregation."
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.circular-dependency:packages/element/src/Scene.ts:9cbbca234b2ff447"
+rule_id = "architecture.circular-dependency"
+path = "packages/element/src/Scene.ts"
+disposition = "valid-but-accepted"
+reason = "Barrel re-export cycle (element/src/Scene.ts <-> element/src/index.ts); idiomatic package-index aggregation."
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.circular-dependency:packages/excalidraw/data/blob.ts:5c1b1535711c051e"
+rule_id = "architecture.circular-dependency"
+path = "packages/excalidraw/data/blob.ts"
+disposition = "actionable"
+reason = "Mutual dependency between data/blob.ts and data/filesystem.ts; two sibling modules that import each other directly."
+
+# Strict recall anchor: the public Algolia DocSearch key was downgraded to a
+# strict-only Low in #246. Keep it pinned so the downgrade can't silently become
+# a full suppression.
+[[finding]]
+profile = "strict"
+finding_id = "security.secret-candidate:dev-docs/docusaurus.config.js:9fe21045a4599527"
+rule_id = "security.secret-candidate"
+path = "dev-docs/docusaurus.config.js"
+line = 139
+disposition = "valid-but-accepted"
+reason = "Public, search-only Algolia DocSearch apiKey in the docs site config; safe to publish and intentionally retained as a strict recall anchor (#246)."

--- a/tests/zoo/expectations/express.toml
+++ b/tests/zoo/expectations/express.toml
@@ -1,0 +1,6 @@
+schema_version = 1
+repo = "express"
+default_coverage = "exhaustive"
+strict_coverage = "selective"
+
+# express emits no default-visible findings at the pinned SHA.

--- a/tests/zoo/expectations/fastapi.toml
+++ b/tests/zoo/expectations/fastapi.toml
@@ -1,0 +1,29 @@
+schema_version = 1
+repo = "fastapi"
+default_coverage = "exhaustive"
+strict_coverage = "selective"
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.circular-dependency:fastapi/__init__.py:81cea0afc607c53a"
+rule_id = "architecture.circular-dependency"
+path = "fastapi/__init__.py"
+disposition = "valid-but-accepted"
+reason = "Package __init__ re-export cycle (fastapi/__init__.py <-> applications.py); an eager package-initialization cycle that upstream relies on import ordering to resolve."
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.circular-dependency:fastapi/_compat/__init__.py:f448052db436d085"
+rule_id = "architecture.circular-dependency"
+path = "fastapi/_compat/__init__.py"
+disposition = "valid-but-accepted"
+reason = "_compat package-init re-export cycle (_compat/__init__.py <-> _compat/v2.py); an intentional Pydantic v1/v2 compatibility shim."
+
+[[finding]]
+profile = "strict"
+finding_id = "language.python.exception-risk:fastapi/applications.py:d5cb1115ff3a9dbb"
+rule_id = "language.python.exception-risk"
+path = "fastapi/applications.py"
+line = 926
+disposition = "valid-but-accepted"
+reason = "assert in a production path used as an internal precondition; downgraded to Low and retained as a strict recall anchor for the Python assert signal."

--- a/tests/zoo/expectations/ignite.toml
+++ b/tests/zoo/expectations/ignite.toml
@@ -1,0 +1,17 @@
+schema_version = 1
+repo = "ignite"
+default_coverage = "exhaustive"
+strict_coverage = "selective"
+
+# ignite emits no default-visible findings at the pinned SHA: every process.exit
+# lives in `src/commands/` and was intentionally downgraded to Low (#249/B1), so
+# it is strict-only. The strict anchor below keeps that downgrade honest.
+
+[[finding]]
+profile = "strict"
+finding_id = "language.javascript.runtime-exit-risk:src/commands/new.ts:199bbf8d553e4213"
+rule_id = "language.javascript.runtime-exit-risk"
+path = "src/commands/new.ts"
+line = 185
+disposition = "valid-but-accepted"
+reason = "CLI command handler that deliberately exits the process; downgraded to Low for cli-executable role and retained as a strict recall anchor."

--- a/tests/zoo/expectations/nowinandroid.toml
+++ b/tests/zoo/expectations/nowinandroid.toml
@@ -1,0 +1,12 @@
+schema_version = 1
+repo = "nowinandroid"
+default_coverage = "exhaustive"
+strict_coverage = "selective"
+
+[[finding]]
+profile = "default"
+finding_id = "language.managed.fatal-exception-risk:feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt:6287d3e94eee5173"
+rule_id = "language.managed.fatal-exception-risk"
+path = "feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt"
+disposition = "actionable"
+reason = "TODO() placeholder on the TopicUiState.Error branch will throw NotImplementedError at runtime if the error state is ever rendered; the rule correctly surfaces an unimplemented production path."

--- a/tests/zoo/expectations/ripgrep.toml
+++ b/tests/zoo/expectations/ripgrep.toml
@@ -1,0 +1,49 @@
+schema_version = 1
+repo = "ripgrep"
+default_coverage = "exhaustive"
+strict_coverage = "selective"
+
+[[finding]]
+profile = "default"
+finding_id = "language.rust.panic-risk:crates/ignore/src/dir.rs:29a9cdea010a693a"
+rule_id = "language.rust.panic-risk"
+path = "crates/ignore/src/dir.rs"
+disposition = "actionable"
+reason = "panic! in library code (Ignore::add_parents invariant) aborts the host process; a genuine library panic the rule should keep High."
+
+# Same stable id (d86c9a3b…) at two distinct lines: aggregation does not merge
+# distinct locations, so both occurrences need their own disambiguated entry.
+[[finding]]
+profile = "default"
+finding_id = "language.rust.panic-risk:crates/matcher/src/lib.rs:d86c9a3b5e601a78"
+rule_id = "language.rust.panic-risk"
+path = "crates/matcher/src/lib.rs"
+line = 507
+disposition = "valid-but-accepted"
+reason = "panic!(\"BUG for NoError ...\") guards an impossible error variant; structurally a library panic but unreachable by construction."
+
+[[finding]]
+profile = "default"
+finding_id = "language.rust.panic-risk:crates/matcher/src/lib.rs:d86c9a3b5e601a78"
+rule_id = "language.rust.panic-risk"
+path = "crates/matcher/src/lib.rs"
+line = 513
+disposition = "valid-but-accepted"
+reason = "Second occurrence of the same impossible-error BUG guard; unreachable by construction."
+
+[[finding]]
+profile = "default"
+finding_id = "language.rust.panic-risk:crates/printer/src/json.rs:a67956c2e99a577d"
+rule_id = "language.rust.panic-risk"
+path = "crates/printer/src/json.rs"
+disposition = "actionable"
+reason = "unwrap() on a replacement Option in library code; a genuine panic path the rule should keep High."
+
+[[finding]]
+profile = "strict"
+finding_id = "language.rust.panic-risk:crates/searcher/src/testutil.rs:f73ce48721b18528"
+rule_id = "language.rust.panic-risk"
+path = "crates/searcher/src/testutil.rs"
+line = 256
+disposition = "valid-but-accepted"
+reason = "panic! in a Rust test-support module (testutil.rs); downgraded to Low for the test-support role (#B2) and retained as a strict recall anchor."

--- a/tests/zoo/expectations/spring-petclinic.toml
+++ b/tests/zoo/expectations/spring-petclinic.toml
@@ -1,0 +1,6 @@
+schema_version = 1
+repo = "spring-petclinic"
+default_coverage = "exhaustive"
+strict_coverage = "selective"
+
+# spring-petclinic emits no default-visible findings at the pinned SHA.

--- a/tests/zoo/expectations/wagtail.toml
+++ b/tests/zoo/expectations/wagtail.toml
@@ -1,0 +1,29 @@
+schema_version = 1
+repo = "wagtail"
+default_coverage = "exhaustive"
+strict_coverage = "selective"
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.circular-dependency:wagtail/admin/views/bulk_action/__init__.py:a2ca81903a3ef0d5"
+rule_id = "architecture.circular-dependency"
+path = "wagtail/admin/views/bulk_action/__init__.py"
+disposition = "valid-but-accepted"
+reason = "Package-init re-export cycle (__init__.py -> dispatcher.py -> registry.py -> __init__.py); idiomatic registry wiring inside one package."
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.circular-dependency:wagtail/actions/publish_revision.py:0da7c5453404677e"
+rule_id = "architecture.circular-dependency"
+path = "wagtail/actions/publish_revision.py"
+disposition = "actionable"
+reason = "Real cross-package eager cycle actions <-> models (publish_revision.py -> models/__init__.py -> models/draft_state.py -> publish_revision.py), part of a 29-file strongly-connected component — genuine coupling."
+
+[[finding]]
+profile = "default"
+finding_id = "language.python.exception-risk:wagtail/images/models.py:b3686c8d8679d8e4"
+rule_id = "language.python.exception-risk"
+path = "wagtail/images/models.py"
+line = 868
+disposition = "valid-but-accepted"
+reason = "Bare `except:` carrying an explicit `# noqa:B901,E722`; upstream has knowingly accepted the broad handler."

--- a/tests/zoo/snapshots/excalidraw.json
+++ b/tests/zoo/snapshots/excalidraw.json
@@ -1,12 +1,10 @@
 {
   "default": {
     "by_priority": {
-      "P0": 8
+      "P0": 6
     },
     "by_rule": {
-      "architecture.circular-dependency": 6,
-      "language.javascript.runtime-exit-risk": 1,
-      "security.secret-candidate": 1
+      "architecture.circular-dependency": 6
     },
     "fingerprints": [
       "architecture.circular-dependency:excalidraw-app/App.tsx:e575ed4f8104d3d4",
@@ -14,11 +12,9 @@
       "architecture.circular-dependency:packages/common/src/index.ts:7b14cf4e6bb5e522",
       "architecture.circular-dependency:packages/element/src/Scene.ts:9cbbca234b2ff447",
       "architecture.circular-dependency:packages/excalidraw/actions/actionHistory.tsx:5c057c5a6edef722",
-      "architecture.circular-dependency:packages/excalidraw/data/blob.ts:5c1b1535711c051e",
-      "language.javascript.runtime-exit-risk:packages/excalidraw/subset/woff2/woff2-bindings.ts:cac7cba895f49cd1",
-      "security.secret-candidate:dev-docs/docusaurus.config.js:9fe21045a4599527"
+      "architecture.circular-dependency:packages/excalidraw/data/blob.ts:5c1b1535711c051e"
     ],
-    "visible_total": 8
+    "visible_total": 6
   },
   "framework": "react",
   "language": "typescript",
@@ -31,23 +27,23 @@
       "architecture.dead-module": 62,
       "architecture.deep-relative-imports": 9,
       "architecture.excessive-fan-out": 23,
-      "architecture.large-file": 84,
+      "architecture.large-file": 83,
       "architecture.test-leak": 3,
       "architecture.too-many-modules": 5,
       "code-marker.fixme": 12,
       "code-marker.hack": 1,
       "code-marker.todo": 80,
       "code-quality.complex-file": 13,
-      "code-quality.complex-function": 151,
+      "code-quality.complex-function": 144,
       "code-quality.deep-control-flow": 56,
-      "code-quality.long-function": 331,
+      "code-quality.long-function": 320,
       "framework.js.var-declaration": 4,
       "framework.react.class-component": 2,
-      "language.javascript.runtime-exit-risk": 8,
+      "language.javascript.runtime-exit-risk": 7,
       "security.env-file-committed": 2,
       "security.secret-candidate": 2,
       "testing.source-without-test": 374
     },
-    "visible_total": 1233
+    "visible_total": 1213
   }
 }

--- a/tests/zoo_expectations_contract.rs
+++ b/tests/zoo_expectations_contract.rs
@@ -1,0 +1,204 @@
+//! Contract for the zoo reviewed-precision expectation layer.
+//!
+//! Drives the pure `scripts/zoo_expectations.py` parse + match + render helpers
+//! with synthetic findings and in-memory expectation text. It is hermetic: no
+//! network, no `.zoo/` clones, no scanner build — just `python3` importing the
+//! module via `PYTHONPATH`. This keeps `cargo test --all` deterministic while
+//! still exercising the matcher that the opt-in `zoo_regression` gate relies on.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+#[test]
+fn python_expectation_matcher_contract() {
+    let root = repo_root();
+    let scripts = root.join("scripts");
+    let temp = tempfile::tempdir().expect("temp dir");
+    let driver = temp.path().join("driver.py");
+    std::fs::write(&driver, DRIVER).expect("write driver");
+
+    let output = Command::new("python3")
+        .arg(&driver)
+        .env("PYTHONPATH", &scripts)
+        .output()
+        .expect("run python3 driver (is python3 on PATH?)");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expectation driver failed.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("ALL OK"),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+const DRIVER: &str = r##"
+import pathlib
+import sys
+import tempfile
+
+import zoo_expectations as ze
+import zoo_triage as zt
+
+HEAD = 'schema_version=1\nrepo="repo"\ndefault_coverage="exhaustive"\nstrict_coverage="selective"\n'
+
+
+def live(fid, rule, path, line=None, line_end=None, profile="default",
+         sev="HIGH", conf="HIGH", prio="P0", title="t", snippet="s"):
+    return ze.LiveFinding(profile, fid, rule, path, line, line_end, sev, conf, prio, title, snippet)
+
+
+def parse(text, repo="repo"):
+    return ze.parse_expectation_text(text, repo, "repo.toml")
+
+
+def block(profile, fid, rule, path, disp, reason, line=None):
+    out = (f'[[finding]]\nprofile="{profile}"\nfinding_id="{fid}"\nrule_id="{rule}"\n'
+           f'path="{path}"\ndisposition="{disp}"\nreason="{reason}"\n')
+    if line is not None:
+        out += f"line={line}\n"
+    return out
+
+
+def kinds(diags):
+    return sorted({d.kind for d in diags})
+
+
+def check(cond, msg):
+    if not cond:
+        print("FAIL:", msg)
+        sys.exit(1)
+
+
+# 1. every default finding labeled exactly once passes
+exp, d = parse(HEAD + block("default", "id1:p:h", "rule.a", "p/a.ts", "actionable", "r"))
+check(d == [], "1 parse clean")
+md, rev = ze.match_repo("repo", exp, [live("id1:p:h", "rule.a", "p/a.ts")], [])
+check(md == [], "1 no diags: " + str(kinds(md)))
+check(rev.actionable == 1 and rev.labeled == 1, "1 counts")
+
+# 2. unlabeled default finding fails
+exp, _ = parse(HEAD)
+md, _ = ze.match_repo("repo", exp, [live("idX", "rule.a", "p/a.ts")], [])
+check(ze.UNLABELED_DEFAULT_FINDING in kinds(md), "2 unlabeled")
+
+# 3. stale default expectation fails
+exp, _ = parse(HEAD + block("default", "idStale", "rule.a", "p/a.ts", "actionable", "r"))
+md, _ = ze.match_repo("repo", exp, [], [])
+check(ze.STALE_EXPECTATION in kinds(md), "3 stale")
+
+# 4. duplicate expectation fails
+body = block("default", "id1", "rule.a", "p/a.ts", "actionable", "r")
+_, d = parse(HEAD + body + body)
+check(ze.DUPLICATE_EXPECTATION in kinds(d), "4 duplicate")
+
+# 5. invalid disposition fails
+_, d = parse(HEAD + block("default", "id1", "rule.a", "p/a.ts", "REVIEW_REQUIRED", "r"))
+check(ze.INVALID_EXPECTATION in kinds(d), "5 invalid disposition")
+
+# 6. empty reason fails
+_, d = parse(HEAD + block("default", "id1", "rule.a", "p/a.ts", "actionable", ""))
+check(ze.INVALID_EXPECTATION in kinds(d), "6 empty reason")
+
+# 7. rule/path mismatch fails even when the finding id matches
+lives = [live("id1", "rule.a", "p/a.ts")]
+exp, _ = parse(HEAD + block("default", "id1", "rule.WRONG", "p/a.ts", "actionable", "r"))
+md, _ = ze.match_repo("repo", exp, lives, [])
+ks = kinds(md)
+check(ze.STALE_EXPECTATION in ks and ze.UNLABELED_DEFAULT_FINDING in ks, "7 rule mismatch " + str(ks))
+exp, _ = parse(HEAD + block("default", "id1", "rule.a", "p/WRONG.ts", "actionable", "r"))
+md, _ = ze.match_repo("repo", exp, lives, [])
+ks = kinds(md)
+check(ze.STALE_EXPECTATION in ks and ze.UNLABELED_DEFAULT_FINDING in ks, "7 path mismatch " + str(ks))
+
+# 8. stable-id collision handled without merging distinct live findings
+coll = [live("idC", "rule.a", "p/a.ts", line=10), live("idC", "rule.a", "p/a.ts", line=20)]
+exp, d = parse(HEAD
+               + block("default", "idC", "rule.a", "p/a.ts", "actionable", "first", line=10)
+               + block("default", "idC", "rule.a", "p/a.ts", "valid-but-accepted", "second", line=20))
+check(d == [], "8a parse")
+md, rev = ze.match_repo("repo", exp, coll, [])
+check(md == [], "8a clean: " + str(kinds(md)))
+check(rev.labeled == 2, "8a both matched individually")
+# without line, the two identical entries collapse (duplicate) and the survivor is ambiguous
+exp, d = parse(HEAD
+               + block("default", "idC", "rule.a", "p/a.ts", "actionable", "first")
+               + block("default", "idC", "rule.a", "p/a.ts", "valid-but-accepted", "second"))
+check(ze.DUPLICATE_EXPECTATION in kinds(d), "8b duplicate")
+md, _ = ze.match_repo("repo", exp, coll, [])
+check(ze.AMBIGUOUS_EXPECTATION in kinds(md), "8b ambiguous " + str(kinds(md)))
+
+# 9. selective strict anchor passes while unrelated strict findings stay unlabeled
+exp, _ = parse(HEAD + block("strict", "idS", "rule.s", "p/s.ts", "valid-but-accepted", "anchor"))
+strict_lives = [live("idS", "rule.s", "p/s.ts", profile="strict"),
+                live("idOther", "rule.s", "p/o.ts", profile="strict")]
+md, rev = ze.match_repo("repo", exp, [], strict_lives)
+check(md == [], "9 clean: " + str(kinds(md)))
+check(rev.strict_anchors == 1, "9 anchors")
+
+# 10. missing strict anchor fails
+exp, _ = parse(HEAD + block("strict", "idGone", "rule.s", "p/s.ts", "actionable", "anchor"))
+md, _ = ze.match_repo("repo", exp, [], [])
+check(ze.MISSING_STRICT_RECALL_ANCHOR in kinds(md), "10 missing anchor")
+
+# 11. false-positive is surfaced but never suppresses the finding
+exp, _ = parse(HEAD + block("default", "idFP", "rule.a", "p/a.ts", "false-positive", "calibration debt"))
+md, rev = ze.match_repo("repo", exp, [live("idFP", "rule.a", "p/a.ts")], [])
+ks = kinds(md)
+check(ze.KNOWN_FALSE_POSITIVE in ks, "11 surfaced")
+check(not ze.is_failure(ze.KNOWN_FALSE_POSITIVE), "11 fp is not a failure")
+check(all(not ze.is_failure(k) for k in ks), "11 no failing kinds " + str(ks))
+check(rev.false_positive == 1 and rev.labeled == 1, "11 still labeled, not suppressed")
+
+# 12. triage output carries evidence + a non-valid placeholder disposition
+lf = live("idT", "rule.a", "p/a.ts", line=42, snippet="boom()", title="Title")
+out = zt.render_triage_entry("repo", lf)
+for needle in ["idT", "rule.a", "p/a.ts:42", "boom()", "Title", "REVIEW_REQUIRED", "P0", "HIGH"]:
+    check(needle in out, "12 missing " + needle)
+_, d = parse(HEAD + block("default", "idT", "rule.a", "p/a.ts", "REVIEW_REQUIRED", "x"))
+check(ze.INVALID_EXPECTATION in kinds(d), "12 review_required rejected")
+exp, _ = parse(HEAD)
+check(len(ze.unlabeled_default(exp, [lf])) == 1, "12 unlabeled helper")
+
+# 13. expectation diagnostics are a separate channel from snapshot drift
+exp, _ = parse(HEAD + block("default", "id1", "rule.a", "p/a.ts", "actionable", "r"))
+ok, _ = ze.match_repo("repo", exp, [live("id1", "rule.a", "p/a.ts")], [])
+bad, _ = ze.match_repo("repo", exp, [live("idX", "rule.a", "p/a.ts")], [])
+check(ze.SNAPSHOT_DRIFT not in {x.kind for x in ok + bad}, "13 matcher never emits drift")
+
+# 14. empty-default repo still requires a valid expectation file
+exp, d = parse(HEAD)
+check(exp is not None and d == [] and exp.findings == (), "14 empty valid")
+miss = pathlib.Path(tempfile.gettempdir()) / "zoo-expectations-missing-xyz.toml"
+if miss.exists():
+    miss.unlink()
+_, d = ze.parse_expectation_file(miss, "repo")
+check(ze.MISSING_EXPECTATION_FILE in kinds(d), "14 missing file")
+
+# 15. manifest repo without an expectation file fails
+d = ze.coverage_diagnostics(["a", "b"], ["a", "b"], ["a"])
+check(ze.MISSING_EXPECTATION_FILE in kinds(d) and any(x.repo == "b" for x in d), "15 missing manifest file")
+
+# 16. extra expectation file for an unknown repo fails
+d = ze.coverage_diagnostics(["a"], ["a"], ["a", "ghost"])
+check(ze.UNKNOWN_EXPECTATION_FILE in kinds(d) and any(x.repo == "ghost" for x in d), "16 unknown file")
+
+# header validation: schema, repo mismatch, unknown profile, unknown field
+_, d = parse('schema_version=2\nrepo="repo"\n')
+check(ze.INVALID_EXPECTATION in kinds(d), "schema version")
+_, d = parse('schema_version=1\nrepo="other"\n', repo="repo")
+check(ze.INVALID_EXPECTATION in kinds(d), "repo mismatch")
+_, d = parse(HEAD + '[[finding]]\nprofile="weird"\nfinding_id="i"\nrule_id="r"\npath="p"\ndisposition="actionable"\nreason="x"\n')
+check(ze.INVALID_EXPECTATION in kinds(d), "unknown profile")
+_, d = parse(HEAD + '[[finding]]\nprofile="default"\nfinding_id="i"\nrule_id="r"\npath="p"\ndisposition="actionable"\nreason="x"\nbogus="y"\n')
+check(ze.INVALID_EXPECTATION in kinds(d), "unknown field")
+
+print("ALL OK")
+"##;

--- a/tests/zoo_runner_contract.rs
+++ b/tests/zoo_runner_contract.rs
@@ -30,6 +30,8 @@ impl Harness {
         fs::create_dir_all(&bin_dir).expect("bin dir");
         copy_script(&root, "zoo.py");
         copy_script(&root, "zoo_scanner.py");
+        copy_script(&root, "zoo_expectations.py");
+        copy_script(&root, "zoo_triage.py");
         fs::write(root.join("Cargo.toml"), CARGO_TOML).expect("Cargo.toml");
         fs::write(root.join("tests/zoo/manifest.toml"), MANIFEST).expect("manifest");
         fs::write(root.join("tests/zoo/snapshots/sample.json"), SNAPSHOT).expect("snapshot");


### PR DESCRIPTION
## What
Adds a human-reviewed, machine-validated **expectation layer** to the real-repo zoo,
on top of the hermetic runner from #249. Snapshots answer *what RepoPilot emitted*;
expectations (`tests/zoo/expectations/<repo>.toml`, one per manifest repo) answer
*how a human reviewed it*. A green zoo now also means: every default-visible finding
was reviewed and classified.

## How
- **Schema (v1):** per-repo TOML, `default_coverage="exhaustive"` / `strict_coverage="selective"`,
  `[[finding]]` entries with closed-enum `disposition` (`actionable` | `valid-but-accepted`
  | `false-positive`) + non-empty `reason`. Optional `line`/`line_end` disambiguate
  findings that share a stable `id` (id = `rule:path:hash`, not globally unique;
  aggregation never merges distinct locations).
- **`scan`** reuses the #249 live reports, compares snapshots **and** validates labels,
  reporting drift and expectation failures on **separate channels**
  (UNLABELED / STALE / DUPLICATE / INVALID / AMBIGUOUS / MISSING ANCHOR / KNOWN FP).
- **`triage`** prints unlabeled findings with full evidence + a copy-paste skeleton
  whose disposition is `REVIEW_REQUIRED` (rejected by validation — never guesses).
- **`report`** adds a reviewed signal-quality summary (actionable/accepted/FP totals,
  reviewed precision *proxy*, actionability rate, by-rule/by-repo).
- Labels never suppress output; `false-positive` is surfaced as calibration debt;
  `--bless` never writes human labels. Code: `zoo_expectations.py` (parse+match,
  hermetic) and `zoo_triage.py` (rendering), kept separate.

## Reviewed results (25 default findings)
9 actionable / 16 valid-but-accepted / 0 false-positive; 4 strict recall anchors
(Algolia key, ripgrep testutil panic, ignite CLI exit, fastapi assert).

## Snapshot reconciliation (excalidraw — no analyzer change)
Reconciles drift the #249 hermetic runner surfaced from already-merged #246/#247:
- default **8 → 6**: −1 secret-candidate (Algolia → strict-only, #246), −1 runtime-exit woff2 (#247).
- strict **1233 → 1213**: generated `woff2-bindings.ts` fully skipped (#247) removes its
  runtime-exit (−1) / large-file (−1) / complex-function (−7) / long-function (−11).
  Algolia key correctly stays in strict. No other snapshot changed.

## Tests
- New hermetic `tests/zoo_expectations_contract.rs` (Rust drives the pure Python matcher
  via PYTHONPATH; 18 scenarios). `cargo test --all` stays network-free.
- `zoo_runner_contract.rs` from #249 remains green.

## Gates
fmt ✓ · clippy -D warnings ✓ · cargo test --all (0 failures) ✓ · release:contract ✓ ·
test:release-contract ✓ · `REPOPILOT_ZOO=1` zoo_regression ✓ · verify-pins ✓.
No analyzer behavior / severity / visibility / schema / version changes.