### PR TITLE
feat(mcp): explain findings from session reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **MCP can now explain emitted findings by stable ID.**
+  `repopilot_explain_finding` reads a file-scoped finding from the latest scan
+  or review in the current MCP session, replays its stored Knowledge Engine
+  inputs against the current workspace, and returns the emitted finding, stored
+  provenance, full role/decision trace, and a deterministic `matched` or
+  `drifted` comparison. Repository, workspace, Git-diff, and framework-project
+  findings are rejected rather than replayed with incomplete file-only context.
+  The tool rejects findings without schema-`0.20` decision provenance, enforces
+  the MCP root boundary, and bypasses the session cache so a newer scan or review
+  cannot reuse a stale explanation. CLI commands, scan/review schemas, finding
+  IDs, baseline behavior, visibility, SARIF, and detector decisions are
+  unchanged.
+
 - **Findings now preserve replayable Knowledge Engine decision provenance.**
   Knowledge-aware findings add optional `provenance.knowledge_decision` data
   containing base severity, signal id, action, decided severity, and reason.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -448,6 +448,7 @@ repopilot mcp [--root PATH]
 | `repopilot_scan` | Full repository audit as a JSON report |
 | `repopilot_context` | Budgeted, AI-ready Markdown brief (optional `focus`, `budget`) |
 | `repopilot_explain_file` | How one file is classified and which rules and signals apply |
+| `repopilot_explain_finding` | Replay a file-scoped emitted finding by stable ID from the current MCP session |
 
 ### Examples
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -38,6 +38,7 @@ non-destructive, idempotent, and closed-world.
 | `repopilot_scan` | Repository or changed-scope JSON scan | `config`, `profile`, `scope`, `base` |
 | `repopilot_context` | Budgeted AI-ready Markdown context | `config`, `profile`, `focus`, `budget` |
 | `repopilot_explain_file` | File-role evidence and ordered rule decision trace | `rule`, `signal` |
+| `repopilot_explain_finding` | Replay a file-scoped emitted finding by stable ID from the current MCP session | `finding_id`, `source` |
 
 `repopilot_explain_file` returns additive JSON fields for explicit scope,
 role evidence, applicability checks, every ordered override, severity
@@ -45,6 +46,17 @@ transitions, and the final default-profile visibility decision. It resolves
 executable-package manifest context from the MCP root so `cli-executable`
 classification matches normal scanning. Its rule base severity comes from the
 rule registry when a known `rule` is supplied.
+
+`repopilot_explain_finding` consumes a stable file-scoped finding ID from
+either `repopilot://last-scan` or `repopilot://last-review`. It uses the stored
+`provenance.knowledge_decision` inputs to replay the rule against the current
+workspace and returns the emitted finding, stored decision, full file/decision
+trace, and a `matched` or `drifted` comparison. A drift result means the source
+file or current bundled knowledge no longer reproduces the recorded action,
+severity, or reason. Repository, workspace, Git-diff, and framework-project
+findings are rejected explicitly because correct replay requires rebuilding
+their wider analysis context. The finding-level severity remains authoritative
+when detector-local policy differs from the Knowledge Engine output.
 
 Every tool accepts a workspace-relative `path` where applicable. Review defaults
 to `scope=changed`, `profile=default`, `fail_on_review=none`, and
@@ -109,9 +121,10 @@ The server exposes:
 Last-result resources appear after the corresponding tool has run. Identical
 non-scan tool calls are served from the in-process session cache; `repopilot_scan`
 uses the persistent cache above because its correctness depends on Git state.
-Session-cache invalidation for `repopilot_review_change`, `repopilot_context`,
-and `repopilot_explain_file` is intentionally left to the next MCP correctness
-PR.
+`repopilot_explain_finding` bypasses the session cache because its result depends
+on the mutable `last-scan` or `last-review` value. Session-cache invalidation for
+`repopilot_review_change`, `repopilot_context`, and `repopilot_explain_file`
+remains separate follow-up work.
 
 ## Prompts
 

