### PR TITLE
feat(languages): add frontend conventions and generated support docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **Generated language support matrix.** `docs/language-support.md` is now
+  rendered from the language frontend registry with a drift test
+  (`REPOPILOT_BLESS=1 cargo test --test language_support_doc`): capability
+  columns are derived from what each frontend actually wires, with the
+  knowledge pack's declared levels shown alongside and known gaps documented
+  instead of hidden.
+- **"Add a language" contributor guide and scaffolder.**
+  `docs/engineering/add-a-language.md` walks the frontend contract end to
+  end (profile → descriptor → grammar → tables → fixtures → zoo acceptance →
+  generated docs), and `scripts/new-language.py` stamps a starter module
+  whose TODOs mirror the checklist.
+
+### Changed
+
+- **Path and naming conventions live on the language frontends.** Test-file
+  naming, the `test_` prefix opt-out (Rust), test-support recognizers (with
+  their role-evidence reasons), and app-entrypoint content probes moved to
+  `frontend.conventions`; the context classifier and role classification
+  consult them, while cross-language path rules stay shared. Behavior-frozen
+  refactor: zoo snapshots unchanged across seven repos.
+
+### Added
+
 - **Language frontend registry skeleton (`src/languages/`).** First brick of
   the 0.21 language contract: static per-language descriptors unifying the
   knowledge-pack profiles, context-classifier kinds, and tree-sitter grammar

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ adoption or CI policy.
 - [Dependency Graph v2 design](engineering/dependency-graph-v2.md)
 - [Signal contract](engineering/signal-contract.md)
 - [Language surface inventory](engineering/language-surface-inventory.md)
+- [Add a language](engineering/add-a-language.md)
 - [Engine pipeline](engineering/engine-pipeline.md)
 - [Graph scan hardening](engineering/graph-scan-hardening.md)
 - [Performance budgets](engineering/performance-budgets.md)

--- a/docs/engineering/add-a-language.md
+++ b/docs/engineering/add-a-language.md
@@ -1,0 +1,66 @@
+# Add a Language
+
+Language support is added by writing tables behind the frontend contract
+(`src/languages/`), not by editing engines. Every step below is enforced by
+a guard test or a generated artifact, so a partial integration fails loudly
+instead of shipping quietly.
+
+Scaffold the module tree first:
+
+```bash
+python3 scripts/new-language.py <id> "<Display Label>"
+```
+
+## Checklist
+
+1. **Knowledge profile** — add (or verify) the `[[languages]]` entry in
+   `src/knowledge/packs/core.toml`: id, name, aliases, extensions,
+   filenames, and an honest `support` level. Detection data lives here and
+   only here; the frontend references the profile by id.
+2. **Descriptor** — `src/languages/<id>/mod.rs`: a `LanguageFrontend` static
+   with the id, label, `LanguageKind`, claimed knowledge ids (dialects
+   included), and grammar bindings. Route the kind in
+   `frontend_for_kind` and register the frontend in `ALL_FRONTENDS`
+   (`src/languages/mod.rs`) — the exhaustive match will not compile until
+   you decide the routing.
+3. **Grammar (optional)** — add the tree-sitter crate to `Cargo.toml`, a
+   `ParseLanguage` variant with a thread-local parser in
+   `src/analysis/parse.rs`, and grammar bindings on the descriptor. The
+   `every_grammar_is_claimed_by_exactly_one_frontend` and pinned-vocabulary
+   guards force the bindings to stay coherent.
+4. **Imports** — `imports.rs` implementing eager edges, line spans, and (only
+   if the language has load-order-neutral imports) deferred edges. Update
+   the `import_extractor_coverage_is_pinned` test deliberately.
+5. **Review tables** — `review.rs`: boundary node kinds, algorithmic node
+   kinds, removed-behavior recognizers, and — for web-facing languages —
+   taint tables (sources, coercions, sink classifier). Update the
+   corresponding pins.
+6. **Runtime risk** — pattern definitions and emitters under
+   `src/audits/code_quality/language_risk/`, referenced from `risk.rs`.
+7. **Conventions** — test-file naming, `test_` prefix applicability,
+   test-support recognizer, entrypoint content probe. Update
+   `path_conventions_are_pinned`.
+8. **Knowledge applicability** — extend `core.toml` rule applicability and
+   calibration for the new language where rules should (or should not)
+   fire.
+9. **Fixtures** — a TP and FP fixture per signal family you wired, under
+   `tests/fixtures/` (see the fixtures README for layout).
+10. **Zoo acceptance** — add a pinned real-world repository to
+    `tests/zoo/manifest.toml`, bless its snapshot, and label the
+    default-visible findings in `tests/zoo/expectations/`. This is the
+    evidence the release rides on.
+11. **Docs** — regenerate the support matrix
+    (`REPOPILOT_BLESS=1 cargo test --test language_support_doc`) and the
+    rules reference if rules changed. The matrix derives capabilities from
+    wiring; if a column is wrong, the wiring is wrong.
+
+## Ground rules
+
+- Refactors of existing languages must be behavior-frozen: zoo snapshots
+  byte-identical, goldens unchanged. New capabilities change snapshots and
+  must arrive with reviewed expectations.
+- New signals ship at `preview` visibility with conservative,
+  high-specificity patterns; the 0.19 lesson applies — downgrade noisy
+  findings via the Knowledge Engine, don't delete detection.
+- The registry is static data assembled at compile time. No plugin runtime,
+  no dynamic loading (see the Knowledge Engine runtime boundaries).

--- a/docs/engineering/language-surface-inventory.md
+++ b/docs/engineering/language-surface-inventory.md
@@ -120,28 +120,36 @@ design (with reason).
 
 ## Conventions and context
 
