### PR TITLE
feat(init): generate GitHub Action and MCP bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+- `repopilot init` can now generate a review-first GitHub Actions workflow and explicit Claude, Cursor, or generic MCP bootstrap examples without modifying external client settings.
 - MCP can now explain stored review signals by `signal_id`, expose retained analysis-handle summaries through `repopilot://analyses`, and return stored-only finding context when a safe live replay is unavailable.
 - Top-level help, README, and CLI/workflow references now provide one
   review-first command chooser, document snapshot and summary output consistently,

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ controls shape it:
 plus review, scan, file explanation, and finding replay tools over stdio so
 coding agents can call it directly:
 
-```bash
-claude mcp add repopilot -- repopilot mcp --root .
-```
+Generate a client-neutral MCP configuration example with
+`repopilot init --mcp-client generic`. Client-specific Claude Code and Cursor
+adapters are available through the same `--mcp-client` option.
 
 The MCP server is synchronous, root-confined, and makes no network or LLM calls.
 See [MCP server](https://github.com/MykytaStel/repopilot/blob/main/docs/mcp.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -466,7 +466,15 @@ repopilot init [OPTIONS]
 repopilot init
 repopilot init --force
 repopilot init --path ./config/repopilot.toml
+repopilot init --github-action
+repopilot init --mcp-client claude
+repopilot init --mcp-client cursor
+repopilot init --all
 ```
+
+Bootstrap flags generate RepoPilot-owned files only. Existing files are preserved
+unless `--force` is passed. MCP bootstrap output is written under
+`.repopilot/bootstrap/`; RepoPilot does not modify external client settings automatically.
 
 ---
 
@@ -491,12 +499,13 @@ repopilot mcp [--root PATH]
 | `repopilot_context` | Budgeted, AI-ready Markdown brief (optional `focus`, `budget`) |
 | `repopilot_explain_file` | How one file is classified and which rules and signals apply |
 | `repopilot_explain_finding` | Replay a file-scoped finding by stable ID and optional evidence occurrence |
+| `repopilot_explain_review_signal` | Explain a stored review signal by stable ID |
 
 ### Examples
 
 ```bash
-# Register with Claude Code
-claude mcp add repopilot -- repopilot mcp --root .
+# Generate a client-neutral MCP configuration example
+repopilot init --mcp-client generic
 
 # Manual smoke test (list the available tools)
 printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | repopilot mcp --root .

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,30 @@ repopilot scan . \
 
 See [Reports](reports.md) for schema and compatibility details.
 
+## Bootstrap Integrations
+
+Generate a review-first GitHub Actions workflow:
+
+```bash
+repopilot init --github-action
+```
+
+Generate an MCP configuration example without editing the external client:
+
+```bash
+repopilot init --mcp-client claude
+repopilot init --mcp-client cursor
+repopilot init --mcp-client generic
+```
+
+Generate the default config plus both integration bootstraps:
+
+```bash
+repopilot init --all
+```
+
+Generated files are deterministic and are not overwritten unless `--force` is passed.
+
 ## GitHub Pull Requests
 
 Use the reusable workflow:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -9,11 +9,8 @@ workspace are rejected.
 
 ## Register
 
-```bash
-claude mcp add repopilot -- repopilot mcp --root .
-```
-
-Generic client configuration:
+Generate a generic configuration with `repopilot init --mcp-client generic`, or
+use this equivalent entry in any compatible client:
 
 ```json
 {
@@ -25,6 +22,10 @@ Generic client configuration:
   }
 }
 ```
+
+Client-specific bootstrap examples are also available through
+`repopilot init --mcp-client claude` and `--mcp-client cursor`. They are thin
+adapters over the same `repopilot mcp --root .` server command.
 
 ## Tool Contract
 

--- a/docs/roadmap/v0.20.md
+++ b/docs/roadmap/v0.20.md
@@ -237,7 +237,7 @@ implementation. The detailed PR plan below remains the acceptance contract.
 | #281 | Done | Shared root confinement protects agent-facing path consumers, human-readable outputs centrally redact sensitive evidence, parsed-facts cache writes use recoverable staged replacement, and Linux/macOS/Windows smoke coverage verifies CLI and cache behavior. | None. |
 | #282 | Done | Top-level help, README, and CLI/workflow references provide a review-first command chooser, document snapshot and summary output consistently, clarify changed-scope versus full-scan behavior, and preserve the reduced command surface. Coverage: `tests/cli_stabilization.rs`. | None. |
 | #283 | Done | Added `repopilot_explain_review_signal`, newest-first `repopilot://analyses` discovery, and structured stored-only finding explanations when live replay is unavailable. MCP unit/integration coverage and public docs lock the additive tool/resource contracts. | Proceed to #284 bootstrap generation. |
-| #284 | Planned | Not started. | Extend the existing `init` command with GitHub Action and MCP bootstrap generation; do not restore `doctor`. |
+| #284 | Done | Extended `init` with deterministic, opt-in GitHub Action and generic/Claude/Cursor MCP bootstrap generation. Existing files are preserved without `--force`, external client settings remain untouched, generated workflow versions follow the running package, and unit/CLI regression coverage verifies generation and reruns. | Proceed to #285 release preparation. |
 | #285 | Planned | Not started. | Bump versions, write v0.20.0 curated release notes, and complete release gates. |
 
 ## Planned PR Sequence

--- a/src/cli/options/init.rs
+++ b/src/cli/options/init.rs
@@ -1,13 +1,32 @@
-use clap::Args;
+use clap::{Args, ValueEnum};
 use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum McpClientArg {
+    Claude,
+    Cursor,
+    Generic,
+}
 
 #[derive(Args)]
 pub struct InitOptions {
-    /// Overwrite an existing config file
+    /// Overwrite RepoPilot-owned generated files
     #[arg(long)]
     pub force: bool,
 
     /// Config file path to write
     #[arg(long, default_value = "repopilot.toml")]
     pub path: PathBuf,
+
+    /// Generate a review-first GitHub Actions workflow
+    #[arg(long)]
+    pub github_action: bool,
+
+    /// Generate an MCP client configuration example
+    #[arg(long, value_enum)]
+    pub mcp_client: Option<McpClientArg>,
+
+    /// Generate config, GitHub Action, and generic MCP bootstrap files
+    #[arg(long)]
+    pub all: bool,
 }

--- a/src/cli/options/mod.rs
+++ b/src/cli/options/mod.rs
@@ -10,7 +10,7 @@ pub mod snapshot;
 pub use ai::{AiCommands, AiOptions};
 pub use baseline::{BaselineCommands, BaselineOptions};
 pub use cache::{CacheCommands, CacheOptions};
-pub use init::InitOptions;
+pub use init::{InitOptions, McpClientArg};
 pub use mcp::McpOptions;
 pub use review::ReviewOptions;
 pub use scan::ScanOptions;
@@ -133,30 +133,32 @@ repopilot ai context . --no-task --output ai-context.md"
     /// Generate a default repopilot.toml configuration file
     #[command(
         about = "Generate a default repopilot.toml configuration file",
-        long_about = "Writes a repopilot.toml with all configurable thresholds set to their defaults.\n\n\
-Edit the generated file to tune thresholds for your project. RepoPilot automatically\n\
+        long_about = "Writes a repopilot.toml and can optionally generate RepoPilot-owned GitHub Action and MCP bootstrap files.\n\n\
+Edit the generated config to tune thresholds for your project. RepoPilot automatically\n\
 reads repopilot.toml from the current working directory for analysis commands,\n\
 including `scan`, `review`, `baseline create`, AI context, and MCP tools.\n\n\
+Bootstrap files are opt-in and external client settings are never modified automatically.\n\n\
 Configuration precedence: CLI flags > repopilot.toml > built-in defaults.",
         after_help = "EXAMPLES:\n  \
 repopilot init\n  \
 repopilot init --force            # overwrite existing config\n  \
-repopilot init --path ./config/repopilot.toml"
+repopilot init --github-action\n  \
+repopilot init --mcp-client generic\n  \
+repopilot init --all"
     )]
     Init(InitOptions),
 
     /// Run a local Model Context Protocol server over stdio
     #[command(
         about = "Run a local Model Context Protocol server over stdio",
