### PR TITLE
refactor(rules): declare scope, inputs, lifecycle and cache policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Every registered rule now declares an internal `RuleRequirements` contract covering execution scope, required fact kinds, lifecycle, cache policy, and produced output. The generated rules reference and rule catalog expose the summary, while findings and scheduler behavior remain unchanged.
 - The scan fact model now acts as a shared `FactStore` and indexes one
   `ParsedArtifact` per analyzed source file. Artifacts preserve imports,
   runtime-deferred imports, conservative export facts, file-role evidence, and a

--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -66,7 +66,7 @@ RepoPilot already provides:
 - `ScanFacts` and `FileFacts` as structured scan inputs;
 - shared parse-once tree-sitter parsing;
 - import extraction and graph-related logic;
-- rule metadata and a rule lifecycle;
+- rule metadata, lifecycle, and explicit scope/fact/cache requirements;
 - a finding contract with evidence, confidence, severity, provenance, and risk;
 - explainable risk scoring;
 - local feedback and suppressions;

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -13,6 +13,10 @@ RepoPilot ships 52 rules across 5 categories. Every finding traces back to one o
 - **Confidence:** LOW
 - **Lifecycle:** experimental
 - **Signal source:** text-heuristic
+- **Execution scope:** repository
+- **Required facts:** file-metadata, file-content, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 An index file re-exports many modules or relies heavily on wildcard exports. Large barrel files can become unstable module hubs and make dependency boundaries harder to understand.
 
@@ -24,6 +28,10 @@ An index file re-exports many modules or relies heavily on wildcard exports. Lar
 - **Confidence:** HIGH
 - **Lifecycle:** stable
 - **Signal source:** import-graph
+- **Execution scope:** repository
+- **Required facts:** imports, exports, file-context, dependency-graph, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 Two or more files import each other, forming a cycle. Circular dependencies make build order undefined, complicate testing, and prevent dead-code elimination.
 
@@ -39,6 +47,10 @@ Two or more files import each other, forming a cycle. Circular dependencies make
 - **Confidence:** HIGH
 - **Lifecycle:** experimental
 - **Signal source:** import-graph
+- **Execution scope:** repository
+- **Required facts:** imports, exports, file-context, dependency-graph, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 This production file is not imported by any other project file and is not a known entrypoint. It may be dead code.
 
@@ -52,6 +64,10 @@ This production file is not imported by any other project file and is not a know
 - **Confidence:** MEDIUM
 - **Lifecycle:** experimental
 - **Signal source:** text-heuristic
+- **Execution scope:** repository
+- **Required facts:** file-metadata, file-content, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A file is nested deeply within the directory structure. Deep directory nesting makes the codebase harder to navigate, import from, and maintain.
 
@@ -63,6 +79,10 @@ A file is nested deeply within the directory structure. Deep directory nesting m
 - **Confidence:** MEDIUM
 - **Lifecycle:** preview
 - **Signal source:** text-heuristic
+- **Execution scope:** repository
+- **Required facts:** file-metadata, file-content, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A source file imports across three or more parent directories. Deep relative imports are fragile during refactors and often indicate missing module boundaries or aliases.
 
@@ -74,6 +94,10 @@ A source file imports across three or more parent directories. Deep relative imp
 - **Confidence:** HIGH
 - **Lifecycle:** stable
 - **Signal source:** import-graph
+- **Execution scope:** repository
+- **Required facts:** imports, exports, file-context, dependency-graph, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 This file depends on an unusually large number of other internal modules, making it a fragile integration point that breaks whenever any dependency changes.
 
@@ -89,6 +113,10 @@ This file depends on an unusually large number of other internal modules, making
 - **Confidence:** HIGH
 - **Lifecycle:** stable
 - **Signal source:** import-graph
+- **Execution scope:** repository
+- **Required facts:** imports, exports, file-context, dependency-graph, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 This file is both widely imported (high fan-in) and depends on many other modules (high fan-out). Changes here ripple across the codebase with no stable upstream to absorb them.
 
@@ -104,6 +132,10 @@ This file is both widely imported (high fan-in) and depends on many other module
 - **Confidence:** MEDIUM
 - **Lifecycle:** experimental
 - **Signal source:** text-heuristic
+- **Execution scope:** file
+- **Required facts:** file-metadata, file-content
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 This file has more lines of code than the configured threshold. Large files accumulate responsibilities over time and make navigation and testing harder.
 
@@ -115,6 +147,10 @@ This file has more lines of code than the configured threshold. Large files accu
 - **Confidence:** HIGH
 - **Lifecycle:** experimental
 - **Signal source:** import-graph
+- **Execution scope:** repository
+- **Required facts:** imports, exports, file-context, dependency-graph, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A module imports another module from a higher layer than its own, against the order declared in `[[architecture.layers]]`. Opt-in: emits nothing unless layers are configured.
 
@@ -126,6 +162,10 @@ A module imports another module from a higher layer than its own, against the or
 - **Confidence:** MEDIUM
 - **Lifecycle:** experimental
 - **Signal source:** import-graph
+- **Execution scope:** repository
+- **Required facts:** imports, exports, file-context, dependency-graph, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A file imports a private module from another package instead of using its public API. Auto-enabled on a detected npm/pnpm/Cargo/Go workspace; can also be driven explicitly with `[architecture] package_roots`.
 
@@ -139,6 +179,10 @@ A file imports a private module from another package instead of using its public
 - **Confidence:** HIGH
 - **Lifecycle:** experimental
 - **Signal source:** import-graph
+- **Execution scope:** repository
+- **Required facts:** imports, exports, file-context, dependency-graph, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A production module imports a test or fixture module.
 
@@ -150,6 +194,10 @@ A production module imports a test or fixture module.
 - **Confidence:** MEDIUM
 - **Lifecycle:** experimental
 - **Signal source:** text-heuristic
+- **Execution scope:** repository
+- **Required facts:** file-metadata, file-content, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A directory contains more files than the configured threshold, suggesting it may need to be broken into sub-packages.
 
@@ -163,6 +211,10 @@ A directory contains more files than the configured threshold, suggesting it may
 - **Confidence:** LOW
 - **Lifecycle:** experimental
 - **Signal source:** text-heuristic
+- **Execution scope:** file
+- **Required facts:** file-metadata, file-content
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 A FIXME comment marks known broken or problematic code that has not yet been addressed.
 
@@ -174,6 +226,10 @@ A FIXME comment marks known broken or problematic code that has not yet been add
 - **Confidence:** LOW
 - **Lifecycle:** experimental
 - **Signal source:** text-heuristic
+- **Execution scope:** file
+- **Required facts:** file-metadata, file-content
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 A HACK comment marks a workaround that bypasses a proper solution. Hacks tend to become permanent and break under refactoring.
 
@@ -185,6 +241,10 @@ A HACK comment marks a workaround that bypasses a proper solution. Hacks tend to
 - **Confidence:** LOW
 - **Lifecycle:** experimental
 - **Signal source:** text-heuristic
+- **Execution scope:** file
+- **Required facts:** file-metadata, file-content
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 A TODO comment marks unfinished work. Unresolved TODOs accumulate as technical debt if not tracked in an issue tracker.
 
@@ -196,6 +256,10 @@ A TODO comment marks unfinished work. Unresolved TODOs accumulate as technical d
 - **Confidence:** MEDIUM
 - **Lifecycle:** preview
 - **Signal source:** text-heuristic
+- **Execution scope:** file
+- **Required facts:** file-metadata, file-content
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 The file's branch count density exceeds the complexity threshold, indicating too many execution paths. High complexity increases the defect rate and testing burden.
 
@@ -207,6 +271,10 @@ The file's branch count density exceeds the complexity threshold, indicating too
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** file
+- **Required facts:** file-metadata, parsed-syntax, file-context
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 A function's control flow is deeply nested or branch-heavy, measured by a cognitive-complexity score that weights nesting depth rather than counting branches flatly. Deeply nested logic is disproportionately hard to read, test, and change.
 