--- a/src/commands/mcp/explain_finding.rs
+++ b/src/commands/mcp/explain_finding.rs
@@ -1,0 +1,185 @@
+//! The `repopilot_explain_finding` MCP tool: replay one emitted finding by
+//! stable ID from the latest scan or review stored in this MCP session.
+
+use repopilot::explain::build_finding_explanation_from_report;
+use serde_json::{Value, json};
+use std::path::Path;
+
+pub const TOOL_NAME: &str = "repopilot_explain_finding";
+
+pub fn definition() -> Value {
+    json!({
+        "name": TOOL_NAME,
+        "description": "Explain an emitted finding by stable ID using the latest scan or review in this MCP session. Replays the stored Knowledge Engine inputs against the current workspace, returns the full decision trace, and reports matched vs drifted decisions. Local-only.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "finding_id": {
+                    "type": "string",
+                    "description": "Stable finding ID from the findings array of the selected session report."
+                },
+                "source": {
+                    "type": "string",
+                    "enum": ["last-scan", "last-review"],
+                    "default": "last-scan",
+                    "description": "Session report containing the finding."
+                }
+            },
+            "required": ["finding_id"],
+            "additionalProperties": false
+        },
+        "outputSchema": { "type": "object", "additionalProperties": true },
+        "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": false
+        }
+    })
+}
+
+pub fn call(
+    arguments: &Value,
+    root: &Path,
+    last_scan: Option<&str>,
+    last_review: Option<&str>,
+) -> Result<String, String> {
+    let finding_id = arguments
+        .get("finding_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "`finding_id` is required".to_string())?;
+    let source = arguments
+        .get("source")
+        .and_then(Value::as_str)
+        .unwrap_or("last-scan");
+
+    let report = match source {
+        "last-scan" => last_scan.ok_or_else(|| {
+            "no scan is available in this MCP session; run repopilot_scan first".to_string()
+        })?,
+        "last-review" => last_review.ok_or_else(|| {
+            "no review is available in this MCP session; run repopilot_review_change first"
+                .to_string()
+        })?,
+        other => return Err(format!("invalid source: {other}")),
+    };
+
+    let explanation = build_finding_explanation_from_report(root, report, finding_id, source)?;
+    serde_json::to_string_pretty(&explanation)
+        .map_err(|error| format!("render finding explanation failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repopilot::explain::build_explain_report_with_root;
+    use repopilot::findings::provenance::{
+        AnalysisScope, FindingProvenance, KnowledgeDecisionAction, KnowledgeDecisionProvenance,
+    };
+    use repopilot::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
+    use repopilot::rules::{RuleLifecycle, SignalSource};
+    use std::path::PathBuf;
+
+    fn report_fixture(root: &Path) -> (String, String) {
+        let path = root.join("src/domain/service.rs");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create src");
+        std::fs::write(&path, "pub fn run() { panic!(\"boom\"); }\n").expect("write file");
+
+        let base_severity = Severity::Medium;
+        let signal = "rust.panic";
+        let source_explanation = build_explain_report_with_root(
+            root,
+            &path,
+            Some("language.rust.panic-risk"),
+            Some(signal),
+            base_severity,
+        )
+        .expect("build explanation");
+        let decision = source_explanation.decision.expect("decision");
+        let action = match decision.action.as_str() {
+            "apply" => KnowledgeDecisionAction::Apply,
+            "suppress" => KnowledgeDecisionAction::Suppress,
+            "downgrade" => KnowledgeDecisionAction::Downgrade,
+            "upgrade" => KnowledgeDecisionAction::Upgrade,
+            other => panic!("unexpected action: {other}"),
+        };
+        let finding_id = "language.rust.panic-risk:src/domain/service.rs:1".to_string();
+        let finding = Finding {
+            id: finding_id.clone(),
+            rule_id: "language.rust.panic-risk".to_string(),
+            title: "Panic risk".to_string(),
+            description: "panic can terminate the current operation".to_string(),
+            recommendation: "Return a typed error where possible.".to_string(),
+            category: FindingCategory::CodeQuality,
+            severity: decision.final_severity,
+            confidence: Confidence::High,
+            evidence: vec![Evidence {
+                path: PathBuf::from("src/domain/service.rs"),
+                line_start: 1,
+                line_end: None,
+                snippet: "panic!(\"boom\")".to_string(),
+            }],
+            workspace_package: None,
+            docs_url: None,
+            provenance: FindingProvenance {
+                detector: "language.rust.panic-risk".to_string(),
+                signal_source: SignalSource::Ast,
+                rule_lifecycle: RuleLifecycle::Stable,
+                analysis_scope: AnalysisScope::File,
+                knowledge_decision: Some(KnowledgeDecisionProvenance {
+                    base_severity,
+                    signal: Some(signal.to_string()),
+                    action,
+                    decided_severity: decision.final_severity,
+                    reason: decision.reason,
+                }),
+            },
+            risk: Default::default(),
+        };
+
+        (
+            serde_json::to_string(&json!({
+                "schema_version": "0.20",
+                "root_path": root,
+                "findings": [finding]
+            }))
+            .expect("serialize report"),
+            finding_id,
+        )
+    }
+
+    #[test]
+    fn tool_replays_a_finding_from_last_scan() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (report, finding_id) = report_fixture(temp.path());
+
+        let rendered = call(
+            &json!({
+                "finding_id": finding_id,
+                "source": "last-scan"
+            }),
+            temp.path(),
+            Some(&report),
+            None,
+        )
+        .expect("explain finding");
+
+        let value: Value = serde_json::from_str(&rendered).expect("valid JSON");
+        assert_eq!(value["source_report"], "last-scan");
+        assert_eq!(value["replay"]["status"], "matched");
+        assert!(value["explanation"]["decision"]["trace"].is_array());
+    }
+
+    #[test]
+    fn tool_requires_the_selected_session_report() {
+        let error = call(
+            &json!({ "finding_id": "missing" }),
+            Path::new("."),
+            None,
+            None,
+        )
+        .expect_err("missing scan must fail");
+
+        assert!(error.contains("run repopilot_scan first"));
+    }
+}

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -8,6 +8,7 @@
 
 mod context;
 mod explain_file;
+mod explain_finding;
 mod jsonrpc;
 mod review_change;
 mod scan;
@@ -297,6 +298,7 @@ fn tools_list_result() -> Value {
             scan::definition(),
             context::definition(),
             explain_file::definition(),
+            explain_finding::definition(),
         ]
     })
 }
