### PR TITLE
feat(languages): recognize NestJS primitive pipe sanitizers

### DIFF
--- a/changes/340-nestjs-pipe-sanitizers.md
+++ b/changes/340-nestjs-pipe-sanitizers.md
@@ -1,0 +1,2 @@
+- Treat NestJS `ParseIntPipe`, `ParseFloatPipe`, `ParseBoolPipe`, and `ParseUUIDPipe` controller parameters as validated primitive inputs in taint-lite.
+- Keep `ValidationPipe`, `ParseEnumPipe`, and custom pipes tainted unless their safety can be proven.

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -75,8 +75,6 @@ fn seed_tainted(
 
     let mut assignments: Vec<Assignment<'_>> = Vec::new();
     collect_assignments(root, tables, content, &mut assignments);
-    // Process in document order so a later reassignment overrides an earlier one;
-    // a single forward pass then resolves `a = src; b = a; c = b` chains.
     assignments.sort_by_key(|assignment| assignment.rhs.start_byte());
 
     for assignment in &assignments {
@@ -100,10 +98,9 @@ fn seed_tainted(
 }
 
 /// Seed request-controlled names that are bound directly by a framework
-/// parameter decorator rather than by an assignment. The traversal and binding
-/// extraction are grammar-oriented; the narrow decorator allowlist keeps this
-/// first slice conservative and avoids treating response/DI/custom decorators as
-/// request input.
+/// parameter decorator rather than by an assignment. A narrow set of NestJS
+/// primitive parsing pipes is treated as an opaque clean boundary because its
+/// output cannot carry string injection or path/command metacharacters.
 fn collect_request_bound_parameters(
     node: Node<'_>,
     content: &str,
@@ -113,6 +110,7 @@ fn collect_request_bound_parameters(
     if is_parameter_node(node) {
         let text = node.utf8_text(content.as_bytes()).unwrap_or("");
         if is_nest_request_parameter(text)
+            && !has_nest_primitive_pipe(text)
             && let Some(name) = parameter_binding_name(node, content)
         {
             out.insert(name, SourceKind::HttpRequest);
@@ -138,15 +136,42 @@ fn is_parameter_node(node: Node<'_>) -> bool {
 fn is_nest_request_parameter(text: &str) -> bool {
     ["Body", "Query", "Param", "Headers", "Req", "Request"]
         .iter()
-        .any(|name| {
-            let marker = format!("@{name}");
-            text.find(&marker).is_some_and(|start| {
-                text[start + marker.len()..]
-                    .chars()
-                    .next()
-                    .is_none_or(|next| next == '(' || next.is_whitespace())
-            })
-        })
+        .any(|name| contains_decorator_token(text, name))
+}
+
+fn has_nest_primitive_pipe(text: &str) -> bool {
+    [
+        "ParseIntPipe",
+        "ParseFloatPipe",
+        "ParseBoolPipe",
+        "ParseUUIDPipe",
+    ]
+    .iter()
+    .any(|pipe| contains_identifier_token(text, pipe))
+}
+
+fn contains_decorator_token(text: &str, name: &str) -> bool {
+    let marker = format!("@{name}");
+    text.match_indices(&marker).any(|(start, _)| {
+        let suffix = &text[start + marker.len()..];
+        suffix
+            .chars()
+            .next()
+            .is_none_or(|next| next == '(' || next.is_whitespace())
+    })
+}
+
+fn contains_identifier_token(text: &str, identifier: &str) -> bool {
+    text.match_indices(identifier).any(|(start, _)| {
+        let before = text[..start].chars().next_back();
+        let after = text[start + identifier.len()..].chars().next();
+        before.is_none_or(|ch| !is_identifier_char(ch))
+            && after.is_none_or(|ch| !is_identifier_char(ch))
+    })
+}
+
+fn is_identifier_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$')
 }
 
 fn parameter_binding_name(node: Node<'_>, content: &str) -> Option<String> {
@@ -183,9 +208,6 @@ fn first_binding_identifier(node: Node<'_>, content: &str) -> Option<String> {
         .find_map(|child| first_binding_identifier(child, content))
 }
 
-/// One assignment found in a scope: the local names it targets, its value node,
-/// and whether it is a compound assignment (`+=`, …) that combines with the old
-/// value rather than replacing it.
 struct Assignment<'a> {
     names: Vec<String>,
     rhs: Node<'a>,
@@ -366,4 +388,34 @@ fn sql_taint(
         return tainted.get(first_text).copied();
     }
     node_has_source(first, content, tables)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primitive_nest_pipes_are_recognized_with_token_boundaries() {
+        for pipe in [
+            "ParseIntPipe",
+            "ParseFloatPipe",
+            "ParseBoolPipe",
+            "ParseUUIDPipe",
+        ] {
+            let parameter = format!("@Param(\"id\", {pipe}) id: string");
+            assert!(has_nest_primitive_pipe(&parameter), "missing {pipe}");
+        }
+
+        assert!(!has_nest_primitive_pipe(
+            "@Param(\"id\", MyParseIntPipe) id: string"
+        ));
+    }
+
+    #[test]
+    fn configurable_and_custom_nest_pipes_remain_tainted() {
+        for pipe in ["ValidationPipe", "ParseEnumPipe", "CustomPipe"] {
+            let parameter = format!("@Body({pipe}) body: Payload");
+            assert!(!has_nest_primitive_pipe(&parameter), "unexpected {pipe}");
+        }
+    }
 }

--- a/tests/fixtures/review-zoo/taint/nestjs-pipes/safe/after/src/users.controller.ts
+++ b/tests/fixtures/review-zoo/taint/nestjs-pipes/safe/after/src/users.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get, Param, ParseIntPipe } from "@nestjs/common";
+
+@Controller("users")
+export class UsersController {
+  @Get(":id")
+  findOne(@Param("id", ParseIntPipe) id: number) {
+    return { id };
+  }
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-pipes/safe/before/src/users.controller.ts
+++ b/tests/fixtures/review-zoo/taint/nestjs-pipes/safe/before/src/users.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get, Param, ParseIntPipe } from "@nestjs/common";
+
+@Controller("users")
+export class UsersController {
+  @Get(":id")
+  findOne(@Param("id") id: string) {
+    return { id };
+  }
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-pipes/safe/expected.json
+++ b/tests/fixtures/review-zoo/taint/nestjs-pipes/safe/expected.json
@@ -1,0 +1,4 @@
+{
+  "description": "A primitive NestJS parsing pipe narrows request input without introducing a sensitive sink.",
+  "expect": []
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-pipes/safe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/nestjs-pipes/safe/patch/rationale.md
@@ -1,0 +1,1 @@
+The controller adds `ParseIntPipe` to a request-bound parameter and does not route the parsed primitive into any sensitive sink, so the review must remain quiet.

--- a/tests/fixtures/review-zoo/taint/nestjs-pipes/unsafe/after/src/users.controller.ts
+++ b/tests/fixtures/review-zoo/taint/nestjs-pipes/unsafe/after/src/users.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get, Param } from "@nestjs/common";
+
+class CustomPipe {}
+
+@Controller("users")
+export class UsersController {
+  @Get(":id")
+  findOne(@Param("id", CustomPipe) id: string) {
+    return db.query("SELECT * FROM users WHERE id = " + id);
+  }
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-pipes/unsafe/before/src/users.controller.ts
+++ b/tests/fixtures/review-zoo/taint/nestjs-pipes/unsafe/before/src/users.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get, Param } from "@nestjs/common";
+
+class CustomPipe {}
+
+@Controller("users")
+export class UsersController {
+  @Get(":id")
+  findOne(@Param("id", CustomPipe) id: string) {
+    return db.query("SELECT * FROM users WHERE id = $1", [id]);
+  }
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-pipes/unsafe/expected.json
+++ b/tests/fixtures/review-zoo/taint/nestjs-pipes/unsafe/expected.json
@@ -1,0 +1,12 @@
+{
+  "description": "A custom NestJS pipe is not assumed to sanitize request input before raw SQL concatenation.",
+  "expect": [
+    {
+      "bucket": "definitely",
+      "family": "taint",
+      "kind": "taint.sql",
+      "path": "src/users.controller.ts",
+      "headline": "untrusted input reaches raw SQL"
+    }
+  ]
+}

--- a/tests/fixtures/review-zoo/taint/nestjs-pipes/unsafe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/nestjs-pipes/unsafe/patch/rationale.md
@@ -1,0 +1,1 @@
+The controller uses a custom pipe whose semantics are unknown and replaces a parameterized query with SQL string concatenation, so request taint must still reach the raw SQL sink.


### PR DESCRIPTION
## Summary

Recognize a narrow set of NestJS primitive parsing pipes as clean parameter boundaries while preserving conservative taint behavior for configurable and custom pipes.

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- treat `ParseIntPipe`, `ParseFloatPipe`, `ParseBoolPipe`, and `ParseUUIDPipe` as validated primitive parameter boundaries
- keep `ValidationPipe`, `ParseEnumPipe`, and custom pipes tainted
- add token-boundary checks so similarly named custom classes are not mistaken for built-in pipes
- add focused unit coverage for the allowlist and false-positive boundary
- add safe/unsafe differential review-zoo fixtures
- add a changelog fragment

## Why

PR #339 taught taint-lite to seed NestJS request-bound controller parameters. Without pipe awareness, parameters narrowed to numbers, booleans, or validated UUIDs still behaved like arbitrary request strings and could create avoidable false positives.

This slice remains deliberately narrow. It does not infer the semantics of `ValidationPipe`, enum values, DTO transforms, or custom pipes because those depend on configuration or application-specific code.

## Contract and ownership

- [x] Existing canonical taint signal kinds are reused
- [x] No JSON, SARIF, Action, MCP, baseline, or finding-ID changes are included
- [x] Unknown and configurable pipes remain conservative
- [x] Similar custom class names do not match built-in pipe tokens
- [x] Review-zoo fixtures keep imports stable across before/after

## Verification

CI and CodeQL will validate the PR head.

- [ ] formatting and clippy
- [ ] full Rust test suite
- [ ] differential review-zoo
- [ ] release-contract checks
- [ ] platform smoke checks
- [ ] CodeQL
