### PR TITLE
refactor(languages): move removed-behavior recognizers into frontends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- **Removed-behavior recognizers live on the language frontends.** The
+  extension-dispatched AST walks that detect deleted tests, removed error
+  handling, and removed auth checks now consult per-frontend
+  `RemovedTables`; the walk engine is language-neutral and the extension
+  vocabulary (including the historically unreachable `cts`) is pinned by a
+  guard test. The coarse text fallback for frontend-less languages is
+  unchanged by design. Behavior-frozen refactor.
 - **Boundary and algorithmic review signals are table-driven per language
   frontend.** The per-language node-kind sets behind
   `match_node_for_boundary` and the algorithmic matchers moved to

--- a/docs/engineering/language-surface-inventory.md
+++ b/docs/engineering/language-surface-inventory.md
@@ -71,15 +71,21 @@ design (with reason).
       `taint/sinks.rs` (model) and `taint/ast.rs`. Equivalence evidence: the
       taint test suite unchanged and green, plus the wagtail agent demo
       firing identical signals. (PR-4a)
-- [ ] `src/review/signals/behavioral/keywords.rs:21` — auth keyword
-      vocabulary (strong/exact tokens, mutation verbs). Mostly
-      language-neutral English identifiers; stays shared, but per-frontend
-      *additions* (e.g. Spring `@PreAuthorize`) become table entries. → PR-4.
-- [ ] `src/review/signals/behavioral/removed_ast.rs` — per-language AST
-      queries counting auth checks / try blocks / test cases. → PR-4.
-- [ ] `src/review/signals/behavioral/removed.rs:154` —
-      `supports_coarse_removed_detection(ext)`: extension allowlist for the
-      text fallback. → PR-4.
+- [-] `src/review/signals/behavioral/keywords.rs` — auth keyword vocabulary
+      (strong/exact tokens, mutation verbs). Language-neutral English
+      identifiers; stays shared by design. Per-frontend *additions* (e.g.
+      Spring `@PreAuthorize`) arrive with the Java promotion (PR-8).
+- [x] `src/review/signals/behavioral/removed_ast.rs` — the walks consult the
+      frontend's `RemovedTables` (test-case / error-handling recognizers,
+      auth call kinds), dispatched by extension exactly as before; a file no
+      frontend claims counts zero everywhere, matching the old fall-through.
+      Extension vocabulary pinned (uniqueness + the knowingly-dead `cts`) by
+      `removed_recognizer_extensions_are_pinned`. (PR-4c)
+- [-] `src/review/signals/behavioral/removed.rs` —
+      `supports_coarse_removed_detection(ext)`: the coarse text fallback
+      covers languages that deliberately have *no* frontend (shell, C/C++,
+      PHP, Ruby, Swift). It is fallback policy, not a frontend capability;
+      revisit only when those languages gain frontends.
 - [x] `src/review/signals/classify.rs` — `match_node_for_boundary` takes its
       node kinds from the frontend's `BoundaryKinds` table; keyword
       vocabularies stay shared in the engine. C#'s boundary is deliberately

--- a/src/languages/csharp/mod.rs
+++ b/src/languages/csharp/mod.rs
@@ -1,7 +1,7 @@
 use super::{GrammarBinding, LanguageFrontend};
 use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
-use crate::review::signals::tables::{AlgorithmicKinds, ReviewTables};
+use crate::review::signals::tables::{AlgorithmicKinds, RemovedTables, ReviewTables};
 
 pub(super) static CSHARP: LanguageFrontend = LanguageFrontend {
     id: "csharp",
@@ -55,4 +55,17 @@ static CSHARP_REVIEW: ReviewTables = ReviewTables {
         ],
         if_kinds: &["if_statement"],
     },
+    removed: Some(&CSHARP_REMOVED),
+};
+
+static CSHARP_REMOVED: RemovedTables = RemovedTables {
+    extensions: &["cs"],
+    is_test_case: |node, content| {
+        node.kind() == "method_declaration"
+            && node.utf8_text(content.as_bytes()).is_ok_and(|text| {
+                text.contains("[Test]") || text.contains("[TestMethod]") || text.contains("[Fact]")
+            })
+    },
+    is_error_handling: |node, _| node.kind() == "try_statement",
+    auth_call_kinds: &["invocation_expression"],
 };

