### PR TITLE
feat(csharp): complete C# frontend contract with import extraction, t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 .agents/
 .claude/
 .codex/
+.specify/
 dist/
 .DS_Store
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **C# completes its frontend contract.** `using`-directive import
+  extraction (aliases and `global using` included; `using (resource)` forms
+  excluded) feeds the coupling graph; ASP.NET taint tables
+  (`Request.Query`/`Form`/`Headers` sources → `Process.Start`, SqlCommand
+  `Execute*`, `File.WriteAll*` sinks) flag request-input flows; and AST
+  boundary classification is enabled — the pre-registry dispatch matched a
+  label detection never emits, so `[Authorize]` attributes and security
+  `using` directives never participated before. The support-honesty ledger
+  now names only Rust (its panic-risk accounting, closed next). eshoponweb
+  zoo snapshot unchanged: zero new default-visible findings.
+
+### Added
+
 - **Java taint-lite.** The Java frontend now carries taint tables
   (`HttpServletRequest` sources; JDBC `execute*`, `Runtime.exec`, and
   `Files.write` sinks with a Java-specific `method_invocation` classifier),

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -21,7 +21,7 @@ test rather than hidden.
 | Python | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
 | Go | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
 | Java | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
-| C# | ✓ | — | ✓ | — | ✓ | ✓ | rule-aware |
+| C# | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
 | Kotlin | ✓ | ✓ | ✓ | — | ✓ | ✓ | rule-aware |
 
 Notes:
@@ -30,9 +30,6 @@ Notes:
 family rather than the shared runtime-risk audit, so its column reads “—”
 here; how it counts toward the capability model is tracked in the
 support-honesty ledger.
-- **C# review signals** exclude AST boundary classification: the pre-registry
-dispatch never matched the label detection emits, and enabling it is a
-deliberate behavior change, not a docs update.
 - JavaScript and TypeScript (with their React dialects) share one frontend
 family: the same grammar shapes, import extractor, and signal tables.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,21 +4,24 @@ RepoPilot is a review-first, local CLI for maintainers and coding agents. The
 product should help answer: what changed, which boundaries moved, and how far
 the change reaches before merge.
 
-## Now: 0.21 — agent-run review as the default workflow
+## Now: 0.21 — trust the default output, calibrate it to your repo
 
-The analysis engine is ahead of its adoption. This cycle is about making the
-core promise — deterministic review of a change you didn't write — trivially
-easy to wire in, and letting real users drive what gets built next.
+One larger release, three layers. The language frontend contract landed
+first (registry, per-language tables, generated support matrix, contributor
+guide); the rest of the cycle builds on it:
 
-- documented guardrail recipes: session snapshot + stop-hook review for
-  Claude Code, MCP bootstrap for agent clients, review-first CI gate
-  (see [Guard your agent runs](agent-guardrail.md));
-- a reproducible real-repo demo (pinned zoo checkout) showing a plausible
-  agent edit caught by `repopilot review`;
-- README and docs lead with change review; scan/baseline positioned as the
-  adoption surface;
-- precision work only in response to reported noise — the zoo regression
-  gate holds the current signal quality; no new speculative rules.
+- **contract honesty to zero** — complete C# (imports, taint, boundary),
+  account for Rust's dedicated panic-risk audit, Kotlin taint, framework
+  probes on frontends; the support ledger ends empty;
+- **local knowledge overlays** — a declarative, diffable local file that
+  calibrates known rules to a repository (severity, suppression) without
+  code execution or plugins;
+- **local analysis history** — a `.repopilot/` ledger of past runs:
+  risk deltas vs the previous scan and accumulated agent-session evidence;
+- **new languages via the cheap path** — added as frontend modules with a
+  pinned zoo repository as the acceptance gate;
+- guardrail recipes, reproducible agent-edit demos, and the review-first
+  README continue as the adoption surface.
 
 No hosted service, telemetry, source upload, or implicit LLM integration is
 part of the roadmap.

