### PR TITLE
refactor(engine): introduce AnalysisSession and workspace revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Scan, review, AI-context, baseline, and MCP analysis requests now execute through
+  one immutable `AnalysisSession` that owns the target path, resolved workspace
+  root, workspace revision, repository/scan configuration, and visibility profile.
+  Existing CLI output, report schemas, finding IDs, baselines, and MCP tools are
+  unchanged.
 - GitHub Release notes now come from structurally validated curated
   `docs/releases/v*.md` files while `CHANGELOG.md` remains the full technical
   release journal.

--- a/src/commands/mcp/review_change.rs
+++ b/src/commands/mcp/review_change.rs
@@ -9,7 +9,7 @@ use repopilot::findings::visibility::FindingVisibilityProfile;
 use repopilot::output::OutputFormat;
 use repopilot::review::render::render;
 use repopilot::review::{
-    ReviewSignalGatePolicy, ReviewSignalGateResult, build_review_report_from_input,
+    ReviewSignalGatePolicy, ReviewSignalGateResult, build_review_report_from_session,
     load_review_input,
 };
 use serde_json::{Value, json};
@@ -101,7 +101,6 @@ pub fn call(arguments: &Value) -> Result<String, String> {
     };
     let mode = match scope {
         "changed" => ProductScanMode::ResolvedChanged {
-            repo_root: input.repo_root.clone(),
             changed_files: input.changed_files.clone(),
             base_ref: input.target.base_ref().map(str::to_string),
         },
@@ -138,11 +137,14 @@ pub fn call(arguments: &Value) -> Result<String, String> {
     let baseline_ref = baseline_file
         .as_ref()
         .map(|(baseline, path)| (baseline, path.clone()));
-    let repo_config = scan_result.repo_config;
     let review_started = Instant::now();
-    let mut review_report =
-        build_review_report_from_input(scan_result.summary, input, baseline_ref, &repo_config)
-            .map_err(|error| format!("review failed: {error}"))?;
+    let mut review_report = build_review_report_from_session(
+        scan_result.summary,
+        input,
+        baseline_ref,
+        &scan_result.session,
+    )
+    .map_err(|error| format!("review failed: {error}"))?;
     review_report.timings.diff_loading_us = diff_loading_us;
     review_report.timings.review_signals_us = duration_us(review_started.elapsed());
     if scope == "changed" {

--- a/src/commands/product_scan.rs
+++ b/src/commands/product_scan.rs
@@ -2,7 +2,6 @@ use crate::commands::progress::{finish_spinner, make_spinner};
 use crate::commands::scan_config::{ScanConfigOverrides, build_scan_config};
 use crate::commands::{CliExit, EXIT_RUNTIME, EXIT_USAGE};
 use repopilot::config::loader::{load_default_config, load_optional_config};
-use repopilot::config::model::RepoPilotConfig;
 use repopilot::config::presets::{Preset, apply_preset};
 use repopilot::facts::RepoFactsSummary;
 use repopilot::findings::feedback::apply_local_feedback;
@@ -10,11 +9,12 @@ use repopilot::findings::filter::FindingFilter;
 use repopilot::findings::visibility::{FindingVisibilityProfile, apply_visibility_profile};
 use repopilot::review::diff::ChangedFile;
 use repopilot::scan::scanner::{
-    scan_changed_with_config, scan_path_with_config, scan_path_with_config_and_facts_summary,
-    scan_resolved_changed_with_config,
+    scan_changed_session, scan_resolved_changed_session, scan_session,
+    scan_session_with_facts_summary,
 };
+use repopilot::scan::session::AnalysisSession;
 use repopilot::scan::types::ScanSummary;
-use repopilot::scan::workspace_scan::scan_workspace_with_config;
+use repopilot::scan::workspace_scan::scan_workspace_session;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -25,7 +25,6 @@ pub enum ProductScanMode {
         since: Option<String>,
     },
     ResolvedChanged {
-        repo_root: PathBuf,
         changed_files: Vec<ChangedFile>,
         base_ref: Option<String>,
     },
@@ -46,7 +45,7 @@ pub struct ProductScanRequest {
 pub struct ProductScanResult {
     pub summary: ScanSummary,
     pub repo_facts_summary: Option<RepoFactsSummary>,
-    pub repo_config: RepoPilotConfig,
+    pub session: AnalysisSession,
     pub scan_elapsed: Duration,
 }
 
@@ -80,6 +79,14 @@ fn run_product_scan_internal(
     }
 
     let scan_config = build_scan_config(&repo_config, request.overrides);
+    let session = AnalysisSession::new(
+        request.path.clone(),
+        repo_config,
+        scan_config,
+        request.visibility_profile,
+    );
+    debug_assert!(!session.revision().id().is_empty());
+
     let pb = if request.no_progress {
         None
     } else {
@@ -88,31 +95,21 @@ fn run_product_scan_internal(
     let scan_start = Instant::now();
     let scan_result = match &request.mode {
         ProductScanMode::Full if include_repo_facts_summary => {
-            scan_path_with_config_and_facts_summary(&request.path, &scan_config)
+            scan_session_with_facts_summary(&session)
                 .map(|(summary, facts_summary)| (summary, Some(facts_summary)))
         }
-        ProductScanMode::Full => {
-            scan_path_with_config(&request.path, &scan_config).map(|summary| (summary, None))
-        }
+        ProductScanMode::Full => scan_session(&session).map(|summary| (summary, None)),
         ProductScanMode::Workspace => {
-            scan_workspace_with_config(&request.path, &scan_config).map(|summary| (summary, None))
+            scan_workspace_session(&session).map(|summary| (summary, None))
         }
         ProductScanMode::Changed { since } => {
-            scan_changed_with_config(&request.path, &scan_config, since.as_deref())
-                .map(|summary| (summary, None))
+            scan_changed_session(&session, since.as_deref()).map(|summary| (summary, None))
         }
         ProductScanMode::ResolvedChanged {
-            repo_root,
             changed_files,
             base_ref,
-        } => scan_resolved_changed_with_config(
-            &request.path,
-            &scan_config,
-            repo_root.clone(),
-            changed_files.clone(),
-            base_ref.as_deref(),
-        )
-        .map(|summary| (summary, None)),
+        } => scan_resolved_changed_session(&session, changed_files.clone(), base_ref.as_deref())
+            .map(|summary| (summary, None)),
     };
     let scan_elapsed = scan_start.elapsed();
     finish_spinner(pb);
@@ -120,19 +117,19 @@ fn run_product_scan_internal(
     let (mut summary, repo_facts_summary) = scan_result?;
 
     if !request.ignore_feedback {
-        apply_local_feedback(&mut summary, &request.path)?;
+        apply_local_feedback(&mut summary, session.analysis_path())?;
     }
 
     if !request.pre_visibility_filter.is_empty() {
         request.pre_visibility_filter.apply_to_summary(&mut summary);
     }
 
-    apply_visibility_profile(&mut summary, request.visibility_profile);
+    apply_visibility_profile(&mut summary, session.visibility_profile());
 
     Ok(ProductScanResult {
         summary,
         repo_facts_summary,
-        repo_config,
+        session,
         scan_elapsed,
     })
 }

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -15,7 +15,7 @@ use repopilot::output::OutputFormat;
 use repopilot::report::writer::write_report;
 use repopilot::review::render::{render, render_review_sarif};
 use repopilot::review::{
-    ReviewSignalGatePolicy, ReviewSignalGateResult, build_review_report_from_input,
+    ReviewSignalGatePolicy, ReviewSignalGateResult, build_review_report_from_session,
     load_review_input, load_review_input_since, review_report_for_ci,
 };
 use std::time::{Duration, Instant};
@@ -83,7 +83,6 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
     let diff_loading_us = duration_us(diff_started.elapsed());
     let scan_mode = match scope {
         ReviewScope::Changed => ProductScanMode::ResolvedChanged {
-            repo_root: review_input.repo_root.clone(),
             changed_files: review_input.changed_files.clone(),
             base_ref: review_input.target.base_ref().map(str::to_string),
         },
@@ -116,11 +115,11 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
         .as_ref()
         .map(|(baseline, path)| (baseline, path.clone()));
     let review_started = Instant::now();
-    let mut review_report = build_review_report_from_input(
+    let mut review_report = build_review_report_from_session(
         summary,
         review_input,
         baseline_ref,
-        &scan_result.repo_config,
+        &scan_result.session,
     )?;
     review_report.timings.diff_loading_us = diff_loading_us;
     review_report.timings.review_signals_us = duration_us(review_started.elapsed());

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -52,7 +52,7 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     let output_format = options
         .format
         .map(Into::into)
-        .unwrap_or(scan_result.repo_config.output.default_format);
+        .unwrap_or(scan_result.session.repo_config().output.default_format);
 
     if baseline_flow::uses_baseline_flow(&options) {
         return baseline_flow::run_baseline_scan_flow(

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -14,6 +14,7 @@ pub use blast_radius::compute_blast_radius;
 pub use ci::review_report_for_ci;
 pub use gate::{ReviewSignalGatePolicy, ReviewSignalGateResult};
 pub use report::{
-    ReviewInput, build_review_report, build_review_report_from_input, build_review_report_since,
-    load_review_input, load_review_input_since,
+    ReviewInput, build_review_report, build_review_report_from_input,
+    build_review_report_from_session, build_review_report_since, load_review_input,
+    load_review_input_since,
 };

--- a/src/review/report.rs
+++ b/src/review/report.rs
@@ -13,6 +13,7 @@ use crate::review::model::{ReviewFindingStatus, ReviewReport};
 use crate::review::paths::normalized_review_path;
 use crate::review::signals::{BoundarySignal, composites, detect_boundary_signals, tiered};
 use crate::risk::{apply_blast_radius_overlay, apply_review_overlay};
+use crate::scan::session::AnalysisSession;
 use crate::scan::types::ScanSummary;
 use std::path::{Path, PathBuf};
 
@@ -82,6 +83,15 @@ pub fn build_review_report_since(
 ) -> Result<ReviewReport, crate::review::diff::GitDiffError> {
     let input = load_review_input_since(scan_path, base)?;
     build_review_report_from_input(summary, input, baseline, config)
+}
+
+pub fn build_review_report_from_session(
+    summary: ScanSummary,
+    input: ReviewInput,
+    baseline: Option<(&Baseline, PathBuf)>,
+    session: &AnalysisSession,
+) -> Result<ReviewReport, crate::review::diff::GitDiffError> {
+    build_review_report_from_input(summary, input, baseline, session.repo_config())
 }
 
 pub fn build_review_report_from_input(

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -10,6 +10,8 @@ pub mod markers;
 pub(crate) mod path_classification;
 #[doc(hidden)]
 pub mod scanner;
+#[doc(hidden)]
+pub mod session;
 pub mod types;
 #[doc(hidden)]
 pub mod workspace;

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -11,6 +11,7 @@ use crate::findings::rule_config::{apply_rule_config, rule_config_diagnostics};
 use crate::knowledge::decision::apply_project_decisions;
 use crate::review::diff::ChangedFile;
 use crate::scan::config::ScanConfig;
+use crate::scan::session::AnalysisSession;
 use crate::scan::types::ScanSummary;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -24,6 +25,13 @@ pub fn scan_changed_with_config(
     ChangedScanEngine::new(path, config, base_ref).run()
 }
 
+pub fn scan_changed_session(
+    session: &AnalysisSession,
+    base_ref: Option<&str>,
+) -> io::Result<ScanSummary> {
+    ChangedScanEngine::new(session.analysis_path(), session.scan_config(), base_ref).run()
+}
+
 pub fn scan_resolved_changed_with_config(
     path: &Path,
     config: &ScanConfig,
@@ -32,6 +40,21 @@ pub fn scan_resolved_changed_with_config(
     base_ref: Option<&str>,
 ) -> io::Result<ScanSummary> {
     ChangedScanEngine::resolved(path, config, repo_root, changed_files, base_ref).run()
+}
+
+pub fn scan_resolved_changed_session(
+    session: &AnalysisSession,
+    changed_files: Vec<ChangedFile>,
+    base_ref: Option<&str>,
+) -> io::Result<ScanSummary> {
+    ChangedScanEngine::resolved(
+        session.analysis_path(),
+        session.scan_config(),
+        session.workspace_root().to_path_buf(),
+        changed_files,
+        base_ref,
+    )
+    .run()
 }
 
 struct ChangedScanEngine<'a> {

--- a/src/scan/scanner/full.rs
+++ b/src/scan/scanner/full.rs
@@ -19,6 +19,7 @@ use crate::knowledge::decision::apply_project_decisions;
 use crate::risk::{apply_cluster_overlay, apply_graph_overlay, assess_findings};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
+use crate::scan::session::AnalysisSession;
 use crate::scan::types::{ScanSummary, ScanTimings};
 use std::io;
 use std::path::Path;
@@ -32,11 +33,21 @@ pub fn scan_path_with_config(path: &Path, config: &ScanConfig) -> io::Result<Sca
     ScanEngine::new(path, config).run()
 }
 
+pub fn scan_session(session: &AnalysisSession) -> io::Result<ScanSummary> {
+    ScanEngine::from_session(session).run()
+}
+
 pub fn scan_path_with_config_and_facts_summary(
     path: &Path,
     config: &ScanConfig,
 ) -> io::Result<(ScanSummary, RepoFactsSummary)> {
     ScanEngine::new(path, config).run_with_facts_summary()
+}
+
+pub fn scan_session_with_facts_summary(
+    session: &AnalysisSession,
+) -> io::Result<(ScanSummary, RepoFactsSummary)> {
+    ScanEngine::from_session(session).run_with_facts_summary()
 }
 
 pub struct ScanEngine<'a> {
@@ -71,6 +82,10 @@ pub(super) struct ProjectAnalysisStage {
 impl<'a> ScanEngine<'a> {
     pub fn new(path: &'a Path, config: &'a ScanConfig) -> Self {
         Self { path, config }
+    }
+
+    pub fn from_session(session: &'a AnalysisSession) -> Self {
+        Self::new(session.analysis_path(), session.scan_config())
     }
 
     pub fn run(self) -> io::Result<ScanSummary> {

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -10,8 +10,12 @@ mod full;
 mod summary;
 mod walker;
 
-pub use changed::{scan_changed_with_config, scan_resolved_changed_with_config};
+pub use changed::{
+    scan_changed_session, scan_changed_with_config, scan_resolved_changed_session,
+    scan_resolved_changed_with_config,
+};
 pub use collection::{collect_scan_facts, collect_scan_facts_with_config};
 pub use full::{
     ScanEngine, scan_path, scan_path_with_config, scan_path_with_config_and_facts_summary,
+    scan_session, scan_session_with_facts_summary,
 };

--- a/src/scan/session.rs
+++ b/src/scan/session.rs
@@ -1,0 +1,340 @@
+use crate::config::model::RepoPilotConfig;
+use crate::findings::visibility::FindingVisibilityProfile;
+use crate::scan::config::ScanConfig;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const REVISION_SCHEMA: &str = "analysis-session-v1";
+const CACHE_DIR: &str = ".repopilot/cache";
+
+/// Immutable inputs shared by one RepoPilot analysis pass.
+///
+/// The session keeps scan/review configuration and workspace identity together so
+/// command, MCP, and later cached analysis paths cannot accidentally combine
+/// values captured at different points in time.
+#[derive(Debug, Clone)]
+pub struct AnalysisSession {
+    analysis_path: PathBuf,
+    workspace_root: PathBuf,
+    revision: WorkspaceRevision,
+    repo_config: RepoPilotConfig,
+    scan_config: ScanConfig,
+    visibility_profile: FindingVisibilityProfile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceRevision {
+    id: String,
+}
+
+impl WorkspaceRevision {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+impl AnalysisSession {
+    pub fn new(
+        analysis_path: PathBuf,
+        repo_config: RepoPilotConfig,
+        scan_config: ScanConfig,
+        visibility_profile: FindingVisibilityProfile,
+    ) -> Self {
+        let workspace_root = resolve_workspace_root(&analysis_path);
+        let revision = capture_workspace_revision(&workspace_root);
+
+        Self {
+            analysis_path,
+            workspace_root,
+            revision,
+            repo_config,
+            scan_config,
+            visibility_profile,
+        }
+    }
+
+    pub fn analysis_path(&self) -> &Path {
+        &self.analysis_path
+    }
+
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
+    }
+
+    pub fn revision(&self) -> &WorkspaceRevision {
+        &self.revision
+    }
+
+    pub fn repo_config(&self) -> &RepoPilotConfig {
+        &self.repo_config
+    }
+
+    pub fn scan_config(&self) -> &ScanConfig {
+        &self.scan_config
+    }
+
+    pub fn visibility_profile(&self) -> FindingVisibilityProfile {
+        self.visibility_profile
+    }
+}
+
+fn resolve_workspace_root(path: &Path) -> PathBuf {
+    let command_dir = git_command_dir(path);
+    if let Some(root) = git_text(command_dir, &["rev-parse", "--show-toplevel"]) {
+        let root = PathBuf::from(root);
+        return fs::canonicalize(&root).unwrap_or(root);
+    }
+
+    fs::canonicalize(command_dir).unwrap_or_else(|_| command_dir.to_path_buf())
+}
+
+fn capture_workspace_revision(workspace_root: &Path) -> WorkspaceRevision {
+    let mut hasher = Sha256::new();
+    hasher.update(REVISION_SCHEMA.as_bytes());
+    hasher.update(b"\nroot:");
+    hasher.update(workspace_root.to_string_lossy().as_bytes());
+
+    if let Some(head) = git_text(workspace_root, &["rev-parse", "--verify", "HEAD"]) {
+        hasher.update(b"\nsource:git\nhead:");
+        hasher.update(head.as_bytes());
+
+        match git_bytes(workspace_root, &["status", "--porcelain=v1", "-z", "-uall"]) {
+            Some(status) => {
+                let mut entries = status_entries(&status);
+                entries.sort_by(|left, right| {
+                    (&left.path, &left.status, &left.old_path).cmp(&(
+                        &right.path,
+                        &right.status,
+                        &right.old_path,
+                    ))
+                });
+                hash_status_entries(&mut hasher, workspace_root, entries);
+            }
+            None => hasher.update(b"\nstatus:unavailable"),
+        }
+    } else {
+        hasher.update(b"\nsource:filesystem");
+        hash_root_metadata(&mut hasher, workspace_root);
+    }
+
+    WorkspaceRevision {
+        id: hex(&hasher.finalize()),
+    }
+}
+
+fn hash_status_entries(hasher: &mut Sha256, workspace_root: &Path, entries: Vec<StatusEntry>) {
+    for entry in entries {
+        if is_cache_path(&entry.path) {
+            continue;
+        }
+
+        hasher.update(b"\nstatus:");
+        hasher.update(entry.status.as_bytes());
+        hasher.update(b" ");
+        hasher.update(entry.path.as_bytes());
+        if let Some(old_path) = &entry.old_path {
+            hasher.update(b" <- ");
+            hasher.update(old_path.as_bytes());
+        }
+
+        if let Ok(bytes) = fs::read(workspace_root.join(&entry.path)) {
+            hasher.update(b"\nfile:");
+            hasher.update(entry.path.as_bytes());
+            hasher.update(b"\n");
+            hasher.update(bytes);
+        }
+    }
+}
+
+fn hash_root_metadata(hasher: &mut Sha256, workspace_root: &Path) {
+    let Ok(metadata) = fs::metadata(workspace_root) else {
+        hasher.update(b"\nmetadata:unavailable");
+        return;
+    };
+
+    hasher.update(b"\nlen:");
+    hasher.update(metadata.len().to_le_bytes());
+    if let Ok(modified) = metadata.modified()
+        && let Ok(duration) = modified.duration_since(std::time::UNIX_EPOCH)
+    {
+        hasher.update(b"\nmodified:");
+        hasher.update(duration.as_nanos().to_le_bytes());
+    }
+}
+
+fn git_text(path: &Path, args: &[&str]) -> Option<String> {
+    let output = git_bytes(path, args)?;
+    Some(String::from_utf8_lossy(&output).trim().to_string())
+}
+
+fn git_bytes(path: &Path, args: &[&str]) -> Option<Vec<u8>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(git_command_dir(path))
+        .args(args)
+        .output()
+        .ok()?;
+    output.status.success().then_some(output.stdout)
+}
+
+fn git_command_dir(path: &Path) -> &Path {
+    if path.is_file() {
+        path.parent().unwrap_or(path)
+    } else {
+        path
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StatusEntry {
+    status: String,
+    path: String,
+    old_path: Option<String>,
+}
+
+fn status_entries(status: &[u8]) -> Vec<StatusEntry> {
+    let mut parts = status
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty());
+    let mut entries = Vec::new();
+
+    while let Some(raw) = parts.next() {
+        if raw.len() < 4 {
+            continue;
+        }
+
+        let status = String::from_utf8_lossy(&raw[..2]).to_string();
+        let path = String::from_utf8_lossy(&raw[3..]).replace('\\', "/");
+        let old_path = if raw[0] == b'R' || raw[0] == b'C' || raw[1] == b'R' || raw[1] == b'C' {
+            parts
+                .next()
+                .map(|path| String::from_utf8_lossy(path).replace('\\', "/"))
+        } else {
+            None
+        };
+
+        entries.push(StatusEntry {
+            status,
+            path,
+            old_path,
+        });
+    }
+
+    entries
+}
+
+fn is_cache_path(path: &str) -> bool {
+    path == CACHE_DIR
+        || path.starts_with(&format!("{CACHE_DIR}/"))
+        || path.ends_with(&format!("/{CACHE_DIR}"))
+        || path.contains(&format!("/{CACHE_DIR}/"))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn session_owns_path_configuration_and_profile() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().to_path_buf();
+        let mut repo_config = RepoPilotConfig::default();
+        repo_config.architecture.max_file_lines = 777;
+        let scan_config = ScanConfig {
+            large_file_loc_threshold: 777,
+            ..Default::default()
+        };
+
+        let session = AnalysisSession::new(
+            path.clone(),
+            repo_config,
+            scan_config,
+            FindingVisibilityProfile::Strict,
+        );
+
+        assert_eq!(session.analysis_path(), path.as_path());
+        assert_eq!(
+            session.repo_config().architecture.max_file_lines,
+            session.scan_config().large_file_loc_threshold
+        );
+        assert_eq!(
+            session.visibility_profile(),
+            FindingVisibilityProfile::Strict
+        );
+        assert!(!session.revision().id().is_empty());
+    }
+
+    #[test]
+    fn git_revision_is_stable_for_an_unchanged_workspace() {
+        let temp = initialized_git_repo();
+        let first = default_session(temp.path());
+        let second = default_session(temp.path());
+
+        assert_eq!(first.workspace_root(), second.workspace_root());
+        assert_eq!(first.revision(), second.revision());
+    }
+
+    #[test]
+    fn git_revision_changes_when_a_tracked_file_changes() {
+        let temp = initialized_git_repo();
+        let first = default_session(temp.path());
+
+        std::fs::write(temp.path().join("src.txt"), "changed\n").expect("update tracked file");
+        let second = default_session(temp.path());
+
+        assert_ne!(first.revision(), second.revision());
+    }
+
+    #[test]
+    fn cache_files_do_not_change_the_workspace_revision() {
+        let temp = initialized_git_repo();
+        let first = default_session(temp.path());
+
+        let cache = temp.path().join(".repopilot/cache");
+        std::fs::create_dir_all(&cache).expect("create cache directory");
+        std::fs::write(cache.join("entry.json"), "{}").expect("write cache entry");
+        let second = default_session(temp.path());
+
+        assert_eq!(first.revision(), second.revision());
+    }
+
+    fn default_session(path: &Path) -> AnalysisSession {
+        AnalysisSession::new(
+            path.to_path_buf(),
+            RepoPilotConfig::default(),
+            ScanConfig::default(),
+            FindingVisibilityProfile::Default,
+        )
+    }
+
+    fn initialized_git_repo() -> tempfile::TempDir {
+        let temp = tempdir().expect("tempdir");
+        git(temp.path(), &["init", "--quiet"]);
+        git(
+            temp.path(),
+            &["config", "user.email", "repopilot@example.test"],
+        );
+        git(temp.path(), &["config", "user.name", "RepoPilot Test"]);
+        std::fs::write(temp.path().join("src.txt"), "initial\n").expect("write tracked file");
+        git(temp.path(), &["add", "src.txt"]);
+        git(temp.path(), &["commit", "--quiet", "-m", "initial"]);
+        temp
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args(args)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git command failed: {args:?}");
+    }
+}

--- a/src/scan/workspace_scan.rs
+++ b/src/scan/workspace_scan.rs
@@ -3,6 +3,7 @@ use crate::findings::types::Finding;
 use crate::risk::{apply_cluster_overlay, apply_workspace_hotspot_overlay, sort_findings};
 use crate::scan::config::ScanConfig;
 use crate::scan::scanner::scan_path_with_config;
+use crate::scan::session::AnalysisSession;
 use crate::scan::types::{LanguageSummary, ScanDiagnostic, ScanSummary};
 use crate::scan::workspace::{WorkspacePackage, detect_workspace_packages};
 use rayon::prelude::*;
@@ -24,6 +25,23 @@ pub fn scan_workspace_with_config(
                 "--workspace was requested but no workspace packages were found; scanned as a single package",
             )
             .with_path(path),
+        );
+        return Ok(summary);
+    }
+
+    plan.execute()
+}
+
+pub fn scan_workspace_session(session: &AnalysisSession) -> io::Result<ScanSummary> {
+    let plan = WorkspaceScanPlan::detect(session.analysis_path(), session.scan_config());
+    if plan.packages.is_empty() {
+        let mut summary = crate::scan::scanner::scan_session(session)?;
+        summary.artifacts.diagnostics.push(
+            ScanDiagnostic::warning(
+                "workspace.no-packages",
+                "--workspace was requested but no workspace packages were found; scanned as a single package",
+            )
+            .with_path(session.analysis_path()),
         );
         return Ok(summary);
     }


### PR DESCRIPTION
## Summary

Introduce the immutable `AnalysisSession` foundation planned for RepoPilot 0.20.

Each product analysis request now captures one coherent set of inputs:

```text
analysis path
+ resolved workspace root
+ workspace revision
+ repository configuration
+ scan configuration
+ visibility profile
= AnalysisSession
```

Full scans, changed scans, workspace scans, AI context, baseline creation, CLI review, and MCP scan/review/context paths now execute through the same session-owned analysis inputs.

## Type of change

* [ ] Feature
* [x] Refactor
* [x] Tests
* [ ] Bug fix
* [ ] Documentation
* [ ] CI / repository maintenance

## What changed

* Added the internal `scan::session::AnalysisSession`.
* Added a deterministic `WorkspaceRevision` derived from:

  * the current Git `HEAD`;
  * staged, unstaged, and untracked changes;
  * changed file contents;
  * rename and copy source paths.
* Excluded `.repopilot/cache` changes from workspace revision identity.
* Added session-backed entry points for:

  * full repository scans;
  * scans with repository facts;
  * changed scans;
  * already-resolved changed scans;
  * workspace scans.
* Updated product scan orchestration to create exactly one session per request.
* Updated CLI review and MCP review to consume the repository configuration owned by the same analysis session.
* Preserved the existing low-level scan functions and `ScanEngine::new` for compatibility.
* Added focused tests for:

  * session ownership of path, configuration, and visibility;
  * stable revisions for unchanged repositories;
  * revision changes after tracked source edits;
  * cache files not affecting workspace revision identity.
* Updated the unreleased changelog.

## Why

Before this change, scan and review orchestration passed paths, repository configuration, scan configuration, visibility, and resolved Git state through separate parameters.

That made it possible for later incremental-analysis and caching work to accidentally combine inputs captured at different moments.

`AnalysisSession` establishes one immutable ownership boundary for a single analysis pass:

```text
request
→ capture workspace and configuration
→ create AnalysisSession
→ execute scan/review
→ render existing product output
```

This is the required foundation for the next RepoPilot 0.20 milestones:

* shared `ParsedArtifact` and `FactStore`;
* incremental Context Graph v3;
* content-addressed cache v2;
* deterministic analysis handles for MCP.

## Contract and ownership

* [x] The change stays within the scan, review, and product orchestration boundary.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] Existing scan entry points remain available.
* [x] Existing review construction remains available through compatibility entry points.
* [x] No finding or review-signal behavior changed.
* [x] No finding severity, confidence, evidence, provenance, or visibility changed.
* [x] No report or MCP schema changed.
* [x] No unrelated refactor or generated-file churn is included.

## Compatibility

No intentional user-visible behavior changes:

* no CLI command or flag changes;
* no exit-code changes;
* no scan or review report-schema changes;
* no finding-ID changes;
* no baseline matching changes;
* no SARIF changes;
* no MCP tool or input-schema changes;
* no default/strict visibility changes;
* no cache-schema changes.

The new session-backed APIs remain in the documentation-hidden internal scan surface.

## Scope exclusions

This PR intentionally does not implement:

* shared `ParsedArtifact`;
* `FactStore`;
* parse-once migrations;
* incremental Context Graph v3;
* content-addressed cache v2;
* bounded rule scheduling;
* new review signals;
* new MCP tools;
* MCP analysis handles or pagination;
* CLI or report redesign.

Those remain separate RepoPilot 0.20 milestones.

## Changelog

* [x] `CHANGELOG.md` updated.

## Verification

```bash
cargo test scan::session
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run review:performance
npm run scan:performance
npm run release:contract
npm run test:release-contract
git diff --check
```