### PR TITLE
docs(product): define the v0.20 release and benchmark contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- v0.20 roadmap, performance benchmark matrix, and release scorecard define the
+  product, engineering, and compatibility contract before implementation starts.
+
 ### Changed
 
 - GitHub Release notes now come from structurally validated curated

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,4 +37,6 @@ adoption or CI policy.
 - [Release process](release.md)
 - [Distribution](distribution.md)
 - [Roadmap](roadmap.md)
+- [v0.20 roadmap and release contract](roadmap/v0.20.md)
+- [v0.20 release scorecard](engineering/v0.20-release-scorecard.md)
 - [GitHub ruleset](github-ruleset.md)

--- a/docs/engineering/performance-budgets.md
+++ b/docs/engineering/performance-budgets.md
@@ -47,6 +47,95 @@ the expected speedup afterwards. Criterion stores results under
 `target/criterion` and reports the delta versus the previous run, so benchmark
 `main` first, then the change branch.
 
+## v0.20 Benchmark Matrix
+
+The following matrix extends the initial budgets for the 0.20 release. All
+values use accounted engine time unless noted otherwise.
+
+| Scenario | Size | Budget | Notes |
+|---|---|---:|---|
+| Warm full strict scan | self-scan | <= 600ms | existing 0.19 budget |
+| Report finalization | self-scan | <= 100ms | existing 0.19 budget |
+| Cold changed review | small synthetic | to be baselined | first measurement needed |
+| Warm changed review | small synthetic | to be baselined | after cache warm |
+| Warm full strict scan | medium synthetic | to be baselined | ~1000 files |
+| Warm full strict scan | large synthetic | to be baselined | ~3000 files |
+| Cold changed review | medium synthetic | to be baselined | ~1000 files |
+| Warm changed review | medium synthetic | to be baselined | after cache warm |
+
+### Entries marked "to be baselined"
+
+These scenarios require a stable synthetic fixture and a recorded measurement on
+the pinned environment before a hard budget can be set. The PR that introduces
+each fixture must record the baseline and propose a budget. Until then the
+regression threshold (no more than 10% unexplained regression) applies relative
+to the first recorded measurement.
+
+### Peak memory
+
+Measure peak RSS using `/usr/bin/time -v` (Linux) or `/usr/bin/time -l` (macOS)
+as a practical proxy. Record the result alongside the benchmark run. A hard
+memory budget should be set only after baseline data from the pinned environment
+is available.
+
+### Thread determinism
+
+Output determinism must be verified for 1-thread and multi-thread runs. The
+determinism test compares the full JSON report (excluding wall-clock timing)
+across `RAYON_NUM_THREADS=1` and default thread counts.
+
+### Cache behavior
+
+Benchmark runs should record cache hit, miss, and invalidation rates for warm
+scenarios. The cache benchmark covers:
+
+- unchanged workspace (expect full hit);
+- single file changed (expect targeted miss);
+- new file added (expect miss for new file, hit for others);
+- file removed (expect invalidation for removed file and its dependents).
+
+### Measurement environment
+
+Pin the benchmark environment to a specific machine profile or CI runner type.
+Record the profile alongside results so regressions are comparable. Local
+developer machines are acceptable for relative comparisons; absolute budgets
+should be validated on the pinned environment.
+
+### Rules for budget changes
+
+- A benchmark update must be explicit and justified when a legitimate engine
+  improvement changes expected work.
+- Do not silently increase a budget. Any budget increase requires a PR
+  description explaining the reason.
+- Do not claim a speedup before it is measured on the pinned environment with the
+  full benchmark matrix.
+- The 10% regression threshold applies to accounted engine time. Wall-clock
+  regressions are supporting context only.
+
+### Separating accounted engine time from wall-clock time
+
+Accounted engine time (`scan_timings.accounted_engine_us()`) includes parsing,
+rule execution, graph construction, and report finalization. It excludes process
+startup, argument parsing, I/O to the output file, and terminal rendering.
+Wall-clock time is useful for user experience but is affected by system load,
+I/O scheduling, and terminal speed. Budget enforcement uses accounted engine time
+only.
+
+### Baselining a change
+
+Before measuring a change branch:
+
+```bash
+git switch main
+cargo bench --bench scan_bench       # record baseline
+git switch <change-branch>
+cargo bench --bench scan_bench       # compare against baseline
+```
+
+Criterion stores results under `target/criterion` and reports the delta. The
+baseline measurement must be on the same machine profile as the change
+measurement.
+
 ## Fixture Direction
 
 Add small, medium, and large synthetic repositories before enforcing this as a