@@ -314,7 +316,9 @@ fn handle_tools_call(id: Value, params: &Value, state: &mut ServerState) -> Resp
         return Response::success(id, tool_result(name, Err(message)));
     }
 
-    let use_session_cache = name != scan::TOOL_NAME;
+    // Finding replay depends on the mutable last-scan/last-review session
+    // result, so caching it only by tool arguments would return stale evidence.
+    let use_session_cache = name != scan::TOOL_NAME && name != explain_finding::TOOL_NAME;
     let cache_key = format!("{name}:{}", arguments);
     if use_session_cache && let Some(cached) = state.cache.get(&cache_key) {
         return Response::success(id, tool_result(name, Ok(cached.clone())));
@@ -325,6 +329,12 @@ fn handle_tools_call(id: Value, params: &Value, state: &mut ServerState) -> Resp
         scan::TOOL_NAME => scan::call(&arguments),
         context::TOOL_NAME => context::call(&arguments),
         explain_file::TOOL_NAME => explain_file::call(&arguments, &state.root),
+        explain_finding::TOOL_NAME => explain_finding::call(
+            &arguments,
+            &state.root,
+            state.last_scan.as_deref(),
+            state.last_review.as_deref(),
+        ),
         other => Err(format!("unknown tool: {other}")),
     };
 

--- a/src/commands/mcp/tests.rs
+++ b/src/commands/mcp/tests.rs
@@ -1,4 +1,4 @@
-use super::serve;
+use super::{ServerState, handle_tools_call, scan, serve};
 use serde_json::{Value, json};
 use std::io::Cursor;
 
@@ -94,6 +94,7 @@ fn tools_list_advertises_all_tools_with_schemas() {
             "repopilot_scan",
             "repopilot_context",
             "repopilot_explain_file",
+            "repopilot_explain_finding",
         ]
     );
 
