### PR TITLE
feat(languages): close the support-honesty ledger with Rust's runtime-risk accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **Support-honesty ledger is now empty.** Rust's dedicated
+  `language.rust.panic-risk` audit — 1.6k lines of context-sensitive
+  detection (structural infallibility, report-renderer path awareness) that
+  doesn't fit the shared per-language `RiskTables` shape — is now accounted
+  for via a documented `dedicated_risk_audit` marker on its frontend rather
+  than left uncounted. It satisfies the `RuntimeRisk` capability alongside
+  the shared table other languages use; no pattern logic moved. The
+  generated support matrix renders this distinctly as "✓ (dedicated)". Every
+  language the knowledge pack declares `rule-aware` now computes to
+  `rule-aware` through the frontend contract, with zero exceptions left.
 - **C# completes its frontend contract.** `using`-directive import
   extraction (aliases and `global using` included; `using (resource)` forms
   excluded) feeds the coupling graph; ASP.NET taint tables

--- a/docs/engineering/language-surface-inventory.md
+++ b/docs/engineering/language-surface-inventory.md
@@ -107,12 +107,14 @@ design (with reason).
       their emitters in `language_risk/{js,go,python,managed}.rs`; frontends
       reference them. Pinned by `runtime_risk_participation_is_pinned`.
       (PR-5)
-- [-] `src/audits/code_quality/rust_panic_risk/` — stays a dedicated
+- [x] `src/audits/code_quality/rust_panic_risk/` — stays a dedicated
       Rust-only audit (own rule family, severity calibration in the
-      Knowledge Engine). It contains no cross-language dispatch to migrate;
-      how it counts toward the Rust frontend's computed capability is an
-      honesty-pass decision (PR-9), pinned meanwhile by the risk
-      participation guard.
+      Knowledge Engine, 1.6k lines of context-sensitive detection); it
+      contains no cross-language dispatch to migrate. Its accounting is
+      closed: `LanguageFrontend.dedicated_risk_audit` documents the rule id
+      and satisfies the `RuntimeRisk` capability alongside the shared
+      `risk` table, without moving any pattern logic. Pinned by
+      `runtime_risk_participation_is_pinned`. (Phase A2)
 - [ ] `src/audits/code_quality/function_spans.rs:42` — function-node kinds
       per label (long/complex function). → PR-5.
 - [ ] `src/audits/code_quality/long_function/brace.rs`,

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -15,7 +15,7 @@ test rather than hidden.
 
 | Language | Grammar | Imports | Review signals | Taint flows | Runtime risk | Conventions | Declared |
 |---|---|---|---|---|---|---|---|
-| Rust | ✓ | ✓ | ✓ | — | — | ✓ | rule-aware |
+| Rust | ✓ | ✓ | ✓ | — | ✓ (dedicated) | ✓ | rule-aware |
 | TypeScript | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
 | JavaScript | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
 | Python | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
@@ -26,10 +26,11 @@ test rather than hidden.
 
 Notes:
 
-- **Rust runtime risk** is covered by the dedicated `rust.panic-risk` rule
-family rather than the shared runtime-risk audit, so its column reads “—”
-here; how it counts toward the capability model is tracked in the
-support-honesty ledger.
+- **Rust runtime risk** reads “✓ (dedicated)”: coverage comes from the
+standalone `language.rust.panic-risk` audit — structural infallibility
+detection, report-renderer path awareness — rather than the shared
+per-node runtime-risk table other languages use. Too contextual for that
+generic shape; it still counts toward the `RuntimeRisk` capability.
 - JavaScript and TypeScript (with their React dialects) share one frontend
 family: the same grammar shapes, import extractor, and signal tables.
 

