### PR TITLE
refactor(languages): route grammar and language-kind lookup through registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- **Language detection and parse dispatch now route through the frontend
+  registry.** `ParseLanguage::from_label` delegates to the registry's
+  grammar bindings (the only label→grammar table, pinned by a vocabulary
+  guard test), and `language_kind_from_id` takes the kind from the claiming
+  frontend, leaving the hardcoded map to cover only languages without one.
+  Behavior-frozen refactor: no findings, signals, or output change.
 - **README rewritten around reviewing code you didn't write.** Leads with the
   real-repo demo and the deterministic/local/evidence positioning, moves
   workflow detail into the docs, and links the new agent-guardrail guide.

--- a/docs/engineering/language-surface-inventory.md
+++ b/docs/engineering/language-surface-inventory.md
@@ -18,22 +18,27 @@ design (with reason).
       (`LanguageFrontend.knowledge_ids`) instead of duplicating extensions.
       PR-9 reconciles over-declared levels (java/kotlin/csharp/c/cpp claim
       `rule-aware` today; the guard-test ledger documents the gap).
-- [ ] `src/knowledge/language.rs:68` — `language_kind_from_id`: hardcoded
-      id→`LanguageKind` map, duplicated against the pack. → PR-2.
-- [ ] `src/audits/context/model/kinds.rs:2` — `LanguageKind` enum (43
+- [x] `src/knowledge/language.rs` — `language_kind_from_id`: ids claimed by
+      a frontend now take their kind from the registry; the residual match
+      covers only languages without a frontend and shrinks as frontends are
+      added. Pinned by `frontend_claimed_ids_keep_their_kinds`. (PR-2)
+- [-] `src/audits/context/model/kinds.rs:2` — `LanguageKind` enum (43
       variants). Stays; the registry routes every variant
-      (`frontend_for_kind` is exhaustive). → PR-2 consumers.
+      (`frontend_for_kind` is exhaustive).
 
 ## Parse layer
 
-- [ ] `src/analysis/parse.rs:31` — `ParseLanguage` enum (9 grammars).
-- [ ] `src/analysis/parse.rs:46` — `ParseLanguage::from_label`: label-string
-      → grammar map. Registry `GrammarBinding`s mirror it 1:1 today (guard
-      test enforces lockstep). → PR-2 replaces with registry lookup.
-- [ ] `src/analysis/parse.rs:62` — thread-local parser table. Stays, keyed
-      by `ParseLanguage`; only the label dispatch moves.
-- [ ] `src/scan/parsed_cache.rs`, `src/analysis/artifact.rs` — parse-once
-      caches keyed by label strings. → PR-2.
+- [-] `src/analysis/parse.rs:31` — `ParseLanguage` enum (9 grammars). Stays
+      as the grammar identity; frontends bind labels to it.
+- [x] `src/analysis/parse.rs` — `ParseLanguage::from_label` delegates to
+      `languages::grammar_for_label`; the registry bindings are the only
+      label→grammar table, pinned by `grammar_label_vocabulary_is_pinned`.
+      (PR-2)
+- [-] `src/analysis/parse.rs:62` — thread-local parser table. Stays, keyed
+      by `ParseLanguage`; only the label dispatch moved.
+- [-] `src/scan/parsed_cache.rs`, `src/analysis/artifact.rs` — parse-once
+      caches treat the label as an opaque cache key and route parsing via
+      `from_label`; no dispatch of their own (verified in PR-2).
 
 ## Imports and graph
 
@@ -61,6 +66,10 @@ design (with reason).
       `exec.Command`, JDBC-style `.execute`). → PR-4.
 - [ ] `src/review/signals/taint/sanitizers.rs` — parameterized-query and
       escaping tables. → PR-4.
+- [ ] `src/review/signals/taint/mod.rs:50` — `TaintLang::from_label`: a
+      second, private label→language enum gating which files get taint
+      analysis (found during PR-2). → PR-4; frontends key the tables and the
+      enum dissolves.
 - [ ] `src/review/signals/taint/ast.rs`, `flow.rs` — engine; must lose any
       residual label checks. → PR-4.
 - [ ] `src/review/signals/behavioral/keywords.rs:21` — auth keyword

