### PR TITLE
chore(release): prepare v0.19.0

### DIFF
--- a/.github/workflows/repopilot-pr-review.yml
+++ b/.github/workflows/repopilot-pr-review.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: RepoPilot version to run
         type: string
-        default: "0.18.0"
+        default: "0.19.0"
       fail-on-review:
         description: Review signal gate policy
         type: string
@@ -57,7 +57,7 @@ jobs:
 
       - name: Review pull request
         id: repopilot
-        uses: MykytaStel/repopilot@v0.18.0
+        uses: MykytaStel/repopilot@v0.19.0
         with:
           command: review
           version: ${{ inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+No entries yet.
+
+## [0.19.0] - 2026-06-29
+
 ### Added
 
 - **MCP can now explain emitted findings by stable ID.**
@@ -17,9 +21,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   findings are rejected rather than replayed with incomplete file-only context.
   The tool rejects findings without schema-`0.20` decision provenance, enforces
   the MCP root boundary, and bypasses the session cache so a newer scan or review
-  cannot reuse a stale explanation. CLI commands, scan/review schemas, finding
-  IDs, baseline behavior, visibility, SARIF, and detector decisions are
-  unchanged.
+  cannot reuse a stale explanation. If the same stable ID appears more than once
+  in a report, callers can pass `evidence_path` and `line_start` to select one
+  occurrence; ambiguous calls return structured candidates. CLI commands,
+  scan/review schemas, finding IDs, baseline behavior, visibility, SARIF, and
+  detector decisions are unchanged.
 
 - **Findings now preserve replayable Knowledge Engine decision provenance.**
   Knowledge-aware findings add optional `provenance.knowledge_decision` data
@@ -40,9 +46,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   classifier, including executable-package manifest context, a final
   default-profile visibility step, and explicit scope limits: repository graph context,
   `repopilot.toml` rule overrides, local feedback, baseline state, and full scan
-  filtering are not applied. The MCP tool uses registry default severity for known
-  rules. This is additive explain/MCP JSON; scan, review, SARIF, baseline, receipt,
-  finding IDs, severity decisions, and visibility behavior are unchanged.
+  filtering are not applied. The MCP tool uses detector-specific signal base
+  severity when known, then falls back to registry default severity for known
+  rules. This is additive explain/MCP JSON; scan, review, SARIF, baseline,
+  receipt, finding IDs, severity decisions, and visibility behavior are
+  unchanged.
 
 - **File-role classification now preserves explainable evidence.** The detailed
   classifier records one typed evidence entry for every assigned role, including
@@ -53,11 +61,14 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   copying classifier heuristics. Existing role decisions, finding severity,
   visibility, and report schemas are unchanged.
 
-- **The real-repo zoo now records human-reviewed dispositions for findings.** A
-  new tracked `tests/zoo/expectations/<repo>.toml` layer (one versioned file per
-  manifest repo) sits alongside the generated snapshots: snapshots answer *what
-  RepoPilot emitted*, expectations answer *how a human reviewed it*. Every
-  default-visible finding must be exhaustively labeled `actionable`,
+- **The real-repo zoo now records snapshots and human-reviewed dispositions.** A
+  curated manifest of 11 real open-source repositories is scanned reproducibly
+  via `scripts/zoo.py`, with default-visible snapshots committed under
+  `tests/zoo/snapshots/`. A tracked `tests/zoo/expectations/<repo>.toml` layer
+  (one versioned file per manifest repo) sits alongside those snapshots:
+  snapshots answer *what RepoPilot emitted*, expectations answer *how a human
+  reviewed it*. Every default-visible finding must be exhaustively labeled
+  `actionable`,
   `valid-but-accepted`, or `false-positive` with a non-empty reason; selected
   strict findings act as `selective` recall anchors that fail if they disappear.
   `python3 scripts/zoo.py scan` now validates labels and reports snapshot drift
@@ -97,6 +108,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   agents calling it received a thinner context than the CLI; they now get the same
   aggregate stack/size picture.
 
+- **Release verification now runs both performance guard scripts.** The existing
+  full-scan smoke benchmark is wired into `npm run scan:performance` and the
+  local release gate now runs it next to the changed-review performance check, so
+  the release checklist matches the shipped scripts.
+
 - **Agent-facing docs now document the false-positive/noise-reduction workflow.** MCP docs and AI-context workflow docs now call out strict-mode recall, exact duplicate aggregation, changed-scan limits, and the need for false-negative guard tests before hiding or downgrading signals.
 
 - **`language.javascript.runtime-exit-risk` downgrades `process.exit(...)` in a
@@ -135,15 +151,6 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   (excalidraw 76→1, changesets 38→1) with no loss of true signal.
 
 ### Fixed
-
-- **MCP finding replay can now disambiguate repeated stable IDs.**
-  `repopilot_explain_finding` accepts optional `evidence_path` and `line_start`
-  values to select one report occurrence while preserving the existing
-  baseline-stable finding ID. Calls without a locator remain backward compatible
-  for unique IDs; ambiguous IDs now return a structured candidate list instead
-  of a generic error. Scan/review schema `0.20`, baseline keys, finding IDs,
-  severity, visibility, SARIF, detector decisions, and file-scope replay
-  semantics are unchanged.
 
 - **Workspace-dependent MCP tools no longer return stale session results.**
   Removed the arguments-only in-process result cache from
@@ -291,18 +298,6 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   suppresses violations into such packages. Caught by the real-repo zoo:
   excalidraw dropped from 317 false positives to 0; packages without wildcard
   exports keep their boundary.
-
-### Added
-
-- **Real-repo validation "zoo".** A curated set of 11 real open-source repos
-  (`tests/zoo/manifest.toml`) spanning all 9 AST languages and their frameworks
-  is now scanned reproducibly via `scripts/zoo.py` (`clone`/`scan`/`report`),
-  pinned to fixed commit SHAs and cloned on demand into a gitignored `.zoo/`.
-  Per-repo default-visible finding snapshots are committed under
-  `tests/zoo/snapshots/`, and an opt-in regression test
-  (`REPOPILOT_ZOO=1 cargo test --test zoo_regression`) fails on any drift in
-  real-world output — turning the previously ad-hoc "run on a few real repos and
-  hunt false positives" loop into a permanent, evidence-backed gate.
 
 ## [0.18.0] - 2026-06-18
 
@@ -1139,7 +1134,9 @@ CI and AI-assisted remediation.
 - Added `compare` for diffing two JSON scan reports.
 - Added CI workflow, release workflow, distribution docs, release docs, and ruleset docs.
 
-[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/MykytaStel/repopilot/compare/v0.18.0...v0.19.0
+[0.18.0]: https://github.com/MykytaStel/repopilot/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/MykytaStel/repopilot/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/MykytaStel/repopilot/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/MykytaStel/repopilot/compare/v0.14.0...v0.15.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repopilot"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repopilot"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2024"
 description = "Local-first CLI for reviewing Git changes, security boundaries, and blast radius before merge."
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ controls shape it:
 ## MCP Server
 
 `repopilot mcp` exposes that context — fact-only, the way `--no-task` emits it —
-plus review, scan, and explain, as tools over stdio so coding agents can call it
-directly:
+plus review, scan, file explanation, and finding replay tools over stdio so
+coding agents can call it directly:
 
 ```bash
 claude mcp add repopilot -- repopilot mcp --root .

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ inputs:
   version:
     description: "GitHub Release version to install and checksum-verify."
     required: false
-    default: "0.18.0"
+    default: "0.19.0"
   upload-sarif:
     description: "Automatically upload SARIF output to GitHub Code Scanning"
     required: false

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -108,7 +108,7 @@ Use the reusable workflow:
 ```yaml
 jobs:
   repopilot:
-    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.18.0
+    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.19.0
     with:
       fail-on-review: none
       upload-sarif: false
@@ -117,7 +117,7 @@ jobs:
 Or use the Action directly:
 
 ```yaml
-- uses: MykytaStel/repopilot@v0.18.0
+- uses: MykytaStel/repopilot@v0.19.0
   with:
     command: review
     scope: changed

--- a/docs/integrations/github-code-scanning.md
+++ b/docs/integrations/github-code-scanning.md
@@ -1,8 +1,7 @@
 # GitHub Pull Request Integration
 
-RepoPilot 0.16 can produce a job summary, capped workflow annotations, JSON and
-SARIF artifacts, typed outputs, and an optional sticky PR comment from one
-review run.
+RepoPilot can produce a job summary, capped workflow annotations, JSON and SARIF
+artifacts, typed outputs, and an optional sticky PR comment from one review run.
 
 ## Reusable Workflow
 
@@ -20,7 +19,7 @@ permissions:
 
 jobs:
   review:
-    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.18.0
+    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.19.0
     with:
       fail-on-review: definitely
       fail-on-priority: p1
@@ -36,13 +35,13 @@ This default is read-only and works for fork PRs. It does not use
 ## First-Party Action
 
 ```yaml
-- uses: actions/checkout@v6
+- uses: actions/checkout@v7
   with:
     fetch-depth: 0
 
 - name: RepoPilot review
   id: repopilot
-  uses: MykytaStel/repopilot@v0.18.0
+  uses: MykytaStel/repopilot@v0.19.0
   with:
     command: review
     scope: changed
@@ -69,7 +68,7 @@ permissions:
   security-events: write
 
 steps:
-  - uses: MykytaStel/repopilot@v0.18.0
+  - uses: MykytaStel/repopilot@v0.19.0
     with:
       command: review
       upload-sarif: "true"
@@ -97,7 +96,7 @@ permissions:
   pull-requests: write
 
 steps:
-  - uses: MykytaStel/repopilot@v0.18.0
+  - uses: MykytaStel/repopilot@v0.19.0
     with:
       command: review
       comment: "true"

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -167,8 +167,8 @@ worker built with standard-library channels, so the stdio loop can receive
 `_meta.progressToken` receive start/completion `notifications/progress`.
 No async runtime is used.
 
-HTTP transport, hosted MCP, sampling, and source upload are outside the 0.16
-scope.
+HTTP transport, hosted MCP, sampling, and source upload are outside the current
+local stdio MCP scope.
 
 ## Manual Smoke Test
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -56,8 +56,8 @@ Run the complete local gate:
 
 The gate runs formatting, clippy, all Rust tests, release-contract checks,
 dependency policy and security checks, shell and workflow validation, Cargo and
-npm package dry-runs, rule evaluation, self-scan signal quality, and the
-install-like product smoke suite.
+npm package dry-runs, review and scan performance checks, rule evaluation,
+self-scan signal quality, and the install-like product smoke suite.
 
 Required product workflows include:
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -16,11 +16,11 @@ JSON scan reports include explicit schema metadata. The current schema is 0.20:
 ```json
 {
   "schema_version": "0.20",
-  "repopilot_version": "0.17.0",
+  "repopilot_version": "0.19.0",
   "report": {
     "kind": "scan",
     "schema_version": "0.20",
-    "repopilot_version": "0.17.0"
+    "repopilot_version": "0.19.0"
   },
   "root_path": ".",
   "files_analyzed": 42,
@@ -99,7 +99,7 @@ requested report/receipt and then exits with RepoPilot runtime code `3`.
 may fix bugs without changing the report schema, while future minor releases can
 evolve the schema in a documented way.
 
-Binary `0.18.x` emits schema `0.20`.
+Binary `0.19.x` emits schema `0.20`.
 Schema numbers are monotonic contract revisions, not predictions of the next
 RepoPilot package version.
 
@@ -160,11 +160,11 @@ Example shape:
 ```json
 {
   "schema_version": "0.20",
-  "repopilot_version": "0.17.0",
+  "repopilot_version": "0.19.0",
   "report": {
     "kind": "baseline-scan",
     "schema_version": "0.20",
-    "repopilot_version": "0.17.0"
+    "repopilot_version": "0.19.0"
   },
   "root_path": ".",
   "files_analyzed": 42,
@@ -217,10 +217,10 @@ Receipt JSON is intentionally smaller than a scan report and has its own schema:
   "report": {
     "kind": "receipt",
     "schema_version": "5",
-    "repopilot_version": "0.17.0"
+    "repopilot_version": "0.19.0"
   },
   "tool": "repopilot",
-  "version": "0.17.0",
+  "version": "0.19.0",
   "generated_at": "2026-05-16T00:00:00Z",
   "root_path": ".",
   "git": {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,35 +4,29 @@ RepoPilot is a review-first, local CLI for maintainers and coding agents. The
 product should help answer: what changed, which boundaries moved, and how far
 the change reaches before merge.
 
-## Now: 0.18 — evidence you can click
+## Now: 0.19 — replayable evidence and lower default noise
 
-- point architecture findings at the real import line instead of `line 1`, so a
-  cycle or boundary violation lands on the code that caused it;
-- model detected workspaces (npm/yarn, pnpm, Cargo, `go.work`) as first-class
-  `Package` nodes, and auto-enable `architecture.package-boundary-violation` on
-  them without configuration;
-- score complexity per function (`code-quality.complex-function`, preview) by
-  nesting depth rather than counting branches flatly across a whole file;
-- grow the trust surface: a before/after review golden harness, fixtures for the
-  previously unpinned heuristic rules, a registry-generated
-  [rules reference](rules-reference.md), and config discovery that walks up to
-  the git root;
-- preserve JSON/SARIF, Action output, baseline, and MCP compatibility while new
-  signals stay at preview.
+- make MCP explanations replayable from emitted findings while preserving stable
+  baseline IDs and occurrence-level evidence selection;
+- carry Knowledge Engine decision provenance in schema `0.20` reports so agents
+  can compare stored and current decisions deterministically;
+- expose file-role evidence, executable-package manifest context, and ordered
+  decision traces without changing scan/review severity behavior;
+- keep strict-mode recall while moving low-confidence false positives out of the
+  default profile;
+- use the real-repo zoo snapshots and reviewed expectations as release evidence.
 
-No new rule family, distribution channel, hosted service, telemetry, or implicit
-LLM integration enters `0.18`. The JSON schema stays at `0.19`.
+No hosted service, telemetry, source upload, or implicit LLM integration is part
+of the current roadmap.
 
-## Next: 0.19
+## Next: 0.20
 
-- demote `code-quality.complex-file` now that the per-function rule covers the
-  honest cases (removal lands in `0.20`);
-- open a deprecation window for explicit `[architecture] package_roots` once
-  workspace auto-detection has field data;
-- back the remaining unfixtured heuristic rules with true/false-positive
-  fixtures and broaden the review golden matrix;
-- collect adoption evidence through reproducible reports, issues, and user
-  feedback, and improve first-run examples from observed failures.
+- use reviewed zoo dispositions to calibrate the remaining default-visible noise;
+- broaden replay/explanation coverage only where the required repository context
+  can be reconstructed deterministically;
+- keep deprecations explicit and evidence-backed before removing compatibility
+  surfaces;
+- improve first-run examples from observed user and CI failures.
 
 ## Later
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repopilot",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"description": "Local-first CLI for reviewing Git changes, security boundaries, and blast radius before merge.",
 	"license": "MIT OR Apache-2.0",
 	"repository": {
@@ -21,7 +21,8 @@
 		"product:smoke": "bash scripts/smoke-product.sh",
 		"release:contract": "python3 scripts/release-contract.py check",
 		"test:release-contract": "python3 -m unittest discover -s scripts/tests -p 'test_*.py'",
-		"review:performance": "node scripts/check-review-performance.js"
+		"review:performance": "node scripts/check-review-performance.js",
+		"scan:performance": "node scripts/check-scan-performance.js"
 	},
 	"files": [
 		"bin",
@@ -29,11 +30,11 @@
 		"LICENSE"
 	],
 	"optionalDependencies": {
-		"@repopilot/darwin-arm64": "0.18.0",
-		"@repopilot/darwin-x64": "0.18.0",
-		"@repopilot/linux-arm64-gnu": "0.18.0",
-		"@repopilot/linux-x64-gnu": "0.18.0",
-		"@repopilot/win32-x64-msvc": "0.18.0"
+		"@repopilot/darwin-arm64": "0.19.0",
+		"@repopilot/darwin-x64": "0.19.0",
+		"@repopilot/linux-arm64-gnu": "0.19.0",
+		"@repopilot/linux-x64-gnu": "0.19.0",
+		"@repopilot/win32-x64-msvc": "0.19.0"
 	},
 	"keywords": [
 		"cli",

--- a/scripts/tests/test_release_contract.py
+++ b/scripts/tests/test_release_contract.py
@@ -48,7 +48,7 @@ class ReleaseContractTests(unittest.TestCase):
             "### Fixed\n\n- Current.",
         )
         with self.assertRaises(release_contract.ContractError):
-            release_contract.release_section("0.18.0")
+            release_contract.release_section("0.19.0")
 
     def test_version_from_tag_rejects_non_release_refs(self) -> None:
         self.assertEqual(release_contract.version_from_tag("v0.17.0"), "0.17.0")

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -87,6 +87,12 @@ npm pack --dry-run
 echo "==> Build release binary"
 cargo build --release
 
+echo "==> Changed review performance gate"
+npm run review:performance
+
+echo "==> Full scan performance gate"
+npm run scan:performance
+
 echo "==> Self-review signal quality"
 REVIEW_BASE="$(git tag --sort=-version:refname --merged HEAD | head -n 1 || true)"
 if [[ -z "$(git status --porcelain)" ]] &&

--- a/tests/fixtures/reports/scan-v020.json
+++ b/tests/fixtures/reports/scan-v020.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "0.20",
-  "repopilot_version": "0.18.0",
+  "repopilot_version": "0.19.0",
   "report": {
     "kind": "scan",
     "schema_version": "0.20",
-    "repopilot_version": "0.18.0"
+    "repopilot_version": "0.19.0"
   },
   "root_path": ".",
   "mode": "full",

--- a/tests/zoo_runner_contract.rs
+++ b/tests/zoo_runner_contract.rs
@@ -76,7 +76,7 @@ fn workspace_mode_builds_once_ignores_stale_target_binary_and_keeps_snapshots() 
     assert_contains(&stdout, "scanner mode: workspace");
     assert_contains(&stdout, "scanner profile: release");
     assert_contains(&stdout, format!("scanner binary: {}", h.current.display()));
-    assert_contains(&stdout, "scanner version: 0.18.0");
+    assert_contains(&stdout, "scanner version: 0.19.0");
     assert_contains(
         &stdout,
         "workspace commit: 0123456789abcdef0123456789abcdef01234567",
@@ -140,7 +140,7 @@ fn explicit_version_mismatch_requires_opt_in() {
         &mismatch,
     );
     assert_success(&allowed);
-    assert!(text(&allowed.stdout).contains("workspace version: 0.18.0 (mismatch allowed)"));
+    assert!(text(&allowed.stdout).contains("workspace version: 0.19.0 (mismatch allowed)"));
 }
 
 #[test]
@@ -222,7 +222,7 @@ fn line_count(path: &Path) -> usize {
 }
 
 const CARGO_TOML: &str =
-    "[package]\nname = \"repopilot\"\nversion = \"0.18.0\"\nedition = \"2024\"\n";
+    "[package]\nname = \"repopilot\"\nversion = \"0.19.0\"\nedition = \"2024\"\n";
 const MANIFEST: &str = "[[repo]]\nname = \"sample\"\nurl = \"https://example.invalid/sample.git\"\nsha = \"abc123\"\nlanguage = \"rust\"\n";
 const SNAPSHOT: &str = "{\n  \"default\": {\n    \"by_priority\": {},\n    \"by_rule\": {},\n    \"fingerprints\": [],\n    \"visible_total\": 0\n  },\n  \"framework\": \"\",\n  \"language\": \"rust\",\n  \"repo\": \"sample\",\n  \"sha\": \"abc123\",\n  \"strict\": {\n    \"by_rule\": {},\n    \"visible_total\": 0\n  }\n}\n";
 
@@ -264,12 +264,12 @@ import json, os, sys
 with open(os.environ["FAKE_SCAN_LOG"], "a", encoding="utf-8") as log:
     log.write(sys.argv[0] + "|" + " ".join(sys.argv[1:]) + "\n")
 if sys.argv[1:] == ["--version"]:
-    print("repopilot " + os.environ.get("FAKE_REPOPILOT_VERSION", "0.18.0"))
+    print("repopilot " + os.environ.get("FAKE_REPOPILOT_VERSION", "0.19.0"))
     raise SystemExit(0)
 if len(sys.argv) > 1 and sys.argv[1] == "scan":
     profile = sys.argv[sys.argv.index("--profile") + 1]
-    version = os.environ.get("FAKE_REPOPILOT_VERSION", "0.18.0")
-    schema = os.environ.get("FAKE_REPOPILOT_SCHEMA_VERSION", "0.19")
+    version = os.environ.get("FAKE_REPOPILOT_VERSION", "0.19.0")
+    schema = os.environ.get("FAKE_REPOPILOT_SCHEMA_VERSION", "0.20")
     if profile == "strict":
         version = os.environ.get("FAKE_STRICT_REPOPILOT_VERSION", version)
         schema = os.environ.get("FAKE_STRICT_SCHEMA_VERSION", schema)


### PR DESCRIPTION
## Summary

Prepare RepoPilot `0.19.0` for release.

This release completes the explainable-findings and reliable-MCP milestone:

```text
file-role evidence
→ ordered Knowledge Engine trace
→ replayable finding provenance
→ MCP finding replay
→ occurrence disambiguation
→ fresh workspace-dependent MCP results
```

It also includes the reviewed real-repository zoo, significant default-profile
noise reductions, Graph v2 consumer migrations, structured AI context JSON, and
release performance guards.

## Type of change

* [ ] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Release preparation
* [x] Documentation
* [x] Tests and release verification
* [x] CI / repository maintenance

## What changed

* Updated the Cargo package version to `0.19.0`.
* Updated the Cargo lockfile package version.
* Updated the root npm package to `0.19.0`.
* Updated all optional native npm package dependencies to `0.19.0`.
* Updated the first-party GitHub Action default version.
* Updated the reusable PR-review workflow default version and Action reference.
* Updated documentation examples to use `v0.19.0`.
* Updated report examples and fixtures to identify RepoPilot `0.19.0`.
* Moved current unreleased notes into:

  * `## [0.19.0] - 2026-06-29`.
* Reset `[Unreleased]` for the next development cycle.
* Updated changelog compare links.
* Consolidated duplicated zoo and MCP occurrence notes in the release notes.
* Updated stale version-specific MCP and GitHub integration documentation.
* Added the existing full-scan performance guard to npm scripts.
* Added review and scan performance checks to the complete local release gate.
* Updated release-contract and zoo-runner fixtures for `0.19.0`.

## Release highlights

### Explainable findings

* Findings preserve Knowledge Engine decision provenance.
* File-role classification exposes evidence.
* Rule explanations include ordered applicability and override traces.
* `repopilot_explain_finding` can replay file-scoped findings from MCP session
  scan/review results.
* Repeated stable IDs can be disambiguated with:

  * `evidence_path`;
  * `line_start`.

### Reliable MCP state

* Workspace-dependent MCP tools no longer reuse results cached only by arguments.
* Source, manifest, configuration, feedback, ignore, and Git changes are observed
  on every relevant call.
* `last-scan` and `last-review` remain synchronized with the exact returned
  result.
* The separately validated persistent scan cache remains enabled.

### Signal quality

* Added reviewed expectations for the real-repository zoo.
* Preserved strict-profile recall while reducing default-visible false positives.
* Improved generated-file, JavaScript, Python, managed-language, package-boundary,
  and architecture signal calibration.

### Analysis foundation

* Graph v2 now supports migrated architecture rules, review blast radius, and AI
  hot-file fallback.
* Structured AI context JSON exposes deterministic, budget-aware finding evidence.
* Report schema `0.20` remains the current machine-readable contract.

## Compatibility

* Public CLI command surface is unchanged.
* Scan and review report schema remains `0.20`.
* Existing schema readers remain backward compatible.
* Stable finding IDs and baseline matching are unchanged.
* SARIF structure and behavior are unchanged.
* Existing MCP tool names remain unchanged.
* The occurrence locator is additive.
* Default and strict visibility contracts remain unchanged.
* No hosted service, telemetry, source upload, or implicit LLM integration is
  introduced.

## Release contract

* [x] Cargo and npm versions agree.
* [x] Native optional dependency versions agree.
* [x] Action and reusable workflow defaults agree.
* [x] Changelog contains the matching dated release section.
* [x] `[Unreleased]` is reset.
* [x] Report examples and fixtures identify the new package version.
* [x] Cargo package contents remain bounded.
* [x] npm package remains free of install-time download scripts.
* [x] Release performance guards are wired into the complete local gate.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

npm run release:contract
npm run test:release-contract
npm run review:performance
npm run scan:performance

./scripts/smoke-product.sh
./scripts/verify-release.sh

git diff --check
```

## Post-merge release

Tag the exact reviewed `main` commit:

```bash
git switch main
git pull --ff-only
git tag v0.19.0
git push origin v0.19.0
```
