### PR TITLE
test(review): lock verification plan JSON contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ node_modules/
 .repopilot/cache/
 # Scan caches written under any nested project root (e.g. when scanning a subdir).
 **/.repopilot/cache/
+.agents/
 .claude/
+.codex/
 dist/
 .DS_Store
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+- Bump the report schema to `0.23` and lock the review-signal verification-plan JSON contract for agent/CI consumers.
+
 ### Added
 
 - v0.20 roadmap, performance benchmark matrix, and release scorecard define the

--- a/src/report/schema.rs
+++ b/src/report/schema.rs
@@ -18,7 +18,7 @@ use serde_json::Value;
 use std::io;
 use std::path::PathBuf;
 
-pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.22";
+pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.23";
 const ACCEPTED_SCAN_REPORT_SCHEMA_VERSIONS: &[&str] = &[
     "0.16",
     "0.17",
@@ -26,6 +26,7 @@ const ACCEPTED_SCAN_REPORT_SCHEMA_VERSIONS: &[&str] = &[
     "0.19",
     "0.20",
     "0.21",
+    "0.22",
     SCAN_REPORT_SCHEMA_VERSION,
 ];
 pub const REPOPILOT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -271,4 +272,28 @@ fn validate_current_scan_report(value: &Value) -> Result<(), serde_json::Error> 
 
 fn is_accepted_scan_schema_version(version: &str) -> bool {
     ACCEPTED_SCAN_REPORT_SCHEMA_VERSIONS.contains(&version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn schema_version_tracks_review_signal_verification_contract() {
+        assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.23");
+    }
+
+    #[test]
+    fn accepts_previous_scan_schema_after_review_contract_bump() {
+        let value = json!({
+            "schema_version": "0.22",
+            "report": {
+                "kind": "scan",
+                "schema_version": "0.22"
+            }
+        });
+
+        assert!(validate_current_scan_report(&value).is_ok());
+    }
 }

--- a/src/review/signals/tiered_tests.rs
+++ b/src/review/signals/tiered_tests.rs
@@ -272,3 +272,50 @@ fn review_signal_verification_plans_are_deterministic() {
         right.definitely[0].verification_plan
     );
 }
+
+#[test]
+fn review_signal_verification_plan_serializes_as_stable_steps_array() {
+    let tiered = build_tiered(
+        &[boundary(BoundaryCategory::AccessControl, "src/auth.ts")],
+        &[],
+        &[],
+        &[],
+        &[],
+    );
+
+    let value = serde_json::to_value(&tiered.definitely[0])
+        .expect("review signals should serialize to JSON");
+    let steps = value
+        .get("verification_plan")
+        .and_then(|plan| plan.get("steps"))
+        .and_then(serde_json::Value::as_array)
+        .expect("verification_plan.steps should be a stable JSON array");
+
+    assert_eq!(steps.len(), 3);
+    assert_eq!(
+        steps[0].as_str(),
+        Some(
+            "Open src/auth.ts and confirm the changed diff still supports the review signal: access control changed."
+        )
+    );
+    assert!(steps.iter().any(|step| {
+        step.as_str()
+            .is_some_and(|step| step.contains("static review evidence only"))
+    }));
+}
+
+#[test]
+fn maybe_signal_omits_verification_plan_in_json_contract() {
+    let tiered = build_tiered(
+        &[],
+        &[behavioral(BehavioralKind::NetworkCallAdded, "src/api.ts")],
+        &[],
+        &[],
+        &[],
+    );
+
+    let value =
+        serde_json::to_value(&tiered.maybe[0]).expect("review signals should serialize to JSON");
+
+    assert!(value.get("verification_plan").is_none());
+}

--- a/tests/fixtures/golden/scan-json-schema.golden.json
+++ b/tests/fixtures/golden/scan-json-schema.golden.json
@@ -1,9 +1,9 @@
 {
-  "schema_version": "0.22",
+  "schema_version": "0.23",
   "repopilot_version": "{{VERSION}}",
   "report": {
     "kind": "scan",
-    "schema_version": "0.22",
+    "schema_version": "0.23",
     "repopilot_version": "{{VERSION}}"
   },
   "root_path": "demo-project",

--- a/tests/fixtures/reports/scan-v023.json
+++ b/tests/fixtures/reports/scan-v023.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "0.23",
+  "repopilot_version": "0.19.0",
+  "report": {
+    "kind": "scan",
+    "schema_version": "0.23",
+    "repopilot_version": "0.19.0"
+  },
+  "root_path": ".",
+  "mode": "full",
+  "changed_files_count": 0,
+  "repo_level_rules_included": true,
+  "files_discovered": 2,
+  "files_analyzed": 2,
+  "directories_count": 1,
+  "non_empty_lines": 12,
+  "large_files_skipped": 0,
+  "files_skipped_low_signal": 0,
+  "binary_files_skipped": 0,
+  "skipped_bytes": 0,
+  "languages": [],
+  "findings": [],
+  "detected_frameworks": [],
+  "framework_projects": [],
+  "coupling_graph": null,
+  "context_graph_summary": {
+    "files": 2,
+    "import_edges": 0
+  },
+  "context_graph_cache": {
+    "status": "write",
+    "reason": "context-graph-cache-updated",
+    "cache_path": ".repopilot/cache/repo_context.json"
+  },
+  "scan_duration_us": 100,
+  "health_score": 100,
+  "raw_findings_count": 0,
+  "visible_findings_count": 0,
+  "hidden_suggestions_count": 0,
+  "files_skipped_by_limit": 0,
+  "files_skipped_repopilotignore": 0,
+  "diagnostics": [
+    {
+      "code": "workspace.package-scan-failed",
+      "severity": "warning",
+      "message": "Package scan failed; results are partial.",
+      "path": "packages/api"
+    }
+  ],
+  "risk_summary": {
+    "total": 0,
+    "average_score": 0,
+    "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 }
+  },
+  "raw_signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  },
+  "visible_signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  },
+  "signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  }
+}

--- a/tests/report_schema_contract.rs
+++ b/tests/report_schema_contract.rs
@@ -5,11 +5,11 @@ use serde_json::Value;
 
 #[test]
 fn current_schema_fixture_documents_scan_report_contract() {
-    let current_text = include_str!("fixtures/reports/scan-v022.json");
+    let current_text = include_str!("fixtures/reports/scan-v023.json");
     let current: Value =
         serde_json::from_str(current_text).expect("current report fixture should be valid JSON");
 
-    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.22");
+    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.23");
     assert_eq!(current["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
     assert_eq!(current["report"]["kind"], "scan");
     assert_eq!(
@@ -35,7 +35,7 @@ fn current_schema_fixture_documents_scan_report_contract() {
 
 #[test]
 fn strict_reader_accepts_current_scan_report_shape() {
-    let current_text = include_str!("fixtures/reports/scan-v022.json");
+    let current_text = include_str!("fixtures/reports/scan-v023.json");
     let current = parse_scan_summary_json(current_text)
         .expect("current report should parse into ScanSummary");
 
@@ -67,19 +67,22 @@ fn strict_reader_accepts_current_scan_report_shape() {
 
 #[test]
 fn strict_reader_accepts_previous_scan_report_shapes() {
+    let previous_v022 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v022.json"))
+        .expect("0.22 report should parse during 0.23 transition");
     let previous_v021 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v021.json"))
-        .expect("0.21 report should parse during 0.22 transition");
+        .expect("0.21 report should parse during 0.23 transition");
     let previous_v020 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v020.json"))
-        .expect("0.20 report should parse during 0.22 transition");
+        .expect("0.20 report should parse during 0.23 transition");
     let previous_v019 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v019.json"))
-        .expect("0.19 report should parse during 0.22 transition");
+        .expect("0.19 report should parse during 0.23 transition");
     let previous_v018 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v018.json"))
-        .expect("0.18 report should parse during 0.22 transition");
+        .expect("0.18 report should parse during 0.23 transition");
     let previous_v017 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v017.json"))
-        .expect("0.17 report should parse during 0.22 transition");
+        .expect("0.17 report should parse during 0.23 transition");
     let previous_v016 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v016.json"))
-        .expect("0.16 report should parse during 0.22 transition");
+        .expect("0.16 report should parse during 0.23 transition");
 
+    assert_eq!(previous_v022.metrics.files_discovered, 2);
     assert_eq!(previous_v021.metrics.files_discovered, 2);
     assert_eq!(previous_v020.metrics.files_discovered, 2);
     assert_eq!(previous_v019.metrics.files_discovered, 2);
@@ -102,7 +105,7 @@ fn strict_reader_ignores_occurrence_key_and_decision_fields_on_findings() {
     // still deserialize into `Finding` — proving the addition is genuinely
     // additive for readers that don't know about it yet.
     let mut report: Value =
-        serde_json::from_str(include_str!("fixtures/reports/scan-v022.json")).expect("valid JSON");
+        serde_json::from_str(include_str!("fixtures/reports/scan-v023.json")).expect("valid JSON");
     report["findings"] = serde_json::json!([{
         "id": "rule.example:src/lib.rs:deadbeef",
         "rule_id": "rule.example",


### PR DESCRIPTION
## Summary

Locks the public JSON contract for review-signal verification plans and bumps the report schema to `0.23`.

This follows the verification-plan work for sensitive review signals by making the new JSON shape explicit and regression-tested for agent/CI consumers.

## Type of change

* [ ] Feature
* [ ] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Bumped `SCAN_REPORT_SCHEMA_VERSION` from `0.22` to `0.23`.
* Kept `0.22` accepted for backward compatibility.
* Added a schema regression test for the new contract version.
* Added a backward-compatibility test for the previous schema.
* Added JSON serialization coverage for `verification_plan.steps`.
* Added a contract test proving maybe-sensitive review signals omit `verification_plan`.
* Updated `CHANGELOG.md` with the schema/contract change.

## Why

PR #282 introduced optional `verification_plan` data for high-confidence, definitely-sensitive review signals. Since this is now part of review JSON, it needs an explicit schema bump and contract coverage so CI bots, MCP consumers, and agent integrations can rely on the shape.

This keeps the feature additive, deterministic, and safe for existing consumers that ignore unknown fields.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
* [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
* [x] No unrelated refactor or generated-file churn is included

Subsystems:

* `report::schema`
* `review::signals::tiered`
* `CHANGELOG.md`

Public behavior affected:

* Review/scan schema version is now `0.23`.
* `0.22` remains accepted for existing scan report parsing.
* `verification_plan.steps` is now covered as a stable JSON array shape.
* Non-qualifying review signals continue to omit `verification_plan`.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
git diff --check
```