-- [ ] `src/scan/path_classification.rs:34` — test-like filename conventions
-      (`test_*`, `*_test`, `tests.rs`, Rust-specific carve-outs from the
-      0.18 low-signal fix). → PR-6 (`frontend().conventions`).
-- [ ] Test-support allowlist (`testutil.rs`, `test_utils.rs`, …) and
-      `FileRole::TestSupport` wiring from the 0.19 cycle — role logic stays
-      in the context classifier; the *name lists* become convention data. →
-      PR-6.
+- [-] `src/scan/path_classification.rs` — the low-signal audit-path
+      heuristic keeps its own (deliberately different) vocabulary from the
+      role classifier's `is_test_file`; unifying them is a behavior change,
+      tracked as a known residual, not a refactor default.
+- [x] Test-file naming, the `test_` prefix opt-out, test-support
+      recognizers (Rust allowlist + managed source-set shapes, evidence
+      reasons preserved), and entrypoint content probes live on
+      `frontend.conventions` (`languages/conventions.rs`); the classifier
+      helpers and role classification consult them. Shared path components
+      (`tests/`, `__tests__/`, `tests_` prefix) and the entrypoint
+      *filename* list stay cross-language by design. Pinned by
+      `path_conventions_are_pinned`. (PR-6)
 - [-] `src/audits/context/classify/` — role/paradigm/runtime classification
       consumes shared context signals; stays the owner of cross-language
       context. Frontend conventions feed it; it does not move. (Declared
       `context-aware` pack levels are justified here, which is why the PR-1
       honesty ledger only covers `rule-aware` claims.)
 - [ ] `src/audits/framework/` + manifest readers (`package.json`,
-      `pyproject.toml`, `go.mod`, …) — framework probes per ecosystem. →
-      PR-6 (probe registration), detection logic unchanged.
+      `pyproject.toml`, `go.mod`, …) — framework probes per ecosystem.
+      Deferred: probe registration moves when a frontend actually needs to
+      contribute one (Java/Spring in the promotion PR); detection logic
+      unchanged either way.
 
 ## Output and docs
 
-- [ ] `docs/language-support.md` — hand-maintained tier table, already
-      drifted from the pack (pack says java/kotlin/csharp/c/cpp are
-      rule-aware; doc says Tier 2; the wiring says context at best). → PR-7
-      generates it from the registry with a BLESS drift test.
+- [x] `docs/language-support.md` — generated from the registry
+      (`languages/reference.rs`, BLESS drift test
+      `tests/language_support_doc.rs`): capability columns derived from
+      wiring, declared pack levels shown alongside, honest notes for the
+      Rust panic-audit accounting and the unwired C# boundary. (PR-7)
 - [-] `src/output/ai_context/repo_facts.rs`, report renderers — print
       labels/tiers; consume registry values after PR-7, no language logic of
       their own.

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -1,104 +1,57 @@
 # Language and Framework Support
 
-RepoPilot combines generic repository heuristics with language and framework-aware
-rules.
+<!-- @generated from the language frontend registry — do not edit by hand. -->
+<!-- Regenerate with `REPOPILOT_BLESS=1 cargo test --test language_support_doc`. -->
 
-## Support tiers
+RepoPilot combines generic repository heuristics with language-aware
+analysis owned by *language frontends* (`src/languages/`). The capability
+columns below are derived from what each frontend actually wires — a column
+cannot be claimed without the code behind it. `Declared` is the support
+level the bundled knowledge pack asserts; where it exceeds the wired
+capabilities, the gap is tracked by the registry's support-honesty guard
+test rather than hidden.
 
-### Tier 1 — rule-aware
+## Frontend capabilities
 
-These languages and ecosystems have deeper rule coverage:
+| Language | Grammar | Imports | Review signals | Taint flows | Runtime risk | Conventions | Declared |
+|---|---|---|---|---|---|---|---|
+| Rust | ✓ | ✓ | ✓ | — | — | ✓ | rule-aware |
+| TypeScript | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
+| JavaScript | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
+| Python | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
+| Go | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
+| Java | ✓ | ✓ | ✓ | — | ✓ | ✓ | rule-aware |
+| C# | ✓ | — | ✓ | — | ✓ | ✓ | rule-aware |
+| Kotlin | ✓ | ✓ | ✓ | — | ✓ | ✓ | rule-aware |
 
-- Rust
-- JavaScript
-- TypeScript
-- React
-- React Native
-- Expo
-- Python
-- Go
+Notes:
 
-### Tier 2 — context-aware / partial
+- **Rust runtime risk** is covered by the dedicated `rust.panic-risk` rule
+family rather than the shared runtime-risk audit, so its column reads “—”
+here; how it counts toward the capability model is tracked in the
+support-honesty ledger.
+- **C# review signals** exclude AST boundary classification: the pre-registry
+dispatch never matched the label detection emits, and enabling it is a
+deliberate behavior change, not a docs update.
+- JavaScript and TypeScript (with their React dialects) share one frontend
+family: the same grammar shapes, import extractor, and signal tables.
 
-These languages may have detection, import extraction, long-function checks, or
-runtime-risk checks, but not full framework-specific coverage:
+## Detected languages without a frontend
 
-- Java
-- Kotlin
-- C#
-- C
-- C++
+Files in these languages still contribute to repository size, scan
+scope, file roles (via the shared context classifier), and generic findings;
+they have no language-specific extractors.
 
-### Tier 3 — detect-only / generic
-
-Other files can still contribute to repository size, scan scope, and generic
-findings when supported by the scanner.
-
-## Current rule families
-
-### Architecture
-
-- large files
-- too many modules per directory
-- deep nesting
-- deep relative imports
-- risky barrel files
-- excessive fan-out
-- high-instability hubs
-- circular dependencies
-
-### Code quality
-
-- long functions
-- complexity density
-- TODO/FIXME/HACK markers
-- language runtime-risk patterns
-
-### Security
-
-- hardcoded secret candidates
-- private key candidates
-- committed `.env` files
-
-### Testing
-
-- missing test folders
-- source files without test counterparts
-
-### Framework
-
-- React Native architecture profile
-- Hermes / New Architecture mismatch
-- React Native deprecated APIs
-- React Native dependency health
-- React class components
-- PropTypes in typed React projects
-- JavaScript `var`
-- debug `console.log`
-
-## Framework detection
-
-RepoPilot detects framework signals from project files such as:
-
-- `package.json`
-- React Native native configuration files
-- Expo config
-- `requirements.txt`
-- `pyproject.toml`
-- `go.mod`
-
-Detected frameworks are used to reduce irrelevant findings. For example, React web
-rules should not run on every React Native project just because React is installed.
+- **Context-aware (shared classifier):** Swift, PHP, Ruby, Dart, Scala, Shell, PowerShell, SQL, HTML, CSS, SCSS, Elixir, Erlang, Haskell, OCaml, F#, Terraform, Dockerfile, Nix.
+- **Import-aware:** C/C++ Header.
+- **Detect-only:** R, Julia, Lua, Perl, Zig, Solidity, Objective-C, YAML, TOML, JSON, Markdown.
+- **Declared rule-aware without wiring:** C, C++.
 
 ## Rule philosophy
 
