### PR TITLE
fix(provenance): derive analysis scope from audit execution kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,15 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **Finding analysis scope now comes from the audit execution boundary.**
+  File, project, and framework runners stamp `file`, `repository`, and
+  `framework-project`; graph/coupling paths explicitly stamp repository scope.
+  Registry enrichment preserves this value instead of deriving it from
+  `signal_source`, so project text heuristics such as
+  `architecture.too-many-modules` cannot enter file-only replay. Signal source,
+  severity, confidence, visibility, finding IDs, schema `0.20`, baseline
+  behavior, and detector decisions are unchanged.
+
 - **Real-repo zoo scans now build and run the current workspace RepoPilot by
   default.** `python3 scripts/zoo.py scan` invokes Cargo once, uses the
   executable Cargo reports, and prints scanner provenance before scanning so

--- a/docs/engineering/signal-contract.md
+++ b/docs/engineering/signal-contract.md
@@ -19,6 +19,11 @@ Signal sources are explicit: `text-heuristic`, `ast`, `config-file`,
 `dependency-manifest`, `import-graph`, `framework-detector`, `git-diff`, or
 `mixed`. A text heuristic must not claim AST provenance.
 
+Analysis scope is independent from signal source. File audit runners stamp
+`file`, project audit runners stamp `repository`, and framework audit runners
+stamp `framework-project`. A project audit may use text-heuristic evidence, and
+that does not make the finding file-scoped.
+
 The rule catalog and its quality gate are validated by `cargo test`
 (`tests/rule_eval_fixture_coverage.rs`), which runs every rule against its bundled
 true-positive/false-positive fixtures.

--- a/src/audits/metadata.rs
+++ b/src/audits/metadata.rs
@@ -1,3 +1,4 @@
+use crate::findings::provenance::AnalysisScope;
 use crate::findings::types::FindingCategory;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -13,6 +14,15 @@ impl AuditKind {
             Self::File => "file",
             Self::Project => "project",
             Self::Framework => "framework",
+        }
+    }
+
+    /// Evidence source and execution scope are separate contracts.
+    pub fn analysis_scope(self) -> AnalysisScope {
+        match self {
+            Self::File => AnalysisScope::File,
+            Self::Project => AnalysisScope::Repository,
+            Self::Framework => AnalysisScope::FrameworkProject,
         }
     }
 }
@@ -54,6 +64,15 @@ mod tests {
         assert_eq!(AuditKind::File.label(), "file");
         assert_eq!(AuditKind::Project.label(), "project");
         assert_eq!(AuditKind::Framework.label(), "framework");
+        assert_eq!(AuditKind::File.analysis_scope(), AnalysisScope::File);
+        assert_eq!(
+            AuditKind::Project.analysis_scope(),
+            AnalysisScope::Repository
+        );
+        assert_eq!(
+            AuditKind::Framework.analysis_scope(),
+            AnalysisScope::FrameworkProject
+        );
     }
 
     #[test]

