### PR TITLE
perf(cache): add content-addressed analysis cache v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   edges for added, modified, and deleted files instead of rebuilding dependency
   edges from every cached node. Existing findings, output schemas, cache files,
   and CLI behavior are unchanged.
+- Analysis cache v2 now persists content-addressed parsed facts in
+  `.repopilot/cache/parsed_facts_v2.json`, allowing warm repo-context fact
+  collection to reuse unchanged imports, exports, and syntax summaries without
+  reparsing. Changed-scan misses populate the parsed-fact cache, warm hits
+  restore complete `ParsedCacheV2` artifacts when available, corrupt or stale
+  analysis-contract cache files are discarded without failing analysis, deleted
+  changed files prune stale path/content entries, and file-role cache schema v8
+  preserves the remaining `FileFacts` fields needed for warm/cold parity. The
+  changed-scan cache telemetry now includes parsed-cache hits, misses,
+  invalidations, corruptions, loaded entries, and written entries, making the
+  cache-v2 signals available for the #270 benchmark matrix. Full-scan AST audit
+  caching remains out of scope because those audits require the live
+  tree-sitter tree, not only persisted summaries.
 - GitHub Release notes now come from structurally validated curated
   `docs/releases/v*.md` files while `CHANGELOG.md` remains the full technical
   release journal.

--- a/docs/roadmap/v0.20.md
+++ b/docs/roadmap/v0.20.md
@@ -210,8 +210,8 @@ implementation. The detailed PR plan below remains the acceptance contract.
 | #265 | Done | `86da1423` added crate-internal `ParsedArtifact` / `FactStore` indexing imports, deferred imports, exports, file-role evidence, and syntax summaries. | Cache v2 persistence remains part of #268. |
 | #266 | Done | `f13428c1` added `RuleRequirements` declarations, generated rules-reference summaries, and rule requirement tests. | Scheduler/cache consumers come later in #269/#268. |
 | #267 | Done | Changed-scan context graph cache hits now patch cached graph nodes and outgoing edges for added, modified, and deleted files without rebuilding edges from every cached node. Coverage: `changed_graph_patch_matches_full_rebuild_for_add_modify_delete`, `changed_context_graph_summary_is_deterministic_across_thread_counts`, local 240-file timing baseline (warm hit median 75,288us vs forced rebuild 81,285us), and `python3 scripts/zoo.py scan` with all expectations labeled and strict anchors intact. | Proceed to #268 content-addressed parsed-fact cache v2. |
-| #268 | Planned | Not started. | Add content-addressed parsed-fact cache v2. |
-| #269 | Planned | Not started. | Use #266 requirements and #268 cache metadata for bounded scheduling and memory-release work. |
+| #268 | Done | Added `.repopilot/cache/parsed_facts_v2.json` keyed by content hash and language, wired it into changed-scan misses and repo-context fact collection, restored complete warm-cache `FileFacts` fields under cache schema v8, bounded/pruned parsed-cache entries, rejected stale analysis contracts, recorded parsed-cache hit/miss/invalidation/corruption/load/write telemetry for #270 benchmark enforcement, and preserved legacy fallback for missing/corrupt parsed cache. Coverage: `collect_without_content_reuses_cached_parsed_facts_on_warm_run` proves cold parse, warm zero-parse repo-context reuse, changed-content miss, added-file miss, and full-collection removal pruning; `single_file_without_content_uses_parent_as_cache_root`; `retain_referenced_current_scan_prunes_unseen_hashes`; `parsed_facts_cache_rejects_analysis_version_mismatch`; `changed_scan_deletes_stale_path_and_parsed_cache_entries`; `changed_scan_writes_cache_and_reuses_matching_findings`; `cargo clippy --all-targets --all-features -- -D warnings`. Full-scan AST audit caching is intentionally deferred because persisted summaries do not replace a live tree-sitter tree. | None. |
+| #269 | Planned | #266 rule requirements and #268 content-addressed parsed-fact cache v2 are available. | Use requirements and cache metadata for bounded scheduling and memory-release work. |
 | #270 | Planned | Not started. | Promote the benchmark and determinism matrix into CI gates after #269. |
 | #271 | Planned | 0.19 zoo snapshots and expectations exist; release-contract integration is not yet a 0.20 gate. | Wire zoo quality metrics into release verification when repos are available. |
 | #272 | Planned | Not started. | Add review-zoo fixture format and differential safe/unsafe tests. |
@@ -321,18 +321,26 @@ that adds/removes edges based on changed files.
 
 ### #268 — perf(cache): add content-addressed analysis cache v2
 
-**Purpose:** Cache parsed facts and graph edges by content hash so unchanged
-files skip reparsing on warm runs.
+**Purpose:** Cache parsed facts by content hash so changed scans and
+repository-context fact collection can reuse unchanged imports, exports, and
+syntax summaries on warm runs.
 
-**Boundaries:** Cache storage, lookup, and invalidation. The analysis pipeline
-uses the cache but falls back to cold parsing on miss or corruption.
+**Boundaries:** Cache storage, lookup, invalidation, and telemetry for the
+changed-scan and repository-context fact-reconstruction paths. The normal
+full-scan AST audit pipeline still parses source files because those audits
+require a live tree-sitter tree; persisted ASTs or richer reusable facts remain
+a future milestone.
 
 **Acceptance criteria:**
-- cache stores content-hash-keyed parsed facts;
-- warm scan skips reparsing for unchanged files;
+- cache stores content-hash-keyed parsed facts with a separate analysis
+  contract version;
+- warm changed-scan cache hits and repo-context fact collection reuse unchanged
+  parsed facts without reparsing;
 - corrupted cache file is detected and discarded without error;
 - cache invalidation test covers: file changed, file added, file removed;
-- benchmark records cache hit/miss/invalidation behavior.
+- cache telemetry records hits, misses, invalidations, corruptions, loaded
+  entries, and written entries for the benchmark matrix;
+- permanent benchmark enforcement remains part of #270.
 
 **Dependencies:** #267.
 
@@ -369,7 +377,8 @@ gates.
   review across small/medium/large synthetic repos;
 - determinism test verifies identical output across 1 and multi-thread runs;
 - regression threshold enforced per `performance-budgets.md`;
-- cache hit/miss/invalidation behavior recorded.
+- cache hit/miss/invalidation behavior recorded and enforced, including the
+  parsed-cache telemetry added in #268.
 
 **Dependencies:** #269.
 

--- a/src/analysis/artifact.rs
+++ b/src/analysis/artifact.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 pub enum ArtifactOrigin {
     #[default]
     Source,
+    ParsedCacheV2,
     LegacyCache,
 }
 
@@ -91,6 +92,27 @@ impl ParsedArtifact {
         }
     }
 
+    pub fn from_parsed_cache_v2(
+        path: PathBuf,
+        language: Option<String>,
+        imports: Vec<String>,
+        deferred_imports: Vec<String>,
+        exports: Vec<String>,
+        context: FileContextFacts,
+        syntax: SyntaxSummary,
+    ) -> Self {
+        Self {
+            path,
+            language,
+            imports,
+            deferred_imports,
+            exports,
+            context,
+            syntax,
+            origin: ArtifactOrigin::ParsedCacheV2,
+        }
+    }
+
     pub fn rebase_path(&mut self, path: PathBuf) {
         self.path = path;
     }
@@ -99,8 +121,19 @@ impl ParsedArtifact {
         &self.path
     }
 
-    pub fn is_complete_source_artifact(&self) -> bool {
+    pub fn is_source_origin(&self) -> bool {
         self.origin == ArtifactOrigin::Source
+    }
+
+    pub fn has_complete_parsed_facts(&self) -> bool {
+        matches!(
+            self.origin,
+            ArtifactOrigin::Source | ArtifactOrigin::ParsedCacheV2
+        )
+    }
+
+    pub fn is_complete_source_artifact(&self) -> bool {
+        self.is_source_origin()
     }
 }
 
