### PR TITLE
feat(mcp): explain review signals and expose analysis history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+- MCP can now explain stored review signals by `signal_id`, expose retained analysis-handle summaries through `repopilot://analyses`, and return stored-only finding context when a safe live replay is unavailable.
 - Top-level help, README, and CLI/workflow references now provide one
   review-first command chooser, document snapshot and summary output consistently,
   clarify changed-scope versus full-scan behavior, and preserve the intentionally

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -38,7 +38,8 @@ non-destructive, idempotent, and closed-world.
 | `repopilot_scan` | Repository or changed-scope JSON scan | `config`, `profile`, `scope`, `base`, `offset`, `limit` |
 | `repopilot_context` | Budgeted AI-ready Markdown context | `config`, `profile`, `focus`, `budget`, `analysis_handle` |
 | `repopilot_explain_file` | File-role evidence and ordered rule decision trace | `rule`, `signal` |
-| `repopilot_explain_finding` | Replay a file-scoped finding by stable ID and optional occurrence locator | `finding_id`, `source`, `analysis_handle`, `evidence_path`, `line_start` |
+| `repopilot_explain_finding` | Replay a file-scoped finding by stable ID and optional occurrence locator; returns a stored-only fallback when safe replay is unavailable | `finding_id`, `source`, `analysis_handle`, `evidence_path`, `line_start` |
+| `repopilot_explain_review_signal` | Explain one review signal with provenance, gate state, impact, verification, and limitations | `signal_id`, `analysis_handle` |
 
 Every `tools/call` result includes `workspaceRevision`. Successful scan and
 review results additionally include `analysisHandle`; the server retains the
@@ -164,6 +165,7 @@ The server exposes:
 - `repopilot://rules`: the rule catalog;
 - `repopilot://repository-summary`: workspace/config/baseline/feedback and
   session-result availability without triggering a scan;
+- `repopilot://analyses`: newest-first summaries for retained scan/review handles;
 - `repopilot://last-scan`: the last successful scan in this session;
 - `repopilot://last-review`: the last successful review in this session.
 

--- a/docs/roadmap/v0.20.md
+++ b/docs/roadmap/v0.20.md
@@ -234,9 +234,9 @@ implementation. The detailed PR plan below remains the acceptance contract.
 | #278 | Done | `ai context --format json` now emits schema v3 with a canonical `repopilot-analysis` envelope, shared `FindingRecord`/`DecisionRecord` entries, verification-plan counts, explicit budget/summary metadata, deterministic ordering, and an updated golden contract. Markdown input/output behavior and budget semantics remain unchanged. | Proceed to #279 verdict-first CLI summaries. |
 | #279 | Done | Scan and review console output now start with a shared PASS/REVIEW/BLOCK decision summary. Scan adds `--output-style summary`; review adds `--detail summary|findings|full` and `--max-findings`, while full detail renders evidence, recommendations, and deterministic verification plans. JSON, SARIF, and exit codes remain unchanged. | Proceed to #280 delta-focused Action comments. |
 | #280 | Done | The Action now scans base/head in an isolated worktree, emits deterministic `repopilot-review-delta.json` classifications (`new`/`changed`/`resolved`/`unchanged`) from occurrence identity, limits comments and annotations to changed-code signals plus new/changed findings, updates one marker-owned sticky comment, exposes additive delta-count outputs, and uploads a stable four-file review artifact set. Coverage: `scripts/tests/test_review_delta.py`, `tests/action_delta.rs`, and `tests/action_yml.rs`. | Proceed to #281 analysis-boundary hardening. |
