### PR TITLE
feat: start v0.22 repository intelligence core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Changed
+
+- Reuse one internal graph-v2 context analysis for AI-context degree metrics,
+  direct dependents, and capability state, preserving the existing bounded
+  context summary, JSON, MCP, and readiness contracts.
+
 ## [0.21.0] - 2026-08-06
 
 RepoPilot 0.21 turns deterministic repository analysis into a local merge

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@ adoption or CI policy.
 
 ## Maintainer Guides
 
+- [v0.22 repository intelligence design](engineering/v0.22-repository-intelligence-design.md)
+- [v0.22 Phase A1 context graph specification](engineering/v0.22-phase-a1-context-graph-v2.md)
 - [Analysis platform state](engineering/analysis-platform-state.md)
 - [Dependency Graph v2 design](engineering/dependency-graph-v2.md)
 - [Signal contract](engineering/signal-contract.md)
@@ -40,6 +42,7 @@ adoption or CI policy.
 - [Release process](release.md)
 - [Distribution](distribution.md)
 - [Roadmap](roadmap.md)
+- [v0.22 roadmap and release contract](roadmap/v0.22.md)
 - [v0.21 roadmap and release contract](roadmap/v0.21.md)
 - [v0.20 roadmap and release contract](roadmap/v0.20.md)
 - [v0.20 release scorecard](engineering/v0.20-release-scorecard.md)

--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -101,8 +101,9 @@ facts remain later milestones.
 RepoPilot still needs a deeper fact-based platform with:
 
 - a richer `RepoFacts` model beyond the initial scan-facts bridge;
-- a first-class dependency graph with explicit core types and contracts,
-  following the [Dependency Graph v2 design](dependency-graph-v2.md);
+- completion of the graph-v2 migration for the persisted context graph and its
+  historical bounded cycle projection, following the
+  [Dependency Graph v2 design](dependency-graph-v2.md);
 - symbol facts for definitions, references, ownership, and relationships;
 - rule capabilities that declare which facts and analysis levels a rule needs;
 - language support tiers that make analysis depth and guarantees explicit;
@@ -165,17 +166,17 @@ builder now exist; the builder reuses RepoPilot's shared language-aware import
 resolvers and emits typed edges (`Imports`/`DependsOn`/`TestOf`) carrying
 provenance and a confidence tier. Deterministic internal graph algorithms cover
 degrees, hubs, SCC cycles, neighborhoods, transitive blast radius, directory-level
-dependency aggregation, and summaries. The `architecture.circular-dependency` scan
-rule now consumes the v2 SCC cycle detection internally (the first graph-related
-rule migrated); the remaining algorithms are not yet product-facing.
+dependency aggregation, and summaries. All three import-coupling scan rules and
+review blast radius consume graph v2. AI-context fallback metrics and the primary
+context summary use graph-v2 degrees and direct dependents; the primary summary
+reuses one internal analysis view for degrees, dependents, and capability state.
+The persisted `RepoContextGraph` and historical bounded cycle representation
+remain compatibility surfaces pending differential migration.
 
-1. Migrate remaining graph-related architecture rules to graph v2. The
-   `architecture.circular-dependency` rule now uses graph v2 cycle detection
-   internally (first rule migrated); remaining graph-related rules still need
-   migration.
-2. Feed graph v2 blast radius into review.
-3. Feed graph v2 hot files into AI context.
-4. Add graph capabilities metadata for rules.
-5. Add language support tiers.
-6. Add runtime evidence ingestion.
-7. Add evaluation fixtures.
+1. Migrate the persisted context graph and bounded cycle projection only after
+   graph-v2 parity fixtures cover their deferred-edge and path semantics.
+2. Make graph capability metadata enforce rule requirements and honest skips.
+3. Add language support tiers.
+4. Enrich the internal `RepoFacts` model with symbol/reference relationships.
+5. Add explicit, allowlisted local verification evidence.
+6. Add evaluation fixtures and expand zoo-backed rule coverage.

