### PR TITLE
test(taint): lock array destructuring propagation

### DIFF
--- a/changes/344-array-destructuring-taint-contract.md
+++ b/changes/344-array-destructuring-taint-contract.md
@@ -1,0 +1,2 @@
+- Add review-zoo coverage that locks conservative taint propagation through static array destructuring while keeping clean local arrays silent.
+- Document that exact numeric-index tracking and dynamic index analysis remain outside the current taint-lite contract.

--- a/tests/fixtures/review-zoo/taint/array-destructuring/safe/after/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/array-destructuring/safe/after/src/handler.ts
@@ -1,0 +1,4 @@
+export function findUser() {
+  const [userId] = ["system"];
+  return db.query("SELECT * FROM users WHERE id = $1", [userId]);
+}

--- a/tests/fixtures/review-zoo/taint/array-destructuring/safe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/array-destructuring/safe/before/src/handler.ts
@@ -1,0 +1,5 @@
+export function findUser() {
+  const ids = ["system"];
+  const userId = ids[0];
+  return db.query("SELECT * FROM users WHERE id = $1", [userId]);
+}

--- a/tests/fixtures/review-zoo/taint/array-destructuring/safe/expected.json
+++ b/tests/fixtures/review-zoo/taint/array-destructuring/safe/expected.json
@@ -1,0 +1,3 @@
+{
+  "description": "Array destructuring from a local clean literal must remain silent."
+}

--- a/tests/fixtures/review-zoo/taint/array-destructuring/safe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/array-destructuring/safe/patch/rationale.md
@@ -1,0 +1,1 @@
+Replace indexed access with equivalent clean array destructuring while keeping the parameterized SQL sink unchanged.

--- a/tests/fixtures/review-zoo/taint/array-destructuring/unsafe/after/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/array-destructuring/unsafe/after/src/handler.ts
@@ -1,0 +1,5 @@
+export function runCommand(req: any) {
+  const commands = req.body.commands;
+  const [cmd] = commands;
+  return exec(cmd);
+}

--- a/tests/fixtures/review-zoo/taint/array-destructuring/unsafe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/array-destructuring/unsafe/before/src/handler.ts
@@ -1,0 +1,5 @@
+export function runCommand() {
+  const commands = ["echo safe"];
+  const [cmd] = commands;
+  return execSafe(cmd);
+}

--- a/tests/fixtures/review-zoo/taint/array-destructuring/unsafe/expected.json
+++ b/tests/fixtures/review-zoo/taint/array-destructuring/unsafe/expected.json
@@ -1,0 +1,12 @@
+{
+  "description": "Array destructuring from request input must preserve taint into subprocess execution.",
+  "expect": [
+    {
+      "bucket": "definitely",
+      "family": "taint",
+      "kind": "taint.exec",
+      "path": "src/handler.ts",
+      "headline": "untrusted input reaches subprocess/exec"
+    }
+  ]
+}

--- a/tests/fixtures/review-zoo/taint/array-destructuring/unsafe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/array-destructuring/unsafe/patch/rationale.md
@@ -1,0 +1,1 @@
+Replace a clean local array with request-controlled commands and route the destructured first element into a changed subprocess sink.


### PR DESCRIPTION
## Summary

Add differential review-zoo coverage that locks the current conservative taint behavior for static array destructuring.

## Type of change

- [ ] Feature
- [ ] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation

## What changed

- add a safe fixture where a clean local array is destructured and passed as a SQL bind parameter
- add an unsafe fixture where a request-controlled array is destructured and the first binding reaches `exec`
- keep the SQL sink unchanged in the safe fixture to avoid unrelated behavioral signals
- change the subprocess sink in the unsafe fixture so changed-line gating evaluates `taint.exec`
- use the canonical `untrusted input reaches subprocess/exec` headline
- add a changelog fragment describing the boundary

## Why

The current engine already propagates taint conservatively through array patterns by collecting their local bindings. That behavior was implicit and unprotected by the differential fixture suite. This PR turns it into a regression contract before exact numeric-index state is implemented.

## Scope and non-goals

Included:

- static array destructuring
- clean local arrays
- request-controlled arrays
- subprocess sink propagation
- parameterized SQL safety

Not included:

- exact numeric-index provenance
- static subscript assignment tracking
- dynamic indexes such as `items[userIndex]`
- rest-element provenance
- interprocedural propagation

## Contract and ownership

- [x] No production code changes
- [x] No JSON, SARIF, Action, MCP, baseline, or finding-ID changes
- [x] Existing canonical `taint.exec` behavior is reused
- [x] Extra behavioral signals are permitted only in the unsafe fixture

## Verification

CI and CodeQL will validate the PR head.

- [ ] differential review-zoo
- [ ] full Rust test suite
- [ ] formatting and clippy
- [ ] release-contract checks
- [ ] CodeQL
