### PR TITLE
feat: add local risk memory and merge readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ __pycache__/
 !/.repopilot/.gitkeep
 !/.repopilot/config.toml
 !/.repopilot/config.example.toml
+!/.repopilot/overlay.toml
 .repopilot-patches/
 
 docs/demos/*.tape

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **Opt-in local risk memory.** `scan` and `review` accept
+  `--record-history`, or repositories can enable `[history]` explicitly.
+  Versioned, bounded receipts under `.repopilot/history/` compare only
+  compatible analysis contracts and classify finding occurrences as new,
+  persisting, resolved, or severity-shifted. JSON and human reports project
+  the compatible delta without changing existing exit behavior.
+- **Ownership-aware merge readiness.** Review reports now derive one stable
+  `ready`, `review`, or `blocked` verdict from findings, gates, review signals,
+  blast radius, and CODEOWNERS. The record includes deterministic reason codes,
+  suggested owners, unowned surfaces, verification steps, and limitations;
+  console, Markdown, JSON, MCP review output, and the GitHub Action summary
+  consume the same contract. The record also carries bounded dependency-impact
+  paths so consumers do not have to reconstruct the affected surface.
 - **`.repopilot/overlay.toml` — local knowledge overlays.** A declarative,
   diffable file that calibrates known rules to a repository: `[[overlay]]`
   entries target a `rule` id or a review-signal `kind`, optionally scoped to
@@ -162,6 +175,14 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- **Subdirectory scans could miss repository overlays.** Root
+  `.repopilot/overlay.toml` discovery and MCP cache invalidation now work when
+  the requested analysis target is a nested directory. Generated history and
+  cache files remain excluded from workspace fingerprints, and
+  `--ignore-feedback` now bypasses both legacy feedback and overlays.
+- **Concurrent history writers could exhaust a spin loop or leave a stale lock
+  after interruption.** History now uses an OS-backed file lock with bounded
+  waiting; abandoned lock files no longer block later analyses.
 - **A legitimate `Info` severity decision was silently discarded during enrichment.**
   `Finding::populate_rule_metadata` used `Severity::Info` (which is also
   `Severity::default()`) as a sentinel meaning "the audit never set severity,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -92,11 +92,12 @@ repopilot s <PATH> [OPTIONS]
 | `--no-color` | flag | — | Disable ANSI color in console output |
 | `-o, --output` | path | stdout | Write report to a file instead of stdout |
 | `--receipt` | path | — | Write a compact audit receipt JSON file with tool, git, scope, finding, language, and health metadata |
+| `--record-history` | flag | — | Record this analysis in the bounded local risk-history ledger |
 | `--config` | path | auto-detected | Path to a `repopilot.toml` config file |
 | `--baseline` | path | — | Path to a baseline file; marks findings as new or existing |
 | `--fail-on` | threshold | — | Finding gate by severity/status; exit code 1 on a breach (see [Gates](#gates)) |
 | `--fail-on-priority` | `p0\|p1\|p2\|p3` | — | Finding gate by risk priority; mutually exclusive with `--fail-on` |
-| `--ignore-feedback` | flag | — | Ignore `.repopilot/feedback.yml` local suppressions |
+| `--ignore-feedback` | flag | — | Ignore local overlay and legacy feedback calibration |
 | `--max-file-loc` | integer | `300` | Maximum non-empty LOC before a file is flagged as large |
 | `--max-directory-modules` | integer | `20` | Maximum files per directory before flagging |
 | `--max-directory-depth` | integer | `5` | Maximum nesting depth before flagging |
@@ -262,13 +263,14 @@ repopilot r [PATH] [OPTIONS]
 | `--max-findings` | integer or `none` | `5` | Limit console finding detail |
 | `-o, --output` | path | stdout | Write report to a file instead of stdout |
 | `--sarif-output` | path | — | Write secondary review SARIF without a second scan |
+| `--record-history` | flag | — | Record this review in the bounded local risk-history ledger |
 | `--config` | path | auto-detected | Path to a `repopilot.toml` config file |
 | `--baseline` | path | — | Path to a baseline file |
 | `--fail-on` | threshold | — | Finding gate by severity/status on **in-diff** findings (see [Gates](#gates)) |
 | `--fail-on-priority` | `p0\|p1\|p2\|p3` | — | Finding gate by risk priority on **in-diff** findings; mutually exclusive with `--fail-on` |
 | `--fail-on-review` | `none\|definitely` | `none` | Review-signal gate; config peer `[review] fail_on` |
 | `--no-progress` | flag | — | Disable progress indicators |
-| `--ignore-feedback` | flag | — | Ignore `.repopilot/feedback.yml` local suppressions |
+| `--ignore-feedback` | flag | — | Ignore local overlay and legacy feedback calibration |
 | `--max-file-loc` | integer | `300` | Maximum non-empty LOC before a file is flagged as large |
 | `--max-directory-modules` | integer | `20` | Maximum files per directory before flagging |
 | `--max-directory-depth` | integer | `5` | Maximum nesting depth before flagging |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -55,6 +55,37 @@ repopilot review . --fail-on-review definitely
 Use `--scope full --profile strict` only when a change review also needs the
 complete repository audit.
 
+Every review includes a deterministic merge-readiness record:
+
+- `ready` means no blocking or review-required evidence was found.
+- `review` identifies findings, signals, ownership gaps, or impacted surfaces
+  that need human attention.
+- `blocked` means an active finding or review gate failed.
+
+JSON and MCP review output expose the same `merge_readiness` object used by the
+console and Markdown renderers.
+
+## Compare Risk Across Runs
+
+History is local, bounded, and disabled by default. Record two compatible
+analyses to see what is new, persisting, resolved, or changed severity:
+
+```bash
+repopilot scan . --record-history
+repopilot scan . --record-history --format json
+```
+
+The same opt-in is available for review:
+
+```bash
+repopilot review . --record-history
+```
+
+Receipts live under `.repopilot/history/` and are never uploaded. RepoPilot
+compares only runs with the same target, scope, revisions, profile, filters,
+configuration, overlay, and report schema; it never treats an incompatible
+changed-only run as proof that full-scan findings were resolved.
+
 ## Review An Agent Run
 
 Create a marker before an agent starts editing:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,22 @@ repopilot review . --fail-on-review definitely
 See [CLI reference → Gates](cli.md#gates) for the full two-axis gate model
 (finding gate vs review-signal gate).
 
+## Local History
+
+Risk history is opt-in. Enable it for every `scan` and `review` in a repository:
+
+```toml
+[history]
+enabled = true
+max_runs = 50
+max_bytes = 5242880
+```
+
+Alternatively, use `--record-history` for one command. Receipts are stored in
+`.repopilot/history/runs.jsonl`, bounded by both limits, and ignored by Git and
+analysis fingerprints. Invalid or interrupted receipt lines produce diagnostics
+without failing the underlying analysis.
+
 ## Opt-in architecture rules
 
 Two graph rules are **off by default** and emit nothing until you describe your
@@ -215,30 +231,37 @@ repopilot scan . --baseline .repopilot/baseline.json --fail-on new-high
 Do not refresh the baseline just to silence CI. Refresh it only when the team
 explicitly accepts the current findings as technical debt.
 
-## Local Feedback
+## Local Knowledge Overlay
 
-RepoPilot reads repository-local suppressions from `.repopilot/feedback.yml`.
-Finding suppressions use `rule_id + path`; review-signal suppressions use
-namespaced `kind + path`.
+RepoPilot supports path-scoped local rule calibration and suppressions via `.repopilot/overlay.toml`. Overlay decisions are evaluated directly inside the Decision Engine trace (`decide_with_trace` / `explain`).
 
-```yaml
-suppressions:
-  - rule_id: architecture.large-file
-    path: "src/generated/schema.rs"
-    reason: generated schema boundary
-  - kind: behavioral.network-call-added
-    path: "src/generated/**"
-    reason: generated client transport
-    expires: "2026-12-31"
+```toml
+# Suppress a rule for specific paths
+[[overlay]]
+rule = "architecture.large-file"
+path = "src/generated/**"
+reason = "Generated code boundary"
+
+# Override severity for specific paths
+[[overlay]]
+rule = "behavioral.panic-risk"
+path = "src/cli/**"
+severity = "low"
+reason = "CLI handlers can terminate on unrecoverable input"
+
+# Suppress review signals by kind with expiration
+[[overlay]]
+kind = "behavioral.network-call-added"
+path = "src/generated/**"
+reason = "Generated client transport"
+expires = "2026-12-31"
 ```
 
-Suppressions are applied by `scan` and `review`; malformed entries surface as
-report diagnostics rather than silently dropping findings.
+Use `--ignore-feedback` on `scan` or `review` to bypass overlay rules.
 
-Use `--ignore-feedback` on `scan` or `review` for an unsuppressed report.
-Expired review suppressions no longer apply. Reports expose suppression counts
-through `local_feedback` metadata so policy never hides findings silently.
+## Local Feedback (Deprecated)
 
-Do not commit `.repopilot/feedback.yml` by default. Commit it only when the
-suppression is a reviewed team policy; keep temporary or personal suppressions
-local.
+> [!NOTE]
+> `.repopilot/feedback.yml` is deprecated in favor of `.repopilot/overlay.toml`.
+
+Existing `.repopilot/feedback.yml` files continue to function, but raise a deprecation diagnostic suggesting migration to `.repopilot/overlay.toml`.

--- a/docs/knowledge-engine.md
+++ b/docs/knowledge-engine.md
@@ -24,7 +24,7 @@ by `scan`, `review`, `ai`, or CI.
 | Rule metadata | Title, category, default severity, docs URL, description, and recommendation in the rule registry. |
 | Applicability | Knowledge Engine data that defines which languages, frameworks, runtimes, paradigms, and file roles a rule applies to. |
 | Calibration | Deterministic severity, suppression, or risk adjustments based on local file/project context. |
-| Local overlay | A future local file that can tune known rules in an inspectable way. Not enabled by default. |
+| Local overlay | A declarative `.repopilot/overlay.toml` file that calibrates known rules by path/rule/kind in an inspectable way. |
 | Local learning | User-controlled local calibration or fixtures, not model training or remote telemetry. |
 | Declarative context | Infrastructure, config, markup, query, and data-description files that should not be judged like imperative application code. |
 | Infrastructure context | Terraform, Dockerfile, Nix, Kubernetes, Helm, CI workflow, and infra-directory files where orchestration is expected. |
@@ -123,12 +123,13 @@ path/language/content
 Future rules should prefer the shared context signals instead of adding another
 local copy of the same path or language checks inside an individual audit.
 
-## Local Feedback And Future Overlays
+## Local Overlays and Local Feedback
 
-RepoPilot's first local calibration surface is `.repopilot/feedback.yml` for
-explicit suppressions, applied by `scan` and `review`. Future overlays should
-remain inspectable local calibration, not a plugin runtime.
-Local overlays should be normal files that users can review, commit, diff, or
-delete. They may tune known rule severity, confidence, or suppression decisions,
-but they must not execute arbitrary code, load remote packs, or change scan
-behavior silently.
+RepoPilot's primary local calibration surface is `.repopilot/overlay.toml` for path-scoped rule calibration (severity override) and suppressions. Local overlay decisions evaluate directly inside the Decision Engine trace (`decide_with_trace` / `explain`).
+
+`.repopilot/feedback.yml` is deprecated in favor of `.repopilot/overlay.toml`.
+
+Local overlays are inspectable local calibration files, not a plugin runtime:
+- Declarative files that users can review, commit, diff, or delete.
+- Tune known rule severity or suppression decisions with path globs.
+- Cannot execute arbitrary code, load remote packs, or change scan behavior silently.

--- a/docs/superpowers/plans/2026-07-26-repopilot-0-21-implementation.md
+++ b/docs/superpowers/plans/2026-07-26-repopilot-0-21-implementation.md
@@ -1,0 +1,726 @@
+# RepoPilot 0.21 Risk Memory and Merge Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a local-first RepoPilot 0.21 contract that reports compatible
+risk deltas, ownership-aware merge readiness, trustworthy overlay behavior, and
+deeper framework coverage in the existing language frontends.
+
+**Architecture:** Introduce pure canonical history, ownership, and readiness
+records below the output layer. Keep persistence and projection as adapters so
+analysis remains deterministic and side-effect free until explicit history
+recording. Extend language-owned tables with differential safe/unsafe tests,
+without adding engine-level language dispatch.
+
+**Tech Stack:** Rust 2024, serde/serde_json, clap, sha2, globset, tree-sitter,
+existing RepoPilot scan/review/MCP/Action contracts, Python release scripts.
+
+## Global Constraints
+
+- Analysis remains local-only, deterministic, and network-free.
+- No new top-level CLI command.
+- History is opt-in and creates no files while disabled.
+- JSON, MCP, Action, and AI-context changes are additive.
+- Files stay at or below 300 lines and functions at or below 50 lines.
+- Finding history uses occurrence identity; baseline matching stays on stable
+  finding IDs.
+- Default-profile precision and strict-mode recall are preserved.
+- No commit, push, tag, or publication without explicit user authorization.
+
+---
+
+### Task 1: Fix Overlay Tracking and Cache Invalidation
+
+**Files:**
+- Modify: `.gitignore`
+- Modify: `src/commands/mcp/scan_cache.rs`
+- Modify: `src/commands/mcp/scan_cache/git.rs`
+- Modify: `src/commands/mcp/scan_cache/tests/invalidation.rs`
+- Modify: `tests/cli_stabilization.rs`
+
+**Interfaces:**
+- Produces: `git::is_generated_repopilot_path(rel: &str) -> bool`
+- Produces: cache-key control input for `.repopilot/overlay.toml`
+- Preserves: generated `.repopilot/cache/` and `.repopilot/history/` exclusion
+
+- [x] **Step 1: Add failing cache-key tests**
+
+```rust
+#[test]
+fn overlay_changes_invalidate_but_generated_state_does_not() {
+    let (_dir, root) = init_repo();
+    let overlay = root.join(".repopilot/overlay.toml");
+    std::fs::create_dir_all(overlay.parent().unwrap()).unwrap();
+    std::fs::write(&overlay, "[[overlay]]\nrule = \"a\"\n").unwrap();
+    let first = cache_key(&root, &args(&root)).unwrap();
+
+    std::fs::write(&overlay, "[[overlay]]\nrule = \"b\"\n").unwrap();
+    let second = cache_key(&root, &args(&root)).unwrap();
+    assert_ne!(first, second);
+
+    std::fs::create_dir_all(root.join(".repopilot/history")).unwrap();
+    std::fs::write(root.join(".repopilot/history/runs.jsonl"), "{}\n").unwrap();
+    assert_eq!(second, cache_key(&root, &args(&root)).unwrap());
+}
+```
+
+- [x] **Step 2: Run the focused test and confirm RED**
+
+Run:
+`cargo test --lib commands::mcp::scan_cache::tests::invalidation::overlay_changes_invalidate_but_generated_state_does_not`
+
+Expected: overlay edit leaves the key unchanged with the current broad
+`.repopilot` exclusion.
+
+- [x] **Step 3: Narrow generated-state filtering and hash overlay content**
+
+Implement exact generated path matching for `.repopilot/cache` and
+`.repopilot/history`. Add `.repopilot/overlay.toml` beside feedback and ignore
+controls in the cache-key material.
+
+- [x] **Step 4: Make the overlay trackable**
+
+Add `!/.repopilot/overlay.toml` after the broad `/.repopilot/*` rule. Keep
+history and cache ignored.
+
+- [x] **Step 5: Run targeted checks**
+
+Run:
+`cargo test --lib commands::mcp::scan_cache`
+
+Run:
+`cargo test --test cli_stabilization`
+
+Expected: both pass and overlay/history behavior is pinned.
+
+---
+
+### Task 2: Replace the Prototype History Model with a Compatible Receipt Contract
+
+**Files:**
+- Rewrite: `src/history/model.rs`
+- Rewrite: `src/history/delta.rs`
+- Modify: `src/history/mod.rs`
+- Test: `src/history/delta.rs`
+- Test: `tests/history_contract.rs`
+
+**Interfaces:**
+- Produces:
+  `RunReceiptV1 { schema_version, comparison, recorded_at, revision, findings }`
+- Produces:
+  `ComparisonIdentity { workspace, target, scope, base, head, profile, config_fingerprint, overlay_fingerprint, analysis_schema }`
+- Produces:
+  `RiskDelta { comparison, new, persisting, resolved, severity_shifts }`
+- Produces:
+  `compare(current: &RunReceiptV1, prior: &RunReceiptV1) -> ComparisonResult`
+
+- [x] **Step 1: Add failing occurrence-collision and compatibility tests**
+
+```rust
+#[test]
+fn distinct_occurrences_with_one_baseline_id_are_not_merged() {
+    let prior = receipt("full", vec![finding("same-id", "occ-a", Medium)]);
+    let current = receipt(
+        "full",
+        vec![
+            finding("same-id", "occ-a", Medium),
+            finding("same-id", "occ-b", High),
+        ],
+    );
+    let delta = compare(&current, &prior).compatible().unwrap();
+    assert_eq!(delta.persisting.len(), 1);
+    assert_eq!(delta.new.len(), 1);
+}
+
+#[test]
+fn changed_scope_never_resolves_full_scope_occurrences() {
+    let full = receipt("full", vec![finding("a", "occ-a", High)]);
+    let changed = receipt("changed", Vec::new());
+    assert!(matches!(
+        compare(&changed, &full),
+        ComparisonResult::Unavailable(ComparisonUnavailable::ScopeMismatch)
+    ));
+}
+```
+
+- [x] **Step 2: Run the history unit tests and confirm RED**
+
+Run: `cargo test --lib history::delta`
+
+Expected: the prototype uses `stable_finding_key`, has no compatibility result,
+and cannot represent persisting occurrences.
+
+- [x] **Step 3: Implement versioned pure data records**
+
+Use owned, serializable enums and structs. Sort occurrence records by
+occurrence key, then rule/path, before storing or comparing. Keep timestamp out
+of `ComparisonIdentity`.
+
+- [x] **Step 4: Implement compatibility-first delta computation**
+
+Return an explicit unavailable reason before classifying findings. Compare
+occurrence-key maps without overwriting duplicate baseline IDs.
+
+- [x] **Step 5: Verify the model**
+
+Run: `cargo test --lib history`
+
+Run: `cargo test --test history_contract`
+
+Expected: collision, ordering, severity-shift, and mismatch tests pass.
+
+---
+
+### Task 3: Add Safe, Bounded History Storage
+
+**Files:**
+- Rewrite: `src/history/storage.rs`
+- Create: `src/history/diagnostic.rs`
+- Modify: `src/history/mod.rs`
+- Modify: `src/config/model.rs`
+- Modify: `src/config/template.rs`
+- Test: `src/history/storage.rs`
+- Test: `tests/config_loader.rs`
+
+**Interfaces:**
+- Produces:
+  `HistoryStore::new(workspace_root: &Path, limits: HistoryLimits) -> Self`
+- Produces:
+  `HistoryStore::load() -> HistoryLoad`
+- Produces:
+  `HistoryStore::newest_compatible(&ComparisonIdentity) -> CompatibleRun`
+- Produces:
+  `HistoryStore::record(&RunReceiptV1) -> Result<(), HistoryWriteError>`
+- Produces:
+  `HistoryLimits { max_runs: usize, max_bytes: u64 }`
+- Produces: structured `HistoryDiagnostic`
+
+- [x] **Step 1: Add failing storage tests**
+
+Cover:
+
+```rust
+#[test]
+fn disabled_history_configuration_is_the_default() {
+    assert!(!HistorySection::default().enabled);
+}
+
+#[test]
+fn pruning_keeps_complete_json_lines_within_both_limits() {
+    // Record three receipts under max_runs=2 and a small byte cap.
+    // Assert two parseable newest receipts remain and file size is bounded.
+}
+
+#[test]
+fn truncated_tail_is_reported_without_losing_valid_receipts() {
+    // Write one valid line and one truncated line.
+    // Assert one receipt plus HistoryDiagnostic::TruncatedRecord.
+}
+```
+
+- [x] **Step 2: Run focused tests and confirm RED**
+
+Run: `cargo test --lib history::storage`
+
+Run: `cargo test --test config_loader history`
+
+- [x] **Step 3: Implement atomic bounded replacement**
+
+Read valid receipts, append in memory, prune oldest by count and serialized byte
+size, write a sibling staged file, flush, then rename. Reuse the repository's
+recoverable staged-replacement pattern where possible.
+
+- [x] **Step 4: Surface corruption and write diagnostics**
+
+Do not silently discard parsing or IO failures. Return valid records with
+diagnostics; a recording failure does not change analysis success.
+
+- [x] **Step 5: Verify storage and config**
+
+Run: `cargo test --lib history`
+
+Run: `cargo test --test config_loader`
+
+Expected: storage, zero/one limits, corruption, and default-off behavior pass.
+
+---
+
+### Task 4: Integrate Explicit History Recording into Scan and Review
+
+**Files:**
+- Modify: `src/cli/options/scan.rs`
+- Modify: `src/cli/options/review.rs`
+- Modify: `src/commands/product_scan.rs`
+- Modify: `src/commands/scan.rs`
+- Modify: `src/commands/review.rs`
+- Create: `src/history/context.rs`
+- Test: `tests/history_cli.rs`
+- Modify: `tests/cli_stabilization.rs`
+
+**Interfaces:**
+- Produces: `--record-history` on `scan` and `review`
+- Produces:
+  `build_scan_receipt(session, mode, findings) -> RunReceiptV1`
+- Produces:
+  `build_review_receipt(session, review_input, profile, findings) -> RunReceiptV1`
+- Removes: history side effects from `run_product_scan`
+
+- [x] **Step 1: Add failing CLI integration tests**
+
+```rust
+#[test]
+fn scan_does_not_create_history_without_opt_in() {
+    let repo = fixture_repo();
+    repopilot().args(["scan", repo.path_str()]).assert().success();
+    assert!(!repo.path().join(".repopilot/history").exists());
+}
+
+#[test]
+fn compatible_recorded_scans_show_a_delta() {
+    let repo = fixture_repo();
+    run_scan(&repo, &["--record-history"]);
+    introduce_finding(&repo);
+    let output = run_scan(&repo, &["--record-history", "--format", "json"]);
+    assert_eq!(output["risk_delta"]["comparison"]["status"], "compatible");
+}
+```
+
+- [x] **Step 2: Confirm RED**
+
+Run: `cargo test --test history_cli`
+
+- [x] **Step 3: Remove prototype recording from `run_product_scan`**
+
+Keep product scan deterministic. Commands decide whether to load/record history
+after filtering and after review scope/base/head are known.
+
+- [x] **Step 4: Add explicit recording and diagnostics**
+
+Enable recording when `--record-history` or `[history].enabled = true`. Use
+`session.workspace_root()` for storage and the analysis path only as receipt
+target metadata.
+
+- [x] **Step 5: Verify CLI behavior**
+
+Run: `cargo test --test history_cli`
+
+Run: `cargo test --test cli_stabilization`
+
+Run: `cargo test --test scan_command_cli`
+
+Expected: default scans are side-effect free and compatible runs expose deltas.
+
+---
+
+### Task 5: Build Deterministic CODEOWNERS and Boundary Ownership
+
+**Files:**
+- Create: `src/review/ownership/mod.rs`
+- Create: `src/review/ownership/codeowners.rs`
+- Create: `src/review/ownership/model.rs`
+- Modify: `src/review/mod.rs`
+- Test: `src/review/ownership/codeowners.rs`
+- Test: `tests/review_ownership.rs`
+
+**Interfaces:**
+- Produces:
+  `OwnershipIndex::discover(root: &Path) -> OwnershipDiscovery`
+- Produces:
+  `OwnershipIndex::owners_for(path: &Path) -> Vec<Owner>`
+- Produces:
+  `OwnershipSummary::for_impact(changed: &[ChangedFile], impact: &ImpactPaths, index: &OwnershipIndex) -> Self`
+
+- [x] **Step 1: Add failing CODEOWNERS precedence tests**
+
+```rust
+#[test]
+fn last_matching_rule_wins_and_owners_are_deduplicated() {
+    let index = parse("* @all\n/src/ @backend\n/src/auth/ @security @backend\n");
+    assert_eq!(
+        index.owners_for(Path::new("src/auth/session.rs")),
+        vec![owner("@security"), owner("@backend")]
+    );
+}
+```
+
+Also cover discovery precedence `.github/CODEOWNERS`, root `CODEOWNERS`,
+`docs/CODEOWNERS`, comments, escaped spaces, deleted paths, and no-file
+fallback boundaries.
+
+- [x] **Step 2: Confirm RED**
+
+Run: `cargo test --lib review::ownership`
+
+- [x] **Step 3: Implement parser and matcher**
+
+Keep parsing deterministic and GitHub-compatible for supported syntax. Emit an
+explicit limitation diagnostic for unsupported constructs instead of silently
+guessing.
+
+- [x] **Step 4: Implement package/directory fallback**
+
+Use existing workspace/package facts when available; otherwise return the
+first stable top-level directory boundary. Never invent a username or team.
+
+- [x] **Step 5: Verify ownership**
+
+Run: `cargo test --lib review::ownership`
+
+Run: `cargo test --test review_ownership`
+
+Expected: precedence, discovery, fallback, and deterministic ordering pass.
+
+---
+
+### Task 6: Derive the Canonical Merge Readiness Record
+
+**Files:**
+- Create: `src/review/readiness/mod.rs`
+- Create: `src/review/readiness/model.rs`
+- Create: `src/review/readiness/derive.rs`
+- Modify: `src/review/model.rs`
+- Modify: `src/review/report.rs`
+- Modify: `src/output/decision_summary.rs`
+- Test: `src/review/readiness/derive.rs`
+- Test: `tests/review_readiness.rs`
+
+**Interfaces:**
+- Produces:
+  `MergeReadinessRecord { verdict, reasons, impact, ownership, verification, limitations, risk_delta }`
+- Produces: `ReadinessVerdict::{Ready, Review, Blocked}`
+- Produces: stable `ReadinessReasonCode`
+- Produces:
+  `derive_readiness(report, gates, ownership, delta) -> MergeReadinessRecord`
+
+- [x] **Step 1: Add failing verdict tests**
+
+```rust
+#[test]
+fn failed_gate_is_blocked_with_stable_reason_code() {
+    let readiness = derive_readiness(&fixture_with_failed_gate());
+    assert_eq!(readiness.verdict, ReadinessVerdict::Blocked);
+    assert_eq!(readiness.reasons[0].code, ReadinessReasonCode::FindingGateFailed);
+}
+
+#[test]
+fn unowned_impacted_surface_requires_review() {
+    let readiness = derive_readiness(&fixture_with_unowned_impact());
+    assert_eq!(readiness.verdict, ReadinessVerdict::Review);
+}
+```
+
+- [x] **Step 2: Confirm RED**
+
+Run: `cargo test --lib review::readiness`
+
+- [x] **Step 3: Implement pure deterministic derivation**
+
+Precedence is `blocked > review > ready`. Sort reason codes, paths, owners, and
+verification steps deterministically. Use shared redaction for any
+human-readable evidence.
+
+- [x] **Step 4: Make the legacy decision summary a projection**
+
+Map `Ready/Review/Blocked` to existing `PASS/REVIEW/BLOCK` labels so console
+compatibility and exit behavior remain stable.
+
+- [x] **Step 5: Verify readiness**
+
+Run: `cargo test --lib review::readiness`
+
+Run: `cargo test --test review_readiness`
+
+Run: `cargo test --test review_command`
+
+Expected: verdict precedence, ownership reasons, verification, and legacy
+summary compatibility pass.
+
+---
+
+### Task 7: Project Readiness and Risk Delta Across Product Surfaces
+
+**Files:**
+- Modify: `src/report/schema/review.rs`
+- Modify: `src/review/render/console.rs`
+- Modify: `src/review/render/markdown.rs`
+- Modify: `src/review/render/json.rs`
+- Modify: `src/review/render/sarif.rs`
+- Modify: `src/commands/mcp/review_change.rs`
+- Modify: `src/commands/mcp/context.rs`
+- Modify: `src/output/ai_context/json.rs`
+- Modify: `scripts/review_delta.py`
+- Modify: `scripts/repopilot-action-review.sh`
+- Test: `tests/review_readiness.rs`
+- Test: `tests/mcp_cli.rs`
+- Test: `tests/action_delta.rs`
+- Test: `tests/ai_context_golden.rs`
+- Test: `tests/report_schema_contract.rs`
+
+**Interfaces:**
+- Consumes: `MergeReadinessRecord` and `RiskDelta`
+- Produces: additive `merge_readiness` and optional `risk_delta` fields
+- Preserves: existing schema readers, exit codes, and Action artifacts
+
+- [ ] **Step 1: Add failing projection parity tests**
+
+Assert the same fixture has identical verdict, reason-code set, owner set, and
+verification count in JSON, MCP compact/full, Action delta metadata, and AI
+context.
+
+- [ ] **Step 2: Confirm RED**
+
+Run:
+`cargo test --test review_readiness --test mcp_cli --test action_delta --test ai_context_golden`
+
+- [ ] **Step 3: Add shared-record projections**
+
+Render human labels from stable reason codes. Keep SARIF additions under result
+properties or invocation metadata without changing existing result identity.
+
+- [ ] **Step 4: Update additive schema compatibility fixtures**
+
+Advance the report schema only if required by repository policy, retain all
+accepted older versions, and prove strict older readers ignore new fields.
+
+- [ ] **Step 5: Verify all projections**
+
+Run:
+`cargo test --test review_readiness --test mcp_cli --test action_delta --test ai_context_golden --test report_schema_contract`
+
+Expected: parity and compatibility tests pass.
+
+---
+
+### Task 8: Deepen Managed-Language Framework Coverage
+
+**Files:**
+- Modify: `src/languages/java/review.rs`
+- Modify: `src/languages/kotlin/review.rs`
+- Modify: `src/languages/csharp/review.rs`
+- Test: `src/review/signals/taint/tests.rs`
+- Create: managed-language cases under `tests/fixtures/review-zoo/taint/`
+- Modify: `tests/review_zoo.rs`
+
+**Interfaces:**
+- Extends: language-owned `TaintTables`
+- Adds: Spring MVC/Boot, Ktor/Spring, and ASP.NET Core source/sink idioms
+- Preserves: language-neutral taint engine
+
+- [ ] **Step 1: Add one failing unsafe and one passing safe case per framework**
+
+Unsafe cases pass request-derived values to raw SQL, process, or file sinks.
+Safe cases use constants, parameterized APIs, or a supported sanitizer.
+
+- [ ] **Step 2: Confirm RED only for unsafe cases**
+
+Run: `cargo test --lib review::signals::taint`
+
+Run: `cargo test --test review_zoo managed`
+
+- [ ] **Step 3: Add minimal high-specificity frontend patterns**
+
+Do not add global method-name matches. Bind source and sink idioms to the owning
+frontend grammar and framework vocabulary.
+
+- [ ] **Step 4: Verify managed languages**
+
+Run: `cargo test --lib review::signals::taint`
+
+Run: `cargo test --test review_zoo`
+
+Expected: unsafe cases emit expected signals and safe cases remain empty.
+
+---
+
+### Task 9: Deepen TypeScript/JavaScript, Python, and Go Coverage
+
+**Files:**
+- Modify: `src/languages/javascript/review.rs`
+- Modify: `src/languages/python/review.rs`
+- Modify: `src/languages/go/review.rs`
+- Test: `src/review/signals/taint/tests.rs`
+- Create: framework cases under `tests/fixtures/review-zoo/taint/`
+- Modify: `tests/review_zoo.rs`
+
+**Interfaces:**
+- Adds: Next.js App Router, Express, Fastify/Hono, FastAPI/Django/Flask,
+  `net/http`/Gin/Echo/Fiber idioms
+
+- [ ] **Step 1: Add differential fixture tests**
+
+Cover at least one request-to-database/process/file flow and one near-identical
+safe flow for every newly claimed framework family.
+
+- [ ] **Step 2: Confirm RED**
+
+Run: `cargo test --lib review::signals::taint`
+
+- [ ] **Step 3: Extend frontend-owned tables conservatively**
+
+Prefer qualified call shapes and framework-specific access paths. Do not treat
+generic identifiers such as `query`, `body`, `exec`, or `write` as sufficient
+on their own.
+
+- [ ] **Step 4: Verify dynamic and Go frontends**
+
+Run: `cargo test --lib review::signals::taint`
+
+Run: `cargo test --test review_zoo`
+
+Expected: every unsafe/safe pair behaves as specified.
+
+---
+
+### Task 10: Improve Rust Web Boundaries and Panic-Risk Precision
+
+**Files:**
+- Modify: `src/languages/rust/review.rs`
+- Modify focused modules under: `src/audits/code_quality/rust_panic_risk/`
+- Test: `src/review/signals/tests.rs`
+- Test focused modules under: `src/audits/code_quality/rust_panic_risk/`
+- Create: Rust cases under `tests/fixtures/review-zoo/boundary/`
+
+**Interfaces:**
+- Adds: Axum, Actix, and Rocket boundary evidence
+- Preserves: dedicated Rust panic-risk capability and no generic taint claim
+
+- [ ] **Step 1: Add failing web-boundary cases and panic-risk FP guards**
+
+Unsafe/review-worthy cases change handler/auth boundaries. Safe cases change
+ordinary internal functions. Panic-risk guards cover idiomatic infallible or
+test-only contexts currently at risk of noise.
+
+- [ ] **Step 2: Confirm RED**
+
+Run: `cargo test --lib languages::rust`
+
+Run: `cargo test --lib rust_panic_risk`
+
+- [ ] **Step 3: Add focused patterns and contextual guards**
+
+Keep Rust panic-risk in its dedicated audit. Extend frontend boundary metadata
+without creating a taint capability.
+
+- [ ] **Step 4: Verify Rust quality**
+
+Run: `cargo test --lib languages::rust`
+
+Run: `cargo test --lib rust_panic_risk`
+
+Run: `cargo test --test review_zoo`
+
+Expected: new boundary true positives and panic-risk false-positive guards pass.
+
+---
+
+### Task 11: Synchronize Product, Engineering, and Release Documentation
+
+**Files:**
+- Modify: `docs/roadmap.md`
+- Modify: `docs/roadmap/v0.20.md`
+- Modify: `docs/engineering/analysis-platform-state.md`
+- Modify: `docs/engineering/language-surface-inventory.md`
+- Modify generated: `docs/language-support.md`
+- Modify: `docs/configuration.md`
+- Modify: `docs/commands.md`
+- Modify: `CHANGELOG.md` only within `[Unreleased]`
+- Create or modify: `docs/releases/v0.21.0.md`
+- Modify: `specs/001-021-risk-memory-merge-readiness/spec.md`
+
+**Interfaces:**
+- Produces: one exact release promise and status across all documentation
+- Marks: v0.20 release preparation done
+- Marks: 0.21 spec status `Implemented` only after verified implementation
+
+- [ ] **Step 1: Add or update documentation contract tests**
+
+Pin history defaults/options, overlay tracking, readiness fields, language
+matrix generation, and v0.20 completion status in existing doc/CLI contract
+tests.
+
+- [ ] **Step 2: Confirm documentation drift is detected**
+
+Run:
+`cargo test --test cli_stabilization --test language_support_doc`
+
+Run:
+`python3 scripts/release-contract.py check`
+
+- [ ] **Step 3: Update current-state and user workflow docs**
+
+Lead with the user outcome: record risk, review readiness, inspect owners and
+verification, then use Action/MCP projections. Remove stale graph/language
+checklist claims.
+
+- [ ] **Step 4: Update release notes and changelog**
+
+Describe user-visible outcomes, compatibility, opt-in history, language depth,
+and limitations. Do not claim zoo measurements unless freshly verified.
+
+- [ ] **Step 5: Regenerate and verify docs**
+
+Run:
+`REPOPILOT_BLESS=1 cargo test --test language_support_doc`
+
+Run:
+`cargo test --test cli_stabilization`
+
+Run:
+`python3 scripts/release-contract.py check`
+
+Expected: generated and curated docs agree.
+
+---
+
+### Task 12: Full 0.21 Verification and Spec Closure
+
+**Files:**
+- Modify only if evidence requires:
+  `specs/001-021-risk-memory-merge-readiness/spec.md`
+- Modify only if evidence requires:
+  `docs/releases/v0.21.0.md`
+
+**Interfaces:**
+- Consumes: all tasks above
+- Produces: release-gate evidence without publishing
+
+- [ ] **Step 1: Run formatting and lint gates**
+
+Run: `cargo fmt --all -- --check`
+
+Run: `cargo clippy --all-targets --all-features -- -D warnings`
+
+- [ ] **Step 2: Run the complete test and contract gates**
+
+Run: `cargo test --all`
+
+Run: `python3 scripts/release-contract.py check`
+
+Run: `npm run test:release-contract`
+
+- [ ] **Step 3: Run performance and self-scan gates**
+
+Run: `npm run review:performance`
+
+Run: `cargo run -- scan . --fail-on-priority p1`
+
+- [ ] **Step 4: Run zoo evidence when available**
+
+Run: `python3 scripts/zoo.py scan`
+
+If `.zoo/` is unavailable, record that fact and omit measured zoo claims.
+
+- [ ] **Step 5: Run release verification**
+
+Run: `bash scripts/verify-release.sh`
+
+Do not bump, tag, publish, commit, or push.
+
+- [ ] **Step 6: Close the spec from evidence**
+
+Change the tracked spec status from `Approved` to `Implemented` only when every
+acceptance scenario and applicable success criterion has a passing test or
+documented gate result.

--- a/docs/superpowers/specs/2026-07-26-repopilot-0-21-breakthrough-design.md
+++ b/docs/superpowers/specs/2026-07-26-repopilot-0-21-breakthrough-design.md
@@ -1,0 +1,138 @@
+# RepoPilot 0.21 Breakthrough Release Design
+
+## Product Direction
+
+RepoPilot 0.21 turns deterministic analysis into a local merge decision. The
+release answers four questions in one workflow:
+
+1. Did repository risk improve or regress?
+2. What code and dependency surfaces did the change affect?
+3. Who should review those surfaces?
+4. What must be verified before merge?
+
+The release remains local-only, deterministic, review-first, and compatible
+with existing command and report surfaces.
+
+## Release Pillars
+
+### Risk Memory
+
+Opt-in local history stores versioned, bounded run receipts. A comparison
+identity prevents incompatible scopes, profiles, configurations, overlays, or
+base/head revisions from producing false risk deltas. Finding occurrences, not
+line-insensitive baseline IDs, are the comparison unit.
+
+### Merge Readiness
+
+A shared merge-readiness record combines the current decision verdict,
+changed-code signals, dependency impact, ownership, verification steps, known
+limitations, and an optional compatible risk delta. Its verdict is one of:
+
+- `ready`: no blocking or review-required reason remains;
+- `review`: human verification or ownership attention is required;
+- `blocked`: the active decision contract contains a blocking reason.
+
+Stable reason codes make the verdict inspectable and testable.
+
+### Ownership-Aware Impact
+
+RepoPilot parses GitHub-compatible CODEOWNERS files and applies last-matching
+rule precedence. Changed and impacted files receive deterministic owner
+suggestions. When no named owner exists, RepoPilot reports package or directory
+boundaries without inventing people or mining Git history.
+
+### Existing-Language Depth
+
+The release improves current rule-aware frontends instead of adding a shallow
+ninth language:
+
+- Java: Spring MVC and Spring Boot request-to-sink flows;
+- Kotlin: Spring and Ktor flows plus Kotlin call-expression precision;
+- C#: ASP.NET Core request/model-binding flows;
+- TypeScript and JavaScript: Next.js App Router, Express, Fastify, and Hono;
+- Python: FastAPI, Django, and Flask flows;
+- Go: `net/http`, Gin, Echo, and Fiber flows;
+- Rust: Axum, Actix, and Rocket boundary evidence plus panic-risk precision.
+
+Every behavior change requires a minimal unsafe fixture and a near-identical
+safe guard. Rust does not gain a generic taint claim without an evidence-backed
+design.
+
+### Trust Hardening
+
+The committed overlay participates in cache and workspace fingerprints, while
+generated history and cache state do not. History writes are bounded and
+atomically replace pruned state. Corruption and write failures are visible as
+structured diagnostics without turning a successful analysis into a false
+failure.
+
+## Architecture
+
+### Canonical Records
+
+`RunReceiptV1` owns one analysis contract and its occurrence records.
+`ComparisonIdentity` determines compatibility. `RiskDelta` classifies two
+compatible receipts. `MergeReadinessRecord` is the only source for human and
+machine readiness projections.
+
+The records are pure data. Storage, comparison, ownership discovery, verdict
+derivation, and rendering remain separate focused modules.
+
+### Data Flow
+
+1. Analysis produces findings, decisions, changed-code signals, and impact.
+2. Ownership discovery maps changed and impacted paths.
+3. Optional history lookup selects the newest compatible receipt.
+4. Delta computation classifies occurrence records.
+5. Readiness derivation combines decisions, signals, impact, owners,
+   verification, limitations, and the optional delta.
+6. Output adapters render the shared records.
+7. When explicitly enabled, a successful analysis records a bounded receipt.
+
+History recording happens after analysis and cannot change the findings or
+readiness derived for that run.
+
+## Error Handling
+
+- Disabled history creates no state.
+- Missing history is a normal `unavailable` comparison.
+- Unsupported receipt schemas are skipped with a diagnostic.
+- A truncated final JSONL record is ignored and reported.
+- Atomic replacement protects pruning from interrupted writes.
+- Concurrent update detection retries a bounded number of times, then reports
+  that the run was not recorded.
+- Missing or invalid CODEOWNERS degrades to unowned boundaries with a
+  diagnostic; it never invents owners.
+- Invalid overlay entries remain governed by the existing overlay diagnostic
+  contract.
+
+## Compatibility
+
+- No new top-level CLI command.
+- New fields are additive in JSON, MCP, Action, and AI context contracts.
+- Existing exit-code behavior stays stable.
+- History is opt-in through existing command/config surfaces.
+- `.repopilot/overlay.toml` is repository policy and can be committed.
+- `.repopilot/cache/` and `.repopilot/history/` are generated local state.
+
+## Verification Strategy
+
+Development follows red-green-refactor for each behavior:
+
+- comparison compatibility and occurrence collisions;
+- atomic bounded storage and corruption recovery;
+- overlay cache invalidation;
+- CODEOWNERS precedence and fallback boundaries;
+- deterministic readiness verdict and projection parity;
+- per-framework safe/unsafe language fixtures;
+- generated documentation and schema compatibility;
+- full release gate and self-scan before handoff.
+
+## Explicit Non-Goals
+
+- Hosted storage, telemetry, source upload, or implicit LLM calls.
+- Runtime execution or automatic execution of suggested tests.
+- Git-history-based owner inference.
+- A new language frontend.
+- A new top-level command.
+- A plugin runtime or executable overlay rules.

--- a/scripts/repopilot-action-review.sh
+++ b/scripts/repopilot-action-review.sh
@@ -89,6 +89,7 @@ write_review_summary() {
     else
       echo "- **In-diff findings:** $(jq -r '.review.in_diff_findings' "$review_json")"
     fi
+    echo "- **Merge readiness:** $(jq -r '.merge_readiness.verdict // "unavailable"' "$review_json")"
     echo "- **Definitely-sensitive signals:** $(jq -r '.review.tiered_signals.definitely' "$review_json")"
     echo "- **Maybe-sensitive signals:** $(jq -r '.review.tiered_signals.maybe' "$review_json")"
     echo "- **Review gate:** $(jq -r '.review_gate.status // "not-configured"' "$review_json")"

--- a/specs/001-021-risk-memory-merge-readiness/spec.md
+++ b/specs/001-021-risk-memory-merge-readiness/spec.md
@@ -1,0 +1,265 @@
+# Feature Specification: RepoPilot 0.21 Risk Memory and Merge Readiness
+
+**Feature Branch**: `001-021-risk-memory-merge-readiness`
+
+**Created**: 2026-07-26
+
+**Status**: Approved
+
+**Input**: Make RepoPilot 0.21.0 a breakthrough local-first release that shows
+whether a change made repository risk better or worse, what it affects, who
+should review it, and what must be verified before merge. Harden overlays and
+deepen the existing language frontends as part of the same trust contract.
+
+## Product Promise
+
+RepoPilot 0.21 does not stop at finding problems. It explains whether the
+current change improved or regressed repository risk, identifies the affected
+surface and responsible owners, and emits one deterministic merge-readiness
+decision across CLI, reports, GitHub Action, MCP, and AI context.
+
+## User Scenarios & Testing
+
+### User Story 1 - See Risk Regression Across Runs (Priority: P1)
+
+A maintainer or coding agent records compatible local analyses and immediately
+sees which finding occurrences are new, persisting, resolved, or changed in
+severity.
+
+**Why this priority**: This turns isolated reports into evidence of progress and
+prevents an apparently smaller changed scan from being mistaken for a safer
+repository.
+
+**Independent Test**: Record two full scans of the same workspace contract,
+introduce and resolve findings between them, and verify the classified delta.
+
+**Acceptance Scenarios**:
+
+1. **Given** two full scans with the same target, profile, configuration, and
+   overlay contract, **When** the second scan is recorded, **Then** RepoPilot
+   reports new, persisting, resolved, and severity-shift occurrences.
+2. **Given** a previous full scan and a current changed-only scan, **When**
+   RepoPilot looks for a comparison, **Then** it does not classify out-of-scope
+   findings as resolved and explains that no compatible prior run exists.
+3. **Given** two findings with the same baseline ID but different evidence,
+   **When** history computes the delta, **Then** both occurrence identities are
+   retained independently.
+4. **Given** history is not enabled, **When** a scan runs, **Then** no history
+   directory or ledger is created.
+
+---
+
+### User Story 2 - Know Whether a Change Is Ready to Merge (Priority: P1)
+
+A maintainer reviewing a change gets a single `ready`, `review`, or `blocked`
+verdict with exact reasons, affected surfaces, owners, and verification steps.
+
+**Why this priority**: It converts analysis into an actionable merge decision
+instead of leaving users to assemble findings, blast radius, and ownership by
+hand.
+
+**Independent Test**: Review a fixture repository with CODEOWNERS, a dependency
+chain, and changed-code findings, then assert the deterministic readiness
+record and projections.
+
+**Acceptance Scenarios**:
+
+1. **Given** a change with no blocking findings and bounded impact, **When**
+   review completes, **Then** the verdict is `ready` and still lists relevant
+   verification steps.
+2. **Given** a change with review-worthy signals or unowned impacted files,
+   **When** review completes, **Then** the verdict is `review` with explicit
+   reasons.
+3. **Given** a change with a blocking decision under the active profile,
+   **When** review completes, **Then** the verdict is `blocked`.
+4. **Given** matching CODEOWNERS rules, **When** changed and transitively
+   impacted files are evaluated, **Then** the readiness record lists
+   deterministic, deduplicated owner suggestions.
+5. **Given** no CODEOWNERS file, **When** review completes, **Then** RepoPilot
+   reports directory or package ownership boundaries without inventing people.
+
+---
+
+### User Story 3 - Trust Repository Calibration and Cache Freshness (Priority: P1)
+
+A repository can commit `.repopilot/overlay.toml`, and every analysis surface
+observes overlay changes immediately.
+
+**Why this priority**: A stale cached decision after a policy edit invalidates
+the product's trust promise.
+
+**Independent Test**: Run a cached MCP scan, edit only the overlay, rerun it,
+and verify that the result and workspace revision change.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tracked overlay file, **When** its severity or suppression rule
+   changes, **Then** the MCP cache key changes and the next scan recomputes.
+2. **Given** generated cache and history state changes, **When** a workspace
+   fingerprint is computed, **Then** those changes do not invalidate analysis.
+3. **Given** the repository's ignore rules, **When** a user creates an overlay,
+   **Then** Git can track it while generated history remains ignored.
+
+---
+
+### User Story 4 - Get Deeper Results in Existing Languages (Priority: P2)
+
+Users of the eight rule-aware frontends receive framework-aware review and
+security coverage backed by safe/unsafe differential fixtures.
+
+**Why this priority**: Depth and precision in languages already claimed as
+rule-aware provide more trust than adding a shallow ninth language.
+
+**Independent Test**: For each added framework contract, run its paired safe and
+unsafe fixture and verify that only the unsafe flow emits the expected signal.
+
+**Acceptance Scenarios**:
+
+1. **Given** Java, Kotlin, or C# web input reaching a high-specificity sink,
+   **When** review runs, **Then** the matching Spring, Ktor, or ASP.NET flow is
+   detected.
+2. **Given** TypeScript/JavaScript, Python, or Go framework input reaching a
+   supported sink, **When** review runs, **Then** the unsafe fixture emits a
+   signal and the safe counterpart does not.
+3. **Given** Rust Axum, Actix, or Rocket boundary changes, **When** review runs,
+   **Then** boundary evidence is reported without claiming generic Rust taint.
+4. **Given** a new capability claim, **When** the generated support matrix is
+   checked, **Then** the claim is derived from real frontend wiring.
+
+---
+
+### User Story 5 - Consume One Contract Everywhere (Priority: P2)
+
+CLI, JSON, Markdown, GitHub Action, MCP, and AI context consumers receive the
+same risk-delta and merge-readiness meaning.
+
+**Why this priority**: Divergent surface-specific logic makes agent and human
+decisions inconsistent.
+
+**Independent Test**: Analyze one fixture through each applicable projection
+and compare the canonical record fields and counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** one canonical readiness record, **When** it is rendered through
+   human and machine outputs, **Then** verdict, reasons, counts, owners, and
+   verification steps agree.
+2. **Given** an older JSON consumer, **When** it reads the additive 0.21
+   fields, **Then** existing fields and exit-code behavior remain compatible.
+3. **Given** history is unavailable or disabled, **When** a report is emitted,
+   **Then** readiness still works and history availability is explicit.
+
+### Edge Cases
+
+- A scan targets a single file, a subdirectory, or a workspace different from
+  the current directory.
+- A changed scan has no merge base or uses a different base/head pair.
+- The active profile, relevant configuration, overlay, or report schema changes
+  between runs.
+- The ledger contains an interrupted final line, an older supported schema, or
+  an unsupported future schema.
+- Two processes attempt to record history concurrently.
+- Retention is configured to zero, one, or a value that exceeds the byte cap.
+- CODEOWNERS contains escaped spaces, comments, overlapping patterns, negation-
+  like text unsupported by GitHub semantics, or owners repeated across rules.
+- Changed files have no owner, are deleted, or are outside the dependency graph.
+- Sensitive snippets appear in readiness reasons or verification steps.
+- A language framework pattern is syntactically similar to a sink but receives
+  a constant, sanitized, or otherwise untainted value.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: History MUST be opt-in and MUST NOT create files when disabled.
+- **FR-002**: Every run receipt MUST include a schema version, workspace
+  identity, analysis target, scope, revisions, profile, configuration
+  fingerprint, overlay fingerprint, and finding occurrence records.
+- **FR-003**: RepoPilot MUST compare only receipts with compatible comparison
+  identities and MUST explain an unavailable comparison.
+- **FR-004**: Delta matching MUST use occurrence identity, not the baseline
+  finding ID alone.
+- **FR-005**: History storage MUST use the workspace root, remain bounded by run
+  count and bytes, and replace pruned data atomically.
+- **FR-006**: A damaged ledger MUST produce a structured diagnostic without
+  failing the underlying scan.
+- **FR-007**: Wall-clock metadata MUST NOT affect analysis determinism,
+  occurrence identity, report equality, or cache keys.
+- **FR-008**: RepoPilot MUST derive one canonical merge-readiness record with a
+  `ready`, `review`, or `blocked` verdict and ordered reason codes.
+- **FR-009**: Readiness MUST include changed/impacted surfaces, matched owners,
+  unowned surfaces, verification steps, and analysis limitations.
+- **FR-010**: Ownership MUST support GitHub-compatible CODEOWNERS precedence and
+  deterministic fallback package/directory boundaries without Git-history
+  inference.
+- **FR-011**: Human-readable readiness evidence MUST use centralized sensitive
+  evidence redaction.
+- **FR-012**: Risk delta and readiness MUST be projected from shared records
+  across CLI, JSON, Markdown, Action, MCP, and AI context where those surfaces
+  expose review results.
+- **FR-013**: `.repopilot/overlay.toml` MUST be trackable and MUST participate in
+  workspace and MCP scan-cache invalidation.
+- **FR-014**: Generated `.repopilot/cache/` and `.repopilot/history/` changes
+  MUST NOT invalidate analysis fingerprints.
+- **FR-015**: Existing report contracts MUST evolve additively and accepted
+  older schema versions MUST continue to parse.
+- **FR-016**: Existing top-level CLI commands MUST remain unchanged.
+- **FR-017**: New Java, Kotlin, C#, TypeScript/JavaScript, Python, Go, and Rust
+  language behavior MUST have safe/unsafe regression fixtures appropriate to
+  the claimed framework behavior.
+- **FR-018**: New language signals MUST preserve default-profile precision and
+  strict-mode recall according to the repository's false-positive policy.
+- **FR-019**: Support documentation MUST be generated from the frontend registry
+  and MUST NOT advertise unwired capabilities.
+- **FR-020**: The v0.20 release roadmap, analysis platform state, language
+  inventory, 0.21 roadmap, changelog, and release notes MUST agree with shipped
+  and in-progress behavior.
+
+### Key Entities
+
+- **RunReceiptV1**: A bounded local record of one analysis contract and its
+  occurrence-level findings.
+- **ComparisonIdentity**: The fields that determine whether two runs can be
+  compared without producing false resolutions.
+- **RiskDelta**: Ordered new, persisting, resolved, and severity-shift
+  occurrences plus comparison provenance.
+- **MergeReadinessRecord**: Canonical verdict, reasons, impact, ownership,
+  verification, limitations, and optional risk delta.
+- **OwnershipIndex**: Parsed CODEOWNERS rules and deterministic fallback
+  boundaries.
+- **LanguageQualityCase**: A framework-specific safe/unsafe fixture pair and
+  expected review behavior.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Full-vs-changed and incompatible-profile regression tests produce
+  zero false `resolved` classifications.
+- **SC-002**: Two colliding baseline IDs with different occurrences remain two
+  independent history entries and delta results.
+- **SC-003**: Editing only `overlay.toml` invalidates the cached MCP scan in an
+  integration test; editing generated history does not.
+- **SC-004**: One readiness fixture produces identical verdict, reason codes,
+  owner set, and verification count across every supported projection.
+- **SC-005**: Every new language behavior has at least one unsafe true-positive
+  and one near-identical safe false-positive guard.
+- **SC-006**: All default-visible zoo findings remain reviewed and labeled; no
+  measured zoo claim is made when the zoo is unavailable.
+- **SC-007**: History retention never exceeds the configured positive run count
+  or byte cap after a successful write.
+- **SC-008**: The full RepoPilot release gate passes before 0.21 handoff.
+
+## Assumptions
+
+- Existing `FindingRecord`, `DecisionRecord`, occurrence keys, impact paths,
+  workspace revisions, and centralized redaction remain the canonical
+  foundations.
+- GitHub-compatible CODEOWNERS files are discovered in `.github/`, repository
+  root, then `docs/`, matching GitHub precedence.
+- History timestamps are useful local metadata but are excluded from
+  deterministic projections unless a user explicitly inspects the ledger.
+- Runtime execution, automatic test execution, hosted sync, telemetry, implicit
+  LLM calls, and a new language frontend are outside 0.21.
+- No commits, pushes, tags, or publication occur without explicit user
+  authorization.

--- a/src/cli/options/review.rs
+++ b/src/cli/options/review.rs
@@ -76,6 +76,10 @@ pub struct ReviewOptions {
     #[arg(long, value_name = "PATH")]
     pub sarif_output: Option<PathBuf>,
 
+    /// Record this review in the bounded local history ledger
+    #[arg(long)]
+    pub record_history: bool,
+
     /// Override the large-file LOC threshold
     #[arg(long)]
     pub max_file_loc: Option<usize>,

--- a/src/cli/options/scan.rs
+++ b/src/cli/options/scan.rs
@@ -47,6 +47,10 @@ pub struct ScanOptions {
     #[arg(long, value_name = "PATH")]
     pub receipt: Option<PathBuf>,
 
+    /// Record this scan in the bounded local history ledger
+    #[arg(long)]
+    pub record_history: bool,
+
     /// Path to a repopilot.toml config file
     #[arg(long)]
     pub config: Option<PathBuf>,

--- a/src/commands/mcp/scan_cache.rs
+++ b/src/commands/mcp/scan_cache.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 
 const SCHEMA: &str = "mcp-scan-cache-v1";
 const FEEDBACK_PATH: &str = ".repopilot/feedback.yml";
+const OVERLAY_PATH: &str = ".repopilot/overlay.toml";
 const REPOPILOT_IGNORE_FILENAME: &str = ".repopilotignore";
 
 /// The cache key for a scan call, or `None` when cache correctness cannot be
@@ -53,6 +54,8 @@ fn cache_key_with_metadata(
     hasher.update(config_blob(path, arguments).as_bytes());
     hasher.update(b"\nfeedback:");
     hasher.update(path_blob(path.join(FEEDBACK_PATH)).as_bytes());
+    hasher.update(b"\noverlay:");
+    hasher.update(path_blob(repo_root.join(OVERLAY_PATH)).as_bytes());
     hasher.update(b"\nrepopilotignore:");
     hasher.update(path_blob(repopilotignore_path(path)).as_bytes());
     hasher.update(b"\nignore-sources:");

--- a/src/commands/mcp/scan_cache/git.rs
+++ b/src/commands/mcp/scan_cache/git.rs
@@ -3,8 +3,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const CACHE_DIR: &str = ".repopilot/cache";
-
 pub(super) fn working_tree_fingerprint(repo_root: &Path) -> Option<String> {
     let head = git(repo_root, &["rev-parse", "HEAD"])?;
     let status_args = ["status", "--porcelain=v1", "-z", "-uall"];
@@ -157,8 +155,10 @@ fn status_entries(status: &[u8]) -> Vec<StatusEntry> {
 }
 
 fn is_cache_path(rel: &str) -> bool {
-    rel == CACHE_DIR
-        || rel.starts_with(&format!("{CACHE_DIR}/"))
-        || rel.ends_with(&format!("/{CACHE_DIR}"))
-        || rel.contains(&format!("/{CACHE_DIR}/"))
+    let normalized = rel.replace('\\', "/");
+    let clean = normalized.trim_start_matches("./");
+    let components = clean.split('/').collect::<Vec<_>>();
+    components
+        .windows(2)
+        .any(|pair| pair == [".repopilot", "cache"] || pair == [".repopilot", "history"])
 }

--- a/src/commands/mcp/scan_cache/tests/invalidation.rs
+++ b/src/commands/mcp/scan_cache/tests/invalidation.rs
@@ -170,6 +170,37 @@ fn feedback_and_repopilotignore_content_changes_invalidate_the_key() {
 }
 
 #[test]
+fn overlay_changes_invalidate_but_generated_history_does_not() {
+    let (_dir, root) = init_repo();
+    let scan_path = root.join("src");
+    let overlay = root.join(".repopilot/overlay.toml");
+    std::fs::create_dir_all(overlay.parent().unwrap()).unwrap();
+    std::fs::write(
+        &overlay,
+        "[[overlay]]\nrule = \"security.secret-candidate\"\n",
+    )
+    .unwrap();
+    let first = cache_key(&scan_path, &args(&scan_path)).unwrap();
+
+    std::fs::write(
+        &overlay,
+        "[[overlay]]\nrule = \"architecture.large-file\"\n",
+    )
+    .unwrap();
+    let second = cache_key(&scan_path, &args(&scan_path)).unwrap();
+    assert_ne!(first, second, "an overlay edit must invalidate");
+
+    let history = root.join(".repopilot/history/runs.jsonl");
+    std::fs::create_dir_all(history.parent().unwrap()).unwrap();
+    std::fs::write(history, "{}\n").unwrap();
+    assert_eq!(
+        second,
+        cache_key(&scan_path, &args(&scan_path)).unwrap(),
+        "generated history must not invalidate"
+    );
+}
+
+#[test]
 fn parent_gitignore_change_invalidates_subdir_scan_and_never_serves_stale_cache() {
     let (_dir, root) = init_repo();
     std::fs::write(root.join("src/generated.rs"), "pub fn generated() {}\n").unwrap();

--- a/src/commands/product_scan.rs
+++ b/src/commands/product_scan.rs
@@ -7,7 +7,7 @@ use repopilot::facts::RepoFactsSummary;
 use repopilot::findings::feedback::apply_local_feedback;
 use repopilot::findings::filter::FindingFilter;
 use repopilot::findings::visibility::{FindingVisibilityProfile, apply_visibility_profile};
-use repopilot::knowledge::{active_overlay, init_active_overlay};
+use repopilot::knowledge::{active_overlay, init_active_overlay, init_active_overlay_disabled};
 use repopilot::review::diff::ChangedFile;
 use repopilot::scan::scanner::{
     scan_changed_session, scan_resolved_changed_session, scan_session,
@@ -88,7 +88,11 @@ fn run_product_scan_internal(
     );
     debug_assert!(!session.revision().id().is_empty());
 
-    init_active_overlay(&request.path);
+    if request.ignore_feedback {
+        init_active_overlay_disabled();
+    } else {
+        init_active_overlay(session.workspace_root());
+    }
 
     let pb = if request.no_progress {
         None

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -11,6 +11,7 @@ use repopilot::baseline::reader::read_baseline;
 use repopilot::config::loader::{load_default_config, load_optional_config};
 use repopilot::config::model::{ReviewFailOn, ReviewScope};
 use repopilot::findings::visibility::FindingVisibilityProfile;
+use repopilot::history::{AnalysisScope, ReceiptContext, record_session};
 use repopilot::output::{DetailLevel, FindingRenderLimit, OutputFormat};
 use repopilot::report::writer::write_report;
 use repopilot::review::render::{ReviewRenderOptions, render_review_sarif, render_with_options};
@@ -81,6 +82,7 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
         )?
     };
     let diff_loading_us = duration_us(diff_started.elapsed());
+    let history_target = review_input.target.clone();
     let scan_mode = match scope {
         ReviewScope::Changed => ProductScanMode::ResolvedChanged {
             changed_files: review_input.changed_files.clone(),
@@ -107,8 +109,8 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
     })?;
     let summary = scan_result.summary;
 
-    let baseline_file = match options.baseline {
-        Some(baseline_path) => Some((read_baseline(&baseline_path)?, baseline_path)),
+    let baseline_file = match options.baseline.as_ref() {
+        Some(baseline_path) => Some((read_baseline(baseline_path)?, baseline_path.clone())),
         None => None,
     };
     let baseline_ref = baseline_file
@@ -142,6 +144,26 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
         });
     let review_gate = ReviewSignalGateResult::evaluate(&review_report, review_gate_policy);
     review_report.timings.gating_us = duration_us(gating_started.elapsed());
+    if (options.record_history || scan_result.session.repo_config().history.enabled)
+        && !review_report.summary.has_error_diagnostics()
+    {
+        let outcome = record_session(
+            &scan_result.session,
+            review_history_context(scope, &history_target, &options),
+            &review_report.summary.artifacts.findings,
+        );
+        if let Some(repopilot::history::ComparisonResult::Compatible(delta)) = outcome.comparison {
+            review_report.summary.artifacts.risk_delta = Some(delta);
+        }
+        for diagnostic in outcome.diagnostics {
+            review_report.summary.artifacts.diagnostics.push(
+                repopilot::scan::types::ScanDiagnostic::warning(
+                    format!("history.{}", diagnostic.kind.code()),
+                    diagnostic.message,
+                ),
+            );
+        }
+    }
     let output_format: OutputFormat = options.format.into();
     let render_options = ReviewRenderOptions {
         detail: options
@@ -197,6 +219,48 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn review_history_context(
+    scope: ReviewScope,
+    target: &repopilot::review::diff::OwnedDiffTarget,
+    options: &ReviewOptions,
+) -> ReceiptContext {
+    let scope = match scope {
+        ReviewScope::Changed => AnalysisScope::ReviewChanged,
+        ReviewScope::Full => AnalysisScope::ReviewFull,
+    };
+    let selection_fingerprint = repopilot::scan::cache::stable_hash_hex(
+        format!(
+            "{:?}|{:?}|{:?}|{:?}|{:?}",
+            options.scope,
+            options.min_severity,
+            options.min_confidence,
+            options.min_priority,
+            options.profile
+        )
+        .as_bytes(),
+    );
+    match target {
+        repopilot::review::diff::OwnedDiffTarget::WorkingTree => ReceiptContext {
+            scope,
+            base_ref: Some("HEAD".to_string()),
+            head_ref: None,
+            selection_fingerprint: selection_fingerprint.clone(),
+        },
+        repopilot::review::diff::OwnedDiffTarget::Refs { base, head } => ReceiptContext {
+            scope,
+            base_ref: Some(base.clone()),
+            head_ref: Some(head.clone()),
+            selection_fingerprint: selection_fingerprint.clone(),
+        },
+        repopilot::review::diff::OwnedDiffTarget::SinceRef { base } => ReceiptContext {
+            scope,
+            base_ref: Some(base.clone()),
+            head_ref: None,
+            selection_fingerprint,
+        },
+    }
 }
 
 fn duration_us(duration: Duration) -> u64 {

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -8,6 +8,7 @@ use crate::commands::product_scan::{
     ProductScanRequest, enforce_diagnostics_exit_policy, run_product_scan,
 };
 use crate::commands::scan_config::ScanConfigOverrides;
+use repopilot::history::{AnalysisScope, ReceiptContext, record_session};
 use repopilot::output::{
     ColorChoice, ColorDestination, ConsoleOutputStyle, FindingRenderLimit, RenderOptions,
     render_scan_summary_with_options,
@@ -26,6 +27,7 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     let fail_on_priority = options.fail_on_priority.map(Into::into);
     let visibility_profile = validation::scan_visibility_profile(&options);
     let scan_mode = validation::scan_mode_from_options(&options);
+    let history_context = scan_history_context(&scan_mode, &options);
 
     let scan_result = run_product_scan(ProductScanRequest {
         path: options.path.clone(),
@@ -68,6 +70,11 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     if !priority_filter.is_empty() {
         priority_filter.apply_to_summary(&mut summary);
     }
+    if (options.record_history || scan_result.session.repo_config().history.enabled)
+        && !summary.has_error_diagnostics()
+    {
+        apply_history(&mut summary, &scan_result.session, history_context);
+    }
 
     let render_options = render_options_for_scan(&options);
     let render_start = Instant::now();
@@ -87,8 +94,74 @@ pub fn run(options: ScanOptions) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     enforce_diagnostics_exit_policy(&summary)?;
-
     Ok(())
+}
+
+fn apply_history(
+    summary: &mut ScanSummary,
+    session: &repopilot::scan::session::AnalysisSession,
+    context: ReceiptContext,
+) {
+    let outcome = record_session(session, context, &summary.artifacts.findings);
+    if let Some(repopilot::history::ComparisonResult::Compatible(delta)) = outcome.comparison {
+        summary.artifacts.risk_delta = Some(delta);
+    }
+    for diagnostic in outcome.diagnostics {
+        summary
+            .artifacts
+            .diagnostics
+            .push(repopilot::scan::types::ScanDiagnostic::warning(
+                format!("history.{}", diagnostic.kind.code()),
+                diagnostic.message,
+            ));
+    }
+}
+
+fn scan_history_context(
+    mode: &crate::commands::product_scan::ProductScanMode,
+    options: &ScanOptions,
+) -> ReceiptContext {
+    let selection_fingerprint = repopilot::scan::cache::stable_hash_hex(
+        format!(
+            "{:?}|{:?}|{:?}|{:?}|{}|{}|{:?}",
+            options.min_severity,
+            options.min_confidence,
+            options.min_priority,
+            options.rule,
+            options.include_maintainability,
+            options.include_low_signal,
+            options.preset
+        )
+        .as_bytes(),
+    );
+    match mode {
+        crate::commands::product_scan::ProductScanMode::Full => ReceiptContext {
+            scope: AnalysisScope::Full,
+            base_ref: None,
+            head_ref: None,
+            selection_fingerprint: selection_fingerprint.clone(),
+        },
+        crate::commands::product_scan::ProductScanMode::Workspace => ReceiptContext {
+            scope: AnalysisScope::Workspace,
+            base_ref: None,
+            head_ref: None,
+            selection_fingerprint: selection_fingerprint.clone(),
+        },
+        crate::commands::product_scan::ProductScanMode::Changed { since } => ReceiptContext {
+            scope: AnalysisScope::Changed,
+            base_ref: Some(since.clone().unwrap_or_else(|| "HEAD".to_string())),
+            head_ref: None,
+            selection_fingerprint: selection_fingerprint.clone(),
+        },
+        crate::commands::product_scan::ProductScanMode::ResolvedChanged { base_ref, .. } => {
+            ReceiptContext {
+                scope: AnalysisScope::Changed,
+                base_ref: Some(base_ref.clone().unwrap_or_else(|| "HEAD".to_string())),
+                head_ref: None,
+                selection_fingerprint,
+            }
+        }
+    }
 }
 
 pub(super) fn render_options_for_scan(options: &ScanOptions) -> RenderOptions {

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -25,6 +25,7 @@ pub struct RepoPilotConfig {
     pub algorithmic: AlgorithmicSection,
     pub taint: TaintSection,
     pub output: OutputSection,
+    pub history: HistorySection,
 }
 
 /// Per-rule configuration: turn individual rules off or pin their severity.
@@ -358,6 +359,24 @@ impl Default for OutputSection {
     fn default() -> Self {
         Self {
             default_format: OutputFormat::Console,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct HistorySection {
+    pub enabled: bool,
+    pub max_runs: usize,
+    pub max_bytes: u64,
+}
+
+impl Default for HistorySection {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_runs: crate::history::DEFAULT_MAX_RUNS,
+            max_bytes: crate::history::DEFAULT_MAX_BYTES,
         }
     }
 }

--- a/src/config/template.rs
+++ b/src/config/template.rs
@@ -73,6 +73,12 @@ enabled = true
 
 [output]
 default_format = "console"
+
+[history]
+# Opt in to a local, bounded ledger used for compatible risk deltas.
+enabled = false
+max_runs = 50
+max_bytes = 5242880
 "#
     )
 }

--- a/src/history/context.rs
+++ b/src/history/context.rs
@@ -1,0 +1,141 @@
+use crate::findings::types::Finding;
+use crate::history::diagnostic::HistoryDiagnostic;
+use crate::history::model::{
+    AnalysisScope, ComparisonIdentity, ComparisonResult, FindingReceipt, RunReceipt,
+};
+use crate::history::storage::{HistoryLimits, HistoryStore};
+use crate::report::schema::SCAN_REPORT_SCHEMA_VERSION;
+use crate::scan::cache::{config_fingerprint, stable_hash_hex};
+use crate::scan::session::AnalysisSession;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone)]
+pub struct ReceiptContext {
+    pub scope: AnalysisScope,
+    pub base_ref: Option<String>,
+    pub head_ref: Option<String>,
+    pub selection_fingerprint: String,
+}
+
+#[derive(Debug)]
+pub struct HistoryRecordOutcome {
+    pub receipt: RunReceipt,
+    pub comparison: Option<ComparisonResult>,
+    pub diagnostics: Vec<HistoryDiagnostic>,
+    pub recorded: bool,
+}
+
+pub fn record_session(
+    session: &AnalysisSession,
+    context: ReceiptContext,
+    findings: &[Finding],
+) -> HistoryRecordOutcome {
+    let receipt = build_receipt(session, context, findings);
+    let limits = HistoryLimits {
+        max_runs: session.repo_config().history.max_runs,
+        max_bytes: session.repo_config().history.max_bytes,
+    };
+    let store = HistoryStore::new(session.workspace_root(), limits);
+    let loaded = store.load();
+    let compatible = loaded
+        .receipts
+        .iter()
+        .rev()
+        .find(|prior| prior.comparison == receipt.comparison);
+    let prior = compatible.or_else(|| loaded.receipts.last());
+    let comparison = prior.map(|prior| crate::history::delta::compare(&receipt, prior));
+    let mut diagnostics = loaded.diagnostics;
+    let recorded = match store.record(&receipt) {
+        Ok(()) => true,
+        Err(error) => {
+            diagnostics.push(HistoryDiagnostic::write_failed(error.to_string()));
+            false
+        }
+    };
+    HistoryRecordOutcome {
+        receipt,
+        comparison,
+        diagnostics,
+        recorded,
+    }
+}
+
+pub fn build_receipt(
+    session: &AnalysisSession,
+    context: ReceiptContext,
+    findings: &[Finding],
+) -> RunReceipt {
+    let workspace = normalized_path(session.workspace_root());
+    let analysis_target = relative_analysis_target(session);
+    let comparison = ComparisonIdentity {
+        workspace,
+        analysis_target,
+        scope: context.scope,
+        base_revision: resolve_optional_ref(session.workspace_root(), context.base_ref),
+        head_revision: resolve_optional_ref(session.workspace_root(), context.head_ref),
+        profile: session.visibility_profile().label().to_string(),
+        config_fingerprint: config_fingerprint(session.scan_config()),
+        selection_fingerprint: context.selection_fingerprint,
+        overlay_fingerprint: overlay_fingerprint(session.workspace_root()),
+        analysis_schema: SCAN_REPORT_SCHEMA_VERSION.to_string(),
+    };
+    let receipts = findings
+        .iter()
+        .map(|finding| FindingReceipt::from_finding(finding, session.workspace_root()));
+    RunReceipt::new(
+        comparison,
+        chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        session.revision().id().to_string(),
+        receipts,
+    )
+}
+
+fn relative_analysis_target(session: &AnalysisSession) -> String {
+    let absolute = absolute_path(session.analysis_path());
+    absolute
+        .strip_prefix(session.workspace_root())
+        .ok()
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(normalized_path)
+        .unwrap_or_else(|| ".".to_string())
+}
+
+fn absolute_path(path: &Path) -> PathBuf {
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+    fs::canonicalize(&path).unwrap_or(path)
+}
+
+fn resolve_optional_ref(root: &Path, reference: Option<String>) -> Option<String> {
+    reference.map(|reference| {
+        Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(["rev-parse", "--verify", &reference])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+            .filter(|resolved| !resolved.is_empty())
+            .unwrap_or(reference)
+    })
+}
+
+fn overlay_fingerprint(root: &Path) -> String {
+    let path = root.join(".repopilot/overlay.toml");
+    match fs::read(path) {
+        Ok(bytes) => stable_hash_hex(&bytes),
+        Err(_) => stable_hash_hex(b"overlay:missing"),
+    }
+}
+
+fn normalized_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}

--- a/src/history/delta.rs
+++ b/src/history/delta.rs
@@ -1,0 +1,269 @@
+use crate::history::model::{
+    ComparisonProvenance, ComparisonResult, ComparisonUnavailable, FindingReceipt, RiskDelta,
+    RunReceipt, SeverityShift,
+};
+use std::collections::BTreeMap;
+
+pub fn compare(current: &RunReceipt, prior: &RunReceipt) -> ComparisonResult {
+    if current.schema_version != prior.schema_version {
+        return ComparisonResult::Unavailable(ComparisonUnavailable::SchemaMismatch);
+    }
+    if let Some(reason) = incompatible_identity(current, prior) {
+        return ComparisonResult::Unavailable(reason);
+    }
+    ComparisonResult::Compatible(compute_compatible_delta(current, prior))
+}
+
+fn incompatible_identity(
+    current: &RunReceipt,
+    prior: &RunReceipt,
+) -> Option<ComparisonUnavailable> {
+    let current = &current.comparison;
+    let prior = &prior.comparison;
+    if current.workspace != prior.workspace {
+        Some(ComparisonUnavailable::WorkspaceMismatch)
+    } else if current.analysis_target != prior.analysis_target {
+        Some(ComparisonUnavailable::TargetMismatch)
+    } else if current.scope != prior.scope {
+        Some(ComparisonUnavailable::ScopeMismatch)
+    } else if current.base_revision != prior.base_revision
+        || current.head_revision != prior.head_revision
+    {
+        Some(ComparisonUnavailable::RevisionRangeMismatch)
+    } else if current.profile != prior.profile {
+        Some(ComparisonUnavailable::ProfileMismatch)
+    } else if current.config_fingerprint != prior.config_fingerprint {
+        Some(ComparisonUnavailable::ConfigMismatch)
+    } else if current.selection_fingerprint != prior.selection_fingerprint {
+        Some(ComparisonUnavailable::SelectionMismatch)
+    } else if current.overlay_fingerprint != prior.overlay_fingerprint {
+        Some(ComparisonUnavailable::OverlayMismatch)
+    } else if current.analysis_schema != prior.analysis_schema {
+        Some(ComparisonUnavailable::AnalysisSchemaMismatch)
+    } else {
+        None
+    }
+}
+
+fn compute_compatible_delta(current: &RunReceipt, prior: &RunReceipt) -> RiskDelta {
+    let current_by_occurrence = by_occurrence(&current.findings);
+    let prior_by_occurrence = by_occurrence(&prior.findings);
+    let mut delta = RiskDelta {
+        comparison: ComparisonProvenance {
+            prior_revision: prior.revision.clone(),
+            current_revision: current.revision.clone(),
+        },
+        ..RiskDelta::default()
+    };
+
+    for (key, current_finding) in &current_by_occurrence {
+        match prior_by_occurrence.get(key) {
+            Some(prior_finding) => {
+                delta.persisting_findings.push((*current_finding).clone());
+                if prior_finding.severity != current_finding.severity {
+                    delta.severity_shifts.push(SeverityShift {
+                        occurrence_key: key.clone(),
+                        rule_id: current_finding.rule_id.clone(),
+                        path: current_finding.path.clone(),
+                        old_severity: prior_finding.severity,
+                        new_severity: current_finding.severity,
+                    });
+                }
+            }
+            None => delta.new_findings.push((*current_finding).clone()),
+        }
+    }
+
+    for (key, prior_finding) in &prior_by_occurrence {
+        if !current_by_occurrence.contains_key(key) {
+            delta.resolved_findings.push((*prior_finding).clone());
+        }
+    }
+    delta
+}
+
+fn by_occurrence(findings: &[FindingReceipt]) -> BTreeMap<String, &FindingReceipt> {
+    findings
+        .iter()
+        .map(|finding| (finding.occurrence_key.clone(), finding))
+        .collect()
+}
+
+impl RiskDelta {
+    pub fn render_console(&self) -> String {
+        if !self.has_changes() {
+            return format!(
+                "Risk Delta: No finding changes; {} occurrence(s) persist.\n",
+                self.persisting_findings.len()
+            );
+        }
+
+        let mut out = String::from("Risk Delta (vs compatible previous run):\n");
+        render_console_findings(&mut out, "+", "new", &self.new_findings);
+        render_console_findings(&mut out, "-", "resolved", &self.resolved_findings);
+        if !self.severity_shifts.is_empty() {
+            out.push_str(&format!(
+                "  ~ {} severity shift(s)\n",
+                self.severity_shifts.len()
+            ));
+            for item in self.severity_shifts.iter().take(5) {
+                out.push_str(&format!(
+                    "    - {} ({}): {:?} -> {:?}\n",
+                    item.rule_id, item.path, item.old_severity, item.new_severity
+                ));
+            }
+        }
+        if !self.persisting_findings.is_empty() {
+            out.push_str(&format!(
+                "  = {} persisting finding occurrence(s)\n",
+                self.persisting_findings.len()
+            ));
+        }
+        out
+    }
+
+    pub fn render_markdown(&self) -> String {
+        let mut out = String::from("### Risk Delta\n\n");
+        if !self.has_changes() {
+            out.push_str(&format!(
+                "No changes; {} finding occurrence(s) persist.\n",
+                self.persisting_findings.len()
+            ));
+            return out;
+        }
+        render_markdown_findings(&mut out, "New", &self.new_findings);
+        render_markdown_findings(&mut out, "Resolved", &self.resolved_findings);
+        if !self.severity_shifts.is_empty() {
+            out.push_str(&format!(
+                "* **{} Severity Shift(s)**\n",
+                self.severity_shifts.len()
+            ));
+        }
+        out
+    }
+}
+
+fn render_console_findings(
+    out: &mut String,
+    marker: &str,
+    label: &str,
+    findings: &[FindingReceipt],
+) {
+    if findings.is_empty() {
+        return;
+    }
+    out.push_str(&format!(
+        "  {marker} {} {label} finding occurrence(s)\n",
+        findings.len()
+    ));
+    for item in findings.iter().take(5) {
+        out.push_str(&format!(
+            "    - [{:?}] {} ({})\n",
+            item.severity, item.rule_id, item.path
+        ));
+    }
+}
+
+fn render_markdown_findings(out: &mut String, label: &str, findings: &[FindingReceipt]) {
+    if findings.is_empty() {
+        return;
+    }
+    out.push_str(&format!("* **{} {label} Finding(s)**\n", findings.len()));
+    for item in findings {
+        out.push_str(&format!(
+            "  * `{:?}` `{}` ({})\n",
+            item.severity, item.rule_id, item.path
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::findings::types::Severity;
+    use crate::history::model::{AnalysisScope, ComparisonIdentity};
+
+    #[test]
+    fn distinct_occurrences_with_one_baseline_id_are_not_merged() {
+        let comparison = comparison(AnalysisScope::Full);
+        let prior = receipt(
+            comparison.clone(),
+            vec![finding("same-id", "occ-a", Severity::Medium)],
+        );
+        let current = receipt(
+            comparison,
+            vec![
+                finding("same-id", "occ-a", Severity::Medium),
+                finding("same-id", "occ-b", Severity::High),
+            ],
+        );
+
+        let ComparisonResult::Compatible(delta) = compare(&current, &prior) else {
+            panic!("matching contracts must compare");
+        };
+        assert_eq!(delta.persisting_findings.len(), 1);
+        assert_eq!(delta.new_findings.len(), 1);
+    }
+
+    #[test]
+    fn changed_scope_never_resolves_full_scope_occurrences() {
+        let full = receipt(
+            comparison(AnalysisScope::Full),
+            vec![finding("a", "occ-a", Severity::High)],
+        );
+        let changed = receipt(comparison(AnalysisScope::Changed), Vec::new());
+        assert_eq!(
+            compare(&changed, &full),
+            ComparisonResult::Unavailable(ComparisonUnavailable::ScopeMismatch)
+        );
+    }
+
+    #[test]
+    fn compatible_occurrence_reports_severity_shift() {
+        let comparison = comparison(AnalysisScope::Full);
+        let prior = receipt(
+            comparison.clone(),
+            vec![finding("a", "occ-a", Severity::Medium)],
+        );
+        let current = receipt(comparison, vec![finding("a", "occ-a", Severity::High)]);
+        let ComparisonResult::Compatible(delta) = compare(&current, &prior) else {
+            panic!("matching contracts must compare");
+        };
+        assert_eq!(delta.persisting_findings.len(), 1);
+        assert_eq!(delta.severity_shifts.len(), 1);
+    }
+
+    fn comparison(scope: AnalysisScope) -> ComparisonIdentity {
+        ComparisonIdentity {
+            workspace: "/repo".to_string(),
+            analysis_target: ".".to_string(),
+            scope,
+            base_revision: None,
+            head_revision: Some("head".to_string()),
+            profile: "default".to_string(),
+            config_fingerprint: "config".to_string(),
+            selection_fingerprint: "selection".to_string(),
+            overlay_fingerprint: "overlay".to_string(),
+            analysis_schema: "scan-report-v0.23".to_string(),
+        }
+    }
+
+    fn receipt(comparison: ComparisonIdentity, findings: Vec<FindingReceipt>) -> RunReceipt {
+        RunReceipt::new(
+            comparison,
+            "2026-07-26T12:00:00Z".to_string(),
+            "head".to_string(),
+            findings,
+        )
+    }
+
+    fn finding(baseline_id: &str, occurrence_key: &str, severity: Severity) -> FindingReceipt {
+        FindingReceipt {
+            baseline_id: baseline_id.to_string(),
+            occurrence_key: occurrence_key.to_string(),
+            rule_id: "rule.test".to_string(),
+            severity,
+            path: "src/main.rs".to_string(),
+        }
+    }
+}

--- a/src/history/diagnostic.rs
+++ b/src/history/diagnostic.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HistoryDiagnosticKind {
+    InvalidRecord,
+    TruncatedRecord,
+    UnsupportedSchema,
+    ReadFailed,
+    WriteFailed,
+}
+
+impl HistoryDiagnosticKind {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::InvalidRecord => "invalid-record",
+            Self::TruncatedRecord => "truncated-record",
+            Self::UnsupportedSchema => "unsupported-schema",
+            Self::ReadFailed => "read-failed",
+            Self::WriteFailed => "write-failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HistoryDiagnostic {
+    pub kind: HistoryDiagnosticKind,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+}
+
+impl HistoryDiagnostic {
+    pub(super) fn at_line(
+        kind: HistoryDiagnosticKind,
+        line: usize,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            line: Some(line),
+        }
+    }
+
+    pub(super) fn read_failed(message: impl Into<String>) -> Self {
+        Self {
+            kind: HistoryDiagnosticKind::ReadFailed,
+            message: message.into(),
+            line: None,
+        }
+    }
+
+    pub(super) fn write_failed(message: impl Into<String>) -> Self {
+        Self {
+            kind: HistoryDiagnosticKind::WriteFailed,
+            message: message.into(),
+            line: None,
+        }
+    }
+}

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -1,0 +1,17 @@
+pub mod context;
+pub mod delta;
+pub mod diagnostic;
+pub mod model;
+pub mod storage;
+
+pub use context::{HistoryRecordOutcome, ReceiptContext, build_receipt, record_session};
+pub use delta::compare;
+pub use diagnostic::{HistoryDiagnostic, HistoryDiagnosticKind};
+pub use model::{
+    AnalysisScope, ComparisonIdentity, ComparisonResult, ComparisonUnavailable, FindingReceipt,
+    RiskDelta, RunReceipt, SeverityShift,
+};
+pub use storage::{
+    DEFAULT_MAX_BYTES, DEFAULT_MAX_RUNS, HISTORY_FILE, HistoryLimits, HistoryLoad, HistoryStore,
+    HistoryWriteError, append_run, read_all_runs, read_last_run,
+};

--- a/src/history/model.rs
+++ b/src/history/model.rs
@@ -1,0 +1,154 @@
+use crate::baseline::key::{normalized_relative_path, stable_finding_key};
+use crate::findings::occurrence::occurrence_key;
+use crate::findings::types::{Finding, Severity};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+pub const HISTORY_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AnalysisScope {
+    Full,
+    Workspace,
+    Changed,
+    ReviewChanged,
+    ReviewFull,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComparisonIdentity {
+    pub workspace: String,
+    pub analysis_target: String,
+    pub scope: AnalysisScope,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_revision: Option<String>,
+    pub profile: String,
+    pub config_fingerprint: String,
+    pub selection_fingerprint: String,
+    pub overlay_fingerprint: String,
+    pub analysis_schema: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FindingReceipt {
+    pub baseline_id: String,
+    pub occurrence_key: String,
+    pub rule_id: String,
+    pub severity: Severity,
+    pub path: String,
+}
+
+impl FindingReceipt {
+    pub fn from_finding(finding: &Finding, root: &Path) -> Self {
+        let path = finding
+            .evidence
+            .first()
+            .map(|evidence| normalized_relative_path(&evidence.path, root))
+            .unwrap_or_else(|| ".".to_string());
+        Self {
+            baseline_id: stable_finding_key(finding, root),
+            occurrence_key: occurrence_key(finding),
+            rule_id: finding.rule_id.clone(),
+            severity: finding.severity,
+            path,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunReceipt {
+    pub schema_version: u32,
+    pub comparison: ComparisonIdentity,
+    pub recorded_at: String,
+    pub revision: String,
+    pub findings: Vec<FindingReceipt>,
+}
+
+impl RunReceipt {
+    pub fn new(
+        comparison: ComparisonIdentity,
+        recorded_at: String,
+        revision: String,
+        findings: impl IntoIterator<Item = FindingReceipt>,
+    ) -> Self {
+        let mut findings = findings.into_iter().collect::<Vec<_>>();
+        findings.sort_by(|left, right| {
+            (
+                &left.occurrence_key,
+                &left.rule_id,
+                &left.path,
+                &left.baseline_id,
+            )
+                .cmp(&(
+                    &right.occurrence_key,
+                    &right.rule_id,
+                    &right.path,
+                    &right.baseline_id,
+                ))
+        });
+        Self {
+            schema_version: HISTORY_SCHEMA_VERSION,
+            comparison,
+            recorded_at,
+            revision,
+            findings,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ComparisonUnavailable {
+    SchemaMismatch,
+    WorkspaceMismatch,
+    TargetMismatch,
+    ScopeMismatch,
+    RevisionRangeMismatch,
+    ProfileMismatch,
+    ConfigMismatch,
+    SelectionMismatch,
+    OverlayMismatch,
+    AnalysisSchemaMismatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", content = "value", rename_all = "kebab-case")]
+pub enum ComparisonResult {
+    Compatible(RiskDelta),
+    Unavailable(ComparisonUnavailable),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SeverityShift {
+    pub occurrence_key: String,
+    pub rule_id: String,
+    pub path: String,
+    pub old_severity: Severity,
+    pub new_severity: Severity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ComparisonProvenance {
+    pub prior_revision: String,
+    pub current_revision: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RiskDelta {
+    pub comparison: ComparisonProvenance,
+    pub new_findings: Vec<FindingReceipt>,
+    pub persisting_findings: Vec<FindingReceipt>,
+    pub resolved_findings: Vec<FindingReceipt>,
+    pub severity_shifts: Vec<SeverityShift>,
+}
+
+impl RiskDelta {
+    pub fn has_changes(&self) -> bool {
+        !self.new_findings.is_empty()
+            || !self.resolved_findings.is_empty()
+            || !self.severity_shifts.is_empty()
+    }
+}

--- a/src/history/storage.rs
+++ b/src/history/storage.rs
@@ -1,0 +1,257 @@
+use crate::history::diagnostic::{HistoryDiagnostic, HistoryDiagnosticKind};
+use crate::history::model::{ComparisonIdentity, HISTORY_SCHEMA_VERSION, RunReceipt};
+use std::fmt;
+use std::fs::{self, File, OpenOptions, TryLockError};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+pub const DEFAULT_MAX_RUNS: usize = 50;
+pub const DEFAULT_MAX_BYTES: u64 = 5 * 1024 * 1024;
+pub const HISTORY_DIR: &str = ".repopilot/history";
+pub const HISTORY_FILE: &str = ".repopilot/history/runs.jsonl";
+const LOCK_FILE: &str = ".repopilot/history/runs.lock";
+const BACKUP_FILE: &str = ".repopilot/history/runs.backup.jsonl";
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HistoryLimits {
+    pub max_runs: usize,
+    pub max_bytes: u64,
+}
+
+impl Default for HistoryLimits {
+    fn default() -> Self {
+        Self {
+            max_runs: DEFAULT_MAX_RUNS,
+            max_bytes: DEFAULT_MAX_BYTES,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct HistoryLoad {
+    pub receipts: Vec<RunReceipt>,
+    pub diagnostics: Vec<HistoryDiagnostic>,
+}
+
+#[derive(Debug)]
+pub enum HistoryWriteError {
+    Busy,
+    Io(io::Error),
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for HistoryWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Busy => write!(formatter, "history ledger is busy"),
+            Self::Io(error) => write!(formatter, "history IO failed: {error}"),
+            Self::Json(error) => write!(formatter, "history serialization failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for HistoryWriteError {}
+
+pub struct HistoryStore {
+    root: PathBuf,
+    limits: HistoryLimits,
+}
+
+impl HistoryStore {
+    pub fn new(root: &Path, limits: HistoryLimits) -> Self {
+        Self {
+            root: root.to_path_buf(),
+            limits,
+        }
+    }
+
+    pub fn load(&self) -> HistoryLoad {
+        load_path(&history_file_path(&self.root))
+    }
+
+    pub fn newest_compatible(&self, identity: &ComparisonIdentity) -> Option<RunReceipt> {
+        self.load()
+            .receipts
+            .into_iter()
+            .rev()
+            .find(|receipt| receipt.comparison == *identity)
+    }
+
+    pub fn record(&self, receipt: &RunReceipt) -> Result<(), HistoryWriteError> {
+        let dir = self.root.join(HISTORY_DIR);
+        fs::create_dir_all(&dir).map_err(HistoryWriteError::Io)?;
+        let _lock = LedgerLock::acquire(&self.root)?;
+        let mut receipts = self.load().receipts;
+        receipts.push(receipt.clone());
+        let rendered = render_bounded(receipts, self.limits)?;
+        replace_ledger(&self.root, &rendered)
+    }
+}
+
+pub fn history_file_path(root: &Path) -> PathBuf {
+    root.join(HISTORY_FILE)
+}
+
+pub fn read_last_run(root: &Path) -> Option<RunReceipt> {
+    read_all_runs(root).pop()
+}
+
+pub fn read_all_runs(root: &Path) -> Vec<RunReceipt> {
+    HistoryStore::new(root, HistoryLimits::default())
+        .load()
+        .receipts
+}
+
+pub fn append_run(root: &Path, receipt: &RunReceipt, max_runs: usize) -> io::Result<()> {
+    HistoryStore::new(
+        root,
+        HistoryLimits {
+            max_runs,
+            max_bytes: DEFAULT_MAX_BYTES,
+        },
+    )
+    .record(receipt)
+    .map_err(io::Error::other)
+}
+
+fn load_path(path: &Path) -> HistoryLoad {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return HistoryLoad::default(),
+        Err(error) => {
+            return HistoryLoad {
+                diagnostics: vec![HistoryDiagnostic::read_failed(error.to_string())],
+                receipts: Vec::new(),
+            };
+        }
+    };
+    parse_lines(&bytes)
+}
+
+fn parse_lines(bytes: &[u8]) -> HistoryLoad {
+    let mut loaded = HistoryLoad::default();
+    let ends_with_newline = bytes.ends_with(b"\n");
+    let text = String::from_utf8_lossy(bytes);
+    let lines = text.lines().collect::<Vec<_>>();
+    for (index, line) in lines.iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<RunReceipt>(line) {
+            Ok(receipt) if receipt.schema_version == HISTORY_SCHEMA_VERSION => {
+                loaded.receipts.push(receipt);
+            }
+            Ok(receipt) => loaded.diagnostics.push(HistoryDiagnostic::at_line(
+                HistoryDiagnosticKind::UnsupportedSchema,
+                index + 1,
+                format!("unsupported history schema {}", receipt.schema_version),
+            )),
+            Err(error) => {
+                let is_truncated = index + 1 == lines.len() && !ends_with_newline;
+                loaded.diagnostics.push(HistoryDiagnostic::at_line(
+                    if is_truncated {
+                        HistoryDiagnosticKind::TruncatedRecord
+                    } else {
+                        HistoryDiagnosticKind::InvalidRecord
+                    },
+                    index + 1,
+                    error.to_string(),
+                ));
+            }
+        }
+    }
+    loaded
+}
+
+fn render_bounded(
+    receipts: Vec<RunReceipt>,
+    limits: HistoryLimits,
+) -> Result<Vec<u8>, HistoryWriteError> {
+    let mut kept = Vec::new();
+    let mut used = 0_u64;
+    for receipt in receipts.into_iter().rev().take(limits.max_runs) {
+        let mut line = serde_json::to_vec(&receipt).map_err(HistoryWriteError::Json)?;
+        line.push(b'\n');
+        if used.saturating_add(line.len() as u64) > limits.max_bytes {
+            break;
+        }
+        used += line.len() as u64;
+        kept.push(line);
+    }
+    kept.reverse();
+    Ok(kept.into_iter().flatten().collect())
+}
+
+fn replace_ledger(root: &Path, contents: &[u8]) -> Result<(), HistoryWriteError> {
+    let primary = history_file_path(root);
+    let backup = root.join(BACKUP_FILE);
+    let temporary = unique_temporary(root);
+    write_staged(&temporary, contents)?;
+    if primary.exists() {
+        let _ = fs::remove_file(&backup);
+        fs::rename(&primary, &backup).map_err(HistoryWriteError::Io)?;
+    }
+    if let Err(error) = fs::rename(&temporary, &primary) {
+        restore_backup(&primary, &backup);
+        let _ = fs::remove_file(&temporary);
+        return Err(HistoryWriteError::Io(error));
+    }
+    let _ = fs::remove_file(backup);
+    Ok(())
+}
+
+fn write_staged(path: &Path, contents: &[u8]) -> Result<(), HistoryWriteError> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(HistoryWriteError::Io)?;
+    file.write_all(contents).map_err(HistoryWriteError::Io)?;
+    file.sync_all().map_err(HistoryWriteError::Io)
+}
+
+fn unique_temporary(root: &Path) -> PathBuf {
+    let suffix = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    root.join(HISTORY_DIR)
+        .join(format!("runs.{}.{}.jsonl.tmp", std::process::id(), suffix))
+}
+
+fn restore_backup(primary: &Path, backup: &Path) {
+    if backup.exists() && !primary.exists() {
+        let _ = fs::rename(backup, primary);
+    }
+}
+
+struct LedgerLock {
+    _file: File,
+}
+
+impl LedgerLock {
+    fn acquire(root: &Path) -> Result<Self, HistoryWriteError> {
+        let path = root.join(LOCK_FILE);
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .map_err(HistoryWriteError::Io)?;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match file.try_lock() {
+                Ok(()) => return Ok(Self { _file: file }),
+                Err(TryLockError::WouldBlock) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                Err(TryLockError::WouldBlock) => return Err(HistoryWriteError::Busy),
+                Err(TryLockError::Error(error)) => return Err(HistoryWriteError::Io(error)),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/history/storage/tests.rs
+++ b/src/history/storage/tests.rs
@@ -1,0 +1,140 @@
+use super::*;
+use crate::config::model::HistorySection;
+use crate::history::model::{AnalysisScope, ComparisonIdentity};
+use std::sync::{Arc, Barrier};
+
+#[test]
+fn history_is_disabled_by_default() {
+    assert!(!HistorySection::default().enabled);
+}
+
+#[test]
+fn append_read_and_count_pruning_preserve_newest_receipts() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = HistoryStore::new(
+        temp.path(),
+        HistoryLimits {
+            max_runs: 2,
+            max_bytes: DEFAULT_MAX_BYTES,
+        },
+    );
+    for revision in 1..=3 {
+        store.record(&receipt(revision)).unwrap();
+    }
+    let loaded = store.load();
+    assert_eq!(loaded.receipts.len(), 2);
+    assert_eq!(loaded.receipts[0].revision, "2");
+    assert_eq!(loaded.receipts[1].revision, "3");
+}
+
+#[test]
+fn truncated_tail_is_reported_without_losing_valid_receipts() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = HistoryStore::new(temp.path(), HistoryLimits::default());
+    store.record(&receipt(1)).unwrap();
+    let mut file = OpenOptions::new()
+        .append(true)
+        .open(history_file_path(temp.path()))
+        .unwrap();
+    write!(file, "{{\"schema_version\":").unwrap();
+    let loaded = store.load();
+    assert_eq!(loaded.receipts.len(), 1);
+    assert!(loaded.diagnostics.iter().any(|item| {
+        item.kind == HistoryDiagnosticKind::TruncatedRecord && item.line == Some(2)
+    }));
+}
+
+#[test]
+fn retention_obeys_byte_limit() {
+    let temp = tempfile::tempdir().unwrap();
+    let line_size = serde_json::to_vec(&receipt(1)).unwrap().len() as u64 + 1;
+    let store = HistoryStore::new(
+        temp.path(),
+        HistoryLimits {
+            max_runs: 10,
+            max_bytes: line_size * 2,
+        },
+    );
+    for revision in 1..=3 {
+        store.record(&receipt(revision)).unwrap();
+    }
+    assert_eq!(store.load().receipts.len(), 2);
+    assert!(fs::metadata(history_file_path(temp.path())).unwrap().len() <= line_size * 2);
+}
+
+#[test]
+fn concurrent_writers_preserve_every_complete_receipt() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(HistoryStore::new(
+        temp.path(),
+        HistoryLimits {
+            max_runs: 16,
+            max_bytes: DEFAULT_MAX_BYTES,
+        },
+    ));
+    let barrier = Arc::new(Barrier::new(8));
+    let handles = (1..=8)
+        .map(|revision| {
+            let store = Arc::clone(&store);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                store.record(&receipt(revision))
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for handle in handles {
+        handle.join().unwrap().unwrap();
+    }
+    let loaded = store.load();
+    assert!(loaded.diagnostics.is_empty());
+    assert_eq!(loaded.receipts.len(), 8);
+}
+
+#[test]
+fn newest_compatible_skips_a_newer_incompatible_receipt() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = HistoryStore::new(temp.path(), HistoryLimits::default());
+    let full = receipt(1);
+    store.record(&full).unwrap();
+    let mut changed = receipt(2);
+    changed.comparison.scope = AnalysisScope::Changed;
+    store.record(&changed).unwrap();
+
+    let compatible = store.newest_compatible(&full.comparison).unwrap();
+
+    assert_eq!(compatible.revision, "1");
+}
+
+#[test]
+fn abandoned_lock_file_does_not_block_future_writes() {
+    let temp = tempfile::tempdir().unwrap();
+    let lock = temp.path().join(LOCK_FILE);
+    fs::create_dir_all(lock.parent().unwrap()).unwrap();
+    fs::write(lock, "abandoned").unwrap();
+
+    HistoryStore::new(temp.path(), HistoryLimits::default())
+        .record(&receipt(1))
+        .unwrap();
+}
+
+fn receipt(revision: usize) -> RunReceipt {
+    RunReceipt::new(
+        ComparisonIdentity {
+            workspace: "/repo".to_string(),
+            analysis_target: ".".to_string(),
+            scope: AnalysisScope::Full,
+            base_revision: None,
+            head_revision: Some(revision.to_string()),
+            profile: "default".to_string(),
+            config_fingerprint: "config".to_string(),
+            selection_fingerprint: "selection".to_string(),
+            overlay_fingerprint: "overlay".to_string(),
+            analysis_schema: "scan-report-v0.23".to_string(),
+        },
+        format!("2026-07-26T12:00:0{revision}Z"),
+        revision.to_string(),
+        Vec::new(),
+    )
+}

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -20,5 +20,5 @@ pub use model::{
 };
 pub use overlay::{
     OverlayEntry, OverlayRules, OverlayTarget, OverlayValidation, active_overlay,
-    init_active_overlay,
+    init_active_overlay, init_active_overlay_disabled,
 };

--- a/src/knowledge/overlay/mod.rs
+++ b/src/knowledge/overlay/mod.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 pub mod rules;
 
-pub use rules::{OverlayRules, active_overlay, init_active_overlay};
+pub use rules::{OverlayRules, active_overlay, init_active_overlay, init_active_overlay_disabled};
 
 pub const OVERLAY_PATH: &str = ".repopilot/overlay.toml";
 

--- a/src/knowledge/overlay/rules.rs
+++ b/src/knowledge/overlay/rules.rs
@@ -16,7 +16,7 @@ static OVERLAY: OnceLock<OverlayRules> = OnceLock::new();
 
 impl OverlayRules {
     pub fn load(root: &Path) -> io::Result<Self> {
-        let overlay_path = root.join(OVERLAY_PATH);
+        let overlay_path = discover_overlay(root).unwrap_or_else(|| root.join(OVERLAY_PATH));
         if !overlay_path.is_file() {
             return Ok(Self {
                 validation: OverlayValidation {
@@ -92,6 +92,20 @@ impl OverlayRules {
     }
 }
 
+fn discover_overlay(start: &Path) -> Option<std::path::PathBuf> {
+    let mut directory = start;
+    loop {
+        let candidate = directory.join(OVERLAY_PATH);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if directory.join(".git").exists() {
+            return None;
+        }
+        directory = directory.parent()?;
+    }
+}
+
 /// Initializes the process-wide overlay for `root`. Must be called exactly
 /// once, before any `decide()` calls happen for this scan/review invocation
 /// — the CLI and MCP server both operate on exactly one repo root per
@@ -112,6 +126,13 @@ pub fn init_active_overlay(root: &Path) -> &'static OverlayRules {
             validation: OverlayValidation::default(),
             matched: Vec::new(),
         })
+    })
+}
+
+pub fn init_active_overlay_disabled() -> &'static OverlayRules {
+    OVERLAY.get_or_init(|| OverlayRules {
+        validation: OverlayValidation::default(),
+        matched: Vec::new(),
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ pub mod frameworks;
 #[doc(hidden)]
 pub mod graph;
 #[doc(hidden)]
+pub mod history;
+#[doc(hidden)]
 pub mod knowledge;
 #[doc(hidden)]
 pub mod languages;

--- a/src/output/decision_summary.rs
+++ b/src/output/decision_summary.rs
@@ -2,6 +2,7 @@ use crate::baseline::gate::CiGateResult;
 use crate::findings::types::Finding;
 use crate::review::ReviewSignalGateResult;
 use crate::review::model::ReviewReport;
+use crate::review::{ReadinessVerdict, derive_readiness};
 use crate::risk::RiskPriority;
 use crate::scan::types::ScanSummary;
 use std::fmt::Write;
@@ -93,6 +94,12 @@ pub fn review_decision_summary(
     ci_gate: Option<&CiGateResult>,
     review_gate: Option<&ReviewSignalGateResult>,
 ) -> DecisionSummary {
+    let readiness = derive_readiness(
+        report,
+        ci_gate,
+        review_gate,
+        report.summary.artifacts.risk_delta.as_ref(),
+    );
     let findings = report.in_diff_findings();
     let stats = finding_stats(&findings);
     let definitely_sensitive = report
@@ -107,20 +114,10 @@ pub fn review_decision_summary(
         .iter()
         .filter(|signal| !signal.suppressed)
         .count();
-    let finding_gate_failed = ci_gate.is_some_and(|gate| !gate.passed());
-    let review_gate_failed = review_gate.is_some_and(|gate| !gate.passed());
-
-    let verdict = if finding_gate_failed || review_gate_failed {
-        DecisionVerdict::Block
-    } else if stats.p0 > 0
-        || stats.p1 > 0
-        || definitely_sensitive > 0
-        || maybe_sensitive > 0
-        || !findings.is_empty()
-    {
-        DecisionVerdict::Review
-    } else {
-        DecisionVerdict::Pass
+    let verdict = match readiness.verdict {
+        ReadinessVerdict::Ready => DecisionVerdict::Pass,
+        ReadinessVerdict::Review => DecisionVerdict::Review,
+        ReadinessVerdict::Blocked => DecisionVerdict::Block,
     };
 
     let headline = match verdict {
@@ -138,27 +135,11 @@ pub fn review_decision_summary(
         }
     };
 
-    let mut reasons = Vec::new();
-    if finding_gate_failed {
-        reasons.push("The configured finding gate failed.".to_string());
-    }
-    if review_gate_failed {
-        reasons.push("The configured definitely-sensitive review gate failed.".to_string());
-    }
-    push_priority_reasons(&mut reasons, stats.p0, stats.p1);
-    if definitely_sensitive > 0 {
-        reasons.push(format!(
-            "{definitely_sensitive} definitely-sensitive review signal(s) require confirmation."
-        ));
-    }
-    if maybe_sensitive > 0 {
-        reasons.push(format!(
-            "{maybe_sensitive} maybe-sensitive review signal(s) are visible."
-        ));
-    }
-    if report.boundary_missing_test {
-        reasons.push("A code boundary changed without a corresponding test change.".to_string());
-    }
+    let reasons = readiness
+        .reasons
+        .into_iter()
+        .map(|reason| format!("{} {}", reason.count, reason.message))
+        .collect();
 
     DecisionSummary {
         verdict,

--- a/src/report/schema.rs
+++ b/src/report/schema.rs
@@ -119,6 +119,8 @@ pub struct ScanJsonReport<'a> {
     pub local_feedback: Option<&'a LocalFeedbackReport>,
     #[serde(skip_serializing_if = "diagnostics_empty")]
     pub diagnostics: &'a [ScanDiagnostic],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk_delta: Option<&'a crate::history::RiskDelta>,
     pub risk_summary: RiskSummary,
     pub raw_signal_quality: crate::findings::quality::SignalQualitySummary,
     pub visible_signal_quality: crate::findings::quality::SignalQualitySummary,
@@ -175,6 +177,7 @@ impl<'a> ScanJsonReport<'a> {
             cache_telemetry: summary.cache_telemetry.as_ref(),
             local_feedback: summary.local_feedback.as_ref(),
             diagnostics: &summary.artifacts.diagnostics,
+            risk_delta: summary.artifacts.risk_delta.as_ref(),
             risk_summary: RiskSummary::from_findings(&summary.artifacts.findings),
             raw_signal_quality: summary.artifacts.raw_signal_quality.clone(),
             visible_signal_quality: summary.artifacts.visible_signal_quality.clone(),

--- a/src/report/schema/review.rs
+++ b/src/report/schema/review.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::review::ImpactPaths;
+use crate::review::MergeReadinessRecord;
 use crate::review::ReviewSignalGateResult;
+use crate::review::derive_readiness;
 use crate::review::signals::BoundarySignal;
 use crate::review::signals::tiered::TieredSignals;
 
@@ -17,6 +19,7 @@ pub struct ReviewJsonReport<'a> {
     pub changed_files: &'a [ChangedFile],
     pub blast_radius: Vec<String>,
     pub impact_paths: &'a ImpactPaths,
+    pub merge_readiness: MergeReadinessRecord,
     pub boundary_signals: &'a [BoundarySignal],
     /// Boundary + behavioral + algorithmic + taint signals by confidence tier.
     /// Additive to `boundary_signals` (which feeds the `definitely` tier); the
@@ -68,6 +71,12 @@ impl<'a> ReviewJsonReport<'a> {
                 .map(|path| path.to_string_lossy().to_string())
                 .collect(),
             impact_paths: &report.impact_paths,
+            merge_readiness: derive_readiness(
+                report,
+                ci_gate,
+                review_gate,
+                report.summary.artifacts.risk_delta.as_ref(),
+            ),
             boundary_signals: &report.boundary_signals,
             tiered_signals: &report.tiered_signals,
             review_timings: report.timings,

--- a/src/review/ci.rs
+++ b/src/review/ci.rs
@@ -67,6 +67,7 @@ pub fn review_report_for_ci(report: &ReviewReport) -> BaselineScanReport {
             raw_signal_quality: in_diff_signal_quality.clone(),
             visible_signal_quality: in_diff_signal_quality.clone(),
             signal_quality: in_diff_signal_quality,
+            risk_delta: None,
         },
     };
     recompute_summary_metrics(&mut summary);

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -6,7 +6,9 @@ mod feedback;
 mod gate;
 mod impact;
 pub mod model;
+mod ownership;
 pub(crate) mod paths;
+mod readiness;
 pub mod render;
 mod report;
 mod signal_pass;
@@ -16,6 +18,12 @@ pub use blast_radius::compute_blast_radius;
 pub use ci::review_report_for_ci;
 pub use gate::{ReviewSignalGatePolicy, ReviewSignalGateResult};
 pub use impact::{AffectedSurface, FileImpact, ImpactPaths, compute_impact_paths};
+pub use ownership::{
+    Owner, OwnershipDiagnostic, OwnershipDiscovery, OwnershipIndex, OwnershipSummary, PathOwnership,
+};
+pub use readiness::{
+    MergeReadinessRecord, ReadinessReason, ReadinessReasonCode, ReadinessVerdict, derive_readiness,
+};
 pub use report::{
     ReviewInput, build_review_report, build_review_report_from_input,
     build_review_report_from_session, build_review_report_since, load_review_input,

--- a/src/review/model.rs
+++ b/src/review/model.rs
@@ -3,6 +3,7 @@ use crate::findings::filter::{FindingFilter, recompute_summary_metrics};
 use crate::findings::types::{Finding, Severity};
 use crate::review::diff::{ChangeStatus, ChangedFile};
 use crate::review::impact::ImpactPaths;
+use crate::review::ownership::{OwnershipDiagnostic, OwnershipSummary};
 use crate::review::signals::BoundarySignal;
 use crate::review::signals::tiered::TieredSignals;
 use crate::scan::types::ScanSummary;
@@ -25,6 +26,8 @@ pub struct ReviewReport {
     pub changed_files: Vec<ChangedFile>,
     pub blast_radius: Vec<PathBuf>,
     pub impact_paths: ImpactPaths,
+    pub ownership: OwnershipSummary,
+    pub ownership_diagnostics: Vec<OwnershipDiagnostic>,
     pub boundary_signals: Vec<BoundarySignal>,
     /// A code boundary (auth / request-trust) changed but no test moved.
     pub boundary_missing_test: bool,

--- a/src/review/ownership/codeowners.rs
+++ b/src/review/ownership/codeowners.rs
@@ -1,0 +1,185 @@
+use super::model::{Owner, OwnershipDiagnostic};
+use globset::{GlobBuilder, GlobMatcher};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const LOCATIONS: [&str; 3] = [".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"];
+
+pub struct OwnershipIndex {
+    source: Option<PathBuf>,
+    rules: Vec<OwnershipRule>,
+}
+
+pub struct OwnershipDiscovery {
+    pub index: OwnershipIndex,
+    pub diagnostics: Vec<OwnershipDiagnostic>,
+}
+
+struct OwnershipRule {
+    matcher: CodeownersMatcher,
+    owners: Vec<Owner>,
+}
+
+enum CodeownersMatcher {
+    Path(GlobMatcher),
+    Component(GlobMatcher),
+}
+
+impl OwnershipIndex {
+    pub fn empty() -> Self {
+        Self {
+            source: None,
+            rules: Vec::new(),
+        }
+    }
+
+    pub fn discover(root: &Path) -> OwnershipDiscovery {
+        for relative in LOCATIONS {
+            let path = root.join(relative);
+            if !path.is_file() {
+                continue;
+            }
+            return match fs::read_to_string(&path) {
+                Ok(content) => Self::parse(&content, PathBuf::from(relative)),
+                Err(error) => OwnershipDiscovery {
+                    index: Self::empty(),
+                    diagnostics: vec![OwnershipDiagnostic {
+                        message: format!("failed to read {relative}: {error}"),
+                        line: None,
+                    }],
+                },
+            };
+        }
+        OwnershipDiscovery {
+            index: Self::empty(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    pub fn from_codeowners(content: &str, source: PathBuf) -> Result<Self, String> {
+        let discovery = Self::parse(content, source);
+        if discovery.diagnostics.is_empty() {
+            Ok(discovery.index)
+        } else {
+            Err(discovery
+                .diagnostics
+                .into_iter()
+                .map(|item| item.message)
+                .collect::<Vec<_>>()
+                .join("; "))
+        }
+    }
+
+    pub fn source(&self) -> Option<&Path> {
+        self.source.as_deref()
+    }
+
+    pub fn owners_for(&self, path: &Path) -> Vec<Owner> {
+        let path = path.to_string_lossy().replace('\\', "/");
+        self.rules
+            .iter()
+            .rev()
+            .find(|rule| rule.matcher.is_match(&path))
+            .map(|rule| rule.owners.clone())
+            .unwrap_or_default()
+    }
+
+    fn parse(content: &str, source: PathBuf) -> OwnershipDiscovery {
+        let mut rules = Vec::new();
+        let mut diagnostics = Vec::new();
+        for (index, line) in content.lines().enumerate() {
+            match parse_rule(line) {
+                Ok(Some(rule)) => rules.push(rule),
+                Ok(None) => {}
+                Err(message) => diagnostics.push(OwnershipDiagnostic {
+                    message,
+                    line: Some(index + 1),
+                }),
+            }
+        }
+        OwnershipDiscovery {
+            index: Self {
+                source: Some(source),
+                rules,
+            },
+            diagnostics,
+        }
+    }
+}
+
+impl CodeownersMatcher {
+    fn is_match(&self, path: &str) -> bool {
+        match self {
+            Self::Path(matcher) => matcher.is_match(path),
+            Self::Component(matcher) => path.split('/').any(|part| matcher.is_match(part)),
+        }
+    }
+}
+
+fn parse_rule(line: &str) -> Result<Option<OwnershipRule>, String> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+        return Ok(None);
+    }
+    let tokens = tokenize(line);
+    if tokens.len() < 2 {
+        return Err("CODEOWNERS rule requires a pattern and at least one owner".to_string());
+    }
+    let matcher = compile_pattern(&tokens[0])?;
+    let mut owners = Vec::new();
+    for value in tokens.into_iter().skip(1) {
+        if !owners.iter().any(|owner: &Owner| owner.value == value) {
+            owners.push(Owner { value });
+        }
+    }
+    Ok(Some(OwnershipRule { matcher, owners }))
+}
+
+fn compile_pattern(raw: &str) -> Result<CodeownersMatcher, String> {
+    if raw.starts_with('!') {
+        return Err("CODEOWNERS does not support negated patterns".to_string());
+    }
+    let anchored = raw.starts_with('/');
+    let mut pattern = raw.trim_start_matches('/').to_string();
+    if pattern.ends_with('/') {
+        pattern.push_str("**");
+    }
+    let has_separator = pattern.contains('/');
+    let glob = GlobBuilder::new(&pattern)
+        .literal_separator(true)
+        .build()
+        .map_err(|error| format!("invalid CODEOWNERS pattern '{raw}': {error}"))?
+        .compile_matcher();
+    if anchored || has_separator {
+        Ok(CodeownersMatcher::Path(glob))
+    } else {
+        Ok(CodeownersMatcher::Component(glob))
+    }
+}
+
+fn tokenize(line: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut escaped = false;
+    for character in line.chars() {
+        if escaped {
+            current.push(character);
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        } else if character.is_whitespace() {
+            if !current.is_empty() {
+                tokens.push(std::mem::take(&mut current));
+            }
+        } else {
+            current.push(character);
+        }
+    }
+    if escaped {
+        current.push('\\');
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}

--- a/src/review/ownership/mod.rs
+++ b/src/review/ownership/mod.rs
@@ -1,0 +1,5 @@
+mod codeowners;
+mod model;
+
+pub use codeowners::{OwnershipDiscovery, OwnershipIndex};
+pub use model::{Owner, OwnershipDiagnostic, OwnershipSummary, PathOwnership};

--- a/src/review/ownership/model.rs
+++ b/src/review/ownership/model.rs
@@ -1,0 +1,92 @@
+use super::OwnershipIndex;
+use crate::review::diff::ChangedFile;
+use crate::review::impact::ImpactPaths;
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct Owner {
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OwnershipDiagnostic {
+    pub message: String,
+    pub line: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PathOwnership {
+    pub path: String,
+    pub owners: Vec<Owner>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_boundary: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct OwnershipSummary {
+    pub paths: Vec<PathOwnership>,
+    pub suggested_owners: Vec<Owner>,
+    pub unowned_paths: Vec<String>,
+    pub fallback_boundaries: Vec<String>,
+}
+
+impl OwnershipSummary {
+    pub fn for_impact(
+        changed: &[ChangedFile],
+        impact: &ImpactPaths,
+        index: &OwnershipIndex,
+    ) -> Self {
+        let mut paths = changed
+            .iter()
+            .map(|file| file.path.clone())
+            .collect::<BTreeSet<_>>();
+        for file in &impact.files {
+            paths.insert(file.path.clone());
+            paths.extend(file.direct_dependents.iter().cloned());
+            paths.extend(file.transitive_dependents.iter().cloned());
+        }
+        Self::for_paths(paths, index)
+    }
+
+    pub fn for_paths(paths: impl IntoIterator<Item = PathBuf>, index: &OwnershipIndex) -> Self {
+        let mut normalized = paths
+            .into_iter()
+            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .collect::<Vec<_>>();
+        normalized.sort();
+        normalized.dedup();
+
+        let mut summary = Self::default();
+        let mut owners = BTreeSet::new();
+        let mut boundaries = BTreeSet::new();
+        for path in normalized {
+            let matched = index.owners_for(path.as_ref());
+            let boundary = matched.is_empty().then(|| fallback_boundary(&path));
+            if matched.is_empty() {
+                summary.unowned_paths.push(path.clone());
+            }
+            if let Some(boundary) = &boundary {
+                boundaries.insert(boundary.clone());
+            }
+            owners.extend(matched.iter().cloned());
+            summary.paths.push(PathOwnership {
+                path,
+                owners: matched,
+                fallback_boundary: boundary,
+            });
+        }
+        summary.suggested_owners = owners.into_iter().collect();
+        summary.fallback_boundaries = boundaries.into_iter().collect();
+        summary
+    }
+}
+
+fn fallback_boundary(path: &str) -> String {
+    path.split('/')
+        .next()
+        .filter(|component| path.contains('/') && !component.is_empty())
+        .unwrap_or(".")
+        .to_string()
+}

--- a/src/review/readiness/derive.rs
+++ b/src/review/readiness/derive.rs
@@ -1,0 +1,184 @@
+use super::model::{MergeReadinessRecord, ReadinessReason, ReadinessReasonCode, ReadinessVerdict};
+use crate::baseline::gate::CiGateResult;
+use crate::findings::decision::build_decision_record;
+use crate::findings::redaction::human_verification_step;
+use crate::history::RiskDelta;
+use crate::review::gate::ReviewSignalGateResult;
+use crate::review::model::ReviewReport;
+use crate::risk::RiskPriority;
+use std::collections::BTreeSet;
+
+pub fn derive_readiness(
+    report: &ReviewReport,
+    ci_gate: Option<&CiGateResult>,
+    review_gate: Option<&ReviewSignalGateResult>,
+    risk_delta: Option<&RiskDelta>,
+) -> MergeReadinessRecord {
+    let mut reasons = Vec::new();
+    let findings = report.in_diff_findings();
+    let p0 = findings
+        .iter()
+        .filter(|finding| finding.risk.priority == RiskPriority::P0)
+        .count();
+    let p1 = findings
+        .iter()
+        .filter(|finding| finding.risk.priority == RiskPriority::P1)
+        .count();
+    let definitely = report
+        .tiered_signals
+        .definitely
+        .iter()
+        .filter(|signal| !signal.suppressed)
+        .count();
+    let maybe = report
+        .tiered_signals
+        .maybe
+        .iter()
+        .filter(|signal| !signal.suppressed)
+        .count();
+
+    push_if(
+        &mut reasons,
+        report.summary.has_error_diagnostics(),
+        ReadinessReasonCode::AnalysisError,
+        1,
+        "Analysis completed with an error diagnostic.",
+    );
+    push_if(
+        &mut reasons,
+        ci_gate.is_some_and(|gate| !gate.passed()),
+        ReadinessReasonCode::FindingGateFailed,
+        ci_gate.map_or(0, |gate| gate.failed_findings),
+        "The configured finding gate failed.",
+    );
+    push_if(
+        &mut reasons,
+        review_gate.is_some_and(|gate| !gate.passed()),
+        ReadinessReasonCode::ReviewSignalGateFailed,
+        review_gate.map_or(0, |gate| gate.failed_signals),
+        "The configured review-signal gate failed.",
+    );
+    push_count(
+        &mut reasons,
+        p0,
+        ReadinessReasonCode::PriorityP0,
+        "P0 finding occurrence(s) affect changed code.",
+    );
+    push_count(
+        &mut reasons,
+        p1,
+        ReadinessReasonCode::PriorityP1,
+        "P1 finding occurrence(s) affect changed code.",
+    );
+    push_count(
+        &mut reasons,
+        definitely,
+        ReadinessReasonCode::DefinitelySensitive,
+        "Definitely-sensitive review signal(s) require confirmation.",
+    );
+    push_count(
+        &mut reasons,
+        maybe,
+        ReadinessReasonCode::MaybeSensitive,
+        "Maybe-sensitive review signal(s) are visible.",
+    );
+    push_if(
+        &mut reasons,
+        report.boundary_missing_test,
+        ReadinessReasonCode::BoundaryMissingTest,
+        1,
+        "A changed boundary has no corresponding test change.",
+    );
+    push_count(
+        &mut reasons,
+        findings.len(),
+        ReadinessReasonCode::VisibleFinding,
+        "Visible finding occurrence(s) affect changed code.",
+    );
+    push_count(
+        &mut reasons,
+        report.ownership.unowned_paths.len(),
+        ReadinessReasonCode::UnownedSurface,
+        "Changed or impacted path(s) have no named owner.",
+    );
+    reasons.sort_by_key(|reason| reason.code);
+
+    MergeReadinessRecord {
+        verdict: verdict(&reasons),
+        reasons,
+        impact: report.impact_paths.clone(),
+        ownership: report.ownership.clone(),
+        verification_steps: verification_steps(report),
+        limitations: limitations(report),
+        risk_delta: risk_delta.cloned(),
+    }
+}
+
+fn verdict(reasons: &[ReadinessReason]) -> ReadinessVerdict {
+    if reasons.iter().any(|reason| {
+        matches!(
+            reason.code,
+            ReadinessReasonCode::AnalysisError
+                | ReadinessReasonCode::FindingGateFailed
+                | ReadinessReasonCode::ReviewSignalGateFailed
+                | ReadinessReasonCode::PriorityP0
+        )
+    }) {
+        ReadinessVerdict::Blocked
+    } else if reasons.is_empty() {
+        ReadinessVerdict::Ready
+    } else {
+        ReadinessVerdict::Review
+    }
+}
+
+fn verification_steps(report: &ReviewReport) -> Vec<String> {
+    let mut steps = BTreeSet::new();
+    for finding in report.in_diff_findings() {
+        let Some(plan) = build_decision_record(finding).verification_plan else {
+            continue;
+        };
+        for step in plan.steps {
+            steps.insert(human_verification_step(finding, &step).into_owned());
+        }
+    }
+    steps.into_iter().collect()
+}
+
+fn limitations(report: &ReviewReport) -> Vec<String> {
+    let mut limitations = vec![
+        "Readiness is derived from static local evidence; RepoPilot does not execute tests."
+            .to_string(),
+    ];
+    if !report.ownership.unowned_paths.is_empty() {
+        limitations.push(
+            "Unowned paths use package or directory boundaries, not inferred people.".to_string(),
+        );
+    }
+    limitations
+}
+
+fn push_count(
+    reasons: &mut Vec<ReadinessReason>,
+    count: usize,
+    code: ReadinessReasonCode,
+    message: &str,
+) {
+    push_if(reasons, count > 0, code, count, message);
+}
+
+fn push_if(
+    reasons: &mut Vec<ReadinessReason>,
+    condition: bool,
+    code: ReadinessReasonCode,
+    count: usize,
+    message: &str,
+) {
+    if condition {
+        reasons.push(ReadinessReason {
+            code,
+            count,
+            message: message.to_string(),
+        });
+    }
+}

--- a/src/review/readiness/mod.rs
+++ b/src/review/readiness/mod.rs
@@ -1,0 +1,5 @@
+mod derive;
+mod model;
+
+pub use derive::derive_readiness;
+pub use model::{MergeReadinessRecord, ReadinessReason, ReadinessReasonCode, ReadinessVerdict};

--- a/src/review/readiness/model.rs
+++ b/src/review/readiness/model.rs
@@ -1,0 +1,56 @@
+use crate::history::RiskDelta;
+use crate::review::ImpactPaths;
+use crate::review::ownership::OwnershipSummary;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReadinessVerdict {
+    Ready,
+    Review,
+    Blocked,
+}
+
+impl ReadinessVerdict {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Review => "review",
+            Self::Blocked => "blocked",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReadinessReasonCode {
+    AnalysisError,
+    FindingGateFailed,
+    ReviewSignalGateFailed,
+    PriorityP0,
+    PriorityP1,
+    DefinitelySensitive,
+    MaybeSensitive,
+    BoundaryMissingTest,
+    VisibleFinding,
+    UnownedSurface,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReadinessReason {
+    pub code: ReadinessReasonCode,
+    pub count: usize,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MergeReadinessRecord {
+    pub verdict: ReadinessVerdict,
+    pub reasons: Vec<ReadinessReason>,
+    pub impact: ImpactPaths,
+    pub ownership: OwnershipSummary,
+    pub verification_steps: Vec<String>,
+    pub limitations: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk_delta: Option<RiskDelta>,
+}

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -3,6 +3,7 @@ use crate::findings::types::Finding;
 use crate::output::decision_summary::{render_decision_summary, review_decision_summary};
 use crate::output::{DetailLevel, FindingRenderLimit};
 use crate::review::ReviewSignalGateResult;
+use crate::review::derive_readiness;
 use crate::review::model::ReviewReport;
 use crate::review::render::ReviewRenderOptions;
 use crate::review::render::helpers::render_ranges_suffix;
@@ -27,6 +28,34 @@ pub fn render_console_with_options(
         &mut output,
         &review_decision_summary(report, ci_gate, review_gate),
     );
+    let readiness = derive_readiness(
+        report,
+        ci_gate,
+        review_gate,
+        report.summary.artifacts.risk_delta.as_ref(),
+    );
+    output.push_str(&format!(
+        "Merge readiness: {}\n",
+        readiness.verdict.label().to_uppercase()
+    ));
+    if !readiness.ownership.suggested_owners.is_empty() {
+        output.push_str(&format!(
+            "Suggested owners: {}\n",
+            readiness
+                .ownership
+                .suggested_owners
+                .iter()
+                .map(|owner| owner.value.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !readiness.ownership.unowned_paths.is_empty() {
+        output.push_str(&format!(
+            "Unowned changed/impacted paths: {}\n",
+            readiness.ownership.unowned_paths.len()
+        ));
+    }
     output.push_str(&format!("Path: {}\n", report.summary.root_path.display()));
     output.push_str(&format!("Git root: {}\n", report.repo_root.display()));
     match &report.baseline_path {

--- a/src/review/render/markdown.rs
+++ b/src/review/render/markdown.rs
@@ -3,6 +3,7 @@ use crate::baseline::gate::CiGateResult;
 use crate::findings::types::Finding;
 use crate::output::render_helpers::escape_table_cell;
 use crate::review::ReviewSignalGateResult;
+use crate::review::derive_readiness;
 use crate::review::model::ReviewReport;
 use crate::review::render::helpers::{render_ranges, status_for_finding};
 use crate::review::signals::tiered::ReviewSignal;
@@ -22,6 +23,28 @@ pub fn render_markdown_with_gates(
 
     output.push_str("# RepoPilot Review Report\n\n");
     output.push_str("## Summary\n\n");
+    let readiness = derive_readiness(
+        report,
+        ci_gate,
+        review_gate,
+        report.summary.artifacts.risk_delta.as_ref(),
+    );
+    output.push_str(&format!(
+        "- **Merge readiness:** `{}`\n",
+        readiness.verdict.label()
+    ));
+    if !readiness.ownership.suggested_owners.is_empty() {
+        output.push_str(&format!(
+            "- **Suggested owners:** {}\n",
+            readiness
+                .ownership
+                .suggested_owners
+                .iter()
+                .map(|owner| format!("`{}`", owner.value))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
     output.push_str(&format!(
         "- **Path:** `{}`\n",
         report.summary.root_path.display()

--- a/src/review/report.rs
+++ b/src/review/report.rs
@@ -12,6 +12,7 @@ use crate::findings::types::{Evidence, Finding, FindingCategory};
 use crate::review::diff::{ChangedFile, OwnedDiffTarget, load_changed_files, resolve_git_root};
 use crate::review::feedback::apply_review_feedback;
 use crate::review::model::{ReviewFindingStatus, ReviewReport};
+use crate::review::ownership::{OwnershipIndex, OwnershipSummary};
 use crate::review::paths::normalized_review_path;
 use crate::review::signals::{BoundarySignal, composites, tiered};
 use crate::risk::{apply_blast_radius_overlay, apply_review_overlay};
@@ -149,6 +150,9 @@ fn classify_findings(
     let blast_radius = compute_blast_radius(&summary, &repo_root, &changed_files);
     let impact_paths =
         compute_impact_paths(&summary, &repo_root, &changed_files, impact_path_depth);
+    let ownership_discovery = OwnershipIndex::discover(&repo_root);
+    let ownership =
+        OwnershipSummary::for_impact(&changed_files, &impact_paths, &ownership_discovery.index);
     composites::enrich_blast_radius(
         &mut boundary_signals,
         summary.artifacts.coupling_graph.as_ref(),
@@ -203,6 +207,8 @@ fn classify_findings(
         changed_files,
         blast_radius,
         impact_paths,
+        ownership,
+        ownership_diagnostics: ownership_discovery.diagnostics,
         boundary_signals,
         boundary_missing_test,
         tiered_signals,

--- a/src/scan/scanner/summary.rs
+++ b/src/scan/scanner/summary.rs
@@ -118,6 +118,7 @@ pub(super) fn build_scan_summary(
             raw_signal_quality: signal_quality.clone(),
             visible_signal_quality: signal_quality.clone(),
             signal_quality,
+            risk_delta: None,
         },
     }
 }

--- a/src/scan/types.rs
+++ b/src/scan/types.rs
@@ -86,6 +86,8 @@ pub struct ScanArtifacts {
     pub hidden_suggestions: Vec<HiddenSuggestionSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<ScanDiagnostic>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk_delta: Option<crate::history::RiskDelta>,
     #[serde(default)]
     pub raw_signal_quality: SignalQualitySummary,
     #[serde(default)]

--- a/tests/action_delta.rs
+++ b/tests/action_delta.rs
@@ -56,7 +56,7 @@ while (($#)); do
 done
 if [[ "$command" == "review" ]]; then
   cat > "$output" <<'JSON'
-{"review":{"in_diff_findings":1,"tiered_signals":{"definitely":0,"maybe":0,"noise":0,"total":0}},"tiered_signals":{"definitely":[],"maybe":[],"noise":[]},"findings":[]}
+{"merge_readiness":{"verdict":"ready"},"review":{"in_diff_findings":1,"tiered_signals":{"definitely":0,"maybe":0,"noise":0,"total":0}},"tiered_signals":{"definitely":[],"maybe":[],"noise":[]},"findings":[]}
 JSON
   printf '{"version":"2.1.0","runs":[]}\n' > "$sarif"
   exit 0
@@ -121,4 +121,5 @@ fi
     assert!(summary.contains("**New findings:** 1"));
     assert!(summary.contains("**Changed findings:** 1"));
     assert!(summary.contains("**Resolved findings:** 1"));
+    assert!(summary.contains("**Merge readiness:** ready"));
 }

--- a/tests/history_cli.rs
+++ b/tests/history_cli.rs
@@ -1,0 +1,122 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn repopilot(root: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+        .current_dir(root)
+        .args(args)
+        .output()
+        .expect("run repopilot")
+}
+
+#[test]
+fn scan_does_not_create_history_without_opt_in() {
+    let repo = fixture_repo();
+    let output = repopilot(repo.path(), &["scan", ".", "--quiet"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    assert!(!repo.path().join(".repopilot/history").exists());
+}
+
+#[test]
+fn scan_record_history_writes_workspace_rooted_versioned_receipt() {
+    let repo = fixture_repo();
+    init_git(repo.path());
+    fs::create_dir_all(repo.path().join("src/nested")).unwrap();
+    let output = repopilot(
+        &repo.path().join("src/nested"),
+        &["scan", ".", "--quiet", "--record-history"],
+    );
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let receipts = read_receipts(repo.path());
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(receipts[0]["schema_version"], 1);
+    assert_eq!(receipts[0]["comparison"]["scope"], "full");
+    assert_eq!(receipts[0]["comparison"]["analysis_target"], "src/nested");
+    assert!(!repo.path().join("src/nested/.repopilot/history").exists());
+}
+
+#[test]
+fn review_record_history_uses_review_scope() {
+    let repo = fixture_repo();
+    init_git(repo.path());
+    fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub fn answer() -> i32 { 43 }\n",
+    )
+    .unwrap();
+    let output = repopilot(
+        repo.path(),
+        &["review", ".", "--record-history", "--format", "json"],
+    );
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let receipts = read_receipts(repo.path());
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(receipts[0]["comparison"]["scope"], "review-changed");
+}
+
+#[test]
+fn second_recorded_scan_projects_a_compatible_risk_delta() {
+    let repo = fixture_repo();
+    init_git(repo.path());
+    let first = repopilot(
+        repo.path(),
+        &["scan", ".", "--record-history", "--format", "json"],
+    );
+    assert!(first.status.success(), "stderr: {}", stderr(&first));
+
+    let second = repopilot(
+        repo.path(),
+        &["scan", ".", "--record-history", "--format", "json"],
+    );
+    assert!(second.status.success(), "stderr: {}", stderr(&second));
+    let report: Value = serde_json::from_slice(&second.stdout).unwrap();
+
+    assert!(report["risk_delta"].is_object());
+    assert!(report["risk_delta"]["new_findings"].is_array());
+    assert!(report["risk_delta"]["persisting_findings"].is_array());
+    assert!(report["risk_delta"]["resolved_findings"].is_array());
+}
+
+fn fixture_repo() -> tempfile::TempDir {
+    let repo = tempfile::tempdir().unwrap();
+    fs::create_dir_all(repo.path().join("src")).unwrap();
+    fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub fn answer() -> i32 { 42 }\n",
+    )
+    .unwrap();
+    repo
+}
+
+fn init_git(root: &Path) {
+    for args in [
+        &["init", "-q"][..],
+        &["config", "user.email", "test@example.com"][..],
+        &["config", "user.name", "Test"][..],
+        &["add", "."][..],
+        &["commit", "-qm", "initial"][..],
+    ] {
+        let output = Command::new("git")
+            .current_dir(root)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "git stderr: {}", stderr(&output));
+    }
+}
+
+fn read_receipts(root: &Path) -> Vec<Value> {
+    fs::read_to_string(root.join(".repopilot/history/runs.jsonl"))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}

--- a/tests/mcp_cli.rs
+++ b/tests/mcp_cli.rs
@@ -115,6 +115,47 @@ fn mcp_server_initializes_lists_tools_and_runs_scan_locally() {
 }
 
 #[test]
+fn mcp_review_projects_the_canonical_merge_readiness_record() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    fs::create_dir_all(temp.path().join("src")).expect("src dir");
+    fs::write(
+        temp.path().join("src/lib.rs"),
+        "pub fn value() -> i32 { 1 }\n",
+    )
+    .unwrap();
+    git(temp.path(), &["init", "-q"]);
+    git(temp.path(), &["config", "user.email", "test@example.com"]);
+    git(temp.path(), &["config", "user.name", "Test"]);
+    git(temp.path(), &["add", "."]);
+    git(temp.path(), &["commit", "-qm", "initial"]);
+    fs::write(
+        temp.path().join("src/lib.rs"),
+        "pub fn value() -> i32 { 2 }\n",
+    )
+    .unwrap();
+
+    let responses = run_mcp(
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}"#,
+            r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"repopilot_review_change","arguments":{"path":"."}}}"#,
+        ],
+        temp.path(),
+    );
+
+    let text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .expect("text content");
+    let report: Value = serde_json::from_str(text).expect("review report is json");
+    assert!(matches!(
+        report["merge_readiness"]["verdict"].as_str(),
+        Some("ready" | "review" | "blocked")
+    ));
+    assert!(report["merge_readiness"]["impact"].is_object());
+    assert!(report["merge_readiness"]["ownership"].is_object());
+}
+
+#[test]
 fn mcp_context_tool_includes_repository_facts() {
     // Phase 1: the context tool wraps the facts-aware renderer (like the CLI),
     // so an agent gets the aggregate stack/size picture, not a thinner brief.

--- a/tests/review_blast_radius.rs
+++ b/tests/review_blast_radius.rs
@@ -151,6 +151,8 @@ fn render_console_includes_blast_radius_section_when_present() {
         changed_files: vec![changed_file("src/a.ts")],
         blast_radius: vec![PathBuf::from("src/b.ts")],
         impact_paths: Default::default(),
+        ownership: Default::default(),
+        ownership_diagnostics: Vec::new(),
         boundary_signals: vec![],
         boundary_missing_test: false,
         tiered_signals: TieredSignals::default(),

--- a/tests/review_ownership.rs
+++ b/tests/review_ownership.rs
@@ -1,0 +1,94 @@
+use repopilot::review::diff::{ChangeStatus, ChangedFile};
+use repopilot::review::{FileImpact, ImpactPaths, OwnershipIndex, OwnershipSummary};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn codeowners_last_matching_rule_wins_and_deduplicates_owners() {
+    let index = OwnershipIndex::from_codeowners(
+        "* @all\n/src/ @backend\n/src/auth/ @security @backend @security\n",
+        PathBuf::from("CODEOWNERS"),
+    )
+    .unwrap();
+
+    assert_eq!(
+        values(index.owners_for(Path::new("src/auth/session.rs"))),
+        vec!["@security", "@backend"]
+    );
+    assert_eq!(
+        values(index.owners_for(Path::new("src/lib.rs"))),
+        vec!["@backend"]
+    );
+}
+
+#[test]
+fn discovery_prefers_dot_github_then_root_then_docs() {
+    let root = tempfile::tempdir().unwrap();
+    fs::create_dir_all(root.path().join(".github")).unwrap();
+    fs::create_dir_all(root.path().join("docs")).unwrap();
+    fs::write(root.path().join("CODEOWNERS"), "* @root\n").unwrap();
+    fs::write(root.path().join("docs/CODEOWNERS"), "* @docs\n").unwrap();
+    fs::write(root.path().join(".github/CODEOWNERS"), "* @github\n").unwrap();
+
+    let discovery = OwnershipIndex::discover(root.path());
+    assert!(discovery.diagnostics.is_empty());
+    assert_eq!(
+        discovery.index.source(),
+        Some(Path::new(".github/CODEOWNERS"))
+    );
+    assert_eq!(
+        values(discovery.index.owners_for(Path::new("src/lib.rs"))),
+        vec!["@github"]
+    );
+}
+
+#[test]
+fn missing_codeowners_reports_stable_boundaries_without_inventing_people() {
+    let index = OwnershipIndex::empty();
+    let summary = OwnershipSummary::for_paths(
+        [
+            PathBuf::from("src/auth/session.rs"),
+            PathBuf::from("src/api.rs"),
+            PathBuf::from("README.md"),
+        ],
+        &index,
+    );
+
+    assert!(summary.suggested_owners.is_empty());
+    assert_eq!(summary.unowned_paths.len(), 3);
+    assert_eq!(summary.fallback_boundaries, vec![".", "src"]);
+}
+
+#[test]
+fn ownership_summary_covers_changed_and_transitively_impacted_paths() {
+    let index = OwnershipIndex::from_codeowners(
+        "/src/auth/ @security\n/src/api/ @platform\n",
+        PathBuf::from("CODEOWNERS"),
+    )
+    .unwrap();
+    let changed = vec![ChangedFile {
+        path: PathBuf::from("src/auth/session.rs"),
+        status: ChangeStatus::Modified,
+        ranges: Vec::new(),
+        hunks: Vec::new(),
+    }];
+    let impact = ImpactPaths {
+        files: vec![FileImpact {
+            path: PathBuf::from("src/auth/session.rs"),
+            direct_dependents: vec![PathBuf::from("src/api/routes.rs")],
+            transitive_dependents: vec![PathBuf::from("web/app.ts")],
+        }],
+        ..ImpactPaths::default()
+    };
+
+    let summary = OwnershipSummary::for_impact(&changed, &impact, &index);
+    assert_eq!(
+        values(summary.suggested_owners),
+        vec!["@platform", "@security"]
+    );
+    assert_eq!(summary.unowned_paths, vec!["web/app.ts"]);
+}
+
+fn values(owners: Vec<repopilot::review::Owner>) -> Vec<String> {
+    owners.into_iter().map(|owner| owner.value).collect()
+}

--- a/tests/review_readiness.rs
+++ b/tests/review_readiness.rs
@@ -1,0 +1,123 @@
+use repopilot::baseline::gate::{CiGateResult, FailOn};
+use repopilot::findings::types::Severity;
+use repopilot::review::diff::{ChangeStatus, ChangedFile};
+use repopilot::review::model::ReviewReport;
+use repopilot::review::{
+    MergeReadinessRecord, OwnershipSummary, ReadinessReasonCode, ReadinessVerdict, derive_readiness,
+};
+use repopilot::scan::types::ScanSummary;
+use std::path::PathBuf;
+
+#[test]
+fn failed_finding_gate_is_blocked_with_stable_reason_code() {
+    let report = report_with_ownership(OwnershipSummary::default());
+    let gate = CiGateResult {
+        fail_on: FailOn::Any(Severity::High),
+        failed_findings: 1,
+    };
+
+    let readiness = derive_readiness(&report, Some(&gate), None, None);
+    assert_eq!(readiness.verdict, ReadinessVerdict::Blocked);
+    assert_eq!(
+        readiness.reasons[0].code,
+        ReadinessReasonCode::FindingGateFailed
+    );
+}
+
+#[test]
+fn unowned_changed_surface_requires_review() {
+    let ownership = OwnershipSummary::for_paths(
+        [PathBuf::from("src/auth/session.rs")],
+        &repopilot::review::OwnershipIndex::empty(),
+    );
+    let readiness = derive_readiness(&report_with_ownership(ownership), None, None, None);
+
+    assert_eq!(readiness.verdict, ReadinessVerdict::Review);
+    assert!(
+        readiness.reasons.iter().any(|reason| {
+            reason.code == ReadinessReasonCode::UnownedSurface && reason.count == 1
+        })
+    );
+}
+
+#[test]
+fn clean_owned_change_is_ready() {
+    let index = repopilot::review::OwnershipIndex::from_codeowners(
+        "/src/ @team\n",
+        PathBuf::from("CODEOWNERS"),
+    )
+    .unwrap();
+    let ownership = OwnershipSummary::for_paths([PathBuf::from("src/lib.rs")], &index);
+    let readiness = derive_readiness(&report_with_ownership(ownership), None, None, None);
+
+    assert_eq!(readiness.verdict, ReadinessVerdict::Ready);
+    assert!(readiness.reasons.is_empty());
+}
+
+#[test]
+fn review_json_projects_the_canonical_readiness_record() {
+    let index = repopilot::review::OwnershipIndex::from_codeowners(
+        "/src/ @team\n",
+        PathBuf::from("CODEOWNERS"),
+    )
+    .unwrap();
+    let report = report_with_ownership(OwnershipSummary::for_paths(
+        [PathBuf::from("src/lib.rs")],
+        &index,
+    ));
+    let rendered = repopilot::review::render::render_json(&report, None).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+
+    assert_eq!(json["merge_readiness"]["verdict"], "ready");
+    assert_eq!(json["merge_readiness"]["impact"]["depth"], 0);
+    assert_eq!(
+        json["merge_readiness"]["ownership"]["suggested_owners"][0]["value"],
+        "@team"
+    );
+    assert!(json["merge_readiness"]["limitations"].is_array());
+}
+
+#[test]
+fn human_reports_project_readiness_and_owners() {
+    let index = repopilot::review::OwnershipIndex::from_codeowners(
+        "/src/ @team\n",
+        PathBuf::from("CODEOWNERS"),
+    )
+    .unwrap();
+    let report = report_with_ownership(OwnershipSummary::for_paths(
+        [PathBuf::from("src/lib.rs")],
+        &index,
+    ));
+
+    let console = repopilot::review::render::render_console(&report, None);
+    let markdown = repopilot::review::render::render_markdown(&report, None);
+    assert!(console.contains("Merge readiness: READY"));
+    assert!(console.contains("Suggested owners: @team"));
+    assert!(markdown.contains("**Merge readiness:** `ready`"));
+    assert!(markdown.contains("**Suggested owners:** `@team`"));
+}
+
+fn report_with_ownership(ownership: OwnershipSummary) -> ReviewReport {
+    ReviewReport {
+        summary: ScanSummary::default(),
+        repo_root: PathBuf::from("/repo"),
+        baseline_path: None,
+        changed_files: vec![ChangedFile {
+            path: PathBuf::from("src/lib.rs"),
+            status: ChangeStatus::Modified,
+            ranges: Vec::new(),
+            hunks: Vec::new(),
+        }],
+        blast_radius: Vec::new(),
+        impact_paths: Default::default(),
+        ownership,
+        ownership_diagnostics: Vec::new(),
+        boundary_signals: Vec::new(),
+        boundary_missing_test: false,
+        tiered_signals: Default::default(),
+        timings: Default::default(),
+        findings: Vec::new(),
+    }
+}
+
+fn _assert_serializable(_: &MergeReadinessRecord) {}

--- a/tests/scan_command_cli.rs
+++ b/tests/scan_command_cli.rs
@@ -510,6 +510,62 @@ fn given_overlay_with_unknown_rule_when_scan_runs_then_validation_diagnostic_is_
 }
 
 #[test]
+fn given_root_overlay_when_scanning_subdirectory_then_overlay_is_loaded() {
+    let project = fixture_project();
+    let repopilot_dir = project.path().join(".repopilot");
+    fs::create_dir_all(&repopilot_dir).expect("create .repopilot dir");
+    fs::write(
+        repopilot_dir.join("overlay.toml"),
+        "[[overlay]]\nrule = \"not-a-real-rule-id\"\nseverity = \"low\"\n",
+    )
+    .expect("write overlay.toml");
+
+    let output = repopilot()
+        .args(["scan", "src", "--format", "json"])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot");
+
+    assert!(output.status.success());
+    let report: Value = serde_json::from_slice(&output.stdout).expect("json output");
+    assert!(report["diagnostics"].as_array().is_some_and(|diagnostics| {
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "overlay.unknown-rule")
+    }));
+}
+
+#[test]
+fn ignore_feedback_bypasses_overlay_validation_and_decisions() {
+    let project = fixture_project();
+    let repopilot_dir = project.path().join(".repopilot");
+    fs::create_dir_all(&repopilot_dir).expect("create .repopilot dir");
+    fs::write(
+        repopilot_dir.join("overlay.toml"),
+        "[[overlay]]\nrule = \"not-a-real-rule-id\"\nseverity = \"low\"\n",
+    )
+    .expect("write overlay.toml");
+
+    let output = repopilot()
+        .args(["scan", ".", "--format", "json", "--ignore-feedback"])
+        .current_dir(project.path())
+        .output()
+        .expect("run repopilot");
+
+    assert!(output.status.success());
+    let report: Value = serde_json::from_slice(&output.stdout).expect("json output");
+    assert!(
+        !report["diagnostics"].as_array().is_some_and(|diagnostics| {
+            diagnostics.iter().any(|diagnostic| {
+                diagnostic["code"]
+                    .as_str()
+                    .is_some_and(|code| code.starts_with("overlay."))
+            })
+        })
+    );
+}
+
+#[test]
 fn given_conflicting_color_flags_when_scan_runs_then_usage_error_is_returned() {
     // Given
     let project = fixture_project();


### PR DESCRIPTION
## What changed

- adds opt-in, bounded local analysis history for `scan` and `review`
- compares only compatible receipts and reports new, persisting, resolved, and severity-shifted finding occurrences
- adds deterministic CODEOWNERS resolution with stable fallback boundaries
- derives one canonical `ready` / `review` / `blocked` merge-readiness record with reasons, impact, owners, verification steps, limitations, and optional risk delta
- projects readiness through console, Markdown, JSON, MCP review output, and the GitHub Action summary
- makes `.repopilot/overlay.toml` trackable, root-discovered for subdirectory scans, and part of MCP cache invalidation
- makes `--ignore-feedback` bypass both overlays and legacy feedback
- documents the approved v0.21 spec, design, implementation plan, CLI, configuration, and changelog contract

## Why

RepoPilot previously produced isolated findings but did not preserve compatible local evidence across runs or assemble findings, change signals, blast radius, ownership, and verification into one merge decision. Overlay edits could also be missed for nested scan targets, which risked stale cached policy decisions.

This is the first complete v0.21 vertical slice. Deeper language/frontend expansion remains explicitly tracked as the next separate slice so this PR stays reviewable.

## User impact

Users can opt into local risk memory with `--record-history` or `[history]`, see whether risk improved or regressed, and consume the same ownership-aware readiness meaning from human and agent-facing surfaces. History remains local-only, disabled by default, bounded by run count and bytes, and excluded from analysis fingerprints.

## Important fixes found during verification

- replaced a flaky spin-based history lock with an OS-backed file lock and bounded wait; abandoned lock files no longer block future runs
- fixed root overlay discovery and MCP cache invalidation for subdirectory scans
- pinned MCP and Action readiness projection with integration tests

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` — 703 library tests, 55 binary tests, all integration and doc tests passed
- `python3 scripts/release-contract.py check`
- `cargo run -- scan . --fail-on-priority p1` — PASS, 0 findings, health 100/100
- concurrency history test repeated 10 times successfully