-| #281 | Done | Shared root confinement protects agent-facing path consumers, human-readable outputs centrally redact sensitive evidence, parsed-facts cache writes use recoverable staged replacement, and Linux/macOS/Windows smoke coverage verifies CLI and cache behavior. | Proceed to #282 v0.20.0 release preparation. |
-| #282 | In progress | Guided CLI workflow selection, synchronized help/reference docs, contextual command guidance, and regression coverage without restoring removed commands. | Complete the guided CLI UX slice. |
-| #283 | Planned | Not started. | Add MCP review-signal explanation, analysis-history discovery, and structured fallback explanations for findings that cannot be replayed safely. |
+| #281 | Done | Shared root confinement protects agent-facing path consumers, human-readable outputs centrally redact sensitive evidence, parsed-facts cache writes use recoverable staged replacement, and Linux/macOS/Windows smoke coverage verifies CLI and cache behavior. | None. |
+| #282 | Done | Top-level help, README, and CLI/workflow references provide a review-first command chooser, document snapshot and summary output consistently, clarify changed-scope versus full-scan behavior, and preserve the reduced command surface. Coverage: `tests/cli_stabilization.rs`. | None. |
+| #283 | Done | Added `repopilot_explain_review_signal`, newest-first `repopilot://analyses` discovery, and structured stored-only finding explanations when live replay is unavailable. MCP unit/integration coverage and public docs lock the additive tool/resource contracts. | Proceed to #284 bootstrap generation. |
 | #284 | Planned | Not started. | Extend the existing `init` command with GitHub Action and MCP bootstrap generation; do not restore `doctor`. |
 | #285 | Planned | Not started. | Bump versions, write v0.20.0 curated release notes, and complete release gates. |
 
@@ -601,7 +601,58 @@ and test cache corruption recovery.
 **Exclusions:** No new security rules, no SBOM generation (unless already
 supported by the release workflow).
 
-### #282 — chore(release): prepare RepoPilot v0.20.0
+### #282 — feat(cli): add guided workflows and contextual next steps
+
+**Purpose:** Help users choose the existing review, scan, snapshot, and AI
+context workflows without expanding the top-level command surface.
+
+**Boundaries:** Help text and synchronized workflow documentation.
+
+**Acceptance criteria:**
+- top-level help offers a concise review-first command chooser;
+- changed-scope and full-scan behavior are described consistently;
+- snapshot and summary workflows are documented across public references;
+- regression coverage proves removed commands remain unavailable.
+
+**Dependencies:** #281.
+
+**Exclusions:** No restored legacy commands and no interactive wizard.
+
+### #283 — feat(mcp): explain review signals and expose analysis history
+
+**Purpose:** Make retained analysis results discoverable and explain review
+signals without requiring an agent to reverse-engineer report JSON.
+
+**Boundaries:** Additive, read-only MCP tools and resources.
+
+**Acceptance criteria:**
+- review signals can be explained by stable `signal_id`;
+- retained scan/review handles are listed newest-first with compact counts;
+- findings that cannot be replayed safely return explicit stored-only context;
+- tool/resource schemas, docs, and regression tests remain synchronized.
+
+**Dependencies:** #277 and #282.
+
+**Exclusions:** No persistent cross-session history and no runtime execution.
+
+### #284 — feat(init): generate GitHub Action and MCP bootstrap
+
+**Purpose:** Extend `init` to generate opt-in GitHub Action and MCP bootstrap
+configuration using existing product surfaces.
+
+**Boundaries:** The existing `init` command and generated configuration only.
+
+**Acceptance criteria:**
+- generated files are deterministic and safe to re-run;
+- existing user configuration is preserved or requires explicit confirmation;
+- generated Action and MCP examples match current documented contracts;
+- targeted CLI tests cover fresh and existing repositories.
+
+**Dependencies:** #282 and #283.
+
+**Exclusions:** No restored `doctor` command and no hosted setup service.
+
+### #285 — chore(release): prepare RepoPilot v0.20.0
 
 **Purpose:** Bump version, write changelog and curated release notes, run all
 gates.
@@ -632,7 +683,7 @@ Every 0.20 PR must pass the existing gate suite:
 - `npm run test:release-contract`
 - `scripts/smoke-product.sh`
 
