### PR TITLE
refactor(languages): move review signal tables into frontends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- **Boundary and algorithmic review signals are table-driven per language
+  frontend.** The per-language node-kind sets behind
+  `match_node_for_boundary` and the algorithmic matchers moved to
+  `ReviewTables` on the frontends; the engines keep the shared keyword
+  vocabularies and stay language-neutral. C#'s AST boundary classification
+  remains unwired — the old dispatch matched a label detection never emits —
+  and is now documented and pinned instead of silently dead. Behavior-frozen
+  refactor.
 - **Taint-lite is now table-driven per language frontend.** The per-language
   source idioms, coercion lists, grammar shapes, and sink classifiers moved
   to `src/languages/{javascript,python,go}/review.rs` as a `TaintTables`

--- a/docs/engineering/language-surface-inventory.md
+++ b/docs/engineering/language-surface-inventory.md
@@ -80,10 +80,15 @@ design (with reason).
 - [ ] `src/review/signals/behavioral/removed.rs:154` —
       `supports_coarse_removed_detection(ext)`: extension allowlist for the
       text fallback. → PR-4.
-- [ ] `src/review/signals/classify.rs:318` — `match_node_for_boundary`:
-      per-language node-kind + keyword boundary matching. → PR-4.
-- [ ] `src/review/signals/algorithmic/lang.rs:13` — `function_name` and
-      node-kind matchers per language label. → PR-4.
+- [x] `src/review/signals/classify.rs` — `match_node_for_boundary` takes its
+      node kinds from the frontend's `BoundaryKinds` table; keyword
+      vocabularies stay shared in the engine. C#'s boundary is deliberately
+      unwired (the old dispatch matched the label "CSharp" while detection
+      emits "C#" — a dead arm; enabling it is a behavior change queued for
+      the honesty pass). Pinned by `review_table_coverage_is_pinned`. (PR-4b)
+- [x] `src/review/signals/algorithmic/lang.rs` — matchers consume the
+      frontend's `AlgorithmicKinds` table (function/loop/call/control-flow/if
+      kinds); label matches are gone from the engine. (PR-4b)
 
 ## Runtime risk and code-quality spans
 

--- a/src/languages/capability.rs
+++ b/src/languages/capability.rs
@@ -41,6 +41,9 @@ pub fn capabilities(frontend: &LanguageFrontend) -> Vec<Capability> {
     if frontend.taint.is_some() {
         wired.push(Capability::TaintFlows);
     }
+    if frontend.review.is_some() {
+        wired.push(Capability::ReviewSignals);
+    }
     wired
 }
 

--- a/src/languages/csharp.rs
+++ b/src/languages/csharp.rs
@@ -1,6 +1,7 @@
 use super::{GrammarBinding, LanguageFrontend};
 use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
+use crate::review::signals::tables::{AlgorithmicKinds, ReviewTables};
 
 pub(super) static CSHARP: LanguageFrontend = LanguageFrontend {
     id: "csharp",
@@ -21,4 +22,37 @@ pub(super) static CSHARP: LanguageFrontend = LanguageFrontend {
     ],
     imports: None,
     taint: None,
+    review: Some(&CSHARP_REVIEW),
+};
+
+// Boundary stays unwired: the old dispatch matched the label "CSharp", but
+// detection emits "C#", so C# never received AST boundary classification.
+// Enabling it is a deliberate behavior change for the honesty pass, not a
+// refactor side effect.
+static CSHARP_REVIEW: ReviewTables = ReviewTables {
+    boundary: None,
+    algorithmic: &AlgorithmicKinds {
+        function_kinds: &[
+            "method_declaration",
+            "constructor_declaration",
+            "local_function_statement",
+        ],
+        loop_kinds: &[
+            "for_statement",
+            "foreach_statement",
+            "while_statement",
+            "do_statement",
+        ],
+        call_kinds: &["invocation_expression"],
+        control_flow_kinds: &[
+            "if_statement",
+            "for_statement",
+            "foreach_statement",
+            "while_statement",
+            "do_statement",
+            "switch_statement",
+            "try_statement",
+        ],
+        if_kinds: &["if_statement"],
+    },
 };

--- a/src/languages/generic.rs
+++ b/src/languages/generic.rs
@@ -12,4 +12,5 @@ pub(super) static GENERIC: LanguageFrontend = LanguageFrontend {
     grammars: &[],
     imports: None,
     taint: None,
+    review: None,
 };