-RepoPilot should not treat every paradigm as a smell.
-
-Functional, object-oriented, procedural, and declarative code can all be valid.
-Rules should use context and confidence instead of assuming one style is always
-better.
-
-Preferred rule design:
+RepoPilot should not treat every paradigm as a smell. Functional,
+object-oriented, procedural, and declarative code can all be valid; rules
+use context and confidence instead of assuming one style is always better:
 
 ```text
 evidence + context + severity + confidence + recommendation
@@ -106,13 +59,13 @@ evidence + context + severity + confidence + recommendation
 
 ## Limitations
 
-RepoPilot is not a full compiler or type checker. Some rules are text-based or
-heuristic. Findings should be treated as review signals, not absolute truth.
+RepoPilot is not a compiler or type checker. Some rules are text-based or
+heuristic; findings are review signals, not absolute truth. Use
+language-specific tools alongside it: `cargo clippy`, `tsc`/ESLint, Ruff and
+Pyright, `go vet`, or your build's own checks.
 
-Use language-specific tools alongside RepoPilot:
+## Adding a language
 
-- Rust: `cargo clippy`, `cargo test`
-- TypeScript: `tsc`, ESLint
-- Python: Ruff, Pyright, pytest
-- Go: `go test`, `go vet`
-- Java/Kotlin: Gradle/Maven checks
+The whole point of the frontend contract is that support is added by
+writing tables, not by editing engines. The checklist lives in
+[Add a language](engineering/add-a-language.md).

--- a/scripts/new-language.py
+++ b/scripts/new-language.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Scaffold a language frontend module tree.
+
+Stamps `src/languages/<id>/` with descriptor and table stubs whose TODOs
+mirror docs/engineering/add-a-language.md. It never touches existing files,
+the registry, or the knowledge pack — the guard tests and the compiler walk
+you through the wiring on purpose.
+
+Usage: python3 scripts/new-language.py <id> "<Display Label>"
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+MOD_TEMPLATE = """\
+use super::conventions::PathConventions;
+use super::{{GrammarBinding, LanguageFrontend}};
+use crate::audits::context::LanguageKind;
+
+// TODO(add-a-language): declare table modules as you wire them.
+// mod imports;
+// mod review;
+// mod risk;
+
+pub(super) static {upper}: LanguageFrontend = LanguageFrontend {{
+    id: "{id}",
+    label: "{label}",
+    // TODO(add-a-language): use the real LanguageKind variant and route it
+    // in `frontend_for_kind` (the exhaustive match will not compile until
+    // you do). Register the frontend in `ALL_FRONTENDS` as well.
+    kind: LanguageKind::Unknown,
+    knowledge_ids: &["{id}"],
+    // TODO(add-a-language): bind detection labels to a ParseLanguage variant
+    // once a tree-sitter grammar is wired in `src/analysis/parse.rs`.
+    grammars: &[],
+    imports: None,
+    taint: None,
+    review: None,
+    risk: None,
+    conventions: &{upper}_CONVENTIONS,
+}};
+
+static {upper}_CONVENTIONS: PathConventions = PathConventions {{
+    // TODO(add-a-language): language test-file naming, e.g.
+    // |name| name.ends_with("_test.{id}")
+    test_file_name: |_| false,
+    test_prefix_marks_test: true,
+    test_support: None,
+    entrypoint_content: None,
+}};
+"""
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    lang_id, label = sys.argv[1], sys.argv[2]
+    if not re.fullmatch(r"[a-z][a-z0-9-]*", lang_id):
+        print(f"id must be a kebab-case slug, got: {lang_id}", file=sys.stderr)
+        return 2
+
+    module = REPO_ROOT / "src" / "languages" / lang_id.replace("-", "_")
+    if module.exists():
+        print(f"refusing to overwrite existing module: {module}", file=sys.stderr)
+        return 1
+
+    module.mkdir(parents=True)
+    upper = lang_id.replace("-", "_").upper()
+    (module / "mod.rs").write_text(
+        MOD_TEMPLATE.format(id=lang_id, label=label, upper=upper),
+        encoding="utf-8",
+    )
+
+    print(f"scaffolded {module}/mod.rs")
+    print("next steps (docs/engineering/add-a-language.md):")
+    print(f"  1. declare `mod {lang_id.replace('-', '_')};` in src/languages/mod.rs")
+    print(f"  2. register &{lang_id.replace('-', '_')}::{upper} in ALL_FRONTENDS")
+    print("  3. route its LanguageKind in frontend_for_kind")
+    print("  4. follow the checklist; the guard tests enforce the rest")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/audits/context/classify/helpers.rs
+++ b/src/audits/context/classify/helpers.rs
@@ -52,7 +52,7 @@ pub fn is_test_file(path: &Path) -> bool {
         .map(|name| name.to_lowercase())
         .unwrap_or_default();
 
-    path_text.starts_with("tests/")
+    if path_text.starts_with("tests/")
         || path_text.starts_with("tests\\")
         || path_text.contains("/tests/")
         || path_text.contains("\\tests\\")
@@ -62,35 +62,21 @@ pub fn is_test_file(path: &Path) -> bool {
         || path_text.contains("\\fixtures\\")
         || path_text.contains("/__tests__/")
         || path_text.contains("\\__tests__\\")
-        || file_name.ends_with(".test.ts")
-        || file_name.ends_with(".test.tsx")
-        || file_name.ends_with(".test.js")
-        || file_name.ends_with(".test.jsx")
-        || file_name.ends_with(".spec.ts")
-        || file_name.ends_with(".spec.tsx")
-        || file_name.ends_with(".spec.js")
-        || file_name.ends_with(".spec.jsx")
-        || file_name.ends_with("_test.go")
-        || file_name.ends_with("_test.py")
-        || file_name.ends_with("test.java")
-        || file_name.ends_with("tests.java")
-        || file_name.ends_with("test.kt")
-        || file_name.ends_with("tests.kt")
-        || file_name.ends_with("test.cs")
-        || file_name.ends_with("tests.cs")
-        // The `test_` prefix is a Python / JS test convention. It is NOT a Rust
-        // one (Rust uses `tests/`, `#[cfg(test)]`, or plural `_tests.rs`), where
-        // it instead collides with production modules like `test_edges.rs`.
-        || (file_name.starts_with("test_") && !file_name.ends_with(".rs"))
-        // Rust test modules carry no path component (a sibling `tests.rs` /
-        // `tests_render.rs` / `*_tests.rs` pulled in via `#[cfg(test)] mod ...;`).
-        // Only the *plural* forms are used for Rust test files; the singular
-        // `*_test.rs` collides with production names (e.g. `source_without_test.rs`),
-        // so it is deliberately omitted — real `*_test.rs` integration tests live
-        // under `tests/` and are already matched by the path checks above.
-        || file_name == "tests.rs"
-        || file_name.ends_with("_tests.rs")
+        // Sibling test modules pulled in without a path component
+        // (`tests_render.rs` and friends) — a cross-language prefix form.
         || file_name.starts_with("tests_")
