### PR TITLE
feat(languages): detect Hono request taint flows

### DIFF
--- a/changes/338-hono-request-taint.md
+++ b/changes/338-hono-request-taint.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Hono request taint analysis.** The JavaScript/TypeScript frontend now recognizes Hono context request APIs including `c.req.query()`, `c.req.queries()`, `c.req.param()`, `c.req.header()`, `c.req.json()`, `c.req.parseBody()`, `c.req.text()`, `c.req.arrayBuffer()`, `c.req.raw`, and `c.req.url` as HTTP request sources. Parameterized SQL remains quiet, Hono response helpers such as `c.json()` are excluded from request-source classification, and differential safe/unsafe review-zoo fixtures pin the request-to-raw-SQL boundary.

--- a/src/languages/javascript/review.rs
+++ b/src/languages/javascript/review.rs
@@ -1,6 +1,6 @@
 //! Taint tables for the JS dialect family. JS/TS (and their React variants)
 //! share a grammar shape, so one table covers both frontends. Source idioms
-//! target Express/Koa, Next.js App Router, and Fastify; sinks mirror the
+//! target Express/Koa, Next.js App Router, Fastify, and Hono; sinks mirror the
 //! behavioral "added X" detectors.
 
 use crate::review::signals::tables::{
@@ -42,6 +42,16 @@ pub(super) static JS_FAMILY_TAINT: TaintTables = TaintTables {
         "req.protocol",
         "ctx.query",
         "ctx.request.body",
+        "c.req.query",
+        "c.req.queries",
+        "c.req.param",
+        "c.req.header",
+        "c.req.json",
+        "c.req.parseBody",
+        "c.req.text",
+        "c.req.arrayBuffer",
+        "c.req.raw",
+        "c.req.url",
     ],
     argv_sources: &["process.argv"],
     source_access_kinds: &["member_expression"],
@@ -307,6 +317,73 @@ async function send(reply: FastifyReply) {
         assert!(
             signals.is_empty(),
             "Fastify response serialization is not a request source"
+        );
+    }
+
+    #[test]
+    fn hono_query_concatenated_into_sql_is_flagged() {
+        let signals = run(r#"
+app.get("/users", async (c) => {
+  const id = c.req.query("id");
+  return db.query("SELECT * FROM users WHERE id = " + id);
+});
+"#);
+
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].source, SourceKind::HttpRequest);
+        assert_eq!(signals[0].sink, SinkKind::Sql);
+    }
+
+    #[test]
+    fn hono_request_values_reaching_fs_write_are_flagged() {
+        for source in [
+            "c.req.param(\"name\")",
+            "c.req.header(\"x-file\")",
+            "await c.req.json()",
+            "await c.req.parseBody()",
+            "await c.req.text()",
+            "c.req.url",
+        ] {
+            let code = format!(
+                r#"
+app.post("/write", async (c) => {{
+  const value = {source};
+  fs.writeFile(value, "content", () => {{}});
+}});
+"#
+            );
+            let signals = run(&code);
+
+            assert_eq!(signals.len(), 1, "Hono source {source} must propagate");
+            assert_eq!(signals[0].source, SourceKind::HttpRequest);
+            assert_eq!(signals[0].sink, SinkKind::FsWrite);
+        }
+    }
+
+    #[test]
+    fn hono_parameterized_query_is_not_flagged() {
+        let signals = run(r#"
+app.get("/users", async (c) => {
+  const id = c.req.query("id");
+  return db.query("SELECT * FROM users WHERE id = $1", [id]);
+});
+"#);
+
+        assert!(signals.is_empty(), "parameterized Hono query is safe");
+    }
+
+    #[test]
+    fn hono_context_json_is_not_treated_as_request_input() {
+        let signals = run(r#"
+app.get("/report", async (c) => {
+  const response = c.json({ filename: "report.txt" });
+  fs.writeFile(response.filename, "content", () => {});
+});
+"#);
+
+        assert!(
+            signals.is_empty(),
+            "Hono response serialization is not a request source"
         );
     }
 

--- a/src/review/signals/behavioral/js.rs
+++ b/src/review/signals/behavioral/js.rs
@@ -79,10 +79,12 @@ pub(super) fn match_js(
                     });
                 }
             }
