### PR TITLE
feat(taint): track exact static array index paths

### DIFF
--- a/changes/346-exact-static-array-index-paths.md
+++ b/changes/346-exact-static-array-index-paths.md
@@ -1,0 +1,1 @@
+- Taint-lite now tracks static numeric array indexes as exact local paths, including index-aware destructuring and clean sibling-preserving overrides.

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -508,9 +508,7 @@ fn access_path(node: Node<'_>, content: &str) -> Option<String> {
 
 fn normalize_access_path(text: &str) -> Option<String> {
     let normalized = text.trim().replace("?.", ".");
-    if normalized.is_empty()
-        || normalized.contains(['(', ')', ' ', '\t', '\n', '\r'])
-    {
+    if normalized.is_empty() || normalized.contains(['(', ')', ' ', '\t', '\n', '\r']) {
         return None;
     }
 
@@ -747,10 +745,7 @@ mod tests {
             normalize_access_path("body?.items?.[0].command"),
             Some("body.items.0.command".into())
         );
-        assert_eq!(
-            normalize_access_path("items[12]"),
-            Some("items.12".into())
-        );
+        assert_eq!(normalize_access_path("items[12]"), Some("items.12".into()));
         assert_eq!(normalize_access_path("body[userKey]"), None);
         assert_eq!(normalize_access_path("items[-1]"), None);
         assert_eq!(normalize_access_path("getBody().id"), None);

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -154,10 +154,10 @@ fn seed_tainted(root: Node<'_>, content: &str, tables: &'static TaintTables) -> 
 
         let rhs_path = value_path(assignment.rhs, content);
         for binding in &assignment.bindings {
-            let binding_source = rhs_path
-                .as_deref()
-                .and_then(|base| tainted.source_for_path(&format!("{base}.{}", binding.path)))
-                .or(source);
+            let binding_source = match rhs_path.as_deref() {
+                Some(base) => tainted.source_for_path(&format!("{base}.{}", binding.path)),
+                None => source,
+            };
             match binding_source {
                 Some(kind) => tainted.mark_name(&binding.name, kind),
                 None if !assignment.augmenting => tainted.clear_name(&binding.name),
@@ -309,10 +309,10 @@ fn collect_assignments<'a>(
     if let Some((lhs, rhs)) = assignment_parts(node, tables) {
         let mut names = Vec::new();
         let mut bindings = Vec::new();
-        if lhs.kind() == "object_pattern" {
-            collect_object_bindings(lhs, content, "", &mut bindings);
-        } else {
-            collect_lhs_names(lhs, content, &mut names);
+        match lhs.kind() {
+            "object_pattern" => collect_object_bindings(lhs, content, "", &mut bindings),
+            "array_pattern" => collect_array_bindings(lhs, content, "", &mut bindings),
+            _ => collect_lhs_names(lhs, content, &mut names),
         }
         let path = access_path(lhs, content);
         if !names.is_empty() || !bindings.is_empty() || path.is_some() {
@@ -403,6 +403,22 @@ fn collect_object_bindings(
     }
 }
 
+fn collect_array_bindings(
+    node: Node<'_>,
+    content: &str,
+    prefix: &str,
+    out: &mut Vec<DestructuredBinding>,
+) {
+    let mut cursor = node.walk();
+    for (index, child) in node.named_children(&mut cursor).enumerate() {
+        if child.kind() == "rest_pattern" {
+            continue;
+        }
+        let path = join_binding_path(prefix, &index.to_string());
+        collect_binding_value(child, content, &path, out);
+    }
+}
+
 fn collect_binding_value(
     node: Node<'_>,
     content: &str,
@@ -419,6 +435,7 @@ fn collect_binding_value(
             }
         }
         "object_pattern" => collect_object_bindings(node, content, path, out),
+        "array_pattern" => collect_array_bindings(node, content, path, out),
         "assignment_pattern" => {
             if let Some(left) = node.child_by_field_name("left") {
                 collect_binding_value(left, content, path, out);
@@ -482,6 +499,7 @@ fn access_path(node: Node<'_>, content: &str) -> Option<String> {
             | "attribute"
             | "selector_expression"
             | "navigation_expression"
+            | "subscript_expression"
     ) {
         return None;
     }
@@ -490,16 +508,58 @@ fn access_path(node: Node<'_>, content: &str) -> Option<String> {
 
 fn normalize_access_path(text: &str) -> Option<String> {
     let normalized = text.trim().replace("?.", ".");
-    if normalized.is_empty() || normalized.contains(['(', ')', '[', ']', ' ', '\t', '\n', '\r']) {
+    if normalized.is_empty()
+        || normalized.contains(['(', ')', ' ', '\t', '\n', '\r'])
+    {
         return None;
     }
-    let mut segments = normalized.split('.');
-    let first = segments.next()?;
-    if !is_identifier(first) || !segments.clone().all(is_identifier) {
+
+    let bytes = normalized.as_bytes();
+    let mut index = 0;
+    let mut segments = Vec::new();
+
+    let first_start = index;
+    while index < bytes.len() && is_identifier_char(bytes[index] as char) {
+        index += 1;
+    }
+    if first_start == index || !is_identifier(&normalized[first_start..index]) {
         return None;
     }
-    segments.next()?;
-    Some(normalized)
+    segments.push(normalized[first_start..index].to_string());
+
+    while index < bytes.len() {
+        match bytes[index] as char {
+            '.' => {
+                index += 1;
+                let start = index;
+                while index < bytes.len() && is_identifier_char(bytes[index] as char) {
+                    index += 1;
+                }
+                if start == index || !is_identifier(&normalized[start..index]) {
+                    return None;
+                }
+                segments.push(normalized[start..index].to_string());
+            }
+            '[' => {
+                index += 1;
+                let start = index;
+                while index < bytes.len() && (bytes[index] as char).is_ascii_digit() {
+                    index += 1;
+                }
+                if start == index || index >= bytes.len() || bytes[index] as char != ']' {
+                    return None;
+                }
+                segments.push(normalized[start..index].to_string());
+                index += 1;
+            }
+            _ => return None,
+        }
+    }
+
+    if segments.len() < 2 {
+        return None;
+    }
+    Some(segments.join("."))
 }
 
 fn is_identifier(segment: &str) -> bool {
@@ -678,16 +738,21 @@ mod tests {
     }
 
     #[test]
-    fn access_paths_reject_calls_and_dynamic_indexes() {
+    fn access_paths_accept_static_indexes_and_reject_dynamic_indexes() {
         assert_eq!(
             normalize_access_path("body.user.id"),
             Some("body.user.id".into())
         );
         assert_eq!(
-            normalize_access_path("body?.user?.id"),
-            Some("body.user.id".into())
+            normalize_access_path("body?.items?.[0].command"),
+            Some("body.items.0.command".into())
+        );
+        assert_eq!(
+            normalize_access_path("items[12]"),
+            Some("items.12".into())
         );
         assert_eq!(normalize_access_path("body[userKey]"), None);
+        assert_eq!(normalize_access_path("items[-1]"), None);
         assert_eq!(normalize_access_path("getBody().id"), None);
     }
 
@@ -702,5 +767,30 @@ mod tests {
             state.source_for_path("body.command"),
             Some(SourceKind::HttpRequest)
         );
+    }
+
+    #[test]
+    fn clean_static_index_does_not_clean_siblings() {
+        let mut state = TaintState::default();
+        state.mark_name("items", SourceKind::HttpRequest);
+        state.clear_path("items.0");
+
+        assert_eq!(state.source_for_path("items.0"), None);
+        assert_eq!(
+            state.source_for_path("items.1"),
+            Some(SourceKind::HttpRequest)
+        );
+    }
+
+    #[test]
+    fn exact_tainted_index_on_clean_array_is_tracked() {
+        let mut state = TaintState::default();
+        state.mark_path("items.0", SourceKind::HttpRequest);
+
+        assert_eq!(
+            state.source_for_path("items.0"),
+            Some(SourceKind::HttpRequest)
+        );
+        assert_eq!(state.source_for_path("items.1"), None);
     }
 }

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -90,12 +90,14 @@ impl TaintState {
         self.clean_paths.insert(path.to_string());
     }
 
-    fn source_for_path(&self, path: &str) -> Option<SourceKind> {
-        if self
-            .clean_paths
+    fn is_path_explicitly_clean(&self, path: &str) -> bool {
+        self.clean_paths
             .iter()
             .any(|clean| path_is_same_or_descendant(path, clean))
-        {
+    }
+
+    fn source_for_path(&self, path: &str) -> Option<SourceKind> {
+        if self.is_path_explicitly_clean(path) {
             return None;
         }
 
@@ -155,7 +157,14 @@ fn seed_tainted(root: Node<'_>, content: &str, tables: &'static TaintTables) -> 
         let rhs_path = value_path(assignment.rhs, content);
         for binding in &assignment.bindings {
             let binding_source = match rhs_path.as_deref() {
-                Some(base) => tainted.source_for_path(&format!("{base}.{}", binding.path)),
+                Some(base) => {
+                    let path = format!("{base}.{}", binding.path);
+                    if tainted.is_path_explicitly_clean(&path) {
+                        None
+                    } else {
+                        tainted.source_for_path(&path).or(source)
+                    }
+                }
                 None => source,
             };
             match binding_source {

--- a/src/review/signals/taint/flow.rs
+++ b/src/review/signals/taint/flow.rs
@@ -507,7 +507,7 @@ fn access_path(node: Node<'_>, content: &str) -> Option<String> {
 }
 
 fn normalize_access_path(text: &str) -> Option<String> {
-    let normalized = text.trim().replace("?.", ".");
+    let normalized = text.trim().replace("?.[", "[").replace("?.", ".");
     if normalized.is_empty() || normalized.contains(['(', ')', ' ', '\t', '\n', '\r']) {
         return None;
     }

--- a/tests/fixtures/review-zoo/taint/exact-static-index/safe/after/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/exact-static-index/safe/after/src/handler.ts
@@ -1,0 +1,6 @@
+export function findUser(req: any) {
+  const items = req.body.items;
+  items[0] = "system";
+  const userId = items[0];
+  return db.query("SELECT * FROM users WHERE id = $1", [userId]);
+}

--- a/tests/fixtures/review-zoo/taint/exact-static-index/safe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/exact-static-index/safe/before/src/handler.ts
@@ -1,0 +1,5 @@
+export function findUser(req: any) {
+  const items = req.body.items;
+  const userId = items[0];
+  return db.query("SELECT * FROM users WHERE id = $1", [userId]);
+}

--- a/tests/fixtures/review-zoo/taint/exact-static-index/safe/expected.json
+++ b/tests/fixtures/review-zoo/taint/exact-static-index/safe/expected.json
@@ -1,0 +1,4 @@
+{
+  "description": "A clean exact static index override remains safe when used as a SQL bind parameter.",
+  "expect": []
+}

--- a/tests/fixtures/review-zoo/taint/exact-static-index/safe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/exact-static-index/safe/patch/rationale.md
@@ -1,0 +1,1 @@
+Overwriting `items[0]` with a trusted literal must clean only that exact index while preserving safe parameterized SQL usage.

--- a/tests/fixtures/review-zoo/taint/exact-static-index/unsafe/after/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/exact-static-index/unsafe/after/src/handler.ts
@@ -1,0 +1,5 @@
+export function runSecondCommand(req: any) {
+  const items = req.body.items;
+  items[0] = "echo safe";
+  return exec(items[1]);
+}

--- a/tests/fixtures/review-zoo/taint/exact-static-index/unsafe/before/src/handler.ts
+++ b/tests/fixtures/review-zoo/taint/exact-static-index/unsafe/before/src/handler.ts
@@ -1,0 +1,5 @@
+export function runSecondCommand() {
+  const items = ["echo safe", "echo ready"];
+  items[0] = "echo safe";
+  return exec("echo ready");
+}

--- a/tests/fixtures/review-zoo/taint/exact-static-index/unsafe/expected.json
+++ b/tests/fixtures/review-zoo/taint/exact-static-index/unsafe/expected.json
@@ -1,0 +1,12 @@
+{
+  "description": "Cleaning one static index must not clean a tainted sibling index used for command execution.",
+  "expect": [
+    {
+      "bucket": "definitely",
+      "family": "taint",
+      "kind": "taint.exec",
+      "path": "src/handler.ts",
+      "headline": "untrusted input reaches subprocess/exec"
+    }
+  ]
+}

--- a/tests/fixtures/review-zoo/taint/exact-static-index/unsafe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/taint/exact-static-index/unsafe/patch/rationale.md
@@ -1,0 +1,1 @@
+A trusted overwrite of `items[0]` must not suppress taint from sibling `items[1]` reaching command execution.


### PR DESCRIPTION
## Summary

Add exact path-sensitive taint tracking for static non-negative array indexes and index-aware array destructuring.

Closes #346.

## Type of change

- [x] Feature
- [x] Precision improvement
- [x] Tests
- [x] Documentation

## What changed

- recognize JavaScript/TypeScript `subscript_expression` nodes as access paths
- normalize static indexes such as `items[0]` to internal exact paths such as `items.0`
- preserve dotted nesting: `payload.items[0].command` becomes `payload.items.0.command`
- reject dynamic, negative, floating-point, and call-based indexes
- collect array destructuring bindings by zero-based path
- support nested object/array patterns and default-value assignment patterns
- prevent whole-RHS fallback from re-tainting a binding whose exact source path is explicitly clean
- add unit tests for normalization, clean overrides, exact tainted indexes, and sibling isolation
- add differential review-zoo safe/unsafe fixtures
- add a changelog fragment

## Behavioral contract

### Clean exact index

```ts
const items = req.body.items;
items[0] = "safe";
const command = items[0];
```

`command` is clean.

### Sibling isolation

```ts
const items = req.body.items;
items[0] = "safe";
exec(items[1]);
```

`items[1]` remains tainted and produces canonical `taint.exec`.

### Exact tainted index

```ts
const items = ["safe"];
items[0] = req.body.command;
exec(items[0]);
```

The exact index is tainted.

## Scope and non-goals

Included:

- static non-negative integer indexes
- nested property/index paths
- exact clean and tainted overrides
- sibling isolation
- contiguous array destructuring

Not included:

- dynamic indexes such as `items[userIndex]`
- negative or floating-point indexes
- sparse array-pattern hole precision
- array rest-element provenance
- collection mutation methods
- heap alias analysis
- interprocedural propagation

## Public contract

- [x] Existing canonical `taint.*` signal kinds are reused
- [x] No JSON, SARIF, Action, MCP, baseline, or finding-ID changes
- [x] Changed-line sink gating is unchanged
- [x] Unknown indexes remain conservative rather than guessed

## Verification

The execution environment could not resolve GitHub for a local checkout, so CI and CodeQL are the compile/test source of truth.

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] full Rust test suite
- [x] `cargo test --test review_zoo`
- [x] release-contract checks
- [x] CodeQL