-        long_about = "Exposes RepoPilot to AI agents (Claude Code, Cursor, …) as MCP tools they can\n\
+        long_about = "Exposes RepoPilot to any compatible client as local MCP tools it can\n\
 call directly. The server speaks JSON-RPC 2.0 over stdin/stdout; nothing is\n\
 uploaded and no AI service is called — every tool runs the same local analysis as\n\
-the CLI.\n\n\
-Register it with your agent, for example:\n  \
-claude mcp add repopilot -- repopilot mcp",
+the CLI. Use `repopilot init --mcp-client generic` or a client-specific bootstrap\n\
+when you need a configuration example.",
         after_help = "EXAMPLES:\n  \
 repopilot mcp                               # run the stdio server (clients launch this)\n  \
-claude mcp add repopilot -- repopilot mcp   # register with Claude Code"
+repopilot mcp --root /path/to/repository    # confine tools to one workspace"
     )]
     Mcp(McpOptions),
 }

--- a/src/commands/dispatch.rs
+++ b/src/commands/dispatch.rs
@@ -13,7 +13,7 @@ pub fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Commands::Snapshot(options) => super::snapshot::run(options),
         Commands::Baseline(options) => super::baseline::run(options.command),
         Commands::Ai(options) => run_ai(options.command),
-        Commands::Init(options) => super::init::run(options.force, options.path),
+        Commands::Init(options) => super::init::run(options),
         Commands::Mcp(options) => super::mcp::run(options),
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,18 +1,226 @@
+use crate::cli::{InitOptions, McpClientArg};
 use repopilot::config::template::default_config_toml;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-pub fn run(force: bool, path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+const ACTION_PATH: &str = ".github/workflows/repopilot-review.yml";
+const MCP_DIR: &str = ".repopilot/bootstrap";
+
+pub fn run(options: InitOptions) -> Result<(), Box<dyn std::error::Error>> {
+    let root = std::env::current_dir()?;
+    run_at(options, &root)
+}
+
+fn run_at(options: InitOptions, root: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let generate_action = options.github_action || options.all;
+    let mcp_client = options
+        .mcp_client
+        .or(options.all.then_some(McpClientArg::Generic));
+
+    let config = default_config_toml();
+    write_owned_file(&options.path, &config, options.force, "RepoPilot config")?;
+
+    if generate_action {
+        write_owned_file(
+            &root.join(ACTION_PATH),
+            &github_action_workflow(),
+            options.force,
+            "GitHub Actions workflow",
+        )?;
+    }
+
+    if let Some(client) = mcp_client {
+        let path = root.join(mcp_output_path(client));
+        write_owned_file(
+            &path,
+            &mcp_bootstrap(client),
+            options.force,
+            "MCP bootstrap",
+        )?;
+    }
+
+    print_next_steps(&options.path, generate_action, mcp_client);
+    Ok(())
+}
+
+fn write_owned_file(
+    path: &Path,
+    content: &str,
+    force: bool,
+    label: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     if path.exists() && !force {
         println!(
-            "Config already exists at {}. Use `repopilot init --force` to overwrite it.",
+            "{label} already exists at {}. Use `repopilot init --force` to overwrite RepoPilot-owned generated files.",
             path.display()
         );
         return Ok(());
     }
 
-    fs::write(&path, default_config_toml())?;
-    println!("Created RepoPilot config at {}", path.display());
-
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, content)?;
+    println!("Created {label} at {}", path.display());
     Ok(())
+}
+
+fn github_action_workflow() -> String {
+    format!(
+        r#"name: RepoPilot review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+jobs:
+  repopilot:
+    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v{}
+    with:
+      fail-on-review: none
+      upload-sarif: true
+"#,
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+fn mcp_output_path(client: McpClientArg) -> PathBuf {
+    let name = match client {
+        McpClientArg::Claude => "claude.json",
+        McpClientArg::Cursor => "cursor.json",
+        McpClientArg::Generic => "generic.json",
+    };
+    Path::new(MCP_DIR).join(name)
+}
+
+fn mcp_bootstrap(client: McpClientArg) -> String {
+    match client {
+        McpClientArg::Claude => r#"{
+  "registration_command": "claude mcp add repopilot -- repopilot mcp --root .",
+  "note": "Run the registration command from the repository root."
+}
+"#
+        .to_string(),
+        McpClientArg::Cursor => r#"{
+  "mcpServers": {
+    "repopilot": {
+      "command": "repopilot",
+      "args": ["mcp", "--root", "."]
+    }
+  },
+  "note": "Copy this server entry into the MCP configuration used by Cursor."
+}
+"#
+        .to_string(),
+        McpClientArg::Generic => r#"{
+  "mcpServers": {
+    "repopilot": {
+      "command": "repopilot",
+      "args": ["mcp", "--root", "."]
+    }
+  }
+}
+"#
+        .to_string(),
+    }
+}
+
+fn print_next_steps(config: &Path, action: bool, mcp: Option<McpClientArg>) {
+    println!();
+    println!("Next:");
+    println!("  repopilot review .");
+    println!("  repopilot scan . --config {}", config.display());
+
+    if action {
+        println!("  git add {ACTION_PATH}");
+        println!("  open a pull request to verify the generated RepoPilot workflow");
+    }
+    if let Some(client) = mcp {
+        println!("  review {}", mcp_output_path(client).display());
+        println!("  copy or register the MCP entry in your client explicitly");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn options(root: &Path) -> InitOptions {
+        InitOptions {
+            force: false,
+            path: root.join("repopilot.toml"),
+            github_action: false,
+            mcp_client: None,
+            all: false,
+        }
+    }
+
+    #[test]
+    fn init_generates_config_action_and_generic_mcp_bootstrap() {
+        let temp = tempdir().expect("temp dir");
+        let mut options = options(temp.path());
+        options.github_action = true;
+        options.mcp_client = Some(McpClientArg::Generic);
+
+        run_at(options, temp.path()).expect("init succeeds");
+
+        assert!(temp.path().join("repopilot.toml").is_file());
+        let action = fs::read_to_string(temp.path().join(ACTION_PATH)).expect("action");
+        assert!(action.contains(&format!(
+            "repopilot-pr-review.yml@v{}",
+            env!("CARGO_PKG_VERSION")
+        )));
+        assert!(action.contains("upload-sarif: true"));
+
+        let mcp = fs::read_to_string(temp.path().join(MCP_DIR).join("generic.json")).expect("mcp");
+        assert!(mcp.contains("\"repopilot\""));
+        assert!(mcp.contains("\"--root\""));
+    }
+
+    #[test]
+    fn init_preserves_existing_generated_files_without_force() {
+        let temp = tempdir().expect("temp dir");
+        let path = temp.path().join("repopilot.toml");
+        fs::write(&path, "custom = true\n").expect("existing config");
+
+        run_at(options(temp.path()), temp.path()).expect("init succeeds");
+
+        assert_eq!(fs::read_to_string(path).expect("config"), "custom = true\n");
+    }
+
+    #[test]
+    fn force_replaces_existing_config() {
+        let temp = tempdir().expect("temp dir");
+        let path = temp.path().join("repopilot.toml");
+        fs::write(&path, "custom = true\n").expect("existing config");
+        let mut options = options(temp.path());
+        options.force = true;
+
+        run_at(options, temp.path()).expect("init succeeds");
+
+        assert_ne!(fs::read_to_string(path).expect("config"), "custom = true\n");
+    }
+
+    #[test]
+    fn every_mcp_bootstrap_is_valid_json_and_launches_or_registers_repopilot() {
+        for client in [
+            McpClientArg::Claude,
+            McpClientArg::Cursor,
+            McpClientArg::Generic,
+        ] {
+            let value: serde_json::Value =
+                serde_json::from_str(&mcp_bootstrap(client)).expect("valid bootstrap JSON");
+            let rendered = value.to_string();
+            assert!(rendered.contains("repopilot"));
+            assert!(rendered.contains("mcp"));
+        }
+    }
 }

--- a/tests/cli_stabilization.rs
+++ b/tests/cli_stabilization.rs
@@ -100,6 +100,31 @@ fn top_level_help_shows_stable_command_surface() {
 }
 
 #[test]
+fn init_generates_opt_in_bootstraps_and_preserves_owned_files() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    run_ok(&["init", "--all"], temp.path());
+
+    let config = temp.path().join("repopilot.toml");
+    let action = temp.path().join(".github/workflows/repopilot-review.yml");
+    let mcp = temp.path().join(".repopilot/bootstrap/generic.json");
+    assert!(config.is_file());
+    assert!(action.is_file());
+    assert!(mcp.is_file());
+    assert!(
+        fs::read_to_string(&action)
+            .expect("generated action")
+            .contains(&format!("@v{}", env!("CARGO_PKG_VERSION")))
+    );
+
+    fs::write(&action, "custom workflow\n").expect("customize action");
+    run_ok(&["init", "--all"], temp.path());
+    assert_eq!(
+        fs::read_to_string(action).expect("preserved action"),
+        "custom workflow\n"
+    );
+}
+
+#[test]
 fn scan_and_review_help_have_flag_descriptions() {
     let temp = tempfile::tempdir().expect("temp dir");
     let scan_help = stdout(&run_ok(&["scan", "--help"], temp.path()));


### PR DESCRIPTION
## Summary

Extends the existing `repopilot init` command with deterministic, opt-in bootstrap generation for GitHub Actions and MCP clients.

Users can now generate a review-first pull request workflow and explicit Claude, Cursor, or generic MCP configuration examples without manually copying documentation snippets.

Existing files are preserved by default, external client settings are never modified automatically, and no legacy `doctor` or separate setup command is introduced.

## Type of change

* [x] Feature
* [x] Refactor
* [x] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

### Expanded `repopilot init`

Added the following options:

```
repopilot init --github-action
repopilot init --mcp-client claude
repopilot init --mcp-client cursor
repopilot init --mcp-client generic
repopilot init --all
```

The existing options remain available:

```
repopilot init
repopilot init --path ./config/repopilot.toml
repopilot init --force
```

### GitHub Actions bootstrap

Running:

```
repopilot init --github-action
```

generates:

```
.github/workflows/repopilot-review.yml
```

The generated workflow:

* runs on pull requests;
* grants only the permissions required by the reusable workflow;
* uses RepoPilot’s review-first reusable workflow;
* enables SARIF upload;
* keeps the review-signal gate advisory by default;
* pins the reusable workflow to the running RepoPilot package version.

Example generated job:

```
jobs:
  repopilot:
    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.20.0
    with:
      fail-on-review: none
      upload-sarif: true
```

### MCP client bootstrap

Running:

```
repopilot init --mcp-client generic
```

generates:

```
.repopilot/bootstrap/generic.json
```

with a client-neutral MCP server entry:

```json
{
  "mcpServers": {
    "repopilot": {
      "command": "repopilot",
      "args": ["mcp", "--root", "."]
    }
  }
}
```

Client-specific adapters are also available:

```
repopilot init --mcp-client claude
repopilot init --mcp-client cursor
```

Claude output includes the explicit registration command:

```
claude mcp add repopilot -- repopilot mcp --root .
```

Cursor output contains the equivalent `mcpServers` entry and a note explaining where it should be copied.

### Combined bootstrap

Running:

```
repopilot init --all
```

generates:

* `repopilot.toml`;
* `.github/workflows/repopilot-review.yml`;
* `.repopilot/bootstrap/generic.json`.

The generated files use the same deterministic templates as the individual options.

### Safe reruns

RepoPilot-owned generated files are not overwritten by default.

When a target already exists, `init` reports it and leaves its contents unchanged.

Explicit replacement requires:

```
repopilot init --force
```

or:

```
repopilot init --all --force
```

This behavior applies independently to the configuration, GitHub Actions workflow, and MCP bootstrap files.

### External settings remain untouched

RepoPilot does not:

* edit Claude settings;
* edit Cursor settings;
* detect or modify another client’s configuration directory;
* register an MCP server automatically;
* push workflow files or commits.

It only writes reviewable files inside the selected repository.

### Contextual next steps

After generation, `init` prints relevant follow-up commands, including:

* running a local review;
* running a configured scan;
* staging the generated workflow;
* reviewing and explicitly registering or copying the MCP configuration.

### Documentation

Updated:

* top-level command help;
* `init --help`;
* MCP help;
* README MCP onboarding;
* CLI reference;
* common workflows;
* MCP documentation;
* v0.20 roadmap.

The documentation now recommends bootstrap generation instead of relying only on manually copied client-specific commands.

### Roadmap

Marks v0.20 roadmap item #284 complete.

The remaining v0.20 work is release preparation:

* version synchronization;
* curated release notes;
* changelog release section;
* release scorecard;
* complete release verification.

## Why

Before this change, RepoPilot documented GitHub Actions and MCP setup, but users still had to manually:

* copy workflow YAML;
* choose the correct Action version;
* understand the required permissions;
* copy MCP configuration snippets;
* translate generic MCP configuration into client-specific setup.

This creates unnecessary onboarding friction and makes documentation drift more likely.

Extending the existing `init` command provides one consistent setup surface without reintroducing the previously removed `doctor` command or adding another overlapping top-level command.

The generated files remain explicit and reviewable. RepoPilot assists setup without silently modifying external systems.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
* [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
* [x] No unrelated refactor or generated-file churn is included

Primary subsystems:

* `repopilot init`;
* CLI init options;
* generated GitHub Actions workflow;
* generated MCP bootstrap examples;
* onboarding documentation.

Public behavior affected:

* `init` accepts additive integration-generation flags;
* `init --all` generates all RepoPilot-owned bootstrap files;
* `--force` applies to all generated files;
* CLI and documentation recommend generated integration examples.

Unchanged contracts:

* existing `repopilot init` usage;
* top-level command surface;
* scan and review behavior;
* JSON, SARIF, baseline, receipt, and Action report schemas;
* MCP tool and resource schemas;
* gate evaluation;
* process exit codes;
* finding IDs and occurrence keys.

No `doctor` command is restored.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```

Focused verification:

```
cargo test --lib commands::init
cargo test --test cli_stabilization
cargo run --quiet -- init --help
python3 scripts/release-contract.py check
```

Manual bootstrap verification:

```
tmp="$(mktemp -d)"
cd "$tmp"

repopilot init --all

test -f repopilot.toml
test -f .github/workflows/repopilot-review.yml
test -f .repopilot/bootstrap/generic.json
```
