### PR TITLE
feat(findings): preserve knowledge decision provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **Findings now preserve replayable Knowledge Engine decision provenance.**
+  Knowledge-aware findings add optional `provenance.knowledge_decision` data
+  containing base severity, signal id, action, decided severity, and reason.
+  Enrichment and detector provenance overrides preserve the replay record.
+  Scan/review report schema moves from `0.19` to `0.20`; readers continue
+  accepting `0.16` through `0.19`. Finding IDs, baseline matching, visibility,
+  risk scoring, SARIF behavior, and detector decisions are unchanged.
+
 - **Rule decisions now expose an ordered, evidence-backed trace.** The Knowledge
   Engine has one trace-producing path that records rule lookup, configured
   applicability checks, the supplied base severity, every override in declaration

--- a/docs/engineering/signal-contract.md
+++ b/docs/engineering/signal-contract.md
@@ -36,6 +36,18 @@ provenance must survive beyond classification. Role evidence does not alter a
 rule by itself; knowledge-pack decisions remain responsible for deciding how a
 role affects severity or suppression.
 
+## Knowledge-Decision Provenance
+
+Findings that pass through the Knowledge Engine preserve an optional replay
+record under `provenance.knowledge_decision`. It contains the supplied base
+severity, optional signal id, action, Knowledge Engine output severity, and
+reason.
+
+This records the Knowledge Engine layer only. A detector may apply a narrower
+local policy afterwards, so the finding-level `severity` remains authoritative.
+Suppressed decisions do not emit findings and remain available through explicit
+decision traces.
+
 ## Finding Contract
 
 Every rendered finding must have:

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -11,15 +11,15 @@ repopilot scan . --format json --output repopilot-report.json
 
 ## JSON report schema
 