--- a/src/languages/go/review.rs
+++ b/src/languages/go/review.rs
@@ -1,7 +1,9 @@
 //! Taint tables for Go. Source idioms target net/http and Gin; sinks mirror
 //! the behavioral "added X" detectors.
 
-use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
+use crate::review::signals::tables::{
+    AlgorithmicKinds, BoundaryKinds, RemovedTables, ReviewTables,
+};
 use crate::review::signals::taint::ast::callee_starts_with;
 use crate::review::signals::taint::sinks::{Sink, SinkKind, callee_text};
 use crate::review::signals::taint::tables::TaintTables;
@@ -132,4 +134,26 @@ pub(super) static GO_REVIEW: ReviewTables = ReviewTables {
         ],
         if_kinds: &["if_statement"],
     },
+    removed: Some(&GO_REMOVED),
+};
+
+pub(super) static GO_REMOVED: RemovedTables = RemovedTables {
+    extensions: &["go"],
+    is_test_case: |node, content| {
+        node.kind() == "function_declaration"
+            && node
+                .child_by_field_name("name")
+                .and_then(|name| name.utf8_text(content.as_bytes()).ok())
+                .is_some_and(|name| name.starts_with("Test"))
+    },
+    // Inspect only the `if` condition, not the whole statement body, so a
+    // nested `if err != nil` does not inflate the enclosing block's count.
+    is_error_handling: |node, content| {
+        node.kind() == "if_statement"
+            && node
+                .child_by_field_name("condition")
+                .and_then(|cond| cond.utf8_text(content.as_bytes()).ok())
+                .is_some_and(|cond| cond.contains("err") && cond.contains("nil"))
+    },
+    auth_call_kinds: &["call_expression"],
 };

--- a/src/languages/java/review.rs
+++ b/src/languages/java/review.rs
@@ -1,7 +1,9 @@
 //! Review-signal tables for Java: boundary node kinds and algorithmic
 //! node-kind sets.
 
-use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
+use crate::review::signals::tables::{
+    AlgorithmicKinds, BoundaryKinds, RemovedTables, ReviewTables,
+};
 
 pub(super) static JAVA_REVIEW: ReviewTables = ReviewTables {
     boundary: Some(&BoundaryKinds {
@@ -28,4 +30,17 @@ pub(super) static JAVA_REVIEW: ReviewTables = ReviewTables {
         ],
         if_kinds: &["if_statement"],
     },
+    removed: Some(&JAVA_REMOVED),
+};
+
+pub(super) static JAVA_REMOVED: RemovedTables = RemovedTables {
+    extensions: &["java"],
+    is_test_case: |node, content| {
+        (node.kind() == "method_declaration" || node.kind() == "function_declaration")
+            && node
+                .utf8_text(content.as_bytes())
+                .is_ok_and(|text| text.contains("@Test"))
+    },
+    is_error_handling: |node, _| node.kind() == "try_statement",
+    auth_call_kinds: &["method_invocation", "call_expression"],
 };

--- a/src/languages/javascript/review.rs
+++ b/src/languages/javascript/review.rs
@@ -2,7 +2,9 @@
 //! share a grammar shape, so one table covers both frontends. Source idioms
 //! target Express/Koa; sinks mirror the behavioral "added X" detectors.
 
-use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
+use crate::review::signals::tables::{
+    AlgorithmicKinds, BoundaryKinds, RemovedTables, ReviewTables,
+};
 use crate::review::signals::taint::sinks::{Sink, SinkKind, callee_text, receiver_method};
 use crate::review::signals::taint::tables::TaintTables;
 use tree_sitter::Node;
@@ -143,4 +145,21 @@ pub(super) static JS_FAMILY_REVIEW: ReviewTables = ReviewTables {
         ],
         if_kinds: &["if_statement"],
     },
+    removed: Some(&JS_FAMILY_REMOVED),
+};
+
+pub(super) static JS_FAMILY_REMOVED: RemovedTables = RemovedTables {
+    extensions: &["js", "mjs", "cjs", "ts", "mts", "cts", "tsx", "jsx"],
+    is_test_case: |node, content| {
+        node.kind() == "call_expression"
+            && node
+                .child_by_field_name("function")
+                .and_then(|callee| callee.utf8_text(content.as_bytes()).ok())
+                .is_some_and(|callee| {
+                    let callee = callee.trim();
+                    callee == "test" || callee == "it" || callee == "describe"
+                })
+    },
+    is_error_handling: |node, _| node.kind() == "try_statement",
+    auth_call_kinds: &["call_expression"],
 };

