### PR TITLE
feat: add capability-aware graph analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Graph-based scan rules now share one graph-v2 snapshot and an internal
+  available/limited/unavailable readiness policy. Absence claims are demoted or
+  skipped when unresolved internal imports weaken them, while proven-edge
+  findings remain actionable. Changed scans now run the same graph-query rules
+  as full scans.
 - Reuse one internal graph-v2 context analysis for AI-context degree metrics,
   direct dependents, and capability state, preserving the existing bounded
   context summary, JSON, MCP, and readiness contracts.

--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -175,7 +175,10 @@ remain compatibility surfaces pending differential migration.
 
 1. Migrate the persisted context graph and bounded cycle projection only after
    graph-v2 parity fixtures cover their deferred-edge and path semantics.
-2. Make graph capability metadata enforce rule requirements and honest skips.
+2. **Done internally in v0.22 A2.** Graph capability metadata now drives an
+   available/limited/unavailable policy for graph-backed scan rules. Full and
+   changed scans share the same graph analysis bundle; a public skipped-analysis
+   projection remains deferred.
 3. Add language support tiers.
 4. Enrich the internal `RepoFacts` model with symbol/reference relationships.
 5. Add explicit, allowlisted local verification evidence.

--- a/docs/engineering/dependency-graph-v2.md
+++ b/docs/engineering/dependency-graph-v2.md
@@ -298,8 +298,11 @@ internal.
 3. **Done (A1).** Feed graph v2 into AI context hot files and primary context
    summary metrics. One internal context analysis view supplies degrees,
    one-hop dependents, and capability state without repeated snapshot builds.
-4. **Done (foundation).** Add graph capability metadata (`graph_capabilities`).
-   No rule consumes it yet; wiring rules to declare required graph facts is next.
+4. **Done (A2).** Graph capability metadata (`graph_capabilities`) feeds the
+   bounded available/limited/unavailable policy used by graph-backed scan rules.
+   Full and changed scans share one runner and one snapshot for coupling metrics,
+   graph queries, and readiness. Public skip diagnostics remain a later additive
+   projection.
 5. Migrate the persisted `RepoContextGraph` schema/cache and historical bounded
    cycle projection after differential fixtures cover deferred imports, Rust
    module-containment edges, changed-scan patching, and cycle ordering.

--- a/docs/engineering/v0.22-phase-a1-context-graph-v2.md
+++ b/docs/engineering/v0.22-phase-a1-context-graph-v2.md
@@ -113,7 +113,8 @@ scheduling can consume them without another graph traversal.
 
 ## Follow-up Boundary
 
-Phase A2 will decide how to migrate historical cycle projection, changed-scan
-context cache, and `RepoContextGraph` serialization onto graph-v2-native inputs.
-That work must start from differential fixtures rather than assuming SCC output
-is compatible with the existing cycle list.
+Phase A2 intentionally established the capability-aware graph-rule contract and
+full/changed scan parity first. Historical cycle projection, changed-scan context
+cache, and `RepoContextGraph` serialization remain a later migration and must
+start from differential fixtures rather than assuming SCC output is compatible
+with the existing cycle list.

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -55,7 +55,9 @@ Deliverables:
 
 - migrate the primary `RepoContextGraph` / `context_graph_summary` projection to
   graph v2 behind deterministic parity fixtures;
-- make graph capability metadata consumable by rule scheduling and diagnostics;
+- make graph capability metadata consumable by rule scheduling and diagnostics
+  (internal readiness and full/changed parity completed in A2; public skip
+  diagnostics remain additive follow-up work);
 - enrich the internal repository fact model without exposing unstable raw facts
   as a new public schema;
 - record parse, facts, graph, rules, and report timing separately;

