### PR TITLE
docs(release): consolidate v0.21.0 changelog and surface it in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,6 @@ precision.
 
 ### Added
 
-- **Fastify request taint analysis.** The JavaScript/TypeScript frontend now
-  recognizes Fastify URL and proxy-derived request metadata, including
-  `request.raw.url`, `request.url`, `request.ip`, `request.ips`,
-  `request.hostname`, and `request.protocol`, as HTTP request sources.
-  Parameterized SQL remains quiet, `reply.send()` is excluded from source
-  classification, and differential safe/unsafe review-zoo fixtures pin the
-  request-to-raw-SQL boundary.
-- **Next.js App Router taint analysis.** The JavaScript/TypeScript frontend
-  now recognizes `NextRequest.nextUrl.searchParams`, `Request.json()`, and
-  `Request.formData()` as HTTP request sources, surfacing changed App Router
-  handlers where untrusted input reaches raw SQL, exec, or filesystem-write
-  sinks through the existing taint-lite contract. Parameterized SQL remains
-  quiet, outbound `Response.json()` is excluded, and differential safe/unsafe
-  review-zoo fixtures pin the precision boundary.
 - **Opt-in local risk memory.** `scan` and `review` accept
   `--record-history`, or repositories can enable `[history]` explicitly.
   Versioned, bounded receipts under `.repopilot/history/` compare only
@@ -58,10 +44,51 @@ precision.
   suppressions still apply as a fallback so existing files keep working
   unchanged until migrated. Supersedes `.repopilot/feedback.yml`, which now
   emits a deprecation warning.
-- **Framework probes refactoring.** Framework detection probes for JS/TS (`NextJs`,
-  `React`, `ReactNative`, `Expo`, `Vue`, `Nuxt`, `Svelte`, `Angular`, `Express`, `NestJs`),
-  Python (`Django`, `Flask`, `FastApi`), and Go (`Gin`, `Echo`, `Fiber`) now register
-  through their respective language frontends in the unified frontend registry.
+- **Field-sensitive taint-lite precision.** The taint-lite flow engine now
+  tracks exact local member and array-index paths instead of collapsing an
+  object or array to one tainted/clean state: request input assigned to a
+  single field or index reaches sinks while clean sibling fields, array
+  elements, and destructured bindings — including property-aware object
+  destructuring and index-aware array destructuring — stay quiet, and a
+  clean, exact field or index reassignment can override prior taint on
+  that path. Rest patterns, computed keys, and dynamic (non-literal) index
+  provenance stay outside this slice's contract, deferred alongside
+  collection-mutation and interprocedural propagation. Differential
+  review-zoo fixtures pin each precision boundary.
+- **Next.js App Router taint analysis.** The JavaScript/TypeScript frontend
+  now recognizes `NextRequest.nextUrl.searchParams`, `Request.json()`, and
+  `Request.formData()` as HTTP request sources, surfacing changed App Router
+  handlers where untrusted input reaches raw SQL, exec, or filesystem-write
+  sinks through the existing taint-lite contract. Parameterized SQL remains
+  quiet, outbound `Response.json()` is excluded, and differential safe/unsafe
+  review-zoo fixtures pin the precision boundary.
+- **Fastify request taint analysis.** The JavaScript/TypeScript frontend now
+  recognizes Fastify URL and proxy-derived request metadata, including
+  `request.raw.url`, `request.url`, `request.ip`, `request.ips`,
+  `request.hostname`, and `request.protocol`, as HTTP request sources.
+  Parameterized SQL remains quiet, `reply.send()` is excluded from source
+  classification, and differential safe/unsafe review-zoo fixtures pin the
+  request-to-raw-SQL boundary.
+- **Hono request taint analysis.** The JavaScript/TypeScript frontend now
+  recognizes Hono context request APIs — `c.req.query()`, `c.req.queries()`,
+  `c.req.param()`, `c.req.header()`, `c.req.json()`, `c.req.parseBody()`,
+  `c.req.text()`, `c.req.arrayBuffer()`, `c.req.raw`, and `c.req.url` — as
+  HTTP request sources. Parameterized SQL remains quiet, `c.json()` response
+  serialization is excluded from request-source classification, and
+  differential safe/unsafe review-zoo fixtures pin the request-to-raw-SQL
+  boundary.
+- **NestJS controller parameter taint analysis.** Controller parameters
+  decorated with `@Body()`, `@Query()`, `@Param()`, `@Headers()`, `@Req()`, or
+  `@Request()` are now treated as HTTP request sources for intra-procedural
+  taint propagation. Response, dependency-injection, and custom decorators
+  remain excluded, parameterized SQL stays quiet, and differential
+  review-zoo fixtures pin the safe and unsafe boundaries.
+- **NestJS primitive pipe sanitizers.** Parameters decorated with the
+  built-in `ParseIntPipe`, `ParseFloatPipe`, `ParseBoolPipe`, or
+  `ParseUUIDPipe` are treated as validated primitive inputs and no longer
+  carry taint into sinks. `ValidationPipe`, `ParseEnumPipe`, and custom
+  pipes stay tainted unless their safety can be proven, keeping the
+  sanitizer boundary conservative.
 - **Kotlin taint analysis.** Added Ktor (`call.receiveText`, `call.parameters`),
   Android (`intent.getStringExtra`, `savedStateHandle.get`), and Servlet request
   sources → `Exec`, `Sql`, and `FsWrite` sinks in Kotlin taint tables. Callee
