### PR TITLE
refactor(languages): move runtime-risk dispatch into frontends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- **Runtime-risk detection dispatches through the language frontends.** The
+  runtime-risk audit consults the frontend's `RiskTables` (AST emitter,
+  line-scanner fallback, comment-sanitizer choice) instead of matching
+  language ids in two places; pattern definitions stay with their emitters
+  and participation is pinned by a guard test. Rust's dedicated panic-risk
+  audit is unchanged. Behavior-frozen refactor: zoo snapshots unchanged
+  across seven repos covering all six runtime-risk languages.
 - **Removed-behavior recognizers live on the language frontends.** The
   extension-dispatched AST walks that detect deleted tests, removed error
   handling, and removed auth checks now consult per-frontend

--- a/docs/engineering/language-surface-inventory.md
+++ b/docs/engineering/language-surface-inventory.md
@@ -98,13 +98,19 @@ design (with reason).
 
 ## Runtime risk and code-quality spans
 
-- [ ] `src/audits/code_quality/language_risk.rs:68` —
-      `is_ast_runtime_language(language_id)` allowlist +
-      `language_risk/{js,go,python,managed}.rs` pattern modules. → PR-5
-      (`frontend().risk`).
-- [ ] `src/audits/code_quality/rust_panic_risk/` — Rust-only audit wired as
-      its own rule family; pattern data joins the Rust frontend, severity
-      calibration stays in the Knowledge Engine. → PR-5.
+- [x] `src/audits/code_quality/language_risk.rs` — the audit dispatches via
+      `frontend.risk` (`RiskTables`: AST emitter + line-scanner emitter +
+      sanitizer choice); the `is_ast_runtime_language` allowlist and both
+      per-language match dispatchers are gone. Pattern definitions stay with
+      their emitters in `language_risk/{js,go,python,managed}.rs`; frontends
+      reference them. Pinned by `runtime_risk_participation_is_pinned`.
+      (PR-5)
+- [-] `src/audits/code_quality/rust_panic_risk/` — stays a dedicated
+      Rust-only audit (own rule family, severity calibration in the
+      Knowledge Engine). It contains no cross-language dispatch to migrate;
+      how it counts toward the Rust frontend's computed capability is an
+      honesty-pass decision (PR-9), pinned meanwhile by the risk
+      participation guard.
 - [ ] `src/audits/code_quality/function_spans.rs:42` — function-node kinds
       per label (long/complex function). → PR-5.
 - [ ] `src/audits/code_quality/long_function/brace.rs`,

--- a/src/audits/code_quality/language_risk.rs
+++ b/src/audits/code_quality/language_risk.rs
@@ -37,47 +37,38 @@ impl LanguageRiskAudit {
             return vec![];
         };
 
-        let Some(language_id) = file.language.as_deref().and_then(language_id_for_name) else {
+        let Some(risk) = file
+            .language
+            .as_deref()
+            .and_then(language_id_for_name)
+            .and_then(crate::languages::frontend_for_knowledge_id)
+            .and_then(|frontend| frontend.risk)
+        else {
             return vec![];
         };
-
-        if !is_ast_runtime_language(language_id) {
-            // Languages without an AST runtime detector (Go, Java/Kotlin, C#)
-            // keep the sanitized line scanner and text-heuristic provenance.
-            return detect_language_risks(language_id, content, &file.path, file);
-        }
 
         match parsed.tree() {
             Some(tree) => {
                 let mut findings = Vec::new();
-                emit_findings_for_tree(language_id, tree, content, &file.path, file, &mut findings);
+                tables::walk_tree_with(
+                    risk.emit_node,
+                    tree,
+                    content,
+                    &file.path,
+                    file,
+                    &mut findings,
+                );
                 findings
             }
             None => {
                 // The file did not parse; fall back to the line scanner but keep
                 // provenance honest by stamping the findings as text-heuristic.
-                let mut findings = detect_language_risks(language_id, content, &file.path, file);
+                let mut findings = detect_language_risks(risk, content, &file.path, file);
                 mark_text_heuristic(&mut findings);
                 findings
             }
         }
     }