--- a/src/audits/architecture/graph_analysis.rs
+++ b/src/audits/architecture/graph_analysis.rs
@@ -1,0 +1,41 @@
+use super::graph_context::GraphAuditContext;
+use super::graph_queries::GraphQueriesAudit;
+use super::import_coupling::ImportCouplingAudit;
+use crate::findings::types::Finding;
+use crate::graph::v2::build_coupling_graph_snapshot;
+use crate::graph::{CouplingGraph, build_coupling_graph_with_resolution};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::ScanFacts;
+use std::path::Path;
+
+pub(crate) struct GraphAnalysisResult {
+    pub(crate) coupling_findings: Vec<Finding>,
+    pub(crate) query_findings: Vec<Finding>,
+    pub(crate) graph: CouplingGraph,
+}
+
+pub(crate) fn run_graph_analysis(
+    facts: &ScanFacts,
+    config: &ScanConfig,
+    root: &Path,
+) -> GraphAnalysisResult {
+    let (graph, resolution) = build_coupling_graph_with_resolution(facts, root);
+    let (snapshot, path_by_id) = build_coupling_graph_snapshot(&graph);
+    let context = GraphAuditContext {
+        facts,
+        config,
+        root,
+        graph: &graph,
+        resolution: &resolution,
+        snapshot: &snapshot,
+        path_by_id: &path_by_id,
+    };
+    let coupling_findings = ImportCouplingAudit.audit(&context);
+    let query_findings = GraphQueriesAudit.audit(&context);
+
+    GraphAnalysisResult {
+        coupling_findings,
+        query_findings,
+        graph,
+    }
+}

--- a/src/audits/architecture/graph_context.rs
+++ b/src/audits/architecture/graph_context.rs
@@ -1,0 +1,16 @@
+use crate::graph::v2::{GraphNodeId, GraphSnapshot};
+use crate::graph::{CouplingGraph, ImportResolutionStats};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::ScanFacts;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+pub(crate) struct GraphAuditContext<'a> {
+    pub(crate) facts: &'a ScanFacts,
+    pub(crate) config: &'a ScanConfig,
+    pub(crate) root: &'a Path,
+    pub(crate) graph: &'a CouplingGraph,
+    pub(crate) resolution: &'a ImportResolutionStats,
+    pub(crate) snapshot: &'a GraphSnapshot,
+    pub(crate) path_by_id: &'a BTreeMap<GraphNodeId, PathBuf>,
+}

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -10,10 +10,11 @@ use std::path::{Path, PathBuf};
 
 use crate::analysis::{ArchitectureClassifier, ArchitectureContext, FileRole, LanguageFamily};
 use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
-use crate::graph::v2::{GraphNodeId, build_coupling_graph_snapshot};
-use crate::graph::{CouplingGraph, ImportResolutionStats};
-use crate::scan::config::ScanConfig;
-use crate::scan::facts::{FileFacts, ScanFacts};
+use crate::graph::ImportResolutionStats;
+use crate::graph::v2::{
+    GraphClaim, GraphNodeId, GraphReadiness, graph_capabilities, graph_readiness,
+};
+use crate::scan::facts::FileFacts;
 
 mod edge_evidence;
 mod layers;
@@ -22,6 +23,7 @@ mod packages;
 #[cfg(test)]
 mod tests;
 
+use super::graph_context::GraphAuditContext;
 use edge_evidence::edge_evidence;
 use layers::LayerIndex;
 use packages::PackageIndex;
