### PR TITLE
feat(cli): add guided workflows and onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+- Top-level help, README, and CLI/workflow references now provide one
+  review-first command chooser, document snapshot and summary output consistently,
+  clarify changed-scope versus full-scan behavior, and preserve the intentionally
+  reduced command surface.
 - Parsed-facts cache writes now use recoverable staged replacement and run cache/CLI smoke coverage on Linux, macOS, and Windows.
 - GitHub Action reviews now produce a deterministic base/head finding delta,
   update one sticky PR comment with only new/changed findings, emit compact

--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ npm install -g repopilot
 Homebrew, curl, GitHub Releases, and source builds are documented in
 [Installation](https://github.com/MykytaStel/repopilot/blob/main/docs/install.md).
 
+## Choose Your Workflow
+
+| Goal | Command |
+|---|---|
+| Review what changed before merge | `repopilot review .` |
+| Review a branch against main | `repopilot review . --base origin/main` |
+| Audit the whole repository | `repopilot scan .` |
+| Adopt existing debt gradually | `repopilot baseline create .` |
+| Review a complete agent run | `repopilot snapshot` then `repopilot review --since-snapshot` |
+| Prepare context for an assistant | `repopilot ai context .` |
+| Connect a local MCP client | `repopilot mcp --root .` |
+
+`review` is the daily change-review workflow. Use `scan` when repository-wide
+architecture, framework, testing, and coupling results must be authoritative.
+
 ## Review A Change
 
 Review the working tree against `HEAD`:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,12 +12,33 @@ Use `-h` for a short summary or `--help` for the full description and examples.
 
 ---
 
+## Which command should I use?
+
+| Goal | Command |
+|---|---|
+| Review local staged, unstaged, and untracked changes | `repopilot review .` |
+| Review a branch before merge | `repopilot review . --base origin/main` |
+| See full evidence and verification steps | `repopilot review . --detail full` |
+| Audit the complete repository | `repopilot scan .` |
+| Show the full recall surface for calibration | `repopilot scan . --profile strict` |
+| Adopt an existing repository without blocking on old debt | `repopilot baseline create .` |
+| Review all work performed after an agent starts | `repopilot snapshot`, then `repopilot review --since-snapshot` |
+| Prepare bounded evidence for an external assistant | `repopilot ai context .` |
+| Give an MCP client direct read-only analysis tools | `repopilot mcp --root .` |
+
+`review` is the default daily workflow. `scan` is the authoritative repository-wide
+audit. Changed scans and changed-scope reviews intentionally omit some repository-level
+architecture, framework, testing, and coupling checks.
+
+---
+
 ## Commands
 
 | Command | Alias | Description |
 |---------|-------|-------------|
-| [`review`](#review) | `r` | Review findings that touch changed Git diff lines |
-| [`scan`](#scan) | `s` | Scan a project, folder, or file for findings |
+| [`review`](#review) | `r` | Review findings and signals that touch a Git change |
+| [`scan`](#scan) | `s` | Scan a project, folder, or file for repository-wide findings |
+| [`snapshot`](#snapshot) | — | Mark repository state before an agent or manual change |
 | [`ai context`](#ai-context) | — | Generate an LLM-ready handoff (context, plan, and guidance) from a scan |
 | [`cache`](#cache) | — | Manage local changed-scan cache files |
 | [`baseline`](#baseline) | `bl` | Manage accepted baseline findings |
@@ -63,7 +84,7 @@ repopilot s <PATH> [OPTIONS]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--format` | `console\|json\|markdown\|html\|sarif` | `console` | Output format |
-| `--output-style` | `compact\|full` | `compact` | Console output style; use `full` for detailed diagnostics |
+| `--output-style` | `summary\|compact\|full` | `compact` | Verdict only, bounded findings, or the complete console report |
 | `--quiet` | flag | — | Suppress progress indicators and next-step hints while keeping findings and status |
 | `--no-progress` | flag | — | Disable progress indicators |
 | `--max-findings` | `N\|none` | compact: 5, full/Markdown: all | Limit rendered human-format finding details; JSON and SARIF remain complete |
@@ -165,6 +186,21 @@ skip repo-level architecture, framework, testing, and coupling rules. Use a full
 scan for authoritative repository-wide risk. Changed-scan summaries include
 `cache_telemetry` with cache hits, misses, skipped files, changed-file reasons,
 per-file cache decisions, and cache timing impact.
+
+---
+
+## `snapshot`
+
+Marks the current repository state before an AI agent or developer begins a change.
+
+```bash
+repopilot snapshot
+# perform the change
+repopilot review --since-snapshot
+```
+
+The snapshot records the starting Git state; it is not a repository backup and does
+not modify commits or working-tree files.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,6 +3,22 @@
 This guide covers the main RepoPilot workflows. Use the [CLI reference](cli.md)
 for every command and flag.
 
+## Choose A Workflow
+
+| Situation | Start here | Why |
+|---|---|---|
+| I changed code locally | `repopilot review .` | Focuses on the current Git diff |
+| I am reviewing a branch or pull request | `repopilot review . --base origin/main` | Compares the branch against its merge base |
+| An AI agent is about to edit the repository | `repopilot snapshot` | Creates a stable before-marker |
+| I want a complete repository audit | `repopilot scan .` | Includes repository-wide rules |
+| I am adopting RepoPilot in an older repository | `repopilot baseline create .` | Separates accepted debt from new findings |
+| I need evidence for an external assistant | `repopilot ai context .` | Produces a bounded local handoff |
+| I want an agent to call RepoPilot directly | `repopilot mcp --root .` | Exposes read-only local MCP tools |
+
+Do not treat changed-scope analysis as a full repository audit. Do not regenerate a
+baseline merely to make a gate pass: a baseline update records an explicit acceptance
+of current findings.
+
 ## Review Before Merge
 
 Review local staged, unstaged, and untracked changes:

--- a/docs/roadmap/v0.20.md
+++ b/docs/roadmap/v0.20.md
@@ -148,6 +148,14 @@ The following are explicitly out of scope for 0.20:
 - Git provider integrations beyond GitHub Actions;
 - `1.0` compatibility guarantees.
 
+### Command-surface stability for the remaining v0.20 work
+
+The remaining v0.20 product work extends existing surfaces. It must not restore the
+removed top-level `vibe`, `harden`, `prompt`, `explain`, `knowledge`, `compare`,
+`doctor`, or `inspect` commands, and must not restore standalone `ai plan` or
+`ai prompt`. Explanation remains an MCP/report capability; onboarding remains part
+of help, documentation, output guidance, and the existing `init` command.
+
 ## Compatibility Contract
 
 RepoPilot 0.20 maintains backward compatibility with 0.19 in the following
@@ -196,7 +204,10 @@ criteria.
 | #279 | feat(cli): redesign review and scan summaries around decisions | G | #273 |
 | #280 | feat(action): add delta-focused PR comments and stable artifacts | G | #279 |
 | #281 | fix(security): harden analysis boundaries, redaction and cache recovery | H | #268 |
-| #282 | chore(release): prepare RepoPilot v0.20.0 | — | all |
+| #282 | feat(cli): add guided workflows and contextual next steps | G | #281 |
+| #283 | feat(mcp): explain review signals and expose analysis history | F | #277, #282 |
+| #284 | feat(init): generate GitHub Action and MCP bootstrap | G | #282, #283 |
+| #285 | chore(release): prepare RepoPilot v0.20.0 | — | all |
 
 ## Implementation Progress
 
@@ -224,7 +235,10 @@ implementation. The detailed PR plan below remains the acceptance contract.
 | #279 | Done | Scan and review console output now start with a shared PASS/REVIEW/BLOCK decision summary. Scan adds `--output-style summary`; review adds `--detail summary|findings|full` and `--max-findings`, while full detail renders evidence, recommendations, and deterministic verification plans. JSON, SARIF, and exit codes remain unchanged. | Proceed to #280 delta-focused Action comments. |
 | #280 | Done | The Action now scans base/head in an isolated worktree, emits deterministic `repopilot-review-delta.json` classifications (`new`/`changed`/`resolved`/`unchanged`) from occurrence identity, limits comments and annotations to changed-code signals plus new/changed findings, updates one marker-owned sticky comment, exposes additive delta-count outputs, and uploads a stable four-file review artifact set. Coverage: `scripts/tests/test_review_delta.py`, `tests/action_delta.rs`, and `tests/action_yml.rs`. | Proceed to #281 analysis-boundary hardening. |
 | #281 | Done | Shared root confinement protects agent-facing path consumers, human-readable outputs centrally redact sensitive evidence, parsed-facts cache writes use recoverable staged replacement, and Linux/macOS/Windows smoke coverage verifies CLI and cache behavior. | Proceed to #282 v0.20.0 release preparation. |
-| #282 | Planned | Not started. | Bump versions, write v0.20.0 curated release notes, and complete release gates. |
+| #282 | In progress | Guided CLI workflow selection, synchronized help/reference docs, contextual command guidance, and regression coverage without restoring removed commands. | Complete the guided CLI UX slice. |
+| #283 | Planned | Not started. | Add MCP review-signal explanation, analysis-history discovery, and structured fallback explanations for findings that cannot be replayed safely. |
+| #284 | Planned | Not started. | Extend the existing `init` command with GitHub Action and MCP bootstrap generation; do not restore `doctor`. |
+| #285 | Planned | Not started. | Bump versions, write v0.20.0 curated release notes, and complete release gates. |
 
 ## Planned PR Sequence
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,15 +21,25 @@ changed-code findings, and blast radius.\n\n\
 It does not upload your repository — all analysis runs locally against files on disk.\n\n\
 Start with `repopilot review`. Use `repopilot scan` for repository-wide audits,\n\
 `repopilot baseline` for gradual CI adoption, and `repopilot ai` for local\n\
-AI-ready remediation context.",
-    after_help = "EXAMPLES:\n  \
+AI-ready remediation context.\n\n\
+Choose by intent:\n  \
+review      inspect the change you are about to merge\n  \
+scan        audit the whole repository\n  \
+snapshot    mark the state before an agent or manual change\n  \
+baseline    adopt existing repository debt without hiding new findings\n  \
+ai context  prepare bounded evidence and a remediation plan for an assistant\n  \
+mcp         expose local read-only analysis tools to an MCP client",
+    after_help = "COMMON WORKFLOWS:\n  \
 repopilot review .                          # review working-tree changes\n  \
-repopilot review . --base origin/main       # review changes vs main\n  \
+repopilot review . --base origin/main       # review a branch before merge\n  \
+repopilot review . --detail full            # show evidence and verification\n  \
 repopilot snapshot                          # mark state before an agent change\n  \
 repopilot review . --since-snapshot         # review the complete agent change\n  \
 repopilot scan .                            # run a repository-wide audit\n  \
-repopilot baseline create .                 # accept current findings\n  \
-repopilot ai context . --focus security     # generate AI-ready context"
+repopilot baseline create .                 # accept current findings as debt\n  \
+repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high\n  \
+repopilot ai context . --focus security     # generate AI-ready context\n  \
+repopilot mcp --root .                      # expose read-only tools to an agent"
 )]
 pub struct Cli {
     #[command(subcommand)]

--- a/src/cli/options/mod.rs
+++ b/src/cli/options/mod.rs
@@ -135,7 +135,8 @@ repopilot ai context . --no-task --output ai-context.md"
         about = "Generate a default repopilot.toml configuration file",
         long_about = "Writes a repopilot.toml with all configurable thresholds set to their defaults.\n\n\
 Edit the generated file to tune thresholds for your project. RepoPilot automatically\n\
-reads repopilot.toml from the current working directory when running `scan`.\n\n\
+reads repopilot.toml from the current working directory for analysis commands,\n\
+including `scan`, `review`, `baseline create`, AI context, and MCP tools.\n\n\
 Configuration precedence: CLI flags > repopilot.toml > built-in defaults.",
         after_help = "EXAMPLES:\n  \
 repopilot init\n  \

--- a/tests/cli_stabilization.rs
+++ b/tests/cli_stabilization.rs
@@ -61,8 +61,25 @@ fn top_level_help_shows_stable_command_surface() {
         "review must be presented before scan\n{help}"
     );
 
-    for command in ["baseline", "scan", "review", "snapshot", "ai", "init"] {
+    for command in [
+        "baseline", "scan", "review", "snapshot", "ai", "init", "mcp",
+    ] {
         assert!(help.contains(command), "help should show {command}\n{help}");
+    }
+
+    for workflow in [
+        "Choose by intent:",
+        "review      inspect the change you are about to merge",
+        "scan        audit the whole repository",
+        "mcp         expose local read-only analysis tools",
+        "COMMON WORKFLOWS:",
+        "repopilot review . --detail full",
+        "repopilot mcp --root .",
+    ] {
+        assert!(
+            help.contains(workflow),
+            "top-level help should guide workflow {workflow:?}\n{help}"
+        );
     }
 
     for removed in [
@@ -94,6 +111,7 @@ fn scan_and_review_help_have_flag_descriptions() {
     assert!(scan_help.contains("Disable progress indicators"));
     assert!(scan_help.contains("Suppress progress indicators and next-step hints"));
     assert!(scan_help.contains("Limit rendered human-format finding details"));
+    assert!(scan_help.contains("summary"));
 
     assert!(review_help.contains("Path to project, folder, or file to review"));
     assert!(review_help.contains("Base Git ref for branch/CI review"));


### PR DESCRIPTION
## Summary

Makes RepoPilot easier to adopt and use by adding one review-first workflow guide across the top-level CLI help, README, CLI reference, and common workflow documentation.

Users can now choose the correct command based on intent instead of having to infer the difference between `review`, `scan`, `snapshot`, `baseline`, AI context, and MCP from separate reference sections.

The change also synchronizes documentation with the current v0.20 CLI surface and explicitly protects the intentionally reduced command set from future feature churn.

## Type of change

* [x] Feature
* [ ] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

### Guided top-level help

The top-level `repopilot --help` output now includes a short intent-based command guide:

```text
Choose by intent:
  review      inspect the change you are about to merge
  scan        audit the whole repository
  snapshot    mark the state before an agent or manual change
  baseline    adopt existing repository debt without hiding new findings
  ai context  prepare bounded evidence and a remediation plan for an assistant
  mcp         expose local read-only analysis tools to an MCP client
```

The examples section is now presented as common workflows and includes:

```bash
repopilot review .
repopilot review . --base origin/main
repopilot review . --detail full
repopilot snapshot
repopilot review . --since-snapshot
repopilot scan .
repopilot baseline create .
repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
repopilot ai context . --focus security
repopilot mcp --root .
```

### Clear review-first onboarding

Added a compact workflow chooser to the README covering:

* local change review;
* branch review before merge;
* full repository audit;
* gradual baseline adoption;
* complete AI-agent run review;
* assistant-ready context;
* direct MCP integration.

The README now explicitly distinguishes:

* `review` as the daily change-review workflow;
* `scan` as the authoritative repository-wide audit.

### CLI reference synchronization

Updated `docs/cli.md` to match the actual executable surface:

* added `snapshot` to the command table;
* documented `summary|compact|full` for `scan --output-style`;
* added a “Which command should I use?” decision table;
* added a dedicated `snapshot` reference section;
* clarified that changed-scope analysis intentionally omits some repository-level checks.

### Common workflow guide

Added a situation-based workflow table to `docs/commands.md`.

It now explains when to use:

* working-tree review;
* branch review;
* snapshot-based agent review;
* full scan;
* baseline adoption;
* AI context;
* MCP.

It also documents two important safety rules:

* changed-scope analysis is not a substitute for a full repository audit;
* a baseline must not be regenerated only to make a CI gate pass.

### Configuration help

Updated `repopilot init --help` to clarify that `repopilot.toml` applies to analysis commands generally, including:

* `scan`;
* `review`;
* `baseline create`;
* AI context;
* MCP tools.

The previous wording incorrectly implied that automatic configuration discovery applied only to `scan`.

### Command-surface stability

Added an explicit v0.20 roadmap contract preventing the restoration of removed top-level commands:

```text
vibe
harden
prompt
explain
knowledge
compare
doctor
inspect
```

The contract also prevents restoring standalone:

```text
ai plan
ai prompt
```

Future v0.20 functionality must extend the existing help, report, MCP, and `init` surfaces instead of recreating overlapping commands.

### Expanded v0.20 roadmap

The release plan now includes:

* guided CLI workflows and onboarding;
* MCP review-signal explanation and analysis history;
* GitHub Action and MCP bootstrap through the existing `init` command;
* final v0.20.0 release preparation.

## Why

RepoPilot already had detailed command help and comprehensive reference documentation, but users still had to understand several product concepts before choosing the correct command:

* changed review versus full scan;
* local working-tree review versus branch review;
* snapshot-based agent workflows;
* baseline adoption;
* AI context versus direct MCP integration.

The missing piece was not more reference text. It was a clear decision path answering:

> What am I trying to do, and which command should I run?

This PR turns the existing command set into a guided product flow without increasing CLI surface area or restoring previously removed commands.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
* [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
* [x] No unrelated refactor or generated-file churn is included

Primary subsystems:

* Clap top-level help;
* CLI reference documentation;
* common workflow documentation;
* README onboarding;
* CLI stabilization tests;
* v0.20 roadmap.

Public behavior affected:

* `repopilot --help` now includes intent-based guidance;
* documentation reflects the current command and output-style surface;
* `init` help describes configuration discovery more accurately.

Unchanged contracts:

* command names and aliases;
* command arguments;
* process exit codes;
* JSON and SARIF schemas;
* baseline behavior;
* Action inputs and outputs;
* MCP tools and response schemas;
* finding IDs and occurrence keys;
* gate evaluation.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```
