### PR TITLE
feat(languages): implement Kotlin taint analysis for Ktor and Android request flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **Kotlin taint analysis.** Added Ktor (`call.receiveText`, `call.parameters`),
+  Android (`intent.getStringExtra`, `savedStateHandle.get`), and Servlet request
+  sources → `Exec`, `Sql`, and `FsWrite` sinks in Kotlin taint tables.
+
 - **Support-honesty ledger is now empty.** Rust's dedicated
   `language.rust.panic-risk` audit — 1.6k lines of context-sensitive
   detection (structural infallibility, report-renderer path awareness) that

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -22,7 +22,7 @@ test rather than hidden.
 | Go | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
 | Java | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
 | C# | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
-| Kotlin | ✓ | ✓ | ✓ | — | ✓ | ✓ | rule-aware |
+| Kotlin | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | rule-aware |
 
 Notes:
 

--- a/src/languages/kotlin/mod.rs
+++ b/src/languages/kotlin/mod.rs
@@ -25,7 +25,7 @@ pub(super) static KOTLIN: LanguageFrontend = LanguageFrontend {
         grammar: ParseLanguage::Kotlin,
     }],
     imports: Some(&KOTLIN_IMPORTS),
-    taint: None,
+    taint: Some(&review::KOTLIN_TAINT),
     review: Some(&review::KOTLIN_REVIEW),
     conventions: &KOTLIN_CONVENTIONS,
     risk: Some(&risk::KOTLIN_RISK),

--- a/src/languages/kotlin/review.rs
+++ b/src/languages/kotlin/review.rs
@@ -4,6 +4,102 @@
 use crate::review::signals::tables::{
     AlgorithmicKinds, BoundaryKinds, RemovedTables, ReviewTables,
 };