--- a/docs/engineering/dependency-graph-v2.md
+++ b/docs/engineering/dependency-graph-v2.md
@@ -19,8 +19,9 @@ external dependency nodes, and unresolved relative imports record a bounded
 diagnostic. Edges carry typed kinds (`Imports` for resolved local files,
 `DependsOn` for external dependencies, `TestOf` for co-located test files),
 provenance, and a confidence tier (high for resolved files, medium for external
-packages, low for unresolved relative imports). It is not yet used by scan
-findings, review blast radius, AI context, or public report schemas.
+packages, low for unresolved relative imports). Graph-v2 projections now back
+the import-coupling scan rules, review blast radius, and AI-context graph metrics
+without exposing raw graph internals in public report schemas.
 
 Graph v2 now has internal algorithms for degree summaries, hubs, SCC-based cycle
 detection, local neighborhoods, transitive blast radius (reverse dependents of a
@@ -59,11 +60,13 @@ roadmap's rule-capability checks, with no command or report consumer yet. The v1
 `compute_metrics`/`RepoContextGraph` paths remain for consumers not yet migrated;
 all migrated outputs are byte-for-byte unchanged and guarded by parity tests.
 
-The largest remaining migration is the context graph subsystem
-(`RepoContextGraph` / `context_graph_summary`), which still backs the *primary* AI
-context graph projection (edit order, blast radius, high-context files). It should
-move to graph v2 only once v2 has equivalent deterministic fixtures and bounded
-behavior, as below.
+The primary `context_graph_summary` now constructs one reusable internal
+graph-v2 analysis view for degree metrics, one-hop dependents, and capability
+state. The persisted `RepoContextGraph` schema and historical bounded cycle
+projection remain compatibility paths: cycle output deliberately excludes
+deferred imports and Rust module-containment edges and is not equivalent to SCC
+membership. Those paths should move only after differential fixtures prove
+equivalent deterministic and bounded behavior.
 
 Today, `CouplingGraph`, `RepoContextGraph`, import extraction, language
 resolvers, review signals, and graph summaries provide useful behavior. Graph
@@ -292,12 +295,11 @@ internal.
    graph-related rules can migrate onto the same snapshot next.
 2. **Done.** Feed graph v2 into review blast radius: the importer inversion is
    sourced from the snapshot via one-hop `direct_dependents`, output unchanged.
-3. **Done (fallback).** Feed graph v2 into AI context hot files: the coupling
-   fallback uses `coupling_file_metrics`. The primary `context_graph_summary`
-   projection still needs migration (see below).
+3. **Done (A1).** Feed graph v2 into AI context hot files and primary context
+   summary metrics. One internal context analysis view supplies degrees,
+   one-hop dependents, and capability state without repeated snapshot builds.
 4. **Done (foundation).** Add graph capability metadata (`graph_capabilities`).
    No rule consumes it yet; wiring rules to declare required graph facts is next.
-5. Migrate the context graph subsystem (`RepoContextGraph` /
-   `context_graph_summary`) to graph v2 so the primary AI context projection and
-   review signals share one model. This is the largest remaining step and should
-   land only behind equivalent deterministic fixtures.
+5. Migrate the persisted `RepoContextGraph` schema/cache and historical bounded
+   cycle projection after differential fixtures cover deferred imports, Rust
+   module-containment edges, changed-scan patching, and cycle ordering.

--- a/docs/engineering/v0.22-phase-a1-context-graph-v2.md
+++ b/docs/engineering/v0.22-phase-a1-context-graph-v2.md
@@ -1,0 +1,119 @@
+# RepoPilot 0.22 Phase A1 — Canonical Context Graph Analysis
+
+**Status:** Approved
+**Parent:** [v0.22 repository intelligence design](v0.22-repository-intelligence-design.md)
+
+## Problem
+
+Graph-based scan rules and review blast radius already use graph v2, but the
+primary context graph summary still constructs graph-v2 snapshots separately for
+degree metrics and direct dependents while retaining a compatibility
+`RepoContextGraph` for changed-scan persistence and public summary stability.
+Graph capability metadata exists but is not available at this context-analysis
+boundary.
+
+The local harness also omits the already registered
+`repopilot_explain_review_signal` tool from `AGENTS.md`, so the harness integrity
+check fails even though the MCP integration tests pass.
+
+## Outcome
+
+- One internal `ContextGraphAnalysis` builds the reusable graph-v2 snapshot,
+  path lookup, degree summary, direct dependents, and capability state once.
+- `summarize_context_graph` consumes that view for hubs, dependencies, and
+  changed blast radius without constructing separate snapshots.
+- Existing `ContextGraphSummary` JSON, ordering, truncation, rule IDs, findings,
+  and readiness results remain byte-compatible.
+- Existing cycle behavior remains unchanged in A1 because it deliberately
+  excludes deferred imports and Rust module-containment edges and its historical
+  bounded-cycle projection is not equivalent to graph-v2 SCC membership.
+- The local harness lists all six registered MCP tools and passes.
+- Targeted benchmarks show no unexplained regression greater than 10%.
+
+## Scope
+
+### In scope
+
+- A focused internal analysis view under `src/graph/context/`.
+- Reuse of `build_coupling_graph_snapshot`, `compute_degrees`,
+  `direct_dependents`, and `graph_capabilities`.
+- Exact parity tests against the current context summary for isolated files,
+  hubs, dependencies, changed blast radius, truncation, and stable ordering.
+- Local `AGENTS.md` MCP-tool parity correction.
+- Targeted graph/context tests, AI-context golden tests, MCP tests, and review
+  performance comparison.
+- Documentation of A1 completion in the graph-v2 and platform-state documents.
+
+### Out of scope
+
+- Removing the persisted `RepoContextGraph` schema or cache.
+- Changing `ContextGraphSummary` or any public report schema.
+- Replacing the historical bounded cycle representation with SCC output.
+- Capability-aware rule scheduling; A1 exposes the internal input required by a
+  later Phase A slice.
+- Broken-code detectors, repository health scoring, verification execution, or
+  new MCP tools.
+- New public commands.
+
+## Interfaces
+
+Add an internal type in `src/graph/context/analysis.rs`:
+
+```rust
+pub(super) struct ContextGraphAnalysis {
+    path_by_id: BTreeMap<GraphNodeId, PathBuf>,
+    degrees: GraphDegreeSummary,
+    dependents: BTreeMap<GraphNodeId, BTreeSet<GraphNodeId>>,
+    capabilities: GraphCapabilities,
+}
+```
+
+The constructor builds one temporary `GraphSnapshot`, computes the reusable
+derived values, and then drops the snapshot rather than retaining a duplicate
+graph representation in memory.
+
+Required methods:
+
+```rust
+impl ContextGraphAnalysis {
+    pub(super) fn from_graph(graph: &RepoContextGraph) -> Self;
+    pub(super) fn file_metrics(&self) -> Vec<FileMetrics>;
+    pub(super) fn direct_dependents_by_path(
+        &self,
+    ) -> BTreeMap<PathBuf, BTreeSet<PathBuf>>;
+    pub(super) fn capabilities(&self) -> &GraphCapabilities;
+}
+```
+
+`summarize_context_graph` constructs one view and uses its metrics and dependents.
+Capabilities remain internal in A1 and are covered by tests so later rule
+scheduling can consume them without another graph traversal.
+
+## Constraints
+
+- No public schema or CLI change.
+- No additional filesystem scan or source parse.
+- Stable ordering must come from ordered maps/sets and existing summary sorts.
+- Deferred imports remain excluded from cycle detection only, matching the
+  existing contract.
+- The compatibility cache schema version does not change.
+- Files remain below the repository's 300-line guidance.
+- No network, time-dependent output, or randomness.
+
+## Verification
+
+- [ ] Local harness reports no MCP parity error.
+- [ ] New analysis-view unit tests prove isolated nodes, degree/path mapping,
+      dependent direction, and capability counts.
+- [ ] Context summary parity tests cover output ordering and truncation.
+- [ ] Existing graph/context and AI-context tests pass.
+- [ ] MCP CLI integration tests pass.
+- [ ] Changed-review performance gate passes with no budget increase.
+- [ ] `git diff --check` and formatting pass.
+
+## Follow-up Boundary
+
+Phase A2 will decide how to migrate historical cycle projection, changed-scan
+context cache, and `RepoContextGraph` serialization onto graph-v2-native inputs.
+That work must start from differential fixtures rather than assuming SCC output
+is compatible with the existing cycle list.

--- a/docs/engineering/v0.22-repository-intelligence-design.md
+++ b/docs/engineering/v0.22-repository-intelligence-design.md
@@ -1,0 +1,212 @@
+# RepoPilot 0.22 Repository Intelligence Design
+
+**Status:** Draft for user review
+**Release contract:** `docs/roadmap/v0.22.md`
+
+## Intent
+
+RepoPilot 0.22 develops the existing product rather than recreating it. The
+public entry points remain `review` for a change and `scan` for a repository.
+MCP, GitHub Action, JSON, SARIF, and AI context expose the same underlying
+analysis.
+
+The release is designed for two primary users:
+
+- developers and coding agents that need a fast, evidence-backed pre-merge loop;
+- maintainers that need a deeper, incremental view of repository health.
+
+## Chosen Approach
+
+Use one evidence-driven intelligence core instead of either a rules-first
+expansion or a standalone command runner.
+
+A rules-first release would increase catalog size before signal quality and
+shared facts are strong enough. A verification-first release would duplicate
+task-runner behavior without understanding why a failure matters. The chosen
+approach deepens facts, graph, capabilities, and canonical evidence first, then
+adds conservative broken-code detectors and explicit verification.
+
+## Architecture
+
+```text
+files + manifests + Git change
+              |
+              v
+incremental analysis session
+  - content identities
+  - parsed artifacts
+  - repository facts
+  - cache telemetry
+              |
+              v
+graph v2 + capability state
+  - typed nodes and edges
+  - provenance and confidence
+  - bounded diagnostics
+              |
+              v
+analysis consumers
+  - audit rules
+  - review signals
+  - broken-code evidence
+  - repository-health evidence
+              |
+              v
+optional configured verification
+  - selected check IDs only
+  - bounded child processes
+  - structured outcomes
+              |
+              v
+canonical evidence and readiness
+              |
+              v
+CLI / JSON / SARIF / MCP / Action / AI context
+```
+
+### Analysis Session
+
+One command invocation owns one analysis session. It resolves workspace and
+configuration identities, collects file inputs, reuses compatible parsed facts,
+builds required derived facts, and makes those immutable results available to
+consumers. Consumers do not rescan the filesystem or reparse the same content.
+
+The session records bounded timing and cache telemetry. Timing never participates
+in deterministic output identities.
+
+### Facts and Capabilities
+
+Facts describe observed repository data. Capabilities describe whether the
+current scope and language support are sufficient for a consumer to make a
+claim. A missing capability produces an explicit skipped/limited state rather
+than a low-quality finding.
+
+Rule requirements remain declarative. The scheduler uses them to avoid work not
+required by the active profile, scope, and rule set.
+
+### Graph
+
+Graph v2 is the canonical dependency representation. The immediate migration
+target is the primary context graph still used by AI context. Migration must
+preserve output through parity fixtures before the old path is retired.
+
+The graph remains internal and bounded. Public outputs receive stable summaries,
+impact paths, capabilities, and diagnostics rather than raw unstable graph data.
+
+### Evidence Model
+
+All evidence has a stable category, location or repository scope, provenance,
+confidence, applicability, bounded supporting details, and limitations. When
+applicable it also carries impacted paths, ownership suggestions, and a
+verification recommendation or result.
+
+Static findings, review signals, and verification outcomes remain distinguishable
+evidence types. The canonical readiness derivation consumes them without
+flattening their semantics.
+
+### Verification
+
+Verification policies are repository configuration, not call-time shell input.
+A request can select configured check IDs but cannot modify their executable,
+arguments, working directory, or environment contract.
+
+Each execution produces one of: passed, failed, timed out, unavailable, cancelled,
+or skipped as inapplicable. Output is bounded and redacted. Failed execution
+cannot erase static evidence; passed execution can satisfy a matching readiness
+requirement only when that relationship is explicit and deterministic.
+
+Because repository commands execute repository-controlled code, MCP calls that
+request verification cannot retain the current read-only annotation. Static MCP
+calls remain read-only.
+
+## Product Flows
+
+### Developer and Coding-Agent Flow
+
+1. Determine the exact Git change or snapshot range.
+2. Load cached facts for unchanged content.
+3. Analyze changed files and only required dependency context.
+4. Derive findings, signals, impact, owners, and limitations.
+5. Optionally execute explicitly requested configured checks.
+6. Produce one readiness verdict and stable reason codes.
+7. Let the agent query exact findings or signals through existing explain tools.
+8. Repeat after edits with revision-aware invalidation.
+
+### Maintainer Flow
+
+1. Run a full or scheduled local scan.
+2. Reuse compatible facts and graph state.
+3. Derive repository-wide findings, hotspots, boundary drift, and health groups.
+4. Compare occurrence-level results with compatible local history.
+5. Run selected configured checks when explicitly requested.
+6. Prioritize current problems and regressions without hiding accepted debt.
+7. Export the same canonical evidence through reports, MCP, or AI context.
+
+## Error and Trust Boundaries
+
+- Unresolved or ambiguous relationships retain uncertainty.
+- Corrupt cache entries are ignored with diagnostics; analysis runs fresh.
+- Unsupported language semantics never become definitive broken-code findings.
+- Verification spawn errors and timeouts are visible and do not crash static
+  analysis.
+- Child output cannot exceed configured storage or response bounds.
+- Workspace edits invalidate incompatible handles and verification cache entries.
+- Root confinement applies to configuration, working directories, evidence
+  paths, and MCP arguments.
+- Human-facing evidence passes through centralized redaction.
+- RepoPilot never claims a repository is safe; it reports what evidence was and
+  was not evaluated.
+
+## Performance Design
+
+Performance work follows measured stage costs rather than broad optimization.
+
+- Preserve existing review and scan budgets as the baseline.
+- Treat changed review latency as the primary product budget.
+- Build or load each parsed artifact once per content identity.
+- Build each required graph snapshot once per compatible analysis session.
+- Cache only deterministic results with complete invalidation inputs.
+- Do not cache uncertainty as successful evidence.
+- Record cold/warm behavior and hit/miss/invalidation counts.
+- Measure peak RSS before adopting a hard memory ceiling.
+- Require deterministic output across supported thread counts.
+
+## Delivery Decomposition
+
+The release is too large for one implementation plan. It is divided into five
+independent phase specs, each followed by its own implementation plan:
+
+1. A — unified intelligence core and primary context-graph migration;
+2. B — conservative broken-code evidence;
+3. C — repository health and antipattern prioritization;
+4. D — explicit local verification;
+5. E — product convergence, evaluation, and release evidence.
+
+Phase A starts with a small corrective slice that restores local harness parity
+for the already registered MCP explain tool. That correction does not expand the
+public MCP contract.
+
+## Acceptance Criteria
+
+- Existing `review`, `scan`, and MCP workflows remain operational throughout.
+- No removed diagnostic command is restored.
+- One shared facts/graph path backs graph-based rules, review impact, and primary
+  AI context graph output by the end of Phase A.
+- Broken-code findings are capability-gated and fixture-backed.
+- Repository health is a projection of canonical evidence, not a new opaque
+  score.
+- Verification is explicit, allowlisted, bounded, cancellable, redacted, and
+  revision-aware.
+- Default-visible rule claims have appropriate deterministic and zoo evidence.
+- Existing performance budgets hold unless an explicit measured change is
+  approved.
+- All public projections remain compatible and deterministic.
+
+## First Spec After Approval
+
+Create `docs/engineering/v0.22-phase-a1-context-graph-v2.md`. Its scope is
+limited to MCP harness parity, deterministic context-graph parity fixtures, one
+reusable graph-v2 analysis view for the primary AI-context graph projection,
+and targeted performance comparison. Retiring the persisted `RepoContextGraph`
+compatibility model requires a later slice after every cache and changed-scan
+consumer has migrated.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,28 +4,31 @@ RepoPilot is a review-first, local CLI for maintainers and coding agents. The
 product should help answer: what changed, which boundaries moved, and how far
 the change reaches before merge.
 
-## Now: 0.21 — trust the default output, calibrate it to your repo
+## Now: 0.22 — repository intelligence and local verification
 
-One larger release, three layers. The language frontend contract landed
-first (registry, per-language tables, generated support matrix, contributor
-guide); the rest of the cycle builds on it:
+RepoPilot 0.22 turns the existing `review` and `scan` workflows into two
+projections of one evidence-driven repository intelligence core:
 
-- **contract honesty to zero** — complete C# (imports, taint, boundary),
-  account for Rust's dedicated panic-risk audit, Kotlin taint, framework
-  probes on frontends; the support ledger ends empty;
-- **local knowledge overlays** — a declarative, diffable local file that
-  calibrates known rules to a repository (severity, suppression) without
-  code execution or plugins;
-- **local analysis history** — a `.repopilot/` ledger of past runs:
-  risk deltas vs the previous scan and accumulated agent-session evidence;
-- **new languages via the cheap path** — added as frontend modules with a
-  pinned zoo repository as the acceptance gate;
-- guardrail recipes, reproducible agent-edit demos, and the review-first
-  README continue as the adoption surface.
+- **fast change review** for developers and coding agents, using the Git diff
+  plus only the repository context needed to explain risk and blast radius;
+- **incremental repository health** for maintainers, covering architecture
+  drift, broken-code evidence, antipatterns, hotspots, and risk trends;
+- **explicit local verification** through repository-configured, allowlisted
+  checks whose results participate in the same canonical readiness decision;
+- **measured signal quality and performance**, with zoo-backed rule evidence,
+  deterministic cache behavior, and separate review/scan budgets.
 
-No hosted service, telemetry, source upload, or implicit LLM integration is
-part of the roadmap. Details:
-[v0.21 roadmap and release contract](roadmap/v0.21.md).
+The release deepens the existing commands and MCP tools. It does not restore
+removed diagnostic commands, add a hosted service, upload source, introduce
+telemetry, or put an implicit LLM inside RepoPilot. Details:
+[v0.22 roadmap and release contract](roadmap/v0.22.md).
+
+## Shipped: 0.21
+
+Compatible local risk history, ownership-aware merge readiness, repository
+knowledge overlays, unified language frontend contracts, and deeper
+field-sensitive taint-lite precision. Details:
+[v0.21 release contract](roadmap/v0.21.md).
 
 ## Shipped: 0.20
 

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -1,0 +1,271 @@
+# RepoPilot 0.22 — Repository Intelligence and Local Verification
+
+The technical architecture and product flows are defined in the
+[v0.22 repository intelligence design](../engineering/v0.22-repository-intelligence-design.md).
+
+## Problem Statement
+
+RepoPilot 0.21 can make a deterministic merge-readiness decision from findings,
+changed-code signals, ownership, dependency impact, and compatible local risk
+history. Its next limitation is not the absence of more rules. Repository facts,
+graph consumers, rule capabilities, verification guidance, and quality evidence
+are not yet one complete product loop.
+
+Developers and coding agents need a fast answer about the change in front of
+them. Maintainers need a deeper view of repository health and regressions. Both
+workflows must share the same evidence and must not produce contradictory
+interpretations of the repository.
+
+## Product Outcome
+
+RepoPilot 0.22 answers five questions through the existing `review` and `scan`
+commands:
+
+1. What is probably broken or risky?
+2. What structural evidence supports that conclusion?
+3. Which code, package, or ownership boundary can be affected?
+4. Which explicit local checks can verify the conclusion?
+5. Did the change or repository become healthier than its compatible history?
+
+`review` is the latency-sensitive developer and agent loop. `scan` is the
+incremental maintainer audit. CLI, JSON, SARIF, MCP, GitHub Action, and AI context
+remain projections of shared canonical records.
+
+## Release Principles
+
+- Preserve local-only, deterministic static analysis and zero source upload.
+- Keep `review` and `scan`; do not reintroduce `doctor`, `inspect`, `compare`,
+  `ai plan`, or `ai prompt` as public commands.
+- Parse a content identity once and reuse its facts across eligible consumers.
+- Build dependency context once per analysis session and preserve uncertainty.
+- Never execute a repository command implicitly.
+- Treat verification output as evidence, not as permission to suppress static
+  findings automatically.
+- Prefer measured signal quality over a larger unvalidated rule catalog.
+- Keep public schema changes additive throughout the `0.x` compatibility window.
+
+## Release Flow
+
+### Phase A — Unified Intelligence Core
+
+Complete the transition from distributed facts and graph consumers to one
+capability-aware analysis session.
+
+Deliverables:
+
+- migrate the primary `RepoContextGraph` / `context_graph_summary` projection to
+  graph v2 behind deterministic parity fixtures;
+- make graph capability metadata consumable by rule scheduling and diagnostics;
+- enrich the internal repository fact model without exposing unstable raw facts
+  as a new public schema;
+- record parse, facts, graph, rules, and report timing separately;
+- preserve current rule IDs, severities, output ordering, and review verdicts
+  unless a separately reviewed correctness change requires otherwise.
+
+Definition of done:
+
+- review blast radius, graph-based scan rules, and primary AI context graph data
+  derive from graph v2;
+- no duplicate import parsing or graph reconstruction remains on those paths;
+- parity fixtures cover cycles, disconnected files, unresolved imports,
+  cross-directory dependencies, and bounded output;
+- existing performance budgets do not regress by more than 10% without an
+  explicit approved budget change.
+
+### Phase B — Broken-Code Evidence
+
+Add conservative detectors for failures RepoPilot can prove from local static
+facts rather than attempting to replace compilers or type checkers.
+
+Initial evidence families:
+
+- unresolved local imports and modules with language-aware confidence;
+- deleted or renamed exported symbols still referenced within supported local
+  analysis boundaries;
+- changed public surface with impacted callers or dependents;
+- manifest/source dependency mismatch where deterministic local metadata is
+  sufficient;
+- changed production boundary without a corresponding test change;
+- unreachable or orphaned code only when graph capabilities make the conclusion
+  trustworthy.
+
+Definition of done:
+
+- every default-visible detector has an unsafe fixture and a near-identical safe
+  guard;
+- unsupported resolution modes produce bounded limitations, not findings stated
+  as facts;
+- changed-scope and full-scan paths agree for the same evidence;
+- findings explain breakage, location, confidence, impact, and verification.
+
+### Phase C — Repository Health and Antipatterns
+
+Turn isolated architecture and code-quality findings into a bounded maintainer
+view without inventing a second scoring system.
+
+Deliverables:
+
+- graph-derived hotspots and cross-boundary coupling;
+- architecture drift and layer-policy evidence;
+- maintainability antipatterns backed by AST or graph facts;
+- test concentration and uncovered changed-boundary signals;
+- compatible historical deltas for repository health categories;
+- prioritized output based on evidence, confidence, severity, and impact.
+
+Definition of done:
+
+- the health view is available through `scan`, JSON, MCP, and AI context rather
+  than a new top-level command;
+- distinct logical problems remain distinct findings;
+- stable and default-visible rules have labeled zoo evidence;
+- the scorecard clearly separates measured evidence from unknown quality.
+
+### Phase D — Explicit Local Verification
+
+Allow RepoPilot to run repository-defined checks only through an explicit,
+bounded policy.
+
+Security contract:
+
+- checks are declared in `repopilot.toml`; callers select declared check IDs and
+  cannot submit arbitrary commands or arguments;
+- execution is off by default and requires an explicit CLI or MCP request;
+- each check declares working directory, timeout, output limit, and applicability;
+- environment inheritance is conservative and documented; secrets are never
+  copied into reports;
+- stdout and stderr are bounded and redacted before human or agent projection;
+- a timeout, spawn error, or non-zero exit is structured evidence;
+- static analysis remains usable when verification is disabled or unavailable;
+- caching keys include command policy, relevant workspace revision, RepoPilot
+  version, and verification schema.
+
+Initial check roles:
+
+- tests;
+- build or compile;
+- type checking;
+- linting.
+
+Definition of done:
+
+- explicit checks contribute to the canonical readiness record with stable
+  reason codes;
+- MCP advertises execution effects honestly and preserves workspace confinement;
+- cancellation and timeouts terminate the managed child process;
+- cache reuse never serves evidence from an incompatible workspace revision;
+- fixtures cover success, failure, timeout, excessive output, missing executable,
+  stale cache, redaction, and disabled execution.
+
+### Phase E — Product Convergence and Release Evidence
+
+Make the new core coherent across all supported product surfaces and validate it
+on realistic repositories.
+
+Deliverables:
+
+- CLI, JSON, SARIF, MCP, Action, and AI-context projection parity;
+- developer workflow documentation for change review and agent guardrails;
+- maintainer workflow documentation for repository health and historical deltas;
+- reproducible demonstrations for broken-code, graph impact, and verification;
+- expanded zoo expectations and a generated rule scorecard;
+- release scorecard covering correctness, signal quality, latency, memory,
+  determinism, cache behavior, and distribution channels.
+
+Definition of done:
+
+- all public projections read shared canonical evidence and readiness records;
+- no release claim exceeds fixture or zoo evidence;
+- cold and warm review/scan performance is measured on the pinned matrix;
+- the complete release and self-scan gates pass on the final release head.
+
+## Performance Contract
+
+The existing budgets in `docs/engineering/performance-budgets.md` remain the
+baseline until a measured replacement is approved.
+
+`review` is the primary latency contract:
+
+- analyze the diff plus the smallest required repository context;
+- avoid full-repository rule execution when declared capabilities do not require
+  it;
+- reuse content-addressed parsed facts and compatible graph derivations;
+- report cache hits, misses, invalidations, and stage timings;
+- prevent an unexplained regression greater than 10% in an existing scenario.
+
+`scan` is the depth contract:
+
+- use the same facts and graph representations as review;
+- incrementally recompute only invalidated facts and derived relationships where
+  correctness can be proven;
+- keep output deterministic across supported thread counts;
+- measure peak RSS before setting a hard memory ceiling.
+
+## MCP Contract
+
+The existing six tools remain the base MCP surface. New intelligence should
+flow through `repopilot_review_change`, `repopilot_scan`, `repopilot_context`,
+and the existing explain tools before any additional tool is considered.
+
+Static calls remain read-only. A call that explicitly requests configured local
+verification must advertise its execution effects and cannot accept arbitrary
+shell text. Analysis handles, workspace revisions, pagination, response bounds,
+progress, cancellation, and root confinement remain mandatory.
+
+## Evaluation Contract
+
+For a rule to become stable or materially affect the default verdict, require:
+
+- deterministic unit or integration fixtures;
+- an unsafe example and a near-identical safe guard;
+- changed-scope and full-scan coverage when applicable;
+- labeled real-repository evidence where the zoo supports the language or
+  framework;
+- explicit lifecycle and capability requirements;
+- zero known false-positive debt for promotion to stable unless an exception is
+  documented in the release scorecard.
+
+The release target is to increase zoo-backed coverage of high-value rules, not
+to maximize the raw rule count.
+
+## Compatibility and Non-Goals
+
+Out of scope for 0.22:
+
+- hosted dashboards, remote storage, telemetry, or source upload;
+- implicit LLM calls or an embedded AI reviewer;
+- arbitrary command execution from CLI or MCP arguments;
+- automatic source modification or autofix;
+- a new top-level command;
+- restoring removed diagnostic commands;
+- a plugin runtime or executable overlay policy;
+- a new language frontend without pinned zoo acceptance evidence;
+- whole-program type checking or a claim of compiler equivalence;
+- unrestricted interprocedural taint, heap alias analysis, or generic Rust taint.
+
+## Release Gates
+
+Every implementation slice uses targeted tests. The final release gate includes:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+npm run release:contract
+npm run test:release-contract
+npm run review:performance
+npm run scan:performance
+cargo run -- scan . --fail-on-priority p1
+./scripts/smoke-product.sh
+./scripts/verify-release.sh
+```
+
+Zoo-based claims additionally require the pinned repositories to be available,
+fresh scans, reviewed expectation labels, and a regenerated scorecard.
+
+## Implementation Order
+
+Each phase is split into independently reviewable PRs. The first implementation
+spec after this release contract is Phase A1: graph-v2 parity for the primary AI
+context projection. Phase D begins only after the shared evidence model and
+capability scheduling are stable enough to consume verification results without
+creating a parallel decision path.

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -1,10 +1,6 @@
 use crate::audits::context::{FileRole, classify_file};
 use crate::findings::types::Finding;
-use crate::graph::v2::{build_coupling_graph_snapshot, direct_dependents};
-use crate::graph::{
-    CouplingGraph, coupling_file_metrics, detect_cycles_bounded,
-    without_rust_module_containment_edges,
-};
+use crate::graph::{CouplingGraph, detect_cycles_bounded, without_rust_module_containment_edges};
 use crate::review::diff::{ChangeStatus, ChangedFile};
 use crate::risk::RiskPriority;
 use crate::scan::facts::{FileFacts, ScanFacts};
@@ -97,10 +93,12 @@ pub struct RepoContextGraphLoad {
     pub cache_info: ContextGraphCacheInfo,
 }
 
+mod analysis;
 mod cache;
 mod graph_impl;
 mod summary;
 
+use analysis::ContextGraphAnalysis;
 pub use cache::{
     context_graph_cache_miss, context_graph_cache_path, load_repo_context_graph,
     write_repo_context_graph,

--- a/src/graph/context/analysis.rs
+++ b/src/graph/context/analysis.rs
@@ -1,0 +1,182 @@
+use super::RepoContextGraph;
+use crate::graph::FileMetrics;
+use crate::graph::v2::{
+    GraphCapabilities, GraphDegreeSummary, GraphNodeId, build_coupling_graph_snapshot,
+    compute_degrees, direct_dependents, graph_capabilities,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+pub(super) struct ContextGraphAnalysis {
+    path_by_id: BTreeMap<GraphNodeId, PathBuf>,
+    degrees: GraphDegreeSummary,
+    dependents: BTreeMap<GraphNodeId, BTreeSet<GraphNodeId>>,
+    capabilities: GraphCapabilities,
+}
+
+impl ContextGraphAnalysis {
+    pub(super) fn from_graph(graph: &RepoContextGraph) -> Self {
+        let (snapshot, path_by_id) = build_coupling_graph_snapshot(&graph.coupling_graph());
+        let degrees = compute_degrees(&snapshot);
+        let dependents = direct_dependents(&snapshot);
+        let capabilities = graph_capabilities(&snapshot);
+        Self {
+            path_by_id,
+            degrees,
+            dependents,
+            capabilities,
+        }
+    }
+
+    pub(super) fn file_metrics(&self) -> Vec<FileMetrics> {
+        self.degrees
+            .nodes
+            .iter()
+            .filter_map(|degree| {
+                let path = self.path_by_id.get(&degree.node_id)?.clone();
+                Some((
+                    path.clone(),
+                    FileMetrics {
+                        path,
+                        fan_in: degree.fan_in,
+                        fan_out: degree.fan_out,
+                        instability: degree.instability(),
+                    },
+                ))
+            })
+            .collect::<BTreeMap<_, _>>()
+            .into_values()
+            .collect()
+    }
+
+    pub(super) fn direct_dependents_by_path(&self) -> BTreeMap<PathBuf, BTreeSet<PathBuf>> {
+        self.dependents
+            .iter()
+            .filter_map(|(target_id, source_ids)| {
+                let target = self.path_by_id.get(target_id)?.clone();
+                let sources = source_ids
+                    .iter()
+                    .filter_map(|id| self.path_by_id.get(id).cloned())
+                    .collect();
+                Some((target, sources))
+            })
+            .collect()
+    }
+
+    pub(super) fn capabilities(&self) -> &GraphCapabilities {
+        &self.capabilities
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{RepoContextGraph, RepoContextNode};
+    use super::ContextGraphAnalysis;
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn projects_degrees_dependents_and_capabilities_by_path() {
+        let graph = graph_with_edge("a.rs", "b.rs");
+
+        let analysis = ContextGraphAnalysis::from_graph(&graph);
+        let metrics = analysis.file_metrics();
+        let a = metric(&metrics, "a.rs");
+        let b = metric(&metrics, "b.rs");
+
+        assert_eq!(a.fan_out, 1);
+        assert_eq!(b.fan_in, 1);
+        assert_eq!(
+            analysis.direct_dependents_by_path()[Path::new("b.rs")],
+            BTreeSet::from([PathBuf::from("a.rs")])
+        );
+        assert_eq!(analysis.capabilities().resolved_dependency_edges, 1);
+    }
+
+    #[test]
+    fn retains_isolated_nodes_with_zero_degrees() {
+        let mut graph = graph_with_edge("a.rs", "b.rs");
+        graph.nodes.push(node("isolated.rs"));
+
+        let analysis = ContextGraphAnalysis::from_graph(&graph);
+        let metrics = analysis.file_metrics();
+        let isolated = metric(&metrics, "isolated.rs");
+
+        assert_eq!(isolated.fan_in, 0);
+        assert_eq!(isolated.fan_out, 0);
+        assert_eq!(isolated.instability, 0.0);
+    }
+
+    #[test]
+    fn projections_are_deterministic_across_builds() {
+        let graph = graph_with_edge("a.rs", "b.rs");
+
+        let first = ContextGraphAnalysis::from_graph(&graph);
+        let second = ContextGraphAnalysis::from_graph(&graph);
+
+        assert_eq!(metric_keys(&first), metric_keys(&second));
+        assert_eq!(
+            first.direct_dependents_by_path(),
+            second.direct_dependents_by_path()
+        );
+        assert_eq!(first.capabilities(), second.capabilities());
+    }
+
+    fn metric_keys(analysis: &ContextGraphAnalysis) -> Vec<(PathBuf, usize, usize, u32)> {
+        analysis
+            .file_metrics()
+            .into_iter()
+            .map(|metric| {
+                (
+                    metric.path,
+                    metric.fan_in,
+                    metric.fan_out,
+                    metric.instability.to_bits(),
+                )
+            })
+            .collect()
+    }
+
+    fn metric<'a>(
+        metrics: &'a [crate::graph::FileMetrics],
+        path: &str,
+    ) -> &'a crate::graph::FileMetrics {
+        metrics
+            .iter()
+            .find(|metric| metric.path == Path::new(path))
+            .expect("metric should exist")
+    }
+
+    fn graph_with_edge(source: &str, target: &str) -> RepoContextGraph {
+        RepoContextGraph {
+            root_path: PathBuf::from("."),
+            nodes: vec![node(source), node(target)],
+            edges: BTreeMap::from([(
+                PathBuf::from(source),
+                BTreeSet::from([PathBuf::from(target)]),
+            )]),
+            deferred_edges: BTreeMap::new(),
+            detected_frameworks: Vec::new(),
+            framework_projects: Vec::new(),
+            react_native: None,
+        }
+    }
+
+    fn node(path: &str) -> RepoContextNode {
+        RepoContextNode {
+            path: PathBuf::from(path),
+            language: Some("Rust".to_string()),
+            roles: Vec::new(),
+            frameworks: Vec::new(),
+            runtimes: Vec::new(),
+            paradigms: Vec::new(),
+            workspace_package: None,
+            non_empty_lines: 1,
+            imports: Vec::new(),
+            deferred_imports: Vec::new(),
+            is_test: false,
+            is_generated: false,
+            is_config: false,
+        }
+    }
+}

--- a/src/graph/context/summary.rs
+++ b/src/graph/context/summary.rs
@@ -6,13 +6,48 @@ pub fn summarize_context_graph(
     changed_files: &[ChangedFile],
 ) -> ContextGraphSummary {
     let coupling_graph = graph.coupling_graph();
-    let mut metrics = coupling_file_metrics(&coupling_graph);
-    let node_by_path = graph
+    let analysis = ContextGraphAnalysis::from_graph(graph);
+    let ranked = ranked_metrics(graph, &analysis);
+    let (cycles, cycles_truncated) = bounded_cycles(&coupling_graph);
+    let dependents = analysis.direct_dependents_by_path();
+    let (changed_blast_radius, blast_radius_truncated) =
+        changed_blast_radius(&dependents, changed_files);
+    let (risky_clusters, risky_clusters_truncated) = risky_clusters(findings);
+    let truncated = truncation_labels([
+        ("top_hubs", ranked.top_hubs_truncated),
+        ("top_dependencies", ranked.top_dependencies_truncated),
+        ("cycles", cycles_truncated),
+        ("changed_blast_radius", blast_radius_truncated),
+        ("risky_clusters", risky_clusters_truncated),
+    ]);
+
+    ContextGraphSummary {
+        files: graph.nodes.len(),
+        import_edges: graph.edges.values().map(BTreeSet::len).sum(),
+        top_hubs: ranked.top_hubs,
+        top_dependencies: ranked.top_dependencies,
+        cycles,
+        changed_blast_radius,
+        risky_clusters,
+        truncated,
+    }
+}
+
+struct RankedMetrics {
+    top_hubs: Vec<ContextGraphFileMetric>,
+    top_dependencies: Vec<ContextGraphFileMetric>,
+    top_hubs_truncated: bool,
+    top_dependencies_truncated: bool,
+}
+
+fn ranked_metrics(graph: &RepoContextGraph, analysis: &ContextGraphAnalysis) -> RankedMetrics {
+    let mut metrics = analysis.file_metrics();
+    debug_assert_eq!(analysis.capabilities().file_nodes, metrics.len());
+    let nodes = graph
         .nodes
         .iter()
         .map(|node| (node.path.clone(), node))
         .collect::<HashMap<_, _>>();
-
     metrics.sort_by(|left, right| {
         right
             .fan_out
@@ -20,17 +55,11 @@ pub fn summarize_context_graph(
             .then_with(|| right.fan_in.cmp(&left.fan_in))
             .then_with(|| left.path.cmp(&right.path))
     });
-    let all_top_hubs = metrics
+    let hubs = metrics
         .iter()
         .filter(|metric| metric.fan_out > 0)
-        .map(|metric| metric_from_graph(metric, &node_by_path))
+        .map(|metric| metric_from_graph(metric, &nodes))
         .collect::<Vec<_>>();
-    let top_hubs_truncated = all_top_hubs.len() > MAX_CONTEXT_GRAPH_METRICS;
-    let top_hubs = all_top_hubs
-        .into_iter()
-        .take(MAX_CONTEXT_GRAPH_METRICS)
-        .collect();
-
     metrics.sort_by(|left, right| {
         right
             .fan_in
@@ -38,52 +67,38 @@ pub fn summarize_context_graph(
             .then_with(|| right.fan_out.cmp(&left.fan_out))
             .then_with(|| left.path.cmp(&right.path))
     });
-    let all_top_dependencies = metrics
+    let dependencies = metrics
         .iter()
         .filter(|metric| metric.fan_in > 0)
-        .map(|metric| metric_from_graph(metric, &node_by_path))
+        .map(|metric| metric_from_graph(metric, &nodes))
         .collect::<Vec<_>>();
-    let top_dependencies_truncated = all_top_dependencies.len() > MAX_CONTEXT_GRAPH_METRICS;
-    let top_dependencies = all_top_dependencies
-        .into_iter()
-        .take(MAX_CONTEXT_GRAPH_METRICS)
-        .collect();
+    RankedMetrics {
+        top_hubs_truncated: hubs.len() > MAX_CONTEXT_GRAPH_METRICS,
+        top_dependencies_truncated: dependencies.len() > MAX_CONTEXT_GRAPH_METRICS,
+        top_hubs: hubs.into_iter().take(MAX_CONTEXT_GRAPH_METRICS).collect(),
+        top_dependencies: dependencies
+            .into_iter()
+            .take(MAX_CONTEXT_GRAPH_METRICS)
+            .collect(),
+    }
+}
 
-    let cycle_graph = without_rust_module_containment_edges(&coupling_graph);
-    let mut cycles = detect_cycles_bounded(&cycle_graph, MAX_CONTEXT_GRAPH_CYCLES + 1);
-    let cycles_truncated = cycles.len() > MAX_CONTEXT_GRAPH_CYCLES;
+fn bounded_cycles(graph: &CouplingGraph) -> (Vec<Vec<PathBuf>>, bool) {
+    // The historical path contract excludes deferred and Rust containment edges;
+    // graph-v2 SCC membership is not an equivalent public representation.
+    let graph = without_rust_module_containment_edges(graph);
+    let mut cycles = detect_cycles_bounded(&graph, MAX_CONTEXT_GRAPH_CYCLES + 1);
+    let truncated = cycles.len() > MAX_CONTEXT_GRAPH_CYCLES;
     cycles.truncate(MAX_CONTEXT_GRAPH_CYCLES);
+    (cycles, truncated)
+}
 
-    let (changed_blast_radius, blast_radius_truncated) =
-        changed_blast_radius(&coupling_graph, changed_files);
-    let (risky_clusters, risky_clusters_truncated) = risky_clusters(findings);
-    let mut truncated = Vec::new();
-    if top_hubs_truncated {
-        truncated.push("top_hubs".to_string());
-    }
-    if top_dependencies_truncated {
-        truncated.push("top_dependencies".to_string());
-    }
-    if cycles_truncated {
-        truncated.push("cycles".to_string());
-    }
-    if blast_radius_truncated {
-        truncated.push("changed_blast_radius".to_string());
-    }
-    if risky_clusters_truncated {
-        truncated.push("risky_clusters".to_string());
-    }
-
-    ContextGraphSummary {
-        files: graph.nodes.len(),
-        import_edges: graph.edges.values().map(BTreeSet::len).sum(),
-        top_hubs,
-        top_dependencies,
-        cycles,
-        changed_blast_radius,
-        risky_clusters,
-        truncated,
-    }
+fn truncation_labels<const N: usize>(states: [(&str, bool); N]) -> Vec<String> {
+    states
+        .into_iter()
+        .filter(|(_, truncated)| *truncated)
+        .map(|(label, _)| label.to_string())
+        .collect()
 }
 
 fn metric_from_graph(
@@ -102,7 +117,7 @@ fn metric_from_graph(
 }
 
 fn changed_blast_radius(
-    graph: &CouplingGraph,
+    importers_by_target: &BTreeMap<PathBuf, BTreeSet<PathBuf>>,
     changed_files: &[ChangedFile],
 ) -> (Vec<PathBuf>, bool) {
     if changed_files.is_empty() {
@@ -113,22 +128,6 @@ fn changed_blast_radius(
         .iter()
         .map(|file| file.path.clone())
         .collect::<HashSet<_>>();
-    // Invert the dependency edges through the shared graph v2 one-hop
-    // `direct_dependents`, then key the importer sets back by repository path so
-    // the lookup below is unchanged.
-    let (snapshot, path_by_id) = build_coupling_graph_snapshot(graph);
-    let importers_by_target: BTreeMap<PathBuf, BTreeSet<PathBuf>> = direct_dependents(&snapshot)
-        .into_iter()
-        .filter_map(|(target_id, source_ids)| {
-            let target = path_by_id.get(&target_id)?.clone();
-            let sources = source_ids
-                .iter()
-                .filter_map(|id| path_by_id.get(id).cloned())
-                .collect::<BTreeSet<_>>();
-            Some((target, sources))
-        })
-        .collect();
-
     let mut impacted = BTreeSet::new();
     for path in &changed {
         if let Some(importers) = importers_by_target.get(path) {

--- a/src/graph/context/tests.rs
+++ b/src/graph/context/tests.rs
@@ -106,6 +106,56 @@ fn summary_changed_blast_radius_lists_direct_importers() {
 }
 
 #[test]
+fn summary_orders_tied_metrics_and_retains_isolated_files() {
+    let a = PathBuf::from("src/a.rs");
+    let b = PathBuf::from("src/b.rs");
+    let shared = PathBuf::from("src/shared.rs");
+    let isolated = PathBuf::from("src/isolated.rs");
+    let graph = RepoContextGraph {
+        root_path: PathBuf::from("."),
+        nodes: vec![node(&b), node(&isolated), node(&shared), node(&a)],
+        edges: BTreeMap::from([
+            (a.clone(), BTreeSet::from([shared.clone()])),
+            (b.clone(), BTreeSet::from([shared.clone()])),
+        ]),
+        deferred_edges: BTreeMap::new(),
+        detected_frameworks: Vec::new(),
+        framework_projects: Vec::new(),
+        react_native: None,
+    };
+    let changed = vec![ChangedFile {
+        path: shared.clone(),
+        status: ChangeStatus::Modified,
+        ranges: Vec::new(),
+        hunks: Vec::new(),
+    }];
+
+    let summary = summarize_context_graph(&graph, &[], &changed);
+
+    assert_eq!(summary.files, 4);
+    assert_eq!(summary.import_edges, 2);
+    assert_eq!(
+        summary
+            .top_hubs
+            .iter()
+            .map(|metric| metric.path.clone())
+            .collect::<Vec<_>>(),
+        vec![a.clone(), b.clone()]
+    );
+    assert_eq!(
+        summary
+            .top_dependencies
+            .iter()
+            .map(|metric| metric.path.clone())
+            .collect::<Vec<_>>(),
+        vec![shared.clone()]
+    );
+    assert_eq!(summary.changed_blast_radius, vec![a, b]);
+    assert!(summary.cycles.is_empty());
+    assert!(summary.truncated.is_empty());
+}
+
+#[test]
 fn changed_graph_patch_matches_full_rebuild_for_add_modify_delete() {
     let root = PathBuf::from("/repo");
     let initial_facts = scan_facts(


### PR DESCRIPTION
## What

- define the RepoPilot 0.22 repository-intelligence release contract and phased roadmap
- add one internal graph-v2 context analysis view for degree metrics, direct dependents, and capability state
- reuse that view in the primary context summary while preserving existing cycle, cache, JSON, MCP, and readiness contracts
- add deterministic parity coverage and synchronize the platform/graph documentation

## Why

RepoPilot already had graph-v2-backed scan rules and review blast radius, but the primary context summary still rebuilt separate graph snapshots for related projections. Phase A1 establishes the first shared intelligence-core boundary without restoring removed commands or expanding the public schema.

## Impact

- developers and coding agents keep the same `review` and MCP output with less duplicate graph work
- maintainers get an explicit v0.22 product flow for broken-code evidence, repository health, safe local verification, and measurable signal quality
- historical bounded cycle semantics and the persisted `RepoContextGraph` remain unchanged pending differential Phase A2 migration

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `python3 scripts/release-contract.py check`
- `npm run test:release-contract` (42 tests)
- `cargo run -- scan . --fail-on-priority p1` (0 findings, health 100/100)
- `npm run review:performance` (changed/full ratio 0.364, budget 0.6)
- `npm run scan:performance` (480-file 301 ms; 1000-file 535 ms; warm changed review 259 ms)

The real-repository zoo was not cloned locally, so the optional live zoo scan was not run; committed zoo contracts and snapshots passed through `cargo test --all`.
