### PR TITLE
feat(languages): add frontend registry and capability contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **Language frontend registry skeleton (`src/languages/`).** First brick of
+  the 0.21 language contract: static per-language descriptors unifying the
+  knowledge-pack profiles, context-classifier kinds, and tree-sitter grammar
+  bindings behind one lookup, with guard tests that keep grammar dispatch in
+  lockstep and a support-honesty ledger documenting languages whose declared
+  `rule-aware` level exceeds their actual wiring (java, kotlin, csharp, c,
+  cpp today). Wired to nothing yet — dispatch migrates behind the registry
+  in follow-up, behavior-frozen PRs. Working checklist:
+  `docs/engineering/language-surface-inventory.md`.
 - **"Guard your agent runs" guide (`docs/agent-guardrail.md`).** End-to-end
   recipes for wrapping a coding-agent session with deterministic review:
   session snapshot + stop-hook gate for Claude Code, MCP bootstrap for agent

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ adoption or CI policy.
 - [Analysis platform state](engineering/analysis-platform-state.md)
 - [Dependency Graph v2 design](engineering/dependency-graph-v2.md)
 - [Signal contract](engineering/signal-contract.md)
+- [Language surface inventory](engineering/language-surface-inventory.md)
 - [Engine pipeline](engineering/engine-pipeline.md)
 - [Graph scan hardening](engineering/graph-scan-hardening.md)
 - [Performance budgets](engineering/performance-budgets.md)

