### PR TITLE
refactor(languages): move taint analysis tables into frontends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- **Taint-lite is now table-driven per language frontend.** The per-language
+  source idioms, coercion lists, grammar shapes, and sink classifiers moved
+  to `src/languages/{javascript,python,go}/review.rs` as a `TaintTables`
+  contract; the flow engine is language-neutral and the private `TaintLang`
+  enum is gone — whether a language participates in taint analysis is now
+  visible on its frontend and pinned by a guard test. Behavior-frozen: the
+  full taint test suite and review goldens are unchanged.
 - **Import extraction now lives on the language frontends.** The
   per-language extractors moved from `graph/imports/*` to
   `src/languages/*/imports.rs` behind an `ImportExtractor` contract (eager

--- a/docs/engineering/language-surface-inventory.md
+++ b/docs/engineering/language-surface-inventory.md
@@ -61,20 +61,16 @@ design (with reason).
 
 ## Review signals
 
-- [ ] `src/review/signals/taint/sources.rs:40` — HTTP/process input source
-      patterns, one flat list covering JS/TS, Python, Go, Rust idioms. →
-      PR-4 splits per frontend `ReviewTables`.
-- [ ] `src/review/signals/taint/sinks.rs:60` — SQL/exec/fs/network sink
-      callee tables (`subprocess`, `os.system`, `child_process.exec`,
-      `exec.Command`, JDBC-style `.execute`). → PR-4.
-- [ ] `src/review/signals/taint/sanitizers.rs` — parameterized-query and
-      escaping tables. → PR-4.
-- [ ] `src/review/signals/taint/mod.rs:50` — `TaintLang::from_label`: a
-      second, private label→language enum gating which files get taint
-      analysis (found during PR-2). → PR-4; frontends key the tables and the
-      enum dissolves.
-- [ ] `src/review/signals/taint/ast.rs`, `flow.rs` — engine; must lose any
-      residual label checks. → PR-4.
+- [x] Taint-lite is table-driven: per-language source idioms, coercion
+      lists, grammar shapes, and sink classifiers live in
+      `src/languages/{javascript,python,go}/review.rs` as
+      `taint::tables::TaintTables`; the engines (`flow`, `sources`,
+      `sanitizers`) are language-neutral and `TaintLang` is gone — gating is
+      the frontend's `taint` field, pinned by
+      `taint_participation_is_pinned`. Shared callee helpers stay in
+      `taint/sinks.rs` (model) and `taint/ast.rs`. Equivalence evidence: the
+      taint test suite unchanged and green, plus the wagtail agent demo
+      firing identical signals. (PR-4a)
 - [ ] `src/review/signals/behavioral/keywords.rs:21` — auth keyword
       vocabulary (strong/exact tokens, mutation verbs). Mostly
       language-neutral English identifiers; stays shared, but per-frontend

--- a/src/languages/capability.rs
+++ b/src/languages/capability.rs
@@ -38,6 +38,9 @@ pub fn capabilities(frontend: &LanguageFrontend) -> Vec<Capability> {
     if frontend.imports.is_some() {
         wired.push(Capability::Imports);
     }
+    if frontend.taint.is_some() {
+        wired.push(Capability::TaintFlows);
+    }
     wired
 }
 

--- a/src/languages/csharp.rs
+++ b/src/languages/csharp.rs
@@ -20,4 +20,5 @@ pub(super) static CSHARP: LanguageFrontend = LanguageFrontend {
         },
     ],
     imports: None,
+    taint: None,
 };

--- a/src/languages/generic.rs
+++ b/src/languages/generic.rs
@@ -11,4 +11,5 @@ pub(super) static GENERIC: LanguageFrontend = LanguageFrontend {
     knowledge_ids: &[],
     grammars: &[],
     imports: None,
+    taint: None,
 };

--- a/src/languages/go/mod.rs
+++ b/src/languages/go/mod.rs
@@ -3,6 +3,7 @@ use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
 
 mod imports;
+mod review;
 
 use super::ImportExtractor;
 
@@ -22,4 +23,5 @@ pub(super) static GO: LanguageFrontend = LanguageFrontend {
         grammar: ParseLanguage::Go,
     }],
     imports: Some(&GO_IMPORTS),
+    taint: Some(&review::GO_TAINT),
 };

--- a/src/languages/go/review.rs
+++ b/src/languages/go/review.rs
@@ -1,0 +1,114 @@
+//! Taint tables for Go. Source idioms target net/http and Gin; sinks mirror
+//! the behavioral "added X" detectors.
+
+use crate::review::signals::taint::ast::callee_starts_with;
+use crate::review::signals::taint::sinks::{Sink, SinkKind, callee_text};
+use crate::review::signals::taint::tables::TaintTables;
+use tree_sitter::Node;
+
+pub(super) static GO_TAINT: TaintTables = TaintTables {
+    request_sources: &[
+        "r.URL.Query",
+        "r.FormValue",
+        "r.PostFormValue",
+        "r.PostForm",
+        "r.Form",
+        "r.Body",
+        "r.Header.Get",
+        "c.Query",
+        "c.Param",
+        "c.PostForm",
+        "ctx.Query",
+    ],
+    argv_sources: &["os.Args"],
+    source_access_kinds: &["selector_expression"],
+    coercions: &[
+        "strconv.Atoi",
+        "strconv.ParseInt",
+        "strconv.ParseFloat",
+        "strconv.ParseBool",
+    ],
+    coercion_call_kind: "call_expression",
+    assignment_kinds: &["short_var_declaration", "assignment_statement"],
+    is_flow_scope,
+    is_augmenting,
+    is_string_building,
+    classify_sink,
+};
+
+fn is_flow_scope(node: Node<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "function_declaration" | "method_declaration" | "func_literal"
+    )
+}
+
+fn is_augmenting(node: Node<'_>) -> bool {
+    node.kind() == "assignment_statement" && {
+        let mut cursor = node.walk();
+        node.children(&mut cursor).any(|child| {
+            matches!(
+                child.kind(),
+                "+=" | "-=" | "*=" | "/=" | "%=" | "&=" | "|=" | "^=" | "<<=" | ">>=" | "&^="
+            )
+        })
+    }
+}
+
+fn is_string_building(node: Node<'_>, content: &str) -> bool {
+    node.kind() == "binary_expression"
+        || (node.kind() == "call_expression" && callee_starts_with(node, content, "fmt.Sprint"))
+}
+
+fn classify_sink<'a>(node: Node<'a>, content: &'a str) -> Option<Sink<'a>> {
+    let (callee, args) = callee_text(node, content)?;
+    let kind = if callee.ends_with(".Query")
+        || callee.ends_with(".QueryRow")
+        || callee.ends_with(".QueryContext")
+        || callee.ends_with(".Exec")
+        || callee.ends_with(".ExecContext")
+    {
+        SinkKind::Sql
+    } else if matches!(callee, "exec.Command" | "exec.CommandContext") {
+        SinkKind::Exec
+    } else if matches!(
+        callee,
+        "os.WriteFile" | "os.Create" | "os.CreateTemp" | "ioutil.WriteFile"
+    ) || (callee == "os.OpenFile" && go_open_file_is_write(args, content))
+    {
+        SinkKind::FsWrite
+    } else if matches!(
+        callee,
+        "http.Get"
+            | "http.Post"
+            | "http.PostForm"
+            | "http.NewRequest"
+            | "http.NewRequestWithContext"
+            | "net.Dial"
+            | "net.DialTimeout"
+    ) || callee.ends_with(".Do")
+        || callee.ends_with(".DialContext")
+    {
+        SinkKind::Network
+    } else {
+        return None;
+    };
+    Some(Sink { kind, args })
+}
+
+fn go_open_file_is_write(args: Node<'_>, content: &str) -> bool {
+    let mut cursor = args.walk();
+    let Some(flags) = args.named_children(&mut cursor).nth(1) else {
+        return false;
+    };
+    let text = flags.utf8_text(content.as_bytes()).unwrap_or("");
+    [
+        "os.O_WRONLY",
+        "os.O_RDWR",
+        "os.O_APPEND",
+        "os.O_CREATE",
+        "os.O_TRUNC",
+    ]
+    .iter()
+    .any(|flag| text.contains(flag))
+}