+    {
+        return true;
+    }
+
+    // Language-specific file naming (`.spec.ts`, `_test.go`, plural
+    // `_tests.rs`, …) comes from the frontend's conventions, as does whether
+    // the `test_` prefix convention applies — it is NOT a Rust one (Rust
+    // uses `tests/`, `#[cfg(test)]`, or plural `_tests.rs`), where it
+    // collides with production modules like `test_edges.rs`.
+    let conventions = crate::languages::conventions::conventions_for_path(path);
+    (conventions.test_file_name)(&file_name)
+        || (file_name.starts_with("test_") && conventions.test_prefix_marks_test)
 }
 
 /// True for Rust *test-support* modules — `testutil.rs`, `test_utils.rs`,
@@ -102,41 +88,12 @@ pub fn is_test_file(path: &Path) -> bool {
 /// treat it specially; the file keeps its ordinary production role for every
 /// other rule. An explicit allow list keeps the collision-prone `test_*` prefix
 /// (the production `test_edges.rs` / `source_without_test.rs`) out.
+#[cfg(test)] // production callers go through the frontend conventions
 pub fn is_test_support_file(path: &Path) -> bool {
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .map(|name| name.to_lowercase())
-        .unwrap_or_default();
-
-    matches!(
-        file_name.as_str(),
-        "testutil.rs"
-            | "testutils.rs"
-            | "test_util.rs"
-            | "test_utils.rs"
-            | "test_support.rs"
-            | "test_helper.rs"
-            | "test_helpers.rs"
-    )
-}
-
-/// True for a managed-language *test-support module directory* — a source tree
-/// dedicated to test doubles and helpers shared across modules. This is limited
-/// to Gradle/source-set shapes that indicate a whole helper module/source set,
-/// such as `core/testing/src/main/...`, `core/testsupport/src/main/...`, or
-/// `module/src/testFixtures/...`; a package namespace component like
-/// `app/src/main/kotlin/com/example/testing/...` is ordinary production code.
-pub fn is_managed_test_support_path(path: &Path) -> bool {
-    let components = normalized_components(path);
-
-    components.windows(3).any(|window| {
-        matches!(window[0].as_str(), "testing" | "testsupport")
-            && window[1] == "src"
-            && window[2] == "main"
-    }) || components
-        .windows(2)
-        .any(|window| window[0] == "src" && window[1] == "testfixtures")
+    crate::languages::frontend_for_kind(LanguageKind::Rust)
+        .conventions
+        .test_support
+        .is_some_and(|support| (support.matches)(path))
 }
 
 /// True for *build-tooling* sources — Gradle convention plugins and build logic
@@ -144,13 +101,6 @@ pub fn is_managed_test_support_path(path: &Path) -> bool {
 /// in the application, so a `throw`/`TODO()` there fails the build by design.
 pub fn is_build_tooling_path(path: &Path) -> bool {
     path_contains_component(path, &["build-logic", "buildsrc"])
-}
-
-fn normalized_components(path: &Path) -> Vec<String> {
-    path.to_string_lossy()
-        .split(['/', '\\'])
-        .map(normalize)
-        .collect()
 }
 
 pub fn is_config_file(path: &Path) -> bool {
@@ -246,9 +196,9 @@ pub fn is_app_entrypoint(path: &Path, content: &str, language: LanguageKind) -> 
             | "main.js"
             | "main.tsx"
             | "main.jsx"
-    ) || (language == LanguageKind::Python && content.contains("if __name__ == \"__main__\""))
-        || (language == LanguageKind::Go && content.contains("func main("))
-        || (language == LanguageKind::Rust && content.contains("fn main("))
+    ) || crate::languages::conventions::conventions_for_kind(language)
+        .entrypoint_content
+        .is_some_and(|probe| probe(content))
 }
 
 #[cfg(test)]

--- a/src/audits/context/classify/roles.rs
+++ b/src/audits/context/classify/roles.rs
@@ -3,7 +3,7 @@ use super::frameworks::{
 };
 use super::helpers::{
     is_app_entrypoint, is_build_tooling_path, is_config_file, is_generated_file, is_js_or_ts,
-    is_managed_test_support_path, is_test_support_file, path_contains_component,
+    path_contains_component,
 };
 use super::signals::ContextSignals;
 use crate::audits::context::model::{
@@ -111,27 +111,16 @@ fn classify_static_roles(
         }
     }
 
-    if language == LanguageKind::Rust && is_test_support_file(path) {
-        push_role(
-            roles,
-            evidence,
-            FileRole::TestSupport,
-            RoleEvidenceSource::Path,
-            "recognized Rust test-support helper filename",
-        );
-    }
-
-    if matches!(
-        language,
-        LanguageKind::Java | LanguageKind::Kotlin | LanguageKind::CSharp
-    ) && is_managed_test_support_path(path)
+    if let Some(support) = crate::languages::conventions::conventions_for_kind(language)
+        .test_support
+        .filter(|support| (support.matches)(path))
     {
         push_role(
             roles,
             evidence,
             FileRole::TestSupport,
             RoleEvidenceSource::Path,
-            "recognized managed-language test-support source-set path",
+            support.reason,
         );
     }
 