@@ -220,6 +288,10 @@ A function's control flow is deeply nested or branch-heavy, measured by a cognit
 - **Confidence:** MEDIUM
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** file
+- **Required facts:** file-metadata, parsed-syntax, file-context
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 A source file contains deeply nested control flow blocks (if, loops, match, try). High nesting depth makes code hard to read, maintain, and test.
 
@@ -231,6 +303,10 @@ A source file contains deeply nested control flow blocks (if, loops, match, try)
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** file
+- **Required facts:** file-metadata, parsed-syntax, file-context
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 A function is longer than the configured line threshold. Long functions are harder to test, understand, and safely refactor.
 
@@ -244,6 +320,10 @@ A function is longer than the configured line threshold. Long functions are hard
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** file
+- **Required facts:** file-metadata, parsed-syntax, file-context
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 Go panic and process-exit operations can terminate the program abruptly. Their risk depends on whether the file is test code, CLI boundary code, library code, or domain code.
 
@@ -257,6 +337,10 @@ Go panic and process-exit operations can terminate the program abruptly. Their r
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** file
+- **Required facts:** file-metadata, parsed-syntax, file-context
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 A `process.exit(...)` call terminates the host process, which is expected at a CLI boundary but unsafe in reusable browser, Node, or package code.
 
@@ -270,6 +354,10 @@ A `process.exit(...)` call terminates the host process, which is expected at a C
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** file
+- **Required facts:** file-metadata, parsed-syntax, file-context
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 Generic fatal exceptions and not-implemented placeholders in Java, Kotlin, or C# domain/library code can become runtime failures that callers cannot handle precisely.
 
@@ -283,6 +371,10 @@ Generic fatal exceptions and not-implemented placeholders in Java, Kotlin, or C#
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** file
+- **Required facts:** file-metadata, parsed-syntax, file-context
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 A broad `except:` handler can hide unrelated failures. `assert` (often type-narrowing or an internal invariant) and `raise NotImplementedError` (usually an abstract-method declaration) are overwhelmingly intentional, so they are kept low and surface only under the strict profile.
 
