### PR TITLE
docs(release): audit and freeze RepoPilot v0.21 scope

### DIFF
--- a/changes/348-v0.21-release-audit.md
+++ b/changes/348-v0.21-release-audit.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Audited RepoPilot v0.21 against the implemented release pillars, marked the feature scope complete, narrowed language/framework claims to evidence-backed behavior, froze compatibility boundaries, and deferred interprocedural taint, heap aliases, dynamic indexes, collection mutation semantics, arbitrary validator/model-binding inference, new languages, and command-surface expansion to v0.22.

--- a/docs/roadmap/v0.21-release-audit.md
+++ b/docs/roadmap/v0.21-release-audit.md
@@ -1,0 +1,135 @@
+# RepoPilot v0.21.0 — Release Audit and Scope Freeze
+
+Audit baseline: `main` at `ad7d47ec1caef0c7e7b796efb36d4f981aa70522`.
+
+## Verdict
+
+RepoPilot v0.21 is **feature-complete for release preparation**.
+
+The remaining work is release engineering: version synchronization, curated
+release notes, dated changelog consolidation, distribution pins, and the full
+release verification gate. No new detector family, language frontend, public
+command, or report-schema redesign is required to ship v0.21.
+
+After this audit, new behavior belongs in v0.22 unless it fixes a release blocker,
+a correctness regression, or a broken compatibility contract.
+
+## Evidence by release pillar
+
+| Pillar | Status | Evidence |
+|---|---|---|
+| Risk Memory | Complete | PR #324 added opt-in bounded local history, compatible receipt comparison, occurrence-level deltas, corruption handling, and deterministic projections. |
+| Merge Readiness | Complete | PR #324 added the canonical `ready` / `review` / `blocked` record with stable reasons, verification steps, limitations, and optional risk delta. |
+| Ownership-Aware Impact | Complete | PR #324 added GitHub-compatible CODEOWNERS resolution, fallback boundaries, and owner projections across human and machine surfaces. |
+| Local Knowledge Overlays | Complete | PR #323 added committed `.repopilot/overlay.toml` policy, decision provenance, scoped severity/suppression, diagnostics, and legacy feedback compatibility. |
+| Language Frontend Contract | Complete | PRs #299–#322 centralized grammar, imports, review tables, taint tables, runtime risk, conventions, framework probes, generated capability documentation, and support-honesty accounting. |
+| Existing-Language Depth | Complete with honest boundaries | PRs #307, #317, #320, and #336–#340 deepened Java, C#, Kotlin, and JS/TS framework coverage without claiming unsupported whole-framework semantics. |
+| Field-Sensitive Taint Precision | Complete for v0.21 | PRs #341–#347 added exact local member paths, property-aware object destructuring, static array-index paths, index-aware array destructuring, clean overrides, sibling isolation, and differential fixtures. |
+| Trust Hardening | Complete | Overlay fingerprints, bounded/atomic history, explicit diagnostics, deterministic fixtures, unchanged public gates, and the existing cross-platform/release contracts cover the release boundary. |
+
+## Honest language and framework coverage
+
+Release notes and public documentation must describe only evidence-backed
+behavior:
+
+- **Java:** `HttpServletRequest` sources flowing to JDBC `execute*`,
+  `Runtime.exec`, and `Files.write`; the pinned Spring PetClinic demo proves the
+  request-to-exec path. This is not a claim of arbitrary Spring annotation or
+  DTO model-binding analysis.
+- **Kotlin:** Ktor `call.receive*` / parameters, Android Intent and
+  `SavedStateHandle` inputs, Servlet request sources, Kotlin generic-call
+  normalization, and supported SQL/exec/filesystem sinks. This is not a claim
+  that every Spring Kotlin binding is modeled.
+- **C#:** ASP.NET request-owned `Query`, `Form`, and `Headers` flows to
+  `Process.Start`, `SqlCommand.Execute*`, and `File.WriteAll*`, plus
+  `[Authorize]`-related boundary evidence. Arbitrary DTO/model-binding provenance
+  is outside the release claim.
+- **TypeScript/JavaScript:** Express/Koa-compatible request idioms, Next.js App
+  Router, Fastify, Hono, and NestJS decorated controller parameters. A narrow
+  allowlist of NestJS primitive parsing pipes is treated as a clean boundary;
+  configurable and custom pipes remain conservative.
+- **Python:** the existing Python request/sink frontend participates in projects
+  detected as FastAPI, Django, or Flask. Framework detection does not imply
+  semantic knowledge of every dependency-injection or validation path.
+- **Go:** the existing Go request/sink frontend and framework probes cover
+  `net/http`, Gin, Echo, and Fiber idioms already pinned by tests and zoo
+  repositories.
+- **Rust:** boundary evidence and the dedicated panic-risk audit are supported.
+  v0.21 does not claim generic Rust taint propagation.
+
+## Public contract freeze
+
+The v0.21 release must preserve these boundaries:
+
+- no new top-level CLI command;
+- no removed or renamed command, flag, or exit-code behavior;
+- no breaking JSON, SARIF, baseline, Action, MCP, or AI-context change;
+- no new canonical `taint.*` signal family solely for release packaging;
+- history remains opt-in and local-only;
+- `.repopilot/overlay.toml` remains reviewable repository policy;
+- `.repopilot/cache/` and `.repopilot/history/` remain generated local state;
+- findings and review signals remain deterministic and evidence-backed;
+- release packaging must not introduce telemetry, source upload, hosted storage,
+  or implicit LLM calls.
+
+## Deferred to v0.22
+
+The following work is explicitly outside v0.21 and must not delay the release:
+
+- interprocedural taint summaries or call-graph propagation;
+- heap alias analysis;
+- dynamic indexes such as `items[userIndex]`;
+- collection mutation semantics such as `push`, `splice`, and iterator callbacks;
+- sparse array-hole and rest-element provenance;
+- computed object-key provenance;
+- arbitrary custom sanitizer, pipe, validator, or DTO semantics;
+- generalized Spring annotation/model-binding analysis;
+- generalized ASP.NET DTO model-binding provenance;
+- generic Rust taint analysis;
+- a new language frontend;
+- a plugin runtime or executable repository policy;
+- new top-level commands or a command-surface expansion.
+
+## Required release-preparation PR
+
+The next PR must perform one coordinated version and publication update:
+
+1. bump Cargo, npm, native optional packages, lockfiles, Action defaults, reusable
+   workflows, generated init templates, and public examples to `0.21.0`;
+2. add `docs/releases/v0.21.0.md` with user-facing highlights and honest
+   limitations;
+3. consolidate `[Unreleased]` and release fragments into a dated `0.21.0`
+   changelog section;
+4. update roadmap and documentation links from “current” to “shipped” where
+   appropriate;
+5. verify package contents, Action pins, release artifact names, checksums, and
+   supported distribution channels;
+6. run the full release gate.
+
+## Release definition of done
+
+The v0.21 release commit is ready to tag only when all of the following pass:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+cargo test --test review_zoo
+npm run release:contract
+npm run test:release-contract
+npm run test:npm
+./scripts/smoke-product.sh
+./scripts/verify-release.sh
+cargo package
+npm pack --dry-run
+```
+
+Additional release assertions:
+
+- `cargo run --quiet -- --version` prints `0.21.0`;
+- root and native npm package versions are synchronized;
+- generated GitHub Action/bootstrap examples point to `v0.21.0`;
+- public documentation contains no accidental `v0.20.0` current-version pins;
+- the self-scan and real-repo zoo gates remain green;
+- CodeQL and platform smoke jobs pass on the final release head;
+- the release tag is created only after the release PR is merged.

--- a/docs/roadmap/v0.21.md
+++ b/docs/roadmap/v0.21.md
@@ -21,6 +21,17 @@ release answers four questions in one workflow:
 The release remains local-only, deterministic, review-first, and compatible with
 existing command and report surfaces.
 
+## Release Status
+
+The v0.21 feature scope is complete. The authoritative evidence and remaining
+release-engineering checklist are recorded in the
+[v0.21 release audit and scope freeze](v0.21-release-audit.md).
+
+After the scope freeze, new behavior belongs in v0.22 unless it fixes a release
+blocker, a correctness regression, or a broken compatibility contract. The
+remaining v0.21 work is version synchronization, curated release notes, dated
+changelog consolidation, distribution pins, and the full release gate.
+
 ## Release Pillars
 
 ### Risk Memory
@@ -54,17 +65,24 @@ boundaries without inventing people or mining Git history.
 The release improves current rule-aware frontends instead of adding a shallow
 ninth language:
 
-- Java: Spring MVC and Spring Boot request-to-sink flows;
-- Kotlin: Spring and Ktor flows plus Kotlin call-expression precision;
-- C#: ASP.NET Core request/model-binding flows;
-- TypeScript and JavaScript: Next.js App Router, Express, Fastify, and Hono;
-- Python: FastAPI, Django, and Flask flows;
-- Go: `net/http`, Gin, Echo, and Fiber flows;
-- Rust: Axum, Actix, and Rocket boundary evidence plus panic-risk precision.
+- Java: `HttpServletRequest` inputs flowing to JDBC `execute*`, `Runtime.exec`,
+  and `Files.write`, with a pinned Spring PetClinic demonstration;
+- Kotlin: Ktor, Android, and Servlet request sources plus Kotlin generic-call,
+  flow-scope, and string-template precision;
+- C#: ASP.NET request-owned query, form, and header values flowing to supported
+  process, SQL, and filesystem sinks, plus authorization-boundary evidence;
+- TypeScript and JavaScript: Express/Koa-compatible request idioms, Next.js App
+  Router, Fastify, Hono, and NestJS decorated controller parameters;
+- Python: the existing request/sink frontend used in FastAPI, Django, and Flask
+  repositories, without claiming arbitrary dependency-injection semantics;
+- Go: the existing `net/http`, Gin, Echo, and Fiber request/sink vocabulary and
+  framework probes;
+- Rust: Axum, Actix, and Rocket boundary evidence plus the dedicated panic-risk
+  audit; generic Rust taint is not claimed.
 
 Every behavior change requires a minimal unsafe fixture and a near-identical
-safe guard. Rust does not gain a generic taint claim without an evidence-backed
-design.
+safe guard. Framework detection alone does not imply semantic coverage of every
+validator, dependency-injection path, custom pipe, DTO, or model-binding shape.
 
 ### Trust Hardening
 
@@ -135,6 +153,23 @@ Development follows red-green-refactor for each behavior:
 - per-framework safe/unsafe language fixtures;
 - generated documentation and schema compatibility;
 - full release gate and self-scan before handoff.
+
+## Scope Freeze and v0.22 Deferrals
+
+The following are explicitly outside the v0.21 release and must not delay it:
+
+- interprocedural taint summaries or call-graph propagation;
+- heap alias analysis;
+- dynamic index analysis;
+- collection mutation and iterator-callback provenance;
+- sparse array holes, rest elements, and computed object keys;
+- arbitrary custom sanitizer, validator, pipe, or DTO semantics;
+- generalized Spring annotation/model-binding analysis;
+- generalized ASP.NET DTO model-binding provenance;
+- generic Rust taint analysis;
+- a new language frontend;
+- a plugin runtime or executable overlay rules;
+- a new top-level command.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary

Audit the implemented RepoPilot v0.21 feature set, mark the release feature-complete, align language/framework claims with evidence-backed behavior, and freeze new engine work until the release-preparation PR is complete.

## What changed

- add `docs/roadmap/v0.21-release-audit.md` as the release-readiness source of truth
- map the v0.21 pillars to merged implementation evidence
- mark the remaining work as release engineering rather than feature development
- narrow Java, Kotlin, C#, JavaScript/TypeScript, Python, Go, and Rust claims to behavior actually supported by the frontends and fixtures
- explicitly defer interprocedural taint, heap aliases, dynamic indexes, collection mutations, rest/computed provenance, arbitrary validator/model-binding semantics, generic Rust taint, new languages, and command-surface expansion to v0.22
- add the exact release-preparation checklist and final gate commands
- update the v0.21 release contract with feature-complete status, scope freeze, and the audit link
- add a changelog fragment

## Why

`main` already contains the core v0.21 product: local risk memory, canonical merge readiness, CODEOWNERS-aware impact, local overlays, the unified language frontend contract, deeper framework request flows, and field-sensitive intra-procedural taint precision.

Continuing to add unrelated detector behavior would increase release risk and keep Cargo/npm/Action users on v0.20. This PR establishes an explicit boundary: only release blockers and compatibility regressions may change behavior before v0.21.0 ships.

The audit also corrects overly broad wording. For example, the current implementation proves Java Servlet/JDBC flows, Kotlin Ktor/Android/Servlet flows, and ASP.NET request-owned values; it does not claim arbitrary Spring or ASP.NET DTO model-binding semantics.

## Contract and ownership

- [x] Documentation and release-contract scope only
- [x] No runtime detector or output behavior changes
- [x] No CLI, JSON, SARIF, baseline, Action, MCP, AI-context, signal-kind, or exit-code changes
- [x] No version bump or release tag in this PR
- [x] v0.22 deferrals are explicit and reviewable

## Verification

CI and CodeQL are the verification source because the execution environment cannot resolve GitHub for a local checkout.

- [ ] Markdown/documentation checks
- [ ] release-contract checks
- [ ] full CI
- [ ] CodeQL

## Next PR after merge

`chore(release): prepare RepoPilot v0.21.0`

That PR will synchronize Cargo/npm/native packages/Action pins/templates, add curated release notes, consolidate the dated changelog, and run the complete release gate. It will not create or push the release tag.