--- a/src/languages/conventions.rs
+++ b/src/languages/conventions.rs
@@ -1,0 +1,87 @@
+//! Per-language path and naming conventions.
+//!
+//! The cross-language rules (test directories like `tests/`/`__tests__/`,
+//! the `tests_` filename prefix, build-tooling paths) stay in the context
+//! classifier's helpers; what varies by language lives here: test-file
+//! naming, whether the `test_` prefix convention applies, test-support
+//! recognizers, and app-entrypoint content probes. The entrypoint *filename*
+//! list stays shared — it has always matched union-style across languages.
+
+use super::frontend_for_kind;
+use super::generic::GENERIC;
+use crate::audits::context::LanguageKind;
+use std::path::Path;
+
+/// A test-support recognizer: production modules (or source sets) whose
+/// panics/asserts are test plumbing. The reason string is role evidence and
+/// must stay stable per convention.
+pub struct TestSupportConvention {
+    pub(crate) matches: fn(&Path) -> bool,
+    pub(crate) reason: &'static str,
+}
+
+pub struct PathConventions {
+    /// Language-specific test-file rule over the lowercased file name.
+    pub(crate) test_file_name: fn(&str) -> bool,
+    /// Whether the cross-language `test_` filename prefix marks a test file.
+    /// False for Rust, where it collides with production modules
+    /// (`test_edges.rs`).
+    pub(crate) test_prefix_marks_test: bool,
+    /// Test-support recognizer, when the language has one.
+    pub(crate) test_support: Option<&'static TestSupportConvention>,
+    /// Content probe for app entrypoints (`fn main(`, `if __name__ …`).
+    pub(crate) entrypoint_content: Option<fn(&str) -> bool>,
+}
+
+pub(crate) static GENERIC_CONVENTIONS: PathConventions = PathConventions {
+    test_file_name: |_| false,
+    test_prefix_marks_test: true,
+    test_support: None,
+    entrypoint_content: None,
+};
+
+/// Gradle/source-set shapes dedicating a whole module or source set to test
+/// doubles (`core/testing/src/main/...`, `module/src/testFixtures/...`); a
+/// package namespace component like `.../com/example/testing/...` is
+/// ordinary production code. Shared by the Java, Kotlin, and C# frontends.
+pub(crate) static MANAGED_TEST_SUPPORT: TestSupportConvention = TestSupportConvention {
+    matches: |path| {
+        let components: Vec<String> = path
+            .to_string_lossy()
+            .split(['/', '\\'])
+            .map(|component| component.trim().to_lowercase())
+            .collect();
+
+        components.windows(3).any(|window| {
+            matches!(window[0].as_str(), "testing" | "testsupport")
+                && window[1] == "src"
+                && window[2] == "main"
+        }) || components
+            .windows(2)
+            .any(|window| window[0] == "src" && window[1] == "testfixtures")
+    },
+    reason: "recognized managed-language test-support source-set path",
+};
+
+/// The conventions for the language detection assigns to `path`, falling
+/// back to the generic frontend's conventions.
+pub(crate) fn conventions_for_path(path: &Path) -> &'static PathConventions {
+    crate::knowledge::language::detect_language_for_path(path)
+        .and_then(super::frontend_for_label)
+        .map(|frontend| frontend.conventions)
+        .unwrap_or(GENERIC.conventions)
+}
+
+/// The conventions for a context-classifier kind.
+pub(crate) fn conventions_for_kind(kind: LanguageKind) -> &'static PathConventions {
+    frontend_for_kind(kind).conventions
+}
+
+/// Every distinct conventions table, for guard tests.
+#[cfg(test)]
+pub(crate) fn all_conventions() -> Vec<(&'static str, &'static PathConventions)> {
+    super::all_frontends()
+        .iter()
+        .map(|frontend| (frontend.id, frontend.conventions))
+        .collect()
+}

--- a/src/languages/csharp/mod.rs
+++ b/src/languages/csharp/mod.rs
@@ -1,5 +1,6 @@
 mod risk;
 
+use super::conventions::{MANAGED_TEST_SUPPORT, PathConventions};
 use super::{GrammarBinding, LanguageFrontend};
 use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
@@ -25,6 +26,7 @@ pub(super) static CSHARP: LanguageFrontend = LanguageFrontend {
     imports: None,
     taint: None,
     review: Some(&CSHARP_REVIEW),
+    conventions: &CSHARP_CONVENTIONS,
     risk: Some(&risk::CSHARP_RISK),
 };
 
@@ -71,4 +73,11 @@ static CSHARP_REMOVED: RemovedTables = RemovedTables {
     },
     is_error_handling: |node, _| node.kind() == "try_statement",
     auth_call_kinds: &["invocation_expression"],
+};
+
+static CSHARP_CONVENTIONS: PathConventions = PathConventions {
+    test_file_name: |name| name.ends_with("test.cs") || name.ends_with("tests.cs"),
+    test_prefix_marks_test: true,
+    test_support: Some(&MANAGED_TEST_SUPPORT),
+    entrypoint_content: None,
 };

--- a/src/languages/generic.rs
+++ b/src/languages/generic.rs
@@ -13,5 +13,6 @@ pub(super) static GENERIC: LanguageFrontend = LanguageFrontend {
     imports: None,
     taint: None,
     review: None,
+    conventions: &super::conventions::GENERIC_CONVENTIONS,
     risk: None,
 };

--- a/src/languages/go/mod.rs
+++ b/src/languages/go/mod.rs
@@ -1,3 +1,4 @@
+use super::conventions::PathConventions;
 use super::{GrammarBinding, LanguageFrontend};
 use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
@@ -26,5 +27,13 @@ pub(super) static GO: LanguageFrontend = LanguageFrontend {
     imports: Some(&GO_IMPORTS),
     taint: Some(&review::GO_TAINT),
     review: Some(&review::GO_REVIEW),
+    conventions: &GO_CONVENTIONS,
     risk: Some(&risk::GO_RISK),
+};
+
+static GO_CONVENTIONS: PathConventions = PathConventions {
+    test_file_name: |name| name.ends_with("_test.go"),
+    test_prefix_marks_test: true,
+    test_support: None,
+    entrypoint_content: Some(|content| content.contains("func main(")),
 };

--- a/src/languages/java/mod.rs
+++ b/src/languages/java/mod.rs
@@ -1,3 +1,4 @@
+use super::conventions::{MANAGED_TEST_SUPPORT, PathConventions};
 use super::{GrammarBinding, LanguageFrontend};
 use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
@@ -26,5 +27,13 @@ pub(super) static JAVA: LanguageFrontend = LanguageFrontend {
     imports: Some(&JAVA_IMPORTS),
     taint: None,
     review: Some(&review::JAVA_REVIEW),
+    conventions: &JAVA_CONVENTIONS,
     risk: Some(&risk::JAVA_RISK),
+};
+
+static JAVA_CONVENTIONS: PathConventions = PathConventions {
+    test_file_name: |name| name.ends_with("test.java") || name.ends_with("tests.java"),
+    test_prefix_marks_test: true,
+    test_support: Some(&MANAGED_TEST_SUPPORT),
+    entrypoint_content: None,
 };