--- a/docs/engineering/language-surface-inventory.md
+++ b/docs/engineering/language-surface-inventory.md
@@ -1,0 +1,130 @@
+# Language Surface Inventory
+
+Where language-specific behavior lives today, and which 0.21 migration PR
+moves each row behind the language frontend registry (`src/languages/`).
+This is the working checklist for the 0.21 cycle: a row is done when its
+dispatch happens through a frontend lookup and the row is checked off. Line
+anchors are correct as of the PR-1 commit; expect small drift and trust the
+file, not the number.
+
+Status legend: `[ ]` not migrated · `[x]` migrated · `[-]` stays put by
+design (with reason).
+
+## Detection and identity
+
+- [ ] `src/knowledge/packs/core.toml` — 43 `[[languages]]` profiles: id,
+      name, aliases, extensions, filenames, **declared** `support` level.
+      Stays the detection data source; the registry references profile ids
+      (`LanguageFrontend.knowledge_ids`) instead of duplicating extensions.
+      PR-9 reconciles over-declared levels (java/kotlin/csharp/c/cpp claim
+      `rule-aware` today; the guard-test ledger documents the gap).
+- [ ] `src/knowledge/language.rs:68` — `language_kind_from_id`: hardcoded
+      id→`LanguageKind` map, duplicated against the pack. → PR-2.
+- [ ] `src/audits/context/model/kinds.rs:2` — `LanguageKind` enum (43
+      variants). Stays; the registry routes every variant
+      (`frontend_for_kind` is exhaustive). → PR-2 consumers.
+
+## Parse layer
+
+- [ ] `src/analysis/parse.rs:31` — `ParseLanguage` enum (9 grammars).
+- [ ] `src/analysis/parse.rs:46` — `ParseLanguage::from_label`: label-string
+      → grammar map. Registry `GrammarBinding`s mirror it 1:1 today (guard
+      test enforces lockstep). → PR-2 replaces with registry lookup.
+- [ ] `src/analysis/parse.rs:62` — thread-local parser table. Stays, keyed
+      by `ParseLanguage`; only the label dispatch moves.
+- [ ] `src/scan/parsed_cache.rs`, `src/analysis/artifact.rs` — parse-once
+      caches keyed by label strings. → PR-2.
+
+## Imports and graph
+
+- [ ] `src/graph/imports.rs:30` — `extract_imports_from`: label-string match
+      dispatching to `graph/imports/{rust,ts,python,go,jvm}.rs`. → PR-3
+      (`frontend().imports`).
+- [ ] `src/graph/imports.rs:59` — `extract_deferred_imports_from`: same
+      dispatch for Python function-body imports (0.19 cycle-breaker). → PR-3,
+      byte-identical behavior.
+- [ ] `src/graph/imports/{common,go,jvm,python,rust,ts,lines}.rs` — the
+      per-language extractors. Already per-language (the contract's seed);
+      relocate under `src/languages/*/imports.rs` with thin re-export
+      adapters for one release. → PR-3.
+- [-] `src/graph/resolver/`, `src/graph/v2/` — resolution and graph
+      algorithms consume extracted imports; no language dispatch inside.
+      Stays language-agnostic by contract (guard: no-dispatch lint, PR-7).
+
+## Review signals
+
+- [ ] `src/review/signals/taint/sources.rs:40` — HTTP/process input source
+      patterns, one flat list covering JS/TS, Python, Go, Rust idioms. →
+      PR-4 splits per frontend `ReviewTables`.
+- [ ] `src/review/signals/taint/sinks.rs:60` — SQL/exec/fs/network sink
+      callee tables (`subprocess`, `os.system`, `child_process.exec`,
+      `exec.Command`, JDBC-style `.execute`). → PR-4.
+- [ ] `src/review/signals/taint/sanitizers.rs` — parameterized-query and
+      escaping tables. → PR-4.
+- [ ] `src/review/signals/taint/ast.rs`, `flow.rs` — engine; must lose any
+      residual label checks. → PR-4.
+- [ ] `src/review/signals/behavioral/keywords.rs:21` — auth keyword
+      vocabulary (strong/exact tokens, mutation verbs). Mostly
+      language-neutral English identifiers; stays shared, but per-frontend
+      *additions* (e.g. Spring `@PreAuthorize`) become table entries. → PR-4.
+- [ ] `src/review/signals/behavioral/removed_ast.rs` — per-language AST
+      queries counting auth checks / try blocks / test cases. → PR-4.
+- [ ] `src/review/signals/behavioral/removed.rs:154` —
+      `supports_coarse_removed_detection(ext)`: extension allowlist for the
+      text fallback. → PR-4.
+- [ ] `src/review/signals/classify.rs:318` — `match_node_for_boundary`:
+      per-language node-kind + keyword boundary matching. → PR-4.
+- [ ] `src/review/signals/algorithmic/lang.rs:13` — `function_name` and
+      node-kind matchers per language label. → PR-4.
+
+## Runtime risk and code-quality spans
+
+- [ ] `src/audits/code_quality/language_risk.rs:68` —
+      `is_ast_runtime_language(language_id)` allowlist +
+      `language_risk/{js,go,python,managed}.rs` pattern modules. → PR-5
+      (`frontend().risk`).
+- [ ] `src/audits/code_quality/rust_panic_risk/` — Rust-only audit wired as
+      its own rule family; pattern data joins the Rust frontend, severity
+      calibration stays in the Knowledge Engine. → PR-5.
+- [ ] `src/audits/code_quality/function_spans.rs:42` — function-node kinds
+      per label (long/complex function). → PR-5.
+- [ ] `src/audits/code_quality/long_function/brace.rs`,
+      `complex_function/score.rs` — brace-family vs Python span logic via
+      `LanguageFamily`. `LanguageFamily` (syntax shape) stays a shared
+      concept; per-language node kinds move. → PR-5.
+
+## Conventions and context
+
+- [ ] `src/scan/path_classification.rs:34` — test-like filename conventions
+      (`test_*`, `*_test`, `tests.rs`, Rust-specific carve-outs from the
+      0.18 low-signal fix). → PR-6 (`frontend().conventions`).
+- [ ] Test-support allowlist (`testutil.rs`, `test_utils.rs`, …) and
+      `FileRole::TestSupport` wiring from the 0.19 cycle — role logic stays
+      in the context classifier; the *name lists* become convention data. →
+      PR-6.
+- [-] `src/audits/context/classify/` — role/paradigm/runtime classification
+      consumes shared context signals; stays the owner of cross-language
+      context. Frontend conventions feed it; it does not move. (Declared
+      `context-aware` pack levels are justified here, which is why the PR-1
+      honesty ledger only covers `rule-aware` claims.)
+- [ ] `src/audits/framework/` + manifest readers (`package.json`,
+      `pyproject.toml`, `go.mod`, …) — framework probes per ecosystem. →
+      PR-6 (probe registration), detection logic unchanged.
+
+## Output and docs
+
+- [ ] `docs/language-support.md` — hand-maintained tier table, already
+      drifted from the pack (pack says java/kotlin/csharp/c/cpp are
+      rule-aware; doc says Tier 2; the wiring says context at best). → PR-7
+      generates it from the registry with a BLESS drift test.
+- [-] `src/output/ai_context/repo_facts.rs`, report renderers — print
+      labels/tiers; consume registry values after PR-7, no language logic of
+      their own.
+
+## Out of scope for 0.21
+
+- `src/facts/`, `src/scan/facts.rs` — `FileFacts.language` stays a label
+  string this cycle; swapping to a typed id is a 0.22+ decision after the
+  consumers are registry-driven.
+- MCP/SARIF surfaces — no language dispatch; they inherit whatever the
+  engine emits.

--- a/src/languages/capability.rs
+++ b/src/languages/capability.rs
@@ -1,0 +1,75 @@
+//! Computed frontend capabilities.
+//!
+//! A capability is never declared — it is derived from what a frontend has
+//! actually wired. The knowledge pack *declares* a support level per
+//! language; the registry *computes* one from capabilities. The guard tests
+//! keep a shrinking ledger of languages whose declared level exceeds the
+//! computed one, so the support matrix cannot silently over-promise.
+
+use super::LanguageFrontend;
+use crate::knowledge::model::SupportLevel;
+
+/// What a frontend can actually do, judged by its wiring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Capability {
+    /// Has a bundled tree-sitter grammar.
+    Parse,
+    /// Owns an import extractor (arrives with the imports migration).
+    Imports,
+    /// Owns review signal tables — boundary, behavioral, algorithmic.
+    ReviewSignals,
+    /// Owns taint source/sink/sanitizer tables.
+    TaintFlows,
+    /// Owns runtime-risk patterns.
+    RuntimeRisk,
+    /// Owns test-file and test-support path conventions.
+    TestConventions,
+    /// Owns framework probes.
+    Frameworks,
+}
+
+/// Capabilities currently wired for `frontend`. Only [`Capability::Parse`]
+/// is derivable in the skeleton; each migration PR extends this from the
+/// fields it adds to [`LanguageFrontend`].
+pub fn capabilities(frontend: &LanguageFrontend) -> Vec<Capability> {
+    let mut wired = Vec::new();
+    if !frontend.grammars.is_empty() {
+        wired.push(Capability::Parse);
+    }
+    wired
+}
+
+/// The support level the current wiring justifies.
+///
+/// `rule-aware` requires the full set a rule-aware language actually uses;
+/// `context-aware` requires at least a grammar; anything with an import
+/// extractor but no grammar is `import-aware`; the rest is `detect-only`.
+pub fn computed_support(frontend: &LanguageFrontend) -> SupportLevel {
+    let wired = capabilities(frontend);
+    let has = |capability: Capability| wired.contains(&capability);
+
+    if has(Capability::Parse)
+        && has(Capability::Imports)
+        && has(Capability::ReviewSignals)
+        && has(Capability::RuntimeRisk)
+        && has(Capability::TestConventions)
+    {
+        SupportLevel::RuleAware
+    } else if has(Capability::Parse) {
+        SupportLevel::ContextAware
+    } else if has(Capability::Imports) {
+        SupportLevel::ImportAware
+    } else {
+        SupportLevel::DetectOnly
+    }
+}
+
+/// Total order for comparing declared vs computed support in guard tests.
+pub fn support_rank(level: SupportLevel) -> u8 {
+    match level {
+        SupportLevel::DetectOnly => 0,
+        SupportLevel::ImportAware => 1,
+        SupportLevel::ContextAware => 2,
+        SupportLevel::RuleAware => 3,
+    }
+}