--- a/src/languages/kotlin/review.rs
+++ b/src/languages/kotlin/review.rs
@@ -1,7 +1,9 @@
 //! Review-signal tables for Kotlin: boundary node kinds and algorithmic
 //! node-kind sets.
 
-use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
+use crate::review::signals::tables::{
+    AlgorithmicKinds, BoundaryKinds, RemovedTables, ReviewTables,
+};
 
 pub(super) static KOTLIN_REVIEW: ReviewTables = ReviewTables {
     boundary: Some(&BoundaryKinds {
@@ -22,4 +24,17 @@ pub(super) static KOTLIN_REVIEW: ReviewTables = ReviewTables {
         ],
         if_kinds: &["if_expression"],
     },
+    removed: Some(&KOTLIN_REMOVED),
+};
+
+pub(super) static KOTLIN_REMOVED: RemovedTables = RemovedTables {
+    extensions: &["kt", "kts"],
+    is_test_case: |node, content| {
+        (node.kind() == "method_declaration" || node.kind() == "function_declaration")
+            && node
+                .utf8_text(content.as_bytes())
+                .is_ok_and(|text| text.contains("@Test"))
+    },
+    is_error_handling: |node, _| node.kind() == "try_expression",
+    auth_call_kinds: &["method_invocation", "call_expression"],
 };

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -206,3 +206,17 @@ pub(crate) fn review_for_label(
 ) -> Option<&'static crate::review::signals::tables::ReviewTables> {
     frontend_for_label(label).and_then(|frontend| frontend.review)
 }
+
+/// The removed-behavior recognizers claiming a file extension, if any. This
+/// dispatch predates label-based detection; the extension lists live on the
+/// tables verbatim and the guard tests keep them from drifting or colliding.
+pub(crate) fn removed_for_extension(
+    ext: &str,
+) -> Option<&'static crate::review::signals::tables::RemovedTables> {
+    all_frontends().iter().find_map(|frontend| {
+        frontend
+            .review
+            .and_then(|review| review.removed)
+            .filter(|removed| removed.extensions.contains(&ext))
+    })
+}

--- a/src/languages/python/review.rs
+++ b/src/languages/python/review.rs
@@ -1,7 +1,9 @@
 //! Taint tables for Python. Source idioms target Flask/Django/FastAPI; sinks
 //! mirror the behavioral "added X" detectors.
 
-use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
+use crate::review::signals::tables::{
+    AlgorithmicKinds, BoundaryKinds, RemovedTables, ReviewTables,
+};
 use crate::review::signals::taint::ast::{callee_ends_with, has_descendant_kind};
 use crate::review::signals::taint::sinks::{Sink, SinkKind, callee_text, receiver_method};
 use crate::review::signals::taint::tables::TaintTables;
@@ -159,4 +161,18 @@ pub(super) static PYTHON_REVIEW: ReviewTables = ReviewTables {
         ],
         if_kinds: &["if_statement"],
     },
+    removed: Some(&PYTHON_REMOVED),
+};
+
+pub(super) static PYTHON_REMOVED: RemovedTables = RemovedTables {
+    extensions: &["py"],
+    is_test_case: |node, content| {
+        node.kind() == "function_definition"
+            && node
+                .child_by_field_name("name")
+                .and_then(|name| name.utf8_text(content.as_bytes()).ok())
+                .is_some_and(|name| name.starts_with("test_"))
+    },
+    is_error_handling: |node, _| node.kind() == "try_statement",
+    auth_call_kinds: &["call"],
 };

--- a/src/languages/rust/review.rs
+++ b/src/languages/rust/review.rs
@@ -1,7 +1,10 @@
 //! Review-signal tables for Rust: boundary node kinds and algorithmic
 //! node-kind sets.
 