--- a/src/languages/go/mod.rs
+++ b/src/languages/go/mod.rs
@@ -24,4 +24,5 @@ pub(super) static GO: LanguageFrontend = LanguageFrontend {
     }],
     imports: Some(&GO_IMPORTS),
     taint: Some(&review::GO_TAINT),
+    review: Some(&review::GO_REVIEW),
 };

--- a/src/languages/go/review.rs
+++ b/src/languages/go/review.rs
@@ -1,6 +1,7 @@
 //! Taint tables for Go. Source idioms target net/http and Gin; sinks mirror
 //! the behavioral "added X" detectors.
 
+use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
 use crate::review::signals::taint::ast::callee_starts_with;
 use crate::review::signals::taint::sinks::{Sink, SinkKind, callee_text};
 use crate::review::signals::taint::tables::TaintTables;
@@ -112,3 +113,23 @@ fn go_open_file_is_write(args: Node<'_>, content: &str) -> bool {
     .iter()
     .any(|flag| text.contains(flag))
 }
+
+pub(super) static GO_REVIEW: ReviewTables = ReviewTables {
+    boundary: Some(&BoundaryKinds {
+        decorator_kinds: &[],
+        import_kinds: &["import_spec", "import_declaration"],
+    }),
+    algorithmic: &AlgorithmicKinds {
+        function_kinds: &["function_declaration", "method_declaration"],
+        loop_kinds: &["for_statement"],
+        call_kinds: &["call_expression"],
+        control_flow_kinds: &[
+            "if_statement",
+            "for_statement",
+            "expression_switch_statement",
+            "type_switch_statement",
+            "select_statement",
+        ],
+        if_kinds: &["if_statement"],
+    },
+};

--- a/src/languages/java/mod.rs
+++ b/src/languages/java/mod.rs
@@ -3,6 +3,7 @@ use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
 
 mod imports;
+mod review;
 
 use super::ImportExtractor;
 
@@ -23,4 +24,5 @@ pub(super) static JAVA: LanguageFrontend = LanguageFrontend {
     }],
     imports: Some(&JAVA_IMPORTS),
     taint: None,
+    review: Some(&review::JAVA_REVIEW),
 };

--- a/src/languages/java/review.rs
+++ b/src/languages/java/review.rs
@@ -1,0 +1,31 @@
+//! Review-signal tables for Java: boundary node kinds and algorithmic
+//! node-kind sets.
+
+use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
+
+pub(super) static JAVA_REVIEW: ReviewTables = ReviewTables {
+    boundary: Some(&BoundaryKinds {
+        decorator_kinds: &["annotation"],
+        import_kinds: &["import_declaration"],
+    }),
+    algorithmic: &AlgorithmicKinds {
+        function_kinds: &["method_declaration", "constructor_declaration"],
+        loop_kinds: &[
+            "for_statement",
+            "enhanced_for_statement",
+            "while_statement",
+            "do_statement",
+        ],
+        call_kinds: &["method_invocation"],
+        control_flow_kinds: &[
+            "if_statement",
+            "for_statement",
+            "enhanced_for_statement",
+            "while_statement",
+            "do_statement",
+            "switch_statement",
+            "try_statement",
+        ],
+        if_kinds: &["if_statement"],
+    },
+};

--- a/src/languages/javascript/mod.rs
+++ b/src/languages/javascript/mod.rs
@@ -33,6 +33,7 @@ pub(super) static TYPESCRIPT: LanguageFrontend = LanguageFrontend {
     ],
     imports: Some(&JS_FAMILY_IMPORTS),
     taint: Some(&review::JS_FAMILY_TAINT),
+    review: Some(&review::JS_FAMILY_REVIEW),
 };
 
 pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
@@ -52,4 +53,5 @@ pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
     ],
     imports: Some(&JS_FAMILY_IMPORTS),
     taint: Some(&review::JS_FAMILY_TAINT),
+    review: Some(&review::JS_FAMILY_REVIEW),
 };

--- a/src/languages/javascript/review.rs
+++ b/src/languages/javascript/review.rs
@@ -2,6 +2,7 @@
 //! share a grammar shape, so one table covers both frontends. Source idioms
 //! target Express/Koa; sinks mirror the behavioral "added X" detectors.
 
+use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
 use crate::review::signals::taint::sinks::{Sink, SinkKind, callee_text, receiver_method};
 use crate::review::signals::taint::tables::TaintTables;
 use tree_sitter::Node;
@@ -110,3 +111,36 @@ fn callee_is_or_ends_with(callee: &str, names: &[&str]) -> bool {
         .iter()
         .any(|name| callee == *name || callee.ends_with(&format!(".{name}")))
 }
