### PR TITLE
fix(mcp): disambiguate finding occurrences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,15 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **MCP finding replay can now disambiguate repeated stable IDs.**
+  `repopilot_explain_finding` accepts optional `evidence_path` and `line_start`
+  values to select one report occurrence while preserving the existing
+  baseline-stable finding ID. Calls without a locator remain backward compatible
+  for unique IDs; ambiguous IDs now return a structured candidate list instead
+  of a generic error. Scan/review schema `0.20`, baseline keys, finding IDs,
+  severity, visibility, SARIF, detector decisions, and file-scope replay
+  semantics are unchanged.
+
 - **Workspace-dependent MCP tools no longer return stale session results.**
   Removed the arguments-only in-process result cache from
   `repopilot_review_change`, `repopilot_context`, and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -448,7 +448,7 @@ repopilot mcp [--root PATH]
 | `repopilot_scan` | Full repository audit as a JSON report |
 | `repopilot_context` | Budgeted, AI-ready Markdown brief (optional `focus`, `budget`) |
 | `repopilot_explain_file` | How one file is classified and which rules and signals apply |
-| `repopilot_explain_finding` | Replay a file-scoped emitted finding by stable ID from the current MCP session |
+| `repopilot_explain_finding` | Replay a file-scoped finding by stable ID and optional evidence occurrence |
 
 ### Examples
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -38,7 +38,7 @@ non-destructive, idempotent, and closed-world.
 | `repopilot_scan` | Repository or changed-scope JSON scan | `config`, `profile`, `scope`, `base` |
 | `repopilot_context` | Budgeted AI-ready Markdown context | `config`, `profile`, `focus`, `budget` |
 | `repopilot_explain_file` | File-role evidence and ordered rule decision trace | `rule`, `signal` |
-| `repopilot_explain_finding` | Replay a file-scoped emitted finding by stable ID from the current MCP session | `finding_id`, `source` |
+| `repopilot_explain_finding` | Replay a file-scoped finding by stable ID and optional occurrence locator | `finding_id`, `source`, `evidence_path`, `line_start` |
 
 `repopilot_explain_file` returns additive JSON fields for explicit scope,
 role evidence, applicability checks, every ordered override, severity
@@ -58,6 +58,31 @@ severity, or reason. Repository, workspace, Git-diff, and framework-project
 findings are rejected explicitly because correct replay requires rebuilding
 their wider analysis context. The finding-level severity remains authoritative
 when detector-local policy differs from the Knowledge Engine output.
+
+A finding ID is stable baseline identity, not guaranteed occurrence identity.
+When the selected report contains several entries with the same ID,
+`repopilot_explain_finding` returns:
+
+```json
+{
+  "status": "ambiguous",
+  "finding_id": "…",
+  "candidates": [
+    {
+      "evidence_path": "src/config.rs",
+      "line_start": 10
+    },
+    {
+      "evidence_path": "src/config.rs",
+      "line_start": 20
+    }
+  ]
+}
+```
+
+Pass one candidate back as `evidence_path` plus `line_start` to select the exact
+occurrence. The stable finding ID and baseline matching contract remain
+unchanged.
 
 Every tool accepts a workspace-relative `path` where applicable. Review defaults
 to `scope=changed`, `profile=default`, `fail_on_review=none`, and

--- a/src/commands/mcp/explain_finding.rs
+++ b/src/commands/mcp/explain_finding.rs
@@ -1,7 +1,9 @@
 //! The `repopilot_explain_finding` MCP tool: replay one emitted finding by
 //! stable ID from the latest scan or review stored in this MCP session.
 
-use repopilot::explain::build_finding_explanation_from_report;
+use repopilot::explain::{
+    FindingOccurrenceLocator, build_finding_explanation_selection_from_report,
+};
 use serde_json::{Value, json};
 use std::path::Path;
 
@@ -23,6 +25,15 @@ pub fn definition() -> Value {
                     "enum": ["last-scan", "last-review"],
                     "default": "last-scan",
                     "description": "Session report containing the finding."
+                },
+                "evidence_path": {
+                    "type": "string",
+                    "description": "Optional evidence path from an ambiguity candidate. Used with line_start to select one occurrence without changing the stable finding ID."
+                },
+                "line_start": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Optional evidence start line from an ambiguity candidate."
                 }
             },
             "required": ["finding_id"],
