### PR TITLE
refactor(languages): route framework detection probes through language frontend registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **Framework probes refactoring.** Framework detection probes for JS/TS (`NextJs`,
+  `React`, `ReactNative`, `Expo`, `Vue`, `Nuxt`, `Svelte`, `Angular`, `Express`, `NestJs`),
+  Python (`Django`, `Flask`, `FastApi`), and Go (`Gin`, `Echo`, `Fiber`) now register
+  through their respective language frontends in the unified frontend registry.
+
 - **Kotlin taint analysis.** Added Ktor (`call.receiveText`, `call.parameters`),
   Android (`intent.getStringExtra`, `savedStateHandle.get`), and Servlet request
   sources → `Exec`, `Sql`, and `FsWrite` sinks in Kotlin taint tables.

--- a/src/frameworks/detector/go.rs
+++ b/src/frameworks/detector/go.rs
@@ -1,7 +1,7 @@
 use crate::frameworks::types::DetectedFramework;
 use std::path::Path;
 
-pub(super) fn detect_go_frameworks(root: &Path) -> Vec<DetectedFramework> {
+pub(crate) fn detect_go_frameworks(root: &Path) -> Vec<DetectedFramework> {
     let content = match std::fs::read_to_string(root.join("go.mod")) {
         Ok(c) => c,
         Err(_) => return vec![],

--- a/src/frameworks/detector/js.rs
+++ b/src/frameworks/detector/js.rs
@@ -2,7 +2,7 @@ use crate::frameworks::detector::extract_version;
 use crate::frameworks::types::DetectedFramework;
 use std::path::Path;
 
-pub(super) fn detect_js_frameworks(root: &Path) -> Vec<DetectedFramework> {
+pub(crate) fn detect_js_frameworks(root: &Path) -> Vec<DetectedFramework> {
     let pkg_path = root.join("package.json");
     let content = match std::fs::read_to_string(&pkg_path) {
         Ok(c) => c,

--- a/src/frameworks/detector/mod.rs
+++ b/src/frameworks/detector/mod.rs
@@ -1,17 +1,21 @@
 use crate::frameworks::types::DetectedFramework;
 use std::path::Path;
 
-mod go;
-mod js;
-mod python;
+pub(crate) mod go;
+pub(crate) mod js;
+pub(crate) mod python;
 mod workspace;
 
 pub use workspace::detect_framework_projects;
 
 pub fn detect_frameworks(root: &Path) -> Vec<DetectedFramework> {
-    let mut frameworks = js::detect_js_frameworks(root);
-    frameworks.extend(python::detect_python_frameworks(root));
-    frameworks.extend(go::detect_go_frameworks(root));
+    let mut frameworks = Vec::new();
+    for frontend in crate::languages::all_frontends() {
+        if let Some(probe) = frontend.framework_probe {
+            frameworks.extend(probe(root));
+        }
+    }
+    frameworks.dedup();
     frameworks
 }
 

--- a/src/frameworks/detector/python.rs
+++ b/src/frameworks/detector/python.rs
@@ -1,7 +1,7 @@
 use crate::frameworks::types::DetectedFramework;
 use std::path::Path;
 
-pub(super) fn detect_python_frameworks(root: &Path) -> Vec<DetectedFramework> {
+pub(crate) fn detect_python_frameworks(root: &Path) -> Vec<DetectedFramework> {
     let content = match std::fs::read_to_string(root.join("requirements.txt")) {
         Ok(c) => c,
         Err(_) => return vec![],

--- a/src/languages/capability.rs
+++ b/src/languages/capability.rs
@@ -58,6 +58,9 @@ pub fn capabilities(frontend: &LanguageFrontend) -> Vec<Capability> {
     ) {
         wired.push(Capability::TestConventions);
     }
+    if frontend.framework_probe.is_some() {
+        wired.push(Capability::Frameworks);
+    }
     wired
 }
 

--- a/src/languages/csharp/mod.rs
+++ b/src/languages/csharp/mod.rs
@@ -39,6 +39,7 @@ pub(super) static CSHARP: LanguageFrontend = LanguageFrontend {
     conventions: &CSHARP_CONVENTIONS,
     risk: Some(&risk::CSHARP_RISK),
     dedicated_risk_audit: None,
+    framework_probe: None,
 };
 
 static CSHARP_REVIEW: ReviewTables = ReviewTables {

--- a/src/languages/generic.rs
+++ b/src/languages/generic.rs
@@ -16,4 +16,5 @@ pub(super) static GENERIC: LanguageFrontend = LanguageFrontend {
     conventions: &super::conventions::GENERIC_CONVENTIONS,
     risk: None,
     dedicated_risk_audit: None,
+    framework_probe: None,
 };

--- a/src/languages/go/mod.rs
+++ b/src/languages/go/mod.rs
@@ -30,6 +30,7 @@ pub(super) static GO: LanguageFrontend = LanguageFrontend {
     conventions: &GO_CONVENTIONS,
     risk: Some(&risk::GO_RISK),
     dedicated_risk_audit: None,
+    framework_probe: Some(crate::frameworks::detector::go::detect_go_frameworks),
 };
 
 static GO_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/java/mod.rs
+++ b/src/languages/java/mod.rs
@@ -30,6 +30,7 @@ pub(super) static JAVA: LanguageFrontend = LanguageFrontend {
     conventions: &JAVA_CONVENTIONS,
     risk: Some(&risk::JAVA_RISK),
     dedicated_risk_audit: None,
+    framework_probe: None,
 };
 
 static JAVA_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/javascript/mod.rs
+++ b/src/languages/javascript/mod.rs
@@ -39,6 +39,7 @@ pub(super) static TYPESCRIPT: LanguageFrontend = LanguageFrontend {
     conventions: &JS_FAMILY_CONVENTIONS,
     risk: Some(&risk::JS_FAMILY_RISK),
     dedicated_risk_audit: None,
+    framework_probe: Some(crate::frameworks::detector::js::detect_js_frameworks),
 };
 
 pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
@@ -62,6 +63,7 @@ pub(super) static JAVASCRIPT: LanguageFrontend = LanguageFrontend {
     conventions: &JS_FAMILY_CONVENTIONS,
     risk: Some(&risk::JS_FAMILY_RISK),
     dedicated_risk_audit: None,
+    framework_probe: Some(crate::frameworks::detector::js::detect_js_frameworks),
 };
 
 static JS_FAMILY_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/kotlin/mod.rs
+++ b/src/languages/kotlin/mod.rs
@@ -30,6 +30,7 @@ pub(super) static KOTLIN: LanguageFrontend = LanguageFrontend {
     conventions: &KOTLIN_CONVENTIONS,
     risk: Some(&risk::KOTLIN_RISK),
     dedicated_risk_audit: None,
+    framework_probe: None,
 };
 
 static KOTLIN_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -119,6 +119,9 @@ pub struct LanguageFrontend {
     pub(crate) dedicated_risk_audit: Option<&'static str>,
     /// Path and naming conventions (test files, test support, entrypoints).
     pub(crate) conventions: &'static conventions::PathConventions,
+    /// Framework detection probe, when the language frontend owns a probe.
+    pub(crate) framework_probe:
+        Option<fn(&std::path::Path) -> Vec<crate::frameworks::types::DetectedFramework>>,
 }
 
 /// Every registered frontend, including the generic fallback (last).

--- a/src/languages/python/mod.rs
+++ b/src/languages/python/mod.rs
@@ -30,6 +30,7 @@ pub(super) static PYTHON: LanguageFrontend = LanguageFrontend {
     conventions: &PYTHON_CONVENTIONS,
     risk: Some(&risk::PYTHON_RISK),
     dedicated_risk_audit: None,
+    framework_probe: Some(crate::frameworks::detector::python::detect_python_frameworks),
 };
 
 static PYTHON_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/rust/mod.rs
+++ b/src/languages/rust/mod.rs
@@ -33,6 +33,7 @@ pub(super) static RUST: LanguageFrontend = LanguageFrontend {
     // was never designed for. See `dedicated_risk_audit` below.
     risk: None,
     dedicated_risk_audit: Some("language.rust.panic-risk"),
+    framework_probe: None,
 };
 
 static RUST_CONVENTIONS: PathConventions = PathConventions {

--- a/src/languages/tests.rs
+++ b/src/languages/tests.rs
@@ -351,6 +351,23 @@ fn runtime_risk_participation_is_pinned() {
     }
 }
 
+/// Pins which frontends register a framework detection probe.
+#[test]
+fn framework_probe_coverage_is_pinned() {
+    let with_framework_probes: BTreeSet<&str> = ["typescript", "javascript", "python", "go"]
+        .into_iter()
+        .collect();
+
+    for frontend in all_frontends() {
+        assert_eq!(
+            frontend.framework_probe.is_some(),
+            with_framework_probes.contains(frontend.id),
+            "framework probe registration changed for frontend '{}'",
+            frontend.id
+        );
+    }
+}
+
 /// Pins the convention surface: the Rust `test_` prefix opt-out, which
 /// frontends carry a test-support recognizer (and its evidence reason), and
 /// which carry an entrypoint content probe.


### PR DESCRIPTION
## Problem
Item **A4** of spec `0-21-phase-a-contract-completion.md`: Framework detection probes were previously called via hardcoded module calls in `detect_frameworks` rather than being declared on the language frontend registry.

## Solution
- Added `framework_probe` field to `LanguageFrontend` descriptors in `src/languages/mod.rs`.
- Registered probes for `typescript`, `javascript`, `python`, and `go` frontends.
- Refactored `detect_frameworks(root: &Path)` in `src/frameworks/detector/mod.rs` to iterate over `crate::languages::all_frontends()`, delegate to each frontend's `framework_probe`, and deduplicate.
- Wired `Capability::Frameworks` in `src/languages/capability.rs`.
- Added `framework_probe_coverage_is_pinned()` test in `src/languages/tests.rs`.
- Updated `CHANGELOG.md` and marked Phase A spec complete.

## Verification
- `cargo test --lib languages` (23/23 passed)
- `cargo test --lib frameworks::detector` (5/5 passed)
- `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- `python3 scripts/release-contract.py check` (passed)