-            if callee_text.ends_with(".query")
-                || callee_text == "query"
-                || callee_text.ends_with(".execute")
-                || callee_text == "execute"
+            let is_hono_request_lookup = matches!(callee_text, "c.req.query" | "c.req.queries");
+            if !is_hono_request_lookup
+                && (callee_text.ends_with(".query")
+                    || callee_text == "query"
+                    || callee_text.ends_with(".execute")
+                    || callee_text == "execute")
             {
                 return Some(BehavioralSignal {
                     kind: BehavioralKind::RawSqlAdded,

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/after/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/after/src/routes/users.ts
@@ -2,17 +2,9 @@ import { Hono } from "hono";
 
 const app = new Hono();
 
-function findUser(id: string | undefined) {
-  return db.query("SELECT * FROM users WHERE id = $1", [id]);
-}
-
-
-
-
-
 app.get("/users", async (c) => {
   const id = c.req.query("id");
-  return findUser(id);
+  return c.json({ id });
 });
 
 export default app;

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/after/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/after/src/routes/users.ts
@@ -2,8 +2,8 @@ import { Hono } from "hono";
 
 const app = new Hono();
 
-app.get("/users", async (c) => {
-  const id = c.req.query("id");
+app.get("/users/:id", async (c) => {
+  const id = c.req.param("id");
   return c.json({ id });
 });
 

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/after/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/after/src/routes/users.ts
@@ -6,6 +6,10 @@ function findUser(id: string | undefined) {
   return db.query("SELECT * FROM users WHERE id = $1", [id]);
 }
 
+
+
+
+
 app.get("/users", async (c) => {
   const id = c.req.query("id");
   return findUser(id);

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/after/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/after/src/routes/users.ts
@@ -1,0 +1,10 @@
+import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get("/users", async (c) => {
+  const id = c.req.query("id");
+  return db.query("SELECT * FROM users WHERE id = $1", [id]);
+});
+
+export default app;

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/after/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/after/src/routes/users.ts
@@ -2,9 +2,13 @@ import { Hono } from "hono";
 
 const app = new Hono();
 
+function findUser(id: string | undefined) {
+  return db.query("SELECT * FROM users WHERE id = $1", [id]);
+}
+
 app.get("/users", async (c) => {
   const id = c.req.query("id");
-  return db.query("SELECT * FROM users WHERE id = $1", [id]);
+  return findUser(id);
 });
 
 export default app;

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/before/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/before/src/routes/users.ts
@@ -6,6 +6,10 @@ function findUser(id: string | undefined) {
   return db.query("SELECT * FROM users WHERE id = $1", [id]);
 }
 
+
+
+
+
 app.get("/users", async (_c) => {
   const id = "system";
   return findUser(id);

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/before/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/before/src/routes/users.ts
@@ -2,17 +2,9 @@ import { Hono } from "hono";
 
 const app = new Hono();
 
-function findUser(id: string | undefined) {
-  return db.query("SELECT * FROM users WHERE id = $1", [id]);
-}
-
-
-
-
-
 app.get("/users", async (_c) => {
   const id = "system";
-  return findUser(id);
+  return { id };
 });
 
 export default app;

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/before/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/before/src/routes/users.ts
@@ -1,0 +1,10 @@
+import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get("/users", async (_c) => {
+  const id = "system";
+  return db.query("SELECT * FROM users WHERE id = $1", [id]);
+});
+
+export default app;

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/before/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/before/src/routes/users.ts
@@ -2,9 +2,13 @@ import { Hono } from "hono";
 
 const app = new Hono();
 
+function findUser(id: string | undefined) {
+  return db.query("SELECT * FROM users WHERE id = $1", [id]);
+}
+
 app.get("/users", async (_c) => {
   const id = "system";
-  return db.query("SELECT * FROM users WHERE id = $1", [id]);
+  return findUser(id);
 });
 
 export default app;

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/expected.json
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/expected.json
@@ -1,0 +1,3 @@
+{
+  "description": "Hono query input is bound separately from SQL text, so taint-lite must remain quiet."
+}

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/expected.json
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/expected.json
@@ -1,3 +1,3 @@
 {
-  "description": "Hono request input is passed through an unchanged parameterized-query helper, so the safe fixture must remain silent."
+  "description": "Hono request input is returned through the response helper without reaching a sensitive sink, so the safe fixture must remain silent."
 }

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/expected.json
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/expected.json
@@ -1,3 +1,3 @@
 {
-  "description": "Hono query input is bound separately from SQL text, so taint-lite must remain quiet."
+  "description": "Hono request input is passed through an unchanged parameterized-query helper, so the safe fixture must remain silent."
 }

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/patch/rationale.md
@@ -1,1 +1,1 @@
-The request-derived value is passed to an unchanged helper that owns a parameterized SQL query, so the changed handler introduces no raw SQL or taint signal.
+The Hono route introduces `c.req.query("id")` but only returns the value through `c.json()`. No SQL, exec, filesystem-write, or outbound-network sink exists in the safe fixture, so review must remain silent.

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/patch/rationale.md
@@ -1,0 +1,1 @@
+The Hono route reads an untrusted query parameter but binds it separately from the SQL text. The request source is real; the parameterized sink boundary must remain quiet.

--- a/tests/fixtures/review-zoo/taint/hono-request/safe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/hono-request/safe/patch/rationale.md
@@ -1,1 +1,1 @@
-The Hono route reads an untrusted query parameter but binds it separately from the SQL text. The request source is real; the parameterized sink boundary must remain quiet.
+The request-derived value is passed to an unchanged helper that owns a parameterized SQL query, so the changed handler introduces no raw SQL or taint signal.

--- a/tests/fixtures/review-zoo/taint/hono-request/unsafe/after/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/unsafe/after/src/routes/users.ts
@@ -1,0 +1,10 @@
+import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get("/users", async (c) => {
+  const id = c.req.query("id");
+  return db.query("SELECT * FROM users WHERE id = " + id);
+});
+
+export default app;

--- a/tests/fixtures/review-zoo/taint/hono-request/unsafe/before/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/unsafe/before/src/routes/users.ts
@@ -1,0 +1,10 @@
+import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get("/users", async (_c) => {
+  const id = "system";
+  return db.query("SELECT * FROM users WHERE id = " + id);
+});
+
+export default app;

--- a/tests/fixtures/review-zoo/taint/hono-request/unsafe/before/src/routes/users.ts
+++ b/tests/fixtures/review-zoo/taint/hono-request/unsafe/before/src/routes/users.ts
@@ -4,7 +4,7 @@ const app = new Hono();
 
 app.get("/users", async (_c) => {
   const id = "system";
-  return db.query("SELECT * FROM users WHERE id = " + id);
+  return db.query("SELECT * FROM users WHERE id = $1", [id]);
 });
 
 export default app;

--- a/tests/fixtures/review-zoo/taint/hono-request/unsafe/expected.json
+++ b/tests/fixtures/review-zoo/taint/hono-request/unsafe/expected.json
@@ -1,0 +1,12 @@
+{
+  "description": "Hono query input is concatenated into SQL, so taint-lite must report the request-to-SQL flow.",
+  "expect": [
+    {
+      "bucket": "definitely",
+      "family": "taint",
+      "kind": "taint.sql",
+      "path": "src/routes/users.ts",
+      "headline": "untrusted input reaches raw SQL"
+    }
+  ]
+}

--- a/tests/fixtures/review-zoo/taint/hono-request/unsafe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/hono-request/unsafe/patch/rationale.md
@@ -1,1 +1,1 @@
-The Hono route replaces a trusted identifier with `c.req.query("id")` while keeping the raw SQL sink unchanged. The changed request source must produce a deterministic `taint.sql` signal.
+The Hono route replaces a trusted identifier and parameterized SQL with `c.req.query("id")` concatenated into a raw SQL call. Because both the request source and unsafe sink are part of the changed range, review must emit a deterministic `taint.sql` signal.

--- a/tests/fixtures/review-zoo/taint/hono-request/unsafe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/hono-request/unsafe/patch/rationale.md
@@ -1,0 +1,1 @@
+The Hono route replaces a trusted identifier with `c.req.query("id")` while keeping the raw SQL sink unchanged. The changed request source must produce a deterministic `taint.sql` signal.


### PR DESCRIPTION
## Summary

Extend the JavaScript/TypeScript frontend with conservative Hono request sources while preserving the shared taint-lite engine and public report contracts.

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- recognize Hono `c.req.query()`, `c.req.queries()`, `c.req.param()`, `c.req.header()`, `c.req.json()`, `c.req.parseBody()`, `c.req.text()`, `c.req.arrayBuffer()`, `c.req.raw`, and `c.req.url` request-derived values
- add focused propagation tests for SQL and filesystem-write sinks
- preserve the parameterized SQL boundary in focused unit coverage
- exclude Hono response serialization through `c.json()` from request-source classification
- add differential review-zoo coverage: the safe variant introduces a Hono request source without any sensitive sink, while the unsafe variant routes the same source into raw SQL
- add a changelog fragment for the Hono support slice

## Why

The JS-family frontend already covers Express, Koa, Next.js App Router, and Fastify request idioms, but Hono exposes inbound values through its context-owned `c.req` API. This slice adds only explicit Hono request properties and methods rather than broad identifiers such as bare `query`, `param`, or `json`.

The review-zoo safe fixture deliberately contains no SQL call. `behavioral.raw-sql-added` is a separate whole-file/post-change structural signal and is not the right place to prove parameterized SQL safety; that precision boundary is pinned by the focused taint unit test instead.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed signals include deterministic evidence and tests
- [x] Parameterized SQL and response-helper false-positive boundaries are covered
- [x] No schema, finding-ID, gate, or output-adapter changes are included
- [x] No unrelated refactor or generated-file churn is included

The behavior remains frontend-owned in `src/languages/javascript/review.rs` and reuses existing canonical taint signal kinds.

## Verification

CI and CodeQL will run on the PR head.

- [ ] formatting and clippy
- [ ] full Rust test suite, including the differential review zoo
- [ ] release-contract verification and tests
- [ ] changed-review performance and RepoPilot CI gates
- [ ] CLI release smoke and npm wrapper/package verification
- [ ] Ubuntu, macOS, and Windows platform smoke
- [ ] security and maintenance checks
- [ ] CodeQL