--- a/docs/engineering/v0.20-release-scorecard.md
+++ b/docs/engineering/v0.20-release-scorecard.md
@@ -1,0 +1,88 @@
+# v0.20 Release Scorecard
+
+Use this checklist during every 0.20 PR and at release time. Each gate is either
+machine-checkable (run the listed command) or clearly auditable (inspect the
+listed artifact).
+
+## Trust
+
+- [ ] Zero finding contract violations
+  - `cargo test --test rule_eval_fixture_coverage`
+- [ ] Zero unlabeled default zoo findings
+  - `python3 scripts/zoo.py scan` (requires cloned zoo repos)
+- [ ] Zero stale or ambiguous zoo expectations
+  - same `zoo.py scan` run reports stale expectations
+- [ ] Zero known default-visible P0/P1 false positives
+  - `python3 scripts/zoo.py report` shows no `false-positive` entries at P0/P1
+- [ ] All selected strict recall anchors preserved
+  - zoo scan validates strict expectations
+- [ ] Complete evidence and recommendation coverage
+  - `python3 scripts/check-signal-quality.py --scan-json <self-scan>`
+    reports 100% evidence and recommendation coverage
+- [ ] Documentation coverage for high-priority stable rules
+  - `cargo test --test rules_reference_doc` (reference drift test)
+
+## Performance
+
+- [ ] Benchmark matrix recorded
+  - `cargo bench --bench scan_bench` results committed or recorded
+  - warm full scan, report finalization, cold/warm changed review measured
+- [ ] No unexplained regression above threshold
+  - see `docs/engineering/performance-budgets.md` for thresholds
+- [ ] Deterministic outputs across thread counts
+  - dedicated determinism test passes with 1 and multi-thread
+- [ ] Cache invalidation and corruption recovery tested
+  - cache tests cover: hit, miss, file changed, file added, file removed,
+    corrupted cache file
+- [ ] Memory result recorded
+  - peak RSS or practical proxy measured and documented
+
+## Product
+
+- [ ] Install -> init -> useful review workflow
+  - `scripts/smoke-product.sh` covers version, init, review, scan, baseline,
+    AI context
+- [ ] Verdict-first default output
+  - review and scan console output leads with summary verdict
+- [ ] Honest scope limitations
+  - review output documents what is and is not checked
+- [ ] Useful changed-review output
+  - `repopilot review . --base origin/main` produces actionable signals
+- [ ] Bounded MCP responses
+  - MCP responses respect size limits; large finding sets paginate
+- [ ] GitHub Action artifacts verified
+  - Action produces stable report artifacts and delta-focused PR comments
+
+## Compatibility
+
+- [ ] CLI commands unchanged
+  - same command names, subcommands, aliases, exit codes
+- [ ] Baseline identity preserved
+  - 0.19 baselines match findings in 0.20
+- [ ] Finding IDs stable
+  - stable finding IDs unchanged for identical code
+- [ ] SARIF output compatible
+  - SARIF structure unchanged; new properties are additive
+- [ ] Supported report readers
+  - schema `0.16`–`0.20` readers accept 0.20 output
+- [ ] MCP tool names stable
+  - existing MCP tool names and parameters unchanged
+- [ ] Visibility profiles consistent
+  - `default` and `strict` profiles behave as documented
+
+## Distribution
+
+- [ ] Cargo
+  - `cargo install repopilot --version 0.20.0` works
+- [ ] npm
+  - `npm install -g repopilot@0.20.0` works
+- [ ] GitHub Releases
+  - release assets uploaded with checksums
+- [ ] Homebrew
+  - `brew install repopilot` or `brew upgrade repopilot` works
+- [ ] GitHub Action and reusable workflow
+  - Action uses correct version default; reusable workflow pins correct ref
+- [ ] Platform smoke tests
+  - darwin-arm64, darwin-x64, linux-x64-gnu, linux-arm64-gnu, win32-x64-msvc
+- [ ] Checksums and available provenance artifacts
+  - SHA-256 checksums published; SBOM/provenance if supported by release system

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,14 +19,23 @@ the change reaches before merge.
 No hosted service, telemetry, source upload, or implicit LLM integration is part
 of the current roadmap.
 
-## Next: 0.20
+## Next: 0.20 — Trusted Change Intelligence
 
-- use reviewed zoo dispositions to calibrate the remaining default-visible noise;
-- broaden replay/explanation coverage only where the required repository context
-  can be reconstructed deterministically;
-- keep deprecations explicit and evidence-backed before removing compatibility
-  surfaces;
-- improve first-run examples from observed user and CI failures.
+See [roadmap/v0.20.md](roadmap/v0.20.md) for the full release contract,
+performance benchmarks, staged PR sequence, and release scorecard.
+
+- immutable analysis session and shared parsed facts for parse-once performance;
+- incremental context graph and content-addressed cache v2;
+- unified boundary, behavior, algorithm, and taint-lite review deltas with
+  dependency impact paths and deterministic verification plans;
+- canonical decision record across CLI, JSON, SARIF, MCP, AI context, and
+  GitHub Action;
+- promoted real-repo zoo as release evidence with review-zoo differential
+  fixtures;
+- MCP workspace revisions, analysis handles, and pagination;
+- verdict-first CLI output with progressive disclosure;
+- delta-focused GitHub Action PR comments and stable artifacts;
+- hardened analysis boundaries, redaction, and cache corruption recovery.
 
 ## Later
 