--- a/src/languages/javascript/mod.rs
+++ b/src/languages/javascript/mod.rs
@@ -1,6 +1,7 @@
 //! The JavaScript dialect family: JavaScript and TypeScript frontends,
 //! including their React (`.jsx`/`.tsx`) knowledge-pack dialects.
 
+use super::conventions::PathConventions;
 use super::{GrammarBinding, LanguageFrontend};
 use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
@@ -35,6 +36,7 @@ pub(super) static TYPESCRIPT: LanguageFrontend = LanguageFrontend {
     imports: Some(&JS_FAMILY_IMPORTS),
     taint: Some(&review::JS_FAMILY_TAINT),
     review: Some(&review::JS_FAMILY_REVIEW),
+    conventions: &JS_FAMILY_CONVENTIONS,
     risk: Some(&risk::JS_FAMILY_RISK),
 };
 
@@ -56,5 +58,22 @@ pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
     imports: Some(&JS_FAMILY_IMPORTS),
     taint: Some(&review::JS_FAMILY_TAINT),
     review: Some(&review::JS_FAMILY_REVIEW),
+    conventions: &JS_FAMILY_CONVENTIONS,
     risk: Some(&risk::JS_FAMILY_RISK),
+};
+
+static JS_FAMILY_CONVENTIONS: PathConventions = PathConventions {
+    test_file_name: |name| {
+        name.ends_with(".test.ts")
+            || name.ends_with(".test.tsx")
+            || name.ends_with(".test.js")
+            || name.ends_with(".test.jsx")
+            || name.ends_with(".spec.ts")
+            || name.ends_with(".spec.tsx")
+            || name.ends_with(".spec.js")
+            || name.ends_with(".spec.jsx")
+    },
+    test_prefix_marks_test: true,
+    test_support: None,
+    entrypoint_content: None,
 };

--- a/src/languages/kotlin/mod.rs
+++ b/src/languages/kotlin/mod.rs
@@ -1,3 +1,4 @@
+use super::conventions::{MANAGED_TEST_SUPPORT, PathConventions};
 use super::{GrammarBinding, LanguageFrontend};
 use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
@@ -26,5 +27,13 @@ pub(super) static KOTLIN: LanguageFrontend = LanguageFrontend {
     imports: Some(&KOTLIN_IMPORTS),
     taint: None,
     review: Some(&review::KOTLIN_REVIEW),
+    conventions: &KOTLIN_CONVENTIONS,
     risk: Some(&risk::KOTLIN_RISK),
+};
+
+static KOTLIN_CONVENTIONS: PathConventions = PathConventions {
+    test_file_name: |name| name.ends_with("test.kt") || name.ends_with("tests.kt"),
+    test_prefix_marks_test: true,
+    test_support: Some(&MANAGED_TEST_SUPPORT),
+    entrypoint_content: None,
 };

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -20,7 +20,9 @@
 //! not become one.
 
 pub mod capability;
+pub(crate) mod conventions;
 pub(crate) mod import_support;
+mod reference;
 
 mod csharp;
 mod generic;
@@ -33,6 +35,8 @@ mod rust;
 
 #[cfg(test)]
 mod tests;
+
+pub use reference::render_language_support_markdown;
 
 use crate::analysis::parse::{ParseLanguage, ParsedFile};
 use crate::audits::context::LanguageKind;
@@ -102,6 +106,8 @@ pub struct LanguageFrontend {
     /// dedicated `rust_panic_risk` audit is separate and not counted here.
     pub(crate) risk:
         Option<&'static crate::audits::code_quality::language_risk::tables::RiskTables>,
+    /// Path and naming conventions (test files, test support, entrypoints).
+    pub(crate) conventions: &'static conventions::PathConventions,
 }
 
 /// Every registered frontend, including the generic fallback (last).

--- a/src/languages/python/mod.rs
+++ b/src/languages/python/mod.rs
@@ -1,3 +1,4 @@
+use super::conventions::PathConventions;
 use super::{GrammarBinding, LanguageFrontend};
 use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
@@ -26,5 +27,13 @@ pub(super) static PYTHON: LanguageFrontend = LanguageFrontend {
     imports: Some(&PYTHON_IMPORTS),
     taint: Some(&review::PYTHON_TAINT),
     review: Some(&review::PYTHON_REVIEW),
+    conventions: &PYTHON_CONVENTIONS,
     risk: Some(&risk::PYTHON_RISK),
+};
+
+static PYTHON_CONVENTIONS: PathConventions = PathConventions {
+    test_file_name: |name| name.ends_with("_test.py"),
+    test_prefix_marks_test: true,
+    test_support: None,
+    entrypoint_content: Some(|content| content.contains("if __name__ == \"__main__\"")),
 };