--- a/src/languages/java/mod.rs
+++ b/src/languages/java/mod.rs
@@ -22,4 +22,5 @@ pub(super) static JAVA: LanguageFrontend = LanguageFrontend {
         grammar: ParseLanguage::Java,
     }],
     imports: Some(&JAVA_IMPORTS),
+    taint: None,
 };

--- a/src/languages/javascript/mod.rs
+++ b/src/languages/javascript/mod.rs
@@ -6,6 +6,7 @@ use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
 
 mod imports;
+mod review;
 
 use super::ImportExtractor;
 
@@ -31,6 +32,7 @@ pub(super) static TYPESCRIPT: LanguageFrontend = LanguageFrontend {
         },
     ],
     imports: Some(&JS_FAMILY_IMPORTS),
+    taint: Some(&review::JS_FAMILY_TAINT),
 };
 
 pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
@@ -49,4 +51,5 @@ pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
         },
     ],
     imports: Some(&JS_FAMILY_IMPORTS),
+    taint: Some(&review::JS_FAMILY_TAINT),
 };

--- a/src/languages/javascript/review.rs
+++ b/src/languages/javascript/review.rs
@@ -1,0 +1,112 @@
+//! Taint tables for the JS dialect family. JS/TS (and their React variants)
+//! share a grammar shape, so one table covers both frontends. Source idioms
+//! target Express/Koa; sinks mirror the behavioral "added X" detectors.
+
+use crate::review::signals::taint::sinks::{Sink, SinkKind, callee_text, receiver_method};
+use crate::review::signals::taint::tables::TaintTables;
+use tree_sitter::Node;
+
+pub(super) static JS_FAMILY_TAINT: TaintTables = TaintTables {
+    request_sources: &[
+        "req.query",
+        "req.params",
+        "req.body",
+        "req.headers",
+        "req.cookies",
+        "req.url",
+        "request.query",
+        "request.params",
+        "request.body",
+        "request.headers",
+        "request.cookies",
+        "ctx.query",
+        "ctx.request.body",
+    ],
+    argv_sources: &["process.argv"],
+    source_access_kinds: &["member_expression"],
+    coercions: &["Number", "parseInt", "parseFloat", "BigInt", "Boolean"],
+    coercion_call_kind: "call_expression",
+    assignment_kinds: &["variable_declarator", "assignment_expression"],
+    is_flow_scope,
+    // tree-sitter-javascript models `x += …` as a distinct
+    // `augmented_assignment_expression` node that assignment collection does
+    // not pick up, so anything collected is a plain `=`.
+    is_augmenting: |_| false,
+    is_string_building,
+    classify_sink,
+};
+
+fn is_flow_scope(node: Node<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "function_declaration"
+            | "generator_function_declaration"
+            | "method_definition"
+            | "function_expression"
+            | "generator_function"
+            | "arrow_function"
+    )
+}
+
+fn is_string_building(node: Node<'_>, _content: &str) -> bool {
+    matches!(node.kind(), "template_string" | "binary_expression")
+}
+
+fn classify_sink<'a>(node: Node<'a>, content: &'a str) -> Option<Sink<'a>> {
+    let (callee, args) = callee_text(node, content)?;
+    let kind = if callee.ends_with(".query")
+        || callee == "query"
+        || callee.ends_with(".execute")
+        || callee == "execute"
+    {
+        SinkKind::Sql
+    } else if callee_is_or_ends_with(
+        callee,
+        &[
+            "exec",
+            "spawn",
+            "execFile",
+            "fork",
+            "execSync",
+            "spawnSync",
+            "execFileSync",
+        ],
+    ) {
+        SinkKind::Exec
+    } else if callee_is_or_ends_with(
+        callee,
+        &[
+            "writeFile",
+            "writeFileSync",
+            "appendFile",
+            "appendFileSync",
+            "createWriteStream",
+        ],
+    ) {
+        SinkKind::FsWrite
+    } else if callee == "fetch"
+        || callee == "axios"
+        || receiver_method(
+            callee,
+            "axios",
+            &[
+                "request", "get", "post", "put", "patch", "delete", "head", "options",
+            ],
+        )
+        || matches!(
+            callee,
+            "http.request" | "https.request" | "http.get" | "https.get"
+        )
+    {
+        SinkKind::Network
+    } else {
+        return None;
+    };
+    Some(Sink { kind, args })
+}
+
+fn callee_is_or_ends_with(callee: &str, names: &[&str]) -> bool {
+    names
+        .iter()
+        .any(|name| callee == *name || callee.ends_with(&format!(".{name}")))
+}

--- a/src/languages/kotlin/mod.rs
+++ b/src/languages/kotlin/mod.rs
@@ -22,4 +22,5 @@ pub(super) static KOTLIN: LanguageFrontend = LanguageFrontend {
         grammar: ParseLanguage::Kotlin,
     }],
     imports: Some(&KOTLIN_IMPORTS),
+    taint: None,
 };

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -93,6 +93,9 @@ pub struct LanguageFrontend {
     pub grammars: &'static [GrammarBinding],
     /// Import extraction, when the language has an extractor.
     pub(crate) imports: Option<&'static ImportExtractor>,
+    /// Taint-lite tables (sources, sinks, sanitizers, grammar shapes), when
+    /// the language participates in taint analysis.
+    pub(crate) taint: Option<&'static crate::review::signals::taint::tables::TaintTables>,
 }
 
 /// Every registered frontend, including the generic fallback (last).
@@ -185,4 +188,12 @@ pub(crate) fn frontend_for_label(label: &str) -> Option<&'static LanguageFronten
 /// The import extractor for a detection label, if the language has one.
 pub(crate) fn imports_for_label(label: &str) -> Option<&'static ImportExtractor> {
     frontend_for_label(label).and_then(|frontend| frontend.imports)
+}
+
+/// The taint tables for a detection label, if the language participates in
+/// taint analysis.
+pub(crate) fn taint_for_label(
+    label: &str,
+) -> Option<&'static crate::review::signals::taint::tables::TaintTables> {
+    frontend_for_label(label).and_then(|frontend| frontend.taint)
 }