-JSON scan reports include explicit schema metadata. The current schema is 0.19:
+JSON scan reports include explicit schema metadata. The current schema is 0.20:
 
 ```json
 {
-  "schema_version": "0.19",
+  "schema_version": "0.20",
   "repopilot_version": "0.17.0",
   "report": {
     "kind": "scan",
-    "schema_version": "0.19",
+    "schema_version": "0.20",
     "repopilot_version": "0.17.0"
   },
   "root_path": ".",
@@ -99,7 +99,7 @@ requested report/receipt and then exits with RepoPilot runtime code `3`.
 may fix bugs without changing the report schema, while future minor releases can
 evolve the schema in a documented way.
 
-Binary `0.17.x` emits schema `0.19` unless the serialized contract changes.
+Binary `0.18.x` emits schema `0.20`.
 Schema numbers are monotonic contract revisions, not predictions of the next
 RepoPilot package version.
 
@@ -128,7 +128,8 @@ reports do not look clean when meaningful strict-only findings were hidden.
 Schema `0.18` adds the stable review-signal contract, suppression/gate metadata,
 and the explicit review gate result. Schema `0.19` makes the rule registry the
 single source of truth for finding severity/confidence and adds the optional
-`rule_false_positive_notes` map (additive).
+`rule_false_positive_notes` map. Schema `0.20` adds optional replayable
+Knowledge Engine decision provenance to findings.
 
 Migration from pre-`0.13` reports is intentionally consumer-owned:
 
@@ -138,9 +139,9 @@ Migration from pre-`0.13` reports is intentionally consumer-owned:
 | `lines_of_code` | `non_empty_lines` |
 | `skipped_files_count` | `large_files_skipped` |
 
-The current reader accepts `0.16`, `0.17`, `0.18`, and `0.19` scan reports
-during the transition. Baseline files follow their separate baseline schema
-policy.
+The current reader accepts `0.16`, `0.17`, `0.18`, `0.19`, and `0.20` scan
+reports during the transition. Baseline files follow their separate baseline
+schema policy.
 
 ## Baseline JSON reports
 
@@ -158,11 +159,11 @@ Example shape:
 
 ```json
 {
-  "schema_version": "0.19",
+  "schema_version": "0.20",
   "repopilot_version": "0.17.0",
   "report": {
     "kind": "baseline-scan",
-    "schema_version": "0.19",
+    "schema_version": "0.20",
     "repopilot_version": "0.17.0"
   },
   "root_path": ".",
@@ -268,10 +269,30 @@ Every finding includes stable fields documented in [rulesets.md](rulesets.md):
 | `severity` | string | One of `INFO`, `LOW`, `MEDIUM`, `HIGH`, or `CRITICAL`. |
 | `confidence` | string | One of `LOW`, `MEDIUM`, or `HIGH`; used to separate impact from certainty. |
 | `risk` | object | Explainable prioritization assessment with `score`, `priority`, stable `signals`, and `formula_version`. |
-| `provenance` | object | Detector, rule lifecycle, signal source, and analysis scope for explaining where the finding came from. |
+| `provenance` | object | Detector, lifecycle, signal source, analysis scope, and optional `knowledge_decision` replay data. |
 | `docs_url` | string? | Optional documentation link for the rule. |
 | `workspace_package` | string? | Optional monorepo package name. |
 | `evidence` | array | One or more evidence locations. |
+
+### Knowledge-decision provenance
+
+Knowledge-aware findings may include:
+
+```json
+{
+  "knowledge_decision": {
+    "base_severity": "MEDIUM",
+    "signal": "rust.panic",
+    "action": "upgrade",
+    "decided_severity": "HIGH",
+    "reason": "panic in reusable domain code"
+  }
+}
+```
+
+The nested field is omitted when a finding does not use a Knowledge Engine
+decision. `decided_severity` is the Knowledge Engine output; the finding-level
+`severity` remains authoritative after detector-local policy.
 
 ### Risk object
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,7 +19,9 @@ pub mod findings {
         validate_local_feedback,
     };
     pub use crate::findings::filter::{FindingFilter, recompute_summary_metrics};
-    pub use crate::findings::provenance::{AnalysisScope, FindingProvenance};
+    pub use crate::findings::provenance::{
+        AnalysisScope, FindingProvenance, KnowledgeDecisionAction, KnowledgeDecisionProvenance,
+    };
     pub use crate::findings::quality::{
         ConfidenceCounts, RuleLifecycleCounts, SignalQualitySummary, SignalSourceCounts,
         summarize_signal_quality,

--- a/src/audits/code_quality/complexity.rs
+++ b/src/audits/code_quality/complexity.rs
@@ -1,7 +1,7 @@
 use crate::audits::context::classify_file;
 use crate::audits::traits::FileAudit;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
-use crate::knowledge::decision::decide_for_audit_context;
+use crate::knowledge::decision::{decide_for_audit_context, record_decision_provenance};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
 
@@ -18,7 +18,7 @@ impl FileAudit for ComplexityAudit {
 
         let density = file.branch_count.saturating_mul(1000) / file.non_empty_lines;
 
-        let severity = if density >= config.complexity_high_threshold
+        let base_severity = if density >= config.complexity_high_threshold
             && file.non_empty_lines >= MIN_HIGH_COMPLEXITY_LOC
         {
             Severity::High
@@ -29,7 +29,7 @@ impl FileAudit for ComplexityAudit {
         };
 
         let context = classify_file(file);
-        let decision = decide_for_audit_context(RULE_ID, &context, severity, None);
+        let decision = decide_for_audit_context(RULE_ID, &context, base_severity, None);
 
         if decision.is_suppressed() {
             return vec![];
@@ -43,7 +43,7 @@ impl FileAudit for ComplexityAudit {
             config.complexity_medium_threshold
         };
 
-        vec![Finding {
+        let mut finding = Finding {
             id: String::new(),
             rule_id: RULE_ID.to_string(),
             recommendation: Finding::recommendation_for_rule_id(RULE_ID),
@@ -69,7 +69,9 @@ impl FileAudit for ComplexityAudit {
             docs_url: None,
             provenance: Default::default(),
             risk: Default::default(),
-        }]
+        };
+        record_decision_provenance(&mut finding, base_severity, None, &decision);
+        vec![finding]
     }
 }
 

--- a/src/audits/code_quality/language_risk.rs
+++ b/src/audits/code_quality/language_risk.rs
@@ -87,11 +87,13 @@ fn mark_text_heuristic(findings: &mut [Finding]) {
         let lifecycle = lookup_rule_metadata(&finding.rule_id)
             .map(|metadata| metadata.lifecycle)
             .unwrap_or(RuleLifecycle::Preview);
+        let knowledge_decision = finding.provenance.knowledge_decision.take();
         finding.provenance = FindingProvenance {
             detector: finding.rule_id.clone(),
             signal_source: SignalSource::TextHeuristic,
             rule_lifecycle: lifecycle,
             analysis_scope: AnalysisScope::File,
+            knowledge_decision,
         };
     }
 }

--- a/src/audits/code_quality/language_risk/pattern.rs
+++ b/src/audits/code_quality/language_risk/pattern.rs
@@ -1,5 +1,5 @@
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
-use crate::knowledge::decision::decide_for_file;
+use crate::knowledge::decision::{decide_for_file, record_decision_provenance};
 use crate::scan::facts::FileFacts;
 use std::path::Path;
 use tree_sitter::{Node, Tree};
@@ -193,20 +193,13 @@ fn push_pattern_finding(
     file: &FileFacts,
     findings: &mut Vec<Finding>,
 ) {
-    let decision = decide_for_file(
-        pattern.rule_id(),
-        file,
-        pattern.base_severity(),
-        Some(pattern.signal()),
-    );
+    let base_severity = pattern.base_severity();
+    let signal = pattern.signal();
+    let decision = decide_for_file(pattern.rule_id(), file, base_severity, Some(signal));
     if !decision.is_suppressed() {
-        findings.push(build_finding(
-            path,
-            line_number,
-            snippet,
-            pattern,
-            decision.severity,
-        ));
+        let mut finding = build_finding(path, line_number, snippet, pattern, decision.severity);
+        record_decision_provenance(&mut finding, base_severity, Some(signal), &decision);
+        findings.push(finding);
     }
 }
 

--- a/src/audits/code_quality/long_function/mod.rs
+++ b/src/audits/code_quality/long_function/mod.rs
@@ -3,7 +3,7 @@ use crate::audits::context::{AuditContext, FileRole, FrameworkKind, LanguageKind
 use crate::audits::traits::FileAudit;
 use crate::findings::provenance::{AnalysisScope, FindingProvenance};
 use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
-use crate::knowledge::decision::decide_for_audit_context;
+use crate::knowledge::decision::{decide_for_audit_context, record_decision_provenance};
 use crate::rules::{RuleLifecycle, SignalSource, lookup_rule_metadata};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
@@ -81,14 +81,20 @@ impl LongFunctionAudit {
         // function spans from the AST. Languages with no tree-sitter grammar, or
         // the rare parse failure, fall back to the line/brace heuristic, whose
         // findings are stamped with text-heuristic provenance.
-        match parsed.tree() {
+        let mut findings = match parsed.tree() {
             Some(tree) => ast::detect_ast(tree, content, language, &file.path, policy),
             None => {
                 let mut findings = detect_long_functions(content, language, &file.path, policy);
                 mark_text_heuristic(&mut findings);
                 findings
             }
+        };
+
+        for finding in &mut findings {
+            record_decision_provenance(finding, Severity::Medium, None, &decision);
         }
+
+        findings
     }
 }
 
@@ -99,11 +105,13 @@ fn mark_text_heuristic(findings: &mut [Finding]) {
         .map(|metadata| metadata.lifecycle)
         .unwrap_or(RuleLifecycle::Preview);
     for finding in findings {
+        let knowledge_decision = finding.provenance.knowledge_decision.take();
         finding.provenance = FindingProvenance {
             detector: RULE_ID.to_string(),
             signal_source: SignalSource::TextHeuristic,
             rule_lifecycle: lifecycle,
             analysis_scope: AnalysisScope::File,
+            knowledge_decision,
         };
     }
 }

--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -13,7 +13,7 @@ use crate::audits::context::{LanguageKind, classify_file};
 use crate::audits::traits::FileAudit;
 use crate::findings::provenance::{AnalysisScope, FindingProvenance};
 use crate::findings::types::{Finding, Severity};
-use crate::knowledge::decision::decide_for_audit_context;
+use crate::knowledge::decision::{decide_for_audit_context, record_decision_provenance};
 use crate::rules::{RuleLifecycle, SignalSource, lookup_rule_metadata};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
@@ -126,14 +126,21 @@ impl RustPanicRiskAudit {
                         decision.severity
                     };
 
-                    findings.push(build_finding(
+                    let mut finding = build_finding(
                         file,
                         line_number,
                         trimmed_line,
                         *pattern,
                         &context,
                         severity,
-                    ));
+                    );
+                    record_decision_provenance(
+                        &mut finding,
+                        pattern.base_severity(),
+                        Some(pattern.signal()),
+                        &decision,
+                    );
+                    findings.push(finding);
                 }
 
                 findings
@@ -209,14 +216,14 @@ impl RustPanicRiskAudit {
                 decision.severity
             };
 
-            findings.push(build_finding(
-                file,
-                line_number,
-                trimmed,
-                pattern,
-                context,
-                severity,
-            ));
+            let mut finding = build_finding(file, line_number, trimmed, pattern, context, severity);
+            record_decision_provenance(
+                &mut finding,
+                pattern.base_severity(),
+                Some(pattern.signal()),
+                &decision,
+            );
+            findings.push(finding);
 
             if sanitized.ends_with(';') {
                 pending_render_write = false;
@@ -232,11 +239,13 @@ fn mark_text_heuristic(findings: &mut [Finding]) {
         let lifecycle = lookup_rule_metadata(&finding.rule_id)
             .map(|metadata| metadata.lifecycle)
             .unwrap_or(RuleLifecycle::Preview);
+        let knowledge_decision = finding.provenance.knowledge_decision.take();
         finding.provenance = FindingProvenance {
             detector: finding.rule_id.clone(),
             signal_source: SignalSource::TextHeuristic,
             rule_lifecycle: lifecycle,
             analysis_scope: AnalysisScope::File,
+            knowledge_decision,
         };
     }
 }

--- a/src/findings/mod.rs
+++ b/src/findings/mod.rs
@@ -6,5 +6,6 @@ pub mod filter;
 pub mod provenance;
 pub mod quality;
 pub mod rule_config;
+pub mod severity;
 pub mod types;
 pub mod visibility;

--- a/src/findings/provenance.rs
+++ b/src/findings/provenance.rs
@@ -1,3 +1,4 @@
+use crate::findings::severity::Severity;
 use crate::rules::{RuleLifecycle, SignalSource};
 use serde::{Deserialize, Serialize};
 
@@ -7,6 +8,28 @@ pub struct FindingProvenance {
     pub signal_source: SignalSource,
     pub rule_lifecycle: RuleLifecycle,
     pub analysis_scope: AnalysisScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub knowledge_decision: Option<KnowledgeDecisionProvenance>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KnowledgeDecisionProvenance {
+    pub base_severity: Severity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal: Option<String>,
+    pub action: KnowledgeDecisionAction,
+    pub decided_severity: Severity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum KnowledgeDecisionAction {
+    Apply,
+    Suppress,
+    Downgrade,
+    Upgrade,
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -27,7 +50,17 @@ impl Default for FindingProvenance {
             signal_source: SignalSource::Mixed,
             rule_lifecycle: RuleLifecycle::Preview,
             analysis_scope: AnalysisScope::File,
+            knowledge_decision: None,
         }
+    }
+}
+
+impl FindingProvenance {
+    pub fn has_default_metadata(&self) -> bool {
+        self.detector == "unknown"
+            && self.signal_source == SignalSource::Mixed
+            && self.rule_lifecycle == RuleLifecycle::Preview
+            && self.analysis_scope == AnalysisScope::File
     }
 }
 

--- a/src/findings/severity.rs
+++ b/src/findings/severity.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Severity {
+    #[default]
+    Info,
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl Severity {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Severity::Info => "INFO",
+            Severity::Low => "LOW",
+            Severity::Medium => "MEDIUM",
+            Severity::High => "HIGH",
+            Severity::Critical => "CRITICAL",
+        }
+    }
+
+    pub fn lowercase_label(&self) -> &'static str {
+        match self {
+            Severity::Info => "info",
+            Severity::Low => "low",
+            Severity::Medium => "medium",
+            Severity::High => "high",
+            Severity::Critical => "critical",
+        }
+    }
+
+    pub fn is_at_least(&self, threshold: &Severity) -> bool {
+        self >= threshold
+    }
+
+    pub fn from_lowercase_label(value: &str) -> Option<Self> {
+        match value {
+            "info" => Some(Severity::Info),
+            "low" => Some(Severity::Low),
+            "medium" => Some(Severity::Medium),
+            "high" => Some(Severity::High),
+            "critical" => Some(Severity::Critical),
+            _ => None,
+        }
+    }
+}

--- a/src/findings/types.rs
+++ b/src/findings/types.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 use crate::findings::provenance::{AnalysisScope, FindingProvenance};
+pub use crate::findings::severity::Severity;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Finding {
@@ -35,17 +36,6 @@ pub enum FindingCategory {
     Testing,
     Security,
     Framework,
-}
-
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum Severity {
-    #[default]
-    Info,
-    Low,
-    Medium,
-    High,
-    Critical,
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -115,12 +105,14 @@ impl Finding {
         if self.docs_url.as_deref().is_none_or(str::is_empty) {
             self.docs_url = metadata.docs_url.map(str::to_string);
         }
-        if self.provenance == FindingProvenance::default() {
+        if self.provenance.has_default_metadata() {
+            let knowledge_decision = self.provenance.knowledge_decision.take();
             self.provenance = FindingProvenance {
                 detector: metadata.rule_id.to_string(),
                 signal_source: metadata.signal_source,
                 rule_lifecycle: metadata.lifecycle,
                 analysis_scope: AnalysisScope::for_signal_source(metadata.signal_source),
+                knowledge_decision,
             };
         }
 
@@ -157,43 +149,6 @@ impl Finding {
             Self::GENERIC_RECOMMENDATION
         } else {
             self.recommendation.as_str()
-        }
-    }
-}
-
-impl Severity {
-    pub fn label(&self) -> &'static str {
-        match self {
-            Severity::Info => "INFO",
-            Severity::Low => "LOW",
-            Severity::Medium => "MEDIUM",
-            Severity::High => "HIGH",
-            Severity::Critical => "CRITICAL",
-        }
-    }
-
-    pub fn lowercase_label(&self) -> &'static str {
-        match self {
-            Severity::Info => "info",
-            Severity::Low => "low",
-            Severity::Medium => "medium",
-            Severity::High => "high",
-            Severity::Critical => "critical",
-        }
-    }
-
-    pub fn is_at_least(&self, threshold: &Severity) -> bool {
-        self >= threshold
-    }
-
-    pub fn from_lowercase_label(value: &str) -> Option<Self> {
-        match value {
-            "info" => Some(Severity::Info),
-            "low" => Some(Severity::Low),
-            "medium" => Some(Severity::Medium),
-            "high" => Some(Severity::High),
-            "critical" => Some(Severity::Critical),
-            _ => None,
         }
     }
 }

--- a/src/knowledge/decision.rs
+++ b/src/knowledge/decision.rs
@@ -1,4 +1,5 @@
 use crate::audits::context::{AuditContext, classify_file};
+use crate::findings::provenance::{KnowledgeDecisionAction, KnowledgeDecisionProvenance};
 use crate::findings::types::{Finding, Severity};
 use crate::frameworks::DetectedFramework;
 use crate::knowledge::active_knowledge;
@@ -575,10 +576,12 @@ pub fn apply_file_decision(
     mut finding: Finding,
     signal: Option<&str>,
 ) -> Option<Finding> {
-    let decision = decide_for_file(rule_id, file, finding.severity, signal);
+    let base_severity = finding.severity;
+    let decision = decide_for_file(rule_id, file, base_severity, signal);
     if decision.is_suppressed() {
         return None;
     }
+    record_decision_provenance(&mut finding, base_severity, signal, &decision);
     finding.severity = decision.severity;
     Some(finding)
 }
@@ -610,14 +613,36 @@ pub fn apply_project_decisions(facts: &ScanFacts, findings: Vec<Finding>) -> Vec
     findings
         .into_iter()
         .filter_map(|mut finding| {
-            let decision = decide_for_project(&finding.rule_id, facts, finding.severity, None);
+            let base_severity = finding.severity;
+            let decision = decide_for_project(&finding.rule_id, facts, base_severity, None);
             if decision.is_suppressed() {
                 return None;
             }
+            record_decision_provenance(&mut finding, base_severity, None, &decision);
             finding.severity = decision.severity;
             Some(finding)
         })
         .collect()
+}
+
+pub fn record_decision_provenance(
+    finding: &mut Finding,
+    base_severity: Severity,
+    signal: Option<&str>,
+    decision: &RuleDecision,
+) {
+    finding.provenance.knowledge_decision = Some(KnowledgeDecisionProvenance {
+        base_severity,
+        signal: signal.map(str::to_string),
+        action: match decision.action {
+            RuleDecisionAction::Apply => KnowledgeDecisionAction::Apply,
+            RuleDecisionAction::Suppress => KnowledgeDecisionAction::Suppress,
+            RuleDecisionAction::Downgrade => KnowledgeDecisionAction::Downgrade,
+            RuleDecisionAction::Upgrade => KnowledgeDecisionAction::Upgrade,
+        },
+        decided_severity: decision.severity,
+        reason: decision.reason.clone(),
+    });
 }
 
 include!("decision/helpers.rs");

--- a/src/knowledge/decision/tests.rs
+++ b/src/knowledge/decision/tests.rs
@@ -253,3 +253,81 @@ fn disabled_trace_recorder_does_not_materialize_steps() {
 
     assert!(!materialized);
 }
+
+#[test]
+fn applied_file_decision_preserves_replayable_provenance() {
+    use crate::findings::provenance::KnowledgeDecisionAction;
+    use crate::findings::types::{Evidence, FindingCategory};
+    use std::path::PathBuf;
+
+    let file = FileFacts {
+        path: PathBuf::from("src/domain/service.rs"),
+        language: Some("Rust".to_string()),
+        non_empty_lines: 1,
+        branch_count: 0,
+        imports: Vec::new(),
+        content: Some("pub fn run() { panic!(\"boom\"); }\n".to_string()),
+        has_inline_tests: false,
+        in_executable_package: false,
+        deferred_imports: Vec::new(),
+    };
+    let base_severity = Severity::Medium;
+    let signal = "rust.panic";
+    let expected = decide_for_file(
+        "language.rust.panic-risk",
+        &file,
+        base_severity,
+        Some(signal),
+    );
+    assert!(!expected.is_suppressed());
+
+    let finding = Finding {
+        rule_id: "language.rust.panic-risk".to_string(),
+        category: FindingCategory::CodeQuality,
+        severity: base_severity,
+        evidence: vec![Evidence {
+            path: file.path.clone(),
+            line_start: 1,
+            line_end: None,
+            snippet: "panic!(\"boom\")".to_string(),
+        }],
+        ..Finding::default()
+    };
+
+    let mut applied = apply_file_decision("language.rust.panic-risk", &file, finding, Some(signal))
+        .expect("finding should remain visible");
+    applied.populate_rule_metadata();
+
+    let provenance = applied
+        .provenance
+        .knowledge_decision
+        .as_ref()
+        .expect("knowledge decision provenance");
+    assert_eq!(provenance.base_severity, base_severity);
+    assert_eq!(provenance.signal.as_deref(), Some(signal));
+    assert_eq!(provenance.decided_severity, expected.severity);
+    assert_eq!(
+        provenance.action,
+        match expected.action {
+            RuleDecisionAction::Apply => KnowledgeDecisionAction::Apply,
+            RuleDecisionAction::Suppress => KnowledgeDecisionAction::Suppress,
+            RuleDecisionAction::Downgrade => KnowledgeDecisionAction::Downgrade,
+            RuleDecisionAction::Upgrade => KnowledgeDecisionAction::Upgrade,
+        }
+    );
+    assert_eq!(applied.provenance.detector, "language.rust.panic-risk");
+
+    let json = serde_json::to_value(&applied).expect("serialize finding");
+    assert_eq!(json["provenance"]["knowledge_decision"]["signal"], signal);
+    assert_eq!(
+        json["provenance"]["knowledge_decision"]["base_severity"],
+        base_severity.label()
+    );
+}
+
+#[test]
+fn default_provenance_omits_absent_knowledge_decision() {
+    let value = serde_json::to_value(crate::findings::provenance::FindingProvenance::default())
+        .expect("serialize provenance");
+    assert!(value.get("knowledge_decision").is_none());
+}

--- a/src/report/schema.rs
+++ b/src/report/schema.rs
@@ -17,9 +17,9 @@ use serde_json::Value;
 use std::io;
 use std::path::PathBuf;
 
-pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.19";
+pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.20";
 const ACCEPTED_SCAN_REPORT_SCHEMA_VERSIONS: &[&str] =
-    &["0.16", "0.17", "0.18", SCAN_REPORT_SCHEMA_VERSION];
+    &["0.16", "0.17", "0.18", "0.19", SCAN_REPORT_SCHEMA_VERSION];
 pub const REPOPILOT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/review/render/sarif.rs
+++ b/src/review/render/sarif.rs
@@ -56,6 +56,7 @@ pub fn render_review_sarif(report: &ReviewReport) -> Result<String, serde_json::
                 signal_source: signal.provenance.signal_source,
                 rule_lifecycle: signal.provenance.lifecycle,
                 analysis_scope: signal.provenance.analysis_scope,
+                knowledge_decision: None,
             },
             risk: Default::default(),
         });

