### PR TITLE
feat(languages): detect NestJS controller parameter taint flows

### DIFF
--- a/changes/339-nestjs-controller-taint.md
+++ b/changes/339-nestjs-controller-taint.md
@@ -1,0 +1,3 @@
+### Added
+
+- **NestJS controller parameter taint analysis.** RepoPilot now treats request-bound controller parameters decorated with `@Body()`, `@Query()`, `@Param()`, `@Headers()`, `@Req()`, or `@Request()` as HTTP request sources for intra-procedural taint propagation. Response, dependency-injection, and custom decorators remain excluded, parameterized SQL stays quiet, and differential review-zoo fixtures pin the safe and unsafe boundaries.

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -1,12 +1,13 @@
 //! Intra-procedural taint propagation.
 //!
 //! Two passes per function/module scope: seed a set of tainted local names from
-//! assignments whose right-hand side reads a [`source`](super::sources) or
-//! references an already-tainted name — the assignments are processed in a single
-//! document-order forward pass, so `a = src; b = a; c = b` chains carry through —
-//! then report each [`sink`](super::sinks) call — gated to the changed lines —
-//! whose arguments carry a tainted value. Nested functions are analyzed with a
-//! fresh map so local names do not leak between procedures.
+//! request-bound parameters and assignments whose right-hand side reads a
+//! [`source`](super::sources) or references an already-tainted name. Assignments
+//! are processed in a single document-order forward pass, so `a = src; b = a;
+//! c = b` chains carry through. The engine then reports each [`sink`](super::sinks)
+//! call — gated to the changed lines — whose arguments carry a tainted value.
+//! Nested functions are analyzed with a fresh map so local names do not leak
+//! between procedures.
 //!
 //! For SQL the report is suppressed unless the tainted value is built *into* the
 //! query string (concatenation, interpolation, or a `format`/`Sprintf` call) or