--- a/src/analysis/parse.rs
+++ b/src/analysis/parse.rs
@@ -42,20 +42,11 @@ pub(crate) enum ParseLanguage {
 
 impl ParseLanguage {
     /// Maps a RepoPilot language label (as produced by language detection and
-    /// stored on `FileFacts.language`) to a parseable grammar, if any.
+    /// stored on `FileFacts.language`) to a parseable grammar, if any. The
+    /// label→grammar table lives on the language frontend registry; this is
+    /// a convenience alias for grammar consumers.
     pub(crate) fn from_label(label: &str) -> Option<Self> {
-        match label {
-            "Rust" => Some(Self::Rust),
-            "TypeScript" => Some(Self::TypeScript),
-            "TypeScript React" => Some(Self::Tsx),
-            "JavaScript" | "JavaScript React" => Some(Self::JavaScript),
-            "Python" => Some(Self::Python),
-            "Go" => Some(Self::Go),
-            "Java" => Some(Self::Java),
-            "CSharp" | "C#" => Some(Self::CSharp),
-            "Kotlin" => Some(Self::Kotlin),
-            _ => None,
-        }
+        crate::languages::grammar_for_label(label)
     }
 }
 

--- a/src/knowledge/language.rs
+++ b/src/knowledge/language.rs
@@ -66,15 +66,13 @@ pub fn language_kind_from_name(name: &str) -> Option<LanguageKind> {
 }
 
 pub fn language_kind_from_id(id: &str) -> LanguageKind {
+    // Languages with a dedicated frontend own their kind; the match below
+    // covers only detect-/context-level languages without one.
+    if let Some(frontend) = crate::languages::frontend_for_knowledge_id(id) {
+        return frontend.kind;
+    }
+
     match id {
-        "rust" => LanguageKind::Rust,
-        "typescript" | "typescript-react" => LanguageKind::TypeScript,
-        "javascript" | "javascript-react" => LanguageKind::JavaScript,
-        "csharp" => LanguageKind::CSharp,
-        "python" => LanguageKind::Python,
-        "go" => LanguageKind::Go,
-        "java" => LanguageKind::Java,
-        "kotlin" => LanguageKind::Kotlin,
         "swift" => LanguageKind::Swift,
         "c" => LanguageKind::C,
         "cpp" => LanguageKind::Cpp,
@@ -135,6 +133,26 @@ mod tests {
             detect_language_for_path(Path::new("infra/main.tf")),
             Some("Terraform")
         );
+    }
+
+    #[test]
+    fn frontend_claimed_ids_keep_their_kinds() {
+        // Pins the id→kind mapping for ids whose kind now comes from the
+        // language frontend registry, so delegation cannot silently remap.
+        for (id, kind) in [
+            ("rust", LanguageKind::Rust),
+            ("typescript", LanguageKind::TypeScript),
+            ("typescript-react", LanguageKind::TypeScript),
+            ("javascript", LanguageKind::JavaScript),
+            ("javascript-react", LanguageKind::JavaScript),
+            ("python", LanguageKind::Python),
+            ("go", LanguageKind::Go),
+            ("java", LanguageKind::Java),
+            ("csharp", LanguageKind::CSharp),
+            ("kotlin", LanguageKind::Kotlin),
+        ] {
+            assert_eq!(language_kind_from_id(id), kind, "id '{id}' remapped");
+        }
     }
 
     #[test]

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -42,9 +42,20 @@ use crate::audits::context::LanguageKind;
 /// keep the two in lockstep in the meantime.
 pub struct GrammarBinding {
     pub label: &'static str,
-    // Read only by the guard tests until PR-2 routes parse dispatch here.
-    #[allow(dead_code)]
     pub(crate) grammar: ParseLanguage,
+}
+
+/// The grammar bound to a detection label, if any frontend claims it. This
+/// is the single label→grammar table; `ParseLanguage::from_label` delegates
+/// here.
+pub(crate) fn grammar_for_label(label: &str) -> Option<ParseLanguage> {
+    all_frontends().iter().find_map(|frontend| {
+        frontend
+            .grammars
+            .iter()
+            .find(|binding| binding.label == label)
+            .map(|binding| binding.grammar)
+    })
 }
 
 /// Static descriptor for one language (or dialect family) frontend.

--- a/src/languages/tests.rs
+++ b/src/languages/tests.rs
@@ -40,21 +40,23 @@ fn grammar_list_is_exhaustive(grammar: ParseLanguage) {
     }
 }
 
-/// The full label vocabulary `ParseLanguage::from_label` accepts today.
-/// Bindings must cover exactly this set until parse dispatch moves into the
-/// registry; drift in either direction fails below.
-const ALL_PARSE_LABELS: [&str; 11] = [
-    "Rust",
-    "TypeScript",
-    "TypeScript React",
-    "JavaScript",
-    "JavaScript React",
-    "Python",
-    "Go",
-    "Java",
-    "CSharp",
-    "C#",
-    "Kotlin",
+/// The pinned label→grammar vocabulary. The registry is the only
+/// label→grammar table (`ParseLanguage::from_label` delegates to it), so
+/// this pin is what keeps an accidental binding edit — a dropped label or a
+/// dialect pointed at the wrong grammar — from silently changing parse
+/// behavior. Extend it deliberately when a frontend gains a label.
+const PINNED_LABEL_GRAMMARS: [(&str, ParseLanguage); 11] = [
+    ("Rust", ParseLanguage::Rust),
+    ("TypeScript", ParseLanguage::TypeScript),
+    ("TypeScript React", ParseLanguage::Tsx),
+    ("JavaScript", ParseLanguage::JavaScript),
+    ("JavaScript React", ParseLanguage::JavaScript),
+    ("Python", ParseLanguage::Python),
+    ("Go", ParseLanguage::Go),
+    ("Java", ParseLanguage::Java),
+    ("CSharp", ParseLanguage::CSharp),
+    ("C#", ParseLanguage::CSharp),
+    ("Kotlin", ParseLanguage::Kotlin),
 ];
 
 #[test]
@@ -84,25 +86,26 @@ fn every_grammar_is_claimed_by_exactly_one_frontend() {
 }
 
 #[test]
-fn grammar_bindings_stay_in_lockstep_with_parse_dispatch() {
-    let mut bound_labels = BTreeSet::new();
-    for frontend in all_frontends() {
-        for binding in frontend.grammars {
-            assert_eq!(
-                ParseLanguage::from_label(binding.label),
-                Some(binding.grammar),
-                "frontend '{}' binds label '{}' differently than ParseLanguage::from_label",
-                frontend.id,
-                binding.label
-            );
-            bound_labels.insert(binding.label);
-        }
+fn grammar_label_vocabulary_is_pinned() {
+    for (label, grammar) in PINNED_LABEL_GRAMMARS {
+        assert_eq!(
+            grammar_for_label(label),
+            Some(grammar),
+            "label '{label}' no longer resolves to the pinned grammar"
+        );
     }
 
-    let expected: BTreeSet<&str> = ALL_PARSE_LABELS.into_iter().collect();
+    let bound_labels: BTreeSet<&str> = all_frontends()
+        .iter()
+        .flat_map(|frontend| frontend.grammars.iter().map(|binding| binding.label))
+        .collect();
+    let pinned: BTreeSet<&str> = PINNED_LABEL_GRAMMARS
+        .into_iter()
+        .map(|(label, _)| label)
+        .collect();
     assert_eq!(
-        bound_labels, expected,
-        "registry grammar labels and ParseLanguage::from_label drifted apart"
+        bound_labels, pinned,
+        "registry grammar labels drifted from the pinned vocabulary"
     );
 }
 


### PR DESCRIPTION
## Summary

Moves language grammar lookup and language-kind lookup behind the frontend registry added in the previous PR.

This removes two duplicated dispatch tables while keeping parsing, findings, review signals, and output unchanged.

## Type of change

* [ ] Feature
* [x] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* `ParseLanguage::from_label` now delegates to `languages::grammar_for_label`.
* The frontend registry is now the only label-to-grammar mapping.
* `language_kind_from_id` now uses the frontend registry for languages that already have a frontend.
* The remaining hardcoded ID-to-kind match only covers languages without a frontend.
* Added guard tests for the existing grammar-label vocabulary and knowledge-ID mappings.
* Updated the language surface inventory to mark this migration step complete.

## Why

Grammar labels and language kinds were defined both in the new frontend registry and in older hardcoded match statements.

Keeping both implementations would allow them to drift. This PR makes the registry the source of truth for the language frontends that have already been added.

## Behavior

This is a behavior-preserving refactor.

Unchanged:

* language detection;
* parser selection;
* findings and review signals;
* report schemas;
* finding IDs;
* baselines;
* CLI output;
* MCP and GitHub Action behavior.

Import extraction, taint analysis, review tables, runtime-risk logic, conventions, and framework dispatch are still handled by their existing code. Those migrations remain separate follow-up PRs.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] No unrelated refactor or generated-file churn is included

Primary subsystem:

* language frontend registry;
* parser language selection;
* knowledge-language classification.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```

Focused tests:

```bash
cargo test --lib languages
cargo test --lib knowledge::language
cargo test --lib analysis::parse
```