-use crate::review::signals::tables::{AlgorithmicKinds, BoundaryKinds, ReviewTables};
+use crate::review::signals::behavioral::removed_ast::callee_text;
+use crate::review::signals::tables::{
+    AlgorithmicKinds, BoundaryKinds, RemovedTables, ReviewTables,
+};
 
 pub(super) static RUST_REVIEW: ReviewTables = ReviewTables {
     boundary: Some(&BoundaryKinds {
@@ -21,4 +24,28 @@ pub(super) static RUST_REVIEW: ReviewTables = ReviewTables {
         ],
         if_kinds: &["if_expression"],
     },
+    removed: Some(&RUST_REMOVED),
+};
+
+pub(super) static RUST_REMOVED: RemovedTables = RemovedTables {
+    extensions: &["rs"],
+    is_test_case: |node, content| {
+        node.kind() == "function_item"
+            && node
+                .utf8_text(content.as_bytes())
+                .is_ok_and(|text| text.contains("#[test]"))
+    },
+    is_error_handling: |node, content| {
+        let kind = node.kind();
+        let text = node.utf8_text(content.as_bytes()).unwrap_or("");
+        (kind == "match_expression" && text.contains("Err("))
+            || (kind == "if_let_expression" && text.contains("Err("))
+            // Match on the callee (`x.map_err`), not the whole call, so a
+            // `.unwrap_or` buried in an argument does not double-count.
+            || (kind == "call_expression"
+                && callee_text(node, content).is_some_and(|callee: &str| {
+                    callee.contains(".unwrap_or") || callee.contains(".map_err")
+                }))
+    },
+    auth_call_kinds: &["call_expression"],
 };

--- a/src/languages/tests.rs
+++ b/src/languages/tests.rs
@@ -250,6 +250,58 @@ fn review_table_coverage_is_pinned() {
     }
 }
 
+/// Pins the removed-behavior recognizer coverage: which frontends carry one
+/// and the exact extension vocabulary, and that no extension is claimed
+/// twice. `cts` is knowingly unreachable (detection never labels it) —
+/// preserved verbatim from the pre-registry dispatch, not an endorsement.
+#[test]
+fn removed_recognizer_extensions_are_pinned() {
+    let expected: BTreeMap<&str, usize> = [
+        ("js", 2),
+        ("mjs", 2),
+        ("cjs", 2),
+        ("ts", 2),
+        ("mts", 2),
+        ("cts", 2),
+        ("tsx", 2),
+        ("jsx", 2),
+        ("py", 1),
+        ("go", 1),
+        ("rs", 1),
+        ("java", 1),
+        ("kt", 1),
+        ("kts", 1),
+        ("cs", 1),
+    ]
+    .into_iter()
+    .collect();
+
+    let mut claims: BTreeMap<&str, usize> = BTreeMap::new();
+    for frontend in all_frontends() {
+        let Some(removed) = frontend.review.and_then(|review| review.removed) else {
+            continue;
+        };
+        for ext in removed.extensions {
+            *claims.entry(ext).or_default() += 1;
+        }
+    }
+
+    // The JS family table is shared by the typescript and javascript
+    // frontends, so its extensions are claimed twice — by the same static.
+    // Everything else must be claimed exactly once.
+    assert_eq!(
+        claims, expected,
+        "removed-recognizer extension vocabulary drifted"
+    );
+
+    for ext in expected.keys() {
+        assert!(
+            crate::languages::removed_for_extension(ext).is_some(),
+            "extension '{ext}' lost its removed-behavior recognizer"
+        );
+    }
+}
+
 /// The honesty ledger. Languages the bundled pack declares `rule-aware`
 /// whose frontends do not yet justify it. Migration PRs shrink this set by
 /// wiring capabilities (or PR-9 downgrades over-claimed pack declarations —

--- a/src/review/signals/behavioral.rs
+++ b/src/review/signals/behavioral.rs
@@ -25,7 +25,7 @@ mod jvm;
 mod keywords;
 mod python;
 mod removed;
-mod removed_ast;
+pub(crate) mod removed_ast;
 mod rust;
 
 pub use removed::detect_behavioral_removed;

--- a/src/review/signals/behavioral/removed_ast.rs
+++ b/src/review/signals/behavioral/removed_ast.rs
@@ -1,17 +1,23 @@
 //! AST walks backing the "removed behavioral signal" detectors in
 //! [`super::removed`]: counting test cases, try/catch (error-handling) blocks,