--- a/tests/fixtures/golden/scan-json-schema.golden.json
+++ b/tests/fixtures/golden/scan-json-schema.golden.json
@@ -1,9 +1,9 @@
 {
-  "schema_version": "0.19",
+  "schema_version": "0.20",
   "repopilot_version": "{{VERSION}}",
   "report": {
     "kind": "scan",
-    "schema_version": "0.19",
+    "schema_version": "0.20",
     "repopilot_version": "{{VERSION}}"
   },
   "root_path": "demo-project",

--- a/tests/fixtures/reports/scan-v020.json
+++ b/tests/fixtures/reports/scan-v020.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "0.20",
+  "repopilot_version": "0.18.0",
+  "report": {
+    "kind": "scan",
+    "schema_version": "0.20",
+    "repopilot_version": "0.18.0"
+  },
+  "root_path": ".",
+  "mode": "full",
+  "changed_files_count": 0,
+  "repo_level_rules_included": true,
+  "files_discovered": 2,
+  "files_analyzed": 2,
+  "directories_count": 1,
+  "non_empty_lines": 12,
+  "large_files_skipped": 0,
+  "files_skipped_low_signal": 0,
+  "binary_files_skipped": 0,
+  "skipped_bytes": 0,
+  "languages": [],
+  "findings": [],
+  "detected_frameworks": [],
+  "framework_projects": [],
+  "coupling_graph": null,
+  "context_graph_summary": {
+    "files": 2,
+    "import_edges": 0
+  },
+  "context_graph_cache": {
+    "status": "write",
+    "reason": "context-graph-cache-updated",
+    "cache_path": ".repopilot/cache/repo_context.json"
+  },
+  "scan_duration_us": 100,
+  "health_score": 100,
+  "raw_findings_count": 0,
+  "visible_findings_count": 0,
+  "hidden_suggestions_count": 0,
+  "files_skipped_by_limit": 0,
+  "files_skipped_repopilotignore": 0,
+  "diagnostics": [
+    {
+      "code": "workspace.package-scan-failed",
+      "severity": "warning",
+      "message": "Package scan failed; results are partial.",
+      "path": "packages/api"
+    }
+  ],
+  "risk_summary": {
+    "total": 0,
+    "average_score": 0,
+    "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 }
+  },
+  "raw_signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  },
+  "visible_signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  },
+  "signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  }
+}