--- a/src/languages/csharp/imports.rs
+++ b/src/languages/csharp/imports.rs
@@ -1,0 +1,90 @@
+use crate::analysis::parse::ParsedFile;
+use std::collections::{BTreeMap, HashSet};
+
+pub(super) fn eager(parsed: &ParsedFile) -> HashSet<String> {
+    extract(parsed.content())
+}
+
+pub(super) fn spans(parsed: &ParsedFile) -> BTreeMap<String, (usize, usize)> {
+    extract_spans(parsed.content())
+}
+
+/// Line-based `using` directive extraction, mirroring the Java/Kotlin
+/// extractors. Handles `using N;`, `global using N;`, `using static T;`,
+/// and the alias form `using A = N.T;` (the aliased path is the edge).
+/// `using (resource)` statements and `using var x = …` declarations are
+/// resource management, not imports, and are skipped.
+fn extract_spans(content: &str) -> BTreeMap<String, (usize, usize)> {
+    let mut result = BTreeMap::new();
+    for (i, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
+            continue;
+        }
+        let rest = trimmed
+            .strip_prefix("global using ")
+            .or_else(|| trimmed.strip_prefix("using "));
+        let Some(rest) = rest else { continue };
+        let rest = rest
+            .trim_start_matches("static ")
+            .trim_end_matches(';')
+            .trim();
+
+        if rest.starts_with('(') || rest.starts_with("var ") {
+            continue;
+        }
+        // Alias form: the aliased namespace/type path is the real edge.
+        let path = match rest.split_once('=') {
+            Some((_, aliased)) => aliased.trim(),
+            None => rest,
+        };
+        if !path.is_empty() && is_namespace_path(path) {
+            result.entry(path.to_string()).or_insert((i + 1, i + 1));
+        }
+    }
+    result
+}
+
+fn is_namespace_path(path: &str) -> bool {
+    !path.is_empty()
+        && path
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '.' || c == '_')
+}
+
+fn extract(content: &str) -> HashSet<String> {
+    extract_spans(content).into_keys().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_spans;
+
+    #[test]
+    fn extracts_using_directives_and_aliases() {
+        let content = "using System.Text;\n\
+                       global using Microsoft.AspNetCore.Mvc;\n\
+                       using static System.Math;\n\
+                       using Project = PetShop.Domain.Orders;\n";
+        let spans = extract_spans(content);
+        let keys: Vec<&str> = spans.keys().map(String::as_str).collect();
+        assert_eq!(
+            keys,
+            [
+                "Microsoft.AspNetCore.Mvc",
+                "PetShop.Domain.Orders",
+                "System.Math",
+                "System.Text",
+            ]
+        );
+        assert_eq!(spans["System.Text"], (1, 1));
+    }
+
+    #[test]
+    fn skips_resource_management_using_forms() {
+        let content = "using (var stream = File.Open(path))\n\
+                       using var reader = new StreamReader(stream);\n\
+                       // using System.Commented;\n";
+        assert!(extract_spans(content).is_empty());
+    }
+}

--- a/src/languages/csharp/mod.rs
+++ b/src/languages/csharp/mod.rs
@@ -1,10 +1,20 @@
+mod imports;
+mod review;
 mod risk;
 
 use super::conventions::{MANAGED_TEST_SUPPORT, PathConventions};
-use super::{GrammarBinding, LanguageFrontend};
+use super::{GrammarBinding, ImportExtractor, LanguageFrontend};
 use crate::analysis::parse::ParseLanguage;
 use crate::audits::context::LanguageKind;
-use crate::review::signals::tables::{AlgorithmicKinds, RemovedTables, ReviewTables};
+use crate::review::signals::tables::{
+    AlgorithmicKinds, BoundaryKinds, RemovedTables, ReviewTables,
+};
+
+static CSHARP_IMPORTS: ImportExtractor = ImportExtractor {
+    eager: imports::eager,
+    deferred: None,
+    spans: imports::spans,
+};
 
 pub(super) static CSHARP: LanguageFrontend = LanguageFrontend {
     id: "csharp",
@@ -23,19 +33,22 @@ pub(super) static CSHARP: LanguageFrontend = LanguageFrontend {
             grammar: ParseLanguage::CSharp,
         },
     ],
-    imports: None,
-    taint: None,
+    imports: Some(&CSHARP_IMPORTS),
+    taint: Some(&review::CSHARP_TAINT),
     review: Some(&CSHARP_REVIEW),
     conventions: &CSHARP_CONVENTIONS,
     risk: Some(&risk::CSHARP_RISK),
 };
 