--- a/docs/roadmap/v0.20.md
+++ b/docs/roadmap/v0.20.md
@@ -1,0 +1,618 @@
+# RepoPilot 0.20.0 — Trusted Change Intelligence
+
+## Problem Statement
+
+Maintainers and coding agents need to trust `repopilot review` output in daily
+loops: is this change safe to merge, and if not, what exactly should I verify?
+RepoPilot 0.19 provides replayable evidence and low default noise, but the
+engine parses files repeatedly, review signals are independent rather than
+connected, and the decision model varies across output surfaces.
+
+## Product Promise
+
+A fast, deterministic, local-first review engine for human- and AI-generated Git
+changes before merge. The product flow is:
+
+```
+workspace snapshot -> incremental analysis -> contextual evidence
+  -> trusted decision -> impact path -> deterministic verification plan
+  -> human / agent / CI
+```
+
+RepoPilot 0.20 prioritizes:
+
+1. trustworthy default-visible signals;
+2. measurable performance in daily review loops;
+3. one canonical decision model across CLI, JSON, MCP, AI context, SARIF, and
+   GitHub Action;
+4. a complete change-review product experience rather than a large collection of
+   unrelated rules.
+
+## Primary User Workflow
+
+```
+repopilot review . --base origin/main
+```
+
+A maintainer or coding agent runs `review` on a branch. RepoPilot:
+
+1. snapshots the workspace and diff;
+2. parses changed and affected files once, sharing facts;
+3. runs boundary, behavior, algorithm, and taint-lite delta detectors;
+4. maps dependency impact paths from changed files;
+5. produces a canonical decision for each finding: what changed, why it matters,
+   and a deterministic verification plan;
+6. renders a verdict-first summary for the terminal, a structured report for CI,
+   and a bounded response for MCP agents.
+
+## Current 0.19 Foundation
+
+RepoPilot 0.19 ships:
+
+- replayable Knowledge Engine decision provenance (schema `0.20`);
+- `repopilot_explain_finding` MCP tool with occurrence-level selection;
+- file-role evidence, executable-package manifest context, and ordered rule
+  traces;
+- real-repo zoo with snapshots, human-reviewed expectations, and recall anchors;
+- lower default-visible noise for common JS exits, Python asserts, secret
+  candidates, type-only cycles, generated bundles, and test-support panics;
+- Criterion benchmark for synthetic 480-file multi-language scans;
+- five official distribution channels: Cargo, npm, Homebrew, GitHub Releases,
+  and GitHub Action.
+
+## Release Pillars
+
+Each pillar is an implementation milestone with a focused PR sequence.
+
+### A. Analysis Engine v3
+
+Introduce an immutable `AnalysisSession` that owns the workspace snapshot and
+revision identity. Parse each file once into a shared `ParsedArtifact` backed by
+a `FactStore`. Rules declare their scope, required inputs, lifecycle, and cache
+policy so the scheduler can plan bounded deterministic execution. Public DTOs are
+separated from internal engine models to stabilize the report contract without
+coupling consumers to engine internals.
+
+### B. Incremental Analysis and Cache v2
+
+Content-address parsed facts so unchanged files skip reparsing on warm runs.
+Build an incremental repository graph that adds and removes edges rather than
+rebuilding from scratch. Invalidate only when the content hash or declared
+dependencies change, with a corruption-safe fallback that discards the cache and
+proceeds from cold. Enforce a memory discipline: release parsed artifacts after
+their dependent rules complete, and bound peak RSS to a documented practical
+proxy.
+
+### C. Measured Signal Quality
+
+Promote the real-repo zoo to release evidence: every release must pass the zoo
+gate with zero unlabeled default findings, zero stale expectations, and zero
+known default-visible P0/P1 false positives. Add a review-zoo with
+before/patch/after fixtures and safe/unsafe differential tests. Publish rule
+scorecards with lifecycle, precision, recall anchors, and false-positive debt.
+
+### D. Review Intelligence v2
+
+Unify the four review delta types — boundary, behavior, algorithm, and
+taint-lite — into a single review pass that shares parsed facts. Add dependency
+impact paths showing which downstream consumers are affected by a changed file.
+Generate a deterministic verification plan for each high-confidence finding:
+what to check, where, and how to confirm or dismiss. Document honest limitations
+for each delta type (e.g., taint-lite does not track through serialization
+boundaries).
+
+### E. Canonical Finding and Decision Contract
+
+The stable finding ID remains the baseline identity key. Add an occurrence key
+for disambiguating repeated IDs within a single report. Introduce a canonical
+decision record that unifies the severity, confidence, evidence, recommendation,
+and verification plan into one structure shared by CLI, JSON, SARIF, MCP, and AI
+context. Evolve the report schema additively; do not break readers that accept
+schema `0.16` through `0.20`.
+
+### F. MCP for Large Agent Workflows
+
+Add workspace revisions so MCP clients can detect when the workspace changed
+between calls. Return analysis handles that clients can reference in follow-up
+explain or context requests. Add pagination for large finding sets. Support
+summary, compact, and full detail levels. Bound response size to a configurable
+limit. Preserve local, read-only, stdio, root-confined behavior.
+
+### G. Product UX and GitHub Action
+
+Redesign CLI output around a verdict-first summary with progressive disclosure
+into findings. Render honest empty states when no findings are detected. Update
+PR comments to be delta-focused and sticky (update in place rather than
+appending). Compact GitHub annotations. Produce stable report artifacts in the
+Action.
+
+### H. Security, Reliability, and Distribution
+
+Harden path and root confinement in the analysis engine. Add redaction for
+secret-candidate evidence in report output. Test cache corruption recovery paths
+in CI. Verify deterministic outputs across thread counts. Run platform smoke
+tests for each distribution channel. Produce checksums and, where supported by
+the existing release system, SBOM and provenance artifacts.
+
+## Non-Goals
+
+The following are explicitly out of scope for 0.20:
+
+- hosted service, cloud scanning, or remote storage;
+- telemetry, usage analytics, or source upload;
+- implicit LLM calls from scan, review, or MCP tools;
+- automatic code fixes or suggested patches;
+- editor or IDE extensions;
+- arbitrary plugin or custom-rule execution;
+- new programming language support beyond the current nine;
+- Git provider integrations beyond GitHub Actions;
+- `1.0` compatibility guarantees.
+
+## Compatibility Contract
+
+RepoPilot 0.20 maintains backward compatibility with 0.19 in the following
+areas. Any deviation must be documented as a breaking change with migration
+guidance.
+
+| Surface | Contract |
+|---|---|
+| CLI commands | Same command names, subcommands, and aliases |
+| Exit codes | Same exit-code semantics |
+| Baseline files | 0.19 baselines remain valid; new fields are additive |
+| Finding IDs | Stable IDs remain the baseline identity key |
+| JSON report schema | Additive fields only; schema advances to `0.21`; readers accepting `0.16`–`0.20` continue working |
+| SARIF output | Same SARIF structure; new properties are additive |
+| MCP tool names | Same tool names; new tools and parameters are additive |
+| Visibility profiles | `default` and `strict` behave as documented; new profiles are additive |
+| GitHub Action | Same inputs and outputs; new inputs are optional with backward-compatible defaults |
+| Configuration | `repopilot.toml` keys are additive; no removed keys |
+
+## Staged PR Sequence
+
+Actual GitHub PR numbers may differ. The sequence below uses planned numbers
+#263–#282 for reference only.
+
+See [Planned PR Sequence](#planned-pr-sequence) below for detailed acceptance
+criteria.
+
+| # | Title | Pillar | Depends on |
+|---|---|---|---|
+| #263 | docs(product): define the v0.20 release and benchmark contract | — | — |
+| #264 | refactor(engine): introduce AnalysisSession and workspace revisions | A | #263 |
+| #265 | refactor(analysis): add shared ParsedArtifact and FactStore | A | #264 |
+| #266 | refactor(rules): declare scope, inputs, lifecycle and cache policy | A | #265 |
+| #267 | perf(graph): introduce incremental Context Graph v3 | B | #265 |
+| #268 | perf(cache): add content-addressed analysis cache v2 | B | #267 |
+| #269 | perf(engine): add bounded parallel scheduling and memory release | B | #266, #268 |
+| #270 | test(perf): enforce the v0.20 benchmark and determinism matrix | B | #269 |
+| #271 | feat(eval): promote real-repo quality metrics to a release contract | C | #263 |
+| #272 | test(eval): add review-zoo and differential safe/unsafe fixtures | C | #271 |
+| #273 | feat(findings): add occurrence keys and canonical decision records | E | #266 |
+| #274 | feat(review): add dependency impact paths and affected surfaces | D | #265 |
+| #275 | feat(review): unify boundary, behavior, algorithm and taint deltas | D | #274 |
+| #276 | feat(review): generate deterministic verification plans | D | #273, #275 |
+| #277 | feat(mcp): add workspace revisions, analysis handles and pagination | F | #264, #273 |
+| #278 | feat(ai): emit the canonical v0.20 analysis artifact | E | #273, #276 |
+| #279 | feat(cli): redesign review and scan summaries around decisions | G | #273 |
+| #280 | feat(action): add delta-focused PR comments and stable artifacts | G | #279 |
+| #281 | fix(security): harden analysis boundaries, redaction and cache recovery | H | #268 |
+| #282 | chore(release): prepare RepoPilot v0.20.0 | — | all |
+
+## Planned PR Sequence
+
+### #263 — docs(product): define the v0.20 release and benchmark contract
+
+**Purpose:** Establish the authoritative product, engineering, performance, and
+release contract before implementation starts.
+
+**Boundaries:** Documentation, performance budget updates, and scorecard only.
+No engine, rule, or output changes.
+
+**Acceptance criteria:**
+- v0.20 roadmap exists with all pillars, non-goals, and compatibility contract;
+- performance budgets updated with v0.20 benchmark matrix;
+- release scorecard created and linked from docs index;
+- changelog entry under `[Unreleased]`;
+- all existing checks pass.
+
+**Exclusions:** No implementation of AnalysisSession, cache v2, graph v3, review
+detectors, MCP pagination, or other engine work.
+
+### #264 — refactor(engine): introduce AnalysisSession and workspace revisions
+
+**Purpose:** Create the immutable `AnalysisSession` that owns workspace identity,
+revision, and configuration for a single analysis pass.
+
+**Boundaries:** Internal refactor of the scan and review entry points. No new
+public API or output changes.
+
+**Acceptance criteria:**
+- `AnalysisSession` owns workspace root, revision hash, configuration, and
+  profile;
+- scan and review paths use `AnalysisSession` instead of ad-hoc parameters;
+- MCP server creates one session per request;
+- all existing tests pass with no output changes.
+
+**Dependencies:** #263.
+
+**Exclusions:** No parsed-fact sharing, no cache changes, no new MCP tools.
+
+### #265 — refactor(analysis): add shared ParsedArtifact and FactStore
+
+**Purpose:** Parse each file once into a shared `ParsedArtifact` and store
+derived facts in a `FactStore` that multiple rules can read.
+
+**Boundaries:** Internal data structure. Detectors are migrated to read from
+`FactStore` but their logic does not change.
+
+**Acceptance criteria:**
+- each file is parsed at most once per session;
+- `FactStore` holds imports, exports, role evidence, and AST summary;
+- all detectors produce identical findings;
+- benchmark shows no regression.
+
+**Dependencies:** #264.
+
+**Exclusions:** No incremental graph, no content-addressing, no new facts.
+
+### #266 — refactor(rules): declare scope, inputs, lifecycle and cache policy
+
+**Purpose:** Each rule declares what it needs (file facts, graph context,
+workspace metadata) and what it produces, enabling the scheduler to plan
+execution order and caching.
+
+**Boundaries:** Rule metadata declarations. No scheduler changes yet.
+
+**Acceptance criteria:**
+- every registered rule has a `RuleRequirements` declaration;
+- requirements include scope, required fact kinds, lifecycle, and cache policy;
+- `rules-reference.md` generation includes requirements summary;
+- no finding changes.
+
+**Dependencies:** #265.
+
+**Exclusions:** No parallel scheduling, no cache v2 integration.
+
+### #267 — perf(graph): introduce incremental Context Graph v3
+
+**Purpose:** Replace the full-rebuild dependency graph with an incremental graph
+that adds/removes edges based on changed files.
+
+**Boundaries:** Graph construction internals. Graph query API remains the same.
+
+**Acceptance criteria:**
+- incremental graph produces identical edges to full rebuild;
+- warm changed-scan graph construction is faster than full rebuild (to be
+  baselined);
+- graph determinism test passes across thread counts;
+- zoo regression gate passes.
+
+**Dependencies:** #265.
+
+**Exclusions:** No content-addressed caching, no new graph queries.
+
+### #268 — perf(cache): add content-addressed analysis cache v2
+
+**Purpose:** Cache parsed facts and graph edges by content hash so unchanged
+files skip reparsing on warm runs.
+
+**Boundaries:** Cache storage, lookup, and invalidation. The analysis pipeline
+uses the cache but falls back to cold parsing on miss or corruption.
+
+**Acceptance criteria:**
+- cache stores content-hash-keyed parsed facts;
+- warm scan skips reparsing for unchanged files;
+- corrupted cache file is detected and discarded without error;
+- cache invalidation test covers: file changed, file added, file removed;
+- benchmark records cache hit/miss/invalidation behavior.
+
+**Dependencies:** #267.
+
+**Exclusions:** No memory discipline, no scheduling changes.
+
+### #269 — perf(engine): add bounded parallel scheduling and memory release
+
+**Purpose:** Schedule rule execution in parallel within declared dependency
+bounds and release parsed artifacts after their consumers complete.
+
+**Boundaries:** Scheduler internals. Rule execution order may change but
+findings must be deterministic.
+
+**Acceptance criteria:**
+- rules execute in parallel where their requirements allow;
+- parsed artifacts are released after all dependent rules complete;
+- peak memory result is recorded (target to be baselined);
+- output is deterministic across 1, 2, and 4 threads;
+- benchmark shows no regression.
+
+**Dependencies:** #266, #268.
+
+**Exclusions:** No new rules, no output format changes.
+
+### #270 — test(perf): enforce the v0.20 benchmark and determinism matrix
+
+**Purpose:** Add the full v0.20 benchmark matrix and determinism tests as CI
+gates.
+
+**Boundaries:** Benchmark fixtures and test harness. No engine changes.
+
+**Acceptance criteria:**
+- benchmark covers warm full scan, report finalization, cold and warm changed
+  review across small/medium/large synthetic repos;
+- determinism test verifies identical output across 1 and multi-thread runs;
+- regression threshold enforced per `performance-budgets.md`;
+- cache hit/miss/invalidation behavior recorded.
+
+**Dependencies:** #269.
+
+**Exclusions:** No engine optimizations in this PR.
+
+### #271 — feat(eval): promote real-repo quality metrics to a release contract
+
+**Purpose:** Make the zoo gate a required release check: zero unlabeled default
+findings, zero stale expectations, zero known default-visible P0/P1 false
+positives.
+
+**Boundaries:** Zoo tooling and release-contract integration. No rule changes.
+
+**Acceptance criteria:**
+- `release-contract.py` or `verify-release.sh` fails if zoo gate fails (when
+  zoo repos are available);
+- rule scorecards generated from zoo data;
+- scorecard includes lifecycle, precision estimate, and false-positive debt.
+
+**Dependencies:** #263.
+
+**Exclusions:** No review-zoo, no new rules, no false-positive fixes.
+
+### #272 — test(eval): add review-zoo and differential safe/unsafe fixtures
+
+**Purpose:** Add before/patch/after review fixtures and safe/unsafe differential
+tests to measure review signal precision.
+
+**Boundaries:** Test fixtures and evaluation harness. No review detector
+changes.
+
+**Acceptance criteria:**
+- review-zoo fixture format defined with before/patch/after directories;
+- at least three differential fixtures covering boundary, behavior, and
+  taint-lite deltas;
+- safe fixture produces no review signals; unsafe fixture produces expected
+  signals;
+- review-zoo gate integrated into test suite.
+
+**Dependencies:** #271.
+
+**Exclusions:** No review detector improvements, no new delta types.
+
+### #273 — feat(findings): add occurrence keys and canonical decision records
+
+**Purpose:** Add occurrence identity for repeated stable IDs and unify the
+finding decision into a canonical record shared by all output surfaces.
+
+**Boundaries:** Finding data model and serialization. All output surfaces
+updated to use the canonical record.
+
+**Acceptance criteria:**
+- findings with repeated stable IDs get unique occurrence keys;
+- canonical decision record includes severity, confidence, evidence,
+  recommendation, and verification plan;
+- JSON, SARIF, MCP, and AI context use the same decision record;
+- baseline matching uses stable ID (not occurrence key);
+- schema advances additively.
+
+**Dependencies:** #266.
+
+**Exclusions:** No new review detectors, no verification plan generation yet.
+
+### #274 — feat(review): add dependency impact paths and affected surfaces
+
+**Purpose:** For each changed file, trace the dependency graph to show which
+downstream files and modules are affected.
+
+**Boundaries:** Impact path computation and rendering. No new delta detectors.
+
+**Acceptance criteria:**
+- impact paths show file → immediate dependents → transitive dependents up to a
+  configurable depth;
+- review output includes affected surface summary;
+- impact paths are deterministic;
+- performance within review budget.
+
+**Dependencies:** #265.
+
+**Exclusions:** No behavioral or algorithmic delta changes.
+
+### #275 — feat(review): unify boundary, behavior, algorithm and taint deltas
+
+**Purpose:** Run all four delta types in a single review pass sharing parsed
+facts from the `FactStore`.
+
+**Boundaries:** Review pipeline unification. Individual delta logic is preserved.
+
+**Acceptance criteria:**
+- single review pass produces boundary, behavior, algorithm, and taint-lite
+  deltas;
+- each delta type documents its honest limitations;
+- review output unchanged for existing fixtures;
+- review performance within budget.
+
+**Dependencies:** #274.
+
+**Exclusions:** No new delta types, no verification plans yet.
+
+### #276 — feat(review): generate deterministic verification plans
+
+**Purpose:** For each high-confidence review finding, generate a verification
+plan: what to check, where, and how to confirm or dismiss.
+
+**Boundaries:** Verification plan generation and rendering. Plans are
+deterministic and evidence-backed.
+
+**Acceptance criteria:**
+- high-confidence findings include a verification plan;
+- plans reference specific files, lines, and suggested checks;
+- plans are deterministic across runs;
+- plans document what they cannot verify.
+
+**Dependencies:** #273, #275.
+
+**Exclusions:** No automatic fixes, no LLM-generated plans.
+
+### #277 — feat(mcp): add workspace revisions, analysis handles and pagination
+
+**Purpose:** Let MCP clients detect workspace changes, reference previous
+analyses, and paginate large finding sets.
+
+**Boundaries:** MCP tool parameters and response structure. Existing tools
+remain compatible.
+
+**Acceptance criteria:**
+- workspace revision returned in every MCP response;
+- analysis handle returned from scan/review, accepted by explain/context;
+- pagination via `offset`/`limit` on finding lists;
+- response size bounded to configurable limit;
+- existing MCP tests pass unchanged.
+
+**Dependencies:** #264, #273.
+
+**Exclusions:** No streaming, no WebSocket transport, no server-sent events.
+
+### #278 — feat(ai): emit the canonical v0.20 analysis artifact
+
+**Purpose:** `repopilot ai context` emits the canonical decision-record-based
+artifact matching the unified finding model.
+
+**Boundaries:** AI context output format. Input interface unchanged.
+
+**Acceptance criteria:**
+- AI context uses canonical decision records;
+- output includes verification plans when available;
+- budget enforcement unchanged;
+- golden tests updated.
+
+**Dependencies:** #273, #276.
+
+**Exclusions:** No new AI features, no LLM integration.
+
+### #279 — feat(cli): redesign review and scan summaries around decisions
+
+**Purpose:** CLI output leads with a verdict summary, then progressively
+discloses individual findings with their canonical decisions.
+
+**Boundaries:** Console rendering. JSON and SARIF output unchanged.
+
+**Acceptance criteria:**
+- verdict-first summary for review and scan;
+- progressive disclosure: summary → finding list → full detail with `--detail`;
+- honest empty state when no findings detected;
+- existing exit codes preserved.
+
+**Dependencies:** #273.
+
+**Exclusions:** No JSON/SARIF format changes, no new CLI commands.
+
+### #280 — feat(action): add delta-focused PR comments and stable artifacts
+
+**Purpose:** GitHub Action posts delta-focused PR comments that update in place
+and produces stable report artifacts.
+
+**Boundaries:** Action output and PR comment format. Action inputs remain
+backward compatible.
+
+**Acceptance criteria:**
+- PR comment shows only new/changed findings relative to base;
+- comment updates in place (no duplicate comments);
+- report artifacts have stable names across runs;
+- compact annotations for individual findings;
+- existing Action inputs and outputs preserved.
+
+**Dependencies:** #279.
+
+**Exclusions:** No new Action inputs for non-GitHub providers.
+
+### #281 — fix(security): harden analysis boundaries, redaction and cache recovery
+
+**Purpose:** Harden path confinement, add redaction for secret-candidate evidence,
+and test cache corruption recovery.
+
+**Boundaries:** Security and reliability hardening. No feature changes.
+
+**Acceptance criteria:**
+- path traversal outside workspace root rejected in all code paths;
+- secret-candidate evidence redacted in non-JSON report output;
+- corrupted cache detected and recovered without user intervention;
+- determinism verified across thread counts;
+- platform smoke tests pass for all distribution channels.
+
+**Dependencies:** #268.
+
+**Exclusions:** No new security rules, no SBOM generation (unless already
+supported by the release workflow).
+
+### #282 — chore(release): prepare RepoPilot v0.20.0
+
+**Purpose:** Bump version, write changelog and curated release notes, run all
+gates.
+
+**Boundaries:** Version metadata and documentation only.
+
+**Acceptance criteria:**
+- version bumped to 0.20.0 in Cargo.toml, package.json, action.yml, reusable
+  workflow;
+- `CHANGELOG.md` section dated;
+- curated `docs/releases/v0.20.0.md` with required structure;
+- `release-contract.py check` passes;
+- `verify-release.sh` passes;
+- v0.20 release scorecard completed.
+
+**Dependencies:** All previous PRs.
+
+**Exclusions:** No feature work, no last-minute rule changes.
+
+## Release Gates
+
+Every 0.20 PR must pass the existing gate suite:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test --all`
+- `npm run release:contract`
+- `npm run test:release-contract`
+- `scripts/smoke-product.sh`
+
+The release PR (#282) must additionally pass:
+
+- `scripts/verify-release.sh`
+- v0.20 release scorecard (see `docs/engineering/v0.20-release-scorecard.md`)
+
+## Definition of Done
+
+RepoPilot 0.20.0 is ready to release when:
+
+**Requirements (must pass):**
+
+- all pillar PRs merged to `main`;
+- v0.20 release scorecard fully green;
+- zero known default-visible P0/P1 false positives;
+- zoo gate passes with zero unlabeled findings and zero stale expectations;
+- benchmark matrix recorded with no unexplained regressions;
+- deterministic output verified across thread counts;
+- all five distribution channels smoke-tested;
+- release-contract check passes.
+
+**Targets (calibrate during implementation):**
+
+- warm full scan accounted engine time: target improvement over 0.19 baseline
+  (to be measured);
+- warm changed review accounted engine time: target to be baselined;
+- peak memory: target to be baselined;
+- cache warm hit rate on unchanged workspace: target to be baselined;
+- review-zoo precision: target to be baselined after fixtures exist.
+
+**Stretch goals (not blocking release):**
+
+- SBOM and provenance attestation for GitHub Releases;
+- Homebrew formula tested on both Intel and Apple Silicon in CI;
+- review-zoo coverage for all nine languages;
+- MCP streaming responses for large workspaces.

--- a/scripts/release-contract.py
+++ b/scripts/release-contract.py
@@ -360,6 +360,47 @@ def check_removed_vscode_surface() -> None:
         )
 
 
+def check_roadmap_docs() -> None:
+    roadmap = ROOT / "docs" / "roadmap" / "v0.20.md"
+    scorecard = ROOT / "docs" / "engineering" / "v0.20-release-scorecard.md"
+    required_files = {
+        "v0.20 roadmap": roadmap,
+        "v0.20 release scorecard": scorecard,
+    }
+    missing = [name for name, path in required_files.items() if not path.exists()]
+    if missing:
+        raise ContractError(
+            "Missing release documentation:\n  " + "\n  ".join(missing)
+        )
+
+    roadmap_text = read_text(roadmap)
+    required_headings = [
+        "Problem Statement",
+        "Product Promise",
+        "Non-Goals",
+        "Compatibility Contract",
+        "Planned PR Sequence",
+        "Release Gates",
+        "Definition of Done",
+    ]
+    missing_headings = [
+        heading
+        for heading in required_headings
+        if not re.search(rf"^##+ {re.escape(heading)}", roadmap_text, re.MULTILINE)
+    ]
+    if missing_headings:
+        raise ContractError(
+            "v0.20 roadmap missing required headings:\n  "
+            + "\n  ".join(missing_headings)
+        )
+
+    docs_index = read_text(ROOT / "docs" / "README.md")
+    if "roadmap/v0.20.md" not in docs_index:
+        raise ContractError("docs/README.md does not link to v0.20 roadmap")
+    if "v0.20-release-scorecard.md" not in docs_index:
+        raise ContractError("docs/README.md does not link to v0.20 release scorecard")
+
+
 def check_contract(tag: str | None) -> None:
     version = expected_version(tag)
     check_versions(version)
@@ -371,6 +412,7 @@ def check_contract(tag: str | None) -> None:
     check_action_pins()
     check_release_orchestration()
     check_removed_vscode_surface()
+    check_roadmap_docs()
     print(f"Release contract passed for {version}")
 
 

--- a/scripts/tests/test_release_contract.py
+++ b/scripts/tests/test_release_contract.py
@@ -221,6 +221,66 @@ class ReleaseContractTests(unittest.TestCase):
         ):
             release_contract.check_removed_vscode_surface()
 
+    def test_roadmap_docs_require_v020_roadmap_file(self) -> None:
+        self.write("docs/engineering/v0.20-release-scorecard.md", "# Scorecard\n")
+        self.write("docs/README.md", "- [r](roadmap/v0.20.md)\n- [s](engineering/v0.20-release-scorecard.md)\n")
+
+        with self.assertRaisesRegex(
+            release_contract.ContractError, "Missing release documentation"
+        ):
+            release_contract.check_roadmap_docs()
+
+    def test_roadmap_docs_require_v020_scorecard_file(self) -> None:
+        self.write(
+            "docs/roadmap/v0.20.md",
+            "# v0.20\n## Problem Statement\n## Product Promise\n"
+            "## Non-Goals\n## Compatibility Contract\n## Planned PR Sequence\n"
+            "## Release Gates\n## Definition of Done\n",
+        )
+        self.write("docs/README.md", "- [r](roadmap/v0.20.md)\n- [s](engineering/v0.20-release-scorecard.md)\n")
+
+        with self.assertRaisesRegex(
+            release_contract.ContractError, "Missing release documentation"
+        ):
+            release_contract.check_roadmap_docs()
+
+    def test_roadmap_docs_require_headings(self) -> None:
+        self.write("docs/roadmap/v0.20.md", "# v0.20\n## Problem Statement\n")
+        self.write("docs/engineering/v0.20-release-scorecard.md", "# Scorecard\n")
+        self.write("docs/README.md", "- [r](roadmap/v0.20.md)\n- [s](engineering/v0.20-release-scorecard.md)\n")
+
+        with self.assertRaisesRegex(
+            release_contract.ContractError, "missing required headings"
+        ):
+            release_contract.check_roadmap_docs()
+
+    def test_roadmap_docs_require_index_links(self) -> None:
+        self.write(
+            "docs/roadmap/v0.20.md",
+            "# v0.20\n## Problem Statement\n## Product Promise\n"
+            "## Non-Goals\n## Compatibility Contract\n## Planned PR Sequence\n"
+            "## Release Gates\n## Definition of Done\n",
+        )
+        self.write("docs/engineering/v0.20-release-scorecard.md", "# Scorecard\n")
+        self.write("docs/README.md", "- no links here\n")
+
+        with self.assertRaisesRegex(
+            release_contract.ContractError, "does not link"
+        ):
+            release_contract.check_roadmap_docs()
+
+    def test_roadmap_docs_pass_when_complete(self) -> None:
+        self.write(
+            "docs/roadmap/v0.20.md",
+            "# v0.20\n## Problem Statement\n## Product Promise\n"
+            "## Non-Goals\n## Compatibility Contract\n## Planned PR Sequence\n"
+            "## Release Gates\n## Definition of Done\n",
+        )
+        self.write("docs/engineering/v0.20-release-scorecard.md", "# Scorecard\n")
+        self.write("docs/README.md", "- [r](roadmap/v0.20.md)\n- [s](engineering/v0.20-release-scorecard.md)\n")
+
+        release_contract.check_roadmap_docs()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

  - Create the authoritative v0.20 roadmap at `docs/roadmap/v0.20.md` covering
    problem statement, product promise, 8 release pillars (A–H), non-goals,
    compatibility contract, a 20-PR staged sequence with per-PR acceptance
    criteria and exclusions, release gates, and Definition of Done.
  - Add the v0.20 release scorecard at `docs/engineering/v0.20-release-scorecard.md`
    with machine-checkable or auditable gates across trust, performance, product,
    compatibility, and distribution.
  - Extend `docs/engineering/performance-budgets.md` with the v0.20 benchmark
    matrix, baselining protocol, thread determinism, cache behavior, memory proxy,
    and budget-change rules — preserving all existing 0.19 budgets.
  - Update `docs/roadmap.md` "Next: 0.20" to link the detailed roadmap.
  - Link both new documents from `docs/README.md`.
  - Add `check_roadmap_docs()` to `release-contract.py` validating roadmap
    presence, required headings, scorecard presence, and docs index links.
  - Add 5 unit tests for the new contract check.
  - Add `[Unreleased]` changelog entry.

  No engine, rule, output, version, or Action changes. Cargo.toml and
  package.json remain at 0.19.0.

  ## Test plan

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all`
  - [x] `npm run release:contract`
  - [x] `npm run test:release-contract` (25 tests, 5 new)
  - [x] `git diff --check`