### PR TITLE
feat(review): add verification plans for sensitive review signals

### DIFF
--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -212,6 +212,11 @@ fn render_tier_group(
             render_signal_detail(signal),
             render_reach_suffix(signal.blast_radius),
         ));
+        if let Some(plan) = &signal.verification_plan
+            && let Some(step) = plan.steps.first()
+        {
+            output.push_str(&format!("      Verify: {step}\n"));
+        }
     }
     *remaining = remaining.saturating_sub(shown);
     if active.len() > shown {

--- a/src/review/render/markdown.rs
+++ b/src/review/render/markdown.rs
@@ -228,8 +228,8 @@ fn render_markdown_tier(
     }
 
     output.push_str(&format!("### {label}\n\n"));
-    output.push_str("| Signal | Location | Detail | Reach |\n");
-    output.push_str("| --- | --- | --- | --- |\n");
+    output.push_str("| Signal | Location | Detail | Reach | Verification |\n");
+    output.push_str("| --- | --- | --- | --- | --- |\n");
 
     let shown = active.len().min(*remaining);
     for signal in active.iter().take(shown) {
@@ -251,12 +251,19 @@ fn render_markdown_tier(
             0 => "—".to_string(),
             count => format!("imported by {count}"),
         };
+        let verification = signal
+            .verification_plan
+            .as_ref()
+            .and_then(|plan| plan.steps.first())
+            .map(|step| escape_table_cell(step))
+            .unwrap_or_else(|| "—".to_string());
         output.push_str(&format!(
-            "| {} | {} | {} | {} |\n",
+            "| {} | {} | {} | {} | {} |\n",
             escape_table_cell(&signal.headline),
             location,
             detail,
-            reach
+            reach,
+            verification
         ));
     }
 

--- a/src/review/signals/tiered.rs
+++ b/src/review/signals/tiered.rs
@@ -68,6 +68,11 @@ pub struct ReviewSignalProvenance {
     pub analysis_scope: AnalysisScope,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReviewSignalVerificationPlan {
+    pub steps: Vec<String>,
+}
+
 /// One unified review signal, ready to render under its tier.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ReviewSignal {
@@ -97,6 +102,8 @@ pub struct ReviewSignal {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suppression_reason: Option<String>,
     pub gate_eligible: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_plan: Option<ReviewSignalVerificationPlan>,
 }
 
 /// The review's signals grouped by confidence tier.
@@ -307,6 +314,18 @@ fn build_signal(
     signal_source: SignalSource,
 ) -> ReviewSignal {
     let signal_id = stable_hash_hex(format!("{kind}\0{path}").as_bytes())[..16].to_string();
+    let gate_eligible = tier == ConfidenceTier::DefinitelySensitive;
+    let verification_plan = build_verification_plan(
+        kind,
+        family,
+        confidence,
+        &path,
+        line,
+        headline,
+        detail.as_deref(),
+        gate_eligible,
+    );
+
     ReviewSignal {
         signal_id,
         kind: kind.to_string(),
@@ -329,7 +348,114 @@ fn build_signal(
         },
         suppressed: false,
         suppression_reason: None,
-        gate_eligible: tier == ConfidenceTier::DefinitelySensitive,
+        gate_eligible,
+        verification_plan,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_verification_plan(
+    kind: &str,
+    family: SignalFamily,
+    confidence: Confidence,
+    path: &str,
+    line: Option<usize>,
+    headline: &str,
+    detail: Option<&str>,
+    gate_eligible: bool,
+) -> Option<ReviewSignalVerificationPlan> {
+    if !gate_eligible || confidence != Confidence::High || path.is_empty() {
+        return None;
+    }
+
+    let location = match line {
+        Some(line) => format!("{path}:{line}"),
+        None => path.to_string(),
+    };
+    let mut steps = vec![format!(
+        "Open {location} and confirm the changed diff still supports the review signal: {headline}."
+    )];
+
+    if let Some(detail) = detail.filter(|detail| !detail.trim().is_empty()) {
+        steps.push(format!(
+            "Compare the pre-change and post-change code around {location}; verify this detail is still accurate: {detail}."
+        ));
+    }
+
+    steps.push(family_specific_verification_step(kind, family).to_string());
+    steps.push(
+        "This plan is generated from Git diff/static review evidence only — it does not execute code, run tests, or observe runtime behavior. Treat it as a starting point for manual or test-based confirmation, not proof."
+            .to_string(),
+    );
+
+    Some(ReviewSignalVerificationPlan { steps })
+}
+
+fn family_specific_verification_step(kind: &str, family: SignalFamily) -> &'static str {
+    match family {
+        SignalFamily::Boundary => match kind {
+            "boundary.access-control" => {
+                "Confirm the changed access-control path still enforces the expected authentication, authorization, session, or permission behavior, and add or update a focused test when coverage is missing."
+            }
+            "boundary.request-trust" => {
+                "Confirm the changed request-trust surface still enforces the expected CORS, CSP, security-header, cookie, or request validation behavior."
+            }
+            "boundary.deploy-surface" => {
+                "Review the changed deploy or CI surface for privilege, secret, environment, artifact, and production rollout impact before merging."
+            }
+            "boundary.supply-chain" => {
+                "Review the dependency or lockfile change, confirm the package source and version are expected, and run the project's dependency/security checks."
+            }
+            "boundary.secret-config" => {
+                "Confirm no real secret was committed and that runtime configuration still comes from the intended secret-management path."
+            }
+            _ => {
+                "Review the changed boundary with the project owner and confirm it is covered by tests, configuration review, or a manual release checklist."
+            }
+        },
+        SignalFamily::Behavioral => match kind {
+            "behavioral.network-call-added" => {
+                "Confirm the new network call has the expected timeout, retry, error handling, authorization, and data exposure behavior."
+            }
+            "behavioral.subprocess-added" => {
+                "Confirm subprocess arguments cannot be controlled unsafely by user input and that failures are handled explicitly."
+            }
+            "behavioral.fs-write-added" => {
+                "Confirm the filesystem write target is expected, path traversal is not possible, and failures do not leave partial unsafe state."
+            }
+            "behavioral.env-var-introduced" => {
+                "Confirm the new environment variable is documented, validated at startup, and safe when missing or malformed."
+            }
+            "behavioral.migration-added" => {
+                "Review the migration forward/backward path, data-loss risk, locking behavior, and deployment ordering."
+            }
+            "behavioral.error-handling-removed" => {
+                "Confirm removing this error handling cannot hide failures, skip cleanup, or turn recoverable errors into unsafe success paths."
+            }
+            "behavioral.auth-check-removed" => {
+                "Confirm the removed auth check is replaced by an equivalent guard in the same request path or an earlier boundary."
+            }
+            _ => {
+                "Confirm the behavioral change is intentional and covered by a focused test or a documented manual check."
+            }
+        },
+        SignalFamily::Taint => match kind {
+            "taint.sql" => {
+                "Trace the changed input source to the SQL sink and confirm parameterization, escaping, validation, or an equivalent guard blocks injection."
+            }
+            "taint.exec" => {
+                "Trace the changed input source to the subprocess sink and confirm arguments are fixed, allowlisted, or safely encoded."
+            }
+            _ => {
+                "Trace the changed input source to the reported sink and confirm validation, allowlisting, or safe encoding exists on that path."
+            }
+        },
+        SignalFamily::Algorithmic => {
+            "Confirm the algorithmic change is intentional, covered by representative inputs, and does not regress the expected complexity envelope."
+        }
+        SignalFamily::Volume => {
+            "Split or manually sample the large diff so ownership, tests, and risky surfaces are reviewed instead of treating volume as proof."
+        }
     }
 }
 
@@ -352,6 +478,9 @@ fn deduplicate(tiered: &mut TieredSignals) {
                 existing.line_end = existing.evidence_lines.last().copied();
                 existing.line = existing.line_start;
                 existing.blast_radius = existing.blast_radius.max(signal.blast_radius);
+                if existing.verification_plan.is_none() {
+                    existing.verification_plan = signal.verification_plan.clone();
+                }
             })
             .or_insert(signal);
     }

--- a/src/review/signals/tiered_tests.rs
+++ b/src/review/signals/tiered_tests.rs
@@ -203,3 +203,72 @@ fn small_diff_with_nothing_flagged_is_silent() {
     let tiered = build_tiered(&[], &[], &[], &[], &large_diff(2));
     assert!(tiered.is_empty());
 }
+
+#[test]
+fn definitely_sensitive_signals_include_verification_plan() {
+    let tiered = build_tiered(
+        &[boundary(BoundaryCategory::AccessControl, "src/auth.ts")],
+        &[],
+        &[],
+        &[],
+        &[],
+    );
+
+    let plan = tiered.definitely[0]
+        .verification_plan
+        .as_ref()
+        .expect("definitely sensitive review signals should include a verification plan");
+
+    assert!(plan.steps.len() >= 3);
+    assert!(plan.steps[0].contains("src/auth.ts"));
+    assert!(
+        plan.steps
+            .iter()
+            .any(|step| step.contains("static review evidence only"))
+    );
+}
+
+#[test]
+fn maybe_and_noise_signals_do_not_get_verification_plans() {
+    let maybe = build_tiered(
+        &[],
+        &[behavioral(BehavioralKind::NetworkCallAdded, "src/api.ts")],
+        &[],
+        &[],
+        &[],
+    );
+    assert!(maybe.definitely.is_empty());
+    assert!(maybe.maybe[0].verification_plan.is_none());
+
+    let noise = build_tiered(&[], &[], &[], &[], &large_diff(6));
+    assert!(noise.noise[0].verification_plan.is_none());
+}
+
+#[test]
+fn review_signal_verification_plans_are_deterministic() {
+    let left = build_tiered(
+        &[],
+        &[behavioral(
+            BehavioralKind::EnvVarIntroduced,
+            "src/config.ts",
+        )],
+        &[],
+        &[],
+        &[],
+    );
+    let right = build_tiered(
+        &[],
+        &[behavioral(
+            BehavioralKind::EnvVarIntroduced,
+            "src/config.ts",
+        )],
+        &[],
+        &[],
+        &[],
+    );
+
+    assert_eq!(
+        left.definitely[0].verification_plan,
+        right.definitely[0].verification_plan
+    );
+}


### PR DESCRIPTION
## Summary

Adds verification plans to high-confidence, definitely-sensitive review signals so RepoPilot can explain not only **what changed**, but also **how a reviewer should verify it** before merging.

This keeps review signals humble: the plan is generated from Git diff/static evidence only and is explicitly framed as a manual/test-based confirmation checklist, not proof.

## Type of change

* [x] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Tests
* [ ] Documentation
* [ ] CI / repository maintenance

## What changed

* Added `ReviewSignalVerificationPlan` with deterministic `steps`.
* Added optional `verification_plan` to `ReviewSignal`.
* Generates plans only for high-confidence `DefinitelySensitive` signals.
* Keeps `MaybeSensitive` and `LargeDiffOrNoise` signals plan-free to avoid overclaiming.
* Adds family-specific verification guidance for boundary, behavioral, taint, algorithmic, and volume signal families.
* Renders the first verification step in console and Markdown review output.
* Preserves the full verification plan in JSON via `tiered_signals`.
* Adds tests for:

  * definitely-sensitive signals receiving a verification plan;
  * maybe/noise signals not receiving plans;
  * deterministic plan generation.

## Why

PR #281 added verification plans for normal findings, but review-layer signals still only told the reviewer where to look. This PR closes that gap for the most sensitive review signals.

It improves RepoPilot’s value for PR review by turning risky structural signals into actionable verification steps while preserving the product’s “flags, not verdicts” contract.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
* [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
* [x] No unrelated refactor or generated-file churn is included

Subsystem: `review::signals::tiered` and review renderers.

Public behavior affected:

* Review JSON now includes optional `verification_plan` for qualifying `tiered_signals`.
* Console and Markdown review output now show the first verification step for qualifying signals.

Compatibility note:

* This is additive and optional.
* Existing consumers that ignore unknown JSON fields should remain compatible.
* Follow-up recommended: bump/lock the report schema contract for `verification_plan`.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
git diff --check
```