+
+pub(super) static JS_FAMILY_REVIEW: ReviewTables = ReviewTables {
+    boundary: Some(&BoundaryKinds {
+        decorator_kinds: &["decorator"],
+        import_kinds: &["import_statement", "export_statement", "call_expression"],
+    }),
+    algorithmic: &AlgorithmicKinds {
+        function_kinds: &[
+            "function_declaration",
+            "generator_function_declaration",
+            "method_definition",
+        ],
+        loop_kinds: &[
+            "for_statement",
+            "for_in_statement",
+            "for_of_statement",
+            "while_statement",
+            "do_statement",
+        ],
+        call_kinds: &["call_expression"],
+        control_flow_kinds: &[
+            "if_statement",
+            "for_statement",
+            "for_in_statement",
+            "for_of_statement",
+            "while_statement",
+            "do_statement",
+            "switch_statement",
+            "try_statement",
+        ],
+        if_kinds: &["if_statement"],
+    },
+};

--- a/src/languages/kotlin/mod.rs
+++ b/src/languages/kotlin/mod.rs
@@ -3,6 +3,7 @@ use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
 
 mod imports;
+mod review;
 
 use super::ImportExtractor;
 
@@ -23,4 +24,5 @@ pub(super) static KOTLIN: LanguageFrontend = LanguageFrontend {
     }],
     imports: Some(&KOTLIN_IMPORTS),
     taint: None,
+    review: Some(&review::KOTLIN_REVIEW),
 };

--- a/src/languages/kotlin/review.rs
+++ b/src/languages/kotlin/review.rs
@@ -1,0 +1,25 @@
+//! Review-signal tables for Kotlin: boundary node kinds and algorithmic
+//! node-kind sets.
+
+use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
+
+pub(super) static KOTLIN_REVIEW: ReviewTables = ReviewTables {
+    boundary: Some(&BoundaryKinds {
+        decorator_kinds: &["annotation"],
+        import_kinds: &["import_declaration"],
+    }),
+    algorithmic: &AlgorithmicKinds {
+        function_kinds: &["function_declaration"],
+        loop_kinds: &["for_statement", "while_statement", "do_while_statement"],
+        call_kinds: &["call_expression"],
+        control_flow_kinds: &[
+            "if_expression",
+            "when_expression",
+            "for_statement",
+            "while_statement",
+            "do_while_statement",
+            "try_expression",
+        ],
+        if_kinds: &["if_expression"],
+    },
+};

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -96,6 +96,8 @@ pub struct LanguageFrontend {
     /// Taint-lite tables (sources, sinks, sanitizers, grammar shapes), when
     /// the language participates in taint analysis.
     pub(crate) taint: Option<&'static crate::review::signals::taint::tables::TaintTables>,
+    /// Boundary/algorithmic review-signal node-kind tables.
+    pub(crate) review: Option<&'static crate::review::signals::tables::ReviewTables>,
 }
 
 /// Every registered frontend, including the generic fallback (last).
@@ -196,4 +198,11 @@ pub(crate) fn taint_for_label(
     label: &str,
 ) -> Option<&'static crate::review::signals::taint::tables::TaintTables> {
     frontend_for_label(label).and_then(|frontend| frontend.taint)
+}
+
+/// The review-signal tables for a detection label, if wired.
+pub(crate) fn review_for_label(
+    label: &str,
+) -> Option<&'static crate::review::signals::tables::ReviewTables> {
+    frontend_for_label(label).and_then(|frontend| frontend.review)
 }

--- a/src/languages/python/mod.rs
+++ b/src/languages/python/mod.rs
@@ -24,4 +24,5 @@ pub(super) static PYTHON: LanguageFrontend = LanguageFrontend {
     }],
     imports: Some(&PYTHON_IMPORTS),
     taint: Some(&review::PYTHON_TAINT),
+    review: Some(&review::PYTHON_REVIEW),
 };

--- a/src/languages/python/review.rs
+++ b/src/languages/python/review.rs
@@ -1,6 +1,7 @@
 //! Taint tables for Python. Source idioms target Flask/Django/FastAPI; sinks
 //! mirror the behavioral "added X" detectors.
 
+use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
 use crate::review::signals::taint::ast::{callee_ends_with, has_descendant_kind};
 use crate::review::signals::taint::sinks::{Sink, SinkKind, callee_text, receiver_method};
 use crate::review::signals::taint::tables::TaintTables;
@@ -139,3 +140,23 @@ fn quoted_value(text: &str) -> Option<&str> {
     let end = value.as_bytes().iter().position(|byte| *byte == quote)?;
     Some(&value[..end])
 }
