### PR TITLE
test(taint): lock destructuring provenance behavior

### DIFF
--- a/changes/342-destructuring-taint-provenance.md
+++ b/changes/342-destructuring-taint-provenance.md
@@ -1,0 +1,2 @@
+- Lock object-destructuring taint propagation, alias bindings, and parameterized SQL safety with differential review-zoo coverage.
+- Keep rest patterns, computed keys, and array index provenance outside this slice.

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/safe/after/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/safe/after/src/handler.ts
@@ -1,0 +1,4 @@
+export function findUser(req: any) {
+  const { id: userId } = req.body;
+  return db.query("SELECT * FROM users WHERE id = $1", [userId]);
+}

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/safe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/safe/before/src/handler.ts
@@ -1,5 +1,5 @@
 export function findUser(req: any) {
   const body = req.body;
-  const { id } = body;
-  return db.query("SELECT * FROM users WHERE id = $1", [id]);
+  const { id: userId } = body;
+  return db.query("SELECT * FROM users WHERE id = $1", [userId]);
 }

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/safe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/safe/before/src/handler.ts
@@ -1,0 +1,5 @@
+export function findUser(req: any) {
+  const body = req.body;
+  const { id } = body;
+  return db.query("SELECT * FROM users WHERE id = $1", [id]);
+}

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/safe/expected.json
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/safe/expected.json
@@ -1,0 +1,3 @@
+{
+  "description": "Aliased object destructuring remains safe when the value is passed as a SQL bind parameter."
+}

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/safe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/safe/patch/rationale.md
@@ -1,0 +1,1 @@
+Alias destructuring changes local binding shape but preserves parameterized SQL, so no review signal is expected.

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/after/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/after/src/handler.ts
@@ -1,0 +1,4 @@
+export function runCommand(req: any) {
+  const { command: cmd } = req.body;
+  return exec(cmd);
+}

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/before/src/handler.ts
@@ -1,4 +1,4 @@
 export function runCommand(req: any) {
-  const cmd = "echo safe";
-  return exec(cmd);
+  const command = "echo safe";
+  return exec(command);
 }

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/before/src/handler.ts
@@ -1,4 +1,4 @@
 export function runCommand(req: any) {
-  const command = "echo safe";
-  return exec(command);
+  const cmd = "echo safe";
+  return exec(cmd);
 }

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/before/src/handler.ts
@@ -1,0 +1,4 @@
+export function runCommand(req: any) {
+  const command = "echo safe";
+  return exec(command);
+}

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/expected.json
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/expected.json
@@ -1,0 +1,12 @@
+{
+  "description": "Aliased object destructuring from request input must preserve taint into command execution.",
+  "expect": [
+    {
+      "bucket": "definitely",
+      "family": "taint",
+      "kind": "taint.exec",
+      "path": "src/handler.ts",
+      "headline": "untrusted input reaches command execution"
+    }
+  ]
+}

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/expected.json
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/expected.json
@@ -6,7 +6,7 @@
       "family": "taint",
       "kind": "taint.exec",
       "path": "src/handler.ts",
-      "headline": "untrusted input reaches command execution"
+      "headline": "untrusted input reaches subprocess/exec"
     }
   ]
 }

--- a/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/destructuring-provenance/unsafe/patch/rationale.md
@@ -1,0 +1,1 @@
+The change replaces a static command with an aliased binding destructured from `req.body`; taint must survive the pattern and reach `exec`.


### PR DESCRIPTION
## Summary

Lock object-destructuring taint behavior with differential review-zoo coverage for alias bindings and parameterized SQL safety.

## Type of change

- [ ] Feature
- [ ] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation

## What changed

- add an unsafe fixture where `const { command: cmd } = req.body` reaches `exec(cmd)`
- add a safe fixture where `const { id: userId } = req.body` is passed as a SQL bind parameter
- verify alias bindings preserve taint provenance
- verify parameterized SQL remains quiet after destructuring
- add a changelog fragment

## Why

The taint engine already collects identifiers from object patterns, including aliased `pair_pattern` bindings. This slice turns that implicit behavior into a stable regression contract before deeper per-property destructuring precision is introduced.

## Scope and non-goals

Included:

- object destructuring
- aliased bindings
- command-execution propagation
- parameterized SQL boundary

Not included:

- rest-pattern provenance
- computed property keys
- array index sensitivity
- default-value branch semantics
- interprocedural propagation

## Contract and ownership

- [x] No production signal or schema changes
- [x] Existing `taint.exec` behavior is reused
- [x] Safe fixture avoids unrelated import or dependency changes
- [x] Public CLI, JSON, SARIF, Action, MCP, and baseline contracts are unchanged

## Verification

CI and CodeQL will validate the PR head.

- [ ] differential review-zoo
- [ ] full Rust test suite
- [ ] formatting and clippy
- [ ] release-contract checks
- [ ] CodeQL
