### PR TITLE
refactor(analysis): add shared ParsedArtifact and FactStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- The scan fact model now acts as a shared `FactStore` and indexes one
+  `ParsedArtifact` per analyzed source file. Artifacts preserve imports,
+  runtime-deferred imports, conservative export facts, file-role evidence, and a
+  compact syntax summary from the same parse-once view used by file audits.
+  Existing findings, output schemas, CLI behavior, baselines, and MCP contracts
+  are unchanged.
 - Scan, review, AI-context, baseline, and MCP analysis requests now execute through
   one immutable `AnalysisSession` that owns the target path, resolved workspace
   root, workspace revision, repository/scan configuration, and visibility profile.

--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -79,13 +79,22 @@ These capabilities are the foundation for the next architecture. The goal is to
 compose and deepen them, not replace working product paths with parallel
 commands.
 
-The first internal implementation steps now exist in `src/facts`: a facts-core
-skeleton, a minimal `ScanFacts -> RepoFacts` bridge, and an internal `RepoFacts`
-summary projection. The bridge currently preserves only repository root, file
-path, language, and non-empty line count. The summary provides aggregate file,
-language, line, and diagnostic counts without exposing raw facts. AI context now
-includes this summary as aggregate evidence; raw `RepoFacts` remain internal and
-are not exposed through scan JSON, review, report schemas, or MCP.
+The shared facts path now has two connected layers:
+
+- `scan::facts::FactStore` remains compatible with the existing `ScanFacts`
+  name while indexing one `ParsedArtifact` per analyzed source file;
+- each source artifact records imports, deferred/runtime-erased imports, detected
+  exports, file-role evidence, framework/runtime/paradigm context, and a compact
+  syntax-tree summary produced from the same parse-once view used by file audits;
+- legacy changed-scan cache hits are represented explicitly as incomplete
+  artifacts rather than pretending cached schema v7 contains syntax/export facts;
+- the public `ScanFacts -> RepoFacts` bridge deliberately remains the minimal
+  root/path/language/line-count projection, so this refactor does not expand the
+  public facts API or any scan JSON, review, SARIF, or MCP contract.
+
+The richer artifact index is currently crate-internal. Cache v2 persistence, rule
+requirements, deliberate public projections, and additional symbol/reference
+facts remain later milestones.
 
 ## What Is Missing
 

