### PR TITLE
chore(release): generate GitHub notes from curated documents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,16 +178,22 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Generate release notes from changelog
+      - name: Generate release notes from curated docs
+        id: release-notes
         run: |
           python3 scripts/release-contract.py notes \
             --tag "${GITHUB_REF_NAME}" \
             --output dist/release-notes.md
+          {
+            echo "title<<EOF"
+            python3 scripts/release-contract.py title --tag "${GITHUB_REF_NAME}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
-          name: RepoPilot ${{ github.ref_name }}
+          name: ${{ steps.release-notes.outputs.title }}
           files: |
             dist/*.tar.gz
             dist/*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
-No entries yet.
+### Changed
+
+- GitHub Release notes now come from structurally validated curated
+  `docs/releases/v*.md` files while `CHANGELOG.md` remains the full technical
+  release journal.
 
 ## [0.19.0] - 2026-06-29
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -25,8 +25,21 @@ is a build input, not a compatibility promise for older compilers.
 ## Prepare
 
 Update the version consistently in Cargo, npm, the Action, and reusable
-workflow. Add a dated `CHANGELOG.md` section and leave
+workflow. Add a dated `CHANGELOG.md` section for the full technical record, add
+curated GitHub Release notes at `docs/releases/vX.Y.Z.md`, and leave
 `[Unreleased]` ready for the next change.
+
+Curated release notes should stay short and user-facing:
+
+1. `title` and `description` front matter;
+2. three to five highlights;
+3. breaking changes or compatibility notes;
+4. version-pinned Cargo and npm upgrade commands.
+
+Do not add an H1 or a full changelog link to the curated note. The release
+script uses the front-matter title as the GitHub Release title, renders the
+description as the first body paragraph, and appends the tagged `CHANGELOG.md`
+link automatically.
 
 Run the release contract:
 
@@ -37,7 +50,9 @@ python3 scripts/release-contract.py check
 It verifies:
 
 - all release versions and action pins agree;
-- the matching changelog section exists and can produce release notes;
+- the matching changelog section exists;
+- the curated GitHub Release note exists, has the required structure, and can
+  produce the release title and body;
 - local Markdown links resolve;
 - stale npm installer claims are absent;
 - third-party GitHub Actions are pinned to commit SHAs;
@@ -93,7 +108,8 @@ git push origin vX.Y.Z
 ```
 
 The release workflow validates the tag against repository metadata before any
-build. It extracts the GitHub Release body from the matching changelog section,
+build. It renders the GitHub Release title and body from
+`docs/releases/vX.Y.Z.md`, appends the tagged full technical changelog link,
 builds and attests platform archives, publishes crates.io, calls npm publishing,
 and updates the Homebrew tap. The npm workflow publishes checksum-verified
 platform packages before the root package through Trusted Publishing. Missing

--- a/docs/releases/TEMPLATE.md
+++ b/docs/releases/TEMPLATE.md
@@ -1,0 +1,21 @@
+---
+title: Short release title
+description: One sentence describing what this release gives users.
+---
+
+## Highlights
+
+- Highlight 1.
+- Highlight 2.
+- Highlight 3.
+
+## Compatibility
+
+No breaking changes.
+
+## Upgrade
+
+```bash
+cargo install repopilot --version X.Y.Z --force
+npm install -g repopilot@X.Y.Z
+```

--- a/docs/releases/v0.19.0.md
+++ b/docs/releases/v0.19.0.md
@@ -1,0 +1,23 @@
+---
+title: Explainable findings and lower review noise
+description: Agents can replay findings, maintainers can audit rule decisions, and default scans stay quieter without losing strict-mode recall.
+---
+
+## Highlights
+
+- `repopilot_explain_finding` lets MCP clients replay an emitted file-scoped finding by stable ID and see whether it still matches the current workspace.
+- Findings now preserve replayable Knowledge Engine decision provenance and ordered rule traces for explain surfaces without changing normal scan or review behavior.
+- The real-repo zoo now stores snapshots and human-reviewed expectations, so false-positive work is measured instead of guessed.
+- `repopilot ai context --format json` provides deterministic, budget-aware machine handoffs matching the Markdown brief.
+- Default-visible noise is lower for common JavaScript runtime exits, Python asserts and abstract methods, secret candidates, env files, type-only cycles, generated bundles, and test-support panic patterns while strict mode retains recall.
+
+## Compatibility
+
+No CLI command, baseline, SARIF, or finding ID breaking changes are expected. Report schema advances to `0.20`; readers continue accepting `0.16` through `0.19`.
+
+## Upgrade
+
+```bash
+cargo install repopilot --version 0.19.0 --force
+npm install -g repopilot@0.19.0
+```

--- a/scripts/release-contract.py
+++ b/scripts/release-contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate release metadata and extract release notes from CHANGELOG.md."""
+"""Validate release metadata and render curated GitHub release notes."""
 
 from __future__ import annotations
 
@@ -21,6 +21,12 @@ RELEASE_HEADING = re.compile(
 )
 ACTION_USE = re.compile(r"^\s*-?\s*uses:\s*([^@\s]+)@([^\s#]+)", re.MULTILINE)
 PINNED_SHA = re.compile(r"^[0-9a-f]{40}$")
+RELEASE_FRONT_MATTER = re.compile(
+    r"\A---\n(?P<meta>.*?)\n---\n(?P<body>.*)\Z",
+    re.DOTALL,
+)
+RELEASE_SECTION = re.compile(r"^## (?P<title>[^\n]+)$", re.MULTILINE)
+RELEASE_REQUIRED_SECTIONS = ("Highlights", "Compatibility", "Upgrade")
 
 
 class ContractError(RuntimeError):
@@ -101,8 +107,101 @@ def release_section(version: str) -> str:
     end = match.end() + next_heading.start() if next_heading else len(changelog)
     body = changelog[match.end() : end].strip()
     if not body or not re.search(r"^### ", body, re.MULTILINE):
-        raise ContractError(f"CHANGELOG.md release {version} has no release notes")
+        raise ContractError(f"CHANGELOG.md release {version} has no technical entries")
     return body
+
+
+def release_notes(version: str) -> str:
+    title, description, body = release_document(version)
+    if not title:
+        raise ContractError(f"Release title for {version} is empty")
+    return f"{description}\n\n{body}"
+
+
+def release_title(version: str) -> str:
+    title, _description, _body = release_document(version)
+    return f"RepoPilot v{version}: {title}"
+
+
+def release_document(version: str) -> tuple[str, str, str]:
+    curated = ROOT / "docs" / "releases" / f"v{version}.md"
+    if not curated.exists():
+        raise ContractError(f"Missing curated GitHub release notes for {version}")
+
+    text = read_text(curated).strip()
+    if not text:
+        raise ContractError(f"Release notes for {version} are empty")
+    title, description, body = parse_release_document(version, text)
+    validate_release_note_body(version, body)
+    return title, description, body
+
+
+def parse_release_document(version: str, text: str) -> tuple[str, str, str]:
+    match = RELEASE_FRONT_MATTER.match(text)
+    if not match:
+        raise ContractError(
+            f"Release notes for {version} must start with title/description front matter"
+        )
+
+    metadata: dict[str, str] = {}
+    for line in match.group("meta").splitlines():
+        if not line.strip():
+            continue
+        key, separator, value = line.partition(":")
+        if not separator:
+            raise ContractError(f"Invalid release metadata line for {version}: {line}")
+        metadata[key.strip()] = value.strip().strip("\"'")
+
+    title = metadata.get("title", "")
+    description = metadata.get("description", "")
+    body = match.group("body").strip()
+    if not title:
+        raise ContractError(f"Release title for {version} is empty")
+    if not description:
+        raise ContractError(f"Release description for {version} is empty")
+    if not body:
+        raise ContractError(f"Release notes for {version} have no body")
+    return title, description, body
+
+
+def validate_release_note_body(version: str, body: str) -> None:
+    if re.search(r"^# ", body, re.MULTILINE):
+        raise ContractError(f"Release notes for {version} must not include an H1")
+
+    sections = list(RELEASE_SECTION.finditer(body))
+    titles = [section.group("title").strip() for section in sections]
+    if titles[: len(RELEASE_REQUIRED_SECTIONS)] != list(RELEASE_REQUIRED_SECTIONS):
+        expected = ", ".join(f"## {section}" for section in RELEASE_REQUIRED_SECTIONS)
+        raise ContractError(f"Release notes for {version} must start with {expected}")
+
+    highlights = release_section_body(body, sections, "Highlights")
+    highlight_count = len(re.findall(r"^- \S", highlights, re.MULTILINE))
+    if not 3 <= highlight_count <= 5:
+        raise ContractError(
+            f"Release notes for {version} must have 3-5 highlight bullets"
+        )
+
+    upgrade = release_section_body(body, sections, "Upgrade")
+    required_commands = [
+        f"cargo install repopilot --version {version} --force",
+        f"npm install -g repopilot@{version}",
+    ]
+    missing = [command for command in required_commands if command not in upgrade]
+    if missing:
+        raise ContractError(
+            f"Release notes for {version} missing pinned upgrade command: {missing[0]}"
+        )
+
+
+def release_section_body(
+    body: str, sections: list[re.Match[str]], title: str
+) -> str:
+    for index, section in enumerate(sections):
+        if section.group("title").strip() != title:
+            continue
+        end = sections[index + 1].start() if index + 1 < len(sections) else len(body)
+        return body[section.end() : end].strip()
+    raise ContractError(f"Release notes section is missing: {title}")
 
 
 def check_versions(version: str) -> None:
@@ -265,6 +364,7 @@ def check_contract(tag: str | None) -> None:
     version = expected_version(tag)
     check_versions(version)
     release_section(version)
+    release_notes(version)
     check_markdown_links()
     check_npm_claims()
     check_cargo_package()
@@ -276,12 +376,12 @@ def check_contract(tag: str | None) -> None:
 
 def write_notes(tag: str, output: Path) -> None:
     version = version_from_tag(tag)
-    body = release_section(version)
+    body = release_notes(version)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(
         body
         + "\n\n"
-        + f"Full changelog: https://github.com/MykytaStel/repopilot/blob/v{version}/CHANGELOG.md\n",
+        + f"Full technical changelog: https://github.com/MykytaStel/repopilot/blob/{tag}/CHANGELOG.md\n",
         encoding="utf-8",
     )
     print(f"Wrote release notes for {version} to {output}")
@@ -297,6 +397,9 @@ def parse_args() -> argparse.Namespace:
     notes = subparsers.add_parser("notes")
     notes.add_argument("--tag", required=True)
     notes.add_argument("--output", required=True, type=Path)
+
+    title = subparsers.add_parser("title")
+    title.add_argument("--tag", required=True)
     return parser.parse_args()
 
 
@@ -305,8 +408,10 @@ def main() -> int:
     try:
         if args.command == "check":
             check_contract(args.tag)
-        else:
+        elif args.command == "notes":
             write_notes(args.tag, args.output)
+        else:
+            print(release_title(version_from_tag(args.tag)))
     except (ContractError, KeyError, OSError, subprocess.CalledProcessError) as error:
         print(f"release-contract: {error}", file=sys.stderr)
         return 1

--- a/scripts/tests/test_release_contract.py
+++ b/scripts/tests/test_release_contract.py
@@ -35,6 +35,25 @@ class ReleaseContractTests(unittest.TestCase):
         path.write_text(content, encoding="utf-8")
         return path
 
+    def release_note(self, version: str = "0.17.0") -> str:
+        return (
+            "---\n"
+            "title: Explainable review output\n"
+            "description: Agents can understand why findings were emitted.\n"
+            "---\n\n"
+            "## Highlights\n\n"
+            "- First highlight.\n"
+            "- Second highlight.\n"
+            "- Third highlight.\n\n"
+            "## Compatibility\n\n"
+            "No breaking changes.\n\n"
+            "## Upgrade\n\n"
+            "```bash\n"
+            f"cargo install repopilot --version {version} --force\n"
+            f"npm install -g repopilot@{version}\n"
+            "```\n"
+        )
+
     def test_release_section_extracts_only_requested_version(self) -> None:
         self.write(
             "CHANGELOG.md",
@@ -49,6 +68,86 @@ class ReleaseContractTests(unittest.TestCase):
         )
         with self.assertRaises(release_contract.ContractError):
             release_contract.release_section("0.19.0")
+
+    def test_release_notes_require_curated_version_file(self) -> None:
+        with self.assertRaisesRegex(
+            release_contract.ContractError, "Missing curated GitHub release notes"
+        ):
+            release_contract.release_notes("0.17.0")
+
+    def test_release_notes_reject_empty_curated_file(self) -> None:
+        self.write("docs/releases/v0.17.0.md", "\n\n")
+
+        with self.assertRaisesRegex(
+            release_contract.ContractError, "Release notes for 0.17.0 are empty"
+        ):
+            release_contract.release_notes("0.17.0")
+
+    def test_release_notes_read_curated_version_file(self) -> None:
+        self.write("docs/releases/v0.17.0.md", self.release_note())
+
+        self.assertEqual(
+            release_contract.release_notes("0.17.0"),
+            "Agents can understand why findings were emitted.\n\n"
+            "## Highlights\n\n"
+            "- First highlight.\n"
+            "- Second highlight.\n"
+            "- Third highlight.\n\n"
+            "## Compatibility\n\n"
+            "No breaking changes.\n\n"
+            "## Upgrade\n\n"
+            "```bash\n"
+            "cargo install repopilot --version 0.17.0 --force\n"
+            "npm install -g repopilot@0.17.0\n"
+            "```",
+        )
+
+    def test_release_title_uses_curated_front_matter(self) -> None:
+        self.write("docs/releases/v0.17.0.md", self.release_note())
+
+        self.assertEqual(
+            release_contract.release_title("0.17.0"),
+            "RepoPilot v0.17.0: Explainable review output",
+        )
+
+    def test_release_notes_reject_h1_body(self) -> None:
+        self.write(
+            "docs/releases/v0.17.0.md",
+            self.release_note().replace("## Highlights", "# RepoPilot\n\n## Highlights"),
+        )
+
+        with self.assertRaisesRegex(release_contract.ContractError, "must not include an H1"):
+            release_contract.release_notes("0.17.0")
+
+    def test_release_notes_require_expected_sections(self) -> None:
+        self.write(
+            "docs/releases/v0.17.0.md",
+            self.release_note().replace("## Compatibility", "## Details"),
+        )
+
+        with self.assertRaisesRegex(release_contract.ContractError, "must start with"):
+            release_contract.release_notes("0.17.0")
+
+    def test_release_notes_require_three_to_five_highlights(self) -> None:
+        self.write(
+            "docs/releases/v0.17.0.md",
+            self.release_note().replace("- Third highlight.\n", ""),
+        )
+
+        with self.assertRaisesRegex(release_contract.ContractError, "3-5 highlight"):
+            release_contract.release_notes("0.17.0")
+
+    def test_release_notes_require_pinned_upgrade_commands(self) -> None:
+        self.write(
+            "docs/releases/v0.17.0.md",
+            self.release_note().replace(
+                "npm install -g repopilot@0.17.0",
+                "npm update -g repopilot",
+            ),
+        )
+
+        with self.assertRaisesRegex(release_contract.ContractError, "pinned upgrade"):
+            release_contract.release_notes("0.17.0")
 
     def test_version_from_tag_rejects_non_release_refs(self) -> None:
         self.assertEqual(release_contract.version_from_tag("v0.17.0"), "0.17.0")
@@ -92,17 +191,25 @@ class ReleaseContractTests(unittest.TestCase):
             ):
                 release_contract.check_cargo_package()
 
-    def test_write_notes_uses_changelog_body_and_tagged_link(self) -> None:
+    def test_write_notes_uses_curated_body_and_tagged_changelog_link(self) -> None:
         self.write(
             "CHANGELOG.md",
             "## [0.17.0] - 2026-07-01\n\n### Fixed\n\n- Precise review.\n",
+        )
+        self.write(
+            "docs/releases/v0.17.0.md",
+            self.release_note(),
         )
         output = release_contract.ROOT / "dist/notes.md"
 
         release_contract.write_notes("v0.17.0", output)
 
         notes = output.read_text(encoding="utf-8")
-        self.assertIn("### Fixed", notes)
+        self.assertIn("Agents can understand why findings were emitted.", notes)
+        self.assertNotIn("Precise review.", notes)
+        self.assertNotIn("title: Explainable review output", notes)
+        self.assertNotIn("# RepoPilot", notes)
+        self.assertIn("Full technical changelog:", notes)
         self.assertIn("/blob/v0.17.0/CHANGELOG.md", notes)
         self.assertNotIn("0.16.0", notes)
 


### PR DESCRIPTION
## Summary

Separate user-facing GitHub Release notes from the full technical changelog.

Future releases now use a curated `docs/releases/vX.Y.Z.md` document for the
GitHub Release body, while `CHANGELOG.md` remains the detailed engineering and
compatibility journal.

## Type of change

* [ ] Feature
* [x] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [x] CI / repository maintenance

## What changed

* Added `docs/releases/TEMPLATE.md` for curated release notes.
* Added curated release notes for `v0.19.0`.
* Updated `release-contract.py` to:

  * continue validating the matching technical changelog section;
  * require a matching curated release-note document;
  * render GitHub Release notes from the curated document;
  * append the tagged full technical changelog link automatically.
* Updated release-contract tests for:

  * missing curated notes;
  * empty curated notes;
  * reading the correct versioned document;
  * generating notes from curated content rather than the full changelog;
  * using the exact tag in the appended changelog link.
* Updated the release workflow step name.
* Updated release documentation.
* Added a changelog entry describing the new release-note ownership.

## Why

The previous release workflow copied the entire version section from
`CHANGELOG.md` into GitHub Releases.

That document is intentionally detailed and contains rule-level behavior,
compatibility contracts, evaluation measurements, implementation notes, and
regression information. It is useful as an engineering record but too dense for
a user-facing release page.

The new ownership model is:

```text
CHANGELOG.md
→ complete technical record

docs/releases/vX.Y.Z.md
→ concise user-facing release summary
```

This keeps the release workflow automated without forcing one Markdown document
to serve two different audiences.

## Compatibility

* Existing release tags and artifact naming are unchanged.
* Cargo, npm, Homebrew, and GitHub artifact publication are unchanged.
* Release-note generation remains deterministic.
* The full tagged changelog link remains present.
* No CLI, JSON, SARIF, baseline, Action, MCP, or report schema changes are
  introduced.

## Contract and ownership

* [x] Curated release notes and technical changelog have separate ownership.
* [x] The release contract requires both documents.
* [x] The exact release tag is used in the changelog link.
* [x] Release artifacts and publication workflows remain unchanged.
* [x] Focused unit tests cover the new source of release notes.
* [x] No unrelated analyzer or product change is included.

## Changelog

* [x] `CHANGELOG.md` updated.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```