@@ -296,6 +388,10 @@ A broad `except:` handler can hide unrelated failures. `assert` (often type-narr
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** file
+- **Required facts:** file-metadata, parsed-syntax, file-context
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 Rust panic-style operations such as unwrap(), expect(), panic!, todo!, and unimplemented! can be risky in reusable production code. Their severity depends on whether the code is test code, CLI boundary code, library code, or domain code.
 
@@ -311,6 +407,10 @@ Rust panic-style operations such as unwrap(), expect(), panic!, todo!, and unimp
 - **Confidence:** MEDIUM
 - **Lifecycle:** experimental
 - **Signal source:** text-heuristic
+- **Execution scope:** repository
+- **Required facts:** file-metadata, file-content, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 The project has no recognisable test directory (tests/, __tests__, spec/). Without tests, correctness can only be verified manually.
 
@@ -322,6 +422,10 @@ The project has no recognisable test directory (tests/, __tests__, spec/). Witho
 - **Confidence:** LOW
 - **Lifecycle:** experimental
 - **Signal source:** text-heuristic
+- **Execution scope:** repository
+- **Required facts:** file-metadata, file-content, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A source file has no matching test file. Untested code is more likely to regress during refactoring.
 
@@ -335,6 +439,10 @@ A source file has no matching test file. Untested code is more likely to regress
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** config-file
+- **Execution scope:** framework-project
+- **Required facts:** config-file, framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 Django DEBUG mode exposes detailed error pages with stack traces, local variables, and settings values.
 
@@ -348,6 +456,10 @@ Django DEBUG mode exposes detailed error pages with stack traces, local variable
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** config-file
+- **Execution scope:** framework-project
+- **Required facts:** config-file, framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 An empty ALLOWED_HOSTS setting leaves deployed Django services exposed to unsafe Host header handling.
 
@@ -361,6 +473,10 @@ An empty ALLOWED_HOSTS setting leaves deployed Django services exposed to unsafe
 - **Confidence:** MEDIUM
 - **Lifecycle:** preview
 - **Signal source:** text-heuristic
+- **Execution scope:** framework-project
+- **Required facts:** file-content, file-context, framework-context
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 String formatting inside cursor.execute can turn user-controlled values into SQL injection risk.
 
@@ -374,6 +490,10 @@ String formatting inside cursor.execute can turn user-controlled values into SQL
 - **Confidence:** HIGH
 - **Lifecycle:** stable
 - **Signal source:** config-file
+- **Execution scope:** repository
+- **Required facts:** config-file, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A local `.env`/`.env.local` file or a shared `.env.*` variant with credential-shaped content was committed. Local env files commonly hold secrets; shared build env files may hold public browser configuration but still require content inspection.
 
@@ -389,6 +509,10 @@ A local `.env`/`.env.local` file or a shared `.env.*` variant with credential-sh
 - **Confidence:** HIGH
 - **Lifecycle:** stable
 - **Signal source:** text-heuristic
+- **Execution scope:** file
+- **Required facts:** file-metadata, file-content
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 A PEM-encoded private key block was found in a source file. Committed private keys can be extracted from git history even after deletion.
 
@@ -404,6 +528,10 @@ A PEM-encoded private key block was found in a source file. Committed private ke
 - **Confidence:** MEDIUM
 - **Lifecycle:** preview
 - **Signal source:** text-heuristic
+- **Execution scope:** file
+- **Required facts:** file-metadata, file-content
+- **Cache policy:** per-file-content
+- **Produces:** finding
 
 A high-entropy string or a pattern matching a known secret format was found in source code. Hardcoded secrets are exposed to everyone with repository access.
 
@@ -421,6 +549,10 @@ A high-entropy string or a pattern matching a known secret format was found in s
 - **Confidence:** LOW
 - **Lifecycle:** experimental
 - **Signal source:** ast
+- **Execution scope:** framework-project
+- **Required facts:** parsed-syntax, file-context, framework-context
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A console.log statement was found outside of test files. Debug logging left in production code leaks information and adds noise.
 
@@ -432,6 +564,10 @@ A console.log statement was found outside of test files. Debug logging left in p
 - **Confidence:** MEDIUM
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** framework-project
+- **Required facts:** parsed-syntax, file-context, framework-context
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 `var` has function scope and is hoisted, which can produce subtle bugs. Modern JavaScript uses `const` and `let` instead.
 
@@ -445,6 +581,10 @@ A console.log statement was found outside of test files. Debug logging left in p
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** framework-detector
+- **Execution scope:** framework-project
+- **Required facts:** framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 Android, iOS, or Expo configuration disagree about React Native New Architecture. Mismatched platforms produce inconsistent runtime behavior.
 
@@ -458,6 +598,10 @@ Android, iOS, or Expo configuration disagree about React Native New Architecture
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** framework-project
+- **Required facts:** parsed-syntax, file-context, framework-context
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 AsyncStorage was removed from react-native core in v0.60 and throws a runtime error on modern versions.
 
@@ -471,6 +615,10 @@ AsyncStorage was removed from react-native core in v0.60 and throws a runtime er
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** framework-detector
+- **Execution scope:** framework-project
+- **Required facts:** framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 The project uses Turbo Native Modules or Fabric components but package.json does not define codegenConfig.
 
@@ -484,6 +632,10 @@ The project uses Turbo Native Modules or Fabric components but package.json does
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** framework-project
+- **Required facts:** parsed-syntax, file-context, framework-context
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A React Native API removed from core is in use. Replace with the community package equivalent.
 
@@ -497,6 +649,10 @@ A React Native API removed from core is in use. Replace with the community packa
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** framework-project
+- **Required facts:** parsed-syntax, file-context, framework-context
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 Directly assigning to this.state bypasses React change detection; the component will not re-render.
 
@@ -510,6 +666,10 @@ Directly assigning to this.state bypasses React change detection; the component 
 - **Confidence:** MEDIUM
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** framework-project
+- **Required facts:** parsed-syntax, file-context, framework-context
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A FlatList without keyExtractor falls back to array index keys, breaking list reconciliation when items are reordered or removed.
 
@@ -523,6 +683,10 @@ A FlatList without keyExtractor falls back to array index keys, breaking list re
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** framework-detector
+- **Execution scope:** framework-project
+- **Required facts:** framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 Hermes is explicitly disabled. Hermes reduces startup time by 2-3x and is the default engine since React Native 0.70.
 
@@ -536,6 +700,10 @@ Hermes is explicitly disabled. Hermes reduces startup time by 2-3x and is the de
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** framework-detector
+- **Execution scope:** framework-project
+- **Required facts:** framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 Hermes is configured differently across platforms, causing platform-specific runtime and performance behavior.
 
@@ -549,6 +717,10 @@ Hermes is configured differently across platforms, causing platform-specific run
 - **Confidence:** MEDIUM
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** framework-project
+- **Required facts:** parsed-syntax, file-context, framework-context
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 Inline style objects create a new object on every render, defeating memoization in React.memo and PureComponent children.
 
@@ -562,6 +734,10 @@ Inline style objects create a new object on every render, defeating memoization 
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** framework-detector
+- **Execution scope:** framework-project
+- **Required facts:** framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 The project does not have newArchEnabled set. The New Architecture eliminates the async JS bridge and is required by an increasing number of libraries.
 
@@ -575,6 +751,10 @@ The project does not have newArchEnabled set. The New Architecture eliminates th
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** dependency-manifest
+- **Execution scope:** framework-project
+- **Required facts:** dependency-manifest, framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 react-navigation (v4) is no longer maintained and is incompatible with React Native 0.70+.
 
@@ -588,6 +768,10 @@ react-navigation (v4) is no longer maintained and is incompatible with React Nat
 - **Confidence:** MEDIUM
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** framework-project
+- **Required facts:** parsed-syntax, file-context, framework-context
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 Class components are the legacy React API. Function components with hooks are now the recommended approach and are better supported by the React compiler.
 
@@ -601,6 +785,10 @@ Class components are the legacy React API. Function components with hooks are no
 - **Confidence:** MEDIUM
 - **Lifecycle:** preview
 - **Signal source:** ast
+- **Execution scope:** framework-project
+- **Required facts:** parsed-syntax, file-context, framework-context
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 PropTypes adds runtime overhead and was removed from React 19. TypeScript or Flow provide better static type checking without runtime cost.
 
@@ -614,6 +802,10 @@ PropTypes adds runtime overhead and was removed from React 19. TypeScript or Flo
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** dependency-manifest
+- **Execution scope:** framework-project
+- **Required facts:** dependency-manifest, framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 `@react-native-community/async-storage` is unmaintained. The actively maintained fork is `@react-native-async-storage/async-storage`.
 
@@ -627,6 +819,10 @@ PropTypes adds runtime overhead and was removed from React 19. TypeScript or Flo
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** dependency-manifest
+- **Execution scope:** framework-project
+- **Required facts:** dependency-manifest, framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 `react-native-gesture-handler` v1 does not support React Native ≥0.72. Gesture responder internals changed in 0.72.
 
@@ -640,6 +836,10 @@ PropTypes adds runtime overhead and was removed from React 19. TypeScript or Flo
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** dependency-manifest
+- **Execution scope:** framework-project
+- **Required facts:** dependency-manifest, framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 The installed version of `@react-navigation/native` is not compatible with the React Native version in use.
 
@@ -653,6 +853,10 @@ The installed version of `@react-navigation/native` is not compatible with the R
 - **Confidence:** MEDIUM
 - **Lifecycle:** preview
 - **Signal source:** dependency-manifest
+- **Execution scope:** framework-project
+- **Required facts:** dependency-manifest, framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 A dependency in use has no New Architecture (TurboModules / Fabric) support and will break when the New Architecture is enabled.
 
@@ -666,6 +870,10 @@ A dependency in use has no New Architecture (TurboModules / Fabric) support and 
 - **Confidence:** HIGH
 - **Lifecycle:** preview
 - **Signal source:** dependency-manifest
+- **Execution scope:** framework-project
+- **Required facts:** dependency-manifest, framework-context, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
 
 `react-native-reanimated` v2 is not compatible with React Native ≥0.73. v3 introduced breaking changes to the worklet runtime.
 

--- a/src/rules/catalog.rs
+++ b/src/rules/catalog.rs
@@ -32,6 +32,9 @@ pub struct RuleCatalogItem {
     pub false_positive_notes: Option<&'static str>,
     pub semantic_source: &'static str,
     pub required_scope: &'static str,
+    pub required_facts: Vec<&'static str>,
+    pub cache_policy: &'static str,
+    pub produces: Vec<&'static str>,
     pub fixture_coverage: RuleFixtureCoverage,
     pub false_positive_risk: &'static str,
     pub stability_gate_status: &'static str,
@@ -71,7 +74,7 @@ impl From<&'static RuleMetadata> for RuleCatalogItem {
             category: rule.category.label().to_string(),
             severity: rule.default_severity.label().to_string(),
             confidence: rule.default_confidence.label().to_string(),
-            lifecycle: rule.lifecycle,
+            lifecycle: rule.requirements.lifecycle,
             signal_source: rule.signal_source,
             docs_url: rule.docs_url,
             tags: rule.tags,
@@ -79,7 +82,20 @@ impl From<&'static RuleMetadata> for RuleCatalogItem {
             recommendation: rule.recommendation,
             false_positive_notes: rule.false_positive_notes,
             semantic_source: rule.signal_source.label(),
-            required_scope: required_scope(rule.signal_source),
+            required_scope: rule.requirements.scope.label(),
+            required_facts: rule
+                .requirements
+                .fact_kinds
+                .iter()
+                .map(|fact| fact.label())
+                .collect(),
+            cache_policy: rule.requirements.cache_policy.label(),
+            produces: rule
+                .requirements
+                .produces
+                .iter()
+                .map(|output| output.label())
+                .collect(),
             false_positive_risk: false_positive_risk(rule),
             stability_gate_status: stability_gate_status(rule, &fixture_coverage),
             fixture_coverage,
@@ -121,17 +137,6 @@ fn fixture_coverage_for_rule(rule_id: &str) -> RuleFixtureCoverage {
     }
 
     coverage
-}
-
-fn required_scope(source: SignalSource) -> &'static str {
-    match source {
-        SignalSource::ImportGraph => "repository-graph",
-        SignalSource::FrameworkDetector => "project-framework",
-        SignalSource::DependencyManifest | SignalSource::ConfigFile => "project-file",
-        SignalSource::GitDiff => "git-diff",
-        SignalSource::Mixed => "mixed",
-        SignalSource::TextHeuristic | SignalSource::Ast => "file-content",
-    }
 }
 
 fn false_positive_risk(rule: &RuleMetadata) -> &'static str {

--- a/src/rules/metadata.rs
+++ b/src/rules/metadata.rs
@@ -1,4 +1,5 @@
 use crate::findings::types::{Confidence, FindingCategory, Severity};