--- a/src/languages/csharp.rs
+++ b/src/languages/csharp.rs
@@ -1,0 +1,22 @@
+use super::{GrammarBinding, LanguageFrontend};
+use crate::analysis::parse::ParseLanguage;
+use crate::audits::context::LanguageKind;
+
+pub(super) static CSHARP: LanguageFrontend = LanguageFrontend {
+    id: "csharp",
+    label: "C#",
+    kind: LanguageKind::CSharp,
+    knowledge_ids: &["csharp"],
+    // Both labels appear in the wild: detection emits "C#", while some
+    // callers pass the enum-style "CSharp" (mirrors ParseLanguage::from_label).
+    grammars: &[
+        GrammarBinding {
+            label: "C#",
+            grammar: ParseLanguage::CSharp,
+        },
+        GrammarBinding {
+            label: "CSharp",
+            grammar: ParseLanguage::CSharp,
+        },
+    ],
+};

--- a/src/languages/generic.rs
+++ b/src/languages/generic.rs
@@ -1,0 +1,13 @@
+use super::LanguageFrontend;
+use crate::audits::context::LanguageKind;
+
+/// Fallback frontend for every language without dedicated wiring. Such
+/// files still contribute detection, size, scope, and generic findings —
+/// they just have no language-specific extractors.
+pub(super) static GENERIC: LanguageFrontend = LanguageFrontend {
+    id: "generic",
+    label: "Generic",
+    kind: LanguageKind::Unknown,
+    knowledge_ids: &[],
+    grammars: &[],
+};

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -1,0 +1,14 @@
+use super::{GrammarBinding, LanguageFrontend};
+use crate::analysis::parse::ParseLanguage;
+use crate::audits::context::LanguageKind;
+
+pub(super) static GO: LanguageFrontend = LanguageFrontend {
+    id: "go",
+    label: "Go",
+    kind: LanguageKind::Go,
+    knowledge_ids: &["go"],
+    grammars: &[GrammarBinding {
+        label: "Go",
+        grammar: ParseLanguage::Go,
+    }],
+};

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -1,0 +1,14 @@
+use super::{GrammarBinding, LanguageFrontend};
+use crate::analysis::parse::ParseLanguage;
+use crate::audits::context::LanguageKind;
+
+pub(super) static JAVA: LanguageFrontend = LanguageFrontend {
+    id: "java",
+    label: "Java",
+    kind: LanguageKind::Java,
+    knowledge_ids: &["java"],
+    grammars: &[GrammarBinding {
+        label: "Java",
+        grammar: ParseLanguage::Java,
+    }],
+};