--- a/src/languages/reference.rs
+++ b/src/languages/reference.rs
@@ -1,0 +1,147 @@
+//! Renders `docs/language-support.md` from the language frontend registry
+//! and the bundled knowledge pack, so the published support matrix can never
+//! drift from what is actually wired. The drift check lives in
+//! `tests/language_support_doc.rs`; regenerate with
+//! `REPOPILOT_BLESS=1 cargo test --test language_support_doc`.
+
+use super::{LanguageFrontend, all_frontends, frontend_for_knowledge_id};
+use crate::knowledge::active_knowledge;
+use crate::knowledge::model::SupportLevel;
+use std::fmt::Write;
+
+const GENERATED_BANNER: &str = "<!-- @generated from the language frontend registry — do not edit by hand. -->\n<!-- Regenerate with `REPOPILOT_BLESS=1 cargo test --test language_support_doc`. -->";
+
+/// Deterministic Markdown for the language support matrix: one capability row
+/// per frontend (facts derived from wiring, never declared), then the
+/// detect-level languages from the knowledge pack.
+pub fn render_language_support_markdown() -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "# Language and Framework Support\n");
+    let _ = writeln!(out, "{GENERATED_BANNER}\n");
+    let _ = writeln!(
+        out,
+        "RepoPilot combines generic repository heuristics with language-aware\n\
+analysis owned by *language frontends* (`src/languages/`). The capability\n\
+columns below are derived from what each frontend actually wires — a column\n\
+cannot be claimed without the code behind it. `Declared` is the support\n\
+level the bundled knowledge pack asserts; where it exceeds the wired\n\
+capabilities, the gap is tracked by the registry's support-honesty guard\n\
+test rather than hidden.\n"
+    );
+
+    let _ = writeln!(out, "## Frontend capabilities\n");
+    let _ = writeln!(
+        out,
+        "| Language | Grammar | Imports | Review signals | Taint flows | Runtime risk | Conventions | Declared |"
+    );
+    let _ = writeln!(out, "|---|---|---|---|---|---|---|---|");
+    for frontend in all_frontends() {
+        if frontend.id == "generic" {
+            continue;
+        }
+        let _ = writeln!(out, "{}", frontend_row(frontend));
+    }
+    let _ = writeln!(
+        out,
+        "\nNotes:\n\n\
+- **Rust runtime risk** is covered by the dedicated `rust.panic-risk` rule\n\
+  family rather than the shared runtime-risk audit, so its column reads “—”\n\
+  here; how it counts toward the capability model is tracked in the\n\
+  support-honesty ledger.\n\
+- **C# review signals** exclude AST boundary classification: the pre-registry\n\
+  dispatch never matched the label detection emits, and enabling it is a\n\
+  deliberate behavior change, not a docs update.\n\
+- JavaScript and TypeScript (with their React dialects) share one frontend\n\
+  family: the same grammar shapes, import extractor, and signal tables.\n"
+    );
+
+    let _ = writeln!(out, "## Detected languages without a frontend\n");
+    let _ = writeln!(
+        out,
+        "Files in these languages still contribute to repository size, scan\n\
+scope, file roles (via the shared context classifier), and generic findings;\n\
+they have no language-specific extractors.\n"
+    );
+    for (heading, level) in [
+        (
+            "Context-aware (shared classifier)",
+            SupportLevel::ContextAware,
+        ),
+        ("Import-aware", SupportLevel::ImportAware),
+        ("Detect-only", SupportLevel::DetectOnly),
+        (
+            "Declared rule-aware without wiring",
+            SupportLevel::RuleAware,
+        ),
+    ] {
+        let names: Vec<&str> = active_knowledge()
+            .languages
+            .iter()
+            .filter(|profile| {
+                profile.support == level && frontend_for_knowledge_id(&profile.id).is_none()
+            })
+            .map(|profile| profile.name.as_str())
+            .collect();
+        if names.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "- **{heading}:** {}.", names.join(", "));
+    }
+
+    let _ = writeln!(
+        out,
+        "\n## Rule philosophy\n\n\
+RepoPilot should not treat every paradigm as a smell. Functional,\n\
+object-oriented, procedural, and declarative code can all be valid; rules\n\
+use context and confidence instead of assuming one style is always better:\n\n\
+```text\nevidence + context + severity + confidence + recommendation\n```\n\n\
+## Limitations\n\n\
+RepoPilot is not a compiler or type checker. Some rules are text-based or\n\
+heuristic; findings are review signals, not absolute truth. Use\n\
+language-specific tools alongside it: `cargo clippy`, `tsc`/ESLint, Ruff and\n\
+Pyright, `go vet`, or your build's own checks.\n\n\
+## Adding a language\n\n\
+The whole point of the frontend contract is that support is added by\n\
+writing tables, not by editing engines. The checklist lives in\n\
+[Add a language](engineering/add-a-language.md)."
+    );
+
+    out
+}
+
+fn frontend_row(frontend: &LanguageFrontend) -> String {
+    let declared = active_knowledge()
+        .languages
+        .iter()
+        .find(|profile| profile.id == frontend.id)
+        .map(|profile| support_label(profile.support))
+        .unwrap_or("—");
+
+    format!(
+        "| {} | {} | {} | {} | {} | {} | {} | {} |",
+        frontend.label,
+        mark(!frontend.grammars.is_empty()),
+        mark(frontend.imports.is_some()),
+        mark(frontend.review.is_some()),
+        mark(frontend.taint.is_some()),
+        mark(frontend.risk.is_some()),
+        mark(!std::ptr::eq(
+            frontend.conventions,
+            &super::conventions::GENERIC_CONVENTIONS
+        )),
+        declared,
+    )
+}
+
+fn mark(wired: bool) -> &'static str {
+    if wired { "✓" } else { "—" }
+}
+
+fn support_label(level: SupportLevel) -> &'static str {
+    match level {
+        SupportLevel::RuleAware => "rule-aware",
+        SupportLevel::ContextAware => "context-aware",
+        SupportLevel::ImportAware => "import-aware",
+        SupportLevel::DetectOnly => "detect-only",
+    }
+}

--- a/src/languages/rust/mod.rs
+++ b/src/languages/rust/mod.rs
@@ -1,3 +1,4 @@
+use super::conventions::{PathConventions, TestSupportConvention};
 use super::{GrammarBinding, LanguageFrontend};
 use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
@@ -25,5 +26,39 @@ pub(super) static RUST: LanguageFrontend = LanguageFrontend {
     imports: Some(&RUST_IMPORTS),
     taint: None,
     review: Some(&review::RUST_REVIEW),
+    conventions: &RUST_CONVENTIONS,
     risk: None,
+};
+
+static RUST_CONVENTIONS: PathConventions = PathConventions {
+    // Only the plural forms are Rust test-file names; the singular
+    // `test_*`/`*_test` collide with production modules (`test_edges.rs`).
+    test_file_name: |name| name == "tests.rs" || name.ends_with("_tests.rs"),
+    test_prefix_marks_test: false,
+    test_support: Some(&RUST_TEST_SUPPORT),
+    entrypoint_content: Some(|content| content.contains("fn main(")),
+};
+
+/// `testutil.rs`-style helpers: production modules (compiled in normal
+/// builds) whose panics are assertion plumbing. Explicit allowlist keeps the
+/// collision-prone `test_*` prefix out.
+static RUST_TEST_SUPPORT: TestSupportConvention = TestSupportConvention {
+    matches: |path| {
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.to_lowercase())
+            .unwrap_or_default();
+        matches!(
+            file_name.as_str(),
+            "testutil.rs"
+                | "testutils.rs"
+                | "test_util.rs"
+                | "test_utils.rs"
+                | "test_support.rs"
+                | "test_helper.rs"
+                | "test_helpers.rs"
+        )
+    },
+    reason: "recognized Rust test-support helper filename",
 };