@@ -250,5 +251,85 @@ fn context_tool_returns_markdown_brief_matching_its_output_schema() {
         result["content"][0]["text"].as_str(),
         Some(markdown),
         "content text should mirror the structured markdown"
+    );
+}
+
+#[test]
+fn explain_finding_requires_a_session_result() {
+    let responses = initialized_exchange(&[json!({
+        "jsonrpc": "2.0",
+        "id": 8,
+        "method": "tools/call",
+        "params": {
+            "name": "repopilot_explain_finding",
+            "arguments": {
+                "finding_id": "language.rust.panic-risk:src/lib.rs:1"
+            }
+        }
+    })]);
+
+    let result = &responses[0]["result"];
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .is_some_and(|message| message.contains("run repopilot_scan first"))
+    );
+}
+
+#[test]
+fn scan_then_explain_finding_replays_session_finding() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let source_path = temp.path().join("src/lib.rs");
+    std::fs::create_dir_all(source_path.parent().expect("parent"))
+        .expect("create source directory");
+    std::fs::write(&source_path, "pub fn dangerous() { panic!(\"boom\"); }\n")
+        .expect("write Rust source");
+
+    let scan_report = scan::call(&json!({
+        "path": temp.path(),
+        "profile": "strict"
+    }))
+    .expect("scan fixture repository");
+    let scan_value: Value = serde_json::from_str(&scan_report).expect("scan report JSON");
+    let finding_id = scan_value["findings"]
+        .as_array()
+        .expect("findings array")
+        .iter()
+        .find(|finding| {
+            finding["rule_id"] == "language.rust.panic-risk"
+                && finding["provenance"]["analysis_scope"] == "file"
+                && finding["provenance"]["knowledge_decision"].is_object()
+        })
+        .and_then(|finding| finding["id"].as_str())
+        .expect("knowledge-aware Rust panic finding")
+        .to_string();
+
+    let mut state = ServerState {
+        root: temp.path().canonicalize().expect("canonical root"),
+        initialized: true,
+        last_scan: Some(scan_report),
+        ..ServerState::default()
+    };
+    let response = handle_tools_call(
+        json!(9),
+        &json!({
+            "name": "repopilot_explain_finding",
+            "arguments": {
+                "finding_id": finding_id,
+                "source": "last-scan"
+            }
+        }),
+        &mut state,
+    );
+    let result = response.result.expect("MCP result");
+
+    assert_eq!(result["isError"], false, "tool call failed: {result}");
+    assert_eq!(result["structuredContent"]["source_report"], "last-scan");
+    assert_eq!(result["structuredContent"]["replay"]["status"], "matched");
+    assert!(
+        result["structuredContent"]["explanation"]["decision"]["trace"]
+            .as_array()
+            .is_some_and(|trace| !trace.is_empty())
     );
 }