--- a/src/languages/python/mod.rs
+++ b/src/languages/python/mod.rs
@@ -3,6 +3,7 @@ use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
 
 mod imports;
+mod review;
 
 use super::ImportExtractor;
 
@@ -22,4 +23,5 @@ pub(super) static PYTHON: LanguageFrontend = LanguageFrontend {
         grammar: ParseLanguage::Python,
     }],
     imports: Some(&PYTHON_IMPORTS),
+    taint: Some(&review::PYTHON_TAINT),
 };

--- a/src/languages/python/review.rs
+++ b/src/languages/python/review.rs
@@ -1,0 +1,141 @@
+//! Taint tables for Python. Source idioms target Flask/Django/FastAPI; sinks
+//! mirror the behavioral "added X" detectors.
+
+use crate::review::signals::taint::ast::{callee_ends_with, has_descendant_kind};
+use crate::review::signals::taint::sinks::{Sink, SinkKind, callee_text, receiver_method};
+use crate::review::signals::taint::tables::TaintTables;
+use tree_sitter::Node;
+
+pub(super) static PYTHON_TAINT: TaintTables = TaintTables {
+    request_sources: &[
+        "request.args",
+        "request.form",
+        "request.json",
+        "request.values",
+        "request.data",
+        "request.files",
+        "request.GET",
+        "request.POST",
+        "request.query_params",
+        "request.path_params",
+        "request.body",
+        "request.cookies",
+        "request.headers",
+    ],
+    argv_sources: &["sys.argv"],
+    source_access_kinds: &["attribute"],
+    coercions: &["int", "float", "bool"],
+    coercion_call_kind: "call",
+    assignment_kinds: &["assignment", "augmented_assignment"],
+    is_flow_scope,
+    is_augmenting: |node| node.kind() == "augmented_assignment",
+    is_string_building,
+    classify_sink,
+};
+
+fn is_flow_scope(node: Node<'_>) -> bool {
+    matches!(node.kind(), "function_definition" | "lambda")
+}
+
+fn is_string_building(node: Node<'_>, content: &str) -> bool {
+    node.kind() == "binary_operator"
+        || (node.kind() == "string" && has_descendant_kind(node, "interpolation"))
+        || (node.kind() == "call" && callee_ends_with(node, content, ".format"))
+}
+
+fn classify_sink<'a>(node: Node<'a>, content: &'a str) -> Option<Sink<'a>> {
+    let (callee, args) = callee_text(node, content)?;
+    let kind = if callee.ends_with(".execute")
+        || callee.ends_with(".executemany")
+        || callee.ends_with(".query")
+        || callee.ends_with(".raw")
+    {
+        SinkKind::Sql
+    } else if receiver_method(
+        callee,
+        "subprocess",
+        &[
+            "run",
+            "Popen",
+            "call",
+            "check_call",
+            "check_output",
+            "getoutput",
+            "getstatusoutput",
+        ],
+    ) || callee == "os.system"
+        || callee == "os.popen"
+        || callee == "eval"
+        || callee == "exec"
+    {
+        SinkKind::Exec
+    } else if (callee == "open" && python_open_is_write(args, content))
+        || callee.ends_with(".write_text")
+        || callee.ends_with(".write_bytes")
+    {
+        SinkKind::FsWrite
+    } else if receiver_method(
+        callee,
+        "requests",
+        &[
+            "request", "get", "post", "put", "patch", "delete", "head", "options",
+        ],
+    ) || receiver_method(
+        callee,
+        "httpx",
+        &[
+            "request", "get", "post", "put", "patch", "delete", "head", "options",
+        ],
+    ) || callee == "urllib.request.urlopen"
+        || callee == "urlopen"
+    {
+        SinkKind::Network
+    } else {
+        return None;
+    };
+    Some(Sink { kind, args })
+}
+
+fn python_open_is_write(args: Node<'_>, content: &str) -> bool {
+    let mut cursor = args.walk();
+    for (index, arg) in args.named_children(&mut cursor).enumerate() {
+        if index == 0 {
+            continue;
+        }
+
+        let mode = if arg.kind() == "keyword_argument" {
+            let Some(name) = arg.child_by_field_name("name") else {
+                continue;
+            };
+            if name.utf8_text(content.as_bytes()).ok() != Some("mode") {
+                continue;
+            }
+            arg.child_by_field_name("value")
+        } else if index == 1 {
+            Some(arg)
+        } else {
+            None
+        };
+
+        if mode.is_some_and(|mode| {
+            let text = mode.utf8_text(content.as_bytes()).unwrap_or("");
+            quoted_value(text).is_some_and(|value| {
+                value
+                    .chars()
+                    .any(|character| matches!(character, 'w' | 'a' | 'x' | '+'))
+            })
+        }) {
+            return true;
+        }
+    }
+    false
+}
+
+fn quoted_value(text: &str) -> Option<&str> {
+    let text = text.trim();
+    let quote_index = text.find(['\'', '"'])?;
+    let quote = text.as_bytes()[quote_index];
+    let value = &text[quote_index + 1..];
+    let end = value.as_bytes().iter().position(|byte| *byte == quote)?;
+    Some(&value[..end])
+}

--- a/src/languages/rust/mod.rs
+++ b/src/languages/rust/mod.rs
@@ -22,4 +22,5 @@ pub(super) static RUST: LanguageFrontend = LanguageFrontend {
         grammar: ParseLanguage::Rust,
     }],
     imports: Some(&RUST_IMPORTS),
+    taint: None,
 };

--- a/src/languages/tests.rs
+++ b/src/languages/tests.rs
@@ -187,6 +187,25 @@ fn import_extractor_coverage_is_pinned() {
     }
 }
 
+/// Pins which frontends participate in taint-lite. The gate used to be the
+/// private `TaintLang::from_label` enum; now it is the frontend's `taint`
+/// field, and this pin keeps a refactor from silently adding or removing a
+/// language from taint analysis.
+#[test]
+fn taint_participation_is_pinned() {
+    let with_taint: BTreeSet<&str> = ["typescript", "javascript", "python", "go"]
+        .into_iter()
+        .collect();
+    for frontend in all_frontends() {
+        assert_eq!(
+            frontend.taint.is_some(),
+            with_taint.contains(frontend.id),
+            "taint participation changed for frontend '{}'",
+            frontend.id
+        );
+    }
+}
+
 /// The honesty ledger. Languages the bundled pack declares `rule-aware`
 /// whose frontends do not yet justify it. Migration PRs shrink this set by
 /// wiring capabilities (or PR-9 downgrades over-claimed pack declarations —

--- a/src/review/signals/taint/ast.rs
+++ b/src/review/signals/taint/ast.rs
@@ -1,11 +1,11 @@
 use tree_sitter::Node;
 