+
+pub(super) static PYTHON_REVIEW: ReviewTables = ReviewTables {
+    boundary: Some(&BoundaryKinds {
+        decorator_kinds: &["decorator"],
+        import_kinds: &["import_statement", "import_from_statement"],
+    }),
+    algorithmic: &AlgorithmicKinds {
+        function_kinds: &["function_definition"],
+        loop_kinds: &["for_statement", "while_statement"],
+        call_kinds: &["call"],
+        control_flow_kinds: &[
+            "if_statement",
+            "for_statement",
+            "while_statement",
+            "match_statement",
+            "try_statement",
+        ],
+        if_kinds: &["if_statement"],
+    },
+};

--- a/src/languages/rust/mod.rs
+++ b/src/languages/rust/mod.rs
@@ -3,6 +3,7 @@ use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
 
 mod imports;
+mod review;
 
 use super::ImportExtractor;
 
@@ -23,4 +24,5 @@ pub(super) static RUST: LanguageFrontend = LanguageFrontend {
     }],
     imports: Some(&RUST_IMPORTS),
     taint: None,
+    review: Some(&review::RUST_REVIEW),
 };

--- a/src/languages/rust/review.rs
+++ b/src/languages/rust/review.rs
@@ -1,0 +1,24 @@
+//! Review-signal tables for Rust: boundary node kinds and algorithmic
+//! node-kind sets.
+
+use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
+
+pub(super) static RUST_REVIEW: ReviewTables = ReviewTables {
+    boundary: Some(&BoundaryKinds {
+        decorator_kinds: &["attribute_item", "use_declaration"],
+        import_kinds: &[],
+    }),
+    algorithmic: &AlgorithmicKinds {
+        function_kinds: &["function_item"],
+        loop_kinds: &["for_expression", "while_expression", "loop_expression"],
+        call_kinds: &["call_expression"],
+        control_flow_kinds: &[
+            "if_expression",
+            "for_expression",
+            "while_expression",
+            "loop_expression",
+            "match_expression",
+        ],
+        if_kinds: &["if_expression"],
+    },
+};

--- a/src/languages/tests.rs
+++ b/src/languages/tests.rs
@@ -206,6 +206,50 @@ fn taint_participation_is_pinned() {
     }
 }
 
+/// Pins which frontends carry review-signal tables and whether their AST
+/// boundary classification is wired. C#'s boundary stays `None` on purpose:
+/// the old dispatch matched the label "CSharp" while detection emits "C#",
+/// so enabling it is a deliberate behavior change, not a refactor default.
+#[test]
+fn review_table_coverage_is_pinned() {
+    let with_review: BTreeSet<&str> = [
+        "rust",
+        "typescript",
+        "javascript",
+        "python",
+        "go",
+        "java",
+        "kotlin",
+        "csharp",
+    ]
+    .into_iter()
+    .collect();
+    let without_boundary: BTreeSet<&str> = ["csharp"].into_iter().collect();
+
+    for frontend in all_frontends() {
+        match frontend.review {
+            Some(tables) => {
+                assert!(
+                    with_review.contains(frontend.id),
+                    "frontend '{}' unexpectedly gained review tables; update the pin",
+                    frontend.id
+                );
+                assert_eq!(
+                    tables.boundary.is_none(),
+                    without_boundary.contains(frontend.id),
+                    "boundary wiring changed for frontend '{}'",
+                    frontend.id
+                );
+            }
+            None => assert!(
+                !with_review.contains(frontend.id),
+                "frontend '{}' lost its review tables",
+                frontend.id
+            ),
+        }
+    }
+}
+
 /// The honesty ledger. Languages the bundled pack declares `rule-aware`
 /// whose frontends do not yet justify it. Migration PRs shrink this set by
 /// wiring capabilities (or PR-9 downgrades over-claimed pack declarations —

--- a/src/review/signals/algorithmic.rs
+++ b/src/review/signals/algorithmic.rs
@@ -14,6 +14,7 @@ mod lang;
 
 use crate::review::diff::ChangedFile;
 use crate::review::signals::content::ReviewSource;
+use crate::review::signals::tables::AlgorithmicKinds;
 use crate::scan::language::detect_language;
 use lang::{function_name, is_call_node, is_control_flow_node, is_else_if, is_loop_node};
 use serde::Serialize;