--- a/src/explain/finding.rs
+++ b/src/explain/finding.rs
@@ -1,0 +1,426 @@
+use super::builder::build_explain_report_with_root;
+use super::model::ExplainReport;
+use crate::findings::provenance::{
+    AnalysisScope, KnowledgeDecisionAction, KnowledgeDecisionProvenance,
+};
+use crate::findings::types::Finding;
+use serde::Serialize;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FindingExplanationReport {
+    pub source_report: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_schema_version: Option<String>,
+    pub source_root: String,
+    pub finding: Finding,
+    pub stored_decision: KnowledgeDecisionProvenance,
+    pub replay: FindingDecisionReplay,
+    pub explanation: ExplainReport,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FindingDecisionReplay {
+    pub status: FindingReplayStatus,
+    pub action_matches: bool,
+    pub severity_matches: bool,
+    pub reason_matches: bool,
+    pub detector_local_severity_adjustment: bool,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum FindingReplayStatus {
+    Matched,
+    Drifted,
+}
+
+pub fn build_finding_explanation_from_report(
+    mcp_root: &Path,
+    report_json: &str,
+    finding_id: &str,
+    source_report: &str,
+) -> Result<FindingExplanationReport, String> {
+    if finding_id.trim().is_empty() {
+        return Err("`finding_id` must not be empty".to_string());
+    }
+
+    let report: Value = serde_json::from_str(report_json)
+        .map_err(|error| format!("invalid session report: {error}"))?;
+    let findings = report
+        .get("findings")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "session report does not contain a findings array".to_string())?;
+
+    let matches = findings
+        .iter()
+        .filter(|finding| finding.get("id").and_then(Value::as_str) == Some(finding_id))
+        .collect::<Vec<_>>();
+
+    let finding_value = match matches.as_slice() {
+        [] => {
+            return Err(format!(
+                "finding `{finding_id}` was not found in {source_report}"
+            ));
+        }
+        [finding] => (*finding).clone(),
+        _ => {
+            return Err(format!(
+                "finding `{finding_id}` appears more than once in {source_report}"
+            ));
+        }
+    };
+
+    // Review JSON flattens Finding and appends in_diff/baseline_status fields.
+    // Serde ignores those additive fields while preserving the complete Finding.
+    let finding: Finding = serde_json::from_value(finding_value)
+        .map_err(|error| format!("invalid finding `{finding_id}`: {error}"))?;
+
+    if finding.provenance.analysis_scope != AnalysisScope::File {
+        return Err(format!(
+            "finding `{finding_id}` uses `{}` analysis scope;              repopilot_explain_finding currently supports file-scoped findings only",
+            analysis_scope_id(finding.provenance.analysis_scope)
+        ));
+    }
+
+    let stored_decision = finding
+        .provenance
+        .knowledge_decision
+        .clone()
+        .ok_or_else(|| {
+            format!(
+                "finding `{finding_id}` has no knowledge decision provenance; \
+                 run RepoPilot schema 0.20+ and choose a knowledge-aware finding"
+            )
+        })?;
+
+    let canonical_mcp_root = mcp_root
+        .canonicalize()
+        .unwrap_or_else(|_| mcp_root.to_path_buf());
+    let source_root = resolve_source_root(&canonical_mcp_root, &report)?;
+    let evidence = finding
+        .evidence
+        .first()
+        .ok_or_else(|| format!("finding `{finding_id}` has no evidence path"))?;
+    let source_path = resolve_source_path(&canonical_mcp_root, &source_root, &evidence.path)?;
+
+    let explanation = build_explain_report_with_root(
+        &source_root,
+        &source_path,
+        Some(&finding.rule_id),
+        stored_decision.signal.as_deref(),
+        stored_decision.base_severity,
+    )
+    .map_err(|error| format!("finding replay failed: {error}"))?;
+
+    let replayed = explanation
+        .decision
+        .as_ref()
+        .ok_or_else(|| "finding replay did not produce a rule decision".to_string())?;
+    let stored_action = knowledge_action_id(stored_decision.action);
+
+    let action_matches = replayed.action == stored_action;
+    let severity_matches = replayed.final_severity == stored_decision.decided_severity;
+    let reason_matches = replayed.reason == stored_decision.reason;
+    let detector_local_severity_adjustment = finding.severity != stored_decision.decided_severity;
+
+    let mut notes = Vec::new();
+    if !action_matches {
+        notes.push(format!(
+            "decision action changed: stored={} replayed={}",
+            stored_action, replayed.action
+        ));
+    }
+    if !severity_matches {
+        notes.push(format!(
+            "decision severity changed: stored={} replayed={}",
+            stored_decision.decided_severity.label(),
+            replayed.final_severity.label()
+        ));
+    }
+    if !reason_matches {
+        notes.push("decision reason changed".to_string());
+    }
+    if detector_local_severity_adjustment {
+        notes.push(format!(
+            "detector-local policy changed the emitted finding severity from {} to {}",
+            stored_decision.decided_severity.label(),
+            finding.severity.label()
+        ));
+    }
+
+    let status = if action_matches && severity_matches && reason_matches {
+        FindingReplayStatus::Matched
+    } else {
+        FindingReplayStatus::Drifted
+    };
+
+    Ok(FindingExplanationReport {
+        source_report: source_report.to_string(),
+        source_schema_version: report
+            .get("schema_version")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        source_root: source_root.to_string_lossy().to_string(),
+        finding,
+        stored_decision,
+        replay: FindingDecisionReplay {
+            status,
+            action_matches,
+            severity_matches,
+            reason_matches,
+            detector_local_severity_adjustment,
+            notes,
+        },
+        explanation,
+    })
+}
+
+fn resolve_source_root(mcp_root: &Path, report: &Value) -> Result<PathBuf, String> {
+    let value = report
+        .get("root_path")
+        .and_then(Value::as_str)
+        .unwrap_or(".");
+    let candidate = if Path::new(value).is_absolute() {
+        PathBuf::from(value)
+    } else {
+        mcp_root.join(value)
+    };
+    let resolved = candidate.canonicalize().unwrap_or(candidate);
+    ensure_within_mcp_root(mcp_root, &resolved, "session report root")?;
+    Ok(resolved)
+}
+
+fn resolve_source_path(
+    mcp_root: &Path,
+    source_root: &Path,
+    evidence_path: &Path,
+) -> Result<PathBuf, String> {
+    let candidate = if evidence_path.is_absolute() {
+        evidence_path.to_path_buf()
+    } else {
+        source_root.join(evidence_path)
+    };
+    let resolved = candidate.canonicalize().map_err(|error| {
+        format!(
+            "finding evidence file {} is unavailable: {error}",
+            candidate.display()
+        )
+    })?;
+    ensure_within_mcp_root(mcp_root, &resolved, "finding evidence path")?;
+    Ok(resolved)
+}
+
+fn ensure_within_mcp_root(root: &Path, path: &Path, label: &str) -> Result<(), String> {
+    if path.starts_with(root) {
+        Ok(())
+    } else {
+        Err(format!(
+            "{label} {} must stay within MCP root {}",
+            path.display(),
+            root.display()
+        ))
+    }
+}
+
+fn analysis_scope_id(scope: AnalysisScope) -> &'static str {
+    match scope {
+        AnalysisScope::File => "file",
+        AnalysisScope::Repository => "repository",
+        AnalysisScope::Workspace => "workspace",
+        AnalysisScope::GitDiff => "git-diff",
+        AnalysisScope::FrameworkProject => "framework-project",
+    }
+}
+
+fn knowledge_action_id(action: KnowledgeDecisionAction) -> &'static str {
+    match action {
+        KnowledgeDecisionAction::Apply => "apply",
+        KnowledgeDecisionAction::Suppress => "suppress",
+        KnowledgeDecisionAction::Downgrade => "downgrade",
+        KnowledgeDecisionAction::Upgrade => "upgrade",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::findings::provenance::{
+        AnalysisScope, FindingProvenance, KnowledgeDecisionAction, KnowledgeDecisionProvenance,
+    };
+    use crate::findings::types::{Confidence, Evidence, FindingCategory, Severity};
+    use crate::rules::{RuleLifecycle, SignalSource};
+    use serde_json::json;
+
+    fn fixture_report(root: &Path, stored_reason: Option<String>) -> (String, String) {
+        let path = root.join("src/domain/service.rs");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create src");
+        std::fs::write(&path, "pub fn run() { panic!(\"boom\"); }\n").expect("write fixture");
+
+        let base_severity = Severity::Medium;
+        let signal = "rust.panic";
+        let explanation = build_explain_report_with_root(
+            root,
+            &path,
+            Some("language.rust.panic-risk"),
+            Some(signal),
+            base_severity,
+        )
+        .expect("build source explanation");
+        let decision = explanation.decision.expect("decision");
+        let action = match decision.action.as_str() {
+            "apply" => KnowledgeDecisionAction::Apply,
+            "suppress" => KnowledgeDecisionAction::Suppress,
+            "downgrade" => KnowledgeDecisionAction::Downgrade,
+            "upgrade" => KnowledgeDecisionAction::Upgrade,
+            other => panic!("unexpected action: {other}"),
+        };
+
+        let finding_id = "language.rust.panic-risk:src/domain/service.rs:1".to_string();
+        let finding = Finding {
+            id: finding_id.clone(),
+            rule_id: "language.rust.panic-risk".to_string(),
+            title: "Panic risk".to_string(),
+            description: "panic can terminate the current operation".to_string(),
+            recommendation: "Return a typed error where recovery is possible.".to_string(),
+            category: FindingCategory::CodeQuality,
+            severity: decision.final_severity,
+            confidence: Confidence::High,
+            evidence: vec![Evidence {
+                path: PathBuf::from("src/domain/service.rs"),
+                line_start: 1,
+                line_end: None,
+                snippet: "panic!(\"boom\")".to_string(),
+            }],
+            workspace_package: None,
+            docs_url: None,
+            provenance: FindingProvenance {
+                detector: "language.rust.panic-risk".to_string(),
+                signal_source: SignalSource::Ast,
+                rule_lifecycle: RuleLifecycle::Stable,
+                analysis_scope: AnalysisScope::File,
+                knowledge_decision: Some(KnowledgeDecisionProvenance {
+                    base_severity,
+                    signal: Some(signal.to_string()),
+                    action,
+                    decided_severity: decision.final_severity,
+                    reason: stored_reason.or(decision.reason),
+                }),
+            },
+            risk: Default::default(),
+        };
+
+        (
+            serde_json::to_string(&json!({
+                "schema_version": "0.20",
+                "root_path": root,
+                "findings": [finding]
+            }))
+            .expect("serialize report"),
+            finding_id,
+        )
+    }
+
+    #[test]
+    fn replays_a_finding_from_a_session_report() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (report, finding_id) = fixture_report(temp.path(), None);
+
+        let replay =
+            build_finding_explanation_from_report(temp.path(), &report, &finding_id, "last-scan")
+                .expect("replay finding");
+
+        assert_eq!(replay.replay.status, FindingReplayStatus::Matched);
+        assert!(replay.replay.action_matches);
+        assert!(replay.replay.severity_matches);
+        assert!(replay.replay.reason_matches);
+        assert_eq!(replay.finding.id, finding_id);
+        assert!(
+            replay
+                .explanation
+                .decision
+                .as_ref()
+                .is_some_and(|decision| !decision.trace.is_empty())
+        );
+    }
+
+    #[test]
+    fn reports_decision_drift_without_hiding_the_trace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (report, finding_id) =
+            fixture_report(temp.path(), Some("historical reason".to_string()));
+
+        let replay =
+            build_finding_explanation_from_report(temp.path(), &report, &finding_id, "last-review")
+                .expect("replay finding");
+
+        assert_eq!(replay.replay.status, FindingReplayStatus::Drifted);
+        assert!(!replay.replay.reason_matches);
+        assert!(
+            replay
+                .replay
+                .notes
+                .iter()
+                .any(|note| note == "decision reason changed")
+        );
+        assert!(replay.explanation.decision.is_some());
+    }
+
+    #[test]
+    fn rejects_findings_without_knowledge_decision_provenance() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("src/lib.rs");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create src");
+        std::fs::write(&path, "pub fn live() {}\n").expect("write file");
+
+        let finding = Finding {
+            id: "code-marker.todo:src/lib.rs:1".to_string(),
+            rule_id: "code-marker.todo".to_string(),
+            title: "TODO".to_string(),
+            description: "TODO marker".to_string(),
+            category: FindingCategory::CodeQuality,
+            severity: Severity::Low,
+            evidence: vec![Evidence {
+                path: PathBuf::from("src/lib.rs"),
+                line_start: 1,
+                line_end: None,
+                snippet: "TODO".to_string(),
+            }],
+            ..Finding::default()
+        };
+        let report = serde_json::to_string(&json!({
+            "schema_version": "0.20",
+            "root_path": temp.path(),
+            "findings": [finding]
+        }))
+        .expect("serialize report");
+
+        let error = build_finding_explanation_from_report(
+            temp.path(),
+            &report,
+            "code-marker.todo:src/lib.rs:1",
+            "last-scan",
+        )
+        .expect_err("missing knowledge provenance must fail");
+
+        assert!(error.contains("has no knowledge decision provenance"));
+    }
+
+    #[test]
+    fn rejects_repository_scoped_findings_instead_of_file_replay() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (report, finding_id) = fixture_report(temp.path(), None);
+        let mut value: Value = serde_json::from_str(&report).expect("report JSON");
+        value["findings"][0]["provenance"]["analysis_scope"] = json!("repository");
+        let report = serde_json::to_string(&value).expect("serialize report");
+
+        let error =
+            build_finding_explanation_from_report(temp.path(), &report, &finding_id, "last-scan")
+                .expect_err("repository-scoped replay must fail");
+
+        assert!(error.contains("uses `repository` analysis scope"));
+        assert!(error.contains("currently supports file-scoped findings only"));
+    }
+}