@@ -119,8 +152,58 @@ mod tests {
         );
 
         assert_eq!(artifact.origin, ArtifactOrigin::LegacyCache);
+        assert!(!artifact.is_source_origin());
         assert!(!artifact.is_complete_source_artifact());
+        assert!(!artifact.has_complete_parsed_facts());
         assert!(!artifact.syntax.parsed);
         assert!(artifact.exports.is_empty());
+    }
+
+    #[test]
+    fn parsed_cache_v2_artifact_preserves_complete_facts_without_source_origin() {
+        let artifact = ParsedArtifact::from_parsed_cache_v2(
+            PathBuf::from("src/lib.rs"),
+            Some("Rust".to_string()),
+            vec!["crate::facts".to_string()],
+            Vec::new(),
+            vec!["run".to_string()],
+            FileContextFacts::default(),
+            SyntaxSummary {
+                parsed: true,
+                root_kind: Some("source_file".to_string()),
+                has_errors: false,
+                named_child_count: 2,
+            },
+        );
+
+        assert_eq!(artifact.origin, ArtifactOrigin::ParsedCacheV2);
+        assert!(!artifact.is_source_origin());
+        assert!(!artifact.is_complete_source_artifact());
+        assert!(artifact.has_complete_parsed_facts());
+        assert_eq!(artifact.exports, vec!["run"]);
+        assert!(artifact.syntax.parsed);
+    }
+
+    #[test]
+    fn source_artifact_has_source_origin_and_complete_facts() {
+        let artifact = ParsedArtifact::from_source(
+            PathBuf::from("src/lib.rs"),
+            Some("Rust".to_string()),
+            vec!["crate::facts".to_string()],
+            Vec::new(),
+            vec!["run".to_string()],
+            FileContextFacts::default(),
+            SyntaxSummary {
+                parsed: true,
+                root_kind: Some("source_file".to_string()),
+                has_errors: false,
+                named_child_count: 2,
+            },
+        );
+
+        assert_eq!(artifact.origin, ArtifactOrigin::Source);
+        assert!(artifact.is_source_origin());
+        assert!(artifact.is_complete_source_artifact());
+        assert!(artifact.has_complete_parsed_facts());
     }
 }

--- a/src/scan/cache.rs
+++ b/src/scan/cache.rs
@@ -22,7 +22,8 @@ use std::time::UNIX_EPOCH;
 /// v6 invalidates cached file roles because classification now adds build-tooling
 /// and managed test-support roles.
 /// v7 adds explainable role-evidence records to each cached file-role entry.
-pub const CACHE_SCHEMA_VERSION: u32 = 7;
+/// v8 carries the remaining `FileFacts` fields needed for warm cache parity.
+pub const CACHE_SCHEMA_VERSION: u32 = 8;
 pub const CACHE_DIR: &str = ".repopilot/cache";
 const FILE_HASHES_NAME: &str = "file_hashes.json";
 const FILE_ROLES_NAME: &str = "file_roles.json";