@@ -69,26 +70,24 @@ fn seed_tainted(
     content: &str,
     tables: &'static TaintTables,
 ) -> HashMap<String, SourceKind> {
+    let mut tainted = HashMap::new();
+    collect_request_bound_parameters(root, content, tables, &mut tainted);
+
     let mut assignments: Vec<Assignment<'_>> = Vec::new();
     collect_assignments(root, tables, content, &mut assignments);
     // Process in document order so a later reassignment overrides an earlier one;
     // a single forward pass then resolves `a = src; b = a; c = b` chains.
     assignments.sort_by_key(|assignment| assignment.rhs.start_byte());
 
-    let mut tainted: HashMap<String, SourceKind> = HashMap::new();
     for assignment in &assignments {
         match node_has_source(assignment.rhs, content, tables)
             .or_else(|| node_mentions_tainted(assignment.rhs, content, tables, &tainted))
         {
-            // A tainted/source value sets (or re-sets) taint for each target name.
             Some(kind) => {
                 for name in &assignment.names {
                     tainted.insert(name.clone(), kind);
                 }
             }
-            // A clean reassignment clears taint — `x = req.query.id; x = "safe"`.
-            // Compound assignment (`x += …`) combines with the old value, so it
-            // never clears.
             None if !assignment.augmenting => {
                 for name in &assignment.names {
                     tainted.remove(name);
@@ -98,6 +97,90 @@ fn seed_tainted(
         }
     }
     tainted
+}
+
+/// Seed request-controlled names that are bound directly by a framework
+/// parameter decorator rather than by an assignment. The traversal and binding
+/// extraction are grammar-oriented; the narrow decorator allowlist keeps this
+/// first slice conservative and avoids treating response/DI/custom decorators as
+/// request input.
+fn collect_request_bound_parameters(
+    node: Node<'_>,
+    content: &str,
+    tables: &'static TaintTables,
+    out: &mut HashMap<String, SourceKind>,
+) {
+    if is_parameter_node(node) {
+        let text = node.utf8_text(content.as_bytes()).unwrap_or("");
+        if is_nest_request_parameter(text)
+            && let Some(name) = parameter_binding_name(node, content)
+        {
+            out.insert(name, SourceKind::HttpRequest);
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if !(tables.is_flow_scope)(child) {
+            collect_request_bound_parameters(child, content, tables, out);
+        }
+    }
+}
+
+fn is_parameter_node(node: Node<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "required_parameter" | "optional_parameter" | "rest_pattern"
+    )
+}
+
+fn is_nest_request_parameter(text: &str) -> bool {
+    ["Body", "Query", "Param", "Headers", "Req", "Request"]
+        .iter()
+        .any(|name| {
+            let marker = format!("@{name}");
+            text.find(&marker).is_some_and(|start| {
+                text[start + marker.len()..]
+                    .chars()
+                    .next()
+                    .is_none_or(|next| next == '(' || next.is_whitespace())
+            })
+        })
+}
+
+fn parameter_binding_name(node: Node<'_>, content: &str) -> Option<String> {
+    for field in ["pattern", "name"] {
+        if let Some(binding) = node.child_by_field_name(field)
+            && let Some(name) = first_binding_identifier(binding, content)
+        {
+            return Some(name);
+        }
+    }
+
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .filter(|child| !matches!(child.kind(), "decorator" | "type_annotation"))
+        .find_map(|child| first_binding_identifier(child, content))
+}
+
+fn first_binding_identifier(node: Node<'_>, content: &str) -> Option<String> {
+    if matches!(
+        node.kind(),
+        "identifier" | "shorthand_property_identifier_pattern"
+    ) {
+        return node
+            .utf8_text(content.as_bytes())
+            .ok()
+            .map(ToOwned::to_owned);
+    }
+    if matches!(node.kind(), "decorator" | "type_annotation") {
+        return None;
+    }
+
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find_map(|child| first_binding_identifier(child, content))
 }
 
 /// One assignment found in a scope: the local names it targets, its value node,
@@ -134,8 +217,6 @@ fn collect_assignments<'a>(
     }
 }
 
-/// The (target, value) nodes of an assignment-like node, per the grammar's
-/// assignment node kinds from the language's [`TaintTables`].
 fn assignment_parts<'a>(
     node: Node<'a>,
     tables: &'static TaintTables,
@@ -153,9 +234,6 @@ fn assignment_parts<'a>(
     if let Some(rhs) = node.child_by_field_name(rhs_field) {
         return Some((lhs, rhs));
     }
-    // C#'s grammar attaches a declarator's initializer as a trailing
-    // anonymous child rather than a `value` field; a declarator without an
-    // initializer (`let x;`, `int x;`) has no such child and stays `None`.
     if kind == "variable_declarator" {
         let mut cursor = node.walk();
         let init = node
@@ -167,8 +245,6 @@ fn assignment_parts<'a>(
     None
 }
 
-/// Simple local names bound by an assignment target. Member/index/selector
-/// targets (`obj.field = …`, `m[k] = …`) bind no local name and are skipped.
 fn collect_lhs_names(lhs: Node<'_>, content: &str, out: &mut Vec<String>) {
     match lhs.kind() {
         "identifier" | "shorthand_property_identifier_pattern" => {
@@ -206,7 +282,6 @@ fn node_mentions_tainted(
     if (tables.is_flow_scope)(node) {
         return None;
     }
-    // A sanitizer/coercion call neutralizes whatever it wraps; do not descend.
     if super::sanitizers::is_sanitizer_call(node, content, tables) {
         return None;
     }
@@ -274,10 +349,6 @@ fn sink_taint(
     }
 }
 
-/// SQL is unsafe only when the tainted value is part of the *query expression*
-/// (first argument): built into the string, or a query variable/expression that
-/// is itself tainted. A static query string with the value bound as a later
-/// parameter argument is the safe pattern and yields `None`.
 fn sql_taint(
     args: Node<'_>,
     content: &str,
@@ -294,6 +365,5 @@ fn sql_taint(
     if first.kind() == "identifier" {
         return tainted.get(first_text).copied();
     }
-    // A request value used directly as the whole query expression (rare, unsafe).
     node_has_source(first, content, tables)
 }

--- a/tests/fixtures/review-zoo/taint/nestjs-controller/safe/after/src/users.controller.ts
+++ b/tests/fixtures/review-zoo/taint/nestjs-controller/safe/after/src/users.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get, Param } from "@nestjs/common";
+
+@Controller("users")
+export class UsersController {
+  @Get(":id")
+  findOne(@Param("id") id: string) {
+    return { id };
+  }
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-controller/safe/before/src/users.controller.ts
+++ b/tests/fixtures/review-zoo/taint/nestjs-controller/safe/before/src/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Param } from "@nestjs/common";
 
 @Controller("users")
 export class UsersController {

--- a/tests/fixtures/review-zoo/taint/nestjs-controller/safe/before/src/users.controller.ts
+++ b/tests/fixtures/review-zoo/taint/nestjs-controller/safe/before/src/users.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Get } from "@nestjs/common";
+
+@Controller("users")
+export class UsersController {
+  @Get(":id")
+  findOne() {
+    const id = "system";
+    return { id };
+  }
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-controller/safe/expected.json
+++ b/tests/fixtures/review-zoo/taint/nestjs-controller/safe/expected.json
@@ -1,0 +1,3 @@
+{
+  "description": "A NestJS request-bound parameter returned without reaching a sensitive sink must remain silent."
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-controller/safe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/nestjs-controller/safe/patch/rationale.md
@@ -1,0 +1,1 @@
+The controller replaces a trusted literal with a NestJS `@Param("id")` request-bound parameter and returns it as data. Because the value never reaches SQL, subprocess, filesystem, or network sinks, the review must remain silent.

--- a/tests/fixtures/review-zoo/taint/nestjs-controller/unsafe/after/src/users.controller.ts
+++ b/tests/fixtures/review-zoo/taint/nestjs-controller/unsafe/after/src/users.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get, Param } from "@nestjs/common";
+
+@Controller("users")
+export class UsersController {
+  @Get(":id")
+  findOne(@Param("id") id: string) {
+    return db.query("SELECT * FROM users WHERE id = " + id);
+  }
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-controller/unsafe/before/src/users.controller.ts
+++ b/tests/fixtures/review-zoo/taint/nestjs-controller/unsafe/before/src/users.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Get } from "@nestjs/common";
+
+@Controller("users")
+export class UsersController {
+  @Get(":id")
+  findOne() {
+    const id = "system";
+    return db.query("SELECT * FROM users WHERE id = $1", [id]);
+  }
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-controller/unsafe/before/src/users.controller.ts
+++ b/tests/fixtures/review-zoo/taint/nestjs-controller/unsafe/before/src/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Param } from "@nestjs/common";
 
 @Controller("users")
 export class UsersController {

--- a/tests/fixtures/review-zoo/taint/nestjs-controller/unsafe/expected.json
+++ b/tests/fixtures/review-zoo/taint/nestjs-controller/unsafe/expected.json
@@ -1,0 +1,12 @@
+{
+  "description": "A NestJS route parameter concatenated into SQL must produce a deterministic taint signal.",
+  "expect": [
+    {
+      "bucket": "definitely",
+      "family": "taint",
+      "kind": "taint.sql",
+      "path": "src/users.controller.ts",
+      "headline": "untrusted input reaches raw SQL"
+    }
+  ]
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-controller/unsafe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/nestjs-controller/unsafe/patch/rationale.md
@@ -1,0 +1,1 @@
+The change introduces a NestJS `@Param("id")` request-bound parameter and concatenates it into a newly added raw SQL query. Both the source and sink are inside the changed range, so review must emit the canonical `taint.sql` signal.


### PR DESCRIPTION
## Summary

Add conservative NestJS controller parameter taint support while preserving the existing canonical taint signals and public report contracts.

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- seed intra-procedural taint from NestJS request-bound controller parameters
- recognize `@Body()`, `@Query()`, `@Param()`, `@Headers()`, `@Req()`, and `@Request()`
- keep `@Res()`, `@Response()`, dependency-injection decorators, and custom decorators outside the source allowlist
- preserve clean reassignment and parameterized SQL behavior
- add differential safe/unsafe review-zoo coverage
- add a changelog fragment

## Why

Previous JavaScript/TypeScript framework slices covered expression-owned request sources such as `req.query`, `request.nextUrl`, Fastify request metadata, and Hono `c.req`. NestJS commonly binds inbound data directly to decorated controller parameters, so no assignment expression exists to seed the current local taint map.

This slice extends the flow seeding stage to recognize narrowly allowlisted request-bound parameters while keeping signal kinds, schemas, gates, and output adapters unchanged.

## Contract and ownership

- [x] The change remains inside the taint flow engine and JavaScript/TypeScript framework behavior
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] Existing canonical `taint.sql`, `taint.exec`, `taint.fs-write`, and `taint.network` signals are reused
- [x] Parameterized SQL and no-sink boundaries remain quiet
- [x] Response, DI, and custom decorators are not treated as request sources
- [x] No schema or finding-ID changes are included

## Verification

CI and CodeQL will validate the PR head.

- [ ] formatting and clippy
- [ ] full Rust test suite
- [ ] differential review-zoo
- [ ] release-contract checks
- [ ] platform smoke checks
- [ ] CodeQL