-The release PR (#282) must additionally pass:
+The release PR (#285) must additionally pass:
 
 - `scripts/verify-release.sh`
 - v0.20 release scorecard (see `docs/engineering/v0.20-release-scorecard.md`)

--- a/src/commands/mcp/analysis_store.rs
+++ b/src/commands/mcp/analysis_store.rs
@@ -64,6 +64,72 @@ impl AnalysisStore {
     pub fn get(&self, handle: &str) -> Option<&AnalysisRecord> {
         self.records.get(handle)
     }
+
+    pub fn summaries(&self) -> Vec<Value> {
+        self.order
+            .iter()
+            .rev()
+            .filter_map(|handle| {
+                let record = self.records.get(handle)?;
+                let report = serde_json::from_str::<Value>(&record.report).ok();
+                let findings = report
+                    .as_ref()
+                    .and_then(|value| value.get("findings"))
+                    .and_then(Value::as_array)
+                    .map_or(0, Vec::len);
+                let review_signals = report
+                    .as_ref()
+                    .and_then(|value| value.get("tiered_signals"))
+                    .map(count_review_signals)
+                    .unwrap_or(0);
+                Some(json!({
+                    "analysis_handle": handle,
+                    "kind": record.kind.label(),
+                    "workspace_revision": record.workspace_revision,
+                    "findings": findings,
+                    "review_signals": review_signals
+                }))
+            })
+            .collect()
+    }
+}
+
+fn count_review_signals(tiered: &Value) -> usize {
+    ["definitely", "maybe", "noise"]
+        .into_iter()
+        .filter_map(|tier| tiered.get(tier).and_then(Value::as_array))
+        .map(Vec::len)
+        .sum()
+}
+
+#[cfg(test)]
+mod summary_tests {
+    use super::*;
+
+    #[test]
+    fn summaries_are_newest_first_and_count_analysis_contents() {
+        let mut store = AnalysisStore::default();
+        let scan = store.insert(
+            AnalysisKind::Scan,
+            json!({ "findings": [{ "id": "one" }] }).to_string(),
+            "revision-1",
+        );
+        let review = store.insert(
+            AnalysisKind::Review,
+            json!({
+                "findings": [],
+                "tiered_signals": { "definitely": [{}], "maybe": [{}], "noise": [] }
+            })
+            .to_string(),
+            "revision-1",
+        );
+
+        let summaries = store.summaries();
+        assert_eq!(summaries[0]["analysis_handle"], review);
+        assert_eq!(summaries[0]["review_signals"], 2);
+        assert_eq!(summaries[1]["analysis_handle"], scan);
+        assert_eq!(summaries[1]["findings"], 1);
+    }
 }
 
 fn analysis_handle(kind: AnalysisKind, report: &str, workspace_revision: &str) -> String {

--- a/src/commands/mcp/explain_finding.rs
+++ b/src/commands/mcp/explain_finding.rs
@@ -90,15 +90,76 @@ pub fn call(
         other => return Err(format!("invalid source: {other}")),
     };
 
-    let selection = build_finding_explanation_selection_from_report(
+    let selection = match build_finding_explanation_selection_from_report(
         root,
         report,
         finding_id,
         source,
         locator.as_ref(),
-    )?;
+    ) {
+        Ok(selection) => selection,
+        Err(reason) => {
+            return stored_fallback(report, finding_id, source, locator.as_ref(), &reason);
+        }
+    };
     serde_json::to_string_pretty(&selection)
         .map_err(|error| format!("render finding explanation failed: {error}"))
+}
+
+fn stored_fallback(
+    report: &str,
+    finding_id: &str,
+    source: &str,
+    locator: Option<&FindingOccurrenceLocator>,
+    reason: &str,
+) -> Result<String, String> {
+    let report: Value =
+        serde_json::from_str(report).map_err(|error| format!("invalid session report: {error}"))?;
+    let findings = report
+        .get("findings")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "session report does not contain a findings array".to_string())?;
+    let finding = findings.iter().find(|finding| {
+        finding.get("id").and_then(Value::as_str) == Some(finding_id)
+            && locator.is_none_or(|locator| fallback_matches_locator(finding, locator))
+    });
+    let Some(finding) = finding else {
+        return Err(reason.to_string());
+    };
+    let fallback = json!({
+        "status": "stored-only",
+        "source_report": source,
+        "finding_id": finding_id,
+        "message": "The finding is available, but a safe live decision replay is unavailable.",
+        "replay": { "status": "unavailable", "reason": reason },
+        "finding": finding,
+        "decision": finding.get("decision").cloned().unwrap_or(Value::Null),
+        "limitations": [
+            "This fallback preserves stored analysis evidence and does not claim a live replay.",
+            "Re-run the originating scan or review after workspace or configuration changes."
+        ]
+    });
+    serde_json::to_string_pretty(&fallback)
+        .map_err(|error| format!("render finding fallback failed: {error}"))
+}
+
+fn fallback_matches_locator(finding: &Value, locator: &FindingOccurrenceLocator) -> bool {
+    let evidence = finding
+        .get("evidence")
+        .and_then(Value::as_array)
+        .and_then(|items| items.first());
+    locator.evidence_path.as_deref().is_none_or(|path| {
+        evidence
+            .and_then(|item| item.get("path"))
+            .and_then(Value::as_str)
+            == Some(path)
+    }) && locator.line_start.is_none_or(|line| {
+        evidence
+            .and_then(|item| item.get("line_start"))
+            .and_then(Value::as_u64)
+            .and_then(|value| usize::try_from(value).ok())
+            == Some(line)
+    })
 }
 
 #[cfg(test)]
@@ -213,6 +274,35 @@ mod tests {
         .expect_err("missing scan must fail");
 
         assert!(error.contains("run repopilot_scan first"));
+    }
+
+    #[test]
+    fn tool_returns_stored_fallback_when_live_replay_is_unsupported() {
+        let report = json!({
+            "findings": [{
+                "id": "project-wide",
+                "rule_id": "architecture.example",
+                "title": "Project-wide finding",
+                "description": "Stored evidence remains useful.",
+                "decision": { "severity": "medium" },
+                "provenance": { "analysis_scope": "project" },
+                "evidence": [{ "path": "Cargo.toml", "line_start": 1 }]
+            }]
+        })
+        .to_string();
+
+        let rendered = call(
+            &json!({ "finding_id": "project-wide" }),
+            Path::new("."),
+            Some(&report),
+            None,
+        )
+        .expect("stored fallback");
+        let value: Value = serde_json::from_str(&rendered).expect("valid JSON");
+        assert_eq!(value["status"], "stored-only");
+        assert_eq!(value["replay"]["status"], "unavailable");
+        assert_eq!(value["finding"]["id"], "project-wide");
+        assert_eq!(value["decision"]["severity"], "medium");
     }
 
     fn duplicate_report(report: &str) -> String {

--- a/src/commands/mcp/explain_review_signal.rs
+++ b/src/commands/mcp/explain_review_signal.rs
@@ -1,0 +1,155 @@
+//! Explain one unified review signal from a stored MCP review analysis.
+
+use serde_json::{Value, json};
+
+pub const TOOL_NAME: &str = "repopilot_explain_review_signal";
+
+pub fn definition() -> Value {
+    json!({
+        "name": TOOL_NAME,
+        "description": "Explain one review signal by signal_id from the latest or a handle-selected review. Returns provenance, trust tier, gate eligibility, impact context, verification steps, and limitations.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "signal_id": { "type": "string" },
+                "analysis_handle": { "type": "string" }
+            },
+            "required": ["signal_id"],
+            "additionalProperties": false
+        },
+        "outputSchema": { "type": "object", "additionalProperties": true },
+        "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": false
+        }
+    })
+}
+
+pub fn call(arguments: &Value, review_report: Option<&str>) -> Result<String, String> {
+    let signal_id = arguments
+        .get("signal_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "`signal_id` is required".to_string())?;
+    let report = review_report.ok_or_else(|| {
+        "no review is available in this MCP session; run repopilot_review_change first".to_string()
+    })?;
+    let report: Value = serde_json::from_str(report)
+        .map_err(|error| format!("review report is invalid: {error}"))?;
+    let signal = find_signal(&report, signal_id)
+        .ok_or_else(|| format!("review signal not found: {signal_id}"))?;
+    let path = signal
+        .get("path")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    let result = json!({
+        "status": "explained",
+        "signal_id": signal_id,
+        "signal": signal,
+        "why_it_matters": why_it_matters(signal),
+        "impact": impact_for_path(&report, path),
+        "gate": {
+            "eligible": signal.get("gate_eligible").and_then(Value::as_bool).unwrap_or(false),
+            "suppressed": signal.get("suppressed").and_then(Value::as_bool).unwrap_or(false),
+            "suppression_reason": signal.get("suppression_reason").cloned().unwrap_or(Value::Null)
+        },
+        "verification_plan": signal.get("verification_plan").cloned().unwrap_or(Value::Null),
+        "limitations": [
+            "Derived from stored Git diff and static review evidence.",
+            "Does not execute code, run tests, observe runtime behavior, or prove exploitability.",
+            "Re-run repopilot_review_change after workspace edits."
+        ]
+    });
+
+    serde_json::to_string_pretty(&result)
+        .map_err(|error| format!("render review-signal explanation failed: {error}"))
+}
+
+fn find_signal<'a>(report: &'a Value, signal_id: &str) -> Option<&'a Value> {
+    let tiered = report.get("tiered_signals")?;
+    ["definitely", "maybe", "noise"]
+        .into_iter()
+        .filter_map(|tier| tiered.get(tier).and_then(Value::as_array))
+        .flatten()
+        .find(|signal| signal.get("signal_id").and_then(Value::as_str) == Some(signal_id))
+}
+
+fn impact_for_path(report: &Value, path: &str) -> Value {
+    if path.is_empty() {
+        return Value::Null;
+    }
+    report
+        .get("impact_paths")
+        .and_then(|value| value.get("files"))
+        .and_then(Value::as_array)
+        .and_then(|files| {
+            files
+                .iter()
+                .find(|entry| entry.get("path").and_then(Value::as_str) == Some(path))
+        })
+        .cloned()
+        .unwrap_or_else(|| json!({ "path": path }))
+}
+
+fn why_it_matters(signal: &Value) -> String {
+    let family = signal
+        .get("family")
+        .and_then(Value::as_str)
+        .unwrap_or("review");
+    let headline = signal
+        .get("headline")
+        .and_then(Value::as_str)
+        .unwrap_or("change signal detected");
+    match family {
+        "boundary" => format!(
+            "{headline}. Boundary changes can alter access, trust, deployment, dependency, or secret-handling behavior."
+        ),
+        "behavioral" => format!(
+            "{headline}. Behavioral changes may affect external calls, persistence, process execution, migrations, or removed safeguards."
+        ),
+        "algorithmic" => format!(
+            "{headline}. Algorithmic changes can affect complexity, termination, resource use, or edge-case behavior."
+        ),
+        "taint" => format!(
+            "{headline}. This is static reachability evidence to a sensitive sink, not proof of a vulnerability."
+        ),
+        _ => format!("{headline}. Review the changed surface and verify intended behavior."),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explains_signal() {
+        let report = json!({
+            "tiered_signals": {
+                "definitely": [{
+                    "signal_id": "abc123",
+                    "family": "boundary",
+                    "path": "src/auth.rs",
+                    "headline": "access control changed",
+                    "gate_eligible": true,
+                    "suppressed": false,
+                    "verification_plan": { "steps": ["Confirm authorization behavior."] }
+                }],
+                "maybe": [],
+                "noise": []
+            },
+            "impact_paths": {
+                "files": [{ "path": "src/auth.rs", "direct_dependents": ["src/api.rs"] }]
+            }
+        })
+        .to_string();
+
+        let rendered =
+            call(&json!({ "signal_id": "abc123" }), Some(&report)).expect("explain signal");
+        let value: Value = serde_json::from_str(&rendered).expect("valid JSON");
+        assert_eq!(value["status"], "explained");
+        assert_eq!(value["gate"]["eligible"], true);
+        assert_eq!(value["impact"]["direct_dependents"][0], "src/api.rs");
+    }
+}

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -10,6 +10,7 @@ mod analysis_store;
 mod context;
 mod explain_file;
 mod explain_finding;
+mod explain_review_signal;
 mod jsonrpc;
 mod review_change;
 mod scan;
@@ -332,6 +333,7 @@ fn tools_list_result() -> Value {
             context::definition(),
             explain_file::definition(),
             explain_finding::definition(),
+            explain_review_signal::definition(),
         ]
     })
 }