@@ -35,14 +37,13 @@ pub(crate) struct NodeInfo<'a> {
 }
 
 impl GraphQueriesAudit {
-    pub fn audit(
-        &self,
-        facts: &ScanFacts,
-        config: &ScanConfig,
-        graph: &CouplingGraph,
-        resolution: &ImportResolutionStats,
-        root: &Path,
-    ) -> Vec<Finding> {
+    pub(crate) fn audit(&self, analysis: &GraphAuditContext<'_>) -> Vec<Finding> {
+        let facts = analysis.facts;
+        let config = analysis.config;
+        let snapshot = analysis.snapshot;
+        let path_by_id = analysis.path_by_id;
+        let resolution = analysis.resolution;
+        let root = analysis.root;
         let classifier = ArchitectureClassifier::new(&config.module_mappings);
 
         let mut file_context = HashMap::new();
@@ -62,7 +63,7 @@ impl GraphQueriesAudit {
             .map(|f| crate::graph::resolver::normalize_path(&f.path))
             .collect();
 
-        let (snapshot, path_by_id) = build_coupling_graph_snapshot(graph);
+        let capabilities = graph_capabilities(snapshot);
 
         let mut node_info: HashMap<GraphNodeId, NodeInfo> = HashMap::new();
         for node in &snapshot.nodes {
@@ -90,8 +91,11 @@ impl GraphQueriesAudit {
 
         for node in &snapshot.nodes {
             if let Some(info) = node_info.get(&node.id)
-                && let Some(finding) =
-                    dead_module_finding(info, fan_in.get(&node.id).copied(), resolution)
+                && let Some(finding) = dead_module_finding(
+                    info,
+                    fan_in.get(&node.id).copied(),
+                    target_absence_readiness(info, &capabilities, resolution),
+                )
             {
                 findings.push(finding);
             }
@@ -142,7 +146,7 @@ impl GraphQueriesAudit {
 fn dead_module_finding(
     info: &NodeInfo,
     fan_in: Option<usize>,
-    resolution: &ImportResolutionStats,
+    readiness: GraphReadiness,
 ) -> Option<Finding> {
     let ctx = &info.context;
     // "Dead module" only means something for files that participate in the
@@ -171,12 +175,7 @@ fn dead_module_finding(
         return None;
     }
 
-    let stem = info
-        .relative
-        .file_stem()
-        .map(|stem| stem.to_string_lossy())
-        .unwrap_or_default();
-    if resolution.could_target_stem(&stem) {
+    if matches!(readiness, GraphReadiness::Unavailable { .. }) {
         return None;
     }
 
@@ -184,14 +183,17 @@ fn dead_module_finding(
     // `Confidence::Medium` is the "unset, use the registry default" sentinel in
     // `populate_rule_metadata`, so a contextual demotion must use `Low` to
     // survive — otherwise the High default is restored and the demotion is lost.
-    let confidence = if resolution.is_empty() {
-        Confidence::High
-    } else {
+    let confidence = if let GraphReadiness::Limited {
+        unresolved_internal,
+    } = readiness
+    {
         snippet.push_str(&format!(
             " ({} unresolved internal import(s) in the repository — the import graph may be incomplete)",
-            resolution.total()
+            unresolved_internal
         ));
         Confidence::Low
+    } else {
+        Confidence::High
     };
 
     let mut finding = architecture_finding(
@@ -207,6 +209,19 @@ fn dead_module_finding(
     );
     finding.confidence = confidence;
     Some(finding)
+}
+
+fn target_absence_readiness(
+    info: &NodeInfo,
+    capabilities: &crate::graph::v2::GraphCapabilities,
+    resolution: &ImportResolutionStats,
+) -> GraphReadiness {
+    let stem = info
+        .relative
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or_default();
+    graph_readiness(capabilities, resolution, GraphClaim::TargetAbsence(stem))
 }
 
 /// A production file importing a test or fixture file leaks test-only code into

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -2,16 +2,12 @@ use std::path::{Path, PathBuf};
 
 use crate::analysis::{ArchitectureContext, FileRole, LanguageFamily, ModuleKind};
 use crate::findings::types::Confidence;
-use crate::graph::ImportResolutionStats;
+use crate::graph::v2::GraphReadiness;
 use crate::scan::config::{LayerSpec, ScanConfig};
 
 use super::layers::LayerIndex;
 use super::packages::PackageIndex;
 use super::{NodeInfo, dead_module_finding, test_leak_finding};
-
-fn complete_graph() -> ImportResolutionStats {
-    ImportResolutionStats::default()
-}
 
 fn node(
     relative: &str,
@@ -39,7 +35,7 @@ fn prod(relative: &str) -> NodeInfo<'static> {
 #[test]
 fn dead_module_flags_unreferenced_production_file() {
     let info = prod("src/orphan.ts");
-    let finding = dead_module_finding(&info, Some(0), &complete_graph());
+    let finding = dead_module_finding(&info, Some(0), GraphReadiness::Available);
     let finding = finding.expect("unreferenced production file should be flagged");
     assert_eq!(finding.confidence, Confidence::High);
 }
@@ -59,17 +55,17 @@ fn dead_module_ignores_non_code_files() {
         },
         facts: None,
     };
-    assert!(dead_module_finding(&markup, Some(0), &complete_graph()).is_none());
+    assert!(dead_module_finding(&markup, Some(0), GraphReadiness::Available).is_none());
 }
 
 #[test]
 fn dead_module_exempts_entrypoints_public_api_and_imported_files() {
-    let resolution = complete_graph();
+    let readiness = GraphReadiness::Available;
     assert!(
         dead_module_finding(
             &node("src/main.rs", FileRole::Production, true, false),
             Some(0),
-            &resolution
+            readiness
         )
         .is_none()
     );
@@ -77,16 +73,16 @@ fn dead_module_exempts_entrypoints_public_api_and_imported_files() {
         dead_module_finding(
             &node("src/lib.rs", FileRole::Production, false, true),
             Some(0),
-            &resolution
+            readiness
         )
         .is_none()
     );
-    assert!(dead_module_finding(&prod("src/used.ts"), Some(2), &resolution).is_none());
+    assert!(dead_module_finding(&prod("src/used.ts"), Some(2), readiness).is_none());
     assert!(
         dead_module_finding(
             &node("src/foo.test.ts", FileRole::Test, false, false),
             Some(0),
-            &resolution
+            readiness
         )
         .is_none()
     );
@@ -94,11 +90,14 @@ fn dead_module_exempts_entrypoints_public_api_and_imported_files() {
 
 #[test]
 fn dead_module_is_demoted_to_low_when_graph_has_unresolved_imports() {
-    let mut resolution = ImportResolutionStats::default();
-    resolution.record(Path::new("src/other.ts"), "./missing-helper");
-
-    let finding = dead_module_finding(&prod("src/orphan.ts"), Some(0), &resolution)
-        .expect("dead module should still be reported when the graph is merely incomplete");
+    let finding = dead_module_finding(
+        &prod("src/orphan.ts"),
+        Some(0),
+        GraphReadiness::Limited {
+            unresolved_internal: 1,
+        },
+    )
+    .expect("dead module should still be reported when the graph is merely incomplete");
 
     // `Low` (not the `Medium` sentinel) so the registry keeps the demotion.
     assert_eq!(finding.confidence, Confidence::Low);
@@ -113,11 +112,16 @@ fn dead_module_is_demoted_to_low_when_graph_has_unresolved_imports() {
 
 #[test]
 fn dead_module_is_suppressed_when_unresolved_import_could_target_it() {
-    let mut resolution = ImportResolutionStats::default();
-    resolution.record(Path::new("src/other.ts"), "../legacy/orphan");
-
     assert!(
-        dead_module_finding(&prod("src/orphan.ts"), Some(0), &resolution).is_none(),
+        dead_module_finding(
+            &prod("src/orphan.ts"),
+            Some(0),
+            GraphReadiness::Unavailable {
+                unresolved_internal: 1,
+                reason: crate::graph::v2::GraphReadinessReason::UnresolvedTarget,
+            },
+        )
+        .is_none(),
         "an unresolved import matching the candidate's name is a plausible importer"
     );
 }

--- a/src/audits/architecture/import_coupling.rs
+++ b/src/audits/architecture/import_coupling.rs
@@ -1,10 +1,7 @@
+use super::graph_context::GraphAuditContext;
 use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
-use crate::graph::{
-    CouplingGraph, FileMetrics, ImportResolutionStats, build_coupling_graph_with_resolution,
-    coupling_file_metrics,
-};
-use crate::scan::config::ScanConfig;
-use crate::scan::facts::ScanFacts;
+use crate::graph::v2::{GraphClaim, GraphReadiness, graph_capabilities, graph_readiness};
+use crate::graph::{FileMetrics, coupling_file_metrics_from_snapshot};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -19,14 +16,16 @@ use rust_facade::is_pure_rust_facade;
 pub struct ImportCouplingAudit;
 
 impl ImportCouplingAudit {
-    pub fn audit_with_graph(
-        &self,
-        facts: &ScanFacts,
-        config: &ScanConfig,
-        root: &Path,
-    ) -> (Vec<Finding>, CouplingGraph, ImportResolutionStats) {
-        let (graph, resolution) = build_coupling_graph_with_resolution(facts, root);
-        let metrics = coupling_file_metrics(&graph);
+    pub(crate) fn audit(&self, context: &GraphAuditContext<'_>) -> Vec<Finding> {
+        let facts = context.facts;
+        let config = context.config;
+        let root = context.root;
+        let metrics = coupling_file_metrics_from_snapshot(context.snapshot, context.path_by_id);
+        let readiness = graph_readiness(
+            &graph_capabilities(context.snapshot),
+            context.resolution,
+            GraphClaim::RepositoryAbsence,
+        );
 
         let classifier = crate::analysis::ArchitectureClassifier::new(&config.module_mappings);
         let mut findings = Vec::new();
@@ -73,14 +72,14 @@ impl ImportCouplingAudit {
                     config.instability_hub_min_fan_in,
                     config.instability_hub_min_instability_pct,
                     file_facts,
-                    &resolution,
+                    readiness,
                 ));
             }
         }
 
-        cycles::emit_circular_dependency_findings(&graph, &prod_files, root, &mut findings);
+        cycles::emit_circular_dependency_findings(context.graph, &prod_files, root, &mut findings);
 
-        (findings, graph, resolution)
+        findings
     }
 }
 
@@ -137,7 +136,7 @@ fn high_instability_hub_finding(
     min_fan_in: usize,
     min_instability_pct: usize,
     file_facts: Option<&crate::scan::facts::FileFacts>,
-    resolution: &ImportResolutionStats,
+    readiness: GraphReadiness,
 ) -> Finding {
     let path = relative_path(&metric.path, root);
 
@@ -152,14 +151,17 @@ fn high_instability_hub_finding(
     // Instability is derived from fan-in; every unresolved relative import in
     // the repository is a potential missing importer of this file, so the
     // measured fan-in is a lower bound and the instability claim is weaker.
-    let confidence = if resolution.is_empty() {
-        Confidence::High
-    } else {
+    let confidence = if let GraphReadiness::Limited {
+        unresolved_internal,
+    } = readiness
+    {
         snippet.push_str(&format!(
             "\n{} unresolved relative import(s) in the repository — fan-in may be undercounted.",
-            resolution.total()
+            unresolved_internal
         ));
         Confidence::Medium
+    } else {
+        Confidence::High
     };
 
     if let Some(facts) = file_facts

--- a/src/audits/architecture/import_coupling/tests.rs
+++ b/src/audits/architecture/import_coupling/tests.rs
@@ -2,7 +2,8 @@ use std::path::{Path, PathBuf};
 
 use super::high_instability_hub_finding;
 use crate::findings::types::Confidence;
-use crate::graph::{FileMetrics, ImportResolutionStats};
+use crate::graph::FileMetrics;
+use crate::graph::v2::GraphReadiness;
 
 fn hub_metric() -> FileMetrics {
     FileMetrics {
@@ -22,7 +23,7 @@ fn hub_confidence_is_high_when_graph_is_complete() {
         5,
         70,
         None,
-        &ImportResolutionStats::default(),
+        GraphReadiness::Available,
     );
 
     assert_eq!(finding.confidence, Confidence::High);
@@ -34,11 +35,17 @@ fn hub_confidence_is_high_when_graph_is_complete() {
 
 #[test]
 fn hub_confidence_is_demoted_when_unresolved_imports_exist() {
-    let mut resolution = ImportResolutionStats::default();
-    resolution.record(Path::new("src/a.ts"), "./missing");
-
-    let finding =
-        high_instability_hub_finding(&hub_metric(), Path::new(""), 70, 5, 70, None, &resolution);
+    let finding = high_instability_hub_finding(
+        &hub_metric(),
+        Path::new(""),
+        70,
+        5,
+        70,
+        None,
+        GraphReadiness::Limited {
+            unresolved_internal: 1,
+        },
+    );
 
     assert_eq!(finding.confidence, Confidence::Medium);
     assert!(

--- a/src/audits/architecture/mod.rs
+++ b/src/audits/architecture/mod.rs
@@ -1,6 +1,8 @@
 pub mod barrel_file_risk;
 pub mod deep_directory_nesting;
 pub mod deep_relative_imports;
+pub(crate) mod graph_analysis;
+pub(crate) mod graph_context;
 pub mod graph_queries;
 pub mod import_coupling;
 pub mod large_file;

--- a/src/graph/coupling_metrics.rs
+++ b/src/graph/coupling_metrics.rs
@@ -9,6 +9,7 @@
 //! [`compute_metrics`]: super::compute_metrics
 
 use super::{CouplingGraph, FileMetrics};
+use crate::graph::v2::{GraphNodeId, GraphSnapshot};
 use crate::graph::v2::{build_coupling_graph_snapshot, compute_degrees};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -17,9 +18,16 @@ use std::path::PathBuf;
 /// graph v2 degrees. One entry per file, ordered by repository-relative path.
 pub fn coupling_file_metrics(graph: &CouplingGraph) -> Vec<FileMetrics> {
     let (snapshot, path_by_id) = build_coupling_graph_snapshot(graph);
+    coupling_file_metrics_from_snapshot(&snapshot, &path_by_id)
+}
+
+pub(crate) fn coupling_file_metrics_from_snapshot(
+    snapshot: &GraphSnapshot,
+    path_by_id: &BTreeMap<GraphNodeId, PathBuf>,
+) -> Vec<FileMetrics> {
     let mut metrics: BTreeMap<PathBuf, FileMetrics> = BTreeMap::new();
 
-    for degree in compute_degrees(&snapshot).nodes {
+    for degree in compute_degrees(snapshot).nodes {
         let Some(path) = path_by_id.get(&degree.node_id) else {
             continue;
         };

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -7,6 +7,7 @@ mod coupling_metrics;
 mod resolution_stats;
 
 pub use coupling_metrics::coupling_file_metrics;
+pub(crate) use coupling_metrics::coupling_file_metrics_from_snapshot;
 pub use imports::extract_imports;
 pub use resolution_stats::ImportResolutionStats;
 pub use resolver::resolve_import;

--- a/src/graph/v2/mod.rs
+++ b/src/graph/v2/mod.rs
@@ -5,6 +5,7 @@ mod coupling_snapshot;
 mod diagnostic;
 mod edge;
 mod node;
+mod readiness;
 mod snapshot;
 
 pub use algorithms::{
@@ -19,6 +20,7 @@ pub use coupling_snapshot::build_coupling_graph_snapshot;
 pub use diagnostic::GraphDiagnostic;
 pub use edge::{GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance};
 pub use node::{GraphNode, GraphNodeId, GraphNodeKind};
+pub use readiness::{GraphClaim, GraphReadiness, GraphReadinessReason, graph_readiness};
 pub use snapshot::GraphSnapshot;
 
 #[cfg(test)]
@@ -89,5 +91,60 @@ mod tests {
         assert_eq!(snapshot.edges[0].from, source_id);
         assert_eq!(snapshot.edges[0].to, target_id);
         assert_eq!(snapshot.edges[0].kind, GraphEdgeKind::DependsOn);
+    }
+
+    #[test]
+    fn graph_readiness_distinguishes_presence_and_absence_claims() {
+        let capabilities = GraphCapabilities {
+            file_nodes: 2,
+            resolved_dependency_edges: 1,
+            ..GraphCapabilities::default()
+        };
+        let mut resolution = crate::graph::ImportResolutionStats::default();
+        resolution.record(std::path::Path::new("src/a.ts"), "./missing/orphan");
+
+        assert_eq!(
+            graph_readiness(&capabilities, &resolution, GraphClaim::Presence),
+            GraphReadiness::Available
+        );
+        assert_eq!(
+            graph_readiness(&capabilities, &resolution, GraphClaim::RepositoryAbsence),
+            GraphReadiness::Limited {
+                unresolved_internal: 1
+            }
+        );
+        assert_eq!(
+            GraphReadiness::Limited {
+                unresolved_internal: 1
+            }
+            .reason_code(),
+            "graph.unresolved-internal-imports"
+        );
+        assert_eq!(
+            graph_readiness(
+                &capabilities,
+                &resolution,
+                GraphClaim::TargetAbsence("orphan")
+            ),
+            GraphReadiness::Unavailable {
+                unresolved_internal: 1,
+                reason: GraphReadinessReason::UnresolvedTarget,
+            }
+        );
+    }
+
+    #[test]
+    fn graph_readiness_requires_file_capability_for_absence_claims() {
+        assert_eq!(
+            graph_readiness(
+                &GraphCapabilities::default(),
+                &crate::graph::ImportResolutionStats::default(),
+                GraphClaim::RepositoryAbsence
+            ),
+            GraphReadiness::Unavailable {
+                unresolved_internal: 0,
+                reason: GraphReadinessReason::NoFileGraph,
+            }
+        );
     }
 }

--- a/src/graph/v2/readiness.rs
+++ b/src/graph/v2/readiness.rs
@@ -1,0 +1,81 @@
+//! Capability policy for graph-backed claims.
+
+use super::GraphCapabilities;
+use crate::graph::ImportResolutionStats;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphClaim<'a> {
+    Presence,
+    RepositoryAbsence,
+    TargetAbsence(&'a str),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphReadiness {
+    Available,
+    Limited {
+        unresolved_internal: usize,
+    },
+    Unavailable {
+        unresolved_internal: usize,
+        reason: GraphReadinessReason,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphReadinessReason {
+    NoFileGraph,
+    UnresolvedTarget,
+}
+
+impl GraphReadiness {
+    pub fn reason_code(self) -> &'static str {
+        match self {
+            Self::Available => "graph.available",
+            Self::Limited { .. } => "graph.unresolved-internal-imports",
+            Self::Unavailable {
+                reason: GraphReadinessReason::NoFileGraph,
+                ..
+            } => "graph.no-file-graph",
+            Self::Unavailable {
+                reason: GraphReadinessReason::UnresolvedTarget,
+                ..
+            } => "graph.unresolved-target",
+        }
+    }
+}
+
+pub fn graph_readiness(
+    capabilities: &GraphCapabilities,
+    resolution: &ImportResolutionStats,
+    claim: GraphClaim<'_>,
+) -> GraphReadiness {
+    if matches!(claim, GraphClaim::Presence) {
+        return GraphReadiness::Available;
+    }
+
+    let unresolved_internal = resolution.total();
+    if capabilities.file_nodes == 0 {
+        return GraphReadiness::Unavailable {
+            unresolved_internal,
+            reason: GraphReadinessReason::NoFileGraph,
+        };
+    }
+
+    if let GraphClaim::TargetAbsence(stem) = claim
+        && resolution.could_target_stem(stem)
+    {
+        return GraphReadiness::Unavailable {
+            unresolved_internal,
+            reason: GraphReadinessReason::UnresolvedTarget,
+        };
+    }
+
+    if unresolved_internal > 0 {
+        GraphReadiness::Limited {
+            unresolved_internal,
+        }
+    } else {
+        GraphReadiness::Available
+    }
+}

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -1,5 +1,5 @@
 use super::changed_git::collect_changed_scope;
-use crate::audits::architecture::import_coupling::ImportCouplingAudit;
+use crate::audits::architecture::graph_analysis::run_graph_analysis;
 use crate::audits::pipeline::{
     run_framework_audits, run_project_audits, stamp_findings_analysis_scope,
 };
@@ -110,23 +110,21 @@ impl<'a> ChangedScanEngine<'a> {
             &mut file_stage.parsed_cache,
         )?;
         let project_start = Instant::now();
-        let ((project_findings, framework_findings), (coupling_findings, _, _)) = rayon::join(
+        let ((project_findings, framework_findings), graph_analysis) = rayon::join(
             || {
                 rayon::join(
                     || run_project_audits(&repo_stage.repo_context, self.config),
                     || run_framework_audits(&repo_stage.repo_context, self.config),
                 )
             },
-            || {
-                ImportCouplingAudit.audit_with_graph(
-                    &repo_stage.repo_context,
-                    self.config,
-                    &discovery.repo_root,
-                )
-            },
+            || run_graph_analysis(&repo_stage.repo_context, self.config, &discovery.repo_root),
         );
-        let coupling_findings =
-            stamp_findings_analysis_scope(coupling_findings, AnalysisScope::Repository);
+        let coupling_findings = stamp_findings_analysis_scope(
+            graph_analysis.coupling_findings,
+            AnalysisScope::Repository,
+        );
+        let query_findings =
+            stamp_findings_analysis_scope(graph_analysis.query_findings, AnalysisScope::Repository);
 
         file_stage.findings.extend(project_findings);
         file_stage.findings.extend(framework_findings);
@@ -134,6 +132,7 @@ impl<'a> ChangedScanEngine<'a> {
             &repo_stage.repo_context,
             coupling_findings,
         ));
+        file_stage.findings.extend(query_findings);
         let post_scan_audits_us = project_start.elapsed().as_micros() as u64;
         let enrichment_us = enrich_findings_timed(&mut file_stage.findings, &discovery.repo_root);
         apply_rule_config(&mut file_stage.findings, self.config);

--- a/src/scan/scanner/full.rs
+++ b/src/scan/scanner/full.rs
@@ -1,5 +1,5 @@
 use super::{collection, contract_stage};
-use crate::audits::architecture::import_coupling::ImportCouplingAudit;
+use crate::audits::architecture::graph_analysis::run_graph_analysis;
 use crate::audits::pipeline::{
     run_framework_audits, run_project_audits, stamp_findings_analysis_scope,
 };
@@ -214,31 +214,22 @@ impl<'a> ScanEngine<'a> {
         mut findings: Vec<Finding>,
     ) -> ProjectAnalysisStage {
         let start = Instant::now();
-        let (
-            (project_findings, framework_findings),
-            (coupling_findings, coupling_graph, resolution),
-        ) = rayon::join(
+        let ((project_findings, framework_findings), graph_analysis) = rayon::join(
             || {
                 rayon::join(
                     || run_project_audits(&facts, self.config),
                     || run_framework_audits(&facts, self.config),
                 )
             },
-            || ImportCouplingAudit.audit_with_graph(&facts, self.config, self.path),
+            || run_graph_analysis(&facts, self.config, self.path),
         );
-        let query_findings = stamp_findings_analysis_scope(
-            crate::audits::architecture::graph_queries::GraphQueriesAudit.audit(
-                &facts,
-                self.config,
-                &coupling_graph,
-                &resolution,
-                self.path,
-            ),
+        let query_findings =
+            stamp_findings_analysis_scope(graph_analysis.query_findings, AnalysisScope::Repository);
+
+        let coupling_findings = stamp_findings_analysis_scope(
+            graph_analysis.coupling_findings,
             AnalysisScope::Repository,
         );
-
-        let coupling_findings =
-            stamp_findings_analysis_scope(coupling_findings, AnalysisScope::Repository);
 
         findings.extend(project_findings);
         findings.extend(framework_findings);
@@ -248,7 +239,7 @@ impl<'a> ScanEngine<'a> {
         ProjectAnalysisStage {
             facts,
             findings,
-            coupling_graph,
+            coupling_graph: graph_analysis.graph,
             elapsed_us: start.elapsed().as_micros() as u64,
         }
     }

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -630,6 +630,30 @@ fn since_scan_uses_base_ref_scope() {
 }
 
 #[test]
+fn changed_scan_runs_graph_query_rules() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(
+        temp.path().join("src/app.ts"),
+        "export function app() { return 1; }\n",
+    );
+    write(
+        temp.path().join("fixtures/data.ts"),
+        "export const fixture = 1;\n",
+    );
+    commit_all(temp.path(), "initial");
+
+    write(
+        temp.path().join("src/app.ts"),
+        "import { fixture } from '../fixtures/data';\nexport function app() { return fixture; }\n",
+    );
+
+    let changed = scan_changed_json(temp.path(), &["--changed", "--profile", "strict"]);
+
+    assert_rule_present(&changed, "architecture.test-leak");
+}
+
+#[test]
 fn cache_clear_removes_cache_and_is_idempotent() {
     let temp = tempdir().expect("temp dir");
     init_repo(temp.path());


### PR DESCRIPTION
## What changed

- add an internal `available` / `limited` / `unavailable` readiness contract for graph-backed claims
- centralize confidence demotion and safe suppression for absence-based graph rules
- run graph-query rules consistently in full and changed scans
- reuse one graph-v2 snapshot across coupling metrics, readiness, and graph queries
- add regression coverage for changed-scan `architecture.test-leak` detection
- update the v0.22 roadmap, engineering notes, and changelog

## Why

Graph capability metadata existed, but rule consumers interpreted incomplete import evidence independently. Changed scans also skipped `GraphQueriesAudit`, so their repository-level architecture analysis differed from full scans.

This phase establishes one deterministic internal policy: proven edges remain actionable, incomplete absence claims lose confidence, and directly conflicting unresolved imports suppress unsafe conclusions.

## Developer impact

- full and changed scans now apply the same graph-query rules
- incomplete dependency graphs produce more honest confidence behavior
- graph analysis avoids repeated snapshot construction on the scan-rule path
- CLI, JSON, MCP, rule IDs, and public schemas remain compatible

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` — 730 library tests, 55 binary tests, all integration/doc tests
- `python3 scripts/release-contract.py check`
- `npm run test:release-contract` — 42 tests
- `cargo run -- scan . --fail-on-priority p1` — P0 0, P1 0, health 100/100
