### PR TITLE
ci: keep CodeQL actions in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,10 @@ updates:
       time: "10:00"
       timezone: Europe/Kiev
     open-pull-requests-limit: 5
+    groups:
+      codeql-actions:
+        patterns:
+          - github/codeql-action/*
     ignore:
       # v5 requires self-hosted Actions Runner 2.327.1 or newer. Keep the
       # public composite action compatible with older supported runners.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: rust,javascript-typescript
           build-mode: none
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5


### PR DESCRIPTION
## What changed

- update CodeQL `init` and `analyze` together to v4.37.5 (`d1ba80a...`)
- group future `github/codeql-action/*` Dependabot updates into one PR

## Why

Dependabot opened separate updates for `init` and `analyze`. Each isolated PR mixed CodeQL 4.37.5 with 4.37.1 in the same job, causing:

> Loaded a configuration file for version '4.37.5', but running version '4.37.1'

CodeQL lifecycle actions share job state and must use the same release.

## Validation

- both CodeQL lifecycle steps resolve to one pinned SHA
- `actionlint .github/workflows/codeql.yml .github/workflows/ci.yaml`
- YAML parsing for `.github/workflows/codeql.yml` and `.github/dependabot.yml`
- `git diff --check`

Supersedes Dependabot PRs #332 and #334.