--- a/src/analysis/artifact.rs
+++ b/src/analysis/artifact.rs
@@ -1,0 +1,126 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ArtifactOrigin {
+    #[default]
+    Source,
+    LegacyCache,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SyntaxSummary {
+    pub parsed: bool,
+    pub root_kind: Option<String>,
+    pub has_errors: bool,
+    pub named_child_count: usize,
+}
+
+impl SyntaxSummary {
+    pub fn unavailable() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RoleEvidenceFact {
+    pub role: String,
+    pub source: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct FileContextFacts {
+    pub roles: Vec<String>,
+    pub role_evidence: Vec<RoleEvidenceFact>,
+    pub frameworks: Vec<String>,
+    pub runtimes: Vec<String>,
+    pub paradigms: Vec<String>,
+    pub is_test: bool,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ParsedArtifact {
+    pub path: PathBuf,
+    pub language: Option<String>,
+    pub imports: Vec<String>,
+    pub deferred_imports: Vec<String>,
+    pub exports: Vec<String>,
+    pub context: FileContextFacts,
+    pub syntax: SyntaxSummary,
+    pub origin: ArtifactOrigin,
+}
+
+impl ParsedArtifact {
+    pub fn from_source(
+        path: PathBuf,
+        language: Option<String>,
+        imports: Vec<String>,
+        deferred_imports: Vec<String>,
+        exports: Vec<String>,
+        context: FileContextFacts,
+        syntax: SyntaxSummary,
+    ) -> Self {
+        Self {
+            path,
+            language,
+            imports,
+            deferred_imports,
+            exports,
+            context,
+            syntax,
+            origin: ArtifactOrigin::Source,
+        }
+    }
+
+    pub fn from_legacy_cache(
+        path: PathBuf,
+        language: Option<String>,
+        imports: Vec<String>,
+        deferred_imports: Vec<String>,
+        context: FileContextFacts,
+    ) -> Self {
+        Self {
+            path,
+            language,
+            imports,
+            deferred_imports,
+            exports: Vec::new(),
+            context,
+            syntax: SyntaxSummary::unavailable(),
+            origin: ArtifactOrigin::LegacyCache,
+        }
+    }
+
+    pub fn rebase_path(&mut self, path: PathBuf) {
+        self.path = path;
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn is_complete_source_artifact(&self) -> bool {
+        self.origin == ArtifactOrigin::Source
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_cache_artifact_is_explicitly_incomplete() {
+        let artifact = ParsedArtifact::from_legacy_cache(
+            PathBuf::from("src/lib.rs"),
+            Some("Rust".to_string()),
+            vec!["crate::facts".to_string()],
+            Vec::new(),
+            FileContextFacts::default(),
+        );
+
+        assert_eq!(artifact.origin, ArtifactOrigin::LegacyCache);
+        assert!(!artifact.is_complete_source_artifact());
+        assert!(!artifact.syntax.parsed);
+        assert!(artifact.exports.is_empty());
+    }
+}

--- a/src/analysis/exports.rs
+++ b/src/analysis/exports.rs
@@ -1,0 +1,209 @@
+use std::collections::BTreeSet;
+
+pub(crate) fn extract_exports(content: &str, language: Option<&str>) -> Vec<String> {
+    let exports = match language {
+        Some("Rust") => rust_exports(content),
+        Some("TypeScript")
+        | Some("TypeScript React")
+        | Some("JavaScript")
+        | Some("JavaScript React") => javascript_exports(content),
+        Some("Python") => python_exports(content),
+        Some("Go") => go_exports(content),
+        _ => BTreeSet::new(),
+    };
+
+    exports.into_iter().collect()
+}
+
+fn rust_exports(content: &str) -> BTreeSet<String> {
+    let mut exports = BTreeSet::new();
+    const PREFIXES: &[&str] = &[
+        "pub async fn ",
+        "pub fn ",
+        "pub struct ",
+        "pub enum ",
+        "pub trait ",
+        "pub type ",
+        "pub const ",
+        "pub static ",
+        "pub mod ",
+        "pub use ",
+    ];
+
+    for line in content.lines() {
+        let line = line.trim_start();
+        for prefix in PREFIXES {
+            if let Some(rest) = line.strip_prefix(prefix) {
+                if *prefix == "pub use " {
+                    let clean = rest.trim_end_matches(|c: char| c == ';' || c.is_whitespace());
+                    let target = if let Some(as_idx) = clean.rfind(" as ") {
+                        &clean[as_idx + 4..]
+                    } else {
+                        clean.split("::").last().unwrap_or(clean)
+                    };
+                    if let Some(name) = first_identifier(target) {
+                        exports.insert(name.to_string());
+                    }
+                } else {
+                    if let Some(name) = first_identifier(rest) {
+                        exports.insert(name.to_string());
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    exports
+}
+
+fn javascript_exports(content: &str) -> BTreeSet<String> {
+    let mut exports = BTreeSet::new();
+
+    for line in content.lines() {
+        let line = line.trim_start();
+        let Some(rest) = line.strip_prefix("export ") else {
+            continue;
+        };
+
+        if rest.starts_with("default ") {
+            exports.insert("default".to_string());
+            continue;
+        }
+
+        for prefix in [
+            "async function ",
+            "function ",
+            "class ",
+            "const ",
+            "let ",
+            "var ",
+            "type ",
+            "interface ",
+            "enum ",
+            "namespace ",
+        ] {
+            if let Some(value) = rest.strip_prefix(prefix) {
+                if let Some(name) = first_identifier(value) {
+                    exports.insert(name.to_string());
+                }
+                continue;
+            }
+        }
+
+        if let Some(open) = rest.find('{')
+            && let Some(close) = rest[open + 1..].find('}')
+        {
+            let list = &rest[open + 1..open + 1 + close];
+            for item in list.split(',') {
+                let item = item.trim().trim_start_matches("type ").trim();
+                if item.is_empty() {
+                    continue;
+                }
+                let name = item
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .windows(2)
+                    .find_map(|parts| (parts[0] == "as").then_some(parts[1]))
+                    .or_else(|| item.split_whitespace().next());
+                if let Some(name) = name.and_then(first_identifier) {
+                    exports.insert(name.to_string());
+                }
+            }
+        }
+    }
+
+    exports
+}
+
+fn python_exports(content: &str) -> BTreeSet<String> {
+    let mut exports = BTreeSet::new();
+
+    for line in content.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("__all__") else {
+            continue;
+        };
+        let Some((_, value)) = rest.split_once('=') else {
+            continue;
+        };
+
+        for item in value.split(',') {
+            let name = item
+                .trim()
+                .trim_matches(|ch| matches!(ch, '[' | ']' | '(' | ')' | '"' | '\''));
+            if is_identifier(name) {
+                exports.insert(name.to_string());
+            }
+        }
+    }
+
+    exports
+}
+
+fn go_exports(content: &str) -> BTreeSet<String> {
+    let mut exports = BTreeSet::new();
+
+    for line in content.lines() {
+        let line = line.trim_start();
+        for prefix in ["func ", "type ", "var ", "const "] {
+            let Some(rest) = line.strip_prefix(prefix) else {
+                continue;
+            };
+            let rest = rest.trim_start_matches('(').trim_start();
+            if let Some(name) = first_identifier(rest)
+                && name.chars().next().is_some_and(char::is_uppercase)
+            {
+                exports.insert(name.to_string());
+            }
+        }
+    }
+
+    exports
+}
+
+fn first_identifier(value: &str) -> Option<&str> {
+    let value = value.trim_start_matches(|ch: char| !ch.is_ascii_alphabetic() && ch != '_');
+    let end = value
+        .find(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_')
+        .unwrap_or(value.len());
+    let identifier = &value[..end];
+    is_identifier(identifier).then_some(identifier)
+}
+
+fn is_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    chars
+        .next()
+        .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_rust_public_items_deterministically() {
+        let source =
+            "pub struct User;\npub fn load() {}\nfn hidden() {}\npub use crate::api::Client;\n";
+        assert_eq!(
+            extract_exports(source, Some("Rust")),
+            vec!["Client", "User", "load"]
+        );
+    }
+
+    #[test]
+    fn extracts_javascript_named_and_default_exports() {
+        let source = "export const value = 1;\nexport { thing as renamed, type Shape };\nexport default function App() {}\n";
+        assert_eq!(
+            extract_exports(source, Some("TypeScript")),
+            vec!["Shape", "default", "renamed", "value"]
+        );
+    }
+
+    #[test]
+    fn unsupported_language_has_no_guessed_exports() {
+        assert!(extract_exports("class Main {}", Some("Ruby")).is_empty());
+    }
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,7 +1,10 @@
+pub(crate) mod artifact;
+pub(crate) mod exports;
 mod model;
 #[doc(hidden)]
 pub mod parse;
 pub mod path_classifier;
 
+pub(crate) use artifact::{FileContextFacts, ParsedArtifact, RoleEvidenceFact, SyntaxSummary};
 pub use model::{ArchitectureContext, FileRole, LanguageFamily, ModuleKind};
 pub use path_classifier::{ArchitectureClassifier, classify_file_architecture};

--- a/src/analysis/parse.rs
+++ b/src/analysis/parse.rs
@@ -5,6 +5,7 @@
 //! thread keeps one reusable parser per grammar via `thread_local!`, so parsing
 //! is cheap to repeat and safe under the parallel file pipeline.
 
+use crate::analysis::SyntaxSummary;
 use crate::scan::facts::FileFacts;
 use std::cell::{OnceCell, RefCell};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -169,6 +170,20 @@ impl<'a> ParsedFile<'a> {
             })
             .as_ref()
     }
+
+    pub(crate) fn syntax_summary(&self) -> SyntaxSummary {
+        let Some(tree) = self.tree() else {
+            return SyntaxSummary::unavailable();
+        };
+        let root = tree.root_node();
+
+        SyntaxSummary {
+            parsed: true,
+            root_kind: Some(root.kind().to_string()),
+            has_errors: root.has_error(),
+            named_child_count: root.named_child_count(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -259,6 +274,22 @@ mod tests {
     fn parsed_file_without_grammar_has_no_tree() {
         assert!(ParsedFile::new("class Main", Some("Ruby")).tree().is_none());
         assert!(ParsedFile::new("anything", None).tree().is_none());
+    }
+
+    #[test]
+    fn syntax_summary_reuses_the_same_cached_tree() {
+        let parsed = ParsedFile::new(
+            "use crate::facts;
+fn main() {}",
+            Some("Rust"),
+        );
+        let first = parsed.tree().expect("tree") as *const Tree;
+        let summary = parsed.syntax_summary();
+        let second = parsed.tree().expect("same tree") as *const Tree;
+
+        assert_eq!(first, second);
+        assert!(summary.parsed);
+        assert_eq!(summary.root_kind.as_deref(), Some("source_file"));
     }
 
     #[test]

--- a/src/facts/from_scan.rs
+++ b/src/facts/from_scan.rs
@@ -9,7 +9,8 @@ pub fn repo_facts_from_scan(scan: &ScanFacts) -> RepoFacts {
             path: file.path.clone(),
             language: file.language.clone(),
             non_empty_lines: file.non_empty_lines,
-            // Scan facts combine filesystem metadata with detected and analyzed facts.
+            // Keep the public facts projection stable. Rich ParsedArtifact data
+            // remains crate-internal until a deliberate public contract is added.
             source: FactSource::Mixed,
             confidence: FactConfidence::High,
         })
@@ -67,5 +68,37 @@ mod tests {
         assert_eq!(facts.files[0].source, FactSource::Mixed);
         assert_eq!(facts.files[0].confidence, FactConfidence::High);
         assert!(facts.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn internal_artifacts_do_not_expand_the_public_file_fact_contract() {
+        use crate::analysis::{FileContextFacts, ParsedArtifact, SyntaxSummary};
+
+        let mut scan = ScanFacts {
+            root_path: PathBuf::from("/repo"),
+            files: vec![FileFacts {
+                path: PathBuf::from("/repo/src/lib.rs"),
+                language: Some("Rust".to_string()),
+                non_empty_lines: 12,
+                ..FileFacts::default()
+            }],
+            ..ScanFacts::default()
+        };
+        scan.insert_artifact(ParsedArtifact::from_source(
+            PathBuf::from("/repo/src/lib.rs"),
+            Some("Rust".to_string()),
+            vec!["crate::internal".to_string()],
+            Vec::new(),
+            vec!["run".to_string()],
+            FileContextFacts::default(),
+            SyntaxSummary::default(),
+        ));
+
+        let facts = repo_facts_from_scan(&scan);
+
+        assert_eq!(facts.files.len(), 1);
+        assert_eq!(facts.files[0].path, PathBuf::from("/repo/src/lib.rs"));
+        assert_eq!(facts.files[0].language.as_deref(), Some("Rust"));
+        assert_eq!(facts.files[0].non_empty_lines, 12);
     }
 }

--- a/src/scan/facts.rs
+++ b/src/scan/facts.rs
@@ -1,10 +1,12 @@
+use crate::analysis::ParsedArtifact;
 use crate::frameworks::DetectedFramework;
 use crate::frameworks::FrameworkProject;
 use crate::frameworks::ReactNativeArchitectureProfile;
 use crate::scan::types::LanguageSummary;
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ScanFacts {
@@ -19,12 +21,29 @@ pub struct ScanFacts {
     pub skipped_bytes: u64,
     pub languages: Vec<LanguageSummary>,
     pub files: Vec<FileFacts>,
+    pub artifacts: BTreeMap<PathBuf, ParsedArtifact>,
     pub detected_frameworks: Vec<DetectedFramework>,
     pub framework_projects: Vec<FrameworkProject>,
     pub react_native: Option<ReactNativeArchitectureProfile>,
     pub files_skipped_by_limit: usize,
     pub files_skipped_repopilotignore: usize,
     pub repopilotignore_path: Option<PathBuf>,
+}
+
+pub type FactStore = ScanFacts;
+
+impl ScanFacts {
+    pub fn insert_artifact(&mut self, artifact: ParsedArtifact) {
+        self.artifacts.insert(artifact.path.clone(), artifact);
+    }
+
+    pub fn artifact(&self, path: &Path) -> Option<&ParsedArtifact> {
+        self.artifacts.get(path)
+    }
+
+    pub fn artifacts(&self) -> impl Iterator<Item = &ParsedArtifact> {
+        self.artifacts.values()
+    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -64,5 +83,38 @@ impl FileContentProvider {
         }
 
         fs::read_to_string(&file.path).ok().map(Cow::Owned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::{FileContextFacts, SyntaxSummary};
+
+    #[test]
+    fn fact_store_indexes_artifacts_by_path() {
+        let mut store = FactStore::default();
+        let artifact = ParsedArtifact::from_source(
+            PathBuf::from("src/lib.rs"),
+            Some("Rust".to_string()),
+            vec!["crate::facts".to_string()],
+            Vec::new(),
+            vec!["run".to_string()],
+            FileContextFacts::default(),
+            SyntaxSummary {
+                parsed: true,
+                root_kind: Some("source_file".to_string()),
+                has_errors: false,
+                named_child_count: 2,
+            },
+        );
+
+        store.insert_artifact(artifact);
+
+        let stored = store
+            .artifact(Path::new("src/lib.rs"))
+            .expect("artifact should be indexed");
+        assert_eq!(stored.exports, vec!["run"]);
+        assert_eq!(store.artifacts().count(), 1);
     }
 }

--- a/src/scan/scanner/changed/file_analysis.rs
+++ b/src/scan/scanner/changed/file_analysis.rs
@@ -5,6 +5,7 @@ use super::super::changed_telemetry::{change_status_label, record_skipped_cache_
 use super::super::file::{SkipReason, process_file_with_content};
 use super::super::summary::build_language_summary;
 use super::{ChangedDiscoveryStage, ChangedFileAnalysisStage, ChangedScanEngine};
+use crate::analysis::{FileContextFacts, ParsedArtifact, RoleEvidenceFact};
 use crate::audits::pipeline::build_file_audits;
 use crate::findings::types::Finding;
 use crate::review::diff::{ChangeStatus, ChangedFile};
@@ -186,6 +187,9 @@ impl<'a> ChangedScanEngine<'a> {
             &mut per_file.findings,
             repo_root,
         );
+        if let Some(artifact) = &mut per_file.artifact {
+            artifact.rebase_path(per_file.file_facts.path.clone());
+        }
 
         match per_file.skip_reason {
             SkipReason::None => {
@@ -195,7 +199,8 @@ impl<'a> ChangedScanEngine<'a> {
                     *languages.entry(language.clone()).or_insert(0) += 1;
                 }
 
-                if let Some(context) = per_file.context {
+                if let Some(artifact) = per_file.artifact.as_ref() {
+                    let context = &artifact.context;
                     cache.file_roles.insert(
                         cache_path.clone(),
                         FileRoleEntry {
@@ -205,19 +210,19 @@ impl<'a> ChangedScanEngine<'a> {
                             non_empty_lines: per_file.file_facts.non_empty_lines,
                             imports: per_file.file_facts.imports.clone(),
                             deferred_imports: per_file.file_facts.deferred_imports.clone(),
-                            roles: context.roles,
+                            roles: context.roles.clone(),
                             role_evidence: context
                                 .role_evidence
-                                .into_iter()
+                                .iter()
                                 .map(|evidence| FileRoleEvidenceEntry {
-                                    role: evidence.role,
-                                    source: evidence.source,
-                                    reason: evidence.reason,
+                                    role: evidence.role.clone(),
+                                    source: evidence.source.clone(),
+                                    reason: evidence.reason.clone(),
                                 })
                                 .collect(),
-                            frameworks: context.frameworks,
-                            runtimes: context.runtimes,
-                            paradigms: context.paradigms,
+                            frameworks: context.frameworks.clone(),
+                            runtimes: context.runtimes.clone(),
+                            paradigms: context.paradigms.clone(),
                             is_test: context.is_test,
                         },
                     );
@@ -237,6 +242,9 @@ impl<'a> ChangedScanEngine<'a> {
                 graph_file.content = None;
                 graph_patch_files.push(graph_file);
 
+                if let Some(artifact) = per_file.artifact {
+                    facts.insert_artifact(artifact);
+                }
                 facts.files.push(per_file.file_facts);
                 findings.extend(per_file.findings);
             }
@@ -287,7 +295,30 @@ impl<'a> ChangedScanEngine<'a> {
         cached_findings: Vec<Finding>,
     ) {
         let reuse_start = Instant::now();
+        let artifact = ParsedArtifact::from_legacy_cache(
+            PathBuf::from(&role_entry.path),
+            role_entry.language.clone(),
+            role_entry.imports.clone(),
+            role_entry.deferred_imports.clone(),
+            FileContextFacts {
+                roles: role_entry.roles.clone(),
+                role_evidence: role_entry
+                    .role_evidence
+                    .iter()
+                    .map(|evidence| RoleEvidenceFact {
+                        role: evidence.role.clone(),
+                        source: evidence.source.clone(),
+                        reason: evidence.reason.clone(),
+                    })
+                    .collect(),
+                frameworks: role_entry.frameworks.clone(),
+                runtimes: role_entry.runtimes.clone(),
+                paradigms: role_entry.paradigms.clone(),
+                is_test: role_entry.is_test,
+            },
+        );
         let mut graph_file = record_cached_file(facts, languages, &role_entry);
+        facts.insert_artifact(artifact);
         graph_file.content = None;
         graph_patch_files.push(graph_file);
         findings.extend(cached_findings);

--- a/src/scan/scanner/collection.rs
+++ b/src/scan/scanner/collection.rs
@@ -104,6 +104,9 @@ pub(super) fn analyze_discovered_files(
             }
             SkipReason::None => {}
         }
+        if let Some(artifact) = per_file.artifact {
+            facts.insert_artifact(artifact);
+        }
         facts.files.push(per_file.file_facts);
         findings.extend(per_file.findings);
     }

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -1,4 +1,6 @@
+use crate::analysis::exports::extract_exports;
 use crate::analysis::parse::ParsedFile;
+use crate::analysis::{FileContextFacts, ParsedArtifact, RoleEvidenceFact};
 use crate::audits::code_quality::complexity::count_branches;
 use crate::audits::context::classify_file_with_evidence;
 use crate::audits::traits::FileAudit;
@@ -18,26 +20,9 @@ pub(super) struct PerFileResult {
     pub(super) file_facts: FileFacts,
     pub(super) findings: Vec<Finding>,
     pub(super) language: Option<String>,
-    pub(super) context: Option<PerFileContext>,
+    pub(super) artifact: Option<ParsedArtifact>,
     pub(super) skip_reason: SkipReason,
     pub(super) skipped_bytes: u64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct PerFileContext {
-    pub(super) roles: Vec<String>,
-    pub(super) role_evidence: Vec<PerFileRoleEvidence>,
-    pub(super) frameworks: Vec<String>,
-    pub(super) runtimes: Vec<String>,
-    pub(super) paradigms: Vec<String>,
-    pub(super) is_test: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct PerFileRoleEvidence {
-    pub(super) role: String,
-    pub(super) source: String,
-    pub(super) reason: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -227,9 +212,9 @@ fn process_file_inner(
         return Ok(skipped_result_from_loaded(path, loaded));
     };
 
-    let context = PerFileContext::from_file(&full_facts);
+    let context = file_context_facts(&full_facts);
     let mut findings = Vec::new();
-    let (imports, deferred_imports) = {
+    let (imports, deferred_imports, exports, syntax) = {
         // Parse the file at most once and share the syntax tree across both
         // import extraction and every audit. Scoped so the borrow of
         // `full_facts` ends before the import lists are written back and it is moved.
@@ -237,13 +222,24 @@ fn process_file_inner(
         let lang = full_facts.language.as_deref();
         let imports = extract_imports_from(&parsed, lang);
         let deferred_imports = extract_deferred_imports_from(&parsed, lang);
+        let exports = extract_exports(parsed.content(), lang);
         for audit in file_audits {
             findings.extend(audit.audit_parsed(&full_facts, &parsed, config));
         }
-        (imports, deferred_imports)
+        let syntax = parsed.syntax_summary();
+        (imports, deferred_imports, exports, syntax)
     };
     full_facts.imports = imports;
     full_facts.deferred_imports = deferred_imports;
+    let artifact = ParsedArtifact::from_source(
+        full_facts.path.clone(),
+        full_facts.language.clone(),
+        full_facts.imports.clone(),
+        full_facts.deferred_imports.clone(),
+        exports,
+        context,
+        syntax,
+    );
 
     Ok(PerFileResult {
         file_facts: if retain_content {
@@ -253,7 +249,7 @@ fn process_file_inner(
         },
         findings,
         language,
-        context: Some(context),
+        artifact: Some(artifact),
         skip_reason: SkipReason::None,
         skipped_bytes: 0,
     })
@@ -275,18 +271,31 @@ pub(super) fn collect_file_facts(
     // No audits run on this path, so the parse view is built solely to extract
     // imports; it is still parsed at most once via the shared parsers. Bind the
     // result first so the view's borrow of `full_facts` ends before the write.
-    let (imports, deferred_imports) = {
+    let context = file_context_facts(&full_facts);
+    let (imports, deferred_imports, exports, syntax) = {
         let parsed = ParsedFile::for_facts(&full_facts);
         let lang = full_facts.language.as_deref();
         (
             extract_imports_from(&parsed, lang),
             extract_deferred_imports_from(&parsed, lang),
+            extract_exports(parsed.content(), lang),
+            parsed.syntax_summary(),
         )
     };
     full_facts.imports = imports;
     full_facts.deferred_imports = deferred_imports;
+    let artifact = ParsedArtifact::from_source(
+        full_facts.path.clone(),
+        full_facts.language.clone(),
+        full_facts.imports.clone(),
+        full_facts.deferred_imports.clone(),
+        exports,
+        context,
+        syntax,
+    );
 
     record_analyzed_file(facts, languages, &full_facts);
+    facts.insert_artifact(artifact);
     facts.files.push(full_facts);
 
     Ok(())
@@ -359,44 +368,43 @@ fn skipped_result(
         file_facts: empty_file_facts(path, language.clone()),
         findings: Vec::new(),
         language,
-        context: None,
+        artifact: None,
         skip_reason,
         skipped_bytes,
     }
 }
 
-impl PerFileContext {
-    fn from_file(file: &FileFacts) -> Self {
-        let classified = classify_file_with_evidence(file);
-        let context = classified.context;
-        Self {
-            roles: context.role_ids().into_iter().map(str::to_string).collect(),
-            role_evidence: classified
-                .role_evidence
-                .into_iter()
-                .map(|evidence| PerFileRoleEvidence {
-                    role: evidence.role.as_id().to_string(),
-                    source: evidence.source.as_id().to_string(),
-                    reason: evidence.reason.to_string(),
-                })
-                .collect(),
-            frameworks: context
-                .framework_ids()
-                .into_iter()
-                .map(str::to_string)
-                .collect(),
-            runtimes: context
-                .runtime_ids()
-                .into_iter()
-                .map(str::to_string)
-                .collect(),
-            paradigms: context
-                .paradigm_ids()
-                .into_iter()
-                .map(str::to_string)
-                .collect(),
-            is_test: context.is_test,
-        }
+fn file_context_facts(file: &FileFacts) -> FileContextFacts {
+    let classified = classify_file_with_evidence(file);
+    let context = classified.context;
+
+    FileContextFacts {
+        roles: context.role_ids().into_iter().map(str::to_string).collect(),
+        role_evidence: classified
+            .role_evidence
+            .into_iter()
+            .map(|evidence| RoleEvidenceFact {
+                role: evidence.role.as_id().to_string(),
+                source: evidence.source.as_id().to_string(),
+                reason: evidence.reason.to_string(),
+            })
+            .collect(),
+        frameworks: context
+            .framework_ids()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        runtimes: context
+            .runtime_ids()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        paradigms: context
+            .paradigm_ids()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        is_test: context.is_test,
     }
 }
 


### PR DESCRIPTION
## Summary

Add the shared `ParsedArtifact` and `FactStore` foundation for RepoPilot 0.20.

The existing `ScanFacts` model remains compatible with current consumers while gaining an internal deterministic artifact index for analyzed files.

```text
source file
→ one shared ParsedFile
→ imports + deferred imports + exports + syntax summary
→ file-role and runtime context
→ ParsedArtifact
→ FactStore
→ existing audits, graph, findings, and product outputs
```

## Type of change

* [ ] Feature
* [x] Refactor
* [x] Tests
* [x] Documentation
* [ ] Bug fix
* [ ] CI / repository maintenance

## What changed

* Added an internal `ParsedArtifact` model containing:

  * normalized file path;
  * detected language;
  * imports;
  * deferred or runtime-erased imports;
  * conservative exported-symbol facts;
  * file roles and role evidence;
  * framework, runtime, and paradigm context;
  * test-file classification;
  * compact tree-sitter syntax summary;
  * explicit source or legacy-cache origin.
* Added `FactStore` as a compatible name for the existing `ScanFacts` model.
* Added a deterministic `BTreeMap` artifact index keyed by file path.
* Reused the existing lazy `ParsedFile` for:

  * import extraction;
  * AST-based audits;
  * syntax-tree summary generation.
* Added conservative export extraction for:

  * Rust;
  * TypeScript and JavaScript;
  * Python `__all__`;
  * exported Go identifiers.
* Updated the full-scan collection path to register artifacts.
* Updated retained-content and changed-scan paths to register artifacts.
* Rebased changed-file artifact paths to the same normalized paths used by scan facts and cache entries.
* Reconstructed legacy cache hits as explicitly incomplete artifacts:

  * cached imports and context are retained;
  * syntax and export facts are not invented;
  * the existing cache schema remains unchanged.
* Kept the public `RepoFacts` and `FileFact` contract unchanged.
* Added a regression test confirming that internal artifacts do not expand the public facts projection.
* Updated the analysis-platform documentation and unreleased changelog.

## Why

RepoPilot already created a shared lazy syntax-tree view during file analysis, but the results were distributed across:

* `FileFacts`;
* private per-file context;
* changed-scan cache entries;
* import extraction;
* the minimal `RepoFacts` bridge.

That made later analysis stages depend on several partially overlapping representations of the same source file.

This PR creates one internal artifact contract that can be reused by future engine work without changing current findings or product outputs.

It establishes the foundation for:

* declarative rule inputs;
* incremental Context Graph v3;
* content-addressed cache v2;
* richer impact analysis;
* deterministic MCP analysis handles.

## Architecture

### Source analysis

A source file is read once and analyzed through one shared `ParsedFile` view:

```text
FileFacts with source content
→ ParsedFile
→ imports
→ deferred imports
→ file audits
→ syntax summary
→ ParsedArtifact
```

Tree-sitter is still lazy and is materialized only when a consumer needs it.

### Legacy cache compatibility

The current changed-scan cache does not store syntax trees or export facts.

Cache hits therefore produce an artifact with:

```text
origin = LegacyCache
syntax.parsed = false
exports = []
```

This preserves existing cached imports, roles, evidence, framework, runtime, and paradigm context without pretending the cache contains facts it never stored.

### Public API boundary

The richer artifact model remains crate-internal.

The public facts projection remains:

```text
root
file path
language
non-empty line count
fact source
fact confidence
```

No internal artifact types are re-exported through the public `facts` module.

## Contract and ownership

* [x] The change stays within analysis, scan, and facts ownership boundaries.
* [x] Existing file and project audit interfaces remain compatible.
* [x] Public `RepoFacts` and `FileFact` remain compatible.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] No finding IDs changed.
* [x] No severity, confidence, evidence, provenance, or visibility behavior changed.
* [x] No report schema changed.
* [x] No MCP input or output schema changed.
* [x] No cache schema version changed.
* [x] Legacy cache limitations are represented explicitly.
* [x] No unrelated refactor or generated-file churn is included.

## Scope exclusions

This PR intentionally does not implement:

* rule capability declarations;
* rule dependency scheduling;
* new findings or review signals;
* symbol and reference resolution;
* incremental Context Graph v3;
* content-addressed cache v2;
* artifact persistence in the cache;
* public facts-schema expansion;
* report-schema changes;
* MCP handles or pagination;
* scheduler or parallelism changes.

These remain separate RepoPilot 0.20 milestones.

## Changelog

* [x] `CHANGELOG.md` updated.

## Verification

```bash
cargo fmt --all -- --check
cargo check --all-targets --all-features
cargo test analysis::artifact
cargo test analysis::exports
cargo test analysis::parse
cargo test facts
cargo test scan::facts
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run review:performance
npm run scan:performance
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```