-pub(super) fn first_named_arg(args: Node<'_>) -> Option<Node<'_>> {
+pub(crate) fn first_named_arg(args: Node<'_>) -> Option<Node<'_>> {
     let mut cursor = args.walk();
     args.named_children(&mut cursor).next()
 }
 
-pub(super) fn has_descendant_kind(node: Node<'_>, kind: &str) -> bool {
+pub(crate) fn has_descendant_kind(node: Node<'_>, kind: &str) -> bool {
     if node.kind() == kind {
         return true;
     }
@@ -21,10 +21,10 @@ fn callee_text<'a>(node: Node<'a>, content: &'a str) -> Option<&'a str> {
         .map(str::trim)
 }
 
-pub(super) fn callee_ends_with(node: Node<'_>, content: &str, suffix: &str) -> bool {
+pub(crate) fn callee_ends_with(node: Node<'_>, content: &str, suffix: &str) -> bool {
     callee_text(node, content).is_some_and(|text| text.ends_with(suffix))
 }
 
-pub(super) fn callee_starts_with(node: Node<'_>, content: &str, prefix: &str) -> bool {
+pub(crate) fn callee_starts_with(node: Node<'_>, content: &str, prefix: &str) -> bool {
     callee_text(node, content).is_some_and(|text| text.starts_with(prefix))
 }

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -13,10 +13,11 @@
 //! is the query expression itself: a static query string with the value passed as
 //! a separate bind parameter is the safe, parameterized pattern.
 
-use super::ast::{callee_ends_with, callee_starts_with, first_named_arg, has_descendant_kind};
-use super::sinks::{Sink, SinkKind, classify_sink};
+use super::TaintSignal;
+use super::ast::first_named_arg;
+use super::sinks::{Sink, SinkKind};
 use super::sources::{SourceKind, node_has_source};
-use super::{TaintLang, TaintSignal};
+use super::tables::TaintTables;
 use crate::review::diff::ChangedFile;
 use crate::review::signals::behavioral::truncate_str;
 use std::collections::HashMap;
@@ -25,55 +26,59 @@ use tree_sitter::Node;
 pub(super) fn detect(
     root: Node<'_>,
     content: &str,
-    lang: TaintLang,
+    tables: &'static TaintTables,
     file: &ChangedFile,
     out: &mut Vec<TaintSignal>,
 ) {
-    detect_scope(root, content, lang, file, out);
+    detect_scope(root, content, tables, file, out);
 }
 
 fn detect_scope(
     root: Node<'_>,
     content: &str,
-    lang: TaintLang,
+    tables: &'static TaintTables,
     file: &ChangedFile,
     out: &mut Vec<TaintSignal>,
 ) {
-    let tainted = seed_tainted(root, content, lang);
-    check_sinks(root, content, lang, file, &tainted, out);
-    detect_nested_scopes(root, content, lang, file, out);
+    let tainted = seed_tainted(root, content, tables);
+    check_sinks(root, content, tables, file, &tainted, out);
+    detect_nested_scopes(root, content, tables, file, out);
 }
 
 fn detect_nested_scopes(
     node: Node<'_>,
     content: &str,
-    lang: TaintLang,
+    tables: &'static TaintTables,
     file: &ChangedFile,
     out: &mut Vec<TaintSignal>,
 ) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if lang.is_flow_scope(child) {
-            detect_scope(child, content, lang, file, out);
+        if (tables.is_flow_scope)(child) {
+            detect_scope(child, content, tables, file, out);
         } else {
-            detect_nested_scopes(child, content, lang, file, out);
+            detect_nested_scopes(child, content, tables, file, out);
         }
     }
 }
 
 // ── Seeding ─────────────────────────────────────────────────────────────────
 
-fn seed_tainted(root: Node<'_>, content: &str, lang: TaintLang) -> HashMap<String, SourceKind> {
+fn seed_tainted(
+    root: Node<'_>,
+    content: &str,
+    tables: &'static TaintTables,
+) -> HashMap<String, SourceKind> {
     let mut assignments: Vec<Assignment<'_>> = Vec::new();
-    collect_assignments(root, lang, content, &mut assignments);
+    collect_assignments(root, tables, content, &mut assignments);
     // Process in document order so a later reassignment overrides an earlier one;
     // a single forward pass then resolves `a = src; b = a; c = b` chains.
     assignments.sort_by_key(|assignment| assignment.rhs.start_byte());
 
     let mut tainted: HashMap<String, SourceKind> = HashMap::new();
     for assignment in &assignments {
-        match node_has_source(assignment.rhs, content, lang)
-            .or_else(|| node_mentions_tainted(assignment.rhs, content, lang, &tainted))
+        match node_has_source(assignment.rhs, content, tables)
+            .or_else(|| node_mentions_tainted(assignment.rhs, content, tables, &tainted))
         {
             // A tainted/source value sets (or re-sets) taint for each target name.
             Some(kind) => {
@@ -106,70 +111,37 @@ struct Assignment<'a> {
 
 fn collect_assignments<'a>(
     node: Node<'a>,
-    lang: TaintLang,
+    tables: &'static TaintTables,
     content: &str,
     out: &mut Vec<Assignment<'a>>,
 ) {
-    if let Some((lhs, rhs)) = assignment_parts(node, lang) {
+    if let Some((lhs, rhs)) = assignment_parts(node, tables) {
         let mut names = Vec::new();
         collect_lhs_names(lhs, content, &mut names);
         if !names.is_empty() {
             out.push(Assignment {
                 names,
                 rhs,
-                augmenting: is_augmenting(node, lang),
+                augmenting: (tables.is_augmenting)(node),
             });
         }
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if !lang.is_flow_scope(child) {
-            collect_assignments(child, lang, content, out);
+        if !(tables.is_flow_scope)(child) {
+            collect_assignments(child, tables, content, out);
         }
     }
 }
 
-/// Whether `node` is a compound assignment that combines with the existing value
-/// (`x += …`), as opposed to a plain replacement (`x = …`, `x := …`).
-fn is_augmenting(node: Node<'_>, lang: TaintLang) -> bool {
-    match lang {
-        TaintLang::Python => node.kind() == "augmented_assignment",
-        TaintLang::Go => {
-            node.kind() == "assignment_statement" && {
-                let mut cursor = node.walk();
-                node.children(&mut cursor).any(|child| {
-                    matches!(
-                        child.kind(),
-                        "+=" | "-="
-                            | "*="
-                            | "/="
-                            | "%="
-                            | "&="
-                            | "|="
-                            | "^="
-                            | "<<="
-                            | ">>="
-                            | "&^="
-                    )
-                })
-            }
-        }
-        // tree-sitter-javascript models `x += …` as a distinct
-        // `augmented_assignment_expression` node that `assignment_parts` does not
-        // collect, so anything collected here is a plain `=`.
-        TaintLang::Js => false,
-    }
-}
-
-/// The (target, value) nodes of an assignment-like node, per grammar.
-fn assignment_parts<'a>(node: Node<'a>, lang: TaintLang) -> Option<(Node<'a>, Node<'a>)> {
+/// The (target, value) nodes of an assignment-like node, per the grammar's
+/// assignment node kinds from the language's [`TaintTables`].
+fn assignment_parts<'a>(
+    node: Node<'a>,
+    tables: &'static TaintTables,
+) -> Option<(Node<'a>, Node<'a>)> {
     let kind = node.kind();
-    let is_assignment = match lang {
-        TaintLang::Js => matches!(kind, "variable_declarator" | "assignment_expression"),
-        TaintLang::Python => matches!(kind, "assignment" | "augmented_assignment"),
-        TaintLang::Go => matches!(kind, "short_var_declaration" | "assignment_statement"),
-    };
-    if !is_assignment {
+    if !tables.assignment_kinds.contains(&kind) {
         return None;
     }
     let (lhs_field, rhs_field) = if kind == "variable_declarator" {
@@ -216,14 +188,14 @@ fn collect_lhs_names(lhs: Node<'_>, content: &str, out: &mut Vec<String>) {
 fn node_mentions_tainted(
     node: Node<'_>,
     content: &str,
-    lang: TaintLang,
+    tables: &'static TaintTables,
     tainted: &HashMap<String, SourceKind>,
 ) -> Option<SourceKind> {
-    if lang.is_flow_scope(node) {
+    if (tables.is_flow_scope)(node) {
         return None;
     }
     // A sanitizer/coercion call neutralizes whatever it wraps; do not descend.
-    if super::sanitizers::is_sanitizer_call(node, content, lang) {
+    if super::sanitizers::is_sanitizer_call(node, content, tables) {
         return None;
     }
     if node.kind() == "identifier" {
@@ -235,7 +207,7 @@ fn node_mentions_tainted(
 
     let mut cursor = node.walk();
     node.named_children(&mut cursor)
-        .find_map(|child| node_mentions_tainted(child, content, lang, tainted))
+        .find_map(|child| node_mentions_tainted(child, content, tables, tainted))
 }
 
 // ── Sink checking ─────────────────────────────────────────────────────────────
@@ -243,15 +215,15 @@ fn node_mentions_tainted(
 fn check_sinks(
     node: Node<'_>,
     content: &str,
-    lang: TaintLang,
+    tables: &'static TaintTables,
     file: &ChangedFile,
     tainted: &HashMap<String, SourceKind>,
     out: &mut Vec<TaintSignal>,
 ) {
-    if let Some(sink) = classify_sink(node, content, lang) {
+    if let Some(sink) = (tables.classify_sink)(node, content) {
         let line = node.start_position().row + 1;
         if file.contains_line(line)
-            && let Some(source) = sink_taint(&sink, content, lang, tainted)
+            && let Some(source) = sink_taint(&sink, content, tables, tainted)
         {
             let call_text = node.utf8_text(content.as_bytes()).unwrap_or("");
             out.push(TaintSignal {
@@ -271,8 +243,8 @@ fn check_sinks(
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if !lang.is_flow_scope(child) {
-            check_sinks(child, content, lang, file, tainted, out);
+        if !(tables.is_flow_scope)(child) {
+            check_sinks(child, content, tables, file, tainted, out);
         }
     }
 }
@@ -280,13 +252,13 @@ fn check_sinks(
 fn sink_taint(
     sink: &Sink<'_>,
     content: &str,
-    lang: TaintLang,
+    tables: &'static TaintTables,
     tainted: &HashMap<String, SourceKind>,
 ) -> Option<SourceKind> {
     match sink.kind {
-        SinkKind::Sql => sql_taint(sink.args, content, lang, tainted),
-        _ => node_has_source(sink.args, content, lang)
-            .or_else(|| node_mentions_tainted(sink.args, content, lang, tainted)),
+        SinkKind::Sql => sql_taint(sink.args, content, tables, tainted),
+        _ => node_has_source(sink.args, content, tables)
+            .or_else(|| node_mentions_tainted(sink.args, content, tables, tainted)),
     }
 }
 
@@ -297,37 +269,19 @@ fn sink_taint(
 fn sql_taint(
     args: Node<'_>,
     content: &str,
-    lang: TaintLang,
+    tables: &'static TaintTables,
     tainted: &HashMap<String, SourceKind>,
 ) -> Option<SourceKind> {
     let first = first_named_arg(args)?;
     let first_text = first.utf8_text(content.as_bytes()).unwrap_or("");
 
-    if is_string_building(first, content, lang) {
-        return node_has_source(first, content, lang)
-            .or_else(|| node_mentions_tainted(first, content, lang, tainted));
+    if (tables.is_string_building)(first, content) {
+        return node_has_source(first, content, tables)
+            .or_else(|| node_mentions_tainted(first, content, tables, tainted));
     }
     if first.kind() == "identifier" {
         return tainted.get(first_text).copied();
     }
     // A request value used directly as the whole query expression (rare, unsafe).
-    node_has_source(first, content, lang)
-}
-
-/// Whether `node` constructs a string from parts — concatenation, interpolation,
-/// or a `format`/`Sprintf` call — the positions where injected input is dangerous.
-fn is_string_building(node: Node<'_>, content: &str, lang: TaintLang) -> bool {
-    match lang {
-        TaintLang::Js => matches!(node.kind(), "template_string" | "binary_expression"),
-        TaintLang::Python => {
-            node.kind() == "binary_operator"
-                || (node.kind() == "string" && has_descendant_kind(node, "interpolation"))
-                || (node.kind() == "call" && callee_ends_with(node, content, ".format"))
-        }
-        TaintLang::Go => {
-            node.kind() == "binary_expression"
-                || (node.kind() == "call_expression"
-                    && callee_starts_with(node, content, "fmt.Sprint"))
-        }
-    }
+    node_has_source(first, content, tables)
 }

--- a/src/review/signals/taint/mod.rs
+++ b/src/review/signals/taint/mod.rs
@@ -20,11 +20,12 @@
 //! - [`flow`] seeds tainted locals from sources and reports when one reaches a
 //!   sink, gated to the changed lines so it stays change-scoped.
 
-mod ast;
+pub(crate) mod ast;
 mod flow;
 mod sanitizers;
-mod sinks;
+pub(crate) mod sinks;
 mod sources;
+pub(crate) mod tables;
 #[cfg(test)]
 mod tests;
 
@@ -32,49 +33,9 @@ use crate::review::diff::ChangedFile;
 use crate::review::signals::content::ReviewSource;
 use crate::scan::language::detect_language;
 use serde::Serialize;
-use tree_sitter::Node;
 
 pub use sinks::SinkKind;
 pub use sources::SourceKind;
-
-/// The languages taint-lite understands. JS/TS (and their React variants) share a
-/// grammar shape, so one matcher covers them.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TaintLang {
-    Js,
-    Python,
-    Go,
-}
-
-impl TaintLang {
-    fn from_label(label: &str) -> Option<Self> {
-        match label {
-            "JavaScript" | "JavaScript React" | "TypeScript" | "TypeScript React" => Some(Self::Js),
-            "Python" => Some(Self::Python),
-            "Go" => Some(Self::Go),
-            _ => None,
-        }
-    }
-
-    fn is_flow_scope(self, node: Node<'_>) -> bool {
-        match self {
-            Self::Js => matches!(
-                node.kind(),
-                "function_declaration"
-                    | "generator_function_declaration"
-                    | "method_definition"
-                    | "function_expression"
-                    | "generator_function"
-                    | "arrow_function"
-            ),
-            Self::Python => matches!(node.kind(), "function_definition" | "lambda"),
-            Self::Go => matches!(
-                node.kind(),
-                "function_declaration" | "method_declaration" | "func_literal"
-            ),
-        }
-    }
-}
 
 /// One untrusted-input-reaches-sink flow found in a changed file.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -99,7 +60,8 @@ pub fn detect_taint(file: &ChangedFile, post_source: Option<&ReviewSource>) -> V
     let Some(post) = post_source else {
         return Vec::new();
     };
-    let Some(lang) = detect_language(&file.path).and_then(TaintLang::from_label) else {
+    let Some(tables) = detect_language(&file.path).and_then(crate::languages::taint_for_label)
+    else {
         return Vec::new();
     };
 
@@ -108,7 +70,7 @@ pub fn detect_taint(file: &ChangedFile, post_source: Option<&ReviewSource>) -> V
     };
 
     let mut signals = Vec::new();
-    flow::detect(tree.root_node(), post.content(), lang, file, &mut signals);
+    flow::detect(tree.root_node(), post.content(), tables, file, &mut signals);
 
     let mut unique: Vec<TaintSignal> = Vec::new();
     for signal in signals {

--- a/src/review/signals/taint/sanitizers.rs
+++ b/src/review/signals/taint/sanitizers.rs
@@ -14,39 +14,20 @@
 //! *their* sink and would cause false negatives if applied to SQL/exec/fs
 //! universally — recognizing them per-sink is a documented follow-up.
 
-use super::TaintLang;
+use super::tables::TaintTables;
 use tree_sitter::Node;
 
-const JS_COERCIONS: &[&str] = &["Number", "parseInt", "parseFloat", "BigInt", "Boolean"];
-
-const PY_COERCIONS: &[&str] = &["int", "float", "bool"];
-
-const GO_COERCIONS: &[&str] = &[
-    "strconv.Atoi",
-    "strconv.ParseInt",
-    "strconv.ParseFloat",
-    "strconv.ParseBool",
-];
-
 /// Whether `node` is a call to a numeric/boolean coercion that universally
-/// neutralizes its argument, so the walkers should not descend into it.
-pub(super) fn is_sanitizer_call(node: Node<'_>, content: &str, lang: TaintLang) -> bool {
-    let is_call = match lang {
-        TaintLang::Js | TaintLang::Go => node.kind() == "call_expression",
-        TaintLang::Python => node.kind() == "call",
-    };
-    if !is_call {
+/// neutralizes its argument, so the walkers should not descend into it. The
+/// coercion list and the grammar's call node kind come from the language's
+/// [`TaintTables`].
+pub(super) fn is_sanitizer_call(node: Node<'_>, content: &str, tables: &TaintTables) -> bool {
+    if node.kind() != tables.coercion_call_kind {
         return false;
     }
     let Some(callee) = node.child_by_field_name("function") else {
         return false;
     };
     let text = callee.utf8_text(content.as_bytes()).unwrap_or("").trim();
-
-    let coercions = match lang {
-        TaintLang::Js => JS_COERCIONS,
-        TaintLang::Python => PY_COERCIONS,
-        TaintLang::Go => GO_COERCIONS,
-    };
-    coercions.contains(&text)
+    tables.coercions.contains(&text)
 }

--- a/src/review/signals/taint/sinks.rs
+++ b/src/review/signals/taint/sinks.rs
@@ -1,12 +1,13 @@
-//! Dangerous-sink classification for taint-lite.
+//! Dangerous-sink model for taint-lite.
 //!
-//! Mirrors the per-language sink patterns the behavioral "added X" detectors
-//! already recognize (`src/review/signals/behavioral/{js,python,go}.rs`), but
-//! returns the call's *argument node* so [`super::flow`] can inspect what flows
-//! in. Kept text/callee-name based to match the behavioral detectors and stay
-//! robust across the JS/TS, Python, and Go grammars.
+//! The per-language sink classifiers live on the language frontends
+//! (`languages/*/review.rs`, wired through
+//! [`TaintTables::classify_sink`](super::tables::TaintTables)); this module
+//! keeps the shared model — [`SinkKind`], [`Sink`] — and the callee-shape
+//! helpers the classifiers share. Classification stays text/callee-name based
+//! to mirror the behavioral "added X" detectors and stay robust across
+//! grammars.
 
-use super::TaintLang;
 use serde::Serialize;
 use tree_sitter::Node;
 
@@ -37,25 +38,13 @@ impl SinkKind {
 }
 
 /// A classified sink call: its kind and the AST node holding its arguments.
-pub(super) struct Sink<'a> {
+pub(crate) struct Sink<'a> {
     pub kind: SinkKind,
     pub args: Node<'a>,
 }
 
-/// Classify `node` as a dangerous sink call, returning its kind and argument node.
-pub(super) fn classify_sink<'a>(
-    node: Node<'a>,
-    content: &'a str,
-    lang: TaintLang,
-) -> Option<Sink<'a>> {
-    match lang {
-        TaintLang::Js => js_sink(node, content),
-        TaintLang::Python => python_sink(node, content),
-        TaintLang::Go => go_sink(node, content),
-    }
-}
-
-fn callee_text<'a>(node: Node<'a>, content: &'a str) -> Option<(&'a str, Node<'a>)> {
+/// The callee text and argument node of a call node, if it is one.
+pub(crate) fn callee_text<'a>(node: Node<'a>, content: &'a str) -> Option<(&'a str, Node<'a>)> {
     if node.kind() != "call_expression" && node.kind() != "call" {
         return None;
     }
@@ -65,217 +54,8 @@ fn callee_text<'a>(node: Node<'a>, content: &'a str) -> Option<(&'a str, Node<'a
     Some((text, args))
 }
 
-fn js_sink<'a>(node: Node<'a>, content: &'a str) -> Option<Sink<'a>> {
-    let (callee, args) = callee_text(node, content)?;
-    let kind = if callee.ends_with(".query")
-        || callee == "query"
-        || callee.ends_with(".execute")
-        || callee == "execute"
-    {
-        SinkKind::Sql
-    } else if callee_is_or_ends_with(
-        callee,
-        &[
-            "exec",
-            "spawn",
-            "execFile",
-            "fork",
-            "execSync",
-            "spawnSync",
-            "execFileSync",
-        ],
-    ) {
-        SinkKind::Exec
-    } else if callee_is_or_ends_with(
-        callee,
-        &[
-            "writeFile",
-            "writeFileSync",
-            "appendFile",
-            "appendFileSync",
-            "createWriteStream",
-        ],
-    ) {
-        SinkKind::FsWrite
-    } else if callee == "fetch"
-        || callee == "axios"
-        || receiver_method(
-            callee,
-            "axios",
-            &[
-                "request", "get", "post", "put", "patch", "delete", "head", "options",
-            ],
-        )
-        || matches!(
-            callee,
-            "http.request" | "https.request" | "http.get" | "https.get"
-        )
-    {
-        SinkKind::Network
-    } else {
-        return None;
-    };
-    Some(Sink { kind, args })
-}
-
-fn python_sink<'a>(node: Node<'a>, content: &'a str) -> Option<Sink<'a>> {
-    let (callee, args) = callee_text(node, content)?;
-    let kind = if callee.ends_with(".execute")
-        || callee.ends_with(".executemany")
-        || callee.ends_with(".query")
-        || callee.ends_with(".raw")
-    {
-        SinkKind::Sql
-    } else if receiver_method(
-        callee,
-        "subprocess",
-        &[
-            "run",
-            "Popen",
-            "call",
-            "check_call",
-            "check_output",
-            "getoutput",
-            "getstatusoutput",
-        ],
-    ) || callee == "os.system"
-        || callee == "os.popen"
-        || callee == "eval"
-        || callee == "exec"
-    {
-        SinkKind::Exec
-    } else if (callee == "open" && python_open_is_write(args, content))
-        || callee.ends_with(".write_text")
-        || callee.ends_with(".write_bytes")
-    {
-        SinkKind::FsWrite
-    } else if receiver_method(
-        callee,
-        "requests",
-        &[
-            "request", "get", "post", "put", "patch", "delete", "head", "options",
-        ],
-    ) || receiver_method(
-        callee,
-        "httpx",
-        &[
-            "request", "get", "post", "put", "patch", "delete", "head", "options",
-        ],
-    ) || callee == "urllib.request.urlopen"
-        || callee == "urlopen"
-    {
-        SinkKind::Network
-    } else {
-        return None;
-    };
-    Some(Sink { kind, args })
-}
-
-fn go_sink<'a>(node: Node<'a>, content: &'a str) -> Option<Sink<'a>> {
-    let (callee, args) = callee_text(node, content)?;
-    let kind = if callee.ends_with(".Query")
-        || callee.ends_with(".QueryRow")
-        || callee.ends_with(".QueryContext")
-        || callee.ends_with(".Exec")
-        || callee.ends_with(".ExecContext")
-    {
-        SinkKind::Sql
-    } else if matches!(callee, "exec.Command" | "exec.CommandContext") {
-        SinkKind::Exec
-    } else if matches!(
-        callee,
-        "os.WriteFile" | "os.Create" | "os.CreateTemp" | "ioutil.WriteFile"
-    ) || (callee == "os.OpenFile" && go_open_file_is_write(args, content))
-    {
-        SinkKind::FsWrite
-    } else if matches!(
-        callee,
-        "http.Get"
-            | "http.Post"
-            | "http.PostForm"
-            | "http.NewRequest"
-            | "http.NewRequestWithContext"
-            | "net.Dial"
-            | "net.DialTimeout"
-    ) || callee.ends_with(".Do")
-        || callee.ends_with(".DialContext")
-    {
-        SinkKind::Network
-    } else {
-        return None;
-    };
-    Some(Sink { kind, args })
-}
-
-fn callee_is_or_ends_with(callee: &str, names: &[&str]) -> bool {
-    names
-        .iter()
-        .any(|name| callee == *name || callee.ends_with(&format!(".{name}")))
-}
-
-fn receiver_method(callee: &str, receiver: &str, methods: &[&str]) -> bool {
+pub(crate) fn receiver_method(callee: &str, receiver: &str, methods: &[&str]) -> bool {
     methods
         .iter()
         .any(|method| callee == format!("{receiver}.{method}"))
-}
-
-fn python_open_is_write(args: Node<'_>, content: &str) -> bool {
-    let mut cursor = args.walk();
-    for (index, arg) in args.named_children(&mut cursor).enumerate() {
-        if index == 0 {
-            continue;
-        }
-
-        let mode = if arg.kind() == "keyword_argument" {
-            let Some(name) = arg.child_by_field_name("name") else {
-                continue;
-            };
-            if name.utf8_text(content.as_bytes()).ok() != Some("mode") {
-                continue;
-            }
-            arg.child_by_field_name("value")
-        } else if index == 1 {
-            Some(arg)
-        } else {
-            None
-        };
-
-        if mode.is_some_and(|mode| {
-            let text = mode.utf8_text(content.as_bytes()).unwrap_or("");
-            quoted_value(text).is_some_and(|value| {
-                value
-                    .chars()
-                    .any(|character| matches!(character, 'w' | 'a' | 'x' | '+'))
-            })
-        }) {
-            return true;
-        }
-    }
-    false
-}
-
-fn go_open_file_is_write(args: Node<'_>, content: &str) -> bool {
-    let mut cursor = args.walk();
-    let Some(flags) = args.named_children(&mut cursor).nth(1) else {
-        return false;
-    };
-    let text = flags.utf8_text(content.as_bytes()).unwrap_or("");
-    [
-        "os.O_WRONLY",
-        "os.O_RDWR",
-        "os.O_APPEND",
-        "os.O_CREATE",
-        "os.O_TRUNC",
-    ]
-    .iter()
-    .any(|flag| text.contains(flag))
-}
-
-fn quoted_value(text: &str) -> Option<&str> {
-    let text = text.trim();
-    let quote_index = text.find(['\'', '"'])?;
-    let quote = text.as_bytes()[quote_index];
-    let value = &text[quote_index + 1..];
-    let end = value.as_bytes().iter().position(|byte| *byte == quote)?;
-    Some(&value[..end])
 }

--- a/src/review/signals/taint/sources.rs
+++ b/src/review/signals/taint/sources.rs
@@ -1,15 +1,16 @@
 //! Untrusted-input source recognition for taint-lite.
 //!
-//! AST-node text is checked for known request/argv idioms. Only member/attribute/
-//! selector nodes participate, so examples inside strings or comments do not
-//! become sources. Matching is whole-token (via [`super::contains_token`]) so
-//! `req.query` is recognized in `req.query.id` but not inside `req.queryString`.
-//! Conservative on purpose: only high-signal, widely-used idioms across
-//! Express/Koa (JS), Flask/Django/FastAPI (Python), and net/http/Gin (Go). Env
-//! vars are intentionally excluded here: they are flagged separately as a
+//! AST-node text is checked for the request/argv idioms in the language's
+//! [`TaintTables`]. Only member/attribute/selector nodes participate, so
+//! examples inside strings or comments do not become sources. Matching is
+//! whole-token (via [`super::contains_token`]) so `req.query` is recognized
+//! in `req.query.id` but not inside `req.queryString`. The idiom lists are
+//! conservative on purpose — only high-signal, widely-used idioms — and env
+//! vars are intentionally excluded: they are flagged separately as a
 //! behavioral signal and are rarely user-controlled.
 
-use super::{TaintLang, contains_token};
+use super::contains_token;
+use super::tables::TaintTables;
 use serde::Serialize;
 use tree_sitter::Node;
 
@@ -33,88 +34,37 @@ impl SourceKind {
     }
 }
 
-const JS_REQUEST: &[&str] = &[
-    "req.query",
-    "req.params",
-    "req.body",
-    "req.headers",
-    "req.cookies",
-    "req.url",
-    "request.query",
-    "request.params",
-    "request.body",
-    "request.headers",
-    "request.cookies",
-    "ctx.query",
-    "ctx.request.body",
-];
-
-const PY_REQUEST: &[&str] = &[
-    "request.args",
-    "request.form",
-    "request.json",
-    "request.values",
-    "request.data",
-    "request.files",
-    "request.GET",
-    "request.POST",
-    "request.query_params",
-    "request.path_params",
-    "request.body",
-    "request.cookies",
-    "request.headers",
-];
-
-const GO_REQUEST: &[&str] = &[
-    "r.URL.Query",
-    "r.FormValue",
-    "r.PostFormValue",
-    "r.PostForm",
-    "r.Form",
-    "r.Body",
-    "r.Header.Get",
-    "c.Query",
-    "c.Param",
-    "c.PostForm",
-    "ctx.Query",
-];
-
 /// The untrusted-input source referenced under `node`, if any. Request idioms
 /// win over argv when both appear.
 pub(super) fn node_has_source(
     node: Node<'_>,
     content: &str,
-    lang: TaintLang,
+    tables: &TaintTables,
 ) -> Option<SourceKind> {
-    let (request, argv): (&[&str], &[&str]) = match lang {
-        TaintLang::Js => (JS_REQUEST, &["process.argv"]),
-        TaintLang::Python => (PY_REQUEST, &["sys.argv"]),
-        TaintLang::Go => (GO_REQUEST, &["os.Args"]),
-    };
-    if node_has_patterns(node, content, lang, request) {
+    if node_has_patterns(node, content, tables, tables.request_sources) {
         return Some(SourceKind::HttpRequest);
     }
-    if node_has_patterns(node, content, lang, argv) {
+    if node_has_patterns(node, content, tables, tables.argv_sources) {
         return Some(SourceKind::ProcessArgs);
     }
     None
 }
 
-fn node_has_patterns(node: Node<'_>, content: &str, lang: TaintLang, patterns: &[&str]) -> bool {
-    if lang.is_flow_scope(node) {
+fn node_has_patterns(
+    node: Node<'_>,
+    content: &str,
+    tables: &TaintTables,
+    patterns: &[&str],
+) -> bool {
+    if (tables.is_flow_scope)(node) {
         return false;
     }
     // A sanitizer/coercion call neutralizes whatever it wraps; do not descend.
-    if super::sanitizers::is_sanitizer_call(node, content, lang) {
+    if super::sanitizers::is_sanitizer_call(node, content, tables) {
         return false;
     }
 
-    let is_access = match lang {
-        TaintLang::Js => node.kind() == "member_expression",
-        TaintLang::Python => node.kind() == "attribute",
-        TaintLang::Go => node.kind() == "selector_expression",
-    };
-    if is_access {
+    if tables.source_access_kinds.contains(&node.kind()) {
         let text = node.utf8_text(content.as_bytes()).unwrap_or("");
         if patterns.iter().any(|pattern| contains_token(text, pattern)) {
             return true;
@@ -123,5 +73,5 @@ fn node_has_patterns(node: Node<'_>, content: &str, lang: TaintLang, patterns: &
 
     let mut cursor = node.walk();
     node.named_children(&mut cursor)
-        .any(|child| node_has_patterns(child, content, lang, patterns))
+        .any(|child| node_has_patterns(child, content, tables, patterns))
 }

--- a/src/review/signals/taint/tables.rs
+++ b/src/review/signals/taint/tables.rs
@@ -1,0 +1,39 @@
+//! The per-language taint contract.
+//!
+//! Everything language-specific in taint-lite lives in one table owned by the
+//! language's frontend (`languages/*/review.rs`): the untrusted-source idiom
+//! lists, the coercion (sanitizer) lists, the grammar node shapes for scopes/
+//! assignments/access, and the sink classifier. The engines in [`super::flow`],
+//! [`super::sources`], and [`super::sanitizers`] are language-neutral and only
+//! consult the table they are handed, so adding taint support for a language
+//! means writing a table — not touching the engine.
+
+use super::sinks::Sink;
+use tree_sitter::Node;
+
+pub struct TaintTables {
+    /// Whole-token idioms that read inbound HTTP request data.
+    pub(crate) request_sources: &'static [&'static str],
+    /// Whole-token idioms that read process command-line arguments.
+    pub(crate) argv_sources: &'static [&'static str],
+    /// Node kinds that access a member/attribute/selector — the only nodes
+    /// whose text is matched against the source idioms.
+    pub(crate) source_access_kinds: &'static [&'static str],
+    /// Callees whose result is a non-string primitive; the walkers treat the
+    /// call as a clean subtree and do not descend.
+    pub(crate) coercions: &'static [&'static str],
+    /// The grammar's call node kind, for recognizing coercion calls.
+    pub(crate) coercion_call_kind: &'static str,
+    /// Node kinds that bind or reassign local names.
+    pub(crate) assignment_kinds: &'static [&'static str],
+    /// Whether a node opens a new flow scope (function/lambda/closure).
+    pub(crate) is_flow_scope: fn(Node<'_>) -> bool,
+    /// Whether an assignment combines with the old value (`x += …`) rather
+    /// than replacing it — a compound assignment never clears taint.
+    pub(crate) is_augmenting: fn(Node<'_>) -> bool,
+    /// Whether a node builds a string from parts (concatenation,
+    /// interpolation, `format`/`Sprintf`) — where injected input is dangerous.
+    pub(crate) is_string_building: for<'a> fn(Node<'a>, &'a str) -> bool,
+    /// Classify a call node as a dangerous sink, exposing its argument node.
+    pub(crate) classify_sink: for<'a> fn(Node<'a>, &'a str) -> Option<Sink<'a>>,
+}


### PR DESCRIPTION
## Summary

Moves language-specific taint-lite configuration into the language frontend registry.

JavaScript/TypeScript, Python, and Go now provide their own source patterns, coercions, grammar rules, and sink classifiers through a shared `TaintTables` contract.

The taint engine no longer needs its own language enum or label-based dispatch.

## Type of change

* [ ] Feature
* [x] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added `TaintTables` for language-specific taint configuration.
* Added taint tables for JavaScript/TypeScript, Python, and Go.
* Added an optional taint contract to `LanguageFrontend`.
* Routed taint analysis through the frontend registry.
* Removed the private `TaintLang` enum.
* Moved source idioms, coercions, grammar shapes, and sink classification into language modules.
* Kept the flow engine, source propagation, and sanitizer logic language-neutral.
* Added `TaintFlows` to computed frontend capabilities.
* Added a guard test for the set of languages participating in taint analysis.
* Updated the language surface inventory.

## Behavior

This is intended to preserve existing behavior.

Unchanged:

* request and process-input sources;
* SQL, subprocess, filesystem, and network sinks;
* coercion handling;
* sanitizer behavior;
* taint propagation;
* signal IDs and evidence;
* review output and gates;
* JSON, SARIF, MCP, and Action contracts.

Taint-lite remains enabled for:

* JavaScript and TypeScript, including React variants;
* Python;
* Go.

Other languages still do not participate in taint-lite analysis.

## Why

Taint analysis previously had its own language enum and several language-specific matches inside the shared engine.

That duplicated the frontend registry and made it harder to see which languages actually supported taint analysis.

After this change, each frontend owns its taint configuration, while the flow engine only works with the supplied tables.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] No unrelated refactor or generated-file churn is included

Primary subsystems:

* language frontend registry;
* review taint-lite analysis;
* source and sink classification.

## Changelog

* [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```

Focused verification:

```bash
cargo test --lib review::signals::taint
cargo test --lib languages
cargo test --test review_zoo
```

Manual regression check:

```bash
python3 scripts/zoo.py clone --only wagtail
scripts/demo-agent-edit.sh .zoo/wagtail
repopilot review .zoo/wagtail
```