+use crate::rules::requirements::RuleRequirements;
 use crate::rules::{RuleLifecycle, SignalSource};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,6 +22,9 @@ pub struct RuleMetadata {
     pub contextual_confidence: bool,
     pub lifecycle: RuleLifecycle,
     pub signal_source: SignalSource,
+    /// Declarative execution contract used by documentation now and by the
+    /// bounded scheduler/cache planner in later v0.20 milestones.
+    pub requirements: RuleRequirements,
     pub docs_url: Option<&'static str>,
     pub description: &'static str,
     pub recommendation: Option<&'static str>,
@@ -40,6 +44,7 @@ impl RuleMetadata {
         contextual_confidence: false,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::TextHeuristic,
+        requirements: RuleRequirements::UNDECLARED,
         docs_url: None,
         description: "",
         recommendation: None,

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -4,10 +4,12 @@ pub mod lifecycle;
 pub mod metadata;
 pub mod reference;
 pub mod registry;
+pub mod requirements;
 pub mod source;
 
 pub use lifecycle::RuleLifecycle;
 pub use metadata::RuleMetadata;
 pub use reference::render_rules_reference_markdown;
 pub use registry::{all_rule_metadata, lookup_rule_metadata};
+pub use requirements::{FactKind, RuleCachePolicy, RuleOutputKind, RuleRequirements, RuleScope};
 pub use source::SignalSource;

--- a/src/rules/reference.rs
+++ b/src/rules/reference.rs
@@ -76,8 +76,38 @@ fn render_rule(out: &mut String, rule: &RuleMetadata) {
     let _ = writeln!(out, "### `{}` — {}\n", rule.rule_id, rule.title);
     let _ = writeln!(out, "- **Severity:** {}", rule.default_severity.label());
     let _ = writeln!(out, "- **Confidence:** {}", rule.default_confidence.label());
-    let _ = writeln!(out, "- **Lifecycle:** {}", rule.lifecycle.label());
-    let _ = writeln!(out, "- **Signal source:** {}\n", rule.signal_source.label());
+    let _ = writeln!(
+        out,
+        "- **Lifecycle:** {}",
+        rule.requirements.lifecycle.label()
+    );
+    let _ = writeln!(out, "- **Signal source:** {}", rule.signal_source.label());
+    let _ = writeln!(
+        out,
+        "- **Execution scope:** {}",
+        rule.requirements.scope.label()
+    );
+    let required_facts = rule
+        .requirements
+        .fact_kinds
+        .iter()
+        .map(|fact| fact.label())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let _ = writeln!(out, "- **Required facts:** {required_facts}");
+    let _ = writeln!(
+        out,
+        "- **Cache policy:** {}",
+        rule.requirements.cache_policy.label()
+    );
+    let produces = rule
+        .requirements
+        .produces
+        .iter()
+        .map(|output| output.label())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let _ = writeln!(out, "- **Produces:** {produces}\n");
 
     let description = rule.description.trim();
     if !description.is_empty() {

--- a/src/rules/registry/architecture.rs
+++ b/src/rules/registry/architecture.rs
@@ -1,6 +1,6 @@
 use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
-use crate::rules::{RuleLifecycle, SignalSource};
+use crate::rules::{RuleLifecycle, RuleRequirements, SignalSource};
 
 pub(super) static RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -12,6 +12,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::file_text(RuleLifecycle::Experimental),
         docs_url: None,
         description: "This file has more lines of code than the configured threshold. Large files accumulate responsibilities over time and make navigation and testing harder.",
         recommendation: Some(
@@ -27,6 +29,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::repository_text(RuleLifecycle::Experimental),
         docs_url: None,
         description: "A file is nested deeply within the directory structure. Deep directory nesting makes the codebase harder to navigate, import from, and maintain.",
         recommendation: Some(
@@ -43,6 +47,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::repository_text(RuleLifecycle::Preview),
         docs_url: None,
         description: "A source file imports across three or more parent directories. Deep relative imports are fragile during refactors and often indicate missing module boundaries or aliases.",
         recommendation: Some(
@@ -58,6 +64,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Low,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::repository_text(RuleLifecycle::Experimental),
         docs_url: None,
         description: "An index file re-exports many modules or relies heavily on wildcard exports. Large barrel files can become unstable module hubs and make dependency boundaries harder to understand.",
         recommendation: Some(
@@ -73,6 +81,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::repository_text(RuleLifecycle::Experimental),
         docs_url: None,
         description: "A directory contains more files than the configured threshold, suggesting it may need to be broken into sub-packages.",
         recommendation: Some(
@@ -88,6 +98,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Stable,
         signal_source: SignalSource::ImportGraph,
+
+        requirements: RuleRequirements::repository_graph(RuleLifecycle::Stable),
         docs_url: Some(
             "https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture",
         ),
@@ -108,6 +120,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Stable,
         signal_source: SignalSource::ImportGraph,
+
+        requirements: RuleRequirements::repository_graph(RuleLifecycle::Stable),
         docs_url: Some(
             "https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture",
         ),
@@ -131,6 +145,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         contextual_confidence: true,
         lifecycle: RuleLifecycle::Stable,
         signal_source: SignalSource::ImportGraph,
+
+        requirements: RuleRequirements::repository_graph(RuleLifecycle::Stable),
         docs_url: Some(
             "https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture",
         ),
@@ -155,6 +171,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         contextual_confidence: true,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::ImportGraph,
+
+        requirements: RuleRequirements::repository_graph(RuleLifecycle::Experimental),
         docs_url: None,
         description: "This production file is not imported by any other project file and is not a known entrypoint. It may be dead code.",
         recommendation: Some(
@@ -173,6 +191,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::ImportGraph,
+
+        requirements: RuleRequirements::repository_graph(RuleLifecycle::Experimental),
         docs_url: None,
         description: "A module imports another module from a higher layer than its own, against the order declared in `[[architecture.layers]]`. Opt-in: emits nothing unless layers are configured.",
         recommendation: Some(
@@ -190,6 +210,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::ImportGraph,
+
+        requirements: RuleRequirements::repository_graph(RuleLifecycle::Experimental),
         docs_url: None,
         description: "A production module imports a test or fixture module.",
         recommendation: Some(
@@ -210,6 +232,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         contextual_confidence: true,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::ImportGraph,
+
+        requirements: RuleRequirements::repository_graph(RuleLifecycle::Experimental),
         docs_url: None,
         description: "A file imports a private module from another package instead of using its public API. Auto-enabled on a detected npm/pnpm/Cargo/Go workspace; can also be driven explicitly with `[architecture] package_roots`.",
         recommendation: Some(

--- a/src/rules/registry/code_quality.rs
+++ b/src/rules/registry/code_quality.rs
@@ -1,6 +1,6 @@
 use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
-use crate::rules::{RuleLifecycle, SignalSource};
+use crate::rules::{RuleLifecycle, RuleRequirements, SignalSource};
 
 pub(super) static RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -12,6 +12,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::file_text(RuleLifecycle::Preview),
         docs_url: None,
         description: "The file's branch count density exceeds the complexity threshold, indicating too many execution paths. High complexity increases the defect rate and testing burden.",
         recommendation: Some(
@@ -28,6 +30,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         contextual_confidence: true,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::file_ast(RuleLifecycle::Preview),
         docs_url: None,
         description: "A function is longer than the configured line threshold. Long functions are harder to test, understand, and safely refactor.",
         recommendation: Some(
@@ -46,6 +50,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Low,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::file_text(RuleLifecycle::Experimental),
         docs_url: None,
         description: "A TODO comment marks unfinished work. Unresolved TODOs accumulate as technical debt if not tracked in an issue tracker.",
         recommendation: Some(
@@ -61,6 +67,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Low,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::file_text(RuleLifecycle::Experimental),
         docs_url: None,
         description: "A FIXME comment marks known broken or problematic code that has not yet been addressed.",
         recommendation: Some(
@@ -76,6 +84,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Low,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::file_text(RuleLifecycle::Experimental),
         docs_url: None,
         description: "A HACK comment marks a workaround that bypasses a proper solution. Hacks tend to become permanent and break under refactoring.",
         recommendation: Some(
@@ -91,6 +101,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::file_ast(RuleLifecycle::Preview),
         docs_url: None,
         description: "A function's control flow is deeply nested or branch-heavy, measured by a cognitive-complexity score that weights nesting depth rather than counting branches flatly. Deeply nested logic is disproportionately hard to read, test, and change.",
         recommendation: Some(
@@ -109,6 +121,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::file_ast(RuleLifecycle::Preview),
         docs_url: None,
         description: "A source file contains deeply nested control flow blocks (if, loops, match, try). High nesting depth makes code hard to read, maintain, and test.",
         recommendation: Some(

--- a/src/rules/registry/framework/react_native.rs
+++ b/src/rules/registry/framework/react_native.rs
@@ -1,6 +1,6 @@
 use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
-use crate::rules::{RuleLifecycle, SignalSource};
+use crate::rules::{RuleLifecycle, RuleRequirements, SignalSource};
 
 pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -11,6 +11,8 @@ pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::framework_ast(RuleLifecycle::Preview),
         docs_url: Some("https://reactnative.dev/docs/stylesheet"),
         description: "Inline style objects create a new object on every render, defeating memoization in React.memo and PureComponent children.",
         recommendation: Some("Extract styles into a StyleSheet.create call outside the component."),
@@ -24,6 +26,8 @@ pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::framework_ast(RuleLifecycle::Preview),
         docs_url: Some("https://reactnative.dev/docs/out-of-tree-platforms"),
         description: "A React Native API removed from core is in use. Replace with the community package equivalent.",
         recommendation: Some(
@@ -39,6 +43,8 @@ pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::framework_ast(RuleLifecycle::Preview),
         docs_url: Some("https://reactnative.dev/docs/flatlist#keyextractor"),
         description: "A FlatList without keyExtractor falls back to array index keys, breaking list reconciliation when items are reordered or removed.",
         recommendation: Some(
@@ -54,6 +60,8 @@ pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::framework_ast(RuleLifecycle::Preview),
         docs_url: Some("https://react-native-async-storage.github.io/async-storage/docs/install"),
         description: "AsyncStorage was removed from react-native core in v0.60 and throws a runtime error on modern versions.",
         recommendation: Some(
@@ -69,6 +77,8 @@ pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::DependencyManifest,
+
+        requirements: RuleRequirements::framework_manifest(RuleLifecycle::Preview),
         docs_url: Some("https://reactnavigation.org/docs/getting-started"),
         description: "react-navigation (v4) is no longer maintained and is incompatible with React Native 0.70+.",
         recommendation: Some(
@@ -84,6 +94,8 @@ pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::framework_ast(RuleLifecycle::Preview),
         docs_url: Some("https://react.dev/reference/react/Component#setstate"),
         description: "Directly assigning to this.state bypasses React change detection; the component will not re-render.",
         recommendation: Some(
@@ -99,6 +111,8 @@ pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::FrameworkDetector,
+
+        requirements: RuleRequirements::framework_detector(RuleLifecycle::Preview),
         docs_url: Some("https://reactnative.dev/docs/new-architecture-intro"),
         description: "The project does not have newArchEnabled set. The New Architecture eliminates the async JS bridge and is required by an increasing number of libraries.",
         recommendation: Some(
@@ -114,6 +128,8 @@ pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::FrameworkDetector,
+
+        requirements: RuleRequirements::framework_detector(RuleLifecycle::Preview),
         docs_url: Some("https://reactnative.dev/docs/new-architecture-intro"),
         description: "Android, iOS, or Expo configuration disagree about React Native New Architecture. Mismatched platforms produce inconsistent runtime behavior.",
         recommendation: Some(
@@ -129,6 +145,8 @@ pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::FrameworkDetector,
+
+        requirements: RuleRequirements::framework_detector(RuleLifecycle::Preview),
         docs_url: Some("https://reactnative.dev/docs/hermes"),
         description: "Hermes is configured differently across platforms, causing platform-specific runtime and performance behavior.",
         recommendation: Some(
@@ -144,6 +162,8 @@ pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::FrameworkDetector,
+
+        requirements: RuleRequirements::framework_detector(RuleLifecycle::Preview),
         docs_url: Some("https://reactnative.dev/docs/hermes"),
         description: "Hermes is explicitly disabled. Hermes reduces startup time by 2-3x and is the default engine since React Native 0.70.",
         recommendation: Some(
@@ -159,6 +179,8 @@ pub(crate) static REACT_NATIVE_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::FrameworkDetector,
+
+        requirements: RuleRequirements::framework_detector(RuleLifecycle::Preview),
         docs_url: Some("https://reactnative.dev/docs/the-new-architecture/codegen"),
         description: "The project uses Turbo Native Modules or Fabric components but package.json does not define codegenConfig.",
         recommendation: Some(

--- a/src/rules/registry/framework/web.rs
+++ b/src/rules/registry/framework/web.rs
@@ -1,6 +1,6 @@
 use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
-use crate::rules::{RuleLifecycle, SignalSource};
+use crate::rules::{RuleLifecycle, RuleRequirements, SignalSource};
 
 pub(crate) static WEB_RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -11,6 +11,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::framework_ast(RuleLifecycle::Preview),
         docs_url: Some(
             "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var",
         ),
@@ -28,6 +30,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Low,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::framework_ast(RuleLifecycle::Experimental),
         docs_url: None,
         description: "A console.log statement was found outside of test files. Debug logging left in production code leaks information and adds noise.",
         recommendation: Some(
@@ -43,6 +47,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::framework_ast(RuleLifecycle::Preview),
         docs_url: Some("https://react.dev/reference/react/Component"),
         description: "Class components are the legacy React API. Function components with hooks are now the recommended approach and are better supported by the React compiler.",
         recommendation: Some(
@@ -58,6 +64,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::framework_ast(RuleLifecycle::Preview),
         docs_url: Some(
             "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes",
         ),
@@ -75,6 +83,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::DependencyManifest,
+
+        requirements: RuleRequirements::framework_manifest(RuleLifecycle::Preview),
         docs_url: Some("https://react-native-async-storage.github.io/async-storage/docs/install"),
         description: "`@react-native-community/async-storage` is unmaintained. The actively maintained fork is `@react-native-async-storage/async-storage`.",
         recommendation: Some(
@@ -90,6 +100,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::DependencyManifest,
+
+        requirements: RuleRequirements::framework_manifest(RuleLifecycle::Preview),
         docs_url: Some("https://reactnavigation.org/docs/getting-started"),
         description: "The installed version of `@react-navigation/native` is not compatible with the React Native version in use.",
         recommendation: Some(
@@ -105,6 +117,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::DependencyManifest,
+
+        requirements: RuleRequirements::framework_manifest(RuleLifecycle::Preview),
         docs_url: Some(
             "https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation",
         ),
@@ -122,6 +136,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::DependencyManifest,
+
+        requirements: RuleRequirements::framework_manifest(RuleLifecycle::Preview),
         docs_url: Some("https://docs.swmansion.com/react-native-gesture-handler/docs/installation"),
         description: "`react-native-gesture-handler` v1 does not support React Native ≥0.72. Gesture responder internals changed in 0.72.",
         recommendation: Some(
@@ -137,6 +153,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::DependencyManifest,
+
+        requirements: RuleRequirements::framework_manifest(RuleLifecycle::Preview),
         docs_url: Some("https://reactnative.dev/docs/new-architecture-intro"),
         description: "A dependency in use has no New Architecture (TurboModules / Fabric) support and will break when the New Architecture is enabled.",
         recommendation: Some(
@@ -152,6 +170,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::ConfigFile,
+
+        requirements: RuleRequirements::framework_config(RuleLifecycle::Preview),
         docs_url: Some("https://docs.djangoproject.com/en/stable/ref/settings/#debug"),
         description: "Django DEBUG mode exposes detailed error pages with stack traces, local variables, and settings values.",
         recommendation: Some(
@@ -167,6 +187,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::ConfigFile,
+
+        requirements: RuleRequirements::framework_config(RuleLifecycle::Preview),
         docs_url: Some("https://docs.djangoproject.com/en/stable/ref/settings/#allowed-hosts"),
         description: "An empty ALLOWED_HOSTS setting leaves deployed Django services exposed to unsafe Host header handling.",
         recommendation: Some(
@@ -182,6 +204,8 @@ pub(crate) static WEB_RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::framework_text(RuleLifecycle::Preview),
         docs_url: Some(
             "https://docs.djangoproject.com/en/stable/topics/db/sql/#passing-parameters-into-raw",
         ),

--- a/src/rules/registry/language.rs
+++ b/src/rules/registry/language.rs
@@ -1,6 +1,6 @@
 use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
-use crate::rules::{RuleLifecycle, SignalSource};
+use crate::rules::{RuleLifecycle, RuleRequirements, SignalSource};
 
 pub(super) static RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -13,6 +13,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         contextual_confidence: true,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::file_ast(RuleLifecycle::Preview),
         docs_url: None,
         description: "Rust panic-style operations such as unwrap(), expect(), panic!, todo!, and unimplemented! can be risky in reusable production code. Their severity depends on whether the code is test code, CLI boundary code, library code, or domain code.",
         recommendation: Some(
@@ -32,6 +34,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::file_ast(RuleLifecycle::Preview),
         docs_url: None,
         description: "Go panic and process-exit operations can terminate the program abruptly. Their risk depends on whether the file is test code, CLI boundary code, library code, or domain code.",
         recommendation: Some(
@@ -51,6 +55,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::file_ast(RuleLifecycle::Preview),
         docs_url: None,
         description: "A broad `except:` handler can hide unrelated failures. `assert` (often type-narrowing or an internal invariant) and `raise NotImplementedError` (usually an abstract-method declaration) are overwhelmingly intentional, so they are kept low and surface only under the strict profile.",
         recommendation: Some(
@@ -70,6 +76,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::file_ast(RuleLifecycle::Preview),
         docs_url: None,
         description: "A `process.exit(...)` call terminates the host process, which is expected at a CLI boundary but unsafe in reusable browser, Node, or package code.",
         recommendation: Some(
@@ -89,6 +97,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::Ast,
+
+        requirements: RuleRequirements::file_ast(RuleLifecycle::Preview),
         docs_url: None,
         description: "Generic fatal exceptions and not-implemented placeholders in Java, Kotlin, or C# domain/library code can become runtime failures that callers cannot handle precisely.",
         recommendation: Some(

--- a/src/rules/registry/mod.rs
+++ b/src/rules/registry/mod.rs
@@ -40,6 +40,7 @@ fn rule_index() -> &'static HashMap<&'static str, &'static RuleMetadata> {
 mod tests {
     use super::*;
     use crate::findings::types::{FindingCategory, Severity};
+    use crate::rules::{RuleCachePolicy, RuleOutputKind};
 
     #[test]
     fn known_rn_rule_returns_metadata() {
@@ -148,6 +149,35 @@ mod tests {
             assert!(
                 !rule.default_confidence.label().is_empty(),
                 "rule {} has empty default confidence",
+                rule.rule_id
+            );
+        }
+    }
+
+    #[test]
+    fn all_registered_rules_declare_requirements() {
+        for rule in all_rules() {
+            assert!(
+                rule.requirements.is_declared(),
+                "rule {} must declare requirements",
+                rule.rule_id
+            );
+            assert_eq!(
+                rule.requirements.lifecycle, rule.lifecycle,
+                "rule {} lifecycle contract drifted",
+                rule.rule_id
+            );
+            assert_ne!(
+                rule.requirements.cache_policy,
+                RuleCachePolicy::Uncached,
+                "rule {} must declare a cache policy",
+                rule.rule_id
+            );
+            assert!(
+                rule.requirements
+                    .produces
+                    .contains(&RuleOutputKind::Finding),
+                "rule {} must declare finding output",
                 rule.rule_id
             );
         }

--- a/src/rules/registry/security.rs
+++ b/src/rules/registry/security.rs
@@ -1,6 +1,6 @@
 use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
-use crate::rules::{RuleLifecycle, SignalSource};
+use crate::rules::{RuleLifecycle, RuleRequirements, SignalSource};
 
 pub(super) static RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -13,6 +13,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         contextual_confidence: true,
         lifecycle: RuleLifecycle::Stable,
         signal_source: SignalSource::ConfigFile,
+
+        requirements: RuleRequirements::repository_config(RuleLifecycle::Stable),
         docs_url: Some("https://12factor.net/config"),
         description: "A local `.env`/`.env.local` file or a shared `.env.*` variant with credential-shaped content was committed. Local env files commonly hold secrets; shared build env files may hold public browser configuration but still require content inspection.",
         recommendation: Some(
@@ -31,6 +33,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Stable,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::file_text(RuleLifecycle::Stable),
         docs_url: Some(
             "https://github.com/MykytaStel/repopilot/blob/main/docs/security.md#reporting-a-security-issue",
         ),
@@ -53,6 +57,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         contextual_confidence: true,
         lifecycle: RuleLifecycle::Preview,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::file_text(RuleLifecycle::Preview),
         docs_url: Some(
             "https://github.com/MykytaStel/repopilot/blob/main/docs/security.md#secret-handling",
         ),

--- a/src/rules/registry/testing.rs
+++ b/src/rules/registry/testing.rs
@@ -1,6 +1,6 @@
 use crate::findings::types::{Confidence, FindingCategory, Severity};
 use crate::rules::metadata::RuleMetadata;
-use crate::rules::{RuleLifecycle, SignalSource};
+use crate::rules::{RuleLifecycle, RuleRequirements, SignalSource};
 
 pub(super) static RULES: &[RuleMetadata] = &[
     RuleMetadata {
@@ -11,6 +11,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Medium,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::repository_text(RuleLifecycle::Experimental),
         docs_url: None,
         description: "The project has no recognisable test directory (tests/, __tests__, spec/). Without tests, correctness can only be verified manually.",
         recommendation: Some(
@@ -26,6 +28,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         default_confidence: Confidence::Low,
         lifecycle: RuleLifecycle::Experimental,
         signal_source: SignalSource::TextHeuristic,
+
+        requirements: RuleRequirements::repository_text(RuleLifecycle::Experimental),
         docs_url: None,
         description: "A source file has no matching test file. Untested code is more likely to regress during refactoring.",
         recommendation: Some(

--- a/src/rules/requirements.rs
+++ b/src/rules/requirements.rs
@@ -1,0 +1,325 @@
+use super::lifecycle::RuleLifecycle;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum RuleScope {
+    File,
+    Repository,
+    FrameworkProject,
+    ChangeSet,
+}
+
+impl RuleScope {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::File => "file",
+            Self::Repository => "repository",
+            Self::FrameworkProject => "framework-project",
+            Self::ChangeSet => "change-set",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum FactKind {
+    FileMetadata,
+    FileContent,
+    ParsedSyntax,
+    Imports,
+    Exports,
+    FileContext,
+    WorkspaceMetadata,
+    DependencyGraph,
+    DependencyManifest,
+    ConfigFile,
+    FrameworkContext,
+    GitDiff,
+}
+
+impl FactKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::FileMetadata => "file-metadata",
+            Self::FileContent => "file-content",
+            Self::ParsedSyntax => "parsed-syntax",
+            Self::Imports => "imports",
+            Self::Exports => "exports",
+            Self::FileContext => "file-context",
+            Self::WorkspaceMetadata => "workspace-metadata",
+            Self::DependencyGraph => "dependency-graph",
+            Self::DependencyManifest => "dependency-manifest",
+            Self::ConfigFile => "config-file",
+            Self::FrameworkContext => "framework-context",
+            Self::GitDiff => "git-diff",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum RuleCachePolicy {
+    PerFileContent,
+    PerWorkspaceRevision,
+    PerChangeSet,
+    Uncached,
+}
+
+impl RuleCachePolicy {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::PerFileContent => "per-file-content",
+            Self::PerWorkspaceRevision => "per-workspace-revision",
+            Self::PerChangeSet => "per-change-set",
+            Self::Uncached => "uncached",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum RuleOutputKind {
+    Finding,
+}
+
+impl RuleOutputKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Finding => "finding",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuleRequirements {
+    pub scope: RuleScope,
+    pub fact_kinds: &'static [FactKind],
+    pub lifecycle: RuleLifecycle,
+    pub cache_policy: RuleCachePolicy,
+    pub produces: &'static [RuleOutputKind],
+}
+
+const FINDING_OUTPUT: &[RuleOutputKind] = &[RuleOutputKind::Finding];
+
+const FILE_TEXT_FACTS: &[FactKind] = &[FactKind::FileMetadata, FactKind::FileContent];
+const FILE_AST_FACTS: &[FactKind] = &[
+    FactKind::FileMetadata,
+    FactKind::ParsedSyntax,
+    FactKind::FileContext,
+];
+const REPOSITORY_TEXT_FACTS: &[FactKind] = &[
+    FactKind::FileMetadata,
+    FactKind::FileContent,
+    FactKind::WorkspaceMetadata,
+];
+const REPOSITORY_CONFIG_FACTS: &[FactKind] = &[FactKind::ConfigFile, FactKind::WorkspaceMetadata];
+const REPOSITORY_GRAPH_FACTS: &[FactKind] = &[
+    FactKind::Imports,
+    FactKind::Exports,
+    FactKind::FileContext,
+    FactKind::DependencyGraph,
+    FactKind::WorkspaceMetadata,
+];
+const REPOSITORY_MIXED_FACTS: &[FactKind] = &[
+    FactKind::FileContent,
+    FactKind::ParsedSyntax,
+    FactKind::FileContext,
+    FactKind::WorkspaceMetadata,
+];
+const FRAMEWORK_AST_FACTS: &[FactKind] = &[
+    FactKind::ParsedSyntax,
+    FactKind::FileContext,
+    FactKind::FrameworkContext,
+];
+const FRAMEWORK_MANIFEST_FACTS: &[FactKind] = &[
+    FactKind::DependencyManifest,
+    FactKind::FrameworkContext,
+    FactKind::WorkspaceMetadata,
+];
+const FRAMEWORK_CONFIG_FACTS: &[FactKind] = &[
+    FactKind::ConfigFile,
+    FactKind::FrameworkContext,
+    FactKind::WorkspaceMetadata,
+];
+const FRAMEWORK_DETECTOR_FACTS: &[FactKind] =
+    &[FactKind::FrameworkContext, FactKind::WorkspaceMetadata];
+const FRAMEWORK_TEXT_FACTS: &[FactKind] = &[
+    FactKind::FileContent,
+    FactKind::FileContext,
+    FactKind::FrameworkContext,
+];
+const CHANGE_SET_FACTS: &[FactKind] = &[FactKind::GitDiff, FactKind::WorkspaceMetadata];
+
+impl RuleRequirements {
+    pub const UNDECLARED: Self = Self {
+        scope: RuleScope::File,
+        fact_kinds: &[],
+        lifecycle: RuleLifecycle::Preview,
+        cache_policy: RuleCachePolicy::Uncached,
+        produces: &[],
+    };
+
+    const fn declared(
+        scope: RuleScope,
+        fact_kinds: &'static [FactKind],
+        lifecycle: RuleLifecycle,
+        cache_policy: RuleCachePolicy,
+    ) -> Self {
+        Self {
+            scope,
+            fact_kinds,
+            lifecycle,
+            cache_policy,
+            produces: FINDING_OUTPUT,
+        }
+    }
+
+    pub const fn file_text(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::File,
+            FILE_TEXT_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerFileContent,
+        )
+    }
+
+    pub const fn file_ast(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::File,
+            FILE_AST_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerFileContent,
+        )
+    }
+
+    pub const fn repository_text(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::Repository,
+            REPOSITORY_TEXT_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerWorkspaceRevision,
+        )
+    }
+
+    pub const fn repository_config(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::Repository,
+            REPOSITORY_CONFIG_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerWorkspaceRevision,
+        )
+    }
+
+    pub const fn repository_graph(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::Repository,
+            REPOSITORY_GRAPH_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerWorkspaceRevision,
+        )
+    }
+
+    pub const fn repository_mixed(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::Repository,
+            REPOSITORY_MIXED_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerWorkspaceRevision,
+        )
+    }
+
+    pub const fn framework_ast(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::FrameworkProject,
+            FRAMEWORK_AST_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerWorkspaceRevision,
+        )
+    }
+
+    pub const fn framework_manifest(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::FrameworkProject,
+            FRAMEWORK_MANIFEST_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerWorkspaceRevision,
+        )
+    }
+
+    pub const fn framework_config(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::FrameworkProject,
+            FRAMEWORK_CONFIG_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerWorkspaceRevision,
+        )
+    }
+
+    pub const fn framework_detector(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::FrameworkProject,
+            FRAMEWORK_DETECTOR_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerWorkspaceRevision,
+        )
+    }
+
+    pub const fn framework_text(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::FrameworkProject,
+            FRAMEWORK_TEXT_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerWorkspaceRevision,
+        )
+    }
+
+    pub const fn change_set(lifecycle: RuleLifecycle) -> Self {
+        Self::declared(
+            RuleScope::ChangeSet,
+            CHANGE_SET_FACTS,
+            lifecycle,
+            RuleCachePolicy::PerChangeSet,
+        )
+    }
+
+    pub fn is_declared(self) -> bool {
+        !self.fact_kinds.is_empty()
+            && !self.produces.is_empty()
+            && self.cache_policy != RuleCachePolicy::Uncached
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_ast_requires_shared_parse_and_context() {
+        let requirements = RuleRequirements::file_ast(RuleLifecycle::Preview);
+
+        assert_eq!(requirements.scope, RuleScope::File);
+        assert!(requirements.fact_kinds.contains(&FactKind::ParsedSyntax));
+        assert!(requirements.fact_kinds.contains(&FactKind::FileContext));
+        assert_eq!(requirements.cache_policy, RuleCachePolicy::PerFileContent);
+        assert!(requirements.is_declared());
+    }
+
+    #[test]
+    fn graph_rules_are_revision_scoped() {
+        let requirements = RuleRequirements::repository_graph(RuleLifecycle::Stable);
+
+        assert_eq!(requirements.scope, RuleScope::Repository);
+        assert!(requirements.fact_kinds.contains(&FactKind::DependencyGraph));
+        assert_eq!(
+            requirements.cache_policy,
+            RuleCachePolicy::PerWorkspaceRevision
+        );
+        assert_eq!(requirements.lifecycle, RuleLifecycle::Stable);
+    }
+
+    #[test]
+    fn undeclared_requirements_are_detectable() {
+        assert!(!RuleRequirements::UNDECLARED.is_declared());
+    }
+}

--- a/src/scan/cache.rs
+++ b/src/scan/cache.rs
@@ -218,6 +218,21 @@ pub fn config_fingerprint(config: &ScanConfig) -> String {
                 docs_url: rule.docs_url,
                 description: rule.description,
                 recommendation: rule.recommendation,
+                required_scope: rule.requirements.scope.label(),
+                required_facts: rule
+                    .requirements
+                    .fact_kinds
+                    .iter()
+                    .map(|fact| fact.label())
+                    .collect(),
+                requirements_lifecycle: rule.requirements.lifecycle.label(),
+                cache_policy: rule.requirements.cache_policy.label(),
+                produces: rule
+                    .requirements
+                    .produces
+                    .iter()
+                    .map(|output| output.label())
+                    .collect(),
             })
             .collect(),
     };
@@ -260,6 +275,11 @@ struct RuleFingerprint {
     docs_url: Option<&'static str>,
     description: &'static str,
     recommendation: Option<&'static str>,
+    required_scope: &'static str,
+    required_facts: Vec<&'static str>,
+    requirements_lifecycle: &'static str,
+    cache_policy: &'static str,
+    produces: Vec<&'static str>,
 }
 
 pub fn relative_cache_path(root: &Path, path: &Path) -> String {

--- a/tests/rule_requirements.rs
+++ b/tests/rule_requirements.rs
@@ -1,0 +1,128 @@
+use repopilot::audits::metadata::AuditKind;
+use repopilot::audits::pipeline::{
+    registered_file_audits, registered_framework_audits, registered_project_audits,
+};
+use repopilot::frameworks::DetectedFramework;
+use repopilot::rules::{
+    RuleCachePolicy, RuleOutputKind, RuleScope, SignalSource, all_rule_metadata,
+    lookup_rule_metadata,
+};
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::facts::ScanFacts;
+
+#[test]
+fn every_registered_rule_declares_a_complete_requirement_contract() {
+    for rule in all_rule_metadata() {
+        assert!(
+            rule.requirements.is_declared(),
+            "{} has undeclared requirements",
+            rule.rule_id
+        );
+        assert_eq!(
+            rule.requirements.lifecycle, rule.lifecycle,
+            "{} lifecycle differs between metadata and requirements",
+            rule.rule_id
+        );
+        assert!(
+            rule.requirements
+                .produces
+                .contains(&RuleOutputKind::Finding),
+            "{} must declare finding output",
+            rule.rule_id
+        );
+
+        match rule.requirements.scope {
+            RuleScope::File => assert_eq!(
+                rule.requirements.cache_policy,
+                RuleCachePolicy::PerFileContent,
+                "{} file rule needs per-file-content cache policy",
+                rule.rule_id
+            ),
+            RuleScope::Repository | RuleScope::FrameworkProject => assert_eq!(
+                rule.requirements.cache_policy,
+                RuleCachePolicy::PerWorkspaceRevision,
+                "{} workspace rule needs per-workspace-revision cache policy",
+                rule.rule_id
+            ),
+            RuleScope::ChangeSet => assert_eq!(
+                rule.requirements.cache_policy,
+                RuleCachePolicy::PerChangeSet,
+                "{} change rule needs per-change-set cache policy",
+                rule.rule_id
+            ),
+        }
+
+        if rule.signal_source == SignalSource::ImportGraph {
+            assert_eq!(
+                rule.requirements.scope,
+                RuleScope::Repository,
+                "{} import-graph rule must be repository-scoped",
+                rule.rule_id
+            );
+        }
+    }
+}
+
+#[test]
+fn requirements_match_registered_audit_execution_scope() {
+    let config = ScanConfig {
+        detect_secret_like_names: true,
+        detect_missing_tests: true,
+        ..ScanConfig::default()
+    };
+
+    assert_scope(
+        registered_file_audits(&config)
+            .iter()
+            .flat_map(|registration| registration.metadata.rule_ids.iter().copied()),
+        AuditKind::File,
+    );
+    assert_scope(
+        registered_project_audits(&config)
+            .iter()
+            .flat_map(|registration| registration.metadata.rule_ids.iter().copied()),
+        AuditKind::Project,
+    );
+
+    let rn_and_django = ScanFacts {
+        detected_frameworks: vec![
+            DetectedFramework::ReactNative { version: None },
+            DetectedFramework::Django { version: None },
+        ],
+        ..ScanFacts::default()
+    };
+    assert_scope(
+        registered_framework_audits(&rn_and_django)
+            .iter()
+            .flat_map(|registration| registration.metadata.rule_ids.iter().copied()),
+        AuditKind::Framework,
+    );
+
+    let react_only = ScanFacts {
+        detected_frameworks: vec![DetectedFramework::React { version: None }],
+        ..ScanFacts::default()
+    };
+    assert_scope(
+        registered_framework_audits(&react_only)
+            .iter()
+            .flat_map(|registration| registration.metadata.rule_ids.iter().copied()),
+        AuditKind::Framework,
+    );
+}
+
+fn assert_scope(rule_ids: impl Iterator<Item = &'static str>, kind: AuditKind) {
+    let expected = match kind {
+        AuditKind::File => RuleScope::File,
+        AuditKind::Project => RuleScope::Repository,
+        AuditKind::Framework => RuleScope::FrameworkProject,
+    };
+
+    for rule_id in rule_ids {
+        let rule = lookup_rule_metadata(rule_id)
+            .unwrap_or_else(|| panic!("missing rule metadata for {rule_id}"));
+        assert_eq!(
+            rule.requirements.scope, expected,
+            "{rule_id} requirements disagree with its registered audit scope"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add a declarative `RuleRequirements` contract for every registered RepoPilot rule.

Each rule now explicitly declares:

```text
execution scope
+ required fact kinds
+ lifecycle
+ cache policy
+ produced outputs
= RuleRequirements
```

This creates the planning contract required by later scheduler and cache-v2 work without changing current rule execution or findings.

## Type of change

* [ ] Feature
* [x] Refactor
* [x] Tests
* [x] Documentation
* [ ] Bug fix
* [ ] CI / repository maintenance

## What changed

* Added the internal rule-requirement model:

  * `RuleScope`;
  * `FactKind`;
  * `RuleCachePolicy`;
  * `RuleOutputKind`;
  * `RuleRequirements`.
* Added a `requirements` declaration to every registered `RuleMetadata`.
* Added requirement presets for:

  * file text analysis;
  * file AST analysis;
  * repository text analysis;
  * repository configuration analysis;
  * repository dependency-graph analysis;
  * framework AST analysis;
  * framework manifests;
  * framework configuration;
  * framework detection;
  * future change-set analysis.
* Declared required facts such as:

  * file metadata and content;
  * parsed syntax;
  * imports and exports;
  * file context;
  * workspace metadata;
  * dependency graph;
  * dependency manifests;
  * configuration files;
  * framework context;
  * Git diff.
* Added validation ensuring:

  * every registered rule has a complete requirements contract;
  * requirements lifecycle matches existing rule lifecycle;
  * file, project, and framework rule scopes match their real audit registration;
  * every current rule produces findings;
  * every rule declares a compatible cache policy.
* Added requirements information to the rule catalog:

  * execution scope;
  * required facts;
  * cache policy;
  * produced outputs.
* Extended generated `docs/rules-reference.md` with the same requirements summary.
* Included rule requirements in the existing cache fingerprint so incompatible metadata changes cannot reuse cached findings.
* Updated the analysis-platform documentation and unreleased changelog.

## Why

Before this change, RepoPilot knew how each rule was executed only through implicit audit registration and signal-source conventions.

That was sufficient for sequential execution, but it was not a stable contract for:

* dependency-aware scheduling;
* parsed-artifact lifetime management;
* content-addressed caching;
* selective rule execution;
* deterministic execution planning.

This PR makes those assumptions explicit:

```text
RuleMetadata
→ RuleRequirements
→ validated registry contract
→ documentation and catalog
→ future scheduler and cache planner
```

## Contract and ownership

* [x] The change stays within rule metadata, catalog, documentation, and cache-fingerprint ownership.
* [x] Every registered rule declares requirements.
* [x] Requirements match actual file, repository, or framework audit registration.
* [x] Existing detector implementations remain unchanged.
* [x] Existing execution order remains unchanged.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] No finding IDs changed.
* [x] No severity or confidence behavior changed.
* [x] No evidence, provenance, risk, or visibility behavior changed.
* [x] No unrelated refactor or generated-file churn is included.

## Compatibility

No intentional user-visible analysis changes:

* no new CLI command or flag;
* no detector-logic changes;
* no scheduler changes;
* no finding additions or removals;
* no finding-ID changes;
* no scan or review schema changes;
* no SARIF changes;
* no baseline changes;
* no MCP input or output changes;
* no cache-storage schema changes.

The cache fingerprint changes intentionally because rule requirements are now part of cache compatibility.

## Verification

```bash
cargo test rules::requirements
cargo test --test rule_requirements
cargo test --test rules_reference_doc
cargo test --test rule_registry
cargo check --all-targets --all-features
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run review:performance
npm run scan:performance
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```