@@ -346,6 +348,11 @@ fn resources_list_result(state: &ServerState) -> Value {
         json!({
             "uri": "repopilot://repository-summary",
             "name": "RepoPilot repository summary",
+            "mimeType": "application/json"
+        }),
+        json!({
+            "uri": "repopilot://analyses",
+            "name": "Available RepoPilot analysis handles",
             "mimeType": "application/json"
         }),
     ];
@@ -372,6 +379,8 @@ fn handle_resource_read(id: Value, params: &Value, state: &ServerState) -> Respo
         .and_then(Value::as_str)
         .unwrap_or_default();
     let text = match uri {
+        "repopilot://analyses" => serde_json::to_string_pretty(&state.analyses.summaries())
+            .unwrap_or_else(|_| "[]".to_string()),
         "repopilot://rules" => {
             let rules = repopilot::rules::all_rule_metadata()
                 .map(|rule| {

--- a/src/commands/mcp/tests.rs
+++ b/src/commands/mcp/tests.rs
@@ -95,6 +95,7 @@ fn tools_list_advertises_all_tools_with_schemas() {
             "repopilot_context",
             "repopilot_explain_file",
             "repopilot_explain_finding",
+            "repopilot_explain_review_signal",
         ]
     );
 
@@ -172,6 +173,12 @@ fn lists_resources_and_prompts() {
         json!({"jsonrpc":"2.0","id":2,"method":"prompts/list"}),
         json!({
             "jsonrpc":"2.0",
+            "id":4,
+            "method":"resources/read",
+            "params":{"uri":"repopilot://analyses"}
+        }),
+        json!({
+            "jsonrpc":"2.0",
             "id":3,
             "method":"prompts/get",
             "params":{"name":"review-change"}
@@ -192,12 +199,20 @@ fn lists_resources_and_prompts() {
             .iter()
             .any(|resource| resource["uri"] == "repopilot://repository-summary")
     );
+    assert!(
+        responses[0]["result"]["resources"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|resource| resource["uri"] == "repopilot://analyses")
+    );
     assert_eq!(
         responses[1]["result"]["prompts"].as_array().unwrap().len(),
         2
     );
+    assert_eq!(responses[2]["result"]["contents"][0]["text"], "[]");
     assert_eq!(
-        responses[2]["result"]["messages"][0]["content"]["type"],
+        responses[3]["result"]["messages"][0]["content"]["type"],
         "text"
     );
 }
@@ -399,6 +414,47 @@ fn scan_paginates_and_handle_is_accepted_by_explain_and_context() {
         context_response.result.expect("context result")["isError"],
         false
     );
+}
+
+#[test]
+fn review_signal_tool_explains_the_latest_stored_signal() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let report = json!({
+        "tiered_signals": {
+            "definitely": [{
+                "signal_id": "signal-1",
+                "family": "behavioral",
+                "path": "src/api.rs",
+                "headline": "external call changed",
+                "gate_eligible": true,
+                "suppressed": false,
+                "verification_plan": { "steps": ["Exercise the changed integration."] }
+            }],
+            "maybe": [],
+            "noise": []
+        },
+        "impact_paths": { "files": [{ "path": "src/api.rs" }] }
+    })
+    .to_string();
+    let mut state = ServerState {
+        root: temp.path().canonicalize().expect("canonical root"),
+        initialized: true,
+        last_review: Some(report),
+        ..ServerState::default()
+    };
+
+    let response = handle_tools_call(
+        json!(20),
+        &json!({
+            "name": "repopilot_explain_review_signal",
+            "arguments": { "signal_id": "signal-1" }
+        }),
+        &mut state,
+    );
+    let result = response.result.expect("tool result");
+    assert_eq!(result["isError"], false, "tool call failed: {result}");
+    assert_eq!(result["structuredContent"]["status"], "explained");
+    assert_eq!(result["structuredContent"]["gate"]["eligible"], true);
 }
 
 #[test]

--- a/src/commands/mcp/tool_call.rs
+++ b/src/commands/mcp/tool_call.rs
@@ -1,5 +1,7 @@
 use super::analysis_store::{self, AnalysisKind, AnalysisRecord};
-use super::{ServerState, context, explain_file, explain_finding, review_change, scan};
+use super::{
+    ServerState, context, explain_file, explain_finding, explain_review_signal, review_change, scan,
+};
 use crate::commands::mcp::jsonrpc::Response;
 use repopilot::scan::session::WorkspaceRevision;
 use serde_json::{Value, json};
@@ -79,6 +81,13 @@ fn dispatch_tool(
         context::TOOL_NAME => context::call(arguments),
         explain_file::TOOL_NAME => explain_file::call(arguments, &state.root),
         explain_finding::TOOL_NAME => call_explain_finding(arguments, state, referenced),
+        explain_review_signal::TOOL_NAME => {
+            let report = referenced
+                .filter(|record| record.kind == AnalysisKind::Review)
+                .map(|record| record.report.as_str())
+                .or(state.last_review.as_deref());
+            explain_review_signal::call(arguments, report)
+        }
         other => Err(format!("unknown tool: {other}")),
     }
 }
@@ -92,8 +101,11 @@ fn referenced_analysis(
     let Some(handle) = arguments.get("analysis_handle").and_then(Value::as_str) else {
         return Ok(None);
     };
-    if !matches!(name, context::TOOL_NAME | explain_finding::TOOL_NAME) {
-        return Err("`analysis_handle` is only accepted by context and explain_finding".into());
+    if !matches!(
+        name,
+        context::TOOL_NAME | explain_finding::TOOL_NAME | explain_review_signal::TOOL_NAME
+    ) {
+        return Err("`analysis_handle` is only accepted by context, explain_finding, and explain_review_signal".into());
     }
     let record = state
         .analyses

--- a/tests/mcp_cli.rs
+++ b/tests/mcp_cli.rs
@@ -90,6 +90,7 @@ fn mcp_server_initializes_lists_tools_and_runs_scan_locally() {
             "repopilot_context",
             "repopilot_explain_file",
             "repopilot_explain_finding",
+            "repopilot_explain_review_signal",
         ]
     );
 


### PR DESCRIPTION
## Summary

Completes RepoPilot’s MCP explanation workflow by adding review-signal explanations, discoverable analysis history, and a safe stored-only fallback for findings that cannot be replayed with sufficient live context.

Agents can now select a retained review analysis by handle, explain a specific review signal by `signal_id`, inspect its gate state, impact, evidence, and verification plan, and discover the analyses currently retained by the MCP session.

All new surfaces remain local, read-only, bounded, and additive.

## Type of change

* [x] Feature
* [x] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

### Review-signal explanation tool

Added a new MCP tool:

```
repopilot_explain_review_signal
```

Inputs:

```
{
  "signal_id": "…",
  "analysis_handle": "review-…"
}
```

`analysis_handle` is optional. Without it, the latest review result in the current MCP session is used.

The tool returns:

* the stored review signal;
* signal family and trust tier;
* detector provenance;
* evidence path and headline;
* gate eligibility;
* suppression state and reason;
* blast-radius or impact-path context;
* deterministic verification plan;
* an explanation of why the signal matters;
* explicit static-analysis limitations.

### Handle-aware signal selection

`analysis_handle` is now accepted by:

* `repopilot_context`;
* `repopilot_explain_finding`;
* `repopilot_explain_review_signal`.

A handle passed to the review-signal explanation tool must reference a retained review analysis.

Unknown, expired, or stale handles continue to fail explicitly through the existing workspace-revision contract.

### Analysis history resource

Added:

```
repopilot://analyses
```

The resource exposes newest-first summaries for the scan and review analyses currently retained in the MCP session.

Each entry contains:

```
{
  "analysis_handle": "review-…",
  "kind": "review",
  "workspace_revision": "…",
  "findings": 4,
  "review_signals": 2
}
```

The resource does not include full reports or source evidence. Clients can use the returned handle with compatible MCP tools.

The existing retention limit remains eight analyses.

### Stored-only finding fallback

`repopilot_explain_finding` previously rejected findings that could not be safely replayed from file-local Knowledge Engine context.

It now returns a structured stored-only explanation when the finding exists in the selected report but live replay is unavailable.

Example:

```
{
  "status": "stored-only",
  "source_report": "last-scan",
  "finding_id": "…",
  "replay": {
    "status": "unavailable",
    "reason": "…"
  },
  "finding": {},
  "decision": {},
  "limitations": []
}
```

This preserves useful stored evidence without falsely claiming that a live decision replay succeeded.

The fallback is applicable to findings whose correct evaluation requires broader context, including repository, project, framework, workspace, or Git-diff analysis.

### MCP contract integration

The new tool:

* advertises an input schema;
* advertises an output schema;
* returns `structuredContent`;
* retains the text fallback;
* is marked read-only;
* is marked non-destructive;
* is marked idempotent;
* remains closed-world;
* inherits workspace revisions;
* inherits response-size enforcement;
* works with retained analysis handles.

### Documentation

Updated the MCP tool table with:

* review-signal explanation;
* stored-only finding fallback behavior.

Updated the resource documentation with:

```
repopilot://analyses
```

Updated the v0.20 roadmap and marked the MCP explanation/history slice complete.

## Why

RepoPilot already retained full scan and review analyses behind session-local handles, but clients could not discover which handles were still available.

Agents also received detailed review signals from `repopilot_review_change`, but had no dedicated MCP surface for asking:

* why was this signal emitted;
* why was it assigned this tier;
* can it fail the gate;
* what code surface may be affected;
* how should the change be verified;
* what limitations should be communicated to the user.

Finding explanation had a separate gap. Correct replay is not possible for every finding scope. Returning only an error discarded useful stored evidence, while attempting a file-only replay would have produced a misleading explanation.

This change gives MCP clients a complete and honest follow-up workflow:

```
review
  → retain analysis handle
  → discover available analyses
  → explain a finding or review signal
  → verify against stated limitations
```

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
* [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
* [x] No unrelated refactor or generated-file churn is included

Primary subsystem:

* local MCP server;
* retained analysis store;
* finding and review-signal explanations;
* MCP resources and schemas.

Public behavior affected:

* one additive MCP tool is available;
* one additive MCP resource is available;
* finding explanation can return `stored-only` instead of failing when safe replay is unavailable;
* `analysis_handle` is accepted by the new signal explanation tool.

Unchanged contracts:

* top-level CLI command surface;
* scan and review CLI behavior;
* scan and review report schemas;
* finding IDs and occurrence keys;
* baseline matching;
* SARIF;
* GitHub Action contracts;
* gate evaluation;
* process exit codes;
* eight-analysis retention limit;
* local-only and read-only MCP behavior.

No top-level `explain` command is restored.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```

Focused verification:

```
cargo test --lib commands::mcp::explain_review_signal
cargo test --lib commands::mcp::analysis_store
cargo test --lib commands::mcp::explain_finding
cargo test --test mcp_cli
python3 scripts/release-contract.py check
```