--- a/src/languages/javascript.rs
+++ b/src/languages/javascript.rs
@@ -1,0 +1,40 @@
+//! The JavaScript dialect family: JavaScript and TypeScript frontends,
+//! including their React (`.jsx`/`.tsx`) knowledge-pack dialects.
+
+use super::{GrammarBinding, LanguageFrontend};
+use crate::analysis::parse::ParseLanguage;
+use crate::audits::context::LanguageKind;
+
+pub(super) static TYPESCRIPT: LanguageFrontend = LanguageFrontend {
+    id: "typescript",
+    label: "TypeScript",
+    kind: LanguageKind::TypeScript,
+    knowledge_ids: &["typescript", "typescript-react"],
+    grammars: &[
+        GrammarBinding {
+            label: "TypeScript",
+            grammar: ParseLanguage::TypeScript,
+        },
+        GrammarBinding {
+            label: "TypeScript React",
+            grammar: ParseLanguage::Tsx,
+        },
+    ],
+};
+
+pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
+    id: "javascript",
+    label: "JavaScript",
+    kind: LanguageKind::JavaScript,
+    knowledge_ids: &["javascript", "javascript-react"],
+    grammars: &[
+        GrammarBinding {
+            label: "JavaScript",
+            grammar: ParseLanguage::JavaScript,
+        },
+        GrammarBinding {
+            label: "JavaScript React",
+            grammar: ParseLanguage::JavaScript,
+        },
+    ],
+};