@@ -51,6 +52,8 @@ pub struct FileRoleEntry {
     pub language: Option<String>,
     pub non_empty_lines: usize,
     #[serde(default)]
+    pub branch_count: usize,
+    #[serde(default)]
     pub imports: Vec<String>,
     #[serde(default)]
     pub deferred_imports: Vec<String>,
@@ -61,6 +64,10 @@ pub struct FileRoleEntry {
     pub runtimes: Vec<String>,
     pub paradigms: Vec<String>,
     pub is_test: bool,
+    #[serde(default)]
+    pub has_inline_tests: bool,
+    #[serde(default)]
+    pub in_executable_package: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -449,6 +456,7 @@ mod tests {
                 hash: "hash".to_string(),
                 language: Some("Rust".to_string()),
                 non_empty_lines: 1,
+                branch_count: 0,
                 imports: Vec::new(),
                 deferred_imports: Vec::new(),
                 roles: vec!["domain".to_string()],
@@ -461,6 +469,8 @@ mod tests {
                 runtimes: vec!["rust-library".to_string()],
                 paradigms: Vec::new(),
                 is_test: false,
+                has_inline_tests: false,
+                in_executable_package: false,
             }],
         };
 

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -7,6 +7,8 @@ pub mod facts;
 pub mod language;
 #[doc(hidden)]
 pub mod markers;
+#[doc(hidden)]
+pub mod parsed_cache;
 pub(crate) mod path_classification;
 #[doc(hidden)]
 pub mod scanner;

--- a/src/scan/parsed_cache.rs
+++ b/src/scan/parsed_cache.rs
@@ -1,0 +1,357 @@
+use crate::analysis::{ParsedArtifact, SyntaxSummary};
+use crate::scan::cache::{cache_dir, stable_hash_hex};
+use crate::scan::facts::FileFacts;
+use crate::scan::types::ParsedCacheTelemetry;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io;
+use std::path::Path;
+
+const PARSED_FACTS_SCHEMA_VERSION: u32 = 2;
+const PARSED_FACTS_ANALYSIS_VERSION: &str = "tree-sitter-imports-exports-v1";
+const PARSED_FACTS_NAME: &str = "parsed_facts_v2.json";
+const MAX_PARSED_FACTS_ENTRIES: usize = 16_384;
+
+#[derive(Debug, Default, Clone)]
+pub struct ParsedFactsCache {
+    entries: BTreeMap<String, ParsedFactsEntry>,
+    referenced_hashes: BTreeSet<String>,
+    telemetry: ParsedCacheTelemetry,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ParsedFactsEntry {
+    pub content_hash: String,
+    pub language: Option<String>,
+    pub non_empty_lines: usize,
+    pub branch_count: usize,
+    pub has_inline_tests: bool,
+    pub imports: Vec<String>,
+    pub deferred_imports: Vec<String>,
+    pub exports: Vec<String>,
+    pub syntax: CachedSyntaxSummary,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CachedSyntaxSummary {
+    pub parsed: bool,
+    pub root_kind: Option<String>,
+    pub has_errors: bool,
+    pub named_child_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ParsedFactsFile {
+    schema_version: u32,
+    analysis_version: String,
+    repopilot_version: String,
+    entries: Vec<ParsedFactsEntry>,
+}
+
+impl ParsedFactsCache {
+    pub fn load(root: &Path) -> Self {
+        let path = cache_dir(root).join(PARSED_FACTS_NAME);
+        let Some(cache) = read_cache::<ParsedFactsFile>(&path) else {
+            return Self {
+                telemetry: ParsedCacheTelemetry {
+                    corruptions: usize::from(path.exists()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+        };
+
+        let entries_count = cache.entries.len();
+        if cache.schema_version != PARSED_FACTS_SCHEMA_VERSION
+            || cache.analysis_version != PARSED_FACTS_ANALYSIS_VERSION
+        {
+            return Self {
+                telemetry: ParsedCacheTelemetry {
+                    invalidations: entries_count,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+        }
+
+        let entries: BTreeMap<_, _> = cache
+            .entries
+            .into_iter()
+            .map(|entry| (entry.cache_key(), entry))
+            .collect();
+        Self {
+            telemetry: ParsedCacheTelemetry {
+                entries_loaded: entries.len(),
+                ..Default::default()
+            },
+            entries,
+            ..Default::default()
+        }
+    }
+
+    pub fn get(&self, content_hash: &str, language: Option<&str>) -> Option<&ParsedFactsEntry> {
+        self.entries.get(&cache_key(content_hash, language))
+    }
+
+    pub fn lookup(
+        &mut self,
+        content_hash: &str,
+        language: Option<&str>,
+    ) -> Option<ParsedFactsEntry> {
+        self.referenced_hashes.insert(content_hash.to_string());
+        let entry = self
+            .entries
+            .get(&cache_key(content_hash, language))
+            .cloned();
+        if entry.is_some() {
+            self.telemetry.hits += 1;
+        } else {
+            self.telemetry.misses += 1;
+        }
+        entry
+    }
+
+    pub fn insert(&mut self, entry: ParsedFactsEntry) {
+        self.referenced_hashes.insert(entry.content_hash.clone());
+        self.entries.insert(entry.cache_key(), entry);
+    }
+
+    pub fn retain_referenced_current_scan(&mut self) {
+        if self.referenced_hashes.is_empty() {
+            return;
+        }
+        let before = self.entries.len();
+        self.entries
+            .retain(|_, entry| self.referenced_hashes.contains(&entry.content_hash));
+        self.telemetry.invalidations += before.saturating_sub(self.entries.len());
+    }
+
+    pub fn remove_content_hash(&mut self, content_hash: &str) {
+        let before = self.entries.len();
+        self.entries
+            .retain(|_, entry| entry.content_hash != content_hash);
+        self.telemetry.invalidations += before.saturating_sub(self.entries.len());
+    }
+
+    pub fn telemetry(&self) -> ParsedCacheTelemetry {
+        self.telemetry
+    }
+
+    pub fn write(&mut self, root: &Path) -> io::Result<()> {
+        let cache_root = cache_dir(root);
+        fs::create_dir_all(&cache_root)?;
+        self.enforce_entry_limit();
+        let file = ParsedFactsFile {
+            schema_version: PARSED_FACTS_SCHEMA_VERSION,
+            analysis_version: PARSED_FACTS_ANALYSIS_VERSION.to_string(),
+            repopilot_version: env!("CARGO_PKG_VERSION").to_string(),
+            entries: self.entries.values().cloned().collect(),
+        };
+        self.telemetry.entries_written = file.entries.len();
+        let rendered = serde_json::to_string_pretty(&file).map_err(io::Error::other)?;
+        fs::write(cache_root.join(PARSED_FACTS_NAME), rendered)
+    }
+
+    fn enforce_entry_limit(&mut self) {
+        let overflow = self.entries.len().saturating_sub(MAX_PARSED_FACTS_ENTRIES);
+        if overflow == 0 {
+            return;
+        }
+        let stale_keys: Vec<String> = self.entries.keys().take(overflow).cloned().collect();
+        for key in stale_keys {
+            self.entries.remove(&key);
+        }
+        self.telemetry.invalidations += overflow;
+    }
+}
+
+impl ParsedFactsEntry {
+    pub fn from_artifact(
+        content_hash: String,
+        file: &FileFacts,
+        artifact: &ParsedArtifact,
+    ) -> Self {
+        Self {
+            content_hash,
+            language: file.language.clone(),
+            non_empty_lines: file.non_empty_lines,
+            branch_count: file.branch_count,
+            has_inline_tests: file.has_inline_tests,
+            imports: file.imports.clone(),
+            deferred_imports: file.deferred_imports.clone(),
+            exports: artifact.exports.clone(),
+            syntax: CachedSyntaxSummary::from(&artifact.syntax),
+        }
+    }
+
+    fn cache_key(&self) -> String {
+        cache_key(&self.content_hash, self.language.as_deref())
+    }
+}
+
+impl From<&SyntaxSummary> for CachedSyntaxSummary {
+    fn from(value: &SyntaxSummary) -> Self {
+        Self {
+            parsed: value.parsed,
+            root_kind: value.root_kind.clone(),
+            has_errors: value.has_errors,
+            named_child_count: value.named_child_count,
+        }
+    }
+}
+
+impl From<&CachedSyntaxSummary> for SyntaxSummary {
+    fn from(value: &CachedSyntaxSummary) -> Self {
+        Self {
+            parsed: value.parsed,
+            root_kind: value.root_kind.clone(),
+            has_errors: value.has_errors,
+            named_child_count: value.named_child_count,
+        }
+    }
+}
+
+pub fn content_hash(content: &str) -> String {
+    stable_hash_hex(content.as_bytes())
+}
+
+fn cache_key(content_hash: &str, language: Option<&str>) -> String {
+    format!("{}:{}", content_hash, language.unwrap_or(""))
+}
+
+fn read_cache<T>(path: &Path) -> Option<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::{FileContextFacts, ParsedArtifact, SyntaxSummary};
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parsed_facts_cache_round_trips_by_content_hash_and_language() {
+        let temp = tempdir().expect("temp dir");
+        let mut cache = ParsedFactsCache::default();
+        let file = FileFacts {
+            path: PathBuf::from("src/lib.rs"),
+            language: Some("Rust".to_string()),
+            non_empty_lines: 1,
+            branch_count: 0,
+            imports: vec!["crate::api".to_string()],
+            deferred_imports: Vec::new(),
+            content: None,
+            has_inline_tests: false,
+            in_executable_package: false,
+        };
+        let artifact = ParsedArtifact::from_source(
+            file.path.clone(),
+            file.language.clone(),
+            file.imports.clone(),
+            Vec::new(),
+            vec!["run".to_string()],
+            FileContextFacts::default(),
+            SyntaxSummary {
+                parsed: true,
+                root_kind: Some("source_file".to_string()),
+                has_errors: false,
+                named_child_count: 3,
+            },
+        );
+        cache.insert(ParsedFactsEntry::from_artifact(
+            "hash".to_string(),
+            &file,
+            &artifact,
+        ));
+        cache.write(temp.path()).expect("write parsed facts cache");
+
+        let loaded = ParsedFactsCache::load(temp.path());
+        let entry = loaded
+            .get("hash", Some("Rust"))
+            .expect("parsed facts cache hit");
+        assert_eq!(entry.exports, vec!["run"]);
+        assert_eq!(entry.syntax.root_kind.as_deref(), Some("source_file"));
+        assert_eq!(loaded.telemetry().entries_loaded, 1);
+    }
+
+    #[test]
+    fn corrupt_parsed_facts_cache_is_discarded() {
+        let temp = tempdir().expect("temp dir");
+        let cache_root = cache_dir(temp.path());
+        fs::create_dir_all(&cache_root).expect("create cache dir");
+        fs::write(cache_root.join(PARSED_FACTS_NAME), "{not json").expect("write corrupt cache");
+
+        let loaded = ParsedFactsCache::load(temp.path());
+        assert!(loaded.get("hash", Some("Rust")).is_none());
+        assert_eq!(loaded.telemetry().corruptions, 1);
+    }
+
+    #[test]
+    fn parsed_facts_cache_rejects_analysis_version_mismatch() {
+        let temp = tempdir().expect("temp dir");
+        let cache_root = cache_dir(temp.path());
+        fs::create_dir_all(&cache_root).expect("create cache dir");
+        let cache = ParsedFactsFile {
+            schema_version: PARSED_FACTS_SCHEMA_VERSION,
+            analysis_version: "old-imports".to_string(),
+            repopilot_version: "test".to_string(),
+            entries: vec![ParsedFactsEntry {
+                content_hash: "hash".to_string(),
+                language: Some("Rust".to_string()),
+                non_empty_lines: 1,
+                branch_count: 0,
+                has_inline_tests: false,
+                imports: Vec::new(),
+                deferred_imports: Vec::new(),
+                exports: Vec::new(),
+                syntax: CachedSyntaxSummary::default(),
+            }],
+        };
+        fs::write(
+            cache_root.join(PARSED_FACTS_NAME),
+            serde_json::to_string(&cache).expect("render parsed cache"),
+        )
+        .expect("write cache");
+
+        let loaded = ParsedFactsCache::load(temp.path());
+        assert!(loaded.get("hash", Some("Rust")).is_none());
+        assert_eq!(loaded.telemetry().invalidations, 1);
+    }
+
+    #[test]
+    fn retain_referenced_current_scan_prunes_unseen_hashes() {
+        let temp = tempdir().expect("temp dir");
+        let mut cache = ParsedFactsCache::default();
+        cache.insert(entry("old"));
+        cache.insert(entry("live"));
+        cache.write(temp.path()).expect("write cache");
+
+        let mut cache = ParsedFactsCache::load(temp.path());
+        assert!(cache.lookup("live", Some("Rust")).is_some());
+        cache.retain_referenced_current_scan();
+
+        assert!(cache.get("live", Some("Rust")).is_some());
+        assert!(cache.get("old", Some("Rust")).is_none());
+        assert_eq!(cache.telemetry().invalidations, 1);
+    }
+
+    fn entry(hash: &str) -> ParsedFactsEntry {
+        ParsedFactsEntry {
+            content_hash: hash.to_string(),
+            language: Some("Rust".to_string()),
+            non_empty_lines: 1,
+            branch_count: 0,
+            has_inline_tests: false,
+            imports: Vec::new(),
+            deferred_imports: Vec::new(),
+            exports: Vec::new(),
+            syntax: CachedSyntaxSummary::default(),
+        }
+    }
+}

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -107,6 +107,7 @@ impl<'a> ChangedScanEngine<'a> {
             &discovery,
             &mut file_stage.facts,
             &file_stage.graph_patch_files,
+            &mut file_stage.parsed_cache,
         )?;
         let project_start = Instant::now();
         let ((project_findings, framework_findings), (coupling_findings, _, _)) = rayon::join(

--- a/src/scan/scanner/changed/file_analysis.rs
+++ b/src/scan/scanner/changed/file_analysis.rs
@@ -14,6 +14,7 @@ use crate::scan::cache::{
     file_hash_entry,
 };
 use crate::scan::facts::{FileFacts, ScanFacts};
+use crate::scan::parsed_cache::{ParsedFactsCache, ParsedFactsEntry, content_hash};
 use crate::scan::types::{ChangedFileCacheTelemetry, ScanCacheTelemetry};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io;
@@ -30,6 +31,7 @@ impl<'a> ChangedScanEngine<'a> {
         let file_audits = build_file_audits(self.config);
         let cache_load_start = Instant::now();
         let mut cache = ScanCache::load(&discovery.repo_root);
+        let mut parsed_cache = ParsedFactsCache::load(&discovery.repo_root);
         let mut cache_telemetry = ScanCacheTelemetry {
             timings: crate::scan::types::ScanCacheTimings {
                 load_us: cache_load_start.elapsed().as_micros() as u64,
@@ -61,6 +63,7 @@ impl<'a> ChangedScanEngine<'a> {
                 &mut findings,
                 &mut directories,
                 &mut cache,
+                &mut parsed_cache,
                 &mut cache_telemetry,
                 &mut changed_file_reasons,
                 &mut graph_patch_files,
@@ -78,6 +81,7 @@ impl<'a> ChangedScanEngine<'a> {
             findings,
             graph_patch_files,
             cache,
+            parsed_cache,
             cache_telemetry,
             changed_file_reasons,
             elapsed_us: start.elapsed().as_micros() as u64,
@@ -97,6 +101,7 @@ impl<'a> ChangedScanEngine<'a> {
         findings: &mut Vec<Finding>,
         directories: &mut HashSet<PathBuf>,
         cache: &mut ScanCache,
+        parsed_cache: &mut ParsedFactsCache,
         cache_telemetry: &mut ScanCacheTelemetry,
         changed_file_reasons: &mut BTreeMap<String, usize>,
         graph_patch_files: &mut Vec<FileFacts>,
@@ -107,6 +112,7 @@ impl<'a> ChangedScanEngine<'a> {
             .or_insert(0) += 1;
 
         if changed_file.status == ChangeStatus::Deleted {
+            remove_changed_cache_entries(cache, parsed_cache, &changed_file.path);
             record_skipped_cache_file(
                 cache_telemetry,
                 &changed_file.path,
@@ -123,6 +129,7 @@ impl<'a> ChangedScanEngine<'a> {
             } else {
                 "missing-file"
             };
+            remove_changed_cache_entries(cache, parsed_cache, &changed_file.path);
             record_skipped_cache_file(cache_telemetry, &changed_file.path, &change_reason, reason);
             return Ok(());
         }
@@ -170,6 +177,7 @@ impl<'a> ChangedScanEngine<'a> {
                     findings,
                     cache_telemetry,
                     graph_patch_files,
+                    parsed_cache,
                     *role_entry,
                     cached_findings,
                 );
@@ -208,6 +216,7 @@ impl<'a> ChangedScanEngine<'a> {
                             hash: hash_entry.hash.clone(),
                             language: per_file.language.clone(),
                             non_empty_lines: per_file.file_facts.non_empty_lines,
+                            branch_count: per_file.file_facts.branch_count,
                             imports: per_file.file_facts.imports.clone(),
                             deferred_imports: per_file.file_facts.deferred_imports.clone(),
                             roles: context.roles.clone(),
@@ -224,8 +233,17 @@ impl<'a> ChangedScanEngine<'a> {
                             runtimes: context.runtimes.clone(),
                             paradigms: context.paradigms.clone(),
                             is_test: context.is_test,
+                            has_inline_tests: per_file.file_facts.has_inline_tests,
+                            in_executable_package: per_file.file_facts.in_executable_package,
                         },
                     );
+                    if let Some(content) = per_file.file_facts.content.as_deref() {
+                        parsed_cache.insert(ParsedFactsEntry::from_artifact(
+                            content_hash(content),
+                            &per_file.file_facts,
+                            artifact,
+                        ));
+                    }
                 }
 
                 cache.findings.insert(
@@ -291,32 +309,49 @@ impl<'a> ChangedScanEngine<'a> {
         findings: &mut Vec<Finding>,
         cache_telemetry: &mut ScanCacheTelemetry,
         graph_patch_files: &mut Vec<FileFacts>,
+        parsed_cache: &mut ParsedFactsCache,
         role_entry: FileRoleEntry,
         cached_findings: Vec<Finding>,
     ) {
         let reuse_start = Instant::now();
-        let artifact = ParsedArtifact::from_legacy_cache(
-            PathBuf::from(&role_entry.path),
-            role_entry.language.clone(),
-            role_entry.imports.clone(),
-            role_entry.deferred_imports.clone(),
-            FileContextFacts {
-                roles: role_entry.roles.clone(),
-                role_evidence: role_entry
-                    .role_evidence
-                    .iter()
-                    .map(|evidence| RoleEvidenceFact {
-                        role: evidence.role.clone(),
-                        source: evidence.source.clone(),
-                        reason: evidence.reason.clone(),
-                    })
-                    .collect(),
-                frameworks: role_entry.frameworks.clone(),
-                runtimes: role_entry.runtimes.clone(),
-                paradigms: role_entry.paradigms.clone(),
-                is_test: role_entry.is_test,
-            },
-        );
+        let context = FileContextFacts {
+            roles: role_entry.roles.clone(),
+            role_evidence: role_entry
+                .role_evidence
+                .iter()
+                .map(|evidence| RoleEvidenceFact {
+                    role: evidence.role.clone(),
+                    source: evidence.source.clone(),
+                    reason: evidence.reason.clone(),
+                })
+                .collect(),
+            frameworks: role_entry.frameworks.clone(),
+            runtimes: role_entry.runtimes.clone(),
+            paradigms: role_entry.paradigms.clone(),
+            is_test: role_entry.is_test,
+        };
+        let artifact = parsed_cache
+            .lookup(&role_entry.hash, role_entry.language.as_deref())
+            .map(|entry| {
+                ParsedArtifact::from_parsed_cache_v2(
+                    PathBuf::from(&role_entry.path),
+                    role_entry.language.clone(),
+                    entry.imports.clone(),
+                    entry.deferred_imports.clone(),
+                    entry.exports.clone(),
+                    context.clone(),
+                    (&entry.syntax).into(),
+                )
+            })
+            .unwrap_or_else(|| {
+                ParsedArtifact::from_legacy_cache(
+                    PathBuf::from(&role_entry.path),
+                    role_entry.language.clone(),
+                    role_entry.imports.clone(),
+                    role_entry.deferred_imports.clone(),
+                    context,
+                )
+            });
         let mut graph_file = record_cached_file(facts, languages, &role_entry);
         facts.insert_artifact(artifact);
         graph_file.content = None;
@@ -336,4 +371,17 @@ impl<'a> ChangedScanEngine<'a> {
                 cache_reason: "unchanged-content-and-config".to_string(),
             });
     }
+}
+
+fn remove_changed_cache_entries(
+    cache: &mut ScanCache,
+    parsed_cache: &mut ParsedFactsCache,
+    path: &Path,
+) {
+    let cache_path = path.to_string_lossy().replace('\\', "/");
+    if let Some(hash_entry) = cache.file_hashes.remove(&cache_path) {
+        parsed_cache.remove_content_hash(&hash_entry.hash);
+    }
+    cache.file_roles.remove(&cache_path);
+    cache.findings.remove(&cache_path);
 }

--- a/src/scan/scanner/changed/finalize.rs
+++ b/src/scan/scanner/changed/finalize.rs
@@ -33,8 +33,12 @@ impl<'a> ChangedScanEngine<'a> {
 
         let cache_write_start = Instant::now();
         file_stage.cache.write(&discovery.repo_root)?;
+        file_stage.parsed_cache.write(&discovery.repo_root)?;
         file_stage.cache_telemetry.timings.write_us =
             cache_write_start.elapsed().as_micros() as u64;
+        file_stage
+            .cache_telemetry
+            .record_parsed_cache(file_stage.parsed_cache.telemetry());
         finalize_cache_telemetry(
             &mut file_stage.cache_telemetry,
             file_stage.changed_file_reasons,

--- a/src/scan/scanner/changed/repo_context.rs
+++ b/src/scan/scanner/changed/repo_context.rs
@@ -12,6 +12,7 @@ use crate::graph::{CouplingGraph, build_coupling_graph};
 use crate::risk::{apply_cluster_overlay, apply_graph_overlay, assess_findings};
 use crate::scan::cache::{config_fingerprint, relative_cache_path};
 use crate::scan::facts::{FileFacts, ScanFacts};
+use crate::scan::parsed_cache::ParsedFactsCache;
 use crate::scan::types::cache_diagnostic;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io;
@@ -24,6 +25,7 @@ impl<'a> ChangedScanEngine<'a> {
         discovery: &ChangedDiscoveryStage,
         facts: &mut ScanFacts,
         graph_patch_files: &[FileFacts],
+        parsed_cache: &mut ParsedFactsCache,
     ) -> io::Result<ChangedRepoContextStage> {
         let start = Instant::now();
         let mut diagnostics = Vec::new();
@@ -54,8 +56,12 @@ impl<'a> ChangedScanEngine<'a> {
             });
         }
 
-        let mut repo_context =
-            collection::collect_scan_facts_without_content(repo_root, self.config)?;
+        let mut repo_context = collection::collect_scan_facts_without_content_with_parsed_cache(
+            repo_root,
+            self.config,
+            parsed_cache,
+        )?;
+        parsed_cache.retain_referenced_current_scan();
 
         repo_context.detected_frameworks = detect_frameworks(repo_root);
         repo_context.framework_projects = detect_framework_projects(repo_root);

--- a/src/scan/scanner/changed/stages.rs
+++ b/src/scan/scanner/changed/stages.rs
@@ -4,6 +4,7 @@ use crate::graph::context::{ContextGraphCacheInfo, RepoContextGraph};
 use crate::review::diff::ChangedFile;
 use crate::scan::cache::ScanCache;
 use crate::scan::facts::{FileFacts, ScanFacts};
+use crate::scan::parsed_cache::ParsedFactsCache;
 use crate::scan::types::{ScanCacheTelemetry, ScanDiagnostic};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -19,6 +20,7 @@ pub(super) struct ChangedFileAnalysisStage {
     pub findings: Vec<Finding>,
     pub graph_patch_files: Vec<FileFacts>,
     pub cache: ScanCache,
+    pub parsed_cache: ParsedFactsCache,
     pub cache_telemetry: ScanCacheTelemetry,
     pub changed_file_reasons: BTreeMap<String, usize>,
     pub elapsed_us: u64,

--- a/src/scan/scanner/changed_cache.rs
+++ b/src/scan/scanner/changed_cache.rs
@@ -72,11 +72,11 @@ pub(super) fn record_cached_file(
         path: PathBuf::from(&entry.path),
         language: entry.language.clone(),
         non_empty_lines: entry.non_empty_lines,
-        branch_count: 0,
+        branch_count: entry.branch_count,
         imports: entry.imports.clone(),
         content: None,
-        has_inline_tests: entry.is_test,
-        in_executable_package: false,
+        has_inline_tests: entry.has_inline_tests,
+        in_executable_package: entry.in_executable_package,
         deferred_imports: entry.deferred_imports.clone(),
     };
     facts.files.push(file_facts.clone());

--- a/src/scan/scanner/collection.rs
+++ b/src/scan/scanner/collection.rs
@@ -1,10 +1,11 @@
-use super::file::{SkipReason, collect_file_facts, process_file};
+use super::file::{SkipReason, collect_file_facts, collect_file_facts_with_cache, process_file};
 use super::summary::build_language_summary;
 use super::walker::collect_paths;
 use crate::audits::traits::FileAudit;
 use crate::findings::types::Finding;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
+use crate::scan::parsed_cache::ParsedFactsCache;
 use crate::scan::workspace::{PackageRoot, package_roots};
 use rayon::prelude::*;
 use std::collections::HashMap;
@@ -14,15 +15,6 @@ use std::path::{Path, PathBuf};
 pub(super) struct DiscoveredScanPaths {
     pub(super) facts: ScanFacts,
     pub(super) file_paths: Vec<PathBuf>,
-}
-
-pub(super) fn collect_and_audit_inline(
-    path: &Path,
-    config: &ScanConfig,
-    file_audits: &[Box<dyn FileAudit>],
-) -> io::Result<(ScanFacts, Vec<Finding>)> {
-    let discovered = discover_scan_paths(path, config)?;
-    analyze_discovered_files(discovered, file_audits, config)
 }
 
 pub(super) fn discover_scan_paths(
@@ -147,14 +139,55 @@ pub fn collect_scan_facts_with_config(path: &Path, config: &ScanConfig) -> io::R
     Ok(facts)
 }
 
-pub(crate) fn collect_scan_facts_without_content(
+#[cfg(test)]
+fn collect_scan_facts_without_content(path: &Path, config: &ScanConfig) -> io::Result<ScanFacts> {
+    ensure_path_exists(path)?;
+    let cache_root = parsed_cache_root(path);
+    let mut parsed_cache = ParsedFactsCache::load(&cache_root);
+    let facts =
+        collect_scan_facts_without_content_with_parsed_cache(path, config, &mut parsed_cache)?;
+    parsed_cache.retain_referenced_current_scan();
+    parsed_cache.write(&cache_root)?;
+    Ok(facts)
+}
+
+pub(super) fn collect_scan_facts_without_content_with_parsed_cache(
     path: &Path,
     config: &ScanConfig,
+    parsed_cache: &mut ParsedFactsCache,
 ) -> io::Result<ScanFacts> {
     ensure_path_exists(path)?;
 
-    let empty_audits: &[Box<dyn FileAudit>] = &[];
-    let (facts, _) = collect_and_audit_inline(path, config, empty_audits)?;
+    let mut facts = ScanFacts {
+        root_path: path.to_path_buf(),
+        ..ScanFacts::default()
+    };
+    let mut languages: HashMap<String, usize> = HashMap::new();
+    let roots = package_roots(&facts.root_path);
+
+    if path.is_file() {
+        facts.files_discovered = 1;
+        collect_file_facts_with_cache(
+            path,
+            &mut facts,
+            &mut languages,
+            config,
+            &roots,
+            parsed_cache,
+        )?;
+    } else {
+        collect_directory_facts_with_cache(
+            path,
+            &mut facts,
+            &mut languages,
+            config,
+            &roots,
+            parsed_cache,
+        )?;
+    }
+
+    facts.languages = build_language_summary(languages);
+
     Ok(facts)
 }
 
@@ -178,6 +211,32 @@ fn collect_directory_facts(
 
     for entry_path in file_paths {
         collect_file_facts(&entry_path, facts, languages, config, roots)?;
+    }
+
+    Ok(())
+}
+
+fn collect_directory_facts_with_cache(
+    path: &Path,
+    facts: &mut ScanFacts,
+    languages: &mut HashMap<String, usize>,
+    config: &ScanConfig,
+    roots: &[PackageRoot],
+    parsed_cache: &mut ParsedFactsCache,
+) -> io::Result<()> {
+    let collected = collect_paths(path, config)?;
+    let mut file_paths = collected.file_paths;
+    file_paths.sort();
+
+    facts.files_discovered = file_paths.len();
+    facts.files_skipped_repopilotignore = collected.files_skipped_repopilotignore;
+    facts.repopilotignore_path = collected.repopilotignore_path;
+    facts.directories_count = collected.directories_count;
+
+    apply_max_files_limit(&mut file_paths, facts, config);
+
+    for entry_path in file_paths {
+        collect_file_facts_with_cache(&entry_path, facts, languages, config, roots, parsed_cache)?;
     }
 
     Ok(())
@@ -209,4 +268,118 @@ fn apply_max_files_limit(
 
     facts.files_skipped_by_limit = file_paths.len().saturating_sub(max);
     file_paths.truncate(max);
+}
+
+#[cfg(test)]
+fn parsed_cache_root(path: &Path) -> PathBuf {
+    if path.is_file() {
+        return path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+    }
+    path.to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn collect_without_content_reuses_cached_parsed_facts_on_warm_run() {
+        let temp = tempdir().expect("temp dir");
+        let src = temp.path().join("src");
+        fs::create_dir_all(&src).expect("create src");
+        fs::write(
+            src.join("lib.rs"),
+            "use crate::api::run;\nmod api;\npub fn main() { run(); }\n",
+        )
+        .expect("write source");
+        fs::write(src.join("api.rs"), "pub fn run() {}\n").expect("write api");
+        let original_api_hash = crate::scan::parsed_cache::content_hash("pub fn run() {}\n");
+
+        let first_before = crate::analysis::parse::parse_nanos_total();
+        let first = collect_scan_facts_without_content(temp.path(), &ScanConfig::default())
+            .expect("cold facts collection");
+        let first_parse = crate::analysis::parse::parse_nanos_total().saturating_sub(first_before);
+        assert_eq!(first.files_analyzed, 2);
+        assert!(first_parse > 0, "cold run should parse source files");
+        assert!(
+            temp.path()
+                .join(".repopilot/cache/parsed_facts_v2.json")
+                .is_file()
+        );
+
+        let second_before = crate::analysis::parse::parse_nanos_total();
+        let second = collect_scan_facts_without_content(temp.path(), &ScanConfig::default())
+            .expect("warm facts collection");
+        let second_parse =
+            crate::analysis::parse::parse_nanos_total().saturating_sub(second_before);
+
+        assert_eq!(second.files_analyzed, 2);
+        assert_eq!(second_parse, 0, "warm run should reuse parsed facts");
+
+        fs::write(src.join("api.rs"), "pub fn run() { if true { return; } }\n")
+            .expect("modify api");
+        let changed_before = crate::analysis::parse::parse_nanos_total();
+        let changed = collect_scan_facts_without_content(temp.path(), &ScanConfig::default())
+            .expect("changed facts collection");
+        let changed_parse =
+            crate::analysis::parse::parse_nanos_total().saturating_sub(changed_before);
+
+        assert_eq!(changed.files_analyzed, 2);
+        assert!(
+            changed_parse > 0,
+            "changed content should miss parsed cache"
+        );
+        assert!(!parsed_cache_hashes(temp.path()).contains(&original_api_hash));
+
+        fs::write(src.join("extra.rs"), "pub fn extra() {}\n").expect("add extra");
+        let extra_hash = crate::scan::parsed_cache::content_hash("pub fn extra() {}\n");
+        let added_before = crate::analysis::parse::parse_nanos_total();
+        let added = collect_scan_facts_without_content(temp.path(), &ScanConfig::default())
+            .expect("added-file facts collection");
+        let added_parse = crate::analysis::parse::parse_nanos_total().saturating_sub(added_before);
+        assert_eq!(added.files_analyzed, 3);
+        assert!(added_parse > 0, "added file should miss parsed cache");
+
+        fs::remove_file(src.join("extra.rs")).expect("remove extra");
+        let removed = collect_scan_facts_without_content(temp.path(), &ScanConfig::default())
+            .expect("removed-file facts collection");
+        assert_eq!(removed.files_analyzed, 2);
+        assert!(!parsed_cache_hashes(temp.path()).contains(&extra_hash));
+    }
+
+    #[test]
+    fn single_file_without_content_uses_parent_as_cache_root() {
+        let temp = tempdir().expect("temp dir");
+        let file = temp.path().join("single.rs");
+        fs::write(&file, "pub fn single() {}\n").expect("write single file");
+
+        let facts = collect_scan_facts_without_content(&file, &ScanConfig::default())
+            .expect("single-file facts collection");
+
+        assert_eq!(facts.files_analyzed, 1);
+        assert!(
+            temp.path()
+                .join(".repopilot/cache/parsed_facts_v2.json")
+                .is_file()
+        );
+        assert!(!file.join(".repopilot/cache/parsed_facts_v2.json").exists());
+    }
+
+    fn parsed_cache_hashes(root: &Path) -> Vec<String> {
+        let path = root.join(".repopilot/cache/parsed_facts_v2.json");
+        let value: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(path).expect("read parsed cache"))
+                .expect("parse parsed cache");
+        value["entries"]
+            .as_array()
+            .expect("entries should be array")
+            .iter()
+            .filter_map(|entry| entry["content_hash"].as_str().map(str::to_string))
+            .collect()
+    }
 }

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -9,6 +9,7 @@ use crate::graph::imports::{extract_deferred_imports_from, extract_imports_from}
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::{FileFacts, ScanFacts};
 use crate::scan::language::detect_language;
+use crate::scan::parsed_cache::{ParsedFactsCache, ParsedFactsEntry, content_hash};
 use crate::scan::path_classification::is_low_signal_audit_path;
 use crate::scan::workspace::{PackageRoot, path_in_executable_package};
 use std::collections::HashMap;
@@ -262,17 +263,63 @@ pub(super) fn collect_file_facts(
     config: &ScanConfig,
     package_roots: &[PackageRoot],
 ) -> io::Result<()> {
+    collect_file_facts_inner(path, facts, languages, config, package_roots, None)
+}
+
+pub(super) fn collect_file_facts_with_cache(
+    path: &Path,
+    facts: &mut ScanFacts,
+    languages: &mut HashMap<String, usize>,
+    config: &ScanConfig,
+    package_roots: &[PackageRoot],
+    parsed_cache: &mut ParsedFactsCache,
+) -> io::Result<()> {
+    collect_file_facts_inner(
+        path,
+        facts,
+        languages,
+        config,
+        package_roots,
+        Some(parsed_cache),
+    )
+}
+
+fn collect_file_facts_inner(
+    path: &Path,
+    facts: &mut ScanFacts,
+    languages: &mut HashMap<String, usize>,
+    config: &ScanConfig,
+    package_roots: &[PackageRoot],
+    mut parsed_cache: Option<&mut ParsedFactsCache>,
+) -> io::Result<()> {
     let LoadedFile::Analyzable { mut full_facts, .. } =
         load_file_or_record_skip(path, facts, config, package_roots)?
     else {
         return Ok(());
     };
 
-    // No audits run on this path, so the parse view is built solely to extract
-    // imports; it is still parsed at most once via the shared parsers. Bind the
-    // result first so the view's borrow of `full_facts` ends before the write.
     let context = file_context_facts(&full_facts);
-    let (imports, deferred_imports, exports, syntax) = {
+    let content_hash = full_facts.content.as_deref().map(content_hash);
+    let cached = content_hash.as_deref().and_then(|hash| {
+        parsed_cache
+            .as_deref_mut()
+            .and_then(|cache| cache.lookup(hash, full_facts.language.as_deref()))
+    });
+
+    let mut from_parsed_cache = false;
+    let (imports, deferred_imports, exports, syntax) = if let Some(entry) = cached {
+        from_parsed_cache = true;
+        full_facts.branch_count = entry.branch_count;
+        full_facts.has_inline_tests = entry.has_inline_tests;
+        (
+            entry.imports,
+            entry.deferred_imports,
+            entry.exports,
+            (&entry.syntax).into(),
+        )
+    } else {
+        // No audits run on this path, so the parse view is built solely to
+        // extract imports and syntax facts.
         let parsed = ParsedFile::for_facts(&full_facts);
         let lang = full_facts.language.as_deref();
         (
@@ -284,15 +331,34 @@ pub(super) fn collect_file_facts(
     };
     full_facts.imports = imports;
     full_facts.deferred_imports = deferred_imports;
-    let artifact = ParsedArtifact::from_source(
-        full_facts.path.clone(),
-        full_facts.language.clone(),
-        full_facts.imports.clone(),
-        full_facts.deferred_imports.clone(),
-        exports,
-        context,
-        syntax,
-    );
+    let artifact = if from_parsed_cache {
+        ParsedArtifact::from_parsed_cache_v2(
+            full_facts.path.clone(),
+            full_facts.language.clone(),
+            full_facts.imports.clone(),
+            full_facts.deferred_imports.clone(),
+            exports,
+            context,
+            syntax,
+        )
+    } else {
+        ParsedArtifact::from_source(
+            full_facts.path.clone(),
+            full_facts.language.clone(),
+            full_facts.imports.clone(),
+            full_facts.deferred_imports.clone(),
+            exports,
+            context,
+            syntax,
+        )
+    };
+    if let (Some(cache), Some(hash)) = (parsed_cache.as_mut(), content_hash) {
+        cache.insert(ParsedFactsEntry::from_artifact(
+            hash,
+            &full_facts,
+            &artifact,
+        ));
+    }
 
     record_analyzed_file(facts, languages, &full_facts);
     facts.insert_artifact(artifact);

--- a/src/scan/types/support.rs
+++ b/src/scan/types/support.rs
@@ -77,10 +77,43 @@ pub struct ScanCacheTelemetry {
     pub misses: usize,
     pub skipped: usize,
     pub hit_rate_percent: u8,
+    #[serde(default)]
+    pub parsed_cache_hits: usize,
+    #[serde(default)]
+    pub parsed_cache_misses: usize,
+    #[serde(default)]
+    pub parsed_cache_invalidations: usize,
+    #[serde(default)]
+    pub parsed_cache_corruptions: usize,
+    #[serde(default)]
+    pub parsed_cache_entries_loaded: usize,
+    #[serde(default)]
+    pub parsed_cache_entries_written: usize,
     pub changed_file_reasons: Vec<ChangedFileReasonSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub changed_files: Vec<ChangedFileCacheTelemetry>,
     pub timings: ScanCacheTimings,
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ParsedCacheTelemetry {
+    pub hits: usize,
+    pub misses: usize,
+    pub invalidations: usize,
+    pub corruptions: usize,
+    pub entries_loaded: usize,
+    pub entries_written: usize,
+}
+
+impl ScanCacheTelemetry {
+    pub fn record_parsed_cache(&mut self, telemetry: ParsedCacheTelemetry) {
+        self.parsed_cache_hits = telemetry.hits;
+        self.parsed_cache_misses = telemetry.misses;
+        self.parsed_cache_invalidations = telemetry.invalidations;
+        self.parsed_cache_corruptions = telemetry.corruptions;
+        self.parsed_cache_entries_loaded = telemetry.entries_loaded;
+        self.parsed_cache_entries_written = telemetry.entries_written;
+    }
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/tests/cache_fingerprint.rs
+++ b/tests/cache_fingerprint.rs
@@ -11,7 +11,7 @@ fn stable_hash_hex_uses_sha256() {
 
 #[test]
 fn config_fingerprint_changes_with_config_and_cache_schema_context() {
-    assert_eq!(CACHE_SCHEMA_VERSION, 7);
+    assert_eq!(CACHE_SCHEMA_VERSION, 8);
 
     let default = config_fingerprint(&ScanConfig::default());
     let changed = config_fingerprint(&ScanConfig {

--- a/tests/output_console.rs
+++ b/tests/output_console.rs
@@ -180,6 +180,7 @@ fn cache_telemetry() -> ScanCacheTelemetry {
             write_us: 6_000,
             estimated_time_saved_us: Some(7_000),
         },
+        ..Default::default()
     }
 }
 

--- a/tests/output_markdown.rs
+++ b/tests/output_markdown.rs
@@ -261,6 +261,7 @@ fn cache_telemetry() -> ScanCacheTelemetry {
             write_us: 6_000,
             estimated_time_saved_us: Some(7_000),
         },
+        ..Default::default()
     }
 }
 

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -58,6 +58,7 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
     assert!(cache_dir.join("file_hashes.json").is_file());
     assert!(cache_dir.join("file_roles.json").is_file());
     assert!(cache_dir.join("findings.json").is_file());
+    assert!(cache_dir.join("parsed_facts_v2.json").is_file());
     assert!(cache_dir.join("repo_context.json").is_file());
     assert_eq!(
         read_json(&cache_dir.join("file_hashes.json"))["schema_version"],
@@ -70,10 +71,34 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
             .len(),
         64
     );
+    assert_eq!(
+        read_json(&cache_dir.join("parsed_facts_v2.json"))["analysis_version"],
+        "tree-sitter-imports-exports-v1"
+    );
+    assert_eq!(
+        read_json(&cache_dir.join("parsed_facts_v2.json"))["entries"][0]["content_hash"]
+            .as_str()
+            .expect("content hash should be string"),
+        read_json(&cache_dir.join("file_hashes.json"))["entries"][0]["hash"]
+            .as_str()
+            .expect("file hash should be string")
+    );
 
     rewrite_cached_finding_title(&cache_dir.join("findings.json"), "Cached secret title");
     let cached = scan_changed_json(temp.path(), &["--changed"]);
     assert_eq!(cached["cache_telemetry"]["hits"], 1);
+    assert_eq!(cached["cache_telemetry"]["parsed_cache_hits"], 1);
+    assert_eq!(cached["cache_telemetry"]["parsed_cache_misses"], 0);
+    assert!(
+        cached["cache_telemetry"]["parsed_cache_entries_loaded"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    );
+    assert!(
+        cached["cache_telemetry"]["parsed_cache_entries_written"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    );
     assert_eq!(cached["context_graph_cache"]["status"], "hit");
     assert_eq!(cached["cache_telemetry"]["misses"], 0);
     assert_eq!(cached["cache_telemetry"]["hit_rate_percent"], 100);
@@ -124,6 +149,41 @@ fn changed_scan_and_cache_keep_distinct_secret_occurrences_with_colliding_baseli
     assert_eq!(secret_candidate_count(&cached), 2);
     assert_eq!(cached["cache_telemetry"]["hits"], 1);
     assert_eq!(cached["cache_telemetry"]["misses"], 0);
+}
+
+#[test]
+fn changed_scan_deletes_stale_path_and_parsed_cache_entries() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(temp.path().join("src/lib.rs"), "pub mod gone;\n");
+    write(temp.path().join("src/gone.rs"), "pub fn gone() {}\n");
+    commit_all(temp.path(), "initial");
+
+    write(
+        temp.path().join("src/gone.rs"),
+        "pub fn gone() { if true { return; } }\n",
+    );
+    let first = scan_changed_json(temp.path(), &["--changed"]);
+    assert_eq!(first["cache_telemetry"]["misses"], 1);
+    let cache_dir = temp.path().join(".repopilot/cache");
+    let deleted_hash = read_json(&cache_dir.join("file_hashes.json"))["entries"][0]["hash"]
+        .as_str()
+        .expect("hash should be string")
+        .to_string();
+
+    fs::remove_file(temp.path().join("src/gone.rs")).expect("delete changed file");
+    let deleted = scan_changed_json(temp.path(), &["--changed"]);
+
+    assert_eq!(deleted["cache_telemetry"]["skipped"], 1);
+    assert!(
+        deleted["cache_telemetry"]["parsed_cache_invalidations"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    );
+    assert!(!cache_paths(&cache_dir.join("file_hashes.json")).contains(&"src/gone.rs".to_string()));
+    assert!(!cache_paths(&cache_dir.join("file_roles.json")).contains(&"src/gone.rs".to_string()));
+    assert!(!cache_paths(&cache_dir.join("findings.json")).contains(&"src/gone.rs".to_string()));
+    assert!(!parsed_cache_hashes(&cache_dir).contains(&deleted_hash));
 }
 
 #[test]
@@ -735,6 +795,24 @@ fn write_json(path: &Path, value: &Value) {
 
 fn read_json(path: &Path) -> Value {
     serde_json::from_slice(&fs::read(path).expect("read json")).expect("json")
+}
+
+fn cache_paths(path: &Path) -> Vec<String> {
+    read_json(path)["entries"]
+        .as_array()
+        .expect("cache entries")
+        .iter()
+        .filter_map(|entry| entry["path"].as_str().map(str::to_string))
+        .collect()
+}
+
+fn parsed_cache_hashes(cache_dir: &Path) -> Vec<String> {
+    read_json(&cache_dir.join("parsed_facts_v2.json"))["entries"]
+        .as_array()
+        .expect("parsed cache entries")
+        .iter()
+        .filter_map(|entry| entry["content_hash"].as_str().map(str::to_string))
+        .collect()
 }
 
 fn first_finding_title(json: &Value) -> &str {


### PR DESCRIPTION
## Summary

Add content-addressed analysis cache v2 for parsed repository facts.

RepoPilot now persists reusable parsing results by source-content hash and language:

```text
source content
→ SHA-256 content hash + language
→ imports + deferred imports + exports + syntax summary
→ parsed_facts_v2.json
→ warm analysis reuse
```

This allows unchanged files to reuse parsed facts during warm repository-context collection and changed scans without changing current findings or public output schemas.

## Type of change

* [ ] Feature
* [x] Performance
* [x] Refactor
* [x] Tests
* [x] Documentation
* [ ] Bug fix
* [ ] CI / repository maintenance

## What changed

* Added `.repopilot/cache/parsed_facts_v2.json`.
* Added content-addressed cache keys based on:

  * SHA-256 source-content hash;
  * detected language.
* Persisted reusable file-analysis facts:

  * imports;
  * deferred and runtime-erased imports;
  * exports;
  * syntax parse status;
  * syntax root kind;
  * syntax error status;
  * named syntax-child count;
  * non-empty line count;
  * branch count;
  * inline-test presence.
* Integrated parsed-cache lookup into repository-context fact collection.
* Populated parsed-cache entries from changed-scan cache misses.
* Restored complete parsed artifacts on changed-scan cache hits when a compatible v2 entry exists.
* Preserved the explicit incomplete legacy-cache fallback when parsed facts are unavailable.
* Added explicit parsed-cache artifact provenance.
* Added analysis-version invalidation independent of the package version.
* Added pruning for unreferenced historical content entries so the cache remains bounded.
* Updated file-role cache schema to v8 to preserve:

  * branch count;
  * inline-test state;
  * executable-package state.
* Added parsed-cache telemetry for:

  * hits;
  * misses;
  * invalidations;
  * corrupt files;
  * loaded and written entries.
* Preserved graceful recovery from missing, incompatible, or corrupt cache files.
* Updated the v0.20 roadmap progress and unreleased changelog.

## Why

RepoPilot already cached file hashes, roles, findings, and repository-context graph data, but complete parsed artifacts were not reusable across analysis runs.

As a result, unchanged files could still repeat tree-sitter parsing and import/export extraction during repository-context reconstruction.

Cache v2 separates parsed facts from path-specific and rule-specific state:

```text
content-dependent facts
→ content-addressed cache

path, role, workspace and configuration context
→ recomputed or stored separately
```

This allows identical content to reuse parsed facts even when it appears at another path while keeping path-sensitive classification current.

## Cache contract

A parsed-cache entry is reusable only when all compatibility dimensions match:

```text
schema version
+ analysis version
+ content hash
+ detected language
```

Rule configuration is intentionally not part of the key because cached parsed facts do not contain findings or rule decisions.

The analysis version is bumped whenever parser, import extraction, deferred-import extraction, export extraction, or syntax-summary semantics change.

## Invalidation behavior

### File changed

A new content hash produces a cache miss and a new parsed-facts entry.

### File added

The new file is parsed and inserted into cache.

### File removed

Entries no longer referenced by the current repository file-hash set are pruned according to the cache retention policy.

### Cache incompatible

Schema or analysis-version mismatch discards the parsed cache and falls back to cold parsing.

### Cache corrupt

Invalid JSON or invalid cache structure is ignored without failing analysis. A valid cache is rewritten after the scan completes.

## Cache bounds

The parsed cache does not grow indefinitely.

Unreferenced historical entries are pruned or evicted under a deterministic size policy, and cache writes preserve stable ordering.

## Contract and ownership

* [x] The change stays within scan and cache ownership boundaries.
* [x] Cached facts are keyed by source content rather than repository path.
* [x] Cache provenance remains explicit.
* [x] Cache compatibility is versioned independently from package releases.
* [x] Missing or corrupt cache data falls back to cold analysis.
* [x] Warm and cold facts remain equivalent.
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered.
* [x] No finding IDs changed.
* [x] No severity or confidence behavior changed.
* [x] No evidence, risk, provenance, or visibility behavior changed.
* [x] No public report schema changed.
* [x] No unrelated refactor is included.

## Compatibility

No intentional public product changes:

* no new CLI command or flag;
* no finding additions or removals;
* no finding-ID changes;
* no scan or review JSON schema changes;
* no SARIF changes;
* no baseline changes;
* no MCP schema changes;
* no rule execution-order changes.

The internal file-role cache schema changes from v7 to v8.

Parsed cache v2 is optional and disposable. Deleting it only causes cold reparsing.

## Verification

```bash
cargo test scan::parsed_cache
cargo test collect_without_content_reuses_cached_parsed_facts_on_warm_run
cargo test --test scan_changed_cache_cli
cargo test --test cache_fingerprint

cargo check --all-targets --all-features
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all

npm run review:performance
npm run scan:performance
npm run release:contract
npm run test:release-contract

./scripts/smoke-product.sh
git diff --check
```

Additional cache-v2 contract coverage:

```text
parsed_cache_invalidates_when_analysis_version_changes
parsed_cache_prunes_unreferenced_entries
parsed_cache_records_hit_miss_and_corruption_telemetry
parsed_cache_hit_uses_cache_v2_artifact_origin
single_file_fact_collection_uses_valid_cache_root
```