@@ -70,16 +97,6 @@ precision.
   and string-building node kinds were also widened (`primary_constructor`,
   `class_initializer`, `property_accessor`, Kotlin's `line`/`multi_line` string
   templates).
-- **Support-honesty ledger is now empty.** Rust's dedicated
-  `language.rust.panic-risk` audit — 1.6k lines of context-sensitive
-  detection (structural infallibility, report-renderer path awareness) that
-  doesn't fit the shared per-language `RiskTables` shape — is now accounted
-  for via a documented `dedicated_risk_audit` marker on its frontend rather
-  than left uncounted. It satisfies the `RuntimeRisk` capability alongside
-  the shared table other languages use; no pattern logic moved. The
-  generated support matrix renders this distinctly as "✓ (dedicated)". Every
-  language the knowledge pack declares `rule-aware` now computes to
-  `rule-aware` through the frontend contract, with zero exceptions left.
 - **C# completes its frontend contract.** `using`-directive import
   extraction (aliases and `global using` included; `using (resource)` forms
   excluded) feeds the coupling graph; ASP.NET taint tables
@@ -98,6 +115,20 @@ precision.
   Spring PetClinic checkout stays at zero findings. A second reproducible
   demo (`scripts/demo-java-agent-edit.sh`, `docs/demos/04-java-agent-review.gif`)
   shows the flow being caught.
+- **Framework probes refactoring.** Framework detection probes for JS/TS (`NextJs`,
+  `React`, `ReactNative`, `Expo`, `Vue`, `Nuxt`, `Svelte`, `Angular`, `Express`, `NestJs`),
+  Python (`Django`, `Flask`, `FastApi`), and Go (`Gin`, `Echo`, `Fiber`) now register
+  through their respective language frontends in the unified frontend registry.
+- **Support-honesty ledger is now empty.** Rust's dedicated
+  `language.rust.panic-risk` audit — 1.6k lines of context-sensitive
+  detection (structural infallibility, report-renderer path awareness) that
+  doesn't fit the shared per-language `RiskTables` shape — is now accounted
+  for via a documented `dedicated_risk_audit` marker on its frontend rather
+  than left uncounted. It satisfies the `RuntimeRisk` capability alongside
+  the shared table other languages use; no pattern logic moved. The
+  generated support matrix renders this distinctly as "✓ (dedicated)". Every
+  language the knowledge pack declares `rule-aware` now computes to
+  `rule-aware` through the frontend contract, with zero exceptions left.
 - **Generated language support matrix.** `docs/language-support.md` is now
   rendered from the language frontend registry with a drift test
   (`REPOPILOT_BLESS=1 cargo test --test language_support_doc`): capability