-}
-
-/// Runtime-risk languages with an AST detector (matched from the syntax tree).
-fn is_ast_runtime_language(language_id: &str) -> bool {
-    matches!(
-        language_id,
-        "python"
-            | "go"
-            | "typescript"
-            | "typescript-react"
-            | "javascript"
-            | "javascript-react"
-            | "java"
-            | "kotlin"
-            | "csharp"
-    )
 }
 
 /// Overrides provenance for line-scanner fallback findings so they report
@@ -99,7 +90,7 @@ fn mark_text_heuristic(findings: &mut [Finding]) {
 }
 
 fn detect_language_risks(
-    language_id: &str,
+    risk: &'static tables::RiskTables,
     content: &str,
     path: &Path,
     file: &FileFacts,
@@ -108,7 +99,7 @@ fn detect_language_risks(
     let mut in_block_comment = false;
 
     for (line_index, raw_line) in content.lines().enumerate() {
-        let sanitized = if language_id == "python" {
+        let sanitized = if risk.sanitizer == tables::RiskLineSanitizer::Python {
             match sanitize_python_line(raw_line) {
                 Some(s) => s,
                 None => continue,
@@ -122,23 +113,14 @@ fn detect_language_risks(
             continue;
         }
 
-        emit_findings_for_line(
-            language_id,
-            trimmed,
-            path,
-            raw_line,
-            line_index,
-            file,
-            &mut findings,
-        );
+        (risk.emit_line)(trimmed, path, raw_line, line_index, file, &mut findings);
     }
 
     findings
 }
 
-mod pattern;
-
-use self::pattern::{emit_findings_for_line, emit_findings_for_tree};
+pub(crate) mod pattern;
+pub(crate) mod tables;
 
 #[cfg(test)]
 mod tests;

--- a/src/audits/code_quality/language_risk/go.rs
+++ b/src/audits/code_quality/language_risk/go.rs
@@ -73,7 +73,7 @@ impl GoRiskPattern {
 
 /// Emits Go runtime-risk findings from the syntax tree: `panic(...)`,
 /// `log.Fatal`/`log.Fatalf`, and `os.Exit`.
-pub(super) fn emit_go_node(
+pub(crate) fn emit_go_node(
     node: Node<'_>,
     content: &str,
     path: &Path,
@@ -116,5 +116,28 @@ pub(super) fn emit_go_node(
             file,
             findings,
         );
+    }
+}
+
+/// Line-scanner fallback: run every Go pattern against one sanitized line.
+pub(crate) fn emit_line(
+    trimmed: &str,
+    path: &Path,
+    raw_line: &str,
+    line_index: usize,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    for pattern in GoRiskPattern::ALL {
+        if pattern.matches(trimmed, path) {
+            push_pattern_finding(
+                pattern,
+                path,
+                line_index + 1,
+                raw_line.trim(),
+                file,
+                findings,
+            );
+        }
     }
 }

--- a/src/audits/code_quality/language_risk/js.rs
+++ b/src/audits/code_quality/language_risk/js.rs
@@ -72,7 +72,7 @@ impl JsRiskPattern {
 /// `bin/`/`scripts/` path, or an app-entrypoint is downgraded to Low (hidden in
 /// the default profile, retained under `--profile strict`), while reusable code
 /// keeps it at High.
-pub(super) fn emit_js_node(
+pub(crate) fn emit_js_node(
     node: Node<'_>,
     content: &str,
     path: &Path,
@@ -112,4 +112,27 @@ fn is_process_exit_call(node: Node<'_>, content: &str) -> bool {
         .child_by_field_name("property")
         .and_then(|n| node_text(n, content));
     object == Some("process") && property == Some("exit")
+}
+
+/// Line-scanner fallback: run every JS-family pattern against one sanitized line.
+pub(crate) fn emit_line(
+    trimmed: &str,
+    path: &Path,
+    raw_line: &str,
+    line_index: usize,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    for pattern in JsRiskPattern::ALL {
+        if pattern.matches(trimmed, path) {
+            push_pattern_finding(
+                pattern,
+                path,
+                line_index + 1,
+                raw_line.trim(),
+                file,
+                findings,
+            );
+        }
+    }
 }

--- a/src/audits/code_quality/language_risk/managed.rs
+++ b/src/audits/code_quality/language_risk/managed.rs
@@ -85,7 +85,7 @@ impl ManagedRiskPattern {
 /// Emits Java runtime-risk findings from the syntax tree: generic fatal
 /// `throw new RuntimeException/IllegalStateException(...)`, not-implemented
 /// throws, and `TODO(...)` placeholders.
-pub(super) fn emit_java_node(
+pub(crate) fn emit_java_node(
     node: Node<'_>,
     content: &str,
     path: &Path,
@@ -137,7 +137,7 @@ pub(super) fn emit_java_node(
 
 /// Emits Kotlin runtime-risk findings: generic fatal `throw RuntimeException/
 /// IllegalStateException(...)`, not-implemented throws, and `TODO(...)`.
-pub(super) fn emit_kotlin_node(
+pub(crate) fn emit_kotlin_node(
     node: Node<'_>,
     content: &str,
     path: &Path,
@@ -190,7 +190,7 @@ pub(super) fn emit_kotlin_node(
 /// Emits C# runtime-risk findings: generic fatal `throw new Exception/
 /// RuntimeException/IllegalStateException(...)`, not-implemented throws, and
 /// `TODO(...)`.
-pub(super) fn emit_csharp_node(
+pub(crate) fn emit_csharp_node(
     node: Node<'_>,
     content: &str,
     path: &Path,
@@ -242,5 +242,51 @@ pub(super) fn emit_csharp_node(
             file,
             findings,
         );
+    }
+}
+
+/// Line-scanner fallback: run every JVM pattern against one sanitized line.
+pub(crate) fn emit_line_jvm(
+    trimmed: &str,
+    path: &Path,
+    raw_line: &str,
+    line_index: usize,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    for pattern in ManagedRiskPattern::JVM_PATTERNS {
+        if pattern.matches(trimmed, path) {
+            push_pattern_finding(
+                pattern,
+                path,
+                line_index + 1,
+                raw_line.trim(),
+                file,
+                findings,
+            );
+        }
+    }
+}
+
+/// Line-scanner fallback: run every C# pattern against one sanitized line.
+pub(crate) fn emit_line_csharp(
+    trimmed: &str,
+    path: &Path,
+    raw_line: &str,
+    line_index: usize,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    for pattern in ManagedRiskPattern::CSHARP_PATTERNS {
+        if pattern.matches(trimmed, path) {
+            push_pattern_finding(
+                pattern,
+                path,
+                line_index + 1,
+                raw_line.trim(),
+                file,
+                findings,
+            );
+        }
     }
 }

--- a/src/audits/code_quality/language_risk/pattern.rs
+++ b/src/audits/code_quality/language_risk/pattern.rs
@@ -2,121 +2,24 @@ use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use crate::knowledge::decision::{decide_for_file, record_decision_provenance};
 use crate::scan::facts::FileFacts;
 use std::path::Path;
-use tree_sitter::{Node, Tree};
+use tree_sitter::Node;
 
 const RUNTIME_ERROR_HANDLING_DOCS_URL: &str =
     "https://owasp.org/www-community/vulnerabilities/Improper_Error_Handling";
 
 #[path = "go.rs"]
-mod go;
+pub(crate) mod go;
 #[path = "js.rs"]
-mod js;
+pub(crate) mod js;
 #[path = "managed.rs"]
-mod managed;
+pub(crate) mod managed;
 #[path = "python.rs"]
-mod python;
+pub(crate) mod python;
 
 use go::GoRiskPattern;
 use js::JsRiskPattern;
 use managed::ManagedRiskPattern;
 use python::PythonRiskPattern;
-
-pub(super) fn emit_findings_for_line(
-    language_id: &str,
-    trimmed: &str,
-    path: &Path,
-    raw_line: &str,
-    line_index: usize,
-    file: &FileFacts,
-    findings: &mut Vec<Finding>,
-) {
-    macro_rules! push_if_matched {
-        ($pattern:expr) => {
-            if $pattern.matches(trimmed, path) {
-                push_pattern_finding(
-                    $pattern,
-                    path,
-                    line_index + 1,
-                    raw_line.trim(),
-                    file,
-                    findings,
-                );
-            }
-        };
-    }
-
-    match language_id {
-        "go" => {
-            for p in GoRiskPattern::ALL {
-                push_if_matched!(p);
-            }
-        }
-        "python" => {
-            for p in PythonRiskPattern::ALL {
-                push_if_matched!(p);
-            }
-        }
-        "typescript" | "typescript-react" | "javascript" | "javascript-react" => {
-            for p in JsRiskPattern::ALL {
-                push_if_matched!(p);
-            }
-        }
-        "java" | "kotlin" => {
-            for p in ManagedRiskPattern::JVM_PATTERNS {
-                push_if_matched!(p);
-            }
-        }
-        "csharp" => {
-            for p in ManagedRiskPattern::CSHARP_PATTERNS {
-                push_if_matched!(p);
-            }
-        }
-        _ => {}
-    }
-}
-
-// ── AST detection (parseable languages) ────────────────────────────────────────
-
-/// Emits runtime-risk findings for `language_id` by walking the parsed syntax
-/// tree, so matches reflect real call/clause structure rather than line text.
-/// Each language's node-level emitter lives in its sibling pattern module
-/// (`go`, `js`, `python`, `managed`); this dispatches to them and recurses.
-pub(super) fn emit_findings_for_tree(
-    language_id: &str,
-    tree: &Tree,
-    content: &str,
-    path: &Path,
-    file: &FileFacts,
-    findings: &mut Vec<Finding>,
-) {
-    walk_tree(tree.root_node(), language_id, content, path, file, findings);
-}
-
-fn walk_tree(
-    node: Node<'_>,
-    language_id: &str,
-    content: &str,
-    path: &Path,
-    file: &FileFacts,
-    findings: &mut Vec<Finding>,
-) {
-    match language_id {
-        "python" => python::emit_python_node(node, content, path, file, findings),
-        "go" => go::emit_go_node(node, content, path, file, findings),
-        "typescript" | "typescript-react" | "javascript" | "javascript-react" => {
-            js::emit_js_node(node, content, path, file, findings)
-        }
-        "java" => managed::emit_java_node(node, content, path, file, findings),
-        "kotlin" => managed::emit_kotlin_node(node, content, path, file, findings),
-        "csharp" => managed::emit_csharp_node(node, content, path, file, findings),
-        _ => {}
-    }
-
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_tree(child, language_id, content, path, file, findings);
-    }
-}
 
 // ── Shared node helpers (used by the per-language emitters) ─────────────────────
 
@@ -140,7 +43,6 @@ fn node_text<'a>(node: Node<'_>, content: &'a str) -> Option<&'a str> {
 // ── Shared finding construction ─────────────────────────────────────────────────
 
 trait RiskPattern {
-    fn matches(&self, trimmed: &str, path: &Path) -> bool;
     fn rule_id(&self) -> &'static str;
     fn signal(&self) -> &'static str;
     fn title(&self) -> &'static str;
@@ -152,9 +54,6 @@ trait RiskPattern {
 macro_rules! impl_risk_pattern {
     ($t:ty) => {
         impl RiskPattern for $t {
-            fn matches(&self, trimmed: &str, path: &Path) -> bool {
-                (*self).matches(trimmed, path)
-            }
             fn rule_id(&self) -> &'static str {
                 (*self).rule_id()
             }

--- a/src/audits/code_quality/language_risk/python.rs
+++ b/src/audits/code_quality/language_risk/python.rs
@@ -82,7 +82,7 @@ impl PythonRiskPattern {
 
 /// Emits Python runtime-risk findings from the syntax tree: bare `except:`,
 /// `assert` statements, and `NotImplementedError` placeholders.
-pub(super) fn emit_python_node(
+pub(crate) fn emit_python_node(
     node: Node<'_>,
     content: &str,
     path: &Path,
@@ -135,4 +135,27 @@ fn raises_bare_not_implemented(node: Node<'_>, content: &str) -> bool {
     node.named_children(&mut cursor).any(|child| {
         child.kind() == "identifier" && node_text(child, content) == Some("NotImplementedError")
     })
+}
+
+/// Line-scanner fallback: run every Python pattern against one sanitized line.
+pub(crate) fn emit_line(
+    trimmed: &str,
+    path: &Path,
+    raw_line: &str,
+    line_index: usize,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    for pattern in PythonRiskPattern::ALL {
+        if pattern.matches(trimmed, path) {
+            push_pattern_finding(
+                pattern,
+                path,
+                line_index + 1,
+                raw_line.trim(),
+                file,
+                findings,
+            );
+        }
+    }
 }

--- a/src/audits/code_quality/language_risk/tables.rs
+++ b/src/audits/code_quality/language_risk/tables.rs
@@ -1,0 +1,60 @@
+//! The per-language runtime-risk contract.
+//!
+//! A language frontend that participates in the runtime-risk audit registers
+//! a [`RiskTables`]: an AST node emitter, a sanitized-line emitter for the
+//! no-parse fallback, and which comment sanitizer its line scanner needs.
+//! The audit in [`super`] is language-neutral and dispatches through the
+//! frontend registry; the pattern definitions stay in
+//! [`super::pattern`]'s per-language modules.
+
+use crate::findings::types::Finding;
+use crate::scan::facts::FileFacts;
+use std::path::Path;
+use tree_sitter::{Node, Tree};
+
+/// Emits findings for one AST node (the walker recurses).
+pub(crate) type NodeEmitter = fn(Node<'_>, &str, &Path, &FileFacts, &mut Vec<Finding>);
+
+/// Emits findings for one sanitized, trimmed line.
+pub(crate) type LineEmitter = fn(&str, &Path, &str, usize, &FileFacts, &mut Vec<Finding>);
+
+/// Which comment sanitizer the line-scanner fallback needs.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RiskLineSanitizer {
+    CStyle,
+    Python,
+}
+
+pub(crate) struct RiskTables {
+    pub(crate) emit_node: NodeEmitter,
+    pub(crate) emit_line: LineEmitter,
+    pub(crate) sanitizer: RiskLineSanitizer,
+}
+
+/// Runs `emit` over every node of `tree`, depth-first — the shared walk the
+/// per-language node emitters plug into.
+pub(crate) fn walk_tree_with(
+    emit: NodeEmitter,
+    tree: &Tree,
+    content: &str,
+    path: &Path,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    walk(tree.root_node(), emit, content, path, file, findings);
+}
+
+fn walk(
+    node: Node<'_>,
+    emit: NodeEmitter,
+    content: &str,
+    path: &Path,
+    file: &FileFacts,
+    findings: &mut Vec<Finding>,
+) {
+    emit(node, content, path, file, findings);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk(child, emit, content, path, file, findings);
+    }
+}

--- a/src/languages/capability.rs
+++ b/src/languages/capability.rs
@@ -44,6 +44,9 @@ pub fn capabilities(frontend: &LanguageFrontend) -> Vec<Capability> {
     if frontend.review.is_some() {
         wired.push(Capability::ReviewSignals);
     }
+    if frontend.risk.is_some() {
+        wired.push(Capability::RuntimeRisk);
+    }
     wired
 }
 

--- a/src/languages/csharp/mod.rs
+++ b/src/languages/csharp/mod.rs
@@ -1,3 +1,5 @@
+mod risk;
+
 use super::{GrammarBinding, LanguageFrontend};
 use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
@@ -23,6 +25,7 @@ pub(super) static CSHARP: LanguageFrontend = LanguageFrontend {
     imports: None,
     taint: None,
     review: Some(&CSHARP_REVIEW),
+    risk: Some(&risk::CSHARP_RISK),
 };
 
 // Boundary stays unwired: the old dispatch matched the label "CSharp", but

--- a/src/languages/csharp/risk.rs
+++ b/src/languages/csharp/risk.rs
@@ -1,0 +1,11 @@
+//! Runtime-risk tables for C#: the emitters live with the pattern
+//! definitions in `audits::code_quality::language_risk`.
+
+use crate::audits::code_quality::language_risk::pattern::managed;
+use crate::audits::code_quality::language_risk::tables::{RiskLineSanitizer, RiskTables};
+
+pub(super) static CSHARP_RISK: RiskTables = RiskTables {
+    emit_node: managed::emit_csharp_node,
+    emit_line: managed::emit_line_csharp,
+    sanitizer: RiskLineSanitizer::CStyle,
+};

--- a/src/languages/generic.rs
+++ b/src/languages/generic.rs
@@ -13,4 +13,5 @@ pub(super) static GENERIC: LanguageFrontend = LanguageFrontend {
     imports: None,
     taint: None,
     review: None,
+    risk: None,
 };

--- a/src/languages/go/mod.rs
+++ b/src/languages/go/mod.rs
@@ -4,6 +4,7 @@ use crate::audits::context::LanguageKind;
 
 mod imports;
 mod review;
+mod risk;
 
 use super::ImportExtractor;
 
@@ -25,4 +26,5 @@ pub(super) static GO: LanguageFrontend = LanguageFrontend {
     imports: Some(&GO_IMPORTS),
     taint: Some(&review::GO_TAINT),
     review: Some(&review::GO_REVIEW),
+    risk: Some(&risk::GO_RISK),
 };

--- a/src/languages/go/risk.rs
+++ b/src/languages/go/risk.rs
@@ -1,0 +1,11 @@
+//! Runtime-risk tables for Go: the emitters live with the pattern
+//! definitions in `audits::code_quality::language_risk`.
+
+use crate::audits::code_quality::language_risk::pattern::go;
+use crate::audits::code_quality::language_risk::tables::{RiskLineSanitizer, RiskTables};
+
+pub(super) static GO_RISK: RiskTables = RiskTables {
+    emit_node: go::emit_go_node,
+    emit_line: go::emit_line,
+    sanitizer: RiskLineSanitizer::CStyle,
+};

--- a/src/languages/java/mod.rs
+++ b/src/languages/java/mod.rs
@@ -4,6 +4,7 @@ use crate::audits::context::LanguageKind;
 
 mod imports;
 mod review;
+mod risk;
 
 use super::ImportExtractor;
 
@@ -25,4 +26,5 @@ pub(super) static JAVA: LanguageFrontend = LanguageFrontend {
     imports: Some(&JAVA_IMPORTS),
     taint: None,
     review: Some(&review::JAVA_REVIEW),
+    risk: Some(&risk::JAVA_RISK),
 };

--- a/src/languages/java/risk.rs
+++ b/src/languages/java/risk.rs
@@ -1,0 +1,11 @@
+//! Runtime-risk tables for Java: the emitters live with the pattern
+//! definitions in `audits::code_quality::language_risk`.
+
+use crate::audits::code_quality::language_risk::pattern::managed;
+use crate::audits::code_quality::language_risk::tables::{RiskLineSanitizer, RiskTables};
+
+pub(super) static JAVA_RISK: RiskTables = RiskTables {
+    emit_node: managed::emit_java_node,
+    emit_line: managed::emit_line_jvm,
+    sanitizer: RiskLineSanitizer::CStyle,
+};

--- a/src/languages/javascript/mod.rs
+++ b/src/languages/javascript/mod.rs
@@ -7,6 +7,7 @@ use crate::audits::context::LanguageKind;
 
 mod imports;
 mod review;
+mod risk;
 
 use super::ImportExtractor;
 
@@ -34,6 +35,7 @@ pub(super) static TYPESCRIPT: LanguageFrontend = LanguageFrontend {
     imports: Some(&JS_FAMILY_IMPORTS),
     taint: Some(&review::JS_FAMILY_TAINT),
     review: Some(&review::JS_FAMILY_REVIEW),
+    risk: Some(&risk::JS_FAMILY_RISK),
 };
 
 pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
@@ -54,4 +56,5 @@ pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
     imports: Some(&JS_FAMILY_IMPORTS),
     taint: Some(&review::JS_FAMILY_TAINT),
     review: Some(&review::JS_FAMILY_REVIEW),
+    risk: Some(&risk::JS_FAMILY_RISK),
 };

--- a/src/languages/javascript/risk.rs
+++ b/src/languages/javascript/risk.rs
@@ -1,0 +1,11 @@
+//! Runtime-risk tables for the JS dialect family: the emitters live with the pattern
+//! definitions in `audits::code_quality::language_risk`.
+
+use crate::audits::code_quality::language_risk::pattern::js;
+use crate::audits::code_quality::language_risk::tables::{RiskLineSanitizer, RiskTables};
+
+pub(super) static JS_FAMILY_RISK: RiskTables = RiskTables {
+    emit_node: js::emit_js_node,
+    emit_line: js::emit_line,
+    sanitizer: RiskLineSanitizer::CStyle,
+};

--- a/src/languages/kotlin/mod.rs
+++ b/src/languages/kotlin/mod.rs
@@ -4,6 +4,7 @@ use crate::audits::context::LanguageKind;
 
 mod imports;
 mod review;
+mod risk;
 
 use super::ImportExtractor;
 
@@ -25,4 +26,5 @@ pub(super) static KOTLIN: LanguageFrontend = LanguageFrontend {
     imports: Some(&KOTLIN_IMPORTS),
     taint: None,
     review: Some(&review::KOTLIN_REVIEW),
+    risk: Some(&risk::KOTLIN_RISK),
 };

--- a/src/languages/kotlin/risk.rs
+++ b/src/languages/kotlin/risk.rs
@@ -1,0 +1,11 @@
+//! Runtime-risk tables for Kotlin: the emitters live with the pattern
+//! definitions in `audits::code_quality::language_risk`.
+
+use crate::audits::code_quality::language_risk::pattern::managed;
+use crate::audits::code_quality::language_risk::tables::{RiskLineSanitizer, RiskTables};
+
+pub(super) static KOTLIN_RISK: RiskTables = RiskTables {
+    emit_node: managed::emit_kotlin_node,
+    emit_line: managed::emit_line_jvm,
+    sanitizer: RiskLineSanitizer::CStyle,
+};

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -98,6 +98,10 @@ pub struct LanguageFrontend {
     pub(crate) taint: Option<&'static crate::review::signals::taint::tables::TaintTables>,
     /// Boundary/algorithmic review-signal node-kind tables.
     pub(crate) review: Option<&'static crate::review::signals::tables::ReviewTables>,
+    /// Runtime-risk audit tables (AST + line-scanner emitters). Rust's
+    /// dedicated `rust_panic_risk` audit is separate and not counted here.
+    pub(crate) risk:
+        Option<&'static crate::audits::code_quality::language_risk::tables::RiskTables>,
 }
 
 /// Every registered frontend, including the generic fallback (last).

--- a/src/languages/python/mod.rs
+++ b/src/languages/python/mod.rs
@@ -4,6 +4,7 @@ use crate::audits::context::LanguageKind;
 
 mod imports;
 mod review;
+mod risk;
 
 use super::ImportExtractor;
 
@@ -25,4 +26,5 @@ pub(super) static PYTHON: LanguageFrontend = LanguageFrontend {
     imports: Some(&PYTHON_IMPORTS),
     taint: Some(&review::PYTHON_TAINT),
     review: Some(&review::PYTHON_REVIEW),
+    risk: Some(&risk::PYTHON_RISK),
 };

--- a/src/languages/python/risk.rs
+++ b/src/languages/python/risk.rs
@@ -1,0 +1,11 @@
+//! Runtime-risk tables for Python: the emitters live with the pattern
+//! definitions in `audits::code_quality::language_risk`.
+
+use crate::audits::code_quality::language_risk::pattern::python;
+use crate::audits::code_quality::language_risk::tables::{RiskLineSanitizer, RiskTables};
+
+pub(super) static PYTHON_RISK: RiskTables = RiskTables {
+    emit_node: python::emit_python_node,
+    emit_line: python::emit_line,
+    sanitizer: RiskLineSanitizer::Python,
+};

--- a/src/languages/rust/mod.rs
+++ b/src/languages/rust/mod.rs
@@ -25,4 +25,5 @@ pub(super) static RUST: LanguageFrontend = LanguageFrontend {
     imports: Some(&RUST_IMPORTS),
     taint: None,
     review: Some(&review::RUST_REVIEW),
+    risk: None,
 };

--- a/src/languages/tests.rs
+++ b/src/languages/tests.rs
@@ -302,6 +302,33 @@ fn removed_recognizer_extensions_are_pinned() {
     }
 }
 
+/// Pins which frontends carry runtime-risk tables. Rust intentionally has
+/// none here: its dedicated `rust_panic_risk` audit is a separate rule
+/// family, and how it counts toward the capability model is a decision for
+/// the honesty pass, not a refactor default.
+#[test]
+fn runtime_risk_participation_is_pinned() {
+    let with_risk: BTreeSet<&str> = [
+        "typescript",
+        "javascript",
+        "python",
+        "go",
+        "java",
+        "kotlin",
+        "csharp",
+    ]
+    .into_iter()
+    .collect();
+    for frontend in all_frontends() {
+        assert_eq!(
+            frontend.risk.is_some(),
+            with_risk.contains(frontend.id),
+            "runtime-risk participation changed for frontend '{}'",
+            frontend.id
+        );
+    }
+}
+
 /// The honesty ledger. Languages the bundled pack declares `rule-aware`
 /// whose frontends do not yet justify it. Migration PRs shrink this set by
 /// wiring capabilities (or PR-9 downgrades over-claimed pack declarations —


### PR DESCRIPTION
## Summary

Moves runtime-risk dispatch into the language frontend registry.

Each frontend now provides a `RiskTables` contract with its AST emitter, line-scanner fallback, and comment sanitizer. The shared runtime-risk audit no longer matches on language IDs.

This is a behavior-preserving refactor.

## Type of change

* [ ] Feature
* [x] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added `RiskTables` to `LanguageFrontend`.
* Moved runtime-risk participation into language frontends.
* Routed AST runtime-risk detection through frontend-provided emitters.
* Routed line-scanner fallback through frontend-provided emitters.
* Moved sanitizer selection into the frontend contract.
* Removed the `is_ast_runtime_language` allowlist.
* Removed language-ID dispatch from the shared runtime-risk pattern module.
* Added `RuntimeRisk` to computed frontend capabilities.
* Added a guard test that pins runtime-risk participation.
* Updated the language surface inventory.

## Supported frontends

Runtime-risk tables are registered for:

* JavaScript and TypeScript;
* Python;
* Go;
* Java;
* Kotlin;
* C#.

Rust keeps its existing dedicated panic-risk audit and is not moved into this shared runtime-risk contract.

## Behavior

The following behavior is intended to remain unchanged:

* runtime-risk rules and severities;
* AST-based detection;
* text fallback when parsing fails;
* provenance for text-heuristic findings;
* comment sanitization;
* finding IDs and evidence;
* default and strict profile visibility;
* JSON, SARIF, MCP, and GitHub Action output.

The per-language pattern definitions remain in their existing modules. Frontends only reference the appropriate emitters.

## Why

Runtime-risk detection previously selected language behavior in two separate places:

* an allowlist deciding whether AST detection was supported;
* match statements choosing AST and line-scanner implementations.

That duplicated language ownership outside the frontend registry.

After this change, the audit only asks the frontend for its runtime-risk contract and stays language-neutral.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] No unrelated refactor or generated-file churn is included

Primary subsystems:

* language frontend registry;
* code-quality runtime-risk audit;
* AST and text fallback dispatch.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```

Focused verification:

```
cargo test --lib languages
cargo test --lib audits::code_quality::language_risk
cargo test --test review_zoo
```