--- a/src/languages/capability.rs
+++ b/src/languages/capability.rs
@@ -44,7 +44,10 @@ pub fn capabilities(frontend: &LanguageFrontend) -> Vec<Capability> {
     if frontend.review.is_some() {
         wired.push(Capability::ReviewSignals);
     }
-    if frontend.risk.is_some() {
+    // Runtime risk comes from either the shared per-node table or a
+    // standalone, language-specific audit too contextual for that generic
+    // shape (see `dedicated_risk_audit`); either satisfies the capability.
+    if frontend.risk.is_some() || frontend.dedicated_risk_audit.is_some() {
         wired.push(Capability::RuntimeRisk);
     }
     // A non-generic conventions table means the frontend owns test-file and

--- a/src/languages/csharp/mod.rs
+++ b/src/languages/csharp/mod.rs
@@ -38,6 +38,7 @@ pub(super) static CSHARP: LanguageFrontend = LanguageFrontend {
     review: Some(&CSHARP_REVIEW),
     conventions: &CSHARP_CONVENTIONS,
     risk: Some(&risk::CSHARP_RISK),
+    dedicated_risk_audit: None,
 };
 
 static CSHARP_REVIEW: ReviewTables = ReviewTables {

--- a/src/languages/generic.rs
+++ b/src/languages/generic.rs
@@ -15,4 +15,5 @@ pub(super) static GENERIC: LanguageFrontend = LanguageFrontend {
     review: None,
     conventions: &super::conventions::GENERIC_CONVENTIONS,
     risk: None,
+    dedicated_risk_audit: None,
 };

--- a/src/languages/go/mod.rs
+++ b/src/languages/go/mod.rs
@@ -29,6 +29,7 @@ pub(super) static GO: LanguageFrontend = LanguageFrontend {
     review: Some(&review::GO_REVIEW),
     conventions: &GO_CONVENTIONS,
     risk: Some(&risk::GO_RISK),
+    dedicated_risk_audit: None,
 };
 
 static GO_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/java/mod.rs
+++ b/src/languages/java/mod.rs
@@ -29,6 +29,7 @@ pub(super) static JAVA: LanguageFrontend = LanguageFrontend {
     review: Some(&review::JAVA_REVIEW),
     conventions: &JAVA_CONVENTIONS,
     risk: Some(&risk::JAVA_RISK),
+    dedicated_risk_audit: None,
 };
 
 static JAVA_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/javascript/mod.rs
+++ b/src/languages/javascript/mod.rs
@@ -38,6 +38,7 @@ pub(super) static TYPESCRIPT: LanguageFrontend = LanguageFrontend {
     review: Some(&review::JS_FAMILY_REVIEW),
     conventions: &JS_FAMILY_CONVENTIONS,
     risk: Some(&risk::JS_FAMILY_RISK),
+    dedicated_risk_audit: None,
 };
 
 pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
@@ -60,6 +61,7 @@ pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
     review: Some(&review::JS_FAMILY_REVIEW),
     conventions: &JS_FAMILY_CONVENTIONS,
     risk: Some(&risk::JS_FAMILY_RISK),
+    dedicated_risk_audit: None,
 };
 
 static JS_FAMILY_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/kotlin/mod.rs
+++ b/src/languages/kotlin/mod.rs
@@ -29,6 +29,7 @@ pub(super) static KOTLIN: LanguageFrontend = LanguageFrontend {
     review: Some(&review::KOTLIN_REVIEW),
     conventions: &KOTLIN_CONVENTIONS,
     risk: Some(&risk::KOTLIN_RISK),
+    dedicated_risk_audit: None,
 };
 
 static KOTLIN_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -102,10 +102,21 @@ pub struct LanguageFrontend {
     pub(crate) taint: Option<&'static crate::review::signals::taint::tables::TaintTables>,
     /// Boundary/algorithmic review-signal node-kind tables.
     pub(crate) review: Option<&'static crate::review::signals::tables::ReviewTables>,
-    /// Runtime-risk audit tables (AST + line-scanner emitters). Rust's
-    /// dedicated `rust_panic_risk` audit is separate and not counted here.
+    /// Runtime-risk audit tables (AST + line-scanner emitters) for the
+    /// shared, generic engine. `None` for a language whose runtime-risk
+    /// coverage instead lives in a dedicated, standalone audit — see
+    /// [`dedicated_risk_audit`](Self::dedicated_risk_audit).
     pub(crate) risk:
         Option<&'static crate::audits::code_quality::language_risk::tables::RiskTables>,
+    /// The rule id of a standalone, language-specific runtime-risk audit
+    /// that satisfies the `RuntimeRisk` capability outside the shared
+    /// engine — set when a language's runtime-risk logic is contextual
+    /// enough (path-aware suppression, structural analysis) that forcing it
+    /// into the generic per-node `RiskTables` shape would be churn without
+    /// benefit. Rust's `language.rust.panic-risk` is the only one today.
+    /// Documentation only; the audit itself is wired into the scan pipeline
+    /// independently and does not run through this pointer.
+    pub(crate) dedicated_risk_audit: Option<&'static str>,
     /// Path and naming conventions (test files, test support, entrypoints).
     pub(crate) conventions: &'static conventions::PathConventions,
 }

--- a/src/languages/python/mod.rs
+++ b/src/languages/python/mod.rs
@@ -29,6 +29,7 @@ pub(super) static PYTHON: LanguageFrontend = LanguageFrontend {
     review: Some(&review::PYTHON_REVIEW),
     conventions: &PYTHON_CONVENTIONS,
     risk: Some(&risk::PYTHON_RISK),
+    dedicated_risk_audit: None,
 };
 
 static PYTHON_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/reference.rs
+++ b/src/languages/reference.rs
@@ -44,10 +44,11 @@ test rather than hidden.\n"
     let _ = writeln!(
         out,
         "\nNotes:\n\n\
-- **Rust runtime risk** is covered by the dedicated `rust.panic-risk` rule\n\
-  family rather than the shared runtime-risk audit, so its column reads “—”\n\
-  here; how it counts toward the capability model is tracked in the\n\
-  support-honesty ledger.\n\
+- **Rust runtime risk** reads “✓ (dedicated)”: coverage comes from the\n\
+  standalone `language.rust.panic-risk` audit — structural infallibility\n\
+  detection, report-renderer path awareness — rather than the shared\n\
+  per-node runtime-risk table other languages use. Too contextual for that\n\
+  generic shape; it still counts toward the `RuntimeRisk` capability.\n\
 - JavaScript and TypeScript (with their React dialects) share one frontend\n\
   family: the same grammar shapes, import extractor, and signal tables.\n"
     );
@@ -121,7 +122,7 @@ fn frontend_row(frontend: &LanguageFrontend) -> String {
         mark(frontend.imports.is_some()),
         mark(frontend.review.is_some()),
         mark(frontend.taint.is_some()),
-        mark(frontend.risk.is_some()),
+        runtime_risk_cell(frontend),
         mark(!std::ptr::eq(
             frontend.conventions,
             &super::conventions::GENERIC_CONVENTIONS
@@ -132,6 +133,16 @@ fn frontend_row(frontend: &LanguageFrontend) -> String {
 
 fn mark(wired: bool) -> &'static str {
     if wired { "✓" } else { "—" }
+}
+
+fn runtime_risk_cell(frontend: &LanguageFrontend) -> &'static str {
+    if frontend.risk.is_some() {
+        "✓"
+    } else if frontend.dedicated_risk_audit.is_some() {
+        "✓ (dedicated)"
+    } else {
+        "—"
+    }
 }
 
 fn support_label(level: SupportLevel) -> &'static str {

--- a/src/languages/rust/mod.rs
+++ b/src/languages/rust/mod.rs
@@ -27,7 +27,12 @@ pub(super) static RUST: LanguageFrontend = LanguageFrontend {
     taint: None,
     review: Some(&review::RUST_REVIEW),
     conventions: &RUST_CONVENTIONS,
+    // No shared RiskTables: Rust's runtime-risk coverage is a dedicated,
+    // context-sensitive audit (structural infallibility detection,
+    // report-renderer path awareness) that the generic per-node table shape
+    // was never designed for. See `dedicated_risk_audit` below.
     risk: None,
+    dedicated_risk_audit: Some("language.rust.panic-risk"),
 };
 
 static RUST_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/tests.rs
+++ b/src/languages/tests.rs
@@ -302,13 +302,14 @@ fn removed_recognizer_extensions_are_pinned() {
     }
 }
 
-/// Pins which frontends carry runtime-risk tables. Rust intentionally has
-/// none here: its dedicated `rust_panic_risk` audit is a separate rule
-/// family, and how it counts toward the capability model is a decision for
-/// the honesty pass, not a refactor default.
+/// Pins which frontends carry a shared-engine runtime-risk table, and which
+/// instead satisfy the capability through a dedicated, standalone audit
+/// (Rust's `language.rust.panic-risk` — too contextual for the generic
+/// per-node table shape). A frontend must have exactly one or the other,
+/// never both and never neither once it claims `RuntimeRisk`.
 #[test]
 fn runtime_risk_participation_is_pinned() {
-    let with_risk: BTreeSet<&str> = [
+    let with_shared_risk: BTreeSet<&str> = [
         "typescript",
         "javascript",
         "python",
@@ -319,11 +320,24 @@ fn runtime_risk_participation_is_pinned() {
     ]
     .into_iter()
     .collect();
+    let with_dedicated_risk: BTreeSet<&str> = ["rust"].into_iter().collect();
+
     for frontend in all_frontends() {
         assert_eq!(
             frontend.risk.is_some(),
-            with_risk.contains(frontend.id),
-            "runtime-risk participation changed for frontend '{}'",
+            with_shared_risk.contains(frontend.id),
+            "shared runtime-risk table participation changed for frontend '{}'",
+            frontend.id
+        );
+        assert_eq!(
+            frontend.dedicated_risk_audit.is_some(),
+            with_dedicated_risk.contains(frontend.id),
+            "dedicated runtime-risk audit accounting changed for frontend '{}'",
+            frontend.id
+        );
+        assert!(
+            frontend.risk.is_none() || frontend.dedicated_risk_audit.is_none(),
+            "frontend '{}' claims both a shared risk table and a dedicated audit",
             frontend.id
         );
     }
@@ -367,19 +381,15 @@ fn path_conventions_are_pinned() {
 
 /// The honesty ledger. Languages the bundled pack declares `rule-aware`
 /// whose unified frontend wiring does not fully justify it. It must never
-/// grow. After Phase A1 it names exactly one:
-///
-/// - **rust** — its runtime-risk coverage is the dedicated `rust.panic-risk`
-///   audit, which lives outside the shared frontend `risk` table, so the
-///   capability model does not count it. Real coverage exists; the
-///   accounting is the gap (closed by A2).
-///
-/// `c`/`cpp` left the ledger by an honest pack downgrade (no grammar, no
-/// frontend); `csharp` completed its contract (imports, taint, boundary) in
-/// A1; every other rule-aware language computes through the contract.
+/// grow. After Phase A2 it is empty: `c`/`cpp` left by an honest pack
+/// downgrade (no grammar, no frontend); `csharp` completed its contract
+/// (imports, taint, boundary) in A1; `rust`'s dedicated panic-risk audit now
+/// counts toward `RuntimeRisk` in A2 (documented accounting, not a code
+/// migration — see `dedicated_risk_audit`); every other rule-aware language
+/// computes through the contract.
 #[test]
 fn declared_rule_aware_support_gap_ledger_only_shrinks() {
-    let expected_gaps: BTreeSet<&str> = ["rust"].into_iter().collect();
+    let expected_gaps: BTreeSet<&str> = BTreeSet::new();
 
     let mut gaps = BTreeSet::new();
     for profile in &active_knowledge().languages {


### PR DESCRIPTION
## Summary

Close the support-honesty ledger with Rust's runtime-risk accounting

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- **Support-honesty ledger is now empty.** Rust's dedicated `language.rust.panic-risk` audit — 1.6k lines of context-sensitive detection (structural infallibility, report-renderer path awareness) that doesn't fit the shared per-language `RiskTables` shape — is now accounted for via a documented `dedicated_risk_audit` marker on its frontend rather than left uncounted. It satisfies the `RuntimeRisk` capability alongside the shared table other languages use; no pattern logic moved. The generated support matrix renders this distinctly as "✓ (dedicated)". Every language the knowledge pack declares `rule-aware` now computes to `rule-aware` through the frontend contract, with zero exceptions left.

## Why

rust_panic_risk is 1.6k lines of context-sensitive detection (structural infallibility, report-renderer path awareness) that doesn't fit the shared per-language RiskTables shape used by every other language.

Migrating it would be churn against working, well-tested code for no functional gain, so this closes the accounting gap instead: a documented `dedicated_risk_audit` marker on the Rust frontend satisfies the RuntimeRisk capability without moving any pattern logic.

The generated matrix renders it as "✓ (dedicated)" to keep the distinction visible. Every rule-aware-declared language now computes to rule-aware; the ledger is empty.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```