-// Boundary stays unwired: the old dispatch matched the label "CSharp", but
-// detection emits "C#", so C# never received AST boundary classification.
-// Enabling it is a deliberate behavior change for the honesty pass, not a
-// refactor side effect.
 static CSHARP_REVIEW: ReviewTables = ReviewTables {
-    boundary: None,
+    // Enabled by the honesty pass: the pre-registry dispatch matched the
+    // label "CSharp" while detection emits "C#", so these node kinds were
+    // dead. C# attributes (`[Authorize]`) and `using` directives now
+    // participate in boundary classification like every other language.
+    boundary: Some(&BoundaryKinds {
+        decorator_kinds: &["attribute"],
+        import_kinds: &["using_directive"],
+    }),
     algorithmic: &AlgorithmicKinds {
         function_kinds: &[
             "method_declaration",

--- a/src/languages/csharp/review.rs
+++ b/src/languages/csharp/review.rs
@@ -1,0 +1,108 @@
+//! Taint tables for C#. Sources are ASP.NET request reads; sinks mirror the
+//! C# behavioral "added X" detectors (`Process.Start`, SqlCommand
+//! `Execute*`, `File.WriteAll*`). Conservative and high-specificity —
+//! ASP.NET request handling is heavily framework-mediated (model binding),
+//! so only unambiguous raw-request idioms participate, and everything ships
+//! at `preview`.
+
+use crate::review::signals::taint::sinks::{Sink, SinkKind};
+use crate::review::signals::taint::tables::TaintTables;
+use tree_sitter::Node;
+
+pub(super) static CSHARP_TAINT: TaintTables = TaintTables {
+    request_sources: &[
+        "Request.Query",
+        "Request.Form",
+        "Request.Headers",
+        "Request.Cookies",
+        "Request.Body",
+        "Request.QueryString",
+        "HttpContext.Request",
+    ],
+    argv_sources: &["Environment.GetCommandLineArgs", "args"],
+    // `Request.Query["id"]` reads through member access; the idiom text
+    // lives on the member_access_expression node.
+    source_access_kinds: &["member_access_expression"],
+    // Coercion pruning is skipped: `int.Parse(...)` is an invocation the
+    // shared walker cannot key off; a request value coerced to an int
+    // rarely reaches a string-built sink.
+    coercions: &[],
+    coercion_call_kind: "invocation_expression",
+    assignment_kinds: &["variable_declarator", "assignment_expression"],
+    is_flow_scope,
+    is_augmenting,
+    is_string_building,
+    classify_sink,
+};
+
+fn is_flow_scope(node: Node<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "method_declaration"
+            | "constructor_declaration"
+            | "local_function_statement"
+            | "lambda_expression"
+            | "anonymous_method_expression"
+    )
+}
+
+fn is_augmenting(node: Node<'_>) -> bool {
+    node.kind() == "assignment_expression" && {
+        let mut cursor = node.walk();
+        node.children(&mut cursor).any(|child| {
+            matches!(
+                child.kind(),
+                "+=" | "-=" | "*=" | "/=" | "%=" | "&=" | "|=" | "^=" | "<<=" | ">>=" | "??="
+            )
+        })
+    }
+}
+
+fn is_string_building(node: Node<'_>, content: &str) -> bool {
+    // `"..." + x` concatenation, `$"...{x}..."` interpolation, or
+    // `string.Format(...)`.
+    node.kind() == "binary_expression"
+        || node.kind() == "interpolated_string_expression"
+        || (node.kind() == "invocation_expression"
+            && csharp_callee(node, content)
+                .is_some_and(|callee| callee == "string.Format" || callee == "String.Format"))
+}
+
+/// The `Object.Method` callee text of an `invocation_expression`, with the
+/// argument list stripped off (same approach as the Java frontend — the
+/// shared `callee_text` helper only understands `call`/`call_expression`).
+fn csharp_callee<'a>(node: Node<'a>, content: &'a str) -> Option<&'a str> {
+    let args = node.child_by_field_name("arguments")?;
+    content
+        .get(node.start_byte()..args.start_byte())
+        .map(str::trim)
+        .filter(|callee| !callee.is_empty())
+}
+
+fn classify_sink<'a>(node: Node<'a>, content: &'a str) -> Option<Sink<'a>> {
+    if node.kind() != "invocation_expression" {
+        return None;
+    }
+    let args = node.child_by_field_name("arguments")?;
+    let callee = csharp_callee(node, content)?;
+
+    let kind = if callee.ends_with(".ExecuteReader")
+        || callee.ends_with(".ExecuteNonQuery")
+        || callee.ends_with(".ExecuteScalar")
+        || callee.ends_with(".ExecuteReaderAsync")
+        || callee.ends_with(".ExecuteNonQueryAsync")
+        || callee.ends_with(".ExecuteScalarAsync")
+    {
+        SinkKind::Sql
+    } else if callee == "Process.Start" {
+        SinkKind::Exec
+    } else if callee.starts_with("File.WriteAll")
+        || callee.starts_with("File.AppendAll")
+        || callee == "File.OpenWrite"
+    {
+        SinkKind::FsWrite
+    } else {
+        return None;
+    };
+    Some(Sink { kind, args })
+}

--- a/src/languages/reference.rs
+++ b/src/languages/reference.rs
@@ -48,9 +48,6 @@ test rather than hidden.\n"
   family rather than the shared runtime-risk audit, so its column reads “—”\n\
   here; how it counts toward the capability model is tracked in the\n\
   support-honesty ledger.\n\
-- **C# review signals** exclude AST boundary classification: the pre-registry\n\
-  dispatch never matched the label detection emits, and enabling it is a\n\
-  deliberate behavior change, not a docs update.\n\
 - JavaScript and TypeScript (with their React dialects) share one frontend\n\
   family: the same grammar shapes, import extractor, and signal tables.\n"
     );

--- a/src/languages/tests.rs
+++ b/src/languages/tests.rs
@@ -161,7 +161,7 @@ fn kinds_route_to_their_frontends_and_the_rest_to_generic() {
 fn import_extractor_coverage_is_pinned() {
     let with_deferred: BTreeSet<&str> =
         ["typescript", "javascript", "python"].into_iter().collect();
-    let without_imports: BTreeSet<&str> = ["csharp", "generic"].into_iter().collect();
+    let without_imports: BTreeSet<&str> = ["generic"].into_iter().collect();
 
     for frontend in all_frontends() {
         match frontend.imports {
@@ -193,7 +193,7 @@ fn import_extractor_coverage_is_pinned() {
 /// language from taint analysis.
 #[test]
 fn taint_participation_is_pinned() {
-    let with_taint: BTreeSet<&str> = ["typescript", "javascript", "python", "go", "java"]
+    let with_taint: BTreeSet<&str> = ["typescript", "javascript", "python", "go", "java", "csharp"]
         .into_iter()
         .collect();
     for frontend in all_frontends() {
@@ -207,9 +207,9 @@ fn taint_participation_is_pinned() {
 }
 
 /// Pins which frontends carry review-signal tables and whether their AST
-/// boundary classification is wired. C#'s boundary stays `None` on purpose:
-/// the old dispatch matched the label "CSharp" while detection emits "C#",
-/// so enabling it is a deliberate behavior change, not a refactor default.
+/// boundary classification is wired. Every table-carrying frontend now has
+/// boundary wired (C#'s historical dead-arm exception was closed by the
+/// honesty pass).
 #[test]
 fn review_table_coverage_is_pinned() {
     let with_review: BTreeSet<&str> = [
@@ -224,7 +224,7 @@ fn review_table_coverage_is_pinned() {
     ]
     .into_iter()
     .collect();
-    let without_boundary: BTreeSet<&str> = ["csharp"].into_iter().collect();
+    let without_boundary: BTreeSet<&str> = BTreeSet::new();
 
     for frontend in all_frontends() {
         match frontend.review {
@@ -367,23 +367,19 @@ fn path_conventions_are_pinned() {
 
 /// The honesty ledger. Languages the bundled pack declares `rule-aware`
 /// whose unified frontend wiring does not fully justify it. It must never
-/// grow. After the honesty pass it names exactly two, each for a documented
-/// reason:
+/// grow. After Phase A1 it names exactly one:
 ///
 /// - **rust** — its runtime-risk coverage is the dedicated `rust.panic-risk`
 ///   audit, which lives outside the shared frontend `risk` table, so the
 ///   capability model does not count it. Real coverage exists; the
-///   accounting is the gap.
-/// - **csharp** — no import extractor and no taint tables yet; boundary
-///   classification is intentionally unwired (the old dispatch matched a
-///   label detection never emits).
+///   accounting is the gap (closed by A2).
 ///
 /// `c`/`cpp` left the ledger by an honest pack downgrade (no grammar, no
-/// frontend → context-aware); every other rule-aware language now computes
-/// to rule-aware through the contract.
+/// frontend); `csharp` completed its contract (imports, taint, boundary) in
+/// A1; every other rule-aware language computes through the contract.
 #[test]
 fn declared_rule_aware_support_gap_ledger_only_shrinks() {
-    let expected_gaps: BTreeSet<&str> = ["csharp", "rust"].into_iter().collect();
+    let expected_gaps: BTreeSet<&str> = ["rust"].into_iter().collect();
 
     let mut gaps = BTreeSet::new();
     for profile in &active_knowledge().languages {

--- a/src/review/signals/taint/ast.rs
+++ b/src/review/signals/taint/ast.rs
@@ -2,7 +2,14 @@ use tree_sitter::Node;
 
 pub(crate) fn first_named_arg(args: Node<'_>) -> Option<Node<'_>> {
     let mut cursor = args.walk();
-    args.named_children(&mut cursor).next()
+    let first = args.named_children(&mut cursor).next()?;
+    // C# wraps each argument in an `argument` node; unwrap to the expression
+    // so sink-side checks see the actual value shape.
+    if first.kind() == "argument" {
+        let mut inner = first.walk();
+        return first.named_children(&mut inner).next();
+    }
+    Some(first)
 }
 
 pub(crate) fn has_descendant_kind(node: Node<'_>, kind: &str) -> bool {

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -149,10 +149,22 @@ fn assignment_parts<'a>(
     } else {
         ("left", "right")
     };
-    Some((
-        node.child_by_field_name(lhs_field)?,
-        node.child_by_field_name(rhs_field)?,
-    ))
+    let lhs = node.child_by_field_name(lhs_field)?;
+    if let Some(rhs) = node.child_by_field_name(rhs_field) {
+        return Some((lhs, rhs));
+    }
+    // C#'s grammar attaches a declarator's initializer as a trailing
+    // anonymous child rather than a `value` field; a declarator without an
+    // initializer (`let x;`, `int x;`) has no such child and stays `None`.
+    if kind == "variable_declarator" {
+        let mut cursor = node.walk();
+        let init = node
+            .named_children(&mut cursor)
+            .filter(|child| child.id() != lhs.id())
+            .last()?;
+        return Some((lhs, init));
+    }
+    None
 }
 
 /// Simple local names bound by an assignment target. Member/index/selector

--- a/src/review/signals/taint/tests.rs
+++ b/src/review/signals/taint/tests.rs
@@ -519,6 +519,79 @@ class App {
     assert!(signals.is_empty());
 }
 
+// ── C# ────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn csharp_request_into_process_start_is_flagged() {
+    let signals = run(
+        "src/App/OrdersController.cs",
+        "C#",
+        r#"
+class OrdersController {
+    public void Export(HttpRequest request) {
+        var format = Request.Query["format"];
+        Process.Start("export.exe " + format);
+    }
+}
+"#,
+    );
+    assert_eq!(signals.len(), 1);
+    assert_eq!(signals[0].sink, SinkKind::Exec);
+    assert_eq!(signals[0].source, SourceKind::HttpRequest);
+}
+
+#[test]
+fn csharp_request_interpolated_into_sql_is_flagged() {
+    let signals = run(
+        "src/App/OrdersController.cs",
+        "C#",
+        r#"
+class OrdersController {
+    public void Find(SqlCommand cmd) {
+        var id = Request.Query["id"];
+        cmd.CommandText = $"SELECT * FROM orders WHERE id = {id}";
+        cmd.ExecuteReader();
+    }
+}
+"#,
+    );
+    // The tainted value flows into CommandText, not the ExecuteReader args —
+    // intra-procedural taint-lite deliberately does not track field state, so
+    // this stays a known limitation; the direct-argument form below must flag.
+    let direct = run(
+        "src/App/OrdersController.cs",
+        "C#",
+        r#"
+class OrdersController {
+    public void Find(Db db) {
+        var id = Request.Query["id"];
+        db.ExecuteScalar("SELECT * FROM orders WHERE id = " + id);
+    }
+}
+"#,
+    );
+    assert!(signals.is_empty());
+    assert_eq!(direct.len(), 1);
+    assert_eq!(direct[0].sink, SinkKind::Sql);
+}
+
+#[test]
+fn csharp_clean_request_read_without_sink_is_not_flagged() {
+    let signals = run(
+        "src/App/OrdersController.cs",
+        "C#",
+        r#"
+class OrdersController {
+    public string Greet() {
+        var name = Request.Query["name"];
+        return "Hello " + name;
+    }
+}
+"#,
+    );
+    assert!(signals.is_empty());
+}
+
 // ── Scope guards ──────────────────────────────────────────────────────────────
 
 #[test]

--- a/src/review/signals/tests.rs
+++ b/src/review/signals/tests.rs
@@ -321,6 +321,26 @@ fn classify_boundary_ast_detects_security_patterns() {
         classify_boundary_ast(Path::new("main.go"), go_code),
         Some(BoundaryCategory::AccessControl)
     );
+
+    // C# attribute (boundary enabled by the honesty pass — the old dispatch
+    // matched a label detection never emits, so this never fired before).
+    let cs_code = r#"
+        class OrdersController {
+            [Authorize(Roles = "admin")]
+            public void Delete(int id) {}
+        }
+    "#;
+    assert_eq!(
+        classify_boundary_ast(Path::new("src/OrdersController.cs"), cs_code),
+        Some(BoundaryCategory::AccessControl)
+    );
+
+    // C# using directive naming a security namespace.
+    let cs_using = "using Microsoft.AspNetCore.Authorization;\n";
+    assert_eq!(
+        classify_boundary_ast(Path::new("src/Startup.cs"), cs_using),
+        Some(BoundaryCategory::AccessControl)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Complete C# frontend contract with import extraction, taint tables, and boundary classification

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

<!-- List the main changes. -->

- **C# completes its frontend contract.** `using`-directive import extraction (aliases and `global using` included; `using (resource)` forms excluded) feeds the coupling graph
- ASP.NET taint tables (`Request.Query`/`Form`/`Headers` sources → `Process.Start`, SqlCommand `Execute*`, `File.WriteAll*` sinks) flag request-input flows
- AST boundary classification is enabled — the pre-registry dispatch matched a label detection never emits, so `[Authorize]` attributes and security `using` directives never participated before. The support-honesty ledger now names only Rust (its panic-risk accounting, closed next). eshoponweb zoo snapshot unchanged: zero new default-visible findings.

## Why

`using`-directive import extraction (aliases and `global using` included; `using (resource)` forms excluded) feeds the coupling graph; ASP.NET taint tables (`Request.Query`/`Form`/`Headers` sources → `Process.Start`, SqlCommand `Execute*`, `File.WriteAll*` sinks) flag request-input flows; and AST boundary classification is enabled — the pre-registry dispatch matched a label detection never emits, so `[Authorize]` attributes and security `using` directives never participated before. The support-honesty ledger now names only Rust (its panic-risk accounting, closed next). eshoponweb zoo snapshot unchanged: zero new default-visible findings.

## Contract and ownership

<!-- Identify the subsystem and any public behavior or schema affected. -->

- [ ] The change stays within a clear subsystem or ownership boundary
- [ ] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [ ] New or changed findings/signals include deterministic evidence and tests
- [ ] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [ ] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [ ] No unrelated refactor or generated-file churn is included

## Changelog

- [x] `CHANGELOG.md` updated (skip for CI-only or doc changes with no user-visible effect)

## Verification

<!-- Paste the commands you ran. -->

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```