--- a/tests/report_schema_contract.rs
+++ b/tests/report_schema_contract.rs
@@ -3,11 +3,11 @@ use serde_json::Value;
 
 #[test]
 fn current_schema_fixture_documents_scan_report_contract() {
-    let current_text = include_str!("fixtures/reports/scan-v019.json");
+    let current_text = include_str!("fixtures/reports/scan-v020.json");
     let current: Value =
         serde_json::from_str(current_text).expect("current report fixture should be valid JSON");
 
-    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.19");
+    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.20");
     assert_eq!(current["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
     assert_eq!(current["report"]["kind"], "scan");
     assert_eq!(
@@ -33,7 +33,7 @@ fn current_schema_fixture_documents_scan_report_contract() {
 
 #[test]
 fn strict_reader_accepts_current_scan_report_shape() {
-    let current_text = include_str!("fixtures/reports/scan-v019.json");
+    let current_text = include_str!("fixtures/reports/scan-v020.json");
     let current = parse_scan_summary_json(current_text)
         .expect("current report should parse into ScanSummary");
 
@@ -65,13 +65,16 @@ fn strict_reader_accepts_current_scan_report_shape() {
 
 #[test]
 fn strict_reader_accepts_previous_scan_report_shapes() {
+    let previous_v019 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v019.json"))
+        .expect("0.19 report should parse during 0.20 transition");
     let previous_v018 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v018.json"))
-        .expect("0.18 report should parse during 0.19 transition");
+        .expect("0.18 report should parse during 0.20 transition");
     let previous_v017 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v017.json"))
-        .expect("0.17 report should parse during 0.19 transition");
+        .expect("0.17 report should parse during 0.20 transition");
     let previous_v016 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v016.json"))
-        .expect("0.16 report should parse during 0.19 transition");
+        .expect("0.16 report should parse during 0.20 transition");
 
+    assert_eq!(previous_v019.metrics.files_discovered, 2);
     assert_eq!(previous_v018.metrics.files_discovered, 2);
     assert_eq!(previous_v017.metrics.files_discovered, 2);
     assert_eq!(previous_v016.metrics.files_discovered, 2);

--- a/tests/review_command.rs
+++ b/tests/review_command.rs
@@ -1,3 +1,4 @@
+use repopilot::report::schema::SCAN_REPORT_SCHEMA_VERSION;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
@@ -26,7 +27,7 @@ fn review_reports_working_tree_findings_on_changed_lines() {
         &["review", ".", "--format", "json", "--profile", "strict"],
     );
 
-    assert_eq!(json["schema_version"], "0.19");
+    assert_eq!(json["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
     assert_eq!(json["report"]["kind"], "review");
     assert!(json["risk_summary"]["total"].as_u64().is_some());
     assert!(json["review"]["in_diff_findings"].as_u64().unwrap() >= 1);


### PR DESCRIPTION
## Summary

Preserve replayable Knowledge Engine decision provenance on findings that pass through context-aware rule evaluation.

Findings can now retain the decision inputs and result that produced their Knowledge Engine severity:

```text
base severity
→ optional signal
→ decision action
→ decided severity
→ reason
```

This creates a stable bridge between scan findings and the decision trace introduced in PR #252.

## Type of change

* [x] Feature
* [x] Refactor
* [x] Tests
* [x] Documentation
* [ ] Bug fix
* [ ] CI / repository maintenance

## What changed

* Added optional `provenance.knowledge_decision` data containing:

  * base severity;
  * optional signal ID;
  * decision action;
  * Knowledge Engine output severity;
  * decision reason.
* Added typed `KnowledgeDecisionProvenance` and `KnowledgeDecisionAction` models.
* Added a shared `record_decision_provenance()` helper.
* Preserved decision provenance through:

  * finding metadata enrichment;
  * AST and text-heuristic provenance overrides;
  * file-level decisions;
  * project-level decisions.
* Added provenance recording to:

  * runtime-risk findings;
  * Rust panic-risk findings;
  * complexity findings;
  * long-function findings.
* Extracted `Severity` into its own findings module while preserving the existing `findings::types::Severity` public path.
* Bumped scan and review report schema from `0.19` to `0.20`.
* Kept report readers backward-compatible with schemas `0.16` through `0.19`.
* Added focused serialization, enrichment, and schema compatibility tests.
* Updated report and signal-contract documentation.
* Updated the changelog.

## Why

RepoPilot can now explain how a rule decision was made, but emitted findings previously kept only the final severity.

That meant a downstream consumer could see:

```text
severity = LOW
```

but could not determine whether the severity came from:

* the detector’s base severity;
* a runtime or file-role override;
* a downgrade;
* an upgrade;
* a rule signal.

This PR preserves that decision result directly on the finding:

```json
{
  "provenance": {
    "knowledge_decision": {
      "base_severity": "HIGH",
      "signal": "js.process-exit",
      "action": "downgrade",
      "decided_severity": "LOW",
      "reason": "CLI boundary code may intentionally terminate the process"
    }
  }
}
```

This enables future finding-level explanation without requiring consumers to guess the original signal or recompute the decision inputs.

## Severity ownership

`knowledge_decision.decided_severity` records the Knowledge Engine output.

The top-level finding `severity` remains authoritative because a detector may apply a narrower local policy after the Knowledge Engine decision.

For example:

```text
Knowledge Engine decision: MEDIUM
Detector-local literal handling: LOW
Final finding severity: LOW
```

## Compatibility

* Finding IDs are unchanged.
* Baseline keys and baseline schema are unchanged.
* Visibility decisions are unchanged.
* Risk scoring behavior is unchanged.
* Rule and detector decisions are unchanged.
* SARIF behavior is unchanged.
* Existing `findings::types::Severity` imports remain supported.
* `knowledge_decision` is optional and omitted for findings that do not pass through the Knowledge Engine.
* Older report schemas `0.16` through `0.19` remain readable.
* Scan and review JSON schema moves to `0.20`.

## Contract and ownership

* [x] The change stays within finding provenance, Knowledge Engine, and report-schema boundaries.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] Decision provenance is deterministic and covered by focused tests.
* [x] Existing findings without Knowledge Engine decisions remain compatible.
* [x] No false-positive or visibility behavior is changed.
* [x] No unrelated generated-file churn is included.

## Changelog

* [x] `CHANGELOG.md` updated.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```