--- a/src/audits/pipeline/framework_audits.rs
+++ b/src/audits/pipeline/framework_audits.rs
@@ -179,7 +179,7 @@ pub fn registered_framework_audits(facts: &ScanFacts) -> Vec<FrameworkAuditRegis
 pub fn run_framework_audits(facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
     let findings = registered_framework_audits(facts)
         .iter()
-        .flat_map(|registration| registration.audit.audit(facts, config))
+        .flat_map(|registration| registration.run(facts, config))
         .collect();
 
     apply_project_decisions(facts, findings)

--- a/src/audits/pipeline/mod.rs
+++ b/src/audits/pipeline/mod.rs
@@ -6,6 +6,7 @@ mod registration;
 pub use file_audits::{build_file_audits, registered_file_audits};
 pub use framework_audits::{registered_framework_audits, run_framework_audits};
 pub use project_audits::{registered_project_audits, run_project_audits};
+pub(crate) use registration::stamp_findings_analysis_scope;
 pub use registration::{
     FileAuditRegistration, FrameworkAuditRegistration, ProjectAuditRegistration,
 };
@@ -14,11 +15,14 @@ pub use registration::{
 mod tests {
     use super::*;
     use crate::audits::metadata::AuditKind;
+    use crate::findings::enrichment::enrich_findings;
+    use crate::findings::provenance::AnalysisScope;
     use crate::frameworks::DetectedFramework;
-    use crate::rules::lookup_rule_metadata;
+    use crate::rules::{SignalSource, lookup_rule_metadata};
     use crate::scan::config::ScanConfig;
-    use crate::scan::facts::ScanFacts;
+    use crate::scan::facts::{FileFacts, ScanFacts};
     use std::collections::HashSet;
+    use std::path::PathBuf;
 
     #[test]
     fn registered_file_audits_have_rule_metadata() {
@@ -98,6 +102,56 @@ mod tests {
                 .iter()
                 .map(|registration| registration.metadata.clone()),
         );
+    }
+
+    #[test]
+    fn project_text_heuristic_scope_survives_registry_enrichment() {
+        let root = PathBuf::from("/repo");
+        let facts = ScanFacts {
+            root_path: root.clone(),
+            files: vec![
+                FileFacts {
+                    path: root.join("src/a.rs"),
+                    language: Some("Rust".to_string()),
+                    non_empty_lines: 1,
+                    ..FileFacts::default()
+                },
+                FileFacts {
+                    path: root.join("src/b.rs"),
+                    language: Some("Rust".to_string()),
+                    non_empty_lines: 1,
+                    ..FileFacts::default()
+                },
+            ],
+            ..ScanFacts::default()
+        };
+        let config = ScanConfig {
+            max_directory_modules: 1,
+            ..ScanConfig::default()
+        };
+
+        let mut findings = run_project_audits(&facts, &config);
+        let finding = findings
+            .iter()
+            .find(|finding| finding.rule_id == "architecture.too-many-modules")
+            .expect("too-many-modules finding");
+        assert_eq!(finding.provenance.analysis_scope, AnalysisScope::Repository);
+
+        enrich_findings(&mut findings, &root);
+        let finding = findings
+            .iter()
+            .find(|finding| finding.rule_id == "architecture.too-many-modules")
+            .expect("enriched too-many-modules finding");
+
+        assert_eq!(finding.provenance.analysis_scope, AnalysisScope::Repository);
+        assert_eq!(
+            finding.provenance.signal_source,
+            SignalSource::TextHeuristic
+        );
+
+        let value = serde_json::to_value(finding).expect("serialize finding");
+        assert_eq!(value["provenance"]["analysis_scope"], "repository");
+        assert_eq!(value["provenance"]["signal_source"], "text-heuristic");
     }
 
     fn assert_registrations_have_rule_metadata(

--- a/src/audits/pipeline/project_audits.rs
+++ b/src/audits/pipeline/project_audits.rs
@@ -86,7 +86,7 @@ pub fn registered_project_audits(config: &ScanConfig) -> Vec<ProjectAuditRegistr
 pub fn run_project_audits(scan_facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
     let findings = registered_project_audits(config)
         .iter()
-        .flat_map(|registration| registration.audit.audit(scan_facts, config))
+        .flat_map(|registration| registration.run(scan_facts, config))
         .collect();
 
     apply_project_decisions(scan_facts, findings)

--- a/src/audits/pipeline/registration.rs
+++ b/src/audits/pipeline/registration.rs
@@ -1,6 +1,10 @@
+use crate::analysis::parse::ParsedFile;
 use crate::audits::metadata::{AuditKind, AuditMetadata};
 use crate::audits::traits::{FileAudit, ProjectAudit};
-use crate::findings::types::FindingCategory;
+use crate::findings::provenance::AnalysisScope;
+use crate::findings::types::{Finding, FindingCategory};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::{FileFacts, ScanFacts};
 
 pub const CODE_MARKER_RULES: &[&str] =
     &["code-marker.todo", "code-marker.fixme", "code-marker.hack"];
@@ -29,7 +33,10 @@ impl FileAuditRegistration {
     }
 
     pub(super) fn into_audit(self) -> Box<dyn FileAudit> {
-        self.audit
+        Box::new(ScopedFileAudit {
+            scope: self.metadata.kind.analysis_scope(),
+            audit: self.audit,
+        })
     }
 }
 
@@ -42,6 +49,13 @@ impl ProjectAuditRegistration {
     pub(super) fn new(metadata: AuditMetadata, audit: Box<dyn ProjectAudit>) -> Self {
         Self { metadata, audit }
     }
+
+    pub(super) fn run(&self, facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
+        stamp_findings_analysis_scope(
+            self.audit.audit(facts, config),
+            self.metadata.kind.analysis_scope(),
+        )
+    }
 }
 
 pub struct FrameworkAuditRegistration {
@@ -53,6 +67,43 @@ impl FrameworkAuditRegistration {
     pub(super) fn new(metadata: AuditMetadata, audit: Box<dyn ProjectAudit>) -> Self {
         Self { metadata, audit }
     }
+
+    pub(super) fn run(&self, facts: &ScanFacts, config: &ScanConfig) -> Vec<Finding> {
+        stamp_findings_analysis_scope(
+            self.audit.audit(facts, config),
+            self.metadata.kind.analysis_scope(),
+        )
+    }
+}
+
+struct ScopedFileAudit {
+    scope: AnalysisScope,
+    audit: Box<dyn FileAudit>,
+}
+
+impl FileAudit for ScopedFileAudit {
+    fn audit(&self, file: &FileFacts, config: &ScanConfig) -> Vec<Finding> {
+        stamp_findings_analysis_scope(self.audit.audit(file, config), self.scope)
+    }
+
+    fn audit_parsed(
+        &self,
+        file: &FileFacts,
+        parsed: &ParsedFile,
+        config: &ScanConfig,
+    ) -> Vec<Finding> {
+        stamp_findings_analysis_scope(self.audit.audit_parsed(file, parsed, config), self.scope)
+    }
+}
+
+pub(crate) fn stamp_findings_analysis_scope(
+    mut findings: Vec<Finding>,
+    scope: AnalysisScope,
+) -> Vec<Finding> {
+    for finding in &mut findings {
+        finding.provenance.analysis_scope = scope;
+    }
+    findings
 }
 
 pub(super) fn file_metadata(

--- a/src/findings/provenance.rs
+++ b/src/findings/provenance.rs
@@ -56,23 +56,10 @@ impl Default for FindingProvenance {
 }
 
 impl FindingProvenance {
+    /// Registry metadata may be missing even after a runner has stamped scope.
     pub fn has_default_metadata(&self) -> bool {
         self.detector == "unknown"
             && self.signal_source == SignalSource::Mixed
             && self.rule_lifecycle == RuleLifecycle::Preview
-            && self.analysis_scope == AnalysisScope::File
-    }
-}
-
-impl AnalysisScope {
-    pub fn for_signal_source(signal_source: SignalSource) -> Self {
-        match signal_source {
-            SignalSource::ConfigFile
-            | SignalSource::DependencyManifest
-            | SignalSource::ImportGraph => Self::Repository,
-            SignalSource::FrameworkDetector => Self::FrameworkProject,
-            SignalSource::GitDiff => Self::GitDiff,
-            SignalSource::TextHeuristic | SignalSource::Ast | SignalSource::Mixed => Self::File,
-        }
     }
 }

--- a/src/findings/types.rs
+++ b/src/findings/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use crate::findings::provenance::{AnalysisScope, FindingProvenance};
+use crate::findings::provenance::FindingProvenance;
 pub use crate::findings::severity::Severity;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -106,12 +106,13 @@ impl Finding {
             self.docs_url = metadata.docs_url.map(str::to_string);
         }
         if self.provenance.has_default_metadata() {
+            let analysis_scope = self.provenance.analysis_scope;
             let knowledge_decision = self.provenance.knowledge_decision.take();
             self.provenance = FindingProvenance {
                 detector: metadata.rule_id.to_string(),
                 signal_source: metadata.signal_source,
                 rule_lifecycle: metadata.lifecycle,
-                analysis_scope: AnalysisScope::for_signal_source(metadata.signal_source),
+                analysis_scope,
                 knowledge_decision,
             };
         }

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -1,8 +1,11 @@
 use super::changed_git::collect_changed_scope;
 use crate::audits::architecture::import_coupling::ImportCouplingAudit;
-use crate::audits::pipeline::{run_framework_audits, run_project_audits};
+use crate::audits::pipeline::{
+    run_framework_audits, run_project_audits, stamp_findings_analysis_scope,
+};
 use crate::findings::aggregation::aggregate_duplicate_findings;
 use crate::findings::enrichment::enrich_findings_timed;
+use crate::findings::provenance::AnalysisScope;
 use crate::findings::quality::summarize_signal_quality_with_contract_violations;
 use crate::findings::rule_config::{apply_rule_config, rule_config_diagnostics};
 use crate::knowledge::decision::apply_project_decisions;
@@ -98,6 +101,9 @@ impl<'a> ChangedScanEngine<'a> {
                 )
             },
         );
+        let coupling_findings =
+            stamp_findings_analysis_scope(coupling_findings, AnalysisScope::Repository);
+
         file_stage.findings.extend(project_findings);
         file_stage.findings.extend(framework_findings);
         file_stage.findings.extend(apply_project_decisions(

--- a/src/scan/scanner/full.rs
+++ b/src/scan/scanner/full.rs
@@ -1,9 +1,12 @@
 use super::{collection, contract_stage};
 use crate::audits::architecture::import_coupling::ImportCouplingAudit;
-use crate::audits::pipeline::{build_file_audits, run_framework_audits, run_project_audits};
+use crate::audits::pipeline::{
+    build_file_audits, run_framework_audits, run_project_audits, stamp_findings_analysis_scope,
+};
 use crate::facts::{RepoFactsSummary, repo_facts_from_scan, summarize_repo_facts};
 use crate::findings::aggregation::aggregate_duplicate_findings;
 use crate::findings::enrichment::enrich_findings_timed;
+use crate::findings::provenance::AnalysisScope;
 use crate::findings::quality::summarize_signal_quality_with_contract_violations;
 use crate::findings::rule_config::{apply_rule_config, rule_config_diagnostics};
 use crate::findings::types::Finding;
@@ -210,13 +213,19 @@ impl<'a> ScanEngine<'a> {
             },
             || ImportCouplingAudit.audit_with_graph(&facts, self.config, self.path),
         );
-        let query_findings = crate::audits::architecture::graph_queries::GraphQueriesAudit.audit(
-            &facts,
-            self.config,
-            &coupling_graph,
-            &resolution,
-            self.path,
+        let query_findings = stamp_findings_analysis_scope(
+            crate::audits::architecture::graph_queries::GraphQueriesAudit.audit(
+                &facts,
+                self.config,
+                &coupling_graph,
+                &resolution,
+                self.path,
+            ),
+            AnalysisScope::Repository,
         );
+
+        let coupling_findings =
+            stamp_findings_analysis_scope(coupling_findings, AnalysisScope::Repository);
 
         findings.extend(project_findings);
         findings.extend(framework_findings);


### PR DESCRIPTION
## Summary

Fix finding provenance so `analysis_scope` is derived from the audit execution boundary rather than inferred from `signal_source`.

File, project, and framework audits now explicitly own the scope of the findings they emit:

```text
File audit      → file
Project audit   → repository
Framework audit → framework-project
```

This prevents repository-level findings that use text-heuristic evidence from being incorrectly classified as file-scoped and passed into file-only finding replay.

## Type of change

* [ ] Feature
* [x] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added a direct mapping from `AuditKind` to `AnalysisScope`.
* Wrapped registered file audits so their findings are stamped with `file` scope.
* Updated project audit registrations to stamp `repository` scope.
* Updated framework audit registrations to stamp `framework-project` scope.
* Explicitly marked import-coupling and graph-query findings as repository-scoped.
* Removed the old `AnalysisScope::for_signal_source()` inference.
* Updated finding enrichment to preserve the scope already assigned by the audit runner.
* Kept `signal_source` independent from `analysis_scope`.
* Added a regression test proving that:

  * `architecture.too-many-modules` remains a `text-heuristic` signal;
  * the same finding is correctly marked as `repository`;
  * registry enrichment preserves that scope;
  * serialized JSON contains the correct provenance.
* Updated the signal contract documentation and changelog.

## Why

`signal_source` and `analysis_scope` represent different concepts:

```text
signal_source  = how the evidence was obtained
analysis_scope = how much repository context the audit required
```

The previous implementation derived scope from signal source. This produced incorrect combinations for audits such as `architecture.too-many-modules`.

That rule is executed as a project audit but uses text-heuristic evidence. The old mapping therefore produced:

```json
{
  "signal_source": "text-heuristic",
  "analysis_scope": "file"
}
```

This was incorrect because the decision depends on repository-level file distribution.

It could also allow the finding to enter `repopilot_explain_finding`, which currently supports only file-scoped replay, and then attempt to replay a repository-level decision with incomplete file-only context.

The corrected provenance is:

```json
{
  "signal_source": "text-heuristic",
  "analysis_scope": "repository"
}
```

## Ownership model

Audit execution owns `analysis_scope`:

```text
FileAuditRegistration
→ AnalysisScope::File

ProjectAuditRegistration
→ AnalysisScope::Repository

FrameworkAuditRegistration
→ AnalysisScope::FrameworkProject
```

Rule metadata continues to own:

* detector identity;
* signal source;
* lifecycle;
* default severity;
* confidence;
* documentation metadata.

Finding enrichment combines both sources without overwriting the runner-owned analysis scope.

## Compatibility

* Scan and review schema remains `0.20`.
* Finding IDs are unchanged.
* Baseline keys and baseline behavior are unchanged.
* Finding severity is unchanged.
* Confidence is unchanged.
* Visibility and strict/default profile behavior are unchanged.
* Knowledge Engine decisions are unchanged.
* Knowledge-decision provenance is preserved.
* MCP input and output schemas are unchanged.
* SARIF behavior is unchanged.

This PR corrects the value of existing `analysis_scope` provenance without introducing a new report field.

## Contract and ownership

* [x] The change stays within audit execution and finding provenance boundaries.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] Audit runners centrally assign scope instead of relying on individual detectors.
* [x] Signal source and analysis scope remain independent contracts.
* [x] A focused regression covers a project audit using text-heuristic evidence.
* [x] Finding IDs, severity, visibility, and detector decisions remain unchanged.
* [x] No unrelated refactor or generated-file churn is included.

## Changelog

* [x] `CHANGELOG.md` updated.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```