+use crate::review::signals::taint::sinks::{Sink, SinkKind};
+use crate::review::signals::taint::tables::TaintTables;
+use tree_sitter::Node;
+
+/// Conservative, high-specificity taint tables for Kotlin (Ktor, Android,
+/// Servlet request sources → Exec / SQL / FsWrite sinks).
+pub(super) static KOTLIN_TAINT: TaintTables = TaintTables {
+    request_sources: &[
+        "call.receive",
+        "call.receiveText",
+        "call.receiveParameters",
+        "call.parameters",
+        "call.request.queryParameters",
+        "call.request.headers",
+        "call.request.cookies",
+        "request.getParameter",
+        "request.getHeader",
+        "intent.getStringExtra",
+        "savedStateHandle.get",
+    ],
+    argv_sources: &[],
+    source_access_kinds: &["call_expression", "navigation_expression"],
+    coercions: &[],
+    coercion_call_kind: "call_expression",
+    assignment_kinds: &["property_delegate", "variable_declaration", "assignment"],
+    is_flow_scope,
+    is_augmenting,
+    is_string_building,
+    classify_sink,
+};
+
+fn is_flow_scope(node: Node<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "function_declaration" | "secondary_constructor" | "lambda_literal"
+    )
+}
+
+fn is_augmenting(node: Node<'_>) -> bool {
+    node.kind() == "assignment" && {
+        let mut cursor = node.walk();
+        node.children(&mut cursor)
+            .any(|child| matches!(child.kind(), "+=" | "-=" | "*=" | "/=" | "%="))
+    }
+}
+
+fn is_string_building(node: Node<'_>, content: &str) -> bool {
+    node.kind() == "additive_expression"
+        || node.kind() == "string_literal"
+        || (node.kind() == "call_expression"
+            && kotlin_callee(node, content)
+                .is_some_and(|callee| callee.ends_with(".format") || callee == "String.format"))
+}
+
+fn kotlin_callee<'a>(node: Node<'a>, content: &'a str) -> Option<&'a str> {
+    let args = node.child_by_field_name("value_arguments").or_else(|| {
+        let mut cursor = node.walk();
+        node.children(&mut cursor)
+            .find(|c| c.kind() == "value_arguments")
+    })?;
+    content
+        .get(node.start_byte()..args.start_byte())
+        .map(str::trim)
+        .filter(|callee| !callee.is_empty())
+}
+
+fn classify_sink<'a>(node: Node<'a>, content: &'a str) -> Option<Sink<'a>> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+    let args = node.child_by_field_name("value_arguments").or_else(|| {
+        let mut cursor = node.walk();
+        node.children(&mut cursor)
+            .find(|c| c.kind() == "value_arguments")
+    })?;
+    let callee = kotlin_callee(node, content)?;
+
+    let kind = if callee.ends_with(".executeQuery")
+        || callee.ends_with(".executeUpdate")
+        || callee.ends_with(".executeLargeUpdate")
+        || callee.ends_with(".execute")
+        || callee.ends_with(".rawQuery")
+    {
+        SinkKind::Sql
+    } else if callee.ends_with(".exec") || callee.contains("ProcessBuilder") {
+        SinkKind::Exec
+    } else if callee.ends_with(".writeText")
+        || callee.ends_with(".writeBytes")
+        || callee == "Files.write"
+    {
+        SinkKind::FsWrite
+    } else {
+        return None;
+    };
+    Some(Sink { kind, args })
+}
 
 pub(super) static KOTLIN_REVIEW: ReviewTables = ReviewTables {
     boundary: Some(&BoundaryKinds {
@@ -38,3 +134,38 @@ pub(super) static KOTLIN_REMOVED: RemovedTables = RemovedTables {
     is_error_handling: |node, _| node.kind() == "try_expression",
     auth_call_kinds: &["method_invocation", "call_expression"],
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::parse::{ParseLanguage, parse};
+
+    #[test]
+    fn classifies_kotlin_sinks_and_sources() {
+        let code = r#"
+            fun handleRequest(call: ApplicationCall) {
+                val input = call.receiveText()
+                File("output.txt").writeText(input)
+                Runtime.getRuntime().exec(input)
+            }
+        "#;
+        let tree = parse(code, ParseLanguage::Kotlin).unwrap();
+        let root = tree.root_node();
+
+        assert!(KOTLIN_TAINT.request_sources.contains(&"call.receiveText"));
+
+        let mut sinks = Vec::new();
+        fn find_calls<'a>(node: Node<'a>, content: &'a str, sinks: &mut Vec<SinkKind>) {
+            if let Some(sink) = classify_sink(node, content) {
+                sinks.push(sink.kind);
+            }
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                find_calls(child, content, sinks);
+            }
+        }
+        find_calls(root, code, &mut sinks);
+
+        assert_eq!(sinks, vec![SinkKind::FsWrite, SinkKind::Exec]);
+    }
+}

--- a/src/languages/tests.rs
+++ b/src/languages/tests.rs
@@ -193,9 +193,17 @@ fn import_extractor_coverage_is_pinned() {
 /// language from taint analysis.
 #[test]
 fn taint_participation_is_pinned() {
-    let with_taint: BTreeSet<&str> = ["typescript", "javascript", "python", "go", "java", "csharp"]
-        .into_iter()
-        .collect();
+    let with_taint: BTreeSet<&str> = [
+        "typescript",
+        "javascript",
+        "python",
+        "go",
+        "java",
+        "kotlin",
+        "csharp",
+    ]
+    .into_iter()
+    .collect();
     for frontend in all_frontends() {
         assert_eq!(
             frontend.taint.is_some(),


### PR DESCRIPTION
## Problem
Item **A3** of spec `0-21-phase-a-contract-completion.md`: Kotlin lacked taint-lite flow tables in the language frontend contract, leaving Kotlin taint participation disabled.

## Solution
- Implemented `KOTLIN_TAINT: TaintTables` in `src/languages/kotlin/review.rs` covering:
  - Ktor (`call.receiveText`, `call.parameters`), Android (`intent.getStringExtra`, `savedStateHandle.get`), and Servlet request sources.
  - Sinks: `Exec`, `Sql`, and `FsWrite`.
- Wired `taint: Some(&review::KOTLIN_TAINT)` into `KOTLIN` `LanguageFrontend`.
- Added `"kotlin"` to `taint_participation_is_pinned()` test pin.
- Added unit tests for Kotlin taint classification.
- Updated `CHANGELOG.md`.

## Verification
- `cargo test --lib languages` (21/21 passed)
- `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- `python3 scripts/release-contract.py check` (passed)