@@ -76,19 +77,22 @@ pub fn detect_algorithmic(
     let Some(post) = post_source else {
         return signals;
     };
-    let Some(language) = detect_language(&file.path) else {
+    let Some(kinds) = detect_language(&file.path)
+        .and_then(crate::languages::review_for_label)
+        .map(|tables| tables.algorithmic)
+    else {
         return signals;
     };
 
     let Some(post_tree) = post.tree() else {
         return signals;
     };
-    let post_fns = collect_functions(post_tree.root_node(), post.content(), language);
+    let post_fns = collect_functions(post_tree.root_node(), post.content(), kinds);
 
     let pre_fns: Vec<FnMetrics> = pre_source
         .map(|src| {
             src.tree()
-                .map(|tree| collect_functions(tree.root_node(), src.content(), language))
+                .map(|tree| collect_functions(tree.root_node(), src.content(), kinds))
                 .unwrap_or_default()
         })
         .unwrap_or_default();
@@ -181,21 +185,30 @@ fn emit_signals(
     }
 }
 
-fn collect_functions(root: Node<'_>, content: &str, language: &str) -> Vec<FnMetrics> {
+fn collect_functions(
+    root: Node<'_>,
+    content: &str,
+    kinds: &'static AlgorithmicKinds,
+) -> Vec<FnMetrics> {
     let mut out = Vec::new();
-    collect_visit(root, content, language, &mut out);
+    collect_visit(root, content, kinds, &mut out);
     out
 }
 
-fn collect_visit(node: Node<'_>, content: &str, language: &str, out: &mut Vec<FnMetrics>) {
-    if let Some(name) = function_name(node, language, content) {
+fn collect_visit(
+    node: Node<'_>,
+    content: &str,
+    kinds: &'static AlgorithmicKinds,
+    out: &mut Vec<FnMetrics>,
+) {
+    if let Some(name) = function_name(node, kinds, content) {
         let start_line = node.start_position().row + 1;
         let end_line = node.end_position().row + 1;
         out.push(FnMetrics {
-            max_nesting: subtree_max_nesting(node, language, 0),
-            has_nested_loop: subtree_has_nested_loop(node, language, false),
+            max_nesting: subtree_max_nesting(node, kinds, 0),
+            has_nested_loop: subtree_has_nested_loop(node, kinds, false),
             line_span: end_line.saturating_sub(start_line) + 1,
-            is_recursive: subtree_calls_function(node, language, content, &name, true),
+            is_recursive: subtree_calls_function(node, kinds, content, &name, true),
             name,
             start_line,
             end_line,
@@ -204,32 +217,36 @@ fn collect_visit(node: Node<'_>, content: &str, language: &str, out: &mut Vec<Fn
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_visit(child, content, language, out);
+        collect_visit(child, content, kinds, out);
     }
 }
 
 /// Deepest control-flow nesting under `node`. `if/else if` chains count once.
-fn subtree_max_nesting(node: Node<'_>, language: &str, depth: usize) -> usize {
-    let is_cf = is_control_flow_node(node.kind(), language) && !is_else_if(node, language);
+fn subtree_max_nesting(node: Node<'_>, kinds: &'static AlgorithmicKinds, depth: usize) -> usize {
+    let is_cf = is_control_flow_node(node.kind(), kinds) && !is_else_if(node, kinds);
     let here = if is_cf { depth + 1 } else { depth };
     let mut max = here;
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        max = max.max(subtree_max_nesting(child, language, here));
+        max = max.max(subtree_max_nesting(child, kinds, here));
     }
     max
 }
 
 /// Whether any loop under `node` sits inside another loop (a potential O(n^2)).
-fn subtree_has_nested_loop(node: Node<'_>, language: &str, inside_loop: bool) -> bool {
-    let is_loop = is_loop_node(node.kind(), language);
+fn subtree_has_nested_loop(
+    node: Node<'_>,
+    kinds: &'static AlgorithmicKinds,
+    inside_loop: bool,
+) -> bool {
+    let is_loop = is_loop_node(node.kind(), kinds);
     if is_loop && inside_loop {
         return true;
     }
     let next = inside_loop || is_loop;
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if subtree_has_nested_loop(child, language, next) {
+        if subtree_has_nested_loop(child, kinds, next) {
             return true;
         }
     }
@@ -238,15 +255,15 @@ fn subtree_has_nested_loop(node: Node<'_>, language: &str, inside_loop: bool) ->
 
 fn subtree_calls_function(
     node: Node<'_>,
-    language: &str,
+    kinds: &'static AlgorithmicKinds,
     content: &str,
     function: &str,
     is_root: bool,
 ) -> bool {
-    if !is_root && function_name(node, language, content).is_some() {
+    if !is_root && function_name(node, kinds, content).is_some() {
         return false;
     }
-    if is_call_node(node, language)
+    if is_call_node(node, kinds)
         && call_target(node, content).is_some_and(|target| {
             target == function
                 || target == format!("self.{function}")
@@ -258,7 +275,7 @@ fn subtree_calls_function(
     }
     let mut cursor = node.walk();
     node.children(&mut cursor)
-        .any(|child| subtree_calls_function(child, language, content, function, false))
+        .any(|child| subtree_calls_function(child, kinds, content, function, false))
 }
 
 fn call_target<'a>(node: Node<'a>, content: &'a str) -> Option<&'a str> {

--- a/src/review/signals/algorithmic/lang.rs
+++ b/src/review/signals/algorithmic/lang.rs
@@ -1,35 +1,19 @@
-//! Per-language tree-sitter node-kind matchers for algorithmic signals.
-//!
-//! Kept separate from the detection logic so the detector stays focused and each
-//! file stays small. These mirror the node sets the code-quality audits use for
-//! the same nine grammars; duplicated here to keep the review signal
-//! self-contained rather than reaching into the audit internals.
+//! Node-kind matchers for algorithmic signals, driven by the language
+//! frontend's [`AlgorithmicKinds`] table so the detector stays
+//! language-neutral.
 
+use crate::review::signals::tables::AlgorithmicKinds;
 use tree_sitter::Node;
 
-/// Returns the declared name when `node` is a named function for `language`.
+/// Returns the declared name when `node` is a named function per the table.
 /// Anonymous functions / arrow callbacks return `None` — they cannot be matched
 /// reliably across the change, and are not the focus of algorithmic signals.
-pub(super) fn function_name(node: Node<'_>, language: &str, content: &str) -> Option<String> {
-    let is_fn = match language {
-        "Rust" => node.kind() == "function_item",
-        "Python" => node.kind() == "function_definition",
-        "Go" => matches!(node.kind(), "function_declaration" | "method_declaration"),
-        "Java" => matches!(
-            node.kind(),
-            "method_declaration" | "constructor_declaration"
-        ),
-        "CSharp" | "C#" => matches!(
-            node.kind(),
-            "method_declaration" | "constructor_declaration" | "local_function_statement"
-        ),
-        "Kotlin" => node.kind() == "function_declaration",
-        _ => matches!(
-            node.kind(),
-            "function_declaration" | "generator_function_declaration" | "method_definition"
-        ),
-    };
-    if !is_fn {
+pub(super) fn function_name(
+    node: Node<'_>,
+    kinds: &AlgorithmicKinds,
+    content: &str,
+) -> Option<String> {
+    if !kinds.function_kinds.contains(&node.kind()) {
         return None;
     }
     let name = node.child_by_field_name("name")?;
@@ -39,123 +23,22 @@ pub(super) fn function_name(node: Node<'_>, language: &str, content: &str) -> Op
         .map(str::to_string)
 }
 
-pub(super) fn is_loop_node(kind: &str, language: &str) -> bool {
-    match language {
-        "Rust" => matches!(
-            kind,
-            "for_expression" | "while_expression" | "loop_expression"
-        ),
-        "Python" => matches!(kind, "for_statement" | "while_statement"),
-        "Go" => kind == "for_statement",
-        "Java" => matches!(
-            kind,
-            "for_statement" | "enhanced_for_statement" | "while_statement" | "do_statement"
-        ),
-        "CSharp" | "C#" => matches!(
-            kind,
-            "for_statement" | "foreach_statement" | "while_statement" | "do_statement"
-        ),
-        "Kotlin" => matches!(
-            kind,
-            "for_statement" | "while_statement" | "do_while_statement"
-        ),
-        _ => matches!(
-            kind,
-            "for_statement"
-                | "for_in_statement"
-                | "for_of_statement"
-                | "while_statement"
-                | "do_statement"
-        ),
-    }
+pub(super) fn is_loop_node(kind: &str, kinds: &AlgorithmicKinds) -> bool {
+    kinds.loop_kinds.contains(&kind)
 }
 
-pub(super) fn is_call_node(node: Node<'_>, language: &str) -> bool {
-    match language {
-        "Python" => node.kind() == "call",
-        "Java" => node.kind() == "method_invocation",
-        "CSharp" | "C#" => node.kind() == "invocation_expression",
-        _ => node.kind() == "call_expression",
-    }
+pub(super) fn is_call_node(node: Node<'_>, kinds: &AlgorithmicKinds) -> bool {
+    kinds.call_kinds.contains(&node.kind())
 }
 
-pub(super) fn is_control_flow_node(kind: &str, language: &str) -> bool {
-    match language {
-        "Rust" => matches!(
-            kind,
-            "if_expression"
-                | "for_expression"
-                | "while_expression"
-                | "loop_expression"
-                | "match_expression"
-        ),
-        "Python" => matches!(
-            kind,
-            "if_statement"
-                | "for_statement"
-                | "while_statement"
-                | "match_statement"
-                | "try_statement"
-        ),
-        "Go" => matches!(
-            kind,
-            "if_statement"
-                | "for_statement"
-                | "expression_switch_statement"
-                | "type_switch_statement"
-                | "select_statement"
-        ),
-        "Java" => matches!(
-            kind,
-            "if_statement"
-                | "for_statement"
-                | "enhanced_for_statement"
-                | "while_statement"
-                | "do_statement"
-                | "switch_statement"
-                | "try_statement"
-        ),
-        "CSharp" | "C#" => matches!(
-            kind,
-            "if_statement"
-                | "for_statement"
-                | "foreach_statement"
-                | "while_statement"
-                | "do_statement"
-                | "switch_statement"
-                | "try_statement"
-        ),
-        "Kotlin" => matches!(
-            kind,
-            "if_expression"
-                | "when_expression"
-                | "for_statement"
-                | "while_statement"
-                | "do_while_statement"
-                | "try_expression"
-        ),
-        _ => matches!(
-            kind,
-            "if_statement"
-                | "for_statement"
-                | "for_in_statement"
-                | "for_of_statement"
-                | "while_statement"
-                | "do_statement"
-                | "switch_statement"
-                | "try_statement"
-        ),
-    }
+pub(super) fn is_control_flow_node(kind: &str, kinds: &AlgorithmicKinds) -> bool {
+    kinds.control_flow_kinds.contains(&kind)
 }
 
 /// Whether `node` is the `if` of an `else if`, so an else-if chain counts as one
 /// level of nesting rather than one per branch.
-pub(super) fn is_else_if(node: Node<'_>, language: &str) -> bool {
-    let is_if = match language {
-        "Rust" | "Kotlin" => node.kind() == "if_expression",
-        _ => node.kind() == "if_statement",
-    };
-    if !is_if {
+pub(super) fn is_else_if(node: Node<'_>, kinds: &AlgorithmicKinds) -> bool {
+    if !kinds.if_kinds.contains(&node.kind()) {
         return false;
     }
     matches!(

--- a/src/review/signals/classify.rs
+++ b/src/review/signals/classify.rs
@@ -320,23 +320,17 @@ fn match_node_for_boundary(
     content: &str,
     language: &str,
 ) -> Option<BoundaryCategory> {
-    // Which node kinds carry a boundary signal differs per language, but the
-    // matching itself is shared and token-aware. `check_request_trust` is only
-    // set for import-like nodes, where a CORS/header library can appear.
-    let check_request_trust = match (language, node.kind()) {
-        ("JavaScript" | "JavaScript React" | "TypeScript" | "TypeScript React", "decorator")
-        | ("Python", "decorator")
-        | ("Rust", "attribute_item" | "use_declaration")
-        | ("Java" | "Kotlin", "annotation")
-        | ("CSharp", "attribute" | "using_directive") => false,
-        (
-            "JavaScript" | "JavaScript React" | "TypeScript" | "TypeScript React",
-            "import_statement" | "export_statement" | "call_expression",
-        )
-        | ("Python", "import_statement" | "import_from_statement")
-        | ("Go", "import_spec" | "import_declaration")
-        | ("Java" | "Kotlin", "import_declaration") => true,
-        _ => return None,
+    // Which node kinds carry a boundary signal comes from the language
+    // frontend's boundary table; the matching itself is shared and
+    // token-aware. `check_request_trust` is only set for import-like nodes,
+    // where a CORS/header library can appear.
+    let kinds = crate::languages::review_for_label(language)?.boundary?;
+    let check_request_trust = if kinds.decorator_kinds.contains(&node.kind()) {
+        false
+    } else if kinds.import_kinds.contains(&node.kind()) {
+        true
+    } else {
+        return None;
     };
 
     let text = node

--- a/src/review/signals/mod.rs
+++ b/src/review/signals/mod.rs
@@ -25,6 +25,7 @@ mod behavioral_tests;
 pub(in crate::review) mod classify;
 pub mod composites;
 pub mod content;
+pub(crate) mod tables;
 pub mod taint;
 #[cfg(test)]
 mod tests;

--- a/src/review/signals/tables.rs
+++ b/src/review/signals/tables.rs
@@ -1,0 +1,41 @@
+//! Per-language review-signal tables owned by the language frontends.
+//!
+//! Like taint's [`TaintTables`](super::taint::tables::TaintTables), these
+//! carry the grammar node-kind sets the review engines consult, so the
+//! engines in [`super::classify`] and [`super::algorithmic`] stay
+//! language-neutral. The keyword vocabularies themselves (auth tokens,
+//! library names) are cross-language and stay in the engines; only node
+//! shapes vary per grammar.
+
+/// Node kinds that can carry a security-boundary name for one language.
+pub struct BoundaryKinds {
+    /// Decorator/annotation/attribute-like nodes — checked for access-control
+    /// vocabulary only (a CORS library cannot appear here).
+    pub(crate) decorator_kinds: &'static [&'static str],
+    /// Import/call-like nodes — checked for access-control vocabulary *and*
+    /// request-trust libraries (CORS / security headers).
+    pub(crate) import_kinds: &'static [&'static str],
+}
+
+/// Node kinds backing the algorithmic-shift signals for one language.
+pub struct AlgorithmicKinds {
+    /// Named-function declaration kinds (anonymous functions are skipped).
+    pub(crate) function_kinds: &'static [&'static str],
+    /// Loop statement/expression kinds.
+    pub(crate) loop_kinds: &'static [&'static str],
+    /// Call node kinds, for recursion detection.
+    pub(crate) call_kinds: &'static [&'static str],
+    /// Control-flow kinds that add a nesting level.
+    pub(crate) control_flow_kinds: &'static [&'static str],
+    /// `if` kinds, for collapsing `else if` chains to one nesting level.
+    pub(crate) if_kinds: &'static [&'static str],
+}
+
+/// The review-signal tables a frontend registers.
+pub struct ReviewTables {
+    /// Boundary node kinds; `None` when the language's AST boundary
+    /// classification is not wired (C# today — its label never matched the
+    /// old dispatch, and enabling it is a behavior change for a later PR).
+    pub(crate) boundary: Option<&'static BoundaryKinds>,
+    pub(crate) algorithmic: &'static AlgorithmicKinds,
+}


### PR DESCRIPTION
## Summary

Moves boundary and algorithmic review configuration into the language frontend registry.

Per-language AST node kinds now live in `ReviewTables` owned by each frontend. The shared review engines keep the common matching logic and no longer dispatch on language labels.

This is a behavior-preserving refactor.

## Type of change

* [ ] Feature
* [x] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added `ReviewTables` to `LanguageFrontend`.
* Added separate `BoundaryKinds` and `AlgorithmicKinds` contracts.
* Moved boundary node kinds into the JavaScript/TypeScript, Python, Go, Java, Kotlin, and Rust frontends.
* Moved algorithmic function, loop, call, control-flow, and conditional node kinds into the frontends.
* Routed boundary classification through `review_for_label`.
* Routed algorithmic matchers through the same frontend tables.
* Removed language-label matches from the shared boundary and algorithmic engines.
* Added `ReviewSignals` to computed frontend capabilities.
* Added a guard test that pins which frontends provide review tables.
* Updated the language surface inventory.

## Behavior

The following behavior is intended to remain unchanged:

* boundary signal matching;
* algorithmic signal matching;
* function and loop detection;
* nesting and growth signals;
* signal IDs and evidence;
* review tiers and gates;
* JSON, SARIF, MCP, and GitHub Action output.

Shared keyword vocabularies remain in the review engine. Only language-specific AST node kinds moved into the frontends.

## C# boundary handling

C# keeps its algorithmic tables, but AST boundary classification remains disabled.

The previous code matched the label:

```
CSharp
```

while normal detection emits:

```
C#
```

That branch was therefore not reached in practice.

This PR documents and pins the existing behavior rather than enabling a new C# signal during a refactor. Enabling it should be handled as a separate behavior change with dedicated tests.

## Why

Boundary and algorithmic analysis still contained hardcoded language matches even after parsing, imports, and taint configuration moved into the frontend registry.

That left language-specific AST knowledge split between the registry and review engines.

After this change, the frontends own their node-kind vocabulary, while the engines remain responsible for language-neutral matching and signal construction.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] No unrelated refactor or generated-file churn is included

Primary subsystems:

* language frontend registry;
* boundary review signals;
* algorithmic review signals.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```

Focused verification:

```
cargo test --lib languages
cargo test --lib review::signals::classify
cargo test --lib review::signals::algorithmic
cargo test --test review_zoo
```
