### PR TITLE
feat(explain): render rule decision trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **Rule decisions now expose an ordered, evidence-backed trace.** The Knowledge
+  Engine has one trace-producing path that records rule lookup, configured
+  applicability checks, the supplied base severity, every override in declaration
+  order (including unmatched and test-skipped entries), severity transitions, and
+  the final decision. Existing `decide*` APIs remain wrappers over the same path,
+  so explanation cannot drift from scan behavior. Normal scan and review paths
+  keep trace recording disabled and do not allocate trace strings or vectors.
+  `repopilot_explain_file` now adds file-role evidence from the context
+  classifier, including executable-package manifest context, a final
+  default-profile visibility step, and explicit scope limits: repository graph context,
+  `repopilot.toml` rule overrides, local feedback, baseline state, and full scan
+  filtering are not applied. The MCP tool uses registry default severity for known
+  rules. This is additive explain/MCP JSON; scan, review, SARIF, baseline, receipt,
+  finding IDs, severity decisions, and visibility behavior are unchanged.
+
 - **File-role classification now preserves explainable evidence.** The detailed
   classifier records one typed evidence entry for every assigned role, including
   whether it came from a path, content/framework marker, package manifest,

--- a/docs/knowledge-engine.md
+++ b/docs/knowledge-engine.md
@@ -58,6 +58,29 @@ RepoPilot keeps this taxonomy explicit with declarative and infrastructure
 context so future rules can narrow applicability instead of treating every file
 as normal application code.
 
+## Decision Traces
+
+The decision engine has one authoritative evaluator. Existing `decide*`
+functions run it with tracing disabled, while explicit traced APIs attach a
+lazy recorder to the same evaluator. Scan and review therefore avoid allocating
+trace labels, criteria, and reasons while explanations cannot silently diverge.
+
+A trace records:
+
+1. whether the rule exists in the bundled knowledge pack;
+2. each configured applicability check and the check that suppressed a rule;
+3. the supplied base severity;
+4. every override in declaration order, including unmatched and test-skipped
+   overrides;
+5. the severity before and after each applied override.
+
+The explain surface adds file-role evidence from the context classifier and a
+final default-profile visibility step. It also states its scope explicitly:
+single-file classification, executable-package manifest context, and bundled
+knowledge are included; repository graph context, `repopilot.toml` rule
+overrides, local feedback, baseline state, and
+full scan filtering are not.
+
 ## Diagnostics
 
 The Knowledge Engine is consumed internally by `scan` and `review`. Its decisions

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -37,7 +37,14 @@ non-destructive, idempotent, and closed-world.
 | `repopilot_review_change` | Changed/full review with findings, signals, blast radius, and gate result | `base`, `head`, `config`, `baseline`, `scope`, `profile`, `fail_on_review`, `detail` |
 | `repopilot_scan` | Repository or changed-scope JSON scan | `config`, `profile`, `scope`, `base` |
 | `repopilot_context` | Budgeted AI-ready Markdown context | `config`, `profile`, `focus`, `budget` |
-| `repopilot_explain_file` | File classification and applicable rules | `rule`, `signal` |
+| `repopilot_explain_file` | File-role evidence and ordered rule decision trace | `rule`, `signal` |
+
+`repopilot_explain_file` returns additive JSON fields for explicit scope,
+role evidence, applicability checks, every ordered override, severity
+transitions, and the final default-profile visibility decision. It resolves
+executable-package manifest context from the MCP root so `cli-executable`
+classification matches normal scanning. Its rule base severity comes from the
+rule registry when a known `rule` is supplied.
 
 Every tool accepts a workspace-relative `path` where applicable. Review defaults
 to `scope=changed`, `profile=default`, `fail_on_review=none`, and

--- a/src/commands/mcp/explain_file.rs
+++ b/src/commands/mcp/explain_file.rs
@@ -1,18 +1,19 @@
 //! The `repopilot_explain_file` MCP tool: how RepoPilot classifies one file and
 //! which rules/signals apply, wrapping the `repopilot::explain` report builder.
 
-use repopilot::explain::{build_explain_report, render_explain_report};
+use repopilot::explain::{build_explain_report_with_root, render_explain_report};
 use repopilot::findings::types::Severity;
 use repopilot::output::OutputFormat;
+use repopilot::rules::lookup_rule_metadata;
 use serde_json::{Value, json};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub const TOOL_NAME: &str = "repopilot_explain_file";
 
 pub fn definition() -> Value {
     json!({
         "name": TOOL_NAME,
-        "description": "Explain how RepoPilot classifies a single file (role, language, test/production context) and which rules and signals apply, with the resulting severity decisions. Returns a JSON explanation. Local-only.",
+        "description": "Explain one file with role evidence, applicability checks, ordered knowledge overrides, severity transitions, default-profile visibility, and explicit scope limits. Returns a JSON explanation. Local-only.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -42,7 +43,7 @@ pub fn definition() -> Value {
     })
 }
 