@@ -52,6 +63,17 @@ pub fn call(
         .get("source")
         .and_then(Value::as_str)
         .unwrap_or("last-scan");
+    let locator = FindingOccurrenceLocator {
+        evidence_path: arguments
+            .get("evidence_path")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        line_start: arguments
+            .get("line_start")
+            .and_then(Value::as_u64)
+            .and_then(|line| usize::try_from(line).ok()),
+    };
+    let locator = (!locator.is_empty()).then_some(locator);
 
     let report = match source {
         "last-scan" => last_scan.ok_or_else(|| {
@@ -64,8 +86,14 @@ pub fn call(
         other => return Err(format!("invalid source: {other}")),
     };
 
-    let explanation = build_finding_explanation_from_report(root, report, finding_id, source)?;
-    serde_json::to_string_pretty(&explanation)
+    let selection = build_finding_explanation_selection_from_report(
+        root,
+        report,
+        finding_id,
+        source,
+        locator.as_ref(),
+    )?;
+    serde_json::to_string_pretty(&selection)
         .map_err(|error| format!("render finding explanation failed: {error}"))
 }
 
@@ -181,5 +209,70 @@ mod tests {
         .expect_err("missing scan must fail");
 
         assert!(error.contains("run repopilot_scan first"));
+    }
+
+    fn duplicate_report(report: &str) -> String {
+        let mut value: Value = serde_json::from_str(report).expect("report JSON");
+        let mut duplicate = value["findings"][0].clone();
+        duplicate["evidence"][0]["line_start"] = json!(2);
+        duplicate["evidence"][0]["snippet"] = json!("panic!(\"second\")");
+        value["findings"]
+            .as_array_mut()
+            .expect("findings array")
+            .push(duplicate);
+        serde_json::to_string(&value).expect("serialize duplicate report")
+    }
+
+    #[test]
+    fn tool_returns_candidates_for_an_ambiguous_stable_id() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (report, finding_id) = report_fixture(temp.path());
+        let report = duplicate_report(&report);
+
+        let rendered = call(
+            &json!({
+                "finding_id": finding_id,
+                "source": "last-scan"
+            }),
+            temp.path(),
+            Some(&report),
+            None,
+        )
+        .expect("ambiguity is structured output");
+
+        let value: Value = serde_json::from_str(&rendered).expect("valid JSON");
+        assert_eq!(value["status"], "ambiguous");
+        assert_eq!(value["candidates"].as_array().map(Vec::len), Some(2));
+        assert_eq!(
+            value["candidates"][0]["evidence_path"],
+            "src/domain/service.rs"
+        );
+        assert_eq!(value["candidates"][0]["line_start"], 1);
+        assert_eq!(value["candidates"][1]["line_start"], 2);
+    }
+
+    #[test]
+    fn tool_resolves_an_ambiguous_id_with_an_occurrence_locator() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (report, finding_id) = report_fixture(temp.path());
+        let report = duplicate_report(&report);
+
+        let rendered = call(
+            &json!({
+                "finding_id": finding_id,
+                "source": "last-scan",
+                "evidence_path": "src/domain/service.rs",
+                "line_start": 2
+            }),
+            temp.path(),
+            Some(&report),
+            None,
+        )
+        .expect("resolve finding occurrence");
+
+        let value: Value = serde_json::from_str(&rendered).expect("valid JSON");
+        assert_eq!(value["finding"]["evidence"][0]["line_start"], 2);
+        assert_eq!(value["replay"]["status"], "matched");
+        assert!(value.get("status").is_none());
     }
 }

