### PR TITLE
test(taint): lock static subscript propagation

### DIFF
--- a/changes/345-static-subscript-taint-contract.md
+++ b/changes/345-static-subscript-taint-contract.md
@@ -1,0 +1,1 @@
+- Add review-zoo coverage for direct static numeric subscript taint propagation and parameterized-safe usage.

--- a/tests/fixtures/review-zoo/taint/static-subscript/safe/after/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/static-subscript/safe/after/src/handler.ts
@@ -1,5 +1,5 @@
 export function findUser() {
-  const ids = ["system"];
+  const ids = ["system", "unused"];
   const userId = ids[0];
   return db.query("SELECT * FROM users WHERE id = $1", [userId]);
 }

--- a/tests/fixtures/review-zoo/taint/static-subscript/safe/after/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/static-subscript/safe/after/src/handler.ts
@@ -1,0 +1,5 @@
+export function findUser() {
+  const ids = ["system"];
+  const userId = ids[0];
+  return db.query("SELECT * FROM users WHERE id = $1", [userId]);
+}

--- a/tests/fixtures/review-zoo/taint/static-subscript/safe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/static-subscript/safe/before/src/handler.ts
@@ -1,0 +1,5 @@
+export function findUser() {
+  const ids = ["system"];
+  const userId = ids[0];
+  return db.query("SELECT * FROM users WHERE id = $1", [userId]);
+}

--- a/tests/fixtures/review-zoo/taint/static-subscript/safe/expected.json
+++ b/tests/fixtures/review-zoo/taint/static-subscript/safe/expected.json
@@ -1,0 +1,4 @@
+{
+  "description": "A static subscript from a clean local array remains safe when used as a SQL bind parameter.",
+  "expect": []
+}

--- a/tests/fixtures/review-zoo/taint/static-subscript/safe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/static-subscript/safe/patch/rationale.md
@@ -1,0 +1,1 @@
+Static numeric subscripts from clean local arrays must remain quiet when the selected value is used as a bind parameter.

--- a/tests/fixtures/review-zoo/taint/static-subscript/unsafe/after/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/static-subscript/unsafe/after/src/handler.ts
@@ -1,0 +1,5 @@
+export function runFirstCommand(req: any) {
+  const commands = req.body.commands;
+  const command = commands[0];
+  return exec(command);
+}

--- a/tests/fixtures/review-zoo/taint/static-subscript/unsafe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/static-subscript/unsafe/before/src/handler.ts
@@ -1,0 +1,5 @@
+export function runFirstCommand() {
+  const commands = ["echo safe"];
+  const command = commands[0];
+  return exec(command);
+}

--- a/tests/fixtures/review-zoo/taint/static-subscript/unsafe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/static-subscript/unsafe/before/src/handler.ts
@@ -1,5 +1,5 @@
 export function runFirstCommand() {
   const commands = ["echo safe"];
   const command = commands[0];
-  return exec(command);
+  return exec("echo safe");
 }

--- a/tests/fixtures/review-zoo/taint/static-subscript/unsafe/expected.json
+++ b/tests/fixtures/review-zoo/taint/static-subscript/unsafe/expected.json
@@ -1,0 +1,12 @@
+{
+  "description": "A request-controlled value selected through a static numeric subscript must remain tainted into subprocess execution.",
+  "expect": [
+    {
+      "bucket": "definitely",
+      "family": "taint",
+      "kind": "taint.exec",
+      "path": "src/handler.ts",
+      "headline": "untrusted input reaches subprocess/exec"
+    }
+  ]
+}

--- a/tests/fixtures/review-zoo/taint/static-subscript/unsafe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/static-subscript/unsafe/patch/rationale.md
@@ -1,0 +1,1 @@
+Selecting index zero from a request-controlled array must preserve taint into subprocess execution.


### PR DESCRIPTION
## Summary

Add differential review-zoo coverage for direct static numeric subscripts before introducing exact index-sensitive taint state.

## Type of change

- [ ] Feature
- [ ] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation

## What changed

- add an unsafe fixture where `req.body.commands[0]` is assigned to a local and reaches `exec`
- add a safe fixture where a clean local array element is passed as a SQL bind parameter
- keep the SQL sink stable in the safe fixture
- change the subprocess sink line in the unsafe fixture so changed-line gating evaluates `taint.exec`
- add a changelog fragment

## Why

The current AST traversal conservatively detects request sources inside static subscript expressions, but this boundary is not protected by the differential fixture suite. Locking it first gives the next production slice a stable baseline for exact `items[0]` clean/tainted overrides.

## Scope and non-goals

Included:

- direct static numeric subscripts
- local assignment propagation
- subprocess sink propagation
- parameterized SQL safety

Not included:

- exact numeric-index state
- subscript assignment cleanup such as `items[0] = "safe"`
- dynamic indexes such as `items[userIndex]`
- array rest elements
- interprocedural propagation

## Contract and ownership

- [x] No production code changes
- [x] Existing canonical `taint.exec` signal is reused
- [x] No JSON, SARIF, Action, MCP, baseline, or finding-ID changes
- [x] Extra behavioral signals are allowed only in the unsafe fixture

## Verification

CI and CodeQL will validate the PR head.

- [ ] differential review-zoo
- [ ] full Rust test suite
- [ ] release-contract checks
- [ ] CodeQL