--- a/src/explain/mod.rs
+++ b/src/explain/mod.rs
@@ -1,8 +1,13 @@
 pub mod builder;
+pub mod finding;
 pub mod model;
 pub mod render;
 
 pub use builder::{build_explain_report, build_explain_report_with_root};
+pub use finding::{
+    FindingDecisionReplay, FindingExplanationReport, FindingReplayStatus,
+    build_finding_explanation_from_report,
+};
 pub use model::{
     ExplainContext, ExplainDecision, ExplainDecisionTraceStep, ExplainReport, ExplainRoleEvidence,
     ExplainScope, ExplainSource,

--- a/tests/mcp_cli.rs
+++ b/tests/mcp_cli.rs
@@ -89,6 +89,7 @@ fn mcp_server_initializes_lists_tools_and_runs_scan_locally() {
             "repopilot_scan",
             "repopilot_context",
             "repopilot_explain_file",
+            "repopilot_explain_finding",
         ]
     );
 


### PR DESCRIPTION
## Summary

Add `repopilot_explain_finding`, a local MCP tool that replays a file-scoped
finding by stable ID from the latest scan or review stored in the current MCP
session.

The tool connects the decision trace from PR #252 with the finding-level
Knowledge Engine provenance introduced in PR #253.

## Type of change