-pub fn call(arguments: &Value) -> Result<String, String> {
+pub fn call(arguments: &Value, root: &Path) -> Result<String, String> {
     let Some(path) = arguments.get("path").and_then(Value::as_str) else {
         return Err("`path` is required".to_string());
     };
@@ -50,10 +51,40 @@ pub fn call(arguments: &Value) -> Result<String, String> {
     let rule = arguments.get("rule").and_then(Value::as_str);
     let signal = arguments.get("signal").and_then(Value::as_str);
 
-    // Lowest base severity so the explanation surfaces every applicable rule.
-    let report = build_explain_report(&path, rule, signal, Severity::Info)
+    let base_severity = rule
+        .and_then(lookup_rule_metadata)
+        .map(|metadata| metadata.default_severity)
+        .unwrap_or(Severity::Info);
+    let report = build_explain_report_with_root(root, &path, rule, signal, base_severity)
         .map_err(|error| format!("explain failed: {error}"))?;
 
     render_explain_report(&report, OutputFormat::Json)
         .map_err(|error| format!("render failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explain_tool_returns_role_evidence_scope_and_decision_trace() {
+        let rendered = call(
+            &json!({
+                "path": "src/lib.rs",
+                "rule": "language.rust.panic-risk",
+                "signal": "rust.panic"
+            }),
+            Path::new("."),
+        )
+        .expect("explain tool call");
+        let value: Value = serde_json::from_str(&rendered).expect("explain JSON");
+        assert_eq!(value["scope"]["analysis_scope"], "single-file");
+        assert!(value["context"]["role_evidence"].is_array());
+        assert!(value["decision"]["trace"].is_array());
+        assert!(
+            value["decision"]["trace"]
+                .as_array()
+                .is_some_and(|steps| !steps.is_empty())
+        );
+    }
 }

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -324,7 +324,7 @@ fn handle_tools_call(id: Value, params: &Value, state: &mut ServerState) -> Resp
         review_change::TOOL_NAME => review_change::call(&arguments),
         scan::TOOL_NAME => scan::call(&arguments),
         context::TOOL_NAME => context::call(&arguments),
-        explain_file::TOOL_NAME => explain_file::call(&arguments),
+        explain_file::TOOL_NAME => explain_file::call(&arguments, &state.root),
         other => Err(format!("unknown tool: {other}")),
     };
 

--- a/src/explain/builder.rs
+++ b/src/explain/builder.rs
@@ -1,20 +1,32 @@
-use crate::audits::context::classify_file;
+use crate::audits::context::classify_file_with_evidence;
 use crate::explain::model::{
-    ExplainContext, ExplainDecision, ExplainReport, ExplainRiskSignal, ExplainSource,
-    ExplainVisibility,
+    ExplainContext, ExplainDecision, ExplainDecisionTraceStep, ExplainReport, ExplainRiskSignal,
+    ExplainRoleEvidence, ExplainScope, ExplainSource, ExplainVisibility,
 };
 use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use crate::findings::visibility::classify_visibility;
-use crate::knowledge::decision::decide_for_file;
+use crate::knowledge::decision::decide_for_file_with_trace;
 use crate::knowledge::language::{detect_language_for_path, profile_by_id};
 use crate::knowledge::model::{RuleDecisionAction, SupportLevel};
 use crate::rules::registry::lookup_rule_metadata;
 use crate::scan::facts::FileFacts;
+use crate::scan::workspace::{package_roots, path_in_executable_package};
 use std::fs;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub fn build_explain_report(
+    path: &Path,
+    rule_id: Option<&str>,
+    signal: Option<&str>,
+    base_severity: Severity,
+) -> Result<ExplainReport, io::Error> {
+    let root = infer_analysis_root(path);
+    build_explain_report_with_root(&root, path, rule_id, signal, base_severity)
+}
+
+pub fn build_explain_report_with_root(
+    root: &Path,
     path: &Path,
     rule_id: Option<&str>,
     signal: Option<&str>,
@@ -24,6 +36,8 @@ pub fn build_explain_report(
     let language_name = detect_language_for_path(path).map(str::to_string);
     let non_empty_lines = count_non_empty_lines(&content);
     let has_inline_tests = has_language_inline_tests(path, language_name.as_deref(), &content);
+    let executable_roots = package_roots(root);
+    let in_executable_package = path_in_executable_package(path, &executable_roots);
 
     let file = FileFacts {
         path: path.to_path_buf(),
@@ -33,11 +47,12 @@ pub fn build_explain_report(
         imports: Vec::new(),
         content: Some(content),
         has_inline_tests,
-        in_executable_package: false,
+        in_executable_package,
         deferred_imports: Vec::new(),
     };
 
-    let audit_context = classify_file(&file);
+    let classified = classify_file_with_evidence(&file);
+    let audit_context = &classified.context;
     let arch_context = crate::analysis::classify_file_architecture(
         &file,
         &crate::scan::config::ScanConfig::default(),
@@ -59,6 +74,15 @@ pub fn build_explain_report(
             .into_iter()
             .map(str::to_string)
             .collect(),
+        role_evidence: classified
+            .role_evidence
+            .iter()
+            .map(|evidence| ExplainRoleEvidence {
+                role: evidence.role.as_id().to_string(),
+                source: evidence.source.as_id().to_string(),
+                reason: evidence.reason.to_string(),
+            })
+            .collect(),
         paradigms: audit_context
             .paradigm_ids()
             .into_iter()
@@ -77,27 +101,79 @@ pub fn build_explain_report(
     };
 
     let decision = rule_id.map(|rule_id| {
-        let decision = decide_for_file(rule_id, &file, base_severity, signal);
+        let traced = decide_for_file_with_trace(rule_id, &file, base_severity, signal);
+        let visibility = explain_visibility(path, rule_id, traced.decision.severity);
+        let mut trace = traced
+            .steps
+            .into_iter()
+            .enumerate()
+            .map(|(index, step)| ExplainDecisionTraceStep {
+                order: index + 1,
+                stage: step.stage.as_id().to_string(),
+                status: step.status.as_id().to_string(),
+                label: step.label,
+                criteria: step.criteria,
+                action: step
+                    .action
+                    .map(|action| decision_action_label(action).to_string()),
+                severity_before: step.severity_before,
+                severity_after: step.severity_after,
+                reason: step.reason,
+                override_index: step.override_index,
+            })
+            .collect::<Vec<_>>();
+
+        trace.push(ExplainDecisionTraceStep {
+            order: trace.len() + 1,
+            stage: "visibility".to_string(),
+            status: if visibility.visible_by_default {
+                "visible".to_string()
+            } else {
+                "hidden".to_string()
+            },
+            label: "default-profile".to_string(),
+            criteria: vec![
+                format!("profile={}", visibility.profile),
+                format!("intent={}", visibility.intent),
+            ],
+            action: None,
+            severity_before: traced.decision.severity,
+            severity_after: traced.decision.severity,
+            reason: visibility.reason.clone(),
+            override_index: None,
+        });
 
         ExplainDecision {
             rule_id: rule_id.to_string(),
             signal: signal.map(str::to_string),
             base_severity,
-            action: decision_action_label(decision.action).to_string(),
-            final_severity: decision.severity,
-            reason: decision.reason,
-            risk_signal: decision.risk_signal.map(|signal| ExplainRiskSignal {
+            action: decision_action_label(traced.decision.action).to_string(),
+            final_severity: traced.decision.severity,
+            reason: traced.decision.reason,
+            risk_signal: traced.decision.risk_signal.map(|signal| ExplainRiskSignal {
                 id: signal.id,
                 label: signal.label,
                 weight: signal.weight,
                 reason: signal.reason,
             }),
-            visibility: Some(explain_visibility(path, rule_id, decision.severity)),
+            trace,
+            visibility: Some(visibility),
         }
     });
 
     Ok(ExplainReport {
         path: path.display().to_string(),
+        scope: ExplainScope {
+            analysis_scope: "single-file".to_string(),
+            decision_source: "bundled-knowledge-pack".to_string(),
+            visibility_profile: "default".to_string(),
+            repository_context_included: false,
+            package_manifest_context_included: true,
+            scan_configuration_included: false,
+            local_feedback_included: false,
+            baseline_included: false,
+            note: "Explains local file classification, executable-package manifest context, and the bundled knowledge decision only; repository graph context, repopilot.toml rule overrides, local feedback, baseline state, and full scan filtering are not applied.".to_string(),
+        },
         source: ExplainSource {
             language_name,
             non_empty_lines,
@@ -106,6 +182,21 @@ pub fn build_explain_report(
         context,
         decision,
     })
+}
+
+fn infer_analysis_root(path: &Path) -> PathBuf {
+    let start = path.parent().unwrap_or_else(|| Path::new("."));
+
+    start
+        .ancestors()
+        .find(|candidate| candidate.join(".git").exists())
+        .or_else(|| {
+            start.ancestors().find(|candidate| {
+                candidate.join("Cargo.toml").is_file() || candidate.join("package.json").is_file()
+            })
+        })
+        .unwrap_or(start)
+        .to_path_buf()
 }
 
 fn count_non_empty_lines(content: &str) -> usize {
@@ -168,7 +259,6 @@ fn explain_visibility(path: &Path, rule_id: &str, severity: Severity) -> Explain
     let category = lookup_rule_metadata(rule_id)
         .map(|metadata| metadata.category.clone())
         .unwrap_or(FindingCategory::CodeQuality);
-
     let finding = Finding {
         rule_id: rule_id.to_string(),
         category,
@@ -182,13 +272,109 @@ fn explain_visibility(path: &Path, rule_id: &str, severity: Severity) -> Explain
         }],
         ..Default::default()
     };
-
     let decision = classify_visibility(&finding);
-
     ExplainVisibility {
         profile: "default".to_string(),
         intent: decision.intent.label().to_string(),
         visible_by_default: decision.visible_by_default,
         reason: decision.reason.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::explain::render::render_explain_report;
+    use crate::output::OutputFormat;
+
+    #[test]
+    fn report_contains_role_evidence_scope_and_ordered_trace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("src/models/value.rs");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create fixture dirs");
+        std::fs::write(&path, "pub fn value() -> usize { 1 }\n").expect("write fixture");
+        let report = build_explain_report(
+            &path,
+            Some("code-quality.long-function"),
+            None,
+            Severity::Medium,
+        )
+        .expect("build explain report");
+
+        assert_eq!(report.scope.analysis_scope, "single-file");
+        assert!(!report.scope.repository_context_included);
+        assert!(
+            report
+                .context
+                .role_evidence
+                .iter()
+                .any(|evidence| { evidence.role == "domain" && evidence.source == "path" })
+        );
+
+        let decision = report.decision.as_ref().expect("rule decision");
+        assert!(!decision.trace.is_empty());
+        assert_eq!(
+            decision.trace.last().expect("visibility step").stage,
+            "visibility"
+        );
+        assert!(
+            decision
+                .trace
+                .windows(2)
+                .all(|pair| pair[0].order + 1 == pair[1].order)
+        );
+
+        let console = render_explain_report(&report, OutputFormat::Console).expect("console");
+        let markdown = render_explain_report(&report, OutputFormat::Markdown).expect("markdown");
+        let json = render_explain_report(&report, OutputFormat::Json).expect("json");
+        assert!(console.contains("Decision trace:"));
+        assert!(markdown.contains("### Role evidence"));
+        let value: serde_json::Value = serde_json::from_str(&json).expect("parse JSON");
+        assert!(value["context"]["role_evidence"].is_array());
+        assert!(value["decision"]["trace"].is_array());
+        assert_eq!(value["scope"]["analysis_scope"], "single-file");
+    }
+
+    #[test]
+    fn executable_manifest_context_matches_scanner_decision() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join("package.json"),
+            r#"{ "name": "demo-cli", "bin": { "demo": "./src/index.js" } }"#,
+        )
+        .expect("write package manifest");
+
+        let path = temp.path().join("src/commands/stop.ts");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create command dir");
+        std::fs::write(&path, "export function stop() { process.exit(1); }\n")
+            .expect("write command");
+
+        let report = build_explain_report_with_root(
+            temp.path(),
+            &path,
+            Some("language.javascript.runtime-exit-risk"),
+            Some("js.process-exit"),
+            Severity::High,
+        )
+        .expect("build manifest-aware explain report");
+
+        assert!(report.scope.package_manifest_context_included);
+        assert!(report.context.role_evidence.iter().any(|evidence| {
+            evidence.role == "cli-executable"
+                && evidence.source == "mixed"
+                && evidence.reason.contains("executable package manifest")
+        }));
+
+        let decision = report.decision.as_ref().expect("decision");
+        assert_eq!(decision.action, "downgrade");
+        assert_eq!(decision.final_severity, Severity::Low);
+        assert!(decision.trace.iter().any(|step| {
+            step.stage == "override"
+                && step.status == "applied"
+                && step
+                    .criteria
+                    .iter()
+                    .any(|criterion| criterion == "role=cli-executable")
+        }));
     }
 }

--- a/src/explain/mod.rs
+++ b/src/explain/mod.rs
@@ -2,6 +2,9 @@ pub mod builder;
 pub mod model;
 pub mod render;
 
-pub use builder::build_explain_report;
-pub use model::{ExplainContext, ExplainDecision, ExplainReport, ExplainSource};
+pub use builder::{build_explain_report, build_explain_report_with_root};
+pub use model::{
+    ExplainContext, ExplainDecision, ExplainDecisionTraceStep, ExplainReport, ExplainRoleEvidence,
+    ExplainScope, ExplainSource,
+};
 pub use render::render_explain_report;

--- a/src/explain/model.rs
+++ b/src/explain/model.rs
@@ -4,10 +4,24 @@ use serde::Serialize;
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ExplainReport {
     pub path: String,
+    pub scope: ExplainScope,
     pub source: ExplainSource,
     pub context: ExplainContext,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub decision: Option<ExplainDecision>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExplainScope {
+    pub analysis_scope: String,
+    pub decision_source: String,
+    pub visibility_profile: String,
+    pub repository_context_included: bool,
+    pub package_manifest_context_included: bool,
+    pub scan_configuration_included: bool,
+    pub local_feedback_included: bool,
+    pub baseline_included: bool,
+    pub note: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -24,6 +38,7 @@ pub struct ExplainContext {
     pub language_support: Option<String>,
     pub frameworks: Vec<String>,
     pub roles: Vec<String>,
+    pub role_evidence: Vec<ExplainRoleEvidence>,
     pub paradigms: Vec<String>,
     pub runtimes: Vec<String>,
     pub is_test: bool,
@@ -34,6 +49,13 @@ pub struct ExplainContext {
     pub module_kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language_family: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExplainRoleEvidence {
+    pub role: String,
+    pub source: String,
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -48,8 +70,25 @@ pub struct ExplainDecision {
     pub reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub risk_signal: Option<ExplainRiskSignal>,
+    pub trace: Vec<ExplainDecisionTraceStep>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub visibility: Option<ExplainVisibility>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExplainDecisionTraceStep {
+    pub order: usize,
+    pub stage: String,
+    pub status: String,
+    pub label: String,
+    pub criteria: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+    pub severity_before: Severity,
+    pub severity_after: Severity,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub override_index: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/explain/render.rs
+++ b/src/explain/render.rs
@@ -1,4 +1,6 @@
-use crate::explain::model::{ExplainDecision, ExplainReport};
+use crate::explain::model::{
+    ExplainDecision, ExplainDecisionTraceStep, ExplainReport, ExplainRoleEvidence,
+};
 use crate::output::OutputFormat;
 
 pub fn render_explain_report(
@@ -16,7 +18,6 @@ pub fn render_explain_report(
 
 fn render_console(report: &ExplainReport) -> String {
     let mut output = String::new();
-
     output.push_str("RepoPilot Explain\n\n");
     output.push_str(&format!("File: {}\n", report.path));
     output.push_str(&format!(
@@ -31,6 +32,38 @@ fn render_console(report: &ExplainReport) -> String {
         "Inline tests: {}\n\n",
         yes_no(report.source.has_inline_tests)
     ));
+
+    output.push_str("Scope:\n");
+    output.push_str(&format!(" Analysis: {}\n", report.scope.analysis_scope));
+    output.push_str(&format!(
+        " Decision source: {}\n",
+        report.scope.decision_source
+    ));
+    output.push_str(&format!(
+        " Visibility profile: {}\n",
+        report.scope.visibility_profile
+    ));
+    output.push_str(&format!(
+        " Repository context: {}\n",
+        yes_no(report.scope.repository_context_included)
+    ));
+    output.push_str(&format!(
+        " Package manifest context: {}\n",
+        yes_no(report.scope.package_manifest_context_included)
+    ));
+    output.push_str(&format!(
+        " Scan configuration: {}\n",
+        yes_no(report.scope.scan_configuration_included)
+    ));
+    output.push_str(&format!(
+        " Local feedback: {}\n",
+        yes_no(report.scope.local_feedback_included)
+    ));
+    output.push_str(&format!(
+        " Baseline: {}\n",
+        yes_no(report.scope.baseline_included)
+    ));
+    output.push_str(&format!(" Note: {}\n\n", report.scope.note));
 
     output.push_str("Audit context:\n");
     output.push_str(&format!(" Language: {}\n", report.context.language));
@@ -50,6 +83,7 @@ fn render_console(report: &ExplainReport) -> String {
         " Roles: {}\n",
         comma_or_none(&report.context.roles)
     ));
+    render_console_role_evidence(&mut output, &report.context.role_evidence);
     output.push_str(&format!(
         " Paradigms: {}\n",
         comma_or_none(&report.context.paradigms)
@@ -63,14 +97,14 @@ fn render_console(report: &ExplainReport) -> String {
         " Production code: {}\n",
         yes_no(report.context.is_production_code)
     ));
-    if let Some(arch_role) = &report.context.architecture_role {
-        output.push_str(&format!(" Architecture role: {}\n", arch_role));
+    if let Some(value) = &report.context.architecture_role {
+        output.push_str(&format!(" Architecture role: {}\n", value));
     }
-    if let Some(mod_kind) = &report.context.module_kind {
-        output.push_str(&format!(" Module kind: {}\n", mod_kind));
+    if let Some(value) = &report.context.module_kind {
+        output.push_str(&format!(" Module kind: {}\n", value));
     }
-    if let Some(lang_family) = &report.context.language_family {
-        output.push_str(&format!(" Language family: {}\n", lang_family));
+    if let Some(value) = &report.context.language_family {
+        output.push_str(&format!(" Language family: {}\n", value));
     }
 
     output.push_str("\nRule decision:\n");
@@ -78,13 +112,25 @@ fn render_console(report: &ExplainReport) -> String {
         Some(decision) => output.push_str(&render_console_decision(decision)),
         None => output.push_str(" not requested; pass --rule <RULE_ID> to evaluate one\n"),
     }
-
     output
+}
+
+fn render_console_role_evidence(output: &mut String, evidence: &[ExplainRoleEvidence]) {
+    output.push_str(" Role evidence:\n");
+    if evidence.is_empty() {
+        output.push_str("  - none\n");
+        return;
+    }
+    for item in evidence {
+        output.push_str(&format!(
+            "  - {} [{}]: {}\n",
+            item.role, item.source, item.reason
+        ));
+    }
 }
 
 fn render_console_decision(decision: &ExplainDecision) -> String {
     let mut output = String::new();
-
     output.push_str(&format!(" Rule: {}\n", decision.rule_id));
     output.push_str(&format!(
         " Signal: {}\n",
@@ -122,12 +168,31 @@ fn render_console_decision(decision: &ExplainDecision) -> String {
         output.push_str(&format!(" Intent: {}\n", visibility.intent));
     }
 
+    output.push_str(" Decision trace:\n");
+    for step in &decision.trace {
+        output.push_str(&format!(
+            "  {}. [{} / {}] {}\n",
+            step.order, step.stage, step.status, step.label
+        ));
+        output.push_str(&format!(
+            "     Severity: {} -> {}\n",
+            step.severity_before.label(),
+            step.severity_after.label()
+        ));
+        if let Some(action) = &step.action {
+            output.push_str(&format!("     Action: {action}\n"));
+        }
+        output.push_str(&format!(
+            "     Criteria: {}\n",
+            comma_or_none(&step.criteria)
+        ));
+        output.push_str(&format!("     Reason: {}\n", step.reason));
+    }
     output
 }
 
 fn render_markdown(report: &ExplainReport) -> String {
     let mut output = String::new();
-
     output.push_str("# RepoPilot Explain\n\n");
     output.push_str(&format!("- **File:** `{}`\n", report.path));
     output.push_str(&format!(
@@ -142,6 +207,41 @@ fn render_markdown(report: &ExplainReport) -> String {
         "- **Inline tests:** {}\n\n",
         yes_no(report.source.has_inline_tests)
     ));
+
+    output.push_str("## Scope\n\n");
+    output.push_str(&format!(
+        "- **Analysis scope:** `{}`\n",
+        report.scope.analysis_scope
+    ));
+    output.push_str(&format!(
+        "- **Decision source:** `{}`\n",
+        report.scope.decision_source
+    ));
+    output.push_str(&format!(
+        "- **Visibility profile:** `{}`\n",
+        report.scope.visibility_profile
+    ));
+    output.push_str(&format!(
+        "- **Repository context included:** {}\n",
+        yes_no(report.scope.repository_context_included)
+    ));
+    output.push_str(&format!(
+        "- **Package manifest context included:** {}\n",
+        yes_no(report.scope.package_manifest_context_included)
+    ));
+    output.push_str(&format!(
+        "- **Scan configuration included:** {}\n",
+        yes_no(report.scope.scan_configuration_included)
+    ));
+    output.push_str(&format!(
+        "- **Local feedback included:** {}\n",
+        yes_no(report.scope.local_feedback_included)
+    ));
+    output.push_str(&format!(
+        "- **Baseline included:** {}\n",
+        yes_no(report.scope.baseline_included)
+    ));
+    output.push_str(&format!("- **Note:** {}\n\n", report.scope.note));
 
     output.push_str("## Audit context\n\n");
     output.push_str(&format!("- **Language:** `{}`\n", report.context.language));
@@ -177,64 +277,104 @@ fn render_markdown(report: &ExplainReport) -> String {
         "- **Production code:** {}\n",
         yes_no(report.context.is_production_code)
     ));
-    if let Some(arch_role) = &report.context.architecture_role {
-        output.push_str(&format!("- **Architecture role:** `{}`\n", arch_role));
+    if let Some(value) = &report.context.architecture_role {
+        output.push_str(&format!("- **Architecture role:** `{}`\n", value));
     }
-    if let Some(mod_kind) = &report.context.module_kind {
-        output.push_str(&format!("- **Module kind:** `{}`\n", mod_kind));
+    if let Some(value) = &report.context.module_kind {
+        output.push_str(&format!("- **Module kind:** `{}`\n", value));
     }
-    if let Some(lang_family) = &report.context.language_family {
-        output.push_str(&format!("- **Language family:** `{}`\n\n", lang_family));
+    if let Some(value) = &report.context.language_family {
+        output.push_str(&format!("- **Language family:** `{}`\n", value));
+    }
+
+    output.push_str("\n### Role evidence\n\n");
+    if report.context.role_evidence.is_empty() {
+        output.push_str("None.\n");
     } else {
-        output.push('\n');
+        for evidence in &report.context.role_evidence {
+            output.push_str(&format!(
+                "- `{}` from `{}` — {}\n",
+                evidence.role, evidence.source, evidence.reason
+            ));
+        }
     }
 
-    output.push_str("## Rule decision\n\n");
+    output.push_str("\n## Rule decision\n\n");
     match &report.decision {
-        Some(decision) => {
-            output.push_str(&format!("- **Rule:** `{}`\n", decision.rule_id));
-            output.push_str(&format!(
-                "- **Signal:** `{}`\n",
-                decision.signal.as_deref().unwrap_or("none")
-            ));
-            output.push_str(&format!(
-                "- **Base severity:** `{}`\n",
-                decision.base_severity.label()
-            ));
-            output.push_str(&format!("- **Action:** `{}`\n", decision.action));
-            output.push_str(&format!(
-                "- **Final severity:** `{}`\n",
-                decision.final_severity.label()
-            ));
-            if let Some(reason) = &decision.reason {
-                output.push_str(&format!("- **Reason:** {reason}\n"));
-            }
-            if let Some(signal) = &decision.risk_signal {
-                output.push_str(&format!(
-                    "- **Risk signal:** {} ({:+}) — {}\n",
-                    signal.label, signal.weight, signal.reason
-                ));
-            }
-            if let Some(visibility) = &decision.visibility {
-                output.push_str(&format!(
-                    "- **Visibility:** `{}` in `{}` profile\n",
-                    if visibility.visible_by_default {
-                        "visible"
-                    } else {
-                        "hidden"
-                    },
-                    visibility.profile
-                ));
-                output.push_str(&format!("- **Intent:** `{}`\n", visibility.intent));
-                output.push_str(&format!("- **Visibility reason:** {}\n", visibility.reason));
-            }
-        }
+        Some(decision) => render_markdown_decision(&mut output, decision),
         None => {
-            output.push_str("No rule was requested. Pass `--rule <RULE_ID>` to evaluate one.\n");
+            output.push_str("No rule was requested. Pass `--rule <RULE_ID>` to evaluate one.\n")
         }
     }
-
     output
+}
+
+fn render_markdown_decision(output: &mut String, decision: &ExplainDecision) {
+    output.push_str(&format!("- **Rule:** `{}`\n", decision.rule_id));
+    output.push_str(&format!(
+        "- **Signal:** `{}`\n",
+        decision.signal.as_deref().unwrap_or("none")
+    ));
+    output.push_str(&format!(
+        "- **Base severity:** `{}`\n",
+        decision.base_severity.label()
+    ));
+    output.push_str(&format!("- **Action:** `{}`\n", decision.action));
+    output.push_str(&format!(
+        "- **Final severity:** `{}`\n",
+        decision.final_severity.label()
+    ));
+    if let Some(reason) = &decision.reason {
+        output.push_str(&format!("- **Reason:** {reason}\n"));
+    }
+    if let Some(signal) = &decision.risk_signal {
+        output.push_str(&format!(
+            "- **Risk signal:** {} ({:+}) — {}\n",
+            signal.label, signal.weight, signal.reason
+        ));
+    }
+    if let Some(visibility) = &decision.visibility {
+        output.push_str(&format!(
+            "- **Visibility:** `{}` in `{}` profile\n",
+            if visibility.visible_by_default {
+                "visible"
+            } else {
+                "hidden"
+            },
+            visibility.profile
+        ));
+        output.push_str(&format!("- **Intent:** `{}`\n", visibility.intent));
+        output.push_str(&format!("- **Visibility reason:** {}\n", visibility.reason));
+    }
+
+    output.push_str("\n### Decision trace\n\n");
+    output.push_str(
+        "| # | Stage | Status | Criteria | Action | Severity | Reason |\n\
+         |---:|---|---|---|---|---|---|\n",
+    );
+    for step in &decision.trace {
+        render_markdown_trace_row(output, step);
+    }
+}
+
+fn render_markdown_trace_row(output: &mut String, step: &ExplainDecisionTraceStep) {
+    let criteria = if step.criteria.is_empty() {
+        "none".to_string()
+    } else {
+        step.criteria.join("; ")
+    };
+    let action = step.action.as_deref().unwrap_or("—");
+    output.push_str(&format!(
+        "| {} | `{}` | `{}` | {} | `{}` | `{} → {}` | {} |\n",
+        step.order,
+        markdown_cell(&step.stage),
+        markdown_cell(&step.status),
+        markdown_cell(&criteria),
+        markdown_cell(action),
+        step.severity_before.label(),
+        step.severity_after.label(),
+        markdown_cell(&step.reason)
+    ));
 }
 
 fn yes_no(value: bool) -> &'static str {
@@ -259,4 +399,8 @@ fn markdown_list(values: &[String]) -> String {
             .collect::<Vec<_>>()
             .join(", ")
     }
+}
+
+fn markdown_cell(value: &str) -> String {
+    value.replace('|', "\\|").replace('\n', " ")
 }

--- a/src/knowledge/decision.rs
+++ b/src/knowledge/decision.rs
@@ -3,11 +3,102 @@ use crate::findings::types::{Finding, Severity};
 use crate::frameworks::DetectedFramework;
 use crate::knowledge::active_knowledge;
 use crate::knowledge::language::{language_id_for_name, profile_by_id};
-use crate::knowledge::model::{RuleDecision, RuleDecisionAction, RuleMatchContext, RuleOverride};
+use crate::knowledge::model::{
+    RuleDecision, RuleDecisionAction, RuleMatchContext, RuleOverride, SupportLevel,
+};
 use crate::scan::facts::{FileFacts, ScanFacts};
 use crate::scan::path_classification::is_low_signal_audit_path;
 use std::collections::HashSet;
 use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecisionTraceStage {
+    RuleLookup,
+    Applicability,
+    BaseDecision,
+    Override,
+}
+
+impl DecisionTraceStage {
+    pub fn as_id(self) -> &'static str {
+        match self {
+            DecisionTraceStage::RuleLookup => "rule-lookup",
+            DecisionTraceStage::Applicability => "applicability",
+            DecisionTraceStage::BaseDecision => "base-decision",
+            DecisionTraceStage::Override => "override",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecisionTraceStatus {
+    Applied,
+    Passed,
+    Failed,
+    Matched,
+    NotMatched,
+    Skipped,
+}
+
+impl DecisionTraceStatus {
+    pub fn as_id(self) -> &'static str {
+        match self {
+            DecisionTraceStatus::Applied => "applied",
+            DecisionTraceStatus::Passed => "passed",
+            DecisionTraceStatus::Failed => "failed",
+            DecisionTraceStatus::Matched => "matched",
+            DecisionTraceStatus::NotMatched => "not-matched",
+            DecisionTraceStatus::Skipped => "skipped",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecisionTraceStep {
+    pub stage: DecisionTraceStage,
+    pub status: DecisionTraceStatus,
+    pub label: String,
+    pub criteria: Vec<String>,
+    pub action: Option<RuleDecisionAction>,
+    pub severity_before: Severity,
+    pub severity_after: Severity,
+    pub reason: String,
+    pub override_index: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuleDecisionTrace {
+    pub decision: RuleDecision,
+    pub steps: Vec<DecisionTraceStep>,
+}
+
+/// Optional trace sink for the shared decision evaluator.
+///
+/// Scan/review decisions use a disabled recorder, so trace labels, criteria, and
+/// reasons are not allocated. Explicit explain APIs enable the recorder while
+/// executing the same evaluator.
+struct TraceRecorder<'a> {
+    steps: Option<&'a mut Vec<DecisionTraceStep>>,
+}
+
+impl<'a> TraceRecorder<'a> {
+    fn disabled() -> Self {
+        Self { steps: None }
+    }
+
+    fn enabled(steps: &'a mut Vec<DecisionTraceStep>) -> Self {
+        Self { steps: Some(steps) }
+    }
+
+    fn push<F>(&mut self, build: F)
+    where
+        F: FnOnce() -> DecisionTraceStep,
+    {
+        if let Some(steps) = self.steps.as_mut() {
+            (*steps).push(build());
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SuppressReason {
@@ -46,74 +137,308 @@ impl From<SuppressReason> for String {
 }
 
 pub fn decide(context: &RuleMatchContext<'_>) -> RuleDecision {
+    let mut trace = TraceRecorder::disabled();
+    decide_internal(context, &mut trace)
+}
+
+pub fn decide_with_trace(context: &RuleMatchContext<'_>) -> RuleDecisionTrace {
+    let mut steps = Vec::new();
+    let decision = {
+        let mut trace = TraceRecorder::enabled(&mut steps);
+        decide_internal(context, &mut trace)
+    };
+    RuleDecisionTrace { decision, steps }
+}
+
+fn decide_internal(context: &RuleMatchContext<'_>, trace: &mut TraceRecorder<'_>) -> RuleDecision {
     let Some(rule) = active_knowledge().rule_by_id(context.rule_id) else {
-        return RuleDecision::apply(context.base_severity);
+        let decision = RuleDecision::apply(context.base_severity);
+        trace.push(|| DecisionTraceStep {
+            stage: DecisionTraceStage::RuleLookup,
+            status: DecisionTraceStatus::NotMatched,
+            label: "knowledge-entry".to_string(),
+            criteria: vec![format!("rule_id={}", context.rule_id)],
+            action: Some(RuleDecisionAction::Apply),
+            severity_before: context.base_severity,
+            severity_after: context.base_severity,
+            reason: "no bundled knowledge entry; preserve the supplied base severity".to_string(),
+            override_index: None,
+        });
+        return decision;
     };
 
-    if !rule.languages.is_empty()
-        && !context
+    trace.push(|| DecisionTraceStep {
+        stage: DecisionTraceStage::RuleLookup,
+        status: DecisionTraceStatus::Matched,
+        label: "knowledge-entry".to_string(),
+        criteria: vec![format!("rule_id={}", context.rule_id)],
+        action: None,
+        severity_before: context.base_severity,
+        severity_after: context.base_severity,
+        reason: "bundled knowledge entry found".to_string(),
+        override_index: None,
+    });
+
+    if !rule.languages.is_empty() {
+        let passed = context
             .languages
             .iter()
-            .any(|l| rule.languages.contains(*l))
-    {
-        return RuleDecision::suppress(SuppressReason::LanguageNotMatched);
+            .any(|language| rule.languages.contains(*language));
+        if let Some(decision) = record_applicability(
+            trace,
+            "language",
+            || {
+                vec![
+                    format!("allowed={}", sorted_values(&rule.languages)),
+                    format!("actual={}", joined_ids(context.languages)),
+                ]
+            },
+            passed,
+            SuppressReason::LanguageNotMatched,
+            context.base_severity,
+        ) {
+            return decision;
+        }
     }
 
-    if let Some(minimum_support) = rule.minimum_support
-        && !language_support_satisfies(rule, context.languages, minimum_support)
-    {
-        return RuleDecision::suppress(SuppressReason::LanguageSupportTooLow);
+    if let Some(minimum_support) = rule.minimum_support {
+        let passed = language_support_satisfies(rule, context.languages, minimum_support);
+        if let Some(decision) = record_applicability(
+            trace,
+            "language-support",
+            || {
+                vec![
+                    format!("minimum={}", support_level_id(minimum_support)),
+                    format!("languages={}", joined_ids(context.languages)),
+                ]
+            },
+            passed,
+            SuppressReason::LanguageSupportTooLow,
+            context.base_severity,
+        ) {
+            return decision;
+        }
     }
 
-    if !rule.frameworks.is_empty()
-        && !context
+    if !rule.frameworks.is_empty() {
+        let passed = context
             .frameworks
             .iter()
-            .any(|f| rule.frameworks.contains(*f))
-    {
-        return RuleDecision::suppress(SuppressReason::FrameworkNotMatched);
+            .any(|framework| rule.frameworks.contains(*framework));
+        if let Some(decision) = record_applicability(
+            trace,
+            "framework",
+            || {
+                vec![
+                    format!("allowed={}", sorted_values(&rule.frameworks)),
+                    format!("actual={}", joined_ids(context.frameworks)),
+                ]
+            },
+            passed,
+            SuppressReason::FrameworkNotMatched,
+            context.base_severity,
+        ) {
+            return decision;
+        }
     }
 
-    if !rule.runtimes.is_empty() && !context.runtimes.iter().any(|r| rule.runtimes.contains(*r)) {
-        return RuleDecision::suppress(SuppressReason::RuntimeNotMatched);
+    if !rule.runtimes.is_empty() {
+        let passed = context
+            .runtimes
+            .iter()
+            .any(|runtime| rule.runtimes.contains(*runtime));
+        if let Some(decision) = record_applicability(
+            trace,
+            "runtime",
+            || {
+                vec![
+                    format!("allowed={}", sorted_values(&rule.runtimes)),
+                    format!("actual={}", joined_ids(context.runtimes)),
+                ]
+            },
+            passed,
+            SuppressReason::RuntimeNotMatched,
+            context.base_severity,
+        ) {
+            return decision;
+        }
     }
 
-    if !rule.paradigms.is_empty()
-        && !context
+    if !rule.paradigms.is_empty() {
+        let passed = context
             .paradigms
             .iter()
-            .any(|p| rule.paradigms.contains(*p))
+            .any(|paradigm| rule.paradigms.contains(*paradigm));
+        if let Some(decision) = record_applicability(
+            trace,
+            "paradigm",
+            || {
+                vec![
+                    format!("allowed={}", sorted_values(&rule.paradigms)),
+                    format!("actual={}", joined_ids(context.paradigms)),
+                ]
+            },
+            passed,
+            SuppressReason::ParadigmNotMatched,
+            context.base_severity,
+        ) {
+            return decision;
+        }
+    }
+
+    if rule.suppress_low_signal
+        && let Some(decision) = record_applicability(
+            trace,
+            "low-signal-path",
+            || vec![format!("is_low_signal={}", context.is_low_signal)],
+            !context.is_low_signal,
+            SuppressReason::LowSignalPath,
+            context.base_severity,
+        )
     {
-        return RuleDecision::suppress(SuppressReason::ParadigmNotMatched);
+        return decision;
     }
 
-    if context.is_low_signal && rule.suppress_low_signal {
-        return RuleDecision::suppress(SuppressReason::LowSignalPath);
+    if rule.suppress_config {
+        let is_config = context.roles.contains(&"config");
+        if let Some(decision) = record_applicability(
+            trace,
+            "config-role",
+            || vec![format!("roles={}", joined_ids(context.roles))],
+            !is_config,
+            SuppressReason::ConfigFile,
+            context.base_severity,
+        ) {
+            return decision;
+        }
     }
 
-    if rule.suppress_config && context.roles.contains(&"config") {
-        return RuleDecision::suppress(SuppressReason::ConfigFile);
-    }
-
-    if rule.suppress_generated && context.roles.contains(&"generated") {
-        return RuleDecision::suppress(SuppressReason::GeneratedFile);
+    if rule.suppress_generated {
+        let is_generated = context.roles.contains(&"generated");
+        if let Some(decision) = record_applicability(
+            trace,
+            "generated-role",
+            || vec![format!("roles={}", joined_ids(context.roles))],
+            !is_generated,
+            SuppressReason::GeneratedFile,
+            context.base_severity,
+        ) {
+            return decision;
+        }
     }
 
     let mut decision =
         RuleDecision::apply(context.base_severity).with_risk_signal(rule.risk.clone());
+    trace.push(|| DecisionTraceStep {
+        stage: DecisionTraceStage::BaseDecision,
+        status: DecisionTraceStatus::Applied,
+        label: "base-severity".to_string(),
+        criteria: vec![format!("base={}", context.base_severity.label())],
+        action: Some(RuleDecisionAction::Apply),
+        severity_before: context.base_severity,
+        severity_after: context.base_severity,
+        reason: if rule.risk.is_some() {
+            "base severity retained and the rule-level risk signal attached".to_string()
+        } else {
+            "base severity retained before ordered overrides".to_string()
+        },
+        override_index: None,
+    });
 
-    for override_rule in &rule.overrides {
+    for (index, override_rule) in rule.overrides.iter().enumerate() {
+        let before = decision.severity;
+
         if context.is_test && !is_test_override(override_rule) {
+            trace.push(|| DecisionTraceStep {
+                stage: DecisionTraceStage::Override,
+                status: DecisionTraceStatus::Skipped,
+                label: format!("override[{index}]"),
+                criteria: override_criteria(override_rule),
+                action: Some(override_rule.action),
+                severity_before: before,
+                severity_after: before,
+                reason: "non-test override skipped because the file is test context".to_string(),
+                override_index: Some(index),
+            });
             continue;
         }
-        if override_matches(override_rule, context) {
-            decision = apply_override(override_rule, decision.severity, rule.risk.clone());
-            if decision.is_suppressed() {
-                return decision;
-            }
+
+        if !override_matches(override_rule, context) {
+            trace.push(|| DecisionTraceStep {
+                stage: DecisionTraceStage::Override,
+                status: DecisionTraceStatus::NotMatched,
+                label: format!("override[{index}]"),
+                criteria: override_criteria(override_rule),
+                action: Some(override_rule.action),
+                severity_before: before,
+                severity_after: before,
+                reason: "override criteria did not all match".to_string(),
+                override_index: Some(index),
+            });
+            continue;
+        }
+
+        decision = apply_override(override_rule, before, rule.risk.clone());
+        trace.push(|| DecisionTraceStep {
+            stage: DecisionTraceStage::Override,
+            status: DecisionTraceStatus::Applied,
+            label: format!("override[{index}]"),
+            criteria: override_criteria(override_rule),
+            action: Some(override_rule.action),
+            severity_before: before,
+            severity_after: decision.severity,
+            reason: decision
+                .reason
+                .clone()
+                .unwrap_or_else(|| format!("override[{index}] matched")),
+            override_index: Some(index),
+        });
+        if decision.is_suppressed() {
+            return decision;
         }
     }
 
+    decision
+}
+
+fn record_applicability<F>(
+    trace: &mut TraceRecorder<'_>,
+    label: &'static str,
+    criteria: F,
+    passed: bool,
+    failure: SuppressReason,
+    severity: Severity,
+) -> Option<RuleDecision>
+where
+    F: FnOnce() -> Vec<String>,
+{
+    let decision = if passed {
+        None
+    } else {
+        Some(RuleDecision::suppress(failure))
+    };
+    let action = decision.as_ref().map(|_| RuleDecisionAction::Suppress);
+    let severity_after = decision.as_ref().map_or(severity, |value| value.severity);
+
+    trace.push(|| DecisionTraceStep {
+        stage: DecisionTraceStage::Applicability,
+        status: if passed {
+            DecisionTraceStatus::Passed
+        } else {
+            DecisionTraceStatus::Failed
+        },
+        label: label.to_string(),
+        criteria: criteria(),
+        action,
+        severity_before: severity,
+        severity_after,
+        reason: if passed {
+            format!("{label} applicability passed")
+        } else {
+            failure.to_string()
+        },
+        override_index: None,
+    });
     decision
 }
 
@@ -134,6 +459,23 @@ pub fn decide_for_audit_context(
     )
 }
 
+pub fn decide_for_audit_context_with_trace(
+    rule_id: &str,
+    context: &AuditContext,
+    base_severity: Severity,
+    signal: Option<&str>,
+) -> RuleDecisionTrace {
+    let language_ids = [context.language_id()];
+    decide_with_context_trace(
+        rule_id,
+        &language_ids,
+        context,
+        false,
+        base_severity,
+        signal,
+    )
+}
+
 pub fn decide_for_file(
     rule_id: &str,
     file: &FileFacts,
@@ -145,6 +487,26 @@ pub fn decide_for_file(
     dedup_static_ids(&mut language_ids);
     let is_low_signal = is_low_signal_audit_path(&file.path) && !context.is_test;
     decide_with_context(
+        rule_id,
+        &language_ids,
+        &context,
+        is_low_signal,
+        base_severity,
+        signal,
+    )
+}
+
+pub fn decide_for_file_with_trace(
+    rule_id: &str,
+    file: &FileFacts,
+    base_severity: Severity,
+    signal: Option<&str>,
+) -> RuleDecisionTrace {
+    let context = classify_file(file);
+    let mut language_ids = language_ids_for_file(file, &context);
+    dedup_static_ids(&mut language_ids);
+    let is_low_signal = is_low_signal_audit_path(&file.path) && !context.is_test;
+    decide_with_context_trace(
         rule_id,
         &language_ids,
         &context,
@@ -181,6 +543,32 @@ fn decide_with_context(
     })
 }
 
+fn decide_with_context_trace(
+    rule_id: &str,
+    language_ids: &[&str],
+    context: &AuditContext,
+    is_low_signal: bool,
+    base_severity: Severity,
+    signal: Option<&str>,
+) -> RuleDecisionTrace {
+    let framework_ids = context.framework_ids();
+    let role_ids = context.role_ids();
+    let paradigm_ids = context.paradigm_ids();
+    let runtime_ids = context.runtime_ids();
+    decide_with_trace(&RuleMatchContext {
+        rule_id,
+        languages: language_ids,
+        frameworks: &framework_ids,
+        roles: &role_ids,
+        paradigms: &paradigm_ids,
+        runtimes: &runtime_ids,
+        is_test: context.is_test,
+        is_low_signal,
+        signal,
+        base_severity,
+    })
+}
+
 pub fn apply_file_decision(
     rule_id: &str,
     file: &FileFacts,
@@ -204,7 +592,6 @@ pub fn decide_for_project(
     let mut language_ids = language_ids_for_project(facts);
     dedup_static_ids(&mut language_ids);
     let framework_ids = framework_ids_for_project(facts);
-
     decide(&RuleMatchContext {
         rule_id,
         languages: &language_ids,

--- a/src/knowledge/decision/helpers.rs
+++ b/src/knowledge/decision/helpers.rs
@@ -189,3 +189,35 @@ fn dedup_static_ids(values: &mut Vec<&'static str>) {
     let mut seen = HashSet::new();
     values.retain(|value| seen.insert(*value));
 }
+
+fn override_criteria(override_rule: &RuleOverride) -> Vec<String> {
+    let mut criteria = Vec::new();
+    if let Some(value) = &override_rule.signal { criteria.push(format!("signal={value}")); }
+    if let Some(value) = &override_rule.language { criteria.push(format!("language={value}")); }
+    if let Some(value) = &override_rule.framework { criteria.push(format!("framework={value}")); }
+    if let Some(value) = &override_rule.runtime { criteria.push(format!("runtime={value}")); }
+    if let Some(value) = &override_rule.paradigm { criteria.push(format!("paradigm={value}")); }
+    if let Some(value) = &override_rule.role { criteria.push(format!("role={value}")); }
+    if criteria.is_empty() { criteria.push("unconditional".to_string()); }
+    criteria
+}
+
+fn sorted_values(values: &HashSet<String>) -> String {
+    if values.is_empty() { return "none".to_string(); }
+    let mut values = values.iter().map(String::as_str).collect::<Vec<_>>();
+    values.sort_unstable();
+    values.join(",")
+}
+
+fn joined_ids(values: &[&str]) -> String {
+    if values.is_empty() { "none".to_string() } else { values.join(",") }
+}
+
+fn support_level_id(level: SupportLevel) -> &'static str {
+    match level {
+        SupportLevel::DetectOnly => "detect-only",
+        SupportLevel::ImportAware => "import-aware",
+        SupportLevel::ContextAware => "context-aware",
+        SupportLevel::RuleAware => "rule-aware",
+    }
+}

--- a/src/knowledge/decision/tests.rs
+++ b/src/knowledge/decision/tests.rs
@@ -150,3 +150,106 @@ fn rust_context(roles: Vec<FileRole>, runtimes: Vec<RuntimeKind>) -> AuditContex
         is_test: false,
     }
 }
+
+#[test]
+fn trace_preserves_ordered_matching_overrides_and_severity_transitions() {
+    let context = AuditContext {
+        language: LanguageKind::Kotlin,
+        frameworks: Vec::new(),
+        roles: vec![FileRole::Domain, FileRole::TestSupport],
+        paradigms: vec![ProgrammingParadigm::ObjectOriented],
+        runtimes: vec![RuntimeKind::Jvm],
+        is_test: false,
+    };
+    let trace = decide_for_audit_context_with_trace(
+        "language.managed.fatal-exception-risk",
+        &context,
+        Severity::Medium,
+        None,
+    );
+    assert_eq!(trace.decision.action, RuleDecisionAction::Downgrade);
+    assert_eq!(trace.decision.severity, Severity::Low);
+    let applied = trace
+        .steps
+        .iter()
+        .filter(|step| {
+            step.stage == DecisionTraceStage::Override
+                && step.status == DecisionTraceStatus::Applied
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(applied.len(), 2);
+    assert_eq!(applied[0].override_index, Some(1));
+    assert_eq!(applied[0].severity_before, Severity::Medium);
+    assert_eq!(applied[0].severity_after, Severity::High);
+    assert_eq!(applied[1].override_index, Some(2));
+    assert_eq!(applied[1].severity_before, Severity::High);
+    assert_eq!(applied[1].severity_after, Severity::Low);
+}
+
+#[test]
+fn trace_records_the_applicability_check_that_suppressed_a_rule() {
+    let context = AuditContext {
+        language: LanguageKind::Python,
+        frameworks: Vec::new(),
+        roles: Vec::new(),
+        paradigms: vec![ProgrammingParadigm::Unknown],
+        runtimes: vec![RuntimeKind::Python],
+        is_test: false,
+    };
+    let trace = decide_for_audit_context_with_trace(
+        "language.rust.panic-risk",
+        &context,
+        Severity::Medium,
+        Some("rust.panic"),
+    );
+    assert!(trace.decision.is_suppressed());
+    let failed = trace
+        .steps
+        .iter()
+        .find(|step| step.status == DecisionTraceStatus::Failed)
+        .expect("failed applicability step");
+    assert_eq!(failed.stage, DecisionTraceStage::Applicability);
+    assert_eq!(failed.label, "language");
+    assert_eq!(failed.action, Some(RuleDecisionAction::Suppress));
+}
+
+#[test]
+fn traced_and_compatibility_decisions_remain_identical() {
+    let context = rust_context(vec![FileRole::Domain], vec![RuntimeKind::RustLibrary]);
+    let compatibility = decide_for_audit_context(
+        "language.rust.panic-risk",
+        &context,
+        Severity::Medium,
+        Some("rust.panic"),
+    );
+    let traced = decide_for_audit_context_with_trace(
+        "language.rust.panic-risk",
+        &context,
+        Severity::Medium,
+        Some("rust.panic"),
+    );
+    assert_eq!(compatibility, traced.decision);
+}
+
+#[test]
+fn disabled_trace_recorder_does_not_materialize_steps() {
+    let mut materialized = false;
+    let mut recorder = TraceRecorder::disabled();
+
+    recorder.push(|| {
+        materialized = true;
+        DecisionTraceStep {
+            stage: DecisionTraceStage::RuleLookup,
+            status: DecisionTraceStatus::Matched,
+            label: "should-not-be-built".to_string(),
+            criteria: vec!["should-not-be-built".to_string()],
+            action: None,
+            severity_before: Severity::Info,
+            severity_after: Severity::Info,
+            reason: "should-not-be-built".to_string(),
+            override_index: None,
+        }
+    });
+
+    assert!(!materialized);
+}


### PR DESCRIPTION
## Summary

Add an ordered, evidence-backed rule decision trace to RepoPilot’s file explanation surface.

The trace uses the same Knowledge Engine evaluation path as normal rule decisions and shows how file context, applicability checks, ordered overrides, severity transitions, and default-profile visibility produce the final result.

## Type of change

* [x] Feature
* [x] Refactor
* [x] Tests
* [x] Documentation
* [ ] Bug fix
* [ ] CI / repository maintenance

## What changed

* Added trace models for:

  * rule lookup;
  * applicability checks;
  * base-severity selection;
  * ordered knowledge overrides;
  * severity transitions;
  * final default-profile visibility.
* Added `decide_with_trace()` and traced file/context decision APIs.
* Kept existing `decide*()` APIs as compatibility wrappers around the same evaluation logic.
* Added file-role evidence from the context classifier to explain reports.
* Made MCP explanations use the rule registry’s default severity for known rules.
* Added explicit explain scope metadata covering:

  * repository context;
  * scan configuration;
  * local feedback;
  * baseline state;
  * visibility profile.
* Updated console, Markdown, JSON, and MCP rendering.
* Added tests for ordered overrides, suppression checks, role evidence, serialization, and renderer output.
* Updated Knowledge Engine and MCP documentation.
* Updated the changelog.

## Why

RepoPilot can currently return a final rule action and severity, but it does not expose the complete path that produced that decision.

This makes context-aware behavior difficult to verify. A user can see that a finding was downgraded or suppressed, but not which language, role, runtime, signal, or ordered override caused it.

This PR makes that process inspectable:

```text
file facts
→ role evidence
→ rule lookup
→ applicability checks
→ base severity
→ ordered overrides
→ final severity
→ default-profile visibility
```

The trace is deterministic and local. It does not call external services or infer explanations separately from the Knowledge Engine.

## Example

A decision trace can now explain:

```text
Rule: language.javascript.runtime-exit-risk
Signal: js.process-exit
Base severity: HIGH

1. Rule entry matched
2. JavaScript applicability passed
3. Generated/config checks passed
4. cli-executable override matched
5. Severity changed HIGH → LOW
6. Finding is hidden in the default profile
```

Role evidence also explains why `cli-executable` matched, including the command path and executable package manifest.

## Compatibility

* Existing rule decision APIs remain available.
* Existing scan and review decision semantics are unchanged.
* Finding IDs are unchanged.
* Baseline matching is unchanged.
* SARIF and receipt schemas are unchanged.
* Scan and review JSON schemas are unchanged.
* Explain/MCP JSON changes are additive.
* No rule detectors or knowledge-pack rules are added or removed.

## Scope

The explain report explicitly identifies which context is included.

Included:

* single-file classification;
* file-role evidence;
* bundled Knowledge Engine applicability and overrides;
* rule registry default severity;
* default-profile visibility.

Not included:

* repository graph decisions;
* local feedback suppressions;
* baseline state;
* full scan filtering;
* project-level configuration not supplied to the explain surface.

## Contract and ownership

* [x] The change stays within the Knowledge Engine and explain/MCP boundaries.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] Decision evidence is deterministic and covered by focused tests.
* [x] Existing rule decisions are exercised through compatibility tests.
* [x] No false-positive or noise-reduction behavior is changed.
* [x] No unrelated generated-file churn is included.

## Changelog

* [x] `CHANGELOG.md` updated.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```