--- a/src/languages/tests.rs
+++ b/src/languages/tests.rs
@@ -329,6 +329,42 @@ fn runtime_risk_participation_is_pinned() {
     }
 }
 
+/// Pins the convention surface: the Rust `test_` prefix opt-out, which
+/// frontends carry a test-support recognizer (and its evidence reason), and
+/// which carry an entrypoint content probe.
+#[test]
+fn path_conventions_are_pinned() {
+    use super::conventions::all_conventions;
+
+    for (id, conventions) in all_conventions() {
+        assert_eq!(
+            conventions.test_prefix_marks_test,
+            id != "rust",
+            "test_ prefix convention changed for frontend '{id}'"
+        );
+
+        let expected_support_reason = match id {
+            "rust" => Some("recognized Rust test-support helper filename"),
+            "java" | "kotlin" | "csharp" => {
+                Some("recognized managed-language test-support source-set path")
+            }
+            _ => None,
+        };
+        assert_eq!(
+            conventions.test_support.map(|support| support.reason),
+            expected_support_reason,
+            "test-support convention changed for frontend '{id}'"
+        );
+
+        let expects_entry_probe = matches!(id, "rust" | "python" | "go");
+        assert_eq!(
+            conventions.entrypoint_content.is_some(),
+            expects_entry_probe,
+            "entrypoint content probe changed for frontend '{id}'"
+        );
+    }
+}
+
 /// The honesty ledger. Languages the bundled pack declares `rule-aware`
 /// whose frontends do not yet justify it. Migration PRs shrink this set by
 /// wiring capabilities (or PR-9 downgrades over-claimed pack declarations —

--- a/tests/language_support_doc.rs
+++ b/tests/language_support_doc.rs
@@ -1,0 +1,41 @@
+//! Drift guard for the published language support matrix.
+//!
+//! `docs/language-support.md` is generated from the language frontend
+//! registry (`render_language_support_markdown`). This test re-renders it in
+//! memory and compares against the committed file so the support matrix can
+//! never fall behind (or ahead of) the wiring. Runs under the ordinary
+//! `cargo test --all` gate.
+//!
+//! Regenerate after a registry change with:
+//!   `REPOPILOT_BLESS=1 cargo test --test language_support_doc`
+
+use repopilot::languages::render_language_support_markdown;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn language_support_doc_matches_registry() {
+    let rendered = render_language_support_markdown();
+    let path = doc_path();
+
+    if std::env::var_os("REPOPILOT_BLESS").is_some() {
+        fs::write(&path, &rendered).expect("failed to write docs/language-support.md");
+        return;
+    }
+
+    let committed = fs::read_to_string(&path)
+        .expect("docs/language-support.md is missing; run `REPOPILOT_BLESS=1 cargo test --test language_support_doc`")
+        .replace("\r\n", "\n");
+
+    assert_eq!(
+        rendered, committed,
+        "docs/language-support.md is out of date with the language frontend registry; \
+regenerate with `REPOPILOT_BLESS=1 cargo test --test language_support_doc`"
+    );
+}
+
+fn doc_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("docs")
+        .join("language-support.md")
+}


### PR DESCRIPTION
## Summary

Moves language-specific path and naming conventions into the frontend registry.

The PR also replaces the hand-written language support page with a generated capability matrix and adds a guide and scaffolding script for adding new languages.

## Type of change

* [x] Feature
* [x] Refactor
* [ ] Bug fix
* [x] Tests
* [x] Documentation
* [ ] CI / repository maintenance

## What changed

* Added frontend-owned path and naming conventions.
* Moved test-file naming rules into language frontends.
* Moved test-support recognizers and evidence reasons into frontends.
* Moved app-entrypoint content probes into frontends.
* Kept shared cross-language path rules in the context classifier.
* Added `Conventions` to computed frontend capabilities.
* Replaced the hand-written language support page with generated documentation.
* Added a drift test for `docs/language-support.md`.
* Added an “Add a language” contributor guide.
* Added `scripts/new-language.py` for creating a frontend module skeleton.
* Updated the language surface inventory and documentation index.

## Conventions

Frontends can now define:

* test file suffixes and exact names;
* whether the shared `test_` prefix applies;
* test-support file recognition;
* test-support role evidence;
* app-entrypoint content probes.

Shared conventions such as `tests/`, `__tests__/`, and common entrypoint filenames remain language-independent.

## Generated support matrix

`docs/language-support.md` is now generated from the frontend registry.

The matrix shows actual wired capabilities:

* grammar;
* imports;
* review signals;
* taint flows;
* runtime risk;
* path conventions;
* declared knowledge-pack support level.

Regenerate it with:

```bash
REPOPILOT_BLESS=1 cargo test --test language_support_doc
```

The test fails when the checked-in documentation differs from the registry.

## Adding a language

Added:

```
docs/engineering/add-a-language.md
scripts/new-language.py
```

The guide covers:

* knowledge-pack profile;
* frontend descriptor;
* grammar binding;
* import extraction;
* review and taint tables;
* runtime-risk support;
* conventions;
* fixtures;
* zoo validation;
* generated documentation.

Create a starter frontend with:

```
python3 scripts/new-language.py <id> "<Display Label>"
```

The script only creates new module files. It does not modify the registry or overwrite existing files.

## Behavior

The conventions migration is intended to preserve existing classification behavior.

Unchanged:

* existing test-file classification;
* test-support roles and evidence;
* app-entrypoint detection;
* scan and review findings;
* finding IDs and baselines;
* report schemas;
* MCP and GitHub Action behavior.

The generated support page changes documentation only. It does not enable new language capabilities.

## Why

Language-specific path rules were still stored in shared classifier modules even after parsing, imports, review tables, and runtime-risk dispatch moved into frontends.

The support documentation was also maintained manually and could drift from the actual implementation.

This change makes frontend wiring the source of truth for both behavior and documentation.

## Contract and ownership

* [x] The change stays within a clear subsystem or ownership boundary
* [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
* [x] No unrelated refactor or generated-file churn is included

Primary subsystems:

* language frontend registry;
* context and role classification;
* language support documentation;
* contributor tooling.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
npm run test:release-contract
./scripts/smoke-product.sh
git diff --check
```

Focused verification:

```
cargo test --lib languages
cargo test --lib audits::context
cargo test --test language_support_doc
python3 scripts/new-language.py --help
```

Generated documentation check:

```
REPOPILOT_BLESS=1 cargo test --test language_support_doc
git diff --exit-code docs/language-support.md
```
