### PR TITLE
fix(frameworks,kotlin): deduplicate framework items cleanly and support generic Kotlin calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Fixed
+
+- **Framework dedup only caught adjacent duplicates.** `detect_frameworks`
+  deduplicated with `Vec::dedup()`, which removes consecutive duplicates
+  only; the same framework reported by two different probes (not adjacent
+  in the list) survived into the final result. Deduplication is now
+  order-independent via a `HashSet`, and `DetectedFramework` derives `Hash`
+  to support it.
+
 ### Added
 
 - **Framework probes refactoring.** Framework detection probes for JS/TS (`NextJs`,
@@ -15,7 +24,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 - **Kotlin taint analysis.** Added Ktor (`call.receiveText`, `call.parameters`),
   Android (`intent.getStringExtra`, `savedStateHandle.get`), and Servlet request
-  sources → `Exec`, `Sql`, and `FsWrite` sinks in Kotlin taint tables.
+  sources → `Exec`, `Sql`, and `FsWrite` sinks in Kotlin taint tables. Callee
+  extraction strips explicit generic type arguments (`call.receive<String>()`),
+  so sink/coercion classification isn't defeated by a type parameter; flow-scope
+  and string-building node kinds were also widened (`primary_constructor`,
+  `class_initializer`, `property_accessor`, Kotlin's `line`/`multi_line` string
+  templates).
 
 - **Support-honesty ledger is now empty.** Rust's dedicated
   `language.rust.panic-risk` audit — 1.6k lines of context-sensitive

--- a/src/frameworks/detector/mod.rs
+++ b/src/frameworks/detector/mod.rs
@@ -15,7 +15,8 @@ pub fn detect_frameworks(root: &Path) -> Vec<DetectedFramework> {
             frameworks.extend(probe(root));
         }
     }
-    frameworks.dedup();
+    let mut seen = std::collections::HashSet::new();
+    frameworks.retain(|item| seen.insert(item.clone()));
     frameworks
 }
 

--- a/src/frameworks/types.rs
+++ b/src/frameworks/types.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use crate::frameworks::react_native::ReactNativeArchitectureProfile;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(tag = "name", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum DetectedFramework {
     ReactNative { version: Option<String> },

--- a/src/languages/kotlin/review.rs
+++ b/src/languages/kotlin/review.rs
@@ -38,7 +38,12 @@ pub(super) static KOTLIN_TAINT: TaintTables = TaintTables {
 fn is_flow_scope(node: Node<'_>) -> bool {
     matches!(
         node.kind(),
-        "function_declaration" | "secondary_constructor" | "lambda_literal"
+        "function_declaration"
+            | "primary_constructor"
+            | "secondary_constructor"
+            | "class_initializer"
+            | "property_accessor"
+            | "lambda_literal"
     )
 }
 
@@ -51,11 +56,15 @@ fn is_augmenting(node: Node<'_>) -> bool {
 }
 
 fn is_string_building(node: Node<'_>, content: &str) -> bool {
-    node.kind() == "additive_expression"
-        || node.kind() == "string_literal"
-        || (node.kind() == "call_expression"
-            && kotlin_callee(node, content)
-                .is_some_and(|callee| callee.ends_with(".format") || callee == "String.format"))
+    matches!(
+        node.kind(),
+        "additive_expression"
+            | "string_literal"
+            | "line_string_expression"
+            | "multi_line_string_expression"
+    ) || (node.kind() == "call_expression"
+        && kotlin_callee(node, content)
+            .is_some_and(|callee| callee.ends_with(".format") || callee == "String.format"))
 }
 
 fn kotlin_callee<'a>(node: Node<'a>, content: &'a str) -> Option<&'a str> {
@@ -64,10 +73,15 @@ fn kotlin_callee<'a>(node: Node<'a>, content: &'a str) -> Option<&'a str> {
         node.children(&mut cursor)
             .find(|c| c.kind() == "value_arguments")
     })?;
-    content
+    let raw = content
         .get(node.start_byte()..args.start_byte())
         .map(str::trim)
-        .filter(|callee| !callee.is_empty())
+        .filter(|callee| !callee.is_empty())?;
+    let callee = match raw.find('<') {
+        Some(idx) => raw[..idx].trim(),
+        None => raw,
+    };
+    Some(callee)
 }
 
 fn classify_sink<'a>(node: Node<'a>, content: &'a str) -> Option<Sink<'a>> {
@@ -167,5 +181,31 @@ mod tests {
         find_calls(root, code, &mut sinks);
 
         assert_eq!(sinks, vec![SinkKind::FsWrite, SinkKind::Exec]);
+    }
+
+    #[test]
+    fn classifies_kotlin_generic_calls_and_sinks() {
+        let code = r#"
+            fun process(call: ApplicationCall) {
+                val data = call.receive<String>()
+                File("output.txt").writeText(data)
+            }
+        "#;
+        let tree = parse(code, ParseLanguage::Kotlin).unwrap();
+        let root = tree.root_node();
+
+        let mut sinks = Vec::new();
+        fn find_calls<'a>(node: Node<'a>, content: &'a str, sinks: &mut Vec<SinkKind>) {
+            if let Some(sink) = classify_sink(node, content) {
+                sinks.push(sink.kind);
+            }
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                find_calls(child, content, sinks);
+            }
+        }
+        find_calls(root, code, &mut sinks);
+
+        assert_eq!(sinks, vec![SinkKind::FsWrite]);
     }
 }


### PR DESCRIPTION
## Summary
- `detect_frameworks` deduplicated with `Vec::dedup()`, which only removes consecutive duplicates — frameworks reported by two different probes (not adjacent in the list) survived. Now deduplicates via a `HashSet` (`DetectedFramework` derives `Hash`).
- Kotlin `kotlin_callee` now strips explicit generic type arguments (`call.receive<String>()` → `call.receive`), so sink/coercion classification isn't defeated by a type parameter. Also widens `is_flow_scope` (`primary_constructor`, `class_initializer`, `property_accessor`) and `is_string_building` (Kotlin's `line`/`multi_line` string templates).

## Test plan
- [x] `cargo test --lib kotlin` (7/7 passed)
- [x] `cargo test --lib framework` (52/52 passed)
- [x] `cargo clippy --lib` (clean)
- [x] `repopilot review . --base HEAD~1` (0 in-diff findings; only a benign "recursion introduced" signal in a test helper)