--- a/src/explain/finding.rs
+++ b/src/explain/finding.rs
@@ -37,12 +37,73 @@ pub enum FindingReplayStatus {
     Drifted,
 }
 
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct FindingOccurrenceLocator {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_start: Option<usize>,
+}
+
+impl FindingOccurrenceLocator {
+    pub fn is_empty(&self) -> bool {
+        self.evidence_path.is_none() && self.line_start.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FindingOccurrenceCandidate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_start: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_end: Option<usize>,
+    pub rule_id: String,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FindingAmbiguityReport {
+    pub status: String,
+    pub source_report: String,
+    pub finding_id: String,
+    pub message: String,
+    pub candidates: Vec<FindingOccurrenceCandidate>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum FindingSelectionReport {
+    Explanation(Box<FindingExplanationReport>),
+    Ambiguity(FindingAmbiguityReport),
+}
+
 pub fn build_finding_explanation_from_report(
     mcp_root: &Path,
     report_json: &str,
     finding_id: &str,
     source_report: &str,
 ) -> Result<FindingExplanationReport, String> {
+    match build_finding_explanation_selection_from_report(
+        mcp_root,
+        report_json,
+        finding_id,
+        source_report,
+        None,
+    )? {
+        FindingSelectionReport::Explanation(report) => Ok(*report),
+        FindingSelectionReport::Ambiguity(ambiguity) => Err(ambiguity.message),
+    }
+}
+
+pub fn build_finding_explanation_selection_from_report(
+    mcp_root: &Path,
+    report_json: &str,
+    finding_id: &str,
+    source_report: &str,
+    locator: Option<&FindingOccurrenceLocator>,
+) -> Result<FindingSelectionReport, String> {
     if finding_id.trim().is_empty() {
         return Err("`finding_id` must not be empty".to_string());
     }
@@ -54,24 +115,59 @@ pub fn build_finding_explanation_from_report(
         .and_then(Value::as_array)
         .ok_or_else(|| "session report does not contain a findings array".to_string())?;
 
-    let matches = findings
+    let id_matches = findings
         .iter()
         .filter(|finding| finding.get("id").and_then(Value::as_str) == Some(finding_id))
         .collect::<Vec<_>>();
 
-    let finding_value = match matches.as_slice() {
-        [] => {
-            return Err(format!(
-                "finding `{finding_id}` was not found in {source_report}"
-            ));
-        }
-        [finding] => (*finding).clone(),
-        _ => {
-            return Err(format!(
-                "finding `{finding_id}` appears more than once in {source_report}"
-            ));
-        }
-    };
+    if id_matches.is_empty() {
+        return Err(format!(
+            "finding `{finding_id}` was not found in {source_report}"
+        ));
+    }
+
+    let active_locator = locator.filter(|locator| !locator.is_empty());
+    let selected_matches = id_matches
+        .iter()
+        .copied()
+        .filter(|finding| {
+            active_locator.is_none_or(|locator| finding_matches_locator(finding, locator))
+        })
+        .collect::<Vec<_>>();
+
+    if selected_matches.is_empty() {
+        return Err(format!(
+            "finding `{finding_id}` has no occurrence matching {} in {source_report}",
+            locator_description(active_locator.expect("active locator"))
+        ));
+    }
+
+    if selected_matches.len() > 1 {
+        let mut candidates = selected_matches
+            .iter()
+            .map(|finding| occurrence_candidate(finding))
+            .collect::<Vec<_>>();
+        candidates.sort_by(|left, right| {
+            left.evidence_path
+                .cmp(&right.evidence_path)
+                .then(left.line_start.cmp(&right.line_start))
+                .then(left.title.cmp(&right.title))
+        });
+
+        let message = format!(
+            "finding `{finding_id}` appears more than once in {source_report}; \
+             provide `evidence_path` and `line_start` from one candidate"
+        );
+        return Ok(FindingSelectionReport::Ambiguity(FindingAmbiguityReport {
+            status: "ambiguous".to_string(),
+            source_report: source_report.to_string(),
+            finding_id: finding_id.to_string(),
+            message,
+            candidates,
+        }));
+    }
+
+    let finding_value = (*selected_matches[0]).clone();
 
     // Review JSON flattens Finding and appends in_diff/baseline_status fields.
     // Serde ignores those additive fields while preserving the complete Finding.
@@ -80,7 +176,8 @@ pub fn build_finding_explanation_from_report(
 
     if finding.provenance.analysis_scope != AnalysisScope::File {
         return Err(format!(
-            "finding `{finding_id}` uses `{}` analysis scope;              repopilot_explain_finding currently supports file-scoped findings only",
+            "finding `{finding_id}` uses `{}` analysis scope; \
+             repopilot_explain_finding currently supports file-scoped findings only",
             analysis_scope_id(finding.provenance.analysis_scope)
         ));
     }
@@ -157,25 +254,108 @@ pub fn build_finding_explanation_from_report(
         FindingReplayStatus::Drifted
     };
 
-    Ok(FindingExplanationReport {
-        source_report: source_report.to_string(),
-        source_schema_version: report
-            .get("schema_version")
-            .and_then(Value::as_str)
-            .map(str::to_string),
-        source_root: source_root.to_string_lossy().to_string(),
-        finding,
-        stored_decision,
-        replay: FindingDecisionReplay {
-            status,
-            action_matches,
-            severity_matches,
-            reason_matches,
-            detector_local_severity_adjustment,
-            notes,
+    Ok(FindingSelectionReport::Explanation(Box::new(
+        FindingExplanationReport {
+            source_report: source_report.to_string(),
+            source_schema_version: report
+                .get("schema_version")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            source_root: source_root.to_string_lossy().to_string(),
+            finding,
+            stored_decision,
+            replay: FindingDecisionReplay {
+                status,
+                action_matches,
+                severity_matches,
+                reason_matches,
+                detector_local_severity_adjustment,
+                notes,
+            },
+            explanation,
         },
-        explanation,
-    })
+    )))
+}
+
+fn finding_matches_locator(finding: &Value, locator: &FindingOccurrenceLocator) -> bool {
+    let evidence = finding
+        .get("evidence")
+        .and_then(Value::as_array)
+        .and_then(|evidence| evidence.first());
+
+    if let Some(expected_path) = locator.evidence_path.as_deref() {
+        let Some(actual_path) = evidence
+            .and_then(|evidence| evidence.get("path"))
+            .and_then(Value::as_str)
+        else {
+            return false;
+        };
+        if normalize_report_path(actual_path) != normalize_report_path(expected_path) {
+            return false;
+        }
+    }
+
+    if let Some(expected_line) = locator.line_start {
+        let Some(actual_line) = evidence
+            .and_then(|evidence| evidence.get("line_start"))
+            .and_then(Value::as_u64)
+            .and_then(|line| usize::try_from(line).ok())
+        else {
+            return false;
+        };
+        if actual_line != expected_line {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn occurrence_candidate(finding: &Value) -> FindingOccurrenceCandidate {
+    let evidence = finding
+        .get("evidence")
+        .and_then(Value::as_array)
+        .and_then(|evidence| evidence.first());
+
+    FindingOccurrenceCandidate {
+        evidence_path: evidence
+            .and_then(|evidence| evidence.get("path"))
+            .and_then(Value::as_str)
+            .map(normalize_report_path),
+        line_start: evidence
+            .and_then(|evidence| evidence.get("line_start"))
+            .and_then(Value::as_u64)
+            .and_then(|line| usize::try_from(line).ok()),
+        line_end: evidence
+            .and_then(|evidence| evidence.get("line_end"))
+            .and_then(Value::as_u64)
+            .and_then(|line| usize::try_from(line).ok()),
+        rule_id: finding
+            .get("rule_id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        title: finding
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+    }
+}
+
+fn locator_description(locator: &FindingOccurrenceLocator) -> String {
+    let mut parts = Vec::new();
+    if let Some(path) = locator.evidence_path.as_deref() {
+        parts.push(format!("evidence_path={}", normalize_report_path(path)));
+    }
+    if let Some(line) = locator.line_start {
+        parts.push(format!("line_start={line}"));
+    }
+    parts.join(", ")
+}
+
+fn normalize_report_path(path: &str) -> String {
+    path.replace('\\', "/")
 }
 
 fn resolve_source_root(mcp_root: &Path, report: &Value) -> Result<PathBuf, String> {

--- a/src/explain/mod.rs
+++ b/src/explain/mod.rs
@@ -7,8 +7,10 @@ pub mod render;
 pub use base_severity::base_severity_for_explain;
 pub use builder::{build_explain_report, build_explain_report_with_root};
 pub use finding::{
-    FindingDecisionReplay, FindingExplanationReport, FindingReplayStatus,
-    build_finding_explanation_from_report,
+    FindingAmbiguityReport, FindingDecisionReplay, FindingExplanationReport,
+    FindingOccurrenceCandidate, FindingOccurrenceLocator, FindingReplayStatus,
+    FindingSelectionReport, build_finding_explanation_from_report,
+    build_finding_explanation_selection_from_report,
 };
 pub use model::{
     ExplainContext, ExplainDecision, ExplainDecisionTraceStep, ExplainReport, ExplainRoleEvidence,


### PR DESCRIPTION
## Summary

Allow `repopilot_explain_finding` to select one concrete report occurrence when
multiple findings share the same stable finding ID.

The stable ID remains unchanged and continues to represent baseline identity.
The MCP tool adds an optional occurrence locator:

```text
evidence_path + line_start
```

Calls without a locator remain backward-compatible when the ID is unique.

## Type of change

* [ ] Feature
* [x] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added `FindingOccurrenceLocator` with:

  * optional `evidence_path`;
  * optional `line_start`.
* Added structured occurrence candidates containing:

  * evidence path;
  * start line;
  * optional end line;
  * rule ID;
  * finding title.
* Added a structured ambiguity result.
* Added a selection API that can return either:

  * a normal finding explanation;
  * an ambiguity report with candidates.
* Preserved the existing `build_finding_explanation_from_report` API for unique
  finding IDs.
* Extended `repopilot_explain_finding` inputs with:

  * `evidence_path`;
  * `line_start`.
* Added deterministic path normalization for locator matching.
* Added tests for:

  * unique IDs remaining backward-compatible;
  * repeated stable IDs returning ordered candidates;
  * selecting the required occurrence by evidence path and line;
  * replaying the selected occurrence normally.
* Updated MCP, CLI, and changelog documentation.

## Why

A RepoPilot finding ID is intentionally stable across line movement and some
evidence changes so that it can be used for baselines and comparisons.

It is therefore not guaranteed to uniquely identify one occurrence within a
single report.

For example, a report may contain:

```json
[
  {
    "id": "security.secret-candidate:src/config.rs:stable-key",
    "evidence": [
      {
        "path": "src/config.rs",
        "line_start": 10
      }
    ]
  },
  {
    "id": "security.secret-candidate:src/config.rs:stable-key",
    "evidence": [
      {
        "path": "src/config.rs",
        "line_start": 20
      }
    ]
  }
]
```

Changing the stable finding ID to include the line would weaken baseline
stability.

Instead, this PR separates the two identities:

```text
finding_id
= stable finding and baseline identity

evidence_path + line_start
= occurrence identity inside one report
```

## Ambiguity response

When a call provides only an ambiguous stable ID, the tool returns successful,
structured output:

```json
{
  "status": "ambiguous",
  "source_report": "last-scan",
  "finding_id": "security.secret-candidate:src/config.rs:stable-key",
  "message": "provide evidence_path and line_start from one candidate",
  "candidates": [
    {
      "evidence_path": "src/config.rs",
      "line_start": 10,
      "rule_id": "security.secret-candidate",
      "title": "Possible hardcoded secret"
    },
    {
      "evidence_path": "src/config.rs",
      "line_start": 20,
      "rule_id": "security.secret-candidate",
      "title": "Possible hardcoded secret"
    }
  ]
}
```

The caller can repeat the request with:

```json
{
  "finding_id": "security.secret-candidate:src/config.rs:stable-key",
  "source": "last-scan",
  "evidence_path": "src/config.rs",
  "line_start": 20
}
```

## Compatibility

* Existing calls using a unique `finding_id` are unchanged.
* Stable finding IDs are unchanged.
* Baseline keys and matching behavior are unchanged.
* Scan and review schema remains `0.20`.
* No new top-level CLI command is added.
* Finding severity and visibility are unchanged.
* File-scope replay restrictions remain unchanged.
* SARIF behavior is unchanged.
* Detector and Knowledge Engine decisions are unchanged.
* The ambiguity response is additive MCP output.

## Contract and ownership

* [x] Stable finding identity remains owned by the baseline contract.
* [x] Report occurrence selection is represented separately.
* [x] Ambiguity is returned as structured data rather than an opaque error.
* [x] Unique-ID behavior remains backward-compatible.
* [x] Paths are normalized deterministically.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] Focused tests cover ambiguity and exact occurrence selection.
* [x] No unrelated finding-ID redesign is included.

## Changelog

* [x] `CHANGELOG.md` updated.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```