-//! and auth-check calls within the changed ranges of a diff.
+//! and auth-check calls within the changed ranges of a diff. The per-language
+//! recognizers live on the language frontends
+//! ([`RemovedTables`](crate::review::signals::tables::RemovedTables),
+//! extension-dispatched); a file whose extension no frontend claims counts
+//! zero everywhere, exactly like the old fall-through arms.
 
 use super::keywords;
+use crate::languages::removed_for_extension;
 use crate::review::diff::ChangedFile;
 use crate::review::signals::content::ReviewSource;
+use crate::review::signals::tables::RemovedTables;
 use tree_sitter::{Node, Tree};
 
 /// The callee portion of a call node — its `object.method` path with the argument
 /// list stripped off, so matching never sees arguments or string literals.
 /// `getUserProfile(session.userId)` yields `getUserProfile`, not the whole call.
 /// Falls back to the `function`/`name` field when there is no `arguments` child.
-fn callee_text<'a>(node: Node<'_>, content: &'a str) -> Option<&'a str> {
+pub(crate) fn callee_text<'a>(node: Node<'_>, content: &'a str) -> Option<&'a str> {
     if let Some(args) = node.child_by_field_name("arguments") {
         return content
             .get(node.start_byte()..args.start_byte())
@@ -28,66 +34,20 @@ pub(super) fn count_test_cases(source: &ReviewSource, ext: &str) -> Option<usize
     let tree = source.tree()?;
     let content = source.content();
     let mut count = 0;
-    walk_tests(tree.root_node(), content, ext, &mut count);
+    if let Some(tables) = removed_for_extension(ext) {
+        walk_tests(tree.root_node(), content, tables, &mut count);
+    }
     Some(count)
 }
 
-fn walk_tests(node: Node<'_>, content: &str, ext: &str, count: &mut usize) {
-    let kind = node.kind();
-    let text = node.utf8_text(content.as_bytes()).unwrap_or("");
-
-    match ext {
-        "js" | "mjs" | "cjs" | "ts" | "mts" | "cts" | "tsx" | "jsx" => {
-            if kind == "call_expression"
-                && let Some(callee) = node.child_by_field_name("function")
-                && let Ok(callee_text) = callee.utf8_text(content.as_bytes())
-            {
-                let val = callee_text.trim();
-                if val == "test" || val == "it" || val == "describe" {
-                    *count += 1;
-                }
-            }
-        }
-        "py" => {
-            if kind == "function_definition"
-                && let Some(name_node) = node.child_by_field_name("name")
-                && let Ok(name_text) = name_node.utf8_text(content.as_bytes())
-                && name_text.starts_with("test_")
-            {
-                *count += 1;
-            }
-        }
-        "go" => {
-            if kind == "function_declaration"
-                && let Some(name_node) = node.child_by_field_name("name")
-                && let Ok(name_text) = name_node.utf8_text(content.as_bytes())
-                && name_text.starts_with("Test")
-            {
-                *count += 1;
-            }
-        }
-        "rs" if kind == "function_item" && text.contains("#[test]") => {
-            *count += 1;
-        }
-        "java" | "kt" | "kts"
-            if (kind == "method_declaration" || kind == "function_declaration")
-                && text.contains("@Test") =>
-        {
-            *count += 1;
-        }
-        "cs" if kind == "method_declaration"
-            && (text.contains("[Test]")
-                || text.contains("[TestMethod]")
-                || text.contains("[Fact]")) =>
-        {
-            *count += 1;
-        }
-        _ => {}
+fn walk_tests(node: Node<'_>, content: &str, tables: &'static RemovedTables, count: &mut usize) {
+    if (tables.is_test_case)(node, content) {
+        *count += 1;
     }
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_tests(child, content, ext, count);
+        walk_tests(child, content, tables, count);
     }
 }
 
@@ -99,8 +59,11 @@ pub(super) fn count_try_blocks(
     ext: &str,
     is_pre: bool,
 ) -> usize {
+    let Some(tables) = removed_for_extension(ext) else {
+        return 0;
+    };
     let mut count = 0;
-    walk_try(tree.root_node(), content, file, ext, is_pre, &mut count);
+    walk_try(tree.root_node(), content, file, tables, is_pre, &mut count);
     count
 }
 
@@ -108,7 +71,7 @@ fn walk_try(
     node: Node<'_>,
     content: &str,
     file: &ChangedFile,
-    ext: &str,
+    tables: &'static RemovedTables,
     is_pre: bool,
     count: &mut usize,
 ) {
@@ -125,44 +88,13 @@ fn walk_try(
         file.contains_line(line)
     };
 
-    if inside {
-        let kind = node.kind();
-        let text = node.utf8_text(content.as_bytes()).unwrap_or("");
-
-        let is_try = match ext {
-            "js" | "mjs" | "cjs" | "ts" | "mts" | "cts" | "tsx" | "jsx" => kind == "try_statement",
-            "py" => kind == "try_statement",
-            "java" | "cs" => kind == "try_statement",
-            "kt" | "kts" => kind == "try_expression",
-            // Inspect only the `if` condition, not the whole statement body, so a
-            // nested `if err != nil` does not inflate the enclosing block's count.
-            "go" => {
-                kind == "if_statement"
-                    && node
-                        .child_by_field_name("condition")
-                        .and_then(|cond| cond.utf8_text(content.as_bytes()).ok())
-                        .is_some_and(|cond| cond.contains("err") && cond.contains("nil"))
-            }
-            "rs" => {
-                (kind == "match_expression" && text.contains("Err("))
-                    || (kind == "if_let_expression" && text.contains("Err("))
-                    // Match on the callee (`x.map_err`), not the whole call, so a
-                    // `.unwrap_or` buried in an argument does not double-count.
-                    || (kind == "call_expression"
-                        && callee_text(node, content).is_some_and(|callee| {
-                            callee.contains(".unwrap_or") || callee.contains(".map_err")
-                        }))
-            }
-            _ => false,
-        };
-        if is_try {
-            *count += 1;
-        }
+    if inside && (tables.is_error_handling)(node, content) {
+        *count += 1;
     }
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_try(child, content, file, ext, is_pre, count);
+        walk_try(child, content, file, tables, is_pre, count);
     }
 }
 
@@ -175,8 +107,11 @@ pub(super) fn count_auth_checks(
     ext: &str,
     is_pre: bool,
 ) -> usize {
+    let Some(tables) = removed_for_extension(ext) else {
+        return 0;
+    };
     let mut count = 0;
-    walk_auth(tree.root_node(), content, file, ext, is_pre, &mut count);
+    walk_auth(tree.root_node(), content, file, tables, is_pre, &mut count);
     count
 }
 
@@ -184,7 +119,7 @@ fn walk_auth(
     node: Node<'_>,
     content: &str,
     file: &ChangedFile,
-    ext: &str,
+    tables: &'static RemovedTables,
     is_pre: bool,
     count: &mut usize,
 ) {
@@ -201,33 +136,20 @@ fn walk_auth(
         file.contains_line(line)
     };
 
-    if inside {
-        let kind = node.kind();
-        let is_call = match ext {
-            "js" | "mjs" | "cjs" | "ts" | "mts" | "cts" | "tsx" | "jsx" => {
-                kind == "call_expression"
-            }
-            "py" => kind == "call",
-            "go" => kind == "call_expression",
-            "rs" => kind == "call_expression",
-            "java" | "kt" | "kts" => kind == "method_invocation" || kind == "call_expression",
-            "cs" => kind == "invocation_expression",
-            _ => false,
-        };
-        // Match only the callee (its `object.method` path), never the arguments
-        // or string literals, and count each call node once — so
-        // `getUserProfile(session.userId)` and `log("authenticate")` do not fire,
-        // and nested calls cannot inflate the count.
-        if is_call
-            && let Some(callee) = callee_text(node, content)
-            && keywords::callee_is_auth_check(callee)
-        {
-            *count += 1;
-        }
+    // Match only the callee (its `object.method` path), never the arguments
+    // or string literals, and count each call node once — so
+    // `getUserProfile(session.userId)` and `log("authenticate")` do not fire,
+    // and nested calls cannot inflate the count.
+    if inside
+        && tables.auth_call_kinds.contains(&node.kind())
+        && let Some(callee) = callee_text(node, content)
+        && keywords::callee_is_auth_check(callee)
+    {
+        *count += 1;
     }
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_auth(child, content, file, ext, is_pre, count);
+        walk_auth(child, content, file, tables, is_pre, count);
     }
 }

--- a/src/review/signals/tables.rs
+++ b/src/review/signals/tables.rs
@@ -31,6 +31,22 @@ pub struct AlgorithmicKinds {
     pub(crate) if_kinds: &'static [&'static str],
 }
 
+/// Recognizers for the "removed behavioral signal" detectors (deleted tests,
+/// removed error handling, removed auth checks).
+pub struct RemovedTables {
+    /// Extensions this table answers for. This dispatch predates label-based
+    /// detection and is kept verbatim — including `cts`, which detection
+    /// never labels today, preserved as-is rather than silently dropped.
+    pub(crate) extensions: &'static [&'static str],
+    /// Whether a node declares one test case (`it(...)`, `def test_…`, …).
+    pub(crate) is_test_case: for<'a> fn(tree_sitter::Node<'a>, &'a str) -> bool,
+    /// Whether a node is an error-handling construct (try/catch,
+    /// `if err != nil`, `match … Err(…)`).
+    pub(crate) is_error_handling: for<'a> fn(tree_sitter::Node<'a>, &'a str) -> bool,
+    /// Call node kinds inspected for auth-check callees.
+    pub(crate) auth_call_kinds: &'static [&'static str],
+}
+
 /// The review-signal tables a frontend registers.
 pub struct ReviewTables {
     /// Boundary node kinds; `None` when the language's AST boundary
@@ -38,4 +54,6 @@ pub struct ReviewTables {
     /// old dispatch, and enabling it is a behavior change for a later PR).
     pub(crate) boundary: Option<&'static BoundaryKinds>,
     pub(crate) algorithmic: &'static AlgorithmicKinds,
+    /// Removed-behavior recognizers; extension-dispatched (legacy).
+    pub(crate) removed: Option<&'static RemovedTables>,
 }


### PR DESCRIPTION
## Summary

Moves removed-behavior recognition into the language frontend registry.

Detection of removed tests, removed error handling, and removed auth checks now uses per-language `RemovedTables` instead of extension-based dispatch inside the shared review engine.

This is a behavior-preserving refactor.

## Type of change

* [ ] Feature
* [x] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added `RemovedTables` to the existing frontend review contract.
* Added removed-behavior recognizers for Rust, JavaScript/TypeScript, Python, Go, Java, Kotlin, and C#.
* Moved test-case recognition into language frontends.
* Moved error-handling recognition into language frontends.
* Moved auth-call node kinds into language frontends.
* Replaced the old extension-based AST dispatch with `removed_for_extension`.
* Kept the shared AST traversal and signal construction language-neutral.
* Added a guard test for extension ownership and duplicate claims.
* Updated the language surface inventory.

## Behavior

The following behavior is intended to remain unchanged:

* removed-test detection;
* removed error-handling detection;
* removed auth-check detection;
* signal IDs and evidence;
* review tiers and gates;
* JSON, SARIF, MCP, and GitHub Action output.

The existing coarse text fallback is unchanged for languages without a frontend, including shell, C/C++, PHP, Ruby, and Swift.

## Extension coverage

Removed-behavior recognizers are registered for:

* `rs`;
* `js`, `mjs`, `cjs`;
* `ts`, `mts`, `cts`, `tsx`, `jsx`;
* `py`;
* `go`;
* `java`;
* `kt`, `kts`;
* `cs`.

The `cts` extension remains in the pinned vocabulary because it existed in the previous dispatch, even though current detection does not emit it. This PR preserves that behavior rather than changing support during a refactor.

## Why

Removed-behavior detection still kept language-specific AST rules inside a shared module and selected them by file extension.

That duplicated the frontend registry and made it harder to see which languages actually supported these recognizers.

After this change, each frontend owns its AST vocabulary, while the review engine remains responsible for traversal, comparison, and signal generation.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] No unrelated refactor or generated-file churn is included

Primary subsystems:

* language frontend registry;
* behavioral review signals;
* removed test, error-handling, and auth recognition.


## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```

Focused verification:

```
cargo test --lib languages
cargo test --lib review::signals::behavioral
cargo test --test review_zoo
```