--- a/src/languages/kotlin.rs
+++ b/src/languages/kotlin.rs
@@ -1,0 +1,14 @@
+use super::{GrammarBinding, LanguageFrontend};
+use crate::analysis::parse::ParseLanguage;
+use crate::audits::context::LanguageKind;
+
+pub(super) static KOTLIN: LanguageFrontend = LanguageFrontend {
+    id: "kotlin",
+    label: "Kotlin",
+    kind: LanguageKind::Kotlin,
+    knowledge_ids: &["kotlin"],
+    grammars: &[GrammarBinding {
+        label: "Kotlin",
+        grammar: ParseLanguage::Kotlin,
+    }],
+};

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -1,0 +1,141 @@
+//! Language frontend registry — the single place that answers "what does
+//! RepoPilot know about language X".
+//!
+//! Today language knowledge is spread across detection profiles
+//! (`knowledge/packs/core.toml`), grammar wiring (`analysis/parse.rs`),
+//! import extractors (`graph/imports/*`), review signal tables, runtime-risk
+//! patterns, and path conventions. Each frontend in this registry will own
+//! its language's slice of those concerns; consumers look the frontend up by
+//! [`LanguageKind`] or knowledge-pack id instead of matching on label
+//! strings.
+//!
+//! This module is the 0.21 skeleton (PR-1): descriptors and guard tests
+//! only, wired to nothing. Follow-up PRs migrate dispatch here one concern
+//! at a time (detection/parse, imports, review tables, risk, conventions),
+//! each behavior-frozen against the zoo snapshots. Per-language files grow
+//! into directories when they gain their first extractor.
+//!
+//! Frontends are static data assembled at compile time — this is not a
+//! plugin system, and per the Knowledge Engine runtime boundaries it must
+//! not become one.
+
+pub mod capability;
+
+mod csharp;
+mod generic;
+mod go;
+mod java;
+mod javascript;
+mod kotlin;
+mod python;
+mod rust;
+
+#[cfg(test)]
+mod tests;
+
+use crate::analysis::parse::ParseLanguage;
+use crate::audits::context::LanguageKind;
+
+/// Binds one detection label (as stored on `FileFacts.language`) to the
+/// tree-sitter grammar that parses it. Mirrors `ParseLanguage::from_label`
+/// until parse dispatch is rewired through the registry; the guard tests
+/// keep the two in lockstep in the meantime.
+pub struct GrammarBinding {
+    pub label: &'static str,
+    // Read only by the guard tests until PR-2 routes parse dispatch here.
+    #[allow(dead_code)]
+    pub(crate) grammar: ParseLanguage,
+}
+
+/// Static descriptor for one language (or dialect family) frontend.
+pub struct LanguageFrontend {
+    /// Stable slug; equals the primary knowledge-pack profile id.
+    pub id: &'static str,
+    /// Primary display label, as produced by language detection.
+    pub label: &'static str,
+    /// Context-classifier kind this frontend answers for.
+    pub kind: LanguageKind,
+    /// Knowledge-pack profile ids this frontend claims, dialects included
+    /// (e.g. `typescript` claims `typescript-react`). Detection data —
+    /// extensions, filenames, aliases — stays in the pack; the frontend
+    /// references profiles instead of duplicating them.
+    pub knowledge_ids: &'static [&'static str],
+    /// Detection labels this frontend can parse, with their grammars.
+    /// Empty for frontends without a bundled tree-sitter grammar.
+    pub grammars: &'static [GrammarBinding],
+}
+
+/// Every registered frontend, including the generic fallback (last).
+static ALL_FRONTENDS: [&LanguageFrontend; 9] = [
+    &rust::RUST,
+    &javascript::TYPESCRIPT,
+    &javascript::JAVASCRIPT,
+    &python::PYTHON,
+    &go::GO,
+    &java::JAVA,
+    &csharp::CSHARP,
+    &kotlin::KOTLIN,
+    &generic::GENERIC,
+];
+
+pub fn all_frontends() -> &'static [&'static LanguageFrontend] {
+    &ALL_FRONTENDS
+}
+
+/// The frontend responsible for `kind`. Kinds without a dedicated frontend
+/// fall back to [`generic::GENERIC`]; the match is exhaustive so adding a
+/// `LanguageKind` variant forces a routing decision here.
+pub fn frontend_for_kind(kind: LanguageKind) -> &'static LanguageFrontend {
+    match kind {
+        LanguageKind::Rust => &rust::RUST,
+        LanguageKind::TypeScript => &javascript::TYPESCRIPT,
+        LanguageKind::JavaScript => &javascript::JAVASCRIPT,
+        LanguageKind::Python => &python::PYTHON,
+        LanguageKind::Go => &go::GO,
+        LanguageKind::Java => &java::JAVA,
+        LanguageKind::CSharp => &csharp::CSHARP,
+        LanguageKind::Kotlin => &kotlin::KOTLIN,
+        LanguageKind::Swift
+        | LanguageKind::C
+        | LanguageKind::Cpp
+        | LanguageKind::CHeader
+        | LanguageKind::Php
+        | LanguageKind::Ruby
+        | LanguageKind::Dart
+        | LanguageKind::Scala
+        | LanguageKind::Shell
+        | LanguageKind::PowerShell
+        | LanguageKind::Sql
+        | LanguageKind::Html
+        | LanguageKind::Css
+        | LanguageKind::Scss
+        | LanguageKind::Elixir
+        | LanguageKind::Erlang
+        | LanguageKind::Haskell
+        | LanguageKind::OCaml
+        | LanguageKind::FSharp
+        | LanguageKind::R
+        | LanguageKind::Julia
+        | LanguageKind::Lua
+        | LanguageKind::Perl
+        | LanguageKind::Zig
+        | LanguageKind::Solidity
+        | LanguageKind::ObjectiveC
+        | LanguageKind::Terraform
+        | LanguageKind::Dockerfile
+        | LanguageKind::Nix
+        | LanguageKind::Json
+        | LanguageKind::Toml
+        | LanguageKind::Yaml
+        | LanguageKind::Markdown
+        | LanguageKind::Unknown => &generic::GENERIC,
+    }
+}
+
+/// The frontend that claims a knowledge-pack profile id, if any.
+pub fn frontend_for_knowledge_id(id: &str) -> Option<&'static LanguageFrontend> {
+    all_frontends()
+        .iter()
+        .copied()
+        .find(|frontend| frontend.knowledge_ids.contains(&id))
+}

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -1,0 +1,14 @@
+use super::{GrammarBinding, LanguageFrontend};
+use crate::analysis::parse::ParseLanguage;
+use crate::audits::context::LanguageKind;
+
+pub(super) static PYTHON: LanguageFrontend = LanguageFrontend {
+    id: "python",
+    label: "Python",
+    kind: LanguageKind::Python,
+    knowledge_ids: &["python"],
+    grammars: &[GrammarBinding {
+        label: "Python",
+        grammar: ParseLanguage::Python,
+    }],
+};

--- a/src/languages/rust.rs
+++ b/src/languages/rust.rs
@@ -1,0 +1,14 @@
+use super::{GrammarBinding, LanguageFrontend};
+use crate::analysis::parse::ParseLanguage;
+use crate::audits::context::LanguageKind;
+
+pub(super) static RUST: LanguageFrontend = LanguageFrontend {
+    id: "rust",
+    label: "Rust",
+    kind: LanguageKind::Rust,
+    knowledge_ids: &["rust"],
+    grammars: &[GrammarBinding {
+        label: "Rust",
+        grammar: ParseLanguage::Rust,
+    }],
+};