--- a/README.md
+++ b/README.md
@@ -99,6 +99,40 @@ Signals are advisory by default. Gate CI on the high-confidence tier:
 repopilot review . --base origin/main --fail-on-review definitely
 ```
 
+Every review also resolves to one merge-readiness verdict — `ready`,
+`review`, or `blocked` — built from findings, review signals, CODEOWNERS,
+and blast radius, with deterministic reason codes and suggested owners.
+Console, Markdown, JSON, MCP, and the GitHub Action summary all read the
+same record.
+
+## Compare risk across runs
+
+History is local, bounded, and off by default. Record two compatible
+analyses to see what's new, persisting, resolved, or changed severity —
+nothing leaves your machine:
+
+```bash
+repopilot review . --record-history
+repopilot scan . --record-history
+```
+
+Receipts live under `.repopilot/history/`.
+
+To calibrate a known rule to your repository instead of silencing it
+project-wide, add a scoped, diffable entry to `.repopilot/overlay.toml`:
+
+```toml
+[[overlay]]
+rule = "behavioral.panic-risk"
+path = "src/cli/**"
+severity = "low"
+reason = "CLI handlers can terminate on unrecoverable input"
+```
+
+Overlay decisions stay visible in `--profile strict` and the decision
+trace — never a silent post-scan filter. Details:
+[Configuration](https://github.com/MykytaStel/repopilot/blob/main/docs/configuration.md).
+
 ## Guard an agent run
 
 Take a snapshot before the agent starts, review everything it did — commits

--- a/changes/338-hono-request-taint.md
+++ b/changes/338-hono-request-taint.md
@@ -1,3 +1,0 @@
-### Added
-
-- **Hono request taint analysis.** The JavaScript/TypeScript frontend now recognizes Hono context request APIs including `c.req.query()`, `c.req.queries()`, `c.req.param()`, `c.req.header()`, `c.req.json()`, `c.req.parseBody()`, `c.req.text()`, `c.req.arrayBuffer()`, `c.req.raw`, and `c.req.url` as HTTP request sources. Parameterized SQL remains quiet, Hono response helpers such as `c.json()` are excluded from request-source classification, and differential safe/unsafe review-zoo fixtures pin the request-to-raw-SQL boundary.

--- a/changes/339-nestjs-controller-taint.md
+++ b/changes/339-nestjs-controller-taint.md
@@ -1,3 +1,0 @@
-### Added
-
-- **NestJS controller parameter taint analysis.** RepoPilot now treats request-bound controller parameters decorated with `@Body()`, `@Query()`, `@Param()`, `@Headers()`, `@Req()`, or `@Request()` as HTTP request sources for intra-procedural taint propagation. Response, dependency-injection, and custom decorators remain excluded, parameterized SQL stays quiet, and differential review-zoo fixtures pin the safe and unsafe boundaries.

--- a/changes/340-nestjs-pipe-sanitizers.md
+++ b/changes/340-nestjs-pipe-sanitizers.md
@@ -1,2 +1,0 @@
-- Treat NestJS `ParseIntPipe`, `ParseFloatPipe`, `ParseBoolPipe`, and `ParseUUIDPipe` controller parameters as validated primitive inputs in taint-lite.
-- Keep `ValidationPipe`, `ParseEnumPipe`, and custom pipes tainted unless their safety can be proven.

--- a/changes/341-field-sensitive-local-taint.md
+++ b/changes/341-field-sensitive-local-taint.md
@@ -1,2 +1,0 @@
-- Track exact local member paths in taint-lite so request input assigned to one object field reaches sinks without tainting clean siblings.
-- Let clean exact-field reassignments override whole-object taint and reduce field-level false positives.

--- a/changes/342-destructuring-taint-provenance.md
+++ b/changes/342-destructuring-taint-provenance.md
@@ -1,2 +1,0 @@
-- Lock object-destructuring taint propagation, alias bindings, and parameterized SQL safety with differential review-zoo coverage.
-- Keep rest patterns, computed keys, and array index provenance outside this slice.

--- a/changes/343-property-aware-destructuring-taint.md
+++ b/changes/343-property-aware-destructuring-taint.md
@@ -1,2 +1,0 @@
-- Improve taint precision for static object destructuring by resolving each local binding against its source property path.
-- Preserve clean field overrides when destructuring from an otherwise tainted object while keeping unknown, rest, and computed patterns conservative.

--- a/changes/344-array-destructuring-taint-contract.md
+++ b/changes/344-array-destructuring-taint-contract.md
@@ -1,2 +1,0 @@
-- Add review-zoo coverage that locks conservative taint propagation through static array destructuring while keeping clean local arrays silent.
-- Document that exact numeric-index tracking and dynamic index analysis remain outside the current taint-lite contract.

--- a/changes/345-static-subscript-taint-contract.md
+++ b/changes/345-static-subscript-taint-contract.md
@@ -1,1 +1,0 @@
-- Add review-zoo coverage for direct static numeric subscript taint propagation and parameterized-safe usage.

--- a/changes/346-exact-static-array-index-paths.md
+++ b/changes/346-exact-static-array-index-paths.md
@@ -1,1 +1,0 @@
-- Taint-lite now tracks static numeric array indexes as exact local paths, including index-aware destructuring and clean sibling-preserving overrides.

--- a/changes/348-v0.21-release-audit.md
+++ b/changes/348-v0.21-release-audit.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Audited RepoPilot v0.21 against the implemented release pillars, marked the feature scope complete, narrowed language/framework claims to evidence-backed behavior, froze compatibility boundaries, and deferred interprocedural taint, heap aliases, dynamic indexes, collection mutation semantics, arbitrary validator/model-binding inference, new languages, and command-surface expansion to v0.22.


### PR DESCRIPTION
## Summary

- Merges 9 unconsolidated changelog fragments from `changes/*.md` (Hono taint, NestJS controller/pipe taint, field-sensitive taint-lite precision — PRs #338-#347) into `CHANGELOG.md`'s `[0.21.0]` section. `release-contract.py check` passed but the release-prep PR (#349) never actually folded these in.
- Reorders the `### Added` list so the release's three flagship pillars (risk memory, merge readiness, `.repopilot/overlay.toml`) lead, matching the order already promised in the section's own intro paragraph, ahead of the language-by-language work.
- Removes the now-merged fragment files from `changes/`.
- Adds a "Compare risk across runs" section to README.md covering `--record-history` and `.repopilot/overlay.toml`, plus a merge-readiness callout under "Review a change" — none of the three headline 0.21 features were mentioned in the README before.

## Verification

- `python3 scripts/release-contract.py check` — passed
- Docs-only change; no code/test surface touched