- [x] Feature
- [x] Tests
- [x] Documentation
- [ ] Refactor
- [ ] Bug fix
- [ ] CI / repository maintenance

## What changed

- Added the `repopilot_explain_finding` MCP tool.
- Added support for selecting a finding from:
  - `last-scan`;
  - `last-review`.
- Replays stored Knowledge Engine inputs:
  - rule ID;
  - base severity;
  - signal ID;
  - stored decision action;
  - stored decided severity;
  - stored reason.
- Returns:
  - the emitted finding;
  - stored decision provenance;
  - current file classification and role evidence;
  - the ordered decision trace;
  - a deterministic `matched` or `drifted` result.
- Reports detector-local severity adjustments separately from Knowledge Engine
  drift.
- Rejects findings without `knowledge_decision` provenance.
- Restricts replay to file-scoped findings.
- Enforces the configured MCP root for report roots and evidence paths.
- Bypasses the MCP session cache because replay depends on mutable
  `last-scan` / `last-review` state.
- Added focused unit and MCP contract tests.
- Updated MCP and CLI documentation.
- Updated the changelog.

## Why

RepoPilot scan and review reports now preserve the decision inputs that produced
a finding, but callers still need to manually reconstruct a file explanation.

This PR makes finding-level explanation directly accessible to MCP clients:

```text
scan or review
→ stable finding ID
→ stored decision provenance
→ replay against current workspace
→ full ordered trace
→ matched or drifted
```
## Replay result

A matched result means the current file and bundled Knowledge Engine reproduce:

the stored action;
the stored decided severity;
the stored reason.

A drifted result means at least one of those values changed.

Detector-local severity adjustments are reported separately and do not
automatically count as Knowledge Engine drift.

## Compatibility

- No new top-level CLI command is added.
- Scan and review JSON schemas are unchanged.
- Finding IDs are unchanged.
- Baseline behavior is unchanged.
- Visibility behavior is unchanged.
- SARIF output is unchanged.
- Detector and Knowledge Engine decisions are unchanged.
- Existing MCP tools remain compatible.

## Contract and ownership

-  The change stays within the explain and MCP boundaries.
-  CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
-  Replay uses deterministic stored provenance.
-  Filesystem access remains inside the configured MCP root.
-  Session-dependent replay bypasses the generic MCP result cache.
-  No unrelated refactor or generated-file churn is included.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
```