--- a/src/languages/tests.rs
+++ b/src/languages/tests.rs
@@ -1,0 +1,208 @@
+//! Guard tests that hold the language frontend contract together:
+//! grammars claimed exactly once, bindings in lockstep with parse dispatch,
+//! knowledge-pack ids resolvable, and a shrinking ledger of languages whose
+//! declared support level exceeds what the wiring justifies.
+
+use super::capability::{computed_support, support_rank};
+use super::*;
+use crate::knowledge::active_knowledge;
+use crate::knowledge::language::{language_kind_from_id, profile_by_id};
+use crate::knowledge::model::SupportLevel;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Forces this list to grow when a `ParseLanguage` variant is added: the
+/// match below stops compiling until the new grammar is routed here and
+/// claimed by a frontend.
+const ALL_GRAMMARS: [ParseLanguage; 9] = [
+    ParseLanguage::Rust,
+    ParseLanguage::TypeScript,
+    ParseLanguage::Tsx,
+    ParseLanguage::JavaScript,
+    ParseLanguage::Python,
+    ParseLanguage::Go,
+    ParseLanguage::Java,
+    ParseLanguage::CSharp,
+    ParseLanguage::Kotlin,
+];
+
+#[allow(dead_code)]
+fn grammar_list_is_exhaustive(grammar: ParseLanguage) {
+    match grammar {
+        ParseLanguage::Rust
+        | ParseLanguage::TypeScript
+        | ParseLanguage::Tsx
+        | ParseLanguage::JavaScript
+        | ParseLanguage::Python
+        | ParseLanguage::Go
+        | ParseLanguage::Java
+        | ParseLanguage::CSharp
+        | ParseLanguage::Kotlin => {}
+    }
+}
+
+/// The full label vocabulary `ParseLanguage::from_label` accepts today.
+/// Bindings must cover exactly this set until parse dispatch moves into the
+/// registry; drift in either direction fails below.
+const ALL_PARSE_LABELS: [&str; 11] = [
+    "Rust",
+    "TypeScript",
+    "TypeScript React",
+    "JavaScript",
+    "JavaScript React",
+    "Python",
+    "Go",
+    "Java",
+    "CSharp",
+    "C#",
+    "Kotlin",
+];
+
+#[test]
+fn every_grammar_is_claimed_by_exactly_one_frontend() {
+    let mut owners: BTreeMap<&'static str, BTreeSet<&'static str>> = BTreeMap::new();
+    for frontend in all_frontends() {
+        for binding in frontend.grammars {
+            owners
+                .entry(grammar_name(binding.grammar))
+                .or_default()
+                .insert(frontend.id);
+        }
+    }
+
+    for grammar in ALL_GRAMMARS {
+        let claimants = owners
+            .get(grammar_name(grammar))
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(
+            claimants.len(),
+            1,
+            "grammar {:?} must be claimed by exactly one frontend, got {claimants:?}",
+            grammar
+        );
+    }
+}
+
+#[test]
+fn grammar_bindings_stay_in_lockstep_with_parse_dispatch() {
+    let mut bound_labels = BTreeSet::new();
+    for frontend in all_frontends() {
+        for binding in frontend.grammars {
+            assert_eq!(
+                ParseLanguage::from_label(binding.label),
+                Some(binding.grammar),
+                "frontend '{}' binds label '{}' differently than ParseLanguage::from_label",
+                frontend.id,
+                binding.label
+            );
+            bound_labels.insert(binding.label);
+        }
+    }
+
+    let expected: BTreeSet<&str> = ALL_PARSE_LABELS.into_iter().collect();
+    assert_eq!(
+        bound_labels, expected,
+        "registry grammar labels and ParseLanguage::from_label drifted apart"
+    );
+}
+
+#[test]
+fn knowledge_ids_resolve_and_route_back_to_their_frontend() {
+    for frontend in all_frontends() {
+        for id in frontend.knowledge_ids {
+            let profile = profile_by_id(id);
+            assert!(
+                profile.is_some(),
+                "frontend '{}' claims knowledge id '{id}' missing from the bundled pack",
+                frontend.id
+            );
+            assert_eq!(
+                language_kind_from_id(id),
+                frontend.kind,
+                "knowledge id '{id}' classifies to a different kind than frontend '{}'",
+                frontend.id
+            );
+            assert_eq!(
+                frontend_for_knowledge_id(id).map(|found| found.id),
+                Some(frontend.id),
+                "knowledge id '{id}' is claimed by more than one frontend"
+            );
+        }
+    }
+}
+
+#[test]
+fn kinds_route_to_their_frontends_and_the_rest_to_generic() {
+    for frontend in all_frontends() {
+        if frontend.id == "generic" {
+            continue;
+        }
+        assert_eq!(frontend_for_kind(frontend.kind).id, frontend.id);
+    }
+
+    for kind in [
+        LanguageKind::Swift,
+        LanguageKind::Cpp,
+        LanguageKind::Terraform,
+        LanguageKind::Markdown,
+        LanguageKind::Unknown,
+    ] {
+        assert_eq!(frontend_for_kind(kind).id, "generic");
+    }
+}
+
+/// The honesty ledger. Languages the bundled pack declares `rule-aware`
+/// whose frontends do not yet justify it. Migration PRs shrink this set by
+/// wiring capabilities (or PR-9 downgrades over-claimed pack declarations —
+/// `c`/`cpp` have no grammar at all and are the first candidates). It must
+/// never grow.
+#[test]
+fn declared_rule_aware_support_gap_ledger_only_shrinks() {
+    let expected_gaps: BTreeSet<&str> = [
+        "c",
+        "cpp",
+        "csharp",
+        "go",
+        "java",
+        "javascript",
+        "kotlin",
+        "python",
+        "rust",
+        "typescript",
+    ]
+    .into_iter()
+    .collect();
+
+    let mut gaps = BTreeSet::new();
+    for profile in &active_knowledge().languages {
+        if profile.support != SupportLevel::RuleAware {
+            continue;
+        }
+        let computed = frontend_for_knowledge_id(&profile.id)
+            .map(computed_support)
+            .unwrap_or(SupportLevel::DetectOnly);
+        if support_rank(computed) < support_rank(SupportLevel::RuleAware) {
+            gaps.insert(profile.id.as_str());
+        }
+    }
+
+    assert_eq!(
+        gaps, expected_gaps,
+        "rule-aware support gaps changed; shrink the ledger when wiring capabilities, \
+         never grow it"
+    );
+}
+
+fn grammar_name(grammar: ParseLanguage) -> &'static str {
+    match grammar {
+        ParseLanguage::Rust => "rust",
+        ParseLanguage::TypeScript => "typescript",
+        ParseLanguage::Tsx => "tsx",
+        ParseLanguage::JavaScript => "javascript",
+        ParseLanguage::Python => "python",
+        ParseLanguage::Go => "go",
+        ParseLanguage::Java => "java",
+        ParseLanguage::CSharp => "csharp",
+        ParseLanguage::Kotlin => "kotlin",
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ pub mod graph;
 #[doc(hidden)]
 pub mod knowledge;
 #[doc(hidden)]
+pub mod languages;
+#[doc(hidden)]
 pub mod output;
 #[doc(hidden)]
 pub mod path_security;


### PR DESCRIPTION
## Summary

Introduces the language frontend registry that will become the central ownership boundary for RepoPilot’s language-specific behavior during the v0.21 cycle.

The new registry defines static descriptors for supported language frontends, unifies language identity across knowledge packs, context classification, and tree-sitter grammar bindings, and computes support capabilities from actual wiring rather than relying only on declared support levels.

This PR intentionally does not migrate existing parsing, import extraction, review-signal, runtime-risk, or framework dispatch yet. It establishes the contracts and guardrails required for those follow-up migrations without changing current analysis behavior.

## Type of change

* [x] Feature
* [x] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

### Language frontend registry

Added a new module:

```
src/languages/
```

Each frontend provides one static `LanguageFrontend` descriptor containing:

* stable frontend ID;
* human-readable label;
* `LanguageKind`;
* associated knowledge-pack language IDs;
* supported grammar-label bindings.

Initial dedicated frontends cover the currently bundled tree-sitter languages and dialect families, including:

* Rust;
* JavaScript;
* TypeScript;
* JSX;
* TSX;
* Python;
* Go;
* Java;
* Kotlin;
* C#;
* generic fallback behavior.

### Grammar bindings

Added explicit `GrammarBinding` records connecting detected language labels to `ParseLanguage`.

This creates one registry-owned representation for mappings that are currently spread across:

* knowledge-pack language profiles;
* context-classifier language kinds;
* `ParseLanguage::from_label`;
* downstream string-based dispatch.

Guard tests keep the registry grammar bindings in lockstep with the existing parser dispatch until parsing is migrated behind the registry in a follow-up PR.

### Frontend lookup API

Added lookup functions for resolving frontends by:

* frontend ID;
* knowledge-pack language ID;
* detected label;
* `LanguageKind`;
* grammar label.

Unknown or unsupported languages resolve to a generic frontend rather than requiring callers to maintain their own fallback logic.

The registry is static and deterministic. It performs no filesystem, parser, or network work.

### Capability model

Added a typed `Capability` enum covering language-specific engine surfaces:

```
Parse
Imports
ReviewSignals
TaintFlows
RuntimeRisk
TestConventions
Frameworks
```

Capabilities are computed from the fields actually wired on a frontend.

The initial registry skeleton can currently derive parse capability from grammar bindings. Follow-up migration PRs will extend `LanguageFrontend` with import extractors, review tables, runtime-risk handlers, conventions, and framework probes.

### Computed support levels

Added `computed_support`, which derives the support level justified by the current frontend wiring.

Current semantics:

* full rule-aware capability requires parsing, imports, review signals, runtime-risk support, and test conventions;
* grammar support establishes context-aware capability;
* import extraction without grammar support establishes import-aware capability;
* other detected languages remain detect-only.

This separates two concepts that were previously easy to conflate:

* support declared by the knowledge pack;
* support justified by actual engine wiring.

### Support-honesty ledger

Added guard coverage documenting languages whose knowledge-pack declaration currently exceeds their computed frontend capability.

The initial ledger records known over-declarations for:

```
java
kotlin
csharp
c
cpp
```

This is intentionally a shrinking migration ledger.

Tests fail when:

* a new unsupported over-declaration appears without being documented;
* an existing ledger entry becomes stale after its frontend gains sufficient wiring;
* registry mappings drift away from grammar or language-kind contracts.

This prevents the public language support matrix from silently over-promising capability.

### Generic frontend

Added a generic frontend for languages without dedicated engine wiring.

Generic languages can continue contributing:

* language detection;
* repository scope;
* size and file metrics;
* generic repository findings;
* language-independent analysis.

They do not falsely claim language-specific parser, import, review, taint, runtime-risk, convention, or framework capability.

### JavaScript and TypeScript dialect family

The JavaScript frontend module groups the related dialects:

* JavaScript;
* JSX;
* TypeScript;
* TSX.

Each dialect retains its own frontend identity and grammar binding while sharing the same registry ownership area.

This prepares later migrations of TypeScript/JavaScript imports, review tables, and framework conventions without collapsing the distinct parser labels.

### Language surface inventory

Added:

```
docs/engineering/language-surface-inventory.md
```

The document inventories every significant language-dispatch surface currently spread through RepoPilot and assigns each migration to a planned v0.21 PR.

Covered surfaces include:

* detection and language identity;
* parser dispatch;
* parsed caches;
* import and deferred-import extraction;
* dependency graph inputs;
* taint sources, sinks, and sanitizers;
* behavioral and algorithmic review tables;
* runtime-risk patterns;
* function span handling;
* test and test-support conventions;
* framework probes;
* generated language-support documentation.

The inventory also records components that intentionally remain language-agnostic.

### Migration boundaries

This PR does not change dispatch for:

* `ParseLanguage::from_label`;
* import extraction;
* deferred imports;
* review signal detection;
* taint analysis;
* runtime-risk audits;
* path classification;
* framework detection;
* language-support documentation generation.

Those changes are split into behavior-frozen follow-up PRs so each migration can be reviewed and tested independently.

### Documentation and changelog

Linked the new language surface inventory from the documentation index.

Updated the changelog with the new frontend registry skeleton, capability model, support-honesty ledger, and the fact that existing dispatch remains unchanged in this PR.

## Why

RepoPilot currently stores language-specific behavior across several independent surfaces:

* knowledge-pack profiles;
* `LanguageKind`;
* parser label matching;
* import extractor dispatch;
* review-signal pattern tables;
* runtime-risk modules;
* test-path conventions;
* framework probes;
* manually maintained language-support documentation.

These surfaces can drift independently.

A language may be detected under one label, parsed under another, claim a support tier that its engine wiring does not justify, or require another hardcoded match when a new subsystem is added.

The frontend registry creates one explicit owner for language-specific capability and dispatch.

The skeleton is introduced before migrating consumers so that:

* behavior remains frozen;
* registry contracts can be tested independently;
* each subsystem can move behind the registry in a small PR;
* declared support can be compared against actual implementation;
* future languages gain one predictable integration point.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] New or changed findings/signals include deterministic evidence and tests
* [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
* [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
* [x] No unrelated refactor or generated-file churn is included

Primary subsystem:

* language frontend contracts;
* language identity and grammar metadata;
* capability and support-level accounting;
* v0.21 language migration documentation.

Public behavior affected:

* no scan or review behavior changes;
* no new language support is claimed;
* no existing support level is changed in this PR;
* an internal registry API becomes available for follow-up migrations;
* known support-level gaps are now explicitly tested and documented.

Unchanged contracts:

* CLI commands and arguments;
* language detection results;
* parser selection;
* scan and review findings;
* finding IDs and occurrence keys;
* baseline matching;
* report schemas;
* SARIF;
* GitHub Action behavior;
* MCP tools and resources;
* process exit codes;
* current language-support documentation.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```

Focused language-registry verification:

```
cargo test --lib languages
cargo test --lib languages::tests
cargo test --lib languages::capability
```

Behavior-freeze verification:

```
cargo test --test review_zoo
cargo test --test cli_release_smoke
python3 scripts/release-contract.py check
```
