### PR TITLE
refactor: converge v0.22 graph state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/demos/*.log
 # Real-repo validation zoo: repos are cloned here on demand, never committed.
 # Only tests/zoo/manifest.toml + tests/zoo/snapshots/*.json are tracked.
 /.zoo/
+
+# Isolated feature workspaces created by local development agents.
+/.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Reuse one internal graph-v2 context analysis for AI-context degree metrics,
   direct dependents, and capability state, preserving the existing bounded
   context summary, JSON, MCP, and readiness contracts.
+- Persist minimal repository context state under cache schema v5 and derive
+  bounded context cycles through graph v2. Full and changed scans now share the
+  same state-to-analysis path; upgrades rebuild the internal cache once without
+  changing public reports or warm changed-scan behavior.
 
 ## [0.21.0] - 2026-08-06
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ adoption or CI policy.
 
 - [v0.22 repository intelligence design](engineering/v0.22-repository-intelligence-design.md)
 - [v0.22 Phase A1 context graph specification](engineering/v0.22-phase-a1-context-graph-v2.md)
+- [v0.22 Phase A3 graph state convergence specification](engineering/v0.22-phase-a3-graph-state-convergence.md)
 - [Analysis platform state](engineering/analysis-platform-state.md)
 - [Dependency Graph v2 design](engineering/dependency-graph-v2.md)
 - [Signal contract](engineering/signal-contract.md)

--- a/docs/engineering/analysis-platform-state.md
+++ b/docs/engineering/analysis-platform-state.md
@@ -170,11 +170,15 @@ dependency aggregation, and summaries. All three import-coupling scan rules and
 review blast radius consume graph v2. AI-context fallback metrics and the primary
 context summary use graph-v2 degrees and direct dependents; the primary summary
 reuses one internal analysis view for degrees, dependents, and capability state.
-The persisted `RepoContextGraph` and historical bounded cycle representation
-remain compatibility surfaces pending differential migration.
+Phase A3 replaced scanner ownership of the persisted `RepoContextGraph` with an
+ordered internal `RepositoryContextState`. Cache schema v5 stores source-derived
+context and resolved relationships, while graph-v2 analysis derives degrees,
+dependents, capabilities, and bounded cycle paths once per summary. The public
+`RepoContextGraph` remains compatibility-only.
 
-1. Migrate the persisted context graph and bounded cycle projection only after
-   graph-v2 parity fixtures cover their deferred-edge and path semantics.
+1. **Done in v0.22 A3.** Persist repository context state and migrate bounded
+   cycle paths after deferred-edge, Rust containment, changed-scan, ordering,
+   and truncation parity coverage.
 2. **Done internally in v0.22 A2.** Graph capability metadata now drives an
    available/limited/unavailable policy for graph-backed scan rules. Full and
    changed scans share the same graph analysis bundle; a public skipped-analysis

--- a/docs/engineering/dependency-graph-v2.md
+++ b/docs/engineering/dependency-graph-v2.md
@@ -61,12 +61,12 @@ roadmap's rule-capability checks, with no command or report consumer yet. The v1
 all migrated outputs are byte-for-byte unchanged and guarded by parity tests.
 
 The primary `context_graph_summary` now constructs one reusable internal
-graph-v2 analysis view for degree metrics, one-hop dependents, and capability
-state. The persisted `RepoContextGraph` schema and historical bounded cycle
-projection remain compatibility paths: cycle output deliberately excludes
-deferred imports and Rust module-containment edges and is not equivalent to SCC
-membership. Those paths should move only after differential fixtures prove
-equivalent deterministic and bounded behavior.
+graph-v2 analysis view for degree metrics, one-hop dependents, capability state,
+and bounded cycle paths. Cache schema v5 persists minimal repository context
+state rather than derived graph results; full and changed scans share that
+state-to-analysis path. The public `RepoContextGraph` remains a compatibility
+view only. Cycle output continues to exclude deferred imports and Rust
+module-containment edges.
 
 Today, `CouplingGraph`, `RepoContextGraph`, import extraction, language
 resolvers, review signals, and graph summaries provide useful behavior. Graph
@@ -303,6 +303,7 @@ internal.
    Full and changed scans share one runner and one snapshot for coupling metrics,
    graph queries, and readiness. Public skip diagnostics remain a later additive
    projection.
-5. Migrate the persisted `RepoContextGraph` schema/cache and historical bounded
-   cycle projection after differential fixtures cover deferred imports, Rust
-   module-containment edges, changed-scan patching, and cycle ordering.
+5. **Done (A3).** Cache schema v5 persists ordered repository context state,
+   scanners no longer use `RepoContextGraph` as canonical state, and bounded
+   context cycles run through graph v2 while preserving deferred-import, Rust
+   containment, changed-scan patching, ordering, and truncation contracts.

--- a/docs/engineering/v0.22-phase-a3-graph-state-convergence-plan.md
+++ b/docs/engineering/v0.22-phase-a3-graph-state-convergence-plan.md
@@ -1,0 +1,598 @@
+# RepoPilot 0.22 Phase A3 Graph State Convergence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make graph v2 the single derived context-analysis path while preserving warm changed-scan behavior and every public context-summary contract.
+
+**Architecture:** Persist an internal, ordered `RepositoryContextState` containing source-derived file context, framework metadata, and resolved eager/deferred coupling relationships. Build one graph-v2 snapshot per summary analysis and use a parity-tested bounded cycle projection instead of the legacy context-summary DFS path; retain `RepoContextGraph` only as a compatibility conversion.
+
+**Tech Stack:** Rust 2024, serde JSON cache, ordered `BTreeMap`/`BTreeSet` state, graph-v2 algorithms, Cargo integration tests.
+
+## Global Constraints
+
+- No public report, JSON, CLI, MCP, finding, readiness, or cache-info field changes.
+- Keep `RepoContextGraph` and `RepoContextNode` exports compatible throughout the `0.x` window.
+- Repository paths are relative and slash-normalized in cached state and fingerprints.
+- Deferred-only and Rust module-containment cycles stay excluded from `ContextGraphSummary`.
+- A compatible warm changed scan does not read unchanged source content.
+- Derived graph metrics, SCCs, rankings, and report fragments are never persisted.
+- Output ordering is deterministic across supported thread counts.
+- Existing pinned performance scenarios may not regress by more than 10% without approval.
+- Source files stay near 300 lines and functions near 50 lines.
+
+---
+
+### Task 1: Graph-v2 bounded cycle-path compatibility
+
+**Files:**
+- Modify: `src/graph/v2/algorithms/cycles/mod.rs`
+- Modify: `src/graph/v2/algorithms/mod.rs`
+- Modify: `src/graph/v2/mod.rs`
+- Modify: `src/graph/mod.rs`
+- Modify: `src/graph/context/analysis.rs`
+- Modify: `src/graph/context/summary.rs`
+- Test: `src/graph/v2/algorithms/cycles/mod.rs`
+- Test: `src/graph/context/tests.rs`
+
+**Interfaces:**
+- Consumes: one full `GraphSnapshot`, repository-relative `path_by_id`, and an ordered set of deferred/Rust-containment edge pairs excluded only during cycle traversal.
+- Produces: `bounded_cycle_paths(snapshot: &GraphSnapshot, excluded_edges: &BTreeSet<(GraphNodeId, GraphNodeId)>, max_cycles: usize) -> BoundedCyclePaths` where `BoundedCyclePaths` contains canonical `Vec<Vec<GraphNodeId>>`, `truncated`, and `depth_exceeded`.
+- Produces: `ContextGraphAnalysis::bounded_cycles(max_cycles) -> BoundedContextCycles` mapped back to repository-relative paths.
+
+- [ ] **Step 1: Write failing graph-v2 path-contract tests**
+
+Add tests proving the new function returns the historical open path shape, rotates the smallest ID first, sorts/deduplicates paths, honors zero/one limits, reports truncation from a `limit + 1` probe, and bounds traversal depth.
+
+```rust
+#[test]
+fn bounded_paths_are_canonical_and_open() {
+    let snapshot = snapshot(&[("b", "c"), ("c", "a"), ("a", "b")]);
+    let result = bounded_cycle_paths(&snapshot, &BTreeSet::new(), 20);
+
+    assert_eq!(result.paths, vec![vec![id("a"), id("b"), id("c")]]);
+    assert!(!result.truncated);
+    assert!(!result.depth_exceeded);
+}
+
+#[test]
+fn bounded_paths_report_truncation_without_returning_the_probe() {
+    let snapshot = snapshot(&[("a", "b"), ("b", "a"), ("c", "d"), ("d", "c")]);
+    let result = bounded_cycle_paths(&snapshot, &BTreeSet::new(), 1);
+
+    assert_eq!(result.paths.len(), 1);
+    assert!(result.truncated);
+}
+
+fn id(label: &str) -> GraphNodeId {
+    GraphNodeId::new(format!("file:{label}"))
+}
+
+fn snapshot(edges: &[(&str, &str)]) -> GraphSnapshot {
+    let labels = edges
+        .iter()
+        .flat_map(|(from, to)| [*from, *to])
+        .collect::<BTreeSet<_>>();
+    GraphSnapshot {
+        nodes: labels
+            .into_iter()
+            .map(|label| GraphNode {
+                id: id(label),
+                kind: GraphNodeKind::File,
+                label: label.to_string(),
+                path: Some(PathBuf::from(label)),
+            })
+            .collect(),
+        edges: edges
+            .iter()
+            .map(|(from, to)| GraphEdge {
+                from: id(from),
+                to: id(to),
+                kind: GraphEdgeKind::Imports,
+                provenance: GraphEdgeProvenance::Import,
+                confidence: GraphEdgeConfidence::High,
+            })
+            .collect(),
+        ..GraphSnapshot::default()
+    }
+}
+```
+
+- [ ] **Step 2: Verify the graph-v2 tests fail for the missing API**
+
+Run: `cargo test graph::v2::algorithms::cycles::tests::bounded_paths --lib`
+
+Expected: compile failure because `bounded_cycle_paths` and `BoundedCyclePaths` do not exist.
+
+- [ ] **Step 3: Implement the bounded graph-v2 traversal**
+
+Add the exact public-within-crate result and entry point:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundedCyclePaths {
+    pub paths: Vec<Vec<GraphNodeId>>,
+    pub truncated: bool,
+    pub depth_exceeded: bool,
+}
+
+pub fn bounded_cycle_paths(
+    snapshot: &GraphSnapshot,
+    excluded_edges: &BTreeSet<(GraphNodeId, GraphNodeId)>,
+    max_cycles: usize,
+) -> BoundedCyclePaths;
+```
+
+Build ordered adjacency only from present nodes and dependency edges not present
+in `excluded_edges`, perform a deterministic bounded DFS, canonicalize each
+discovered back-edge path by rotating its smallest ID first, sort/deduplicate,
+and probe one extra path to set `truncated`.
+
+- [ ] **Step 4: Verify graph-v2 cycle tests pass**
+
+Run: `cargo test graph::v2::algorithms::cycles --lib`
+
+Expected: all cycle unit and property tests pass.
+
+- [ ] **Step 5: Write failing context-summary differential tests**
+
+Add a test helper that evaluates the same `CouplingGraph` through legacy `detect_cycles_bounded` and the new graph-v2 projection. Cover acyclic, two-node, overlapping, deferred-only, Rust parent-to-module, ordered, and truncated cases.
+
+```rust
+#[test]
+fn graph_v2_cycle_projection_matches_historical_context_contract() {
+    for graph in differential_cycle_graphs() {
+        let filtered = without_rust_module_containment_edges(&graph);
+        let expected = detect_cycles_bounded(&filtered, MAX_CONTEXT_GRAPH_CYCLES);
+        let compat = compatibility_graph_with_coupling(graph);
+
+        assert_eq!(summarize_context_graph(&compat, &[], &[]).cycles, expected);
+    }
+}
+
+fn compatibility_graph_with_coupling(graph: CouplingGraph) -> RepoContextGraph {
+    RepoContextGraph {
+        root_path: PathBuf::from("."),
+        nodes: graph.nodes.iter().map(|path| RepoContextNode {
+            path: path.clone(),
+            language: None,
+            roles: Vec::new(),
+            frameworks: Vec::new(),
+            runtimes: Vec::new(),
+            paradigms: Vec::new(),
+            workspace_package: None,
+            non_empty_lines: 1,
+            imports: Vec::new(),
+            deferred_imports: Vec::new(),
+            is_test: false,
+            is_generated: false,
+            is_config: false,
+        }).collect(),
+        edges: graph.edges,
+        deferred_edges: graph.deferred_edges,
+        detected_frameworks: Vec::new(),
+        framework_projects: Vec::new(),
+        react_native: None,
+    }
+}
+```
+
+- [ ] **Step 6: Verify the differential test fails on the legacy summary path**
+
+Run: `cargo test graph_v2_cycle_projection_matches_historical_context_contract --lib`
+
+Expected: failure because context analysis does not expose or consume graph-v2 bounded cycle paths.
+
+- [ ] **Step 7: Move cycle projection into `ContextGraphAnalysis`**
+
+Build the full snapshot once. Derive an ordered set of deferred and Rust
+module-containment edge IDs from the coupling input, pass those exclusions into
+cycle traversal, and keep the full snapshot for degree/dependent projections.
+If traversal reports a depth overflow, call the existing crate-internal cycle
+depth marker so scanner diagnostics stay compatible. Expose:
+
+```rust
+pub(super) struct BoundedContextCycles {
+    pub paths: Vec<Vec<PathBuf>>,
+    pub truncated: bool,
+    pub depth_exceeded: bool,
+}
+
+pub(super) fn bounded_cycles(&self, max_cycles: usize) -> BoundedContextCycles;
+```
+
+Change `summarize_context_graph` to consume this projection and remove its direct call to `detect_cycles_bounded`.
+
+- [ ] **Step 8: Verify context parity and related graph suites**
+
+Run: `cargo test graph::context --lib && cargo test --test coupling_graph && cargo test --test scan_changed_cache_cli`
+
+Expected: all tests pass and existing output assertions remain unchanged.
+
+- [ ] **Step 9: Commit the cycle migration**
+
+```bash
+git add src/graph/v2 src/graph/context
+git commit -m "refactor: move context cycles onto graph v2"
+```
+
+---
+
+### Task 2: Internal repository-context state
+
+**Files:**
+- Create: `src/graph/context/state.rs`
+- Modify: `src/graph/context.rs`
+- Modify: `src/graph/context/graph_impl.rs`
+- Modify: `src/graph/context/analysis.rs`
+- Test: `src/graph/context/tests.rs`
+
+**Interfaces:**
+- Consumes: `ScanFacts`, `CouplingGraph`, `ChangedFile`, and changed `FileFacts`.
+- Produces: crate-internal `RepositoryContextState` with `from_scan_facts`, `to_scan_facts`, `coupling_graph`, `apply_changed_facts`, `from_compat`, and `to_compat`.
+- Preserves: public `RepoContextGraph` constructors and methods by delegating through compatibility conversions.
+
+- [ ] **Step 1: Write failing state construction and conversion tests**
+
+```rust
+#[test]
+fn repository_context_state_round_trips_the_compatibility_view() {
+    let compat = context_graph_with_eager_and_deferred_edges();
+    let state = RepositoryContextState::from_compat(compat.clone());
+
+    assert_eq!(state.to_compat(), compat);
+    assert_eq!(state.coupling_graph(), compat.coupling_graph());
+}
+
+#[test]
+fn state_keeps_sorted_relative_file_records() {
+    let state = RepositoryContextState::from_scan_facts(&facts_out_of_order(), root(), graph());
+
+    assert_eq!(state.file_paths(), vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")]);
+}
+```
+
+Add test-only constructors with exact signatures in `src/graph/context/tests.rs`:
+
+```rust
+fn root() -> &'static Path {
+    Path::new("/repo")
+}
+
+fn facts_out_of_order() -> ScanFacts {
+    ScanFacts {
+        root_path: root().to_path_buf(),
+        files: vec![file_fact("b.rs", &[]), file_fact("a.rs", &[])],
+        ..ScanFacts::default()
+    }
+}
+
+fn graph() -> CouplingGraph {
+    CouplingGraph {
+        nodes: BTreeSet::from([PathBuf::from("a.rs"), PathBuf::from("b.rs")]),
+        ..CouplingGraph::default()
+    }
+}
+```
+
+- [ ] **Step 2: Verify tests fail because the internal state is absent**
+
+Run: `cargo test repository_context_state --lib`
+
+Expected: compile failure for missing `RepositoryContextState`.
+
+- [ ] **Step 3: Implement the minimal ordered state**
+
+Create:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RepositoryContextState {
+    root_path: PathBuf,
+    files: Vec<RepoContextNode>,
+    coupling: CouplingGraph,
+    detected_frameworks: Vec<DetectedFramework>,
+    framework_projects: Vec<FrameworkProject>,
+    react_native: Option<ReactNativeArchitectureProfile>,
+}
+```
+
+Normalize and sort state at every construction boundary. Keep field access
+private; expose focused methods needed by cache, scanner, and analysis.
+
+- [ ] **Step 4: Verify construction and conversion tests pass**
+
+Run: `cargo test repository_context_state --lib`
+
+Expected: all new state tests pass.
+
+- [ ] **Step 5: Write failing changed-patch tests**
+
+Add separate tests for modified eager imports, eager-to-deferred transitions,
+added files, deleted targets, and renamed files. Assert both reconstructed facts
+and coupling edges.
+
+```rust
+#[test]
+fn state_patch_removes_deleted_targets_from_all_edge_sets() {
+    let mut state = state_with_edge("a.rs", "b.rs");
+    state.apply_changed_facts(root(), &[deleted("b.rs")], &[]);
+
+    assert!(!state.coupling_graph().nodes.contains(Path::new("b.rs")));
+    assert!(state.coupling_graph().edges[Path::new("a.rs")].is_empty());
+}
+```
+
+Construct `state_with_edge` through `RepoContextGraph` compatibility conversion
+and construct `deleted` as the existing public diff model:
+
+```rust
+fn state_with_edge(from: &str, to: &str) -> RepositoryContextState {
+    RepositoryContextState::from_compat(compatibility_graph_with_coupling(
+        CouplingGraph {
+            nodes: BTreeSet::from([PathBuf::from(from), PathBuf::from(to)]),
+            edges: BTreeMap::from([(
+                PathBuf::from(from),
+                BTreeSet::from([PathBuf::from(to)]),
+            )]),
+            deferred_edges: BTreeMap::new(),
+        },
+    ))
+}
+
+fn deleted(path: &str) -> ChangedFile {
+    ChangedFile {
+        path: PathBuf::from(path),
+        status: ChangeStatus::Deleted,
+        ranges: Vec::new(),
+        hunks: Vec::new(),
+    }
+}
+```
+
+- [ ] **Step 6: Verify changed-patch tests fail before migration**
+
+Run: `cargo test state_patch --lib`
+
+Expected: failure because `RepositoryContextState::apply_changed_facts` is missing.
+
+- [ ] **Step 7: Move patching and fact reconstruction onto state**
+
+Move the current deterministic resolution helpers behind
+`RepositoryContextState::apply_changed_facts`. Preserve the full re-resolution
+when the known file set changes and source-only patching otherwise. Make public
+`RepoContextGraph` methods convert/delegate so existing consumers remain valid.
+
+- [ ] **Step 8: Verify state, context, and import-resolution suites**
+
+Run: `cargo test graph::context --lib && cargo test --test import_extraction && cargo test --test coupling_graph`
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit the internal state boundary**
+
+```bash
+git add src/graph/context
+git commit -m "refactor: separate repository context state"
+```
+
+---
+
+### Task 3: Context-cache schema migration
+
+**Files:**
+- Modify: `src/graph/context.rs`
+- Modify: `src/graph/context/cache.rs`
+- Modify: `src/scan/scanner/changed/repo_context.rs`
+- Modify: `src/scan/scanner/changed/stages.rs`
+- Modify: `src/scan/scanner/finalize.rs`
+- Test: `src/graph/context/tests.rs`
+- Test: `tests/scan_changed_cache_cli.rs`
+
+**Interfaces:**
+- Consumes: `RepositoryContextState`, config fingerprint, and repository fingerprint.
+- Produces: `load_repository_context_state(root, config) -> Option<RepositoryContextStateLoad>` and `write_repository_context_state(root, config, state) -> io::Result<ContextGraphCacheInfo>`.
+- Preserves: `load_repo_context_graph` and `write_repo_context_graph` as compatibility wrappers around state conversion.
+
+- [ ] **Step 1: Write failing cache schema and deterministic round-trip tests**
+
+```rust
+#[test]
+fn context_state_cache_round_trip_is_deterministic() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = repository_context_state_fixture(dir.path());
+    write_repository_context_state(dir.path(), "config", &state).unwrap();
+    let first = fs::read(context_graph_cache_path(dir.path())).unwrap();
+    write_repository_context_state(dir.path(), "config", &state).unwrap();
+    let second = fs::read(context_graph_cache_path(dir.path())).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(load_repository_context_state(dir.path(), "config").unwrap().state, state);
+}
+
+#[test]
+fn schema_v4_cache_is_rejected_without_partial_deserialization() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir_all(dir.path().join(".repopilot/cache")).unwrap();
+    fs::write(
+        context_graph_cache_path(dir.path()),
+        serde_json::to_vec(&serde_json::json!({
+            "schema_version": 4,
+            "repopilot_version": env!("CARGO_PKG_VERSION"),
+            "config_fingerprint": "config",
+            "resolver_version": "context-graph-v3",
+            "repository_fingerprint": null,
+            "input_fingerprint": "old",
+            "graph_fingerprint": "old",
+            "graph": {}
+        })).unwrap(),
+    ).unwrap();
+
+    assert!(load_repository_context_state(dir.path(), "config").is_none());
+}
+```
+
+- [ ] **Step 2: Verify the cache tests fail for missing state APIs**
+
+Run: `cargo test context_state_cache --lib && cargo test schema_v4_cache --lib`
+
+Expected: compile failure because state cache APIs do not exist.
+
+- [ ] **Step 3: Implement schema v5 state persistence**
+
+Replace the internal payload with:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct CachedRepositoryContextState {
+    schema_version: u32,
+    repopilot_version: String,
+    config_fingerprint: String,
+    resolver_version: String,
+    repository_fingerprint: Option<RepositoryFingerprint>,
+    input_fingerprint: String,
+    relationship_fingerprint: String,
+    state: RepositoryContextState,
+}
+```
+
+Set `CONTEXT_GRAPH_SCHEMA_VERSION` to `5` and use a new exact resolver identity.
+Hash ordered file inputs separately from ordered coupling relationships. Reject
+all metadata or fingerprint mismatches before returning a hit.
+
+- [ ] **Step 4: Verify unit cache tests pass**
+
+Run: `cargo test graph::context --lib`
+
+Expected: round-trip, deterministic bytes, corrupt-cache, old-schema, config,
+and repository-fingerprint tests pass.
+
+- [ ] **Step 5: Write failing warm changed-scan migration tests**
+
+Extend `tests/scan_changed_cache_cli.rs` to assert:
+
+```rust
+assert_eq!(first["context_graph_cache"]["status"], "write");
+assert_eq!(warm["context_graph_cache"]["status"], "hit");
+assert_context_graph_core_equal(
+    &warm["context_graph_summary"],
+    &full["context_graph_summary"],
+);
+```
+
+Define the comparison helper to compare `files`, `import_edges`, `top_hubs`,
+`top_dependencies`, `cycles`, and `risky_clusters`, deliberately excluding only
+`changed_blast_radius` because full and changed scopes have different public
+semantics.
+
+Retain the existing branch-switch, config-change, deferred-import, and stale
+schema fixtures, updating only the explicit schema/resolver fixture values.
+
+- [ ] **Step 6: Verify warm changed-scan test fails before scanner wiring**
+
+Run: `cargo test --test scan_changed_cache_cli context_state`
+
+Expected: failure because scanners still load and store `RepoContextGraph`.
+
+- [ ] **Step 7: Wire full and changed scans to state-cache APIs**
+
+Change `ChangedRepoContextStage.context_graph` to
+`context_state: RepositoryContextState`. Load/patch/write that state, derive
+`ScanFacts` and `CouplingGraph` from it, and pass it directly to context analysis.
+Full finalization constructs the same state once and writes it through the new
+cache API.
+
+- [ ] **Step 8: Verify changed/full cache and schema contracts**
+
+Run: `cargo test --test scan_changed_cache_cli && cargo test --test scan_finalization_cli && cargo test --test report_schema_contract`
+
+Expected: all tests pass with unchanged machine-readable report shapes.
+
+- [ ] **Step 9: Commit cache migration**
+
+```bash
+git add src/graph/context src/scan/scanner tests/scan_changed_cache_cli.rs
+git commit -m "refactor: persist repository context state"
+```
+
+---
+
+### Task 4: Scanner convergence, performance, and documentation
+
+**Files:**
+- Modify: `src/graph/context/summary.rs`
+- Modify: `src/scan/scanner/summary.rs`
+- Modify: `docs/engineering/dependency-graph-v2.md`
+- Modify: `docs/engineering/analysis-platform-state.md`
+- Modify: `docs/roadmap/v0.22.md`
+- Modify: `CHANGELOG.md`
+- Test: `tests/scan_changed_cache_cli.rs`
+- Test: `tests/ai_context_golden.rs`
+- Test: `tests/perf_matrix.rs`
+
+**Interfaces:**
+- Consumes: the completed `RepositoryContextState` and `ContextGraphAnalysis` path.
+- Produces: no new public interface; removes scanner use of `RepoContextGraph` as canonical state.
+
+- [ ] **Step 1: Remove remaining scanner compatibility conversions**
+
+Make summary fallback construction use `RepositoryContextState::from_scan_facts`
+and ensure `summarize_context_state` constructs one `ContextGraphAnalysis`.
+Keep compatibility conversions only in `src/graph/context/` and public facade
+tests. This is an internal refactor protected by the already failing-then-green
+full/changed parity and cache tests from Task 3; do not add a source-text test.
+
+- [ ] **Step 2: Verify projection parity**
+
+Run: `cargo test --test scan_changed_cache_cli && cargo test --test ai_context_golden && cargo test --test mcp_cli`
+
+Expected: all tests pass and golden outputs stay byte-identical.
+
+- [ ] **Step 3: Run targeted performance and determinism checks**
+
+Run: `cargo test --test perf_matrix -- --nocapture`
+
+Run: `npm run review:performance`
+
+Run: `npm run scan:performance`
+
+Expected: deterministic suites pass and no pinned scenario exceeds its current
+budget or regresses by more than 10% against the recorded branch baseline.
+
+- [ ] **Step 4: Update architecture and release documentation**
+
+Mark graph-state convergence complete, document cache schema v5 as an internal
+upgrade miss, record that public `RepoContextGraph` is compatibility-only, and
+add the user-visible performance/correctness note under `[Unreleased]`.
+
+- [ ] **Step 5: Run focused projection and release-contract checks**
+
+Run: `cargo test --test ai_context_golden --test report_schema_contract --test scan_changed_cache_cli --test mcp_cli`
+
+Run: `python3 scripts/release-contract.py check`
+
+Expected: all tests and the release contract pass. If `.zoo/` is absent, report
+the skip and make no zoo-reduction claim.
+
+- [ ] **Step 6: Commit convergence documentation**
+
+```bash
+git add src docs CHANGELOG.md tests
+git commit -m "docs: record graph state convergence"
+```
+
+- [ ] **Step 7: Run the full handoff gate**
+
+Run: `cargo fmt --all -- --check`
+
+Run: `cargo clippy --all-targets --all-features -- -D warnings`
+
+Run: `cargo test --all`
+
+Run: `npm run release:contract`
+
+Run: `npm run test:release-contract`
+
+Run: `cargo run -- scan . --fail-on-priority p1`
+
+Expected: every command exits zero; self-scan reports no P0/P1 finding. Record
+the exact results before pushing or opening the draft PR.

--- a/docs/engineering/v0.22-phase-a3-graph-state-convergence.md
+++ b/docs/engineering/v0.22-phase-a3-graph-state-convergence.md
@@ -1,6 +1,6 @@
 # RepoPilot 0.22 Phase A3 — Graph State Convergence
 
-**Status:** Draft for user review  
+**Status:** Implemented
 **Parent:** [v0.22 repository intelligence design](v0.22-repository-intelligence-design.md)  
 **Predecessors:** [Phase A1](v0.22-phase-a1-context-graph-v2.md) and capability-aware graph rules from Phase A2
 

--- a/docs/engineering/v0.22-phase-a3-graph-state-convergence.md
+++ b/docs/engineering/v0.22-phase-a3-graph-state-convergence.md
@@ -1,0 +1,209 @@
+# RepoPilot 0.22 Phase A3 — Graph State Convergence
+
+**Status:** Draft for user review  
+**Parent:** [v0.22 repository intelligence design](v0.22-repository-intelligence-design.md)  
+**Predecessors:** [Phase A1](v0.22-phase-a1-context-graph-v2.md) and capability-aware graph rules from Phase A2
+
+## Problem
+
+Graph-v2 algorithms now power coupling rules, review impact, context-summary
+degrees, direct dependents, and graph readiness. Full and changed scans still
+persist and patch a separate `RepoContextGraph`, then rebuild a graph-v2
+snapshot for analysis. Historical context-summary cycles also use the legacy
+bounded DFS implementation because graph-v2 SCC membership does not preserve
+the public cycle-path contract.
+
+This leaves three sources of graph behavior:
+
+1. source-derived file context and imports;
+2. the persisted compatibility graph and its changed-scan patching;
+3. graph-v2 snapshots and algorithms used by current consumers.
+
+The duplication makes invalidation, performance, and future symbol/reference
+graph work harder to reason about. Replacing it without differential fixtures
+would risk changed-scan correctness, deferred-import semantics, cycle ordering,
+or public report compatibility.
+
+## Outcome
+
+- One internal `RepositoryContextState` owns the minimal context inputs needed
+  by warm changed scans: repository-relative file records, resolved eager and
+  deferred coupling relationships, and framework metadata.
+- One `ContextGraphAnalysis` builds the graph-v2 snapshot once per compatible
+  analysis session and supplies degrees, dependents, capabilities, and the
+  bounded public cycle projection.
+- The cache stores source-derived context inputs and resolved relationships,
+  not graph-v2 algorithm results.
+- Full and changed scans use the same state-to-analysis path.
+- Existing `ContextGraphSummary` JSON, finding IDs, severities, ordering,
+  readiness, and human output remain compatible.
+- The previous cache schema is rejected as a normal cache miss and rebuilt; it
+  is never partially interpreted.
+
+## Scope
+
+### In scope
+
+- Introduce an internal state type under `src/graph/context/` and move
+  changed-file patching from the public compatibility model onto that type.
+- Persist the state in a new context-cache schema while keeping
+  `.repopilot/cache/repo_context.json` and public cache status fields stable.
+- Build one graph-v2 snapshot from the state's coupling relationships and reuse
+  it for context-summary projections.
+- Add a graph-v2 bounded cycle-path projection that preserves the historical
+  public representation after deferred and Rust containment edges are removed.
+- Add differential fixtures for full/changed parity, add/delete/rename patches,
+  deferred imports, Rust module containment, cycle ordering, truncation, cache
+  invalidation, and thread-count determinism.
+- Keep a compatibility conversion for the public `RepoContextGraph` API during
+  the `0.x` compatibility window; scanners stop treating it as canonical state.
+- Update graph architecture documentation after the migration is verified.
+
+### Out of scope
+
+- Removing the public `RepoContextGraph` and `RepoContextNode` exports.
+- Changing `ContextGraphSummary`, report schema, cache-info schema, CLI flags,
+  MCP tools, finding visibility, or readiness semantics.
+- Persisting raw `GraphSnapshot` values or derived degree/SCC results.
+- Adding symbol/reference edges, language resolvers, new findings, public graph
+  diagnostics, or explicit verification execution.
+- Incrementally patching graph-v2 vectors in place. A changed scan patches the
+  small ordered context state and deterministically rebuilds derived snapshot
+  data without reading unchanged source content.
+
+## Architecture
+
+### Repository context state
+
+Add an internal type with one responsibility: preserve enough stable input to
+reconstruct repository facts and graph-v2 analysis without rescanning unchanged
+source files.
+
+```rust
+pub(crate) struct RepositoryContextState {
+    root_path: PathBuf,
+    files: Vec<RepoContextNode>,
+    coupling: CouplingGraph,
+    detected_frameworks: Vec<DetectedFramework>,
+    framework_projects: Vec<FrameworkProject>,
+    react_native: Option<ReactNativeArchitectureProfile>,
+}
+```
+
+`files` remain sorted by repository-relative path. Coupling nodes and edge
+endpoints use the same normalized relative paths. `apply_changed_facts` removes
+deleted and replaced file records, patches imports for modified files, and
+fully resolves relationships only when the known file set changes. This
+preserves the current correctness boundary without persisting duplicate derived
+metrics.
+
+The existing public `RepoContextGraph` remains serializable for API
+compatibility, but cache and scanner stages consume `RepositoryContextState`.
+Explicit conversion tests prevent the compatibility view from drifting.
+
+### Analysis session
+
+`ContextGraphAnalysis` accepts a `RepositoryContextState` or its coupling view,
+constructs exactly one graph-v2 snapshot, and owns the path lookup plus derived
+projections required by the summary. No renderer, report schema, or AI-context
+consumer reconstructs a graph.
+
+Cycle projection uses graph-v2 traversal primitives but returns the established
+bounded ordered paths. Before traversal it excludes:
+
+- edges represented only by `deferred_edges`;
+- Rust module-containment relationships excluded by the existing contract.
+
+If the differential cycle fixture disagrees with the historical representation,
+the migration stops; A3 does not silently rewrite golden output.
+
+### Cache contract
+
+The context-cache schema version increments once. The serialized payload stores:
+
+- RepoPilot, resolver, configuration, and repository fingerprints;
+- stable input and relationship fingerprints;
+- `RepositoryContextState` data only.
+
+It does not store degrees, SCCs, blast radius, capabilities, rankings, or report
+fragments. Corrupt, old, wrong-revision, wrong-branch, wrong-config, or
+wrong-resolver entries become bounded cache misses. Cache writes remain
+deterministic and atomic behavior is preserved at the existing boundary.
+
+The first scan after upgrading is expected to report a miss/write. Subsequent
+compatible changed scans must report a hit and must not read unchanged source
+content.
+
+## Data flow
+
+```text
+full scan facts ───────┐
+                      ├─> RepositoryContextState ─> context cache
+cached state + patch ─┘              │
+                                     v
+                         one graph-v2 snapshot
+                                     │
+                    ┌────────────────┼────────────────┐
+                    v                v                v
+                 degrees         dependents       cycles/capabilities
+                    └────────────────┼────────────────┘
+                                     v
+                          ContextGraphSummary
+```
+
+## Compatibility rules
+
+- Repository paths remain relative and slash-normalized in fingerprints and
+  serialized state.
+- Public cycle paths, truncation labels, metrics, and ordering remain identical.
+- Deferred-only cycles remain excluded from context-summary cycles.
+- Existing graph-backed findings continue to use their current graph-rule
+  runner and readiness policy.
+- Cache status and reason strings remain stable except for the expected first
+  schema-migration miss.
+- Machine-readable schemas receive no field additions or removals in A3.
+
+## Performance contract
+
+- A warm changed scan performs no full source collection when the context cache
+  is compatible.
+- One context-summary operation builds at most one graph-v2 snapshot.
+- No existing pinned review or scan scenario regresses by more than 10% without
+  a separately approved budget change.
+- Output stays deterministic across supported thread counts.
+- Derived graph data is not persisted merely to improve a microbenchmark; cache
+  reuse must remain revision-correct and explainable.
+
+## Verification
+
+- [ ] Differential unit tests compare legacy and graph-v2 cycle projections for
+      acyclic, self-contained, overlapping, deferred-only, Rust containment,
+      deep, ordered, and truncated graphs.
+- [ ] State conversion and patch tests cover modified, added, deleted, and
+      renamed files plus eager/deferred import transitions.
+- [ ] Cache tests prove round-trip, deterministic bytes, old-schema rejection,
+      corrupt entry recovery, configuration mismatch, and repository revision
+      mismatch.
+- [ ] `tests/scan_changed_cache_cli.rs` proves a warm hit avoids full repository
+      collection and preserves summary parity.
+- [ ] Full and changed scans produce the same context summary for equivalent
+      evidence.
+- [ ] AI-context golden, report-schema, MCP, coupling, and review-impact tests
+      remain unchanged.
+- [ ] Targeted performance checks stay inside existing budgets.
+- [ ] Formatting, clippy, full tests, release contract, and self-scan pass before
+      handoff.
+
+## Delivery boundary
+
+A3 is one focused feature branch with independently reviewable commits:
+
+1. differential cycle contract and graph-v2 projection;
+2. internal repository-context state and compatibility conversion;
+3. cache schema migration and changed-scan wiring;
+4. full/changed scanner convergence, documentation, and performance evidence.
+
+If cache migration requires a public schema change or cannot preserve warm
+changed-scan behavior, stop after the differential seam and split the cache
+change into a separately approved follow-up. Broken-code detectors begin only
+after this graph-state boundary is stable.

--- a/docs/engineering/v0.22-phase-a3-graph-state-convergence.md
+++ b/docs/engineering/v0.22-phase-a3-graph-state-convergence.md
@@ -128,7 +128,7 @@ The context-cache schema version increments once. The serialized payload stores:
 It does not store degrees, SCCs, blast radius, capabilities, rankings, or report
 fragments. Corrupt, old, wrong-revision, wrong-branch, wrong-config, or
 wrong-resolver entries become bounded cache misses. Cache writes remain
-deterministic and atomic behavior is preserved at the existing boundary.
+deterministic and write failures remain visible through existing diagnostics.
 
 The first scan after upgrading is expected to report a miss/write. Subsequent
 compatible changed scans must report a hit and must not read unchanged source

--- a/docs/engineering/v0.22-repository-intelligence-design.md
+++ b/docs/engineering/v0.22-repository-intelligence-design.md
@@ -1,6 +1,6 @@
 # RepoPilot 0.22 Repository Intelligence Design
 
-**Status:** Draft for user review
+**Status:** Approved
 **Release contract:** `docs/roadmap/v0.22.md`
 
 ## Intent
@@ -202,11 +202,11 @@ public MCP contract.
   approved.
 - All public projections remain compatible and deterministic.
 
-## First Spec After Approval
+## Current Phase Status
 
-Create `docs/engineering/v0.22-phase-a1-context-graph-v2.md`. Its scope is
-limited to MCP harness parity, deterministic context-graph parity fixtures, one
-reusable graph-v2 analysis view for the primary AI-context graph projection,
-and targeted performance comparison. Retiring the persisted `RepoContextGraph`
-compatibility model requires a later slice after every cache and changed-scan
-consumer has migrated.
+Phase A1 established one reusable graph-v2 analysis view for the primary
+AI-context graph projection. Phase A2 established capability-aware graph rules
+and full/changed scan parity. The next proposed delivery boundary is
+[Phase A3 graph state convergence](v0.22-phase-a3-graph-state-convergence.md):
+differentiate the historical cycle contract, migrate persisted context inputs,
+and stop scanner paths from treating `RepoContextGraph` as canonical state.

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -54,7 +54,8 @@ capability-aware analysis session.
 Deliverables:
 
 - migrate the primary `RepoContextGraph` / `context_graph_summary` projection to
-  graph v2 behind deterministic parity fixtures;
+  graph v2 behind deterministic parity fixtures (A1 metrics/dependents and A3
+  persisted state/bounded cycles completed);
 - make graph capability metadata consumable by rule scheduling and diagnostics
   (internal readiness and full/changed parity completed in A2; public skip
   diagnostics remain additive follow-up work);

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -96,6 +96,7 @@ pub struct RepoContextGraphLoad {
 mod analysis;
 mod cache;
 mod graph_impl;
+mod state;
 mod summary;
 
 use analysis::ContextGraphAnalysis;
@@ -103,6 +104,7 @@ pub use cache::{
     context_graph_cache_miss, context_graph_cache_path, load_repo_context_graph,
     write_repo_context_graph,
 };
+pub(crate) use state::RepositoryContextState;
 pub use summary::summarize_context_graph;
 
 #[cfg(test)]

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -1,6 +1,6 @@
 use crate::audits::context::{FileRole, classify_file};
 use crate::findings::types::Finding;
-use crate::graph::{CouplingGraph, detect_cycles_bounded, without_rust_module_containment_edges};
+use crate::graph::CouplingGraph;
 use crate::review::diff::{ChangeStatus, ChangedFile};
 use crate::risk::RiskPriority;
 use crate::scan::facts::{FileFacts, ScanFacts};

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -14,8 +14,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 pub const CONTEXT_GRAPH_CACHE_NAME: &str = "repo_context.json";
-pub const CONTEXT_GRAPH_SCHEMA_VERSION: u32 = 4;
-pub const CONTEXT_GRAPH_RESOLVER_VERSION: &str = "context-graph-v3";
+pub const CONTEXT_GRAPH_SCHEMA_VERSION: u32 = 5;
+pub const CONTEXT_GRAPH_RESOLVER_VERSION: &str = "context-state-v1";
 pub const MAX_CONTEXT_GRAPH_CYCLES: usize = 20;
 pub const MAX_CONTEXT_GRAPH_METRICS: usize = 10;
 pub const MAX_CONTEXT_GRAPH_RISKY_CLUSTERS: usize = 20;
@@ -93,6 +93,11 @@ pub struct RepoContextGraphLoad {
     pub cache_info: ContextGraphCacheInfo,
 }
 
+pub(crate) struct RepositoryContextStateLoad {
+    pub(crate) state: RepositoryContextState,
+    pub(crate) cache_info: ContextGraphCacheInfo,
+}
+
 mod analysis;
 mod cache;
 mod graph_impl;
@@ -104,8 +109,10 @@ pub use cache::{
     context_graph_cache_miss, context_graph_cache_path, load_repo_context_graph,
     write_repo_context_graph,
 };
+pub(crate) use cache::{load_repository_context_state, write_repository_context_state};
 pub(crate) use state::RepositoryContextState;
 pub use summary::summarize_context_graph;
+pub(crate) use summary::summarize_repository_context_state;
 
 #[cfg(test)]
 mod tests;

--- a/src/graph/context/analysis.rs
+++ b/src/graph/context/analysis.rs
@@ -1,14 +1,16 @@
 use super::RepoContextGraph;
 use crate::graph::FileMetrics;
 use crate::graph::v2::{
-    GraphCapabilities, GraphDegreeSummary, GraphNodeId, build_coupling_graph_snapshot,
-    compute_degrees, direct_dependents, graph_capabilities,
+    GraphCapabilities, GraphDegreeSummary, GraphNodeId, GraphSnapshot, bounded_cycle_paths,
+    build_coupling_graph_snapshot, compute_degrees, direct_dependents, graph_capabilities,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 pub(super) struct ContextGraphAnalysis {
+    snapshot: GraphSnapshot,
     path_by_id: BTreeMap<GraphNodeId, PathBuf>,
+    excluded_cycle_edges: BTreeSet<(GraphNodeId, GraphNodeId)>,
     degrees: GraphDegreeSummary,
     dependents: BTreeMap<GraphNodeId, BTreeSet<GraphNodeId>>,
     capabilities: GraphCapabilities,
@@ -16,12 +18,16 @@ pub(super) struct ContextGraphAnalysis {
 
 impl ContextGraphAnalysis {
     pub(super) fn from_graph(graph: &RepoContextGraph) -> Self {
-        let (snapshot, path_by_id) = build_coupling_graph_snapshot(&graph.coupling_graph());
+        let coupling = graph.coupling_graph();
+        let excluded_cycle_edges = excluded_cycle_edges(&coupling);
+        let (snapshot, path_by_id) = build_coupling_graph_snapshot(&coupling);
         let degrees = compute_degrees(&snapshot);
         let dependents = direct_dependents(&snapshot);
         let capabilities = graph_capabilities(&snapshot);
         Self {
+            snapshot,
             path_by_id,
+            excluded_cycle_edges,
             degrees,
             dependents,
             capabilities,
@@ -66,6 +72,49 @@ impl ContextGraphAnalysis {
     pub(super) fn capabilities(&self) -> &GraphCapabilities {
         &self.capabilities
     }
+
+    pub(super) fn bounded_cycles(&self, max_cycles: usize) -> BoundedContextCycles {
+        let cycles = bounded_cycle_paths(&self.snapshot, &self.excluded_cycle_edges, max_cycles);
+        BoundedContextCycles {
+            paths: cycles
+                .paths
+                .into_iter()
+                .map(|path| {
+                    path.into_iter()
+                        .filter_map(|id| self.path_by_id.get(&id).cloned())
+                        .collect()
+                })
+                .collect(),
+            truncated: cycles.truncated,
+            depth_exceeded: cycles.depth_exceeded,
+        }
+    }
+}
+
+pub(super) struct BoundedContextCycles {
+    pub(super) paths: Vec<Vec<PathBuf>>,
+    pub(super) truncated: bool,
+    pub(super) depth_exceeded: bool,
+}
+
+fn excluded_cycle_edges(
+    graph: &crate::graph::CouplingGraph,
+) -> BTreeSet<(GraphNodeId, GraphNodeId)> {
+    let filtered = crate::graph::without_rust_module_containment_edges(graph);
+    let node_id = |path: &std::path::Path| GraphNodeId::new(format!("file:{}", path.display()));
+    let mut excluded = BTreeSet::new();
+    for (source, targets) in &graph.edges {
+        let deferred = graph.deferred_edges.get(source);
+        let kept = filtered.edges.get(source);
+        for target in targets {
+            if deferred.is_some_and(|edges| edges.contains(target))
+                || !kept.is_some_and(|edges| edges.contains(target))
+            {
+                excluded.insert((node_id(source), node_id(target)));
+            }
+        }
+    }
+    excluded
 }
 
 #[cfg(test)]
@@ -120,6 +169,26 @@ mod tests {
             second.direct_dependents_by_path()
         );
         assert_eq!(first.capabilities(), second.capabilities());
+    }
+
+    #[test]
+    fn bounded_cycles_exclude_deferred_relationships() {
+        let mut graph = graph_with_edge("a.py", "b.py");
+        graph
+            .edges
+            .entry(PathBuf::from("b.py"))
+            .or_default()
+            .insert(PathBuf::from("a.py"));
+        graph.deferred_edges.insert(
+            PathBuf::from("b.py"),
+            BTreeSet::from([PathBuf::from("a.py")]),
+        );
+
+        let cycles = ContextGraphAnalysis::from_graph(&graph).bounded_cycles(20);
+
+        assert!(cycles.paths.is_empty());
+        assert!(!cycles.truncated);
+        assert!(!cycles.depth_exceeded);
     }
 
     fn metric_keys(analysis: &ContextGraphAnalysis) -> Vec<(PathBuf, usize, usize, u32)> {

--- a/src/graph/context/cache.rs
+++ b/src/graph/context/cache.rs
@@ -2,20 +2,44 @@ use super::*;
 use sha2::{Digest, Sha256};
 use std::process::Command;
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct CachedRepositoryContextState {
+    schema_version: u32,
+    repopilot_version: String,
+    config_fingerprint: String,
+    resolver_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    repository_fingerprint: Option<RepositoryFingerprint>,
+    input_fingerprint: String,
+    relationship_fingerprint: String,
+    state: RepositoryContextState,
+}
+
 pub fn load_repo_context_graph(
     root: &Path,
     config_fingerprint: &str,
 ) -> Option<RepoContextGraphLoad> {
+    let load = load_repository_context_state(root, config_fingerprint)?;
+    Some(RepoContextGraphLoad {
+        graph: load.state.to_compat(),
+        cache_info: load.cache_info,
+    })
+}
+
+pub(crate) fn load_repository_context_state(
+    root: &Path,
+    config_fingerprint: &str,
+) -> Option<RepositoryContextStateLoad> {
     let cache_path = context_graph_cache_path(root);
-    let cached = read_cached_repo_context_graph(&cache_path)?;
-    if !valid_cached_graph(&cached, root, config_fingerprint) {
+    let cached = read_cached_repository_context_state(&cache_path)?;
+    if !valid_cached_state(&cached, root, config_fingerprint) {
         return None;
     }
 
     // This cache stores graph/context metadata only. Changed scans must still
     // analyze changed file contents and patch this graph before scoring.
-    Some(RepoContextGraphLoad {
-        graph: cached.graph,
+    Some(RepositoryContextStateLoad {
+        state: cached.state,
         cache_info: ContextGraphCacheInfo {
             status: "hit".to_string(),
             reason: "valid-context-graph-cache".to_string(),
@@ -29,21 +53,33 @@ pub fn write_repo_context_graph(
     config_fingerprint: &str,
     graph: &RepoContextGraph,
 ) -> io::Result<ContextGraphCacheInfo> {
+    write_repository_context_state(
+        root,
+        config_fingerprint,
+        &RepositoryContextState::from_compat(graph.clone()),
+    )
+}
+
+pub(crate) fn write_repository_context_state(
+    root: &Path,
+    config_fingerprint: &str,
+    state: &RepositoryContextState,
+) -> io::Result<ContextGraphCacheInfo> {
     let cache_path = context_graph_cache_path(root);
     if let Some(parent) = cache_path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let (input_fingerprint, graph_fingerprint) = context_graph_fingerprints(graph);
+    let (input_fingerprint, relationship_fingerprint) = state_fingerprints(state);
     let repository_fingerprint = repository_fingerprint(root);
 
-    if let Some(cached) = read_cached_repo_context_graph(&cache_path)
-        && valid_cached_graph_metadata_for_repository(
+    if let Some(cached) = read_cached_repository_context_state(&cache_path)
+        && valid_cached_state_metadata_for_repository(
             &cached,
             config_fingerprint,
             &repository_fingerprint,
         )
         && cached.input_fingerprint == input_fingerprint
-        && cached.graph_fingerprint == graph_fingerprint
+        && cached.relationship_fingerprint == relationship_fingerprint
     {
         return Ok(ContextGraphCacheInfo {
             status: "hit".to_string(),
@@ -52,15 +88,15 @@ pub fn write_repo_context_graph(
         });
     }
 
-    let cached = CachedRepoContextGraph {
+    let cached = CachedRepositoryContextState {
         schema_version: CONTEXT_GRAPH_SCHEMA_VERSION,
         repopilot_version: env!("CARGO_PKG_VERSION").to_string(),
         config_fingerprint: config_fingerprint.to_string(),
         resolver_version: CONTEXT_GRAPH_RESOLVER_VERSION.to_string(),
         repository_fingerprint,
         input_fingerprint,
-        graph_fingerprint,
-        graph: graph.clone(),
+        relationship_fingerprint,
+        state: state.clone(),
     };
     let rendered = serde_json::to_vec(&cached).map_err(io::Error::other)?;
     fs::write(&cache_path, rendered)?;
@@ -80,30 +116,31 @@ pub fn context_graph_cache_miss(root: &Path, reason: &str) -> ContextGraphCacheI
     }
 }
 
-fn valid_cached_graph(
-    cached: &CachedRepoContextGraph,
+fn valid_cached_state(
+    cached: &CachedRepositoryContextState,
     root: &Path,
     config_fingerprint: &str,
 ) -> bool {
-    if !valid_cached_graph_metadata(cached, root, config_fingerprint) {
+    if !valid_cached_state_metadata(cached, root, config_fingerprint) {
         return false;
     }
 
-    let (input_fingerprint, graph_fingerprint) = context_graph_fingerprints(&cached.graph);
-    cached.input_fingerprint == input_fingerprint && cached.graph_fingerprint == graph_fingerprint
+    let (input_fingerprint, relationship_fingerprint) = state_fingerprints(&cached.state);
+    cached.input_fingerprint == input_fingerprint
+        && cached.relationship_fingerprint == relationship_fingerprint
 }
 
-fn valid_cached_graph_metadata(
-    cached: &CachedRepoContextGraph,
+fn valid_cached_state_metadata(
+    cached: &CachedRepositoryContextState,
     root: &Path,
     config_fingerprint: &str,
 ) -> bool {
     let repository_fingerprint = repository_fingerprint(root);
-    valid_cached_graph_metadata_for_repository(cached, config_fingerprint, &repository_fingerprint)
+    valid_cached_state_metadata_for_repository(cached, config_fingerprint, &repository_fingerprint)
 }
 
-fn valid_cached_graph_metadata_for_repository(
-    cached: &CachedRepoContextGraph,
+fn valid_cached_state_metadata_for_repository(
+    cached: &CachedRepositoryContextState,
     config_fingerprint: &str,
     repository_fingerprint: &Option<RepositoryFingerprint>,
 ) -> bool {
@@ -156,9 +193,13 @@ fn context_graph_fingerprints(graph: &RepoContextGraph) -> (String, String) {
     )
 }
 
-fn read_cached_repo_context_graph(path: &Path) -> Option<CachedRepoContextGraph> {
+fn state_fingerprints(state: &RepositoryContextState) -> (String, String) {
+    context_graph_fingerprints(&state.to_compat())
+}
+
+fn read_cached_repository_context_state(path: &Path) -> Option<CachedRepositoryContextState> {
     let content = fs::read_to_string(path).ok()?;
-    serde_json::from_str::<CachedRepoContextGraph>(&content).ok()
+    serde_json::from_str::<CachedRepositoryContextState>(&content).ok()
 }
 
 fn repository_fingerprint(root: &Path) -> Option<RepositoryFingerprint> {

--- a/src/graph/context/state.rs
+++ b/src/graph/context/state.rs
@@ -1,0 +1,72 @@
+use super::{RepoContextGraph, RepoContextNode};
+use crate::frameworks::{DetectedFramework, FrameworkProject, ReactNativeArchitectureProfile};
+use crate::graph::CouplingGraph;
+use crate::review::diff::ChangedFile;
+use crate::scan::facts::{FileFacts, ScanFacts};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RepositoryContextState {
+    root_path: PathBuf,
+    files: Vec<RepoContextNode>,
+    coupling: CouplingGraph,
+    detected_frameworks: Vec<DetectedFramework>,
+    framework_projects: Vec<FrameworkProject>,
+    react_native: Option<ReactNativeArchitectureProfile>,
+}
+
+impl RepositoryContextState {
+    pub(crate) fn from_scan_facts(facts: &ScanFacts, root: &Path, coupling: CouplingGraph) -> Self {
+        Self::from_compat(RepoContextGraph::from_scan_facts(facts, root, coupling))
+    }
+
+    pub(crate) fn from_compat(graph: RepoContextGraph) -> Self {
+        let mut files = graph.nodes;
+        files.sort_by(|left, right| left.path.cmp(&right.path));
+        let nodes = files.iter().map(|file| file.path.clone()).collect();
+        Self {
+            root_path: graph.root_path,
+            files,
+            coupling: CouplingGraph {
+                edges: graph.edges,
+                deferred_edges: graph.deferred_edges,
+                nodes,
+            },
+            detected_frameworks: graph.detected_frameworks,
+            framework_projects: graph.framework_projects,
+            react_native: graph.react_native,
+        }
+    }
+
+    pub(crate) fn to_compat(&self) -> RepoContextGraph {
+        RepoContextGraph {
+            root_path: self.root_path.clone(),
+            nodes: self.files.clone(),
+            edges: self.coupling.edges.clone(),
+            deferred_edges: self.coupling.deferred_edges.clone(),
+            detected_frameworks: self.detected_frameworks.clone(),
+            framework_projects: self.framework_projects.clone(),
+            react_native: self.react_native.clone(),
+        }
+    }
+
+    pub(crate) fn coupling_graph(&self) -> CouplingGraph {
+        self.coupling.clone()
+    }
+
+    pub(crate) fn to_scan_facts(&self) -> ScanFacts {
+        self.to_compat().to_scan_facts()
+    }
+
+    pub(crate) fn apply_changed_facts(
+        &mut self,
+        root: &Path,
+        changed_files: &[ChangedFile],
+        patch_files: &[FileFacts],
+    ) {
+        let mut graph = self.to_compat();
+        graph.apply_changed_facts(root, changed_files, patch_files);
+        *self = Self::from_compat(graph);
+    }
+}

--- a/src/graph/context/summary.rs
+++ b/src/graph/context/summary.rs
@@ -37,6 +37,14 @@ pub fn summarize_context_graph(
     }
 }
 
+pub(crate) fn summarize_repository_context_state(
+    state: &RepositoryContextState,
+    findings: &[Finding],
+    changed_files: &[ChangedFile],
+) -> ContextGraphSummary {
+    summarize_context_graph(&state.to_compat(), findings, changed_files)
+}
+
 struct RankedMetrics {
     top_hubs: Vec<ContextGraphFileMetric>,
     top_dependencies: Vec<ContextGraphFileMetric>,

--- a/src/graph/context/summary.rs
+++ b/src/graph/context/summary.rs
@@ -5,10 +5,14 @@ pub fn summarize_context_graph(
     findings: &[Finding],
     changed_files: &[ChangedFile],
 ) -> ContextGraphSummary {
-    let coupling_graph = graph.coupling_graph();
     let analysis = ContextGraphAnalysis::from_graph(graph);
     let ranked = ranked_metrics(graph, &analysis);
-    let (cycles, cycles_truncated) = bounded_cycles(&coupling_graph);
+    let bounded_cycles = analysis.bounded_cycles(MAX_CONTEXT_GRAPH_CYCLES);
+    if bounded_cycles.depth_exceeded {
+        crate::graph::mark_cycle_detection_depth_exceeded();
+    }
+    let cycles = bounded_cycles.paths;
+    let cycles_truncated = bounded_cycles.truncated;
     let dependents = analysis.direct_dependents_by_path();
     let (changed_blast_radius, blast_radius_truncated) =
         changed_blast_radius(&dependents, changed_files);
@@ -81,16 +85,6 @@ fn ranked_metrics(graph: &RepoContextGraph, analysis: &ContextGraphAnalysis) -> 
             .take(MAX_CONTEXT_GRAPH_METRICS)
             .collect(),
     }
-}
-
-fn bounded_cycles(graph: &CouplingGraph) -> (Vec<Vec<PathBuf>>, bool) {
-    // The historical path contract excludes deferred and Rust containment edges;
-    // graph-v2 SCC membership is not an equivalent public representation.
-    let graph = without_rust_module_containment_edges(graph);
-    let mut cycles = detect_cycles_bounded(&graph, MAX_CONTEXT_GRAPH_CYCLES + 1);
-    let truncated = cycles.len() > MAX_CONTEXT_GRAPH_CYCLES;
-    cycles.truncate(MAX_CONTEXT_GRAPH_CYCLES);
-    (cycles, truncated)
 }
 
 fn truncation_labels<const N: usize>(states: [(&str, bool); N]) -> Vec<String> {

--- a/src/graph/context/tests.rs
+++ b/src/graph/context/tests.rs
@@ -81,6 +81,30 @@ fn repository_context_state_patch_removes_deleted_targets() {
 }
 
 #[test]
+fn repository_context_state_cache_round_trips_deterministically() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let facts = scan_facts(
+        dir.path(),
+        vec![file_fact("a.ts", &["./b"]), file_fact("b.ts", &[])],
+    );
+    let coupling = build_coupling_graph(&facts, dir.path());
+    let state = RepositoryContextState::from_scan_facts(&facts, dir.path(), coupling);
+
+    write_repository_context_state(dir.path(), "config", &state).expect("first write");
+    let first = fs::read(context_graph_cache_path(dir.path())).expect("first cache");
+    write_repository_context_state(dir.path(), "config", &state).expect("second write");
+    let second = fs::read(context_graph_cache_path(dir.path())).expect("second cache");
+
+    assert_eq!(first, second);
+    assert_eq!(
+        load_repository_context_state(dir.path(), "config")
+            .expect("cache hit")
+            .state,
+        state
+    );
+}
+
+#[test]
 fn summary_caps_cycles_and_marks_truncation() {
     let mut nodes = Vec::new();
     let mut edges = BTreeMap::new();

--- a/src/graph/context/tests.rs
+++ b/src/graph/context/tests.rs
@@ -4,6 +4,83 @@ use crate::graph::build_coupling_graph;
 use crate::risk::{RiskAssessment, priority_for_score};
 
 #[test]
+fn repository_context_state_round_trips_the_compatibility_view() {
+    let compat = RepoContextGraph {
+        root_path: PathBuf::from("."),
+        nodes: vec![node(Path::new("a.rs")), node(Path::new("b.rs"))],
+        edges: BTreeMap::from([(
+            PathBuf::from("a.rs"),
+            BTreeSet::from([PathBuf::from("b.rs")]),
+        )]),
+        deferred_edges: BTreeMap::from([(
+            PathBuf::from("a.rs"),
+            BTreeSet::from([PathBuf::from("b.rs")]),
+        )]),
+        detected_frameworks: Vec::new(),
+        framework_projects: Vec::new(),
+        react_native: None,
+    };
+
+    let state = RepositoryContextState::from_compat(compat.clone());
+
+    assert_eq!(state.to_compat(), compat);
+    assert_eq!(state.coupling_graph(), compat.coupling_graph());
+}
+
+#[test]
+fn repository_context_state_sorts_file_records_by_relative_path() {
+    let root = Path::new("/repo");
+    let facts = scan_facts(root, vec![file_fact("b.rs", &[]), file_fact("a.rs", &[])]);
+    let graph = CouplingGraph {
+        nodes: BTreeSet::from([PathBuf::from("b.rs"), PathBuf::from("a.rs")]),
+        ..CouplingGraph::default()
+    };
+
+    let state = RepositoryContextState::from_scan_facts(&facts, root, graph);
+
+    assert_eq!(
+        state
+            .to_compat()
+            .nodes
+            .into_iter()
+            .map(|node| node.path)
+            .collect::<Vec<_>>(),
+        vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")]
+    );
+}
+
+#[test]
+fn repository_context_state_patch_removes_deleted_targets() {
+    let root = Path::new("/repo");
+    let compat = RepoContextGraph {
+        root_path: root.to_path_buf(),
+        nodes: vec![node(Path::new("a.rs")), node(Path::new("b.rs"))],
+        edges: BTreeMap::from([(
+            PathBuf::from("a.rs"),
+            BTreeSet::from([PathBuf::from("b.rs")]),
+        )]),
+        deferred_edges: BTreeMap::new(),
+        detected_frameworks: Vec::new(),
+        framework_projects: Vec::new(),
+        react_native: None,
+    };
+    let mut state = RepositoryContextState::from_compat(compat);
+    let deleted = ChangedFile {
+        path: PathBuf::from("b.rs"),
+        status: ChangeStatus::Deleted,
+        ranges: Vec::new(),
+        hunks: Vec::new(),
+    };
+
+    state.apply_changed_facts(root, &[deleted], &[]);
+
+    let graph = state.coupling_graph();
+    assert!(!graph.nodes.contains(Path::new("b.rs")));
+    assert!(graph.edges[Path::new("a.rs")].is_empty());
+    assert_eq!(state.to_scan_facts().files.len(), 1);
+}
+
+#[test]
 fn summary_caps_cycles_and_marks_truncation() {
     let mut nodes = Vec::new();
     let mut edges = BTreeMap::new();

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -176,6 +176,10 @@ pub fn clear_cycle_detection_depth_exceeded() {
     CYCLE_DETECTION_DEPTH_EXCEEDED.with(|c| c.set(false));
 }
 
+pub(crate) fn mark_cycle_detection_depth_exceeded() {
+    CYCLE_DETECTION_DEPTH_EXCEEDED.with(|c| c.set(true));
+}
+
 // ── Cycle detection ───────────────────────────────────────────────────────────
 
 const MAX_DFS_DEPTH: usize = 512;

--- a/src/graph/v2/algorithms/cycles/bounded.rs
+++ b/src/graph/v2/algorithms/cycles/bounded.rs
@@ -1,0 +1,204 @@
+use super::super::topology;
+use crate::graph::v2::{GraphNodeId, GraphSnapshot};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundedCyclePaths {
+    pub paths: Vec<Vec<GraphNodeId>>,
+    pub truncated: bool,
+    pub depth_exceeded: bool,
+}
+
+const MAX_DEPTH: usize = 512;
+
+pub fn bounded_cycle_paths(
+    snapshot: &GraphSnapshot,
+    excluded_edges: &BTreeSet<(GraphNodeId, GraphNodeId)>,
+    max_cycles: usize,
+) -> BoundedCyclePaths {
+    if max_cycles == 0 {
+        return BoundedCyclePaths {
+            paths: Vec::new(),
+            truncated: false,
+            depth_exceeded: false,
+        };
+    }
+    let topology = topology(snapshot);
+    let index_by_id = topology
+        .node_ids
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(index, id)| (id, index))
+        .collect::<BTreeMap<_, _>>();
+    let adjacency = topology
+        .node_ids
+        .iter()
+        .map(|id| {
+            topology.outgoing[id]
+                .iter()
+                .filter(|target| !excluded_edges.contains(&(id.clone(), (*target).clone())))
+                .filter_map(|target| index_by_id.get(target).copied())
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut search = Search::new(&topology.node_ids, &adjacency, max_cycles + 1);
+    search.run();
+    canonicalize(&mut search.paths);
+    let truncated = search.paths.len() > max_cycles;
+    search.paths.truncate(max_cycles);
+    BoundedCyclePaths {
+        paths: search.paths,
+        truncated,
+        depth_exceeded: search.depth_exceeded,
+    }
+}
+
+fn canonicalize(paths: &mut Vec<Vec<GraphNodeId>>) {
+    for path in paths.iter_mut() {
+        if let Some(position) = path
+            .iter()
+            .enumerate()
+            .min_by(|left, right| left.1.cmp(right.1))
+            .map(|(position, _)| position)
+        {
+            path.rotate_left(position);
+        }
+    }
+    paths.sort();
+    paths.dedup();
+}
+
+struct Search<'a> {
+    node_ids: &'a [GraphNodeId],
+    adjacency: &'a [Vec<usize>],
+    state: Vec<u8>,
+    stack: Vec<usize>,
+    paths: Vec<Vec<GraphNodeId>>,
+    limit: usize,
+    depth_exceeded: bool,
+}
+
+impl<'a> Search<'a> {
+    fn new(node_ids: &'a [GraphNodeId], adjacency: &'a [Vec<usize>], limit: usize) -> Self {
+        Self {
+            node_ids,
+            adjacency,
+            state: vec![0; node_ids.len()],
+            stack: Vec::new(),
+            paths: Vec::new(),
+            limit,
+            depth_exceeded: false,
+        }
+    }
+
+    fn run(&mut self) {
+        for start in 0..self.node_ids.len() {
+            if self.paths.len() >= self.limit {
+                break;
+            }
+            if self.state[start] == 0 {
+                self.visit(start, 0);
+            }
+        }
+    }
+
+    fn visit(&mut self, node: usize, depth: usize) {
+        if depth > MAX_DEPTH {
+            self.depth_exceeded = true;
+            return;
+        }
+        self.state[node] = 1;
+        self.stack.push(node);
+        for &target in &self.adjacency[node] {
+            if self.paths.len() >= self.limit {
+                break;
+            }
+            match self.state[target] {
+                0 => self.visit(target, depth + 1),
+                1 => self.record_cycle(target),
+                _ => {}
+            }
+        }
+        self.stack.pop();
+        self.state[node] = 2;
+    }
+
+    fn record_cycle(&mut self, target: usize) {
+        let Some(position) = self.stack.iter().position(|node| *node == target) else {
+            return;
+        };
+        self.paths.push(
+            self.stack[position..]
+                .iter()
+                .map(|node| self.node_ids[*node].clone())
+                .collect(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::v2::{
+        GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance, GraphNode,
+        GraphNodeKind,
+    };
+    use std::path::PathBuf;
+
+    #[test]
+    fn bounded_paths_are_canonical_and_open() {
+        let result = bounded_cycle_paths(
+            &snapshot(&[("b", "c"), ("c", "a"), ("a", "b")]),
+            &BTreeSet::new(),
+            20,
+        );
+        assert_eq!(result.paths, vec![vec![id("a"), id("b"), id("c")]]);
+        assert!(!result.truncated);
+        assert!(!result.depth_exceeded);
+    }
+
+    #[test]
+    fn bounded_paths_report_truncation_without_returning_the_probe() {
+        let result = bounded_cycle_paths(
+            &snapshot(&[("a", "b"), ("b", "a"), ("c", "d"), ("d", "c")]),
+            &BTreeSet::new(),
+            1,
+        );
+        assert_eq!(result.paths, vec![vec![id("a"), id("b")]]);
+        assert!(result.truncated);
+    }
+
+    fn id(label: &str) -> GraphNodeId {
+        GraphNodeId::new(format!("file:{label}"))
+    }
+
+    fn snapshot(edges: &[(&str, &str)]) -> GraphSnapshot {
+        let labels = edges
+            .iter()
+            .flat_map(|(from, to)| [*from, *to])
+            .collect::<BTreeSet<_>>();
+        GraphSnapshot {
+            nodes: labels
+                .into_iter()
+                .map(|label| GraphNode {
+                    id: id(label),
+                    kind: GraphNodeKind::File,
+                    label: label.to_string(),
+                    path: Some(PathBuf::from(label)),
+                })
+                .collect(),
+            edges: edges
+                .iter()
+                .map(|(from, to)| GraphEdge {
+                    from: id(from),
+                    to: id(to),
+                    kind: GraphEdgeKind::Imports,
+                    provenance: GraphEdgeProvenance::Import,
+                    confidence: GraphEdgeConfidence::High,
+                })
+                .collect(),
+            ..GraphSnapshot::default()
+        }
+    }
+}

--- a/src/graph/v2/algorithms/cycles/mod.rs
+++ b/src/graph/v2/algorithms/cycles/mod.rs
@@ -2,6 +2,9 @@ use super::topology;
 use crate::graph::v2::{GraphNodeId, GraphSnapshot};
 use std::collections::{BTreeMap, VecDeque};
 
+mod bounded;
+pub use bounded::{BoundedCyclePaths, bounded_cycle_paths};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GraphCycle {
     pub node_ids: Vec<GraphNodeId>,

--- a/src/graph/v2/algorithms/mod.rs
+++ b/src/graph/v2/algorithms/mod.rs
@@ -6,7 +6,7 @@ mod neighborhood;
 mod summary;
 
 pub use blast_radius::{GraphBlastRadius, blast_radius, direct_dependents};
-pub use cycles::{GraphCycle, find_cycles, shortest_cycle};
+pub use cycles::{BoundedCyclePaths, GraphCycle, bounded_cycle_paths, find_cycles, shortest_cycle};
 pub use degree::{GraphDegreeSummary, NodeDegree, compute_degrees, top_fan_in, top_fan_out};
 pub use directory::{DirectoryDependency, GraphDirectoryDependencies, directory_dependencies};
 pub use neighborhood::{GraphNeighborhood, neighborhood};

--- a/src/graph/v2/mod.rs
+++ b/src/graph/v2/mod.rs
@@ -9,10 +9,10 @@ mod readiness;
 mod snapshot;
 
 pub use algorithms::{
-    DirectoryDependency, GraphBlastRadius, GraphCycle, GraphDegreeSummary,
+    BoundedCyclePaths, DirectoryDependency, GraphBlastRadius, GraphCycle, GraphDegreeSummary,
     GraphDirectoryDependencies, GraphNeighborhood, GraphV2Summary, NodeDegree, blast_radius,
-    compute_degrees, direct_dependents, directory_dependencies, find_cycles, neighborhood,
-    shortest_cycle, summarize_graph, top_fan_in, top_fan_out,
+    bounded_cycle_paths, compute_degrees, direct_dependents, directory_dependencies, find_cycles,
+    neighborhood, shortest_cycle, summarize_graph, top_fan_in, top_fan_out,
 };
 pub use builder::graph_snapshot_from_scan;
 pub use capabilities::{GraphCapabilities, graph_capabilities};

--- a/src/scan/scanner/changed/finalize.rs
+++ b/src/scan/scanner/changed/finalize.rs
@@ -5,7 +5,7 @@ use super::{
     ChangedRepoContextStage, ChangedScanEngine,
 };
 use crate::findings::quality::SignalQualitySummary;
-use crate::graph::context::summarize_context_graph;
+use crate::graph::context::summarize_repository_context_state;
 use crate::scan::facts::ScanFacts;
 use crate::scan::types::{ScanMode, ScanSummary, ScanTimings};
 use std::io;
@@ -23,8 +23,8 @@ impl<'a> ChangedScanEngine<'a> {
         let finalization_start = Instant::now();
 
         summary::sort_findings(&mut file_stage.findings);
-        let context_graph_summary = summarize_context_graph(
-            &repo_stage.context_graph,
+        let context_graph_summary = summarize_repository_context_state(
+            &repo_stage.context_state,
             &file_stage.findings,
             &discovery.changed_files,
         );

--- a/src/scan/scanner/changed/repo_context.rs
+++ b/src/scan/scanner/changed/repo_context.rs
@@ -6,7 +6,8 @@ use crate::frameworks::{
     detect_react_native_architecture,
 };
 use crate::graph::context::{
-    RepoContextGraph, context_graph_cache_miss, load_repo_context_graph, write_repo_context_graph,
+    RepositoryContextState, context_graph_cache_miss, load_repository_context_state,
+    write_repository_context_state,
 };
 use crate::graph::{CouplingGraph, build_coupling_graph};
 use crate::risk::{apply_cluster_overlay, apply_graph_overlay, assess_findings};
@@ -32,15 +33,16 @@ impl<'a> ChangedScanEngine<'a> {
         let repo_root = &discovery.repo_root;
         let fingerprint = config_fingerprint(self.config);
 
-        if let Some(mut load) = load_repo_context_graph(repo_root, &fingerprint) {
-            load.graph
+        if let Some(mut load) = load_repository_context_state(repo_root, &fingerprint) {
+            load.state
                 .apply_changed_facts(repo_root, &discovery.changed_files, graph_patch_files);
-            if let Err(error) = write_repo_context_graph(repo_root, &fingerprint, &load.graph) {
+            if let Err(error) = write_repository_context_state(repo_root, &fingerprint, &load.state)
+            {
                 diagnostics.push(cache_diagnostic(&error));
             }
 
-            let repo_context = load.graph.to_scan_facts();
-            let coupling_graph = load.graph.coupling_graph();
+            let repo_context = load.state.to_scan_facts();
+            let coupling_graph = load.state.coupling_graph();
 
             facts.detected_frameworks = repo_context.detected_frameworks.clone();
             facts.framework_projects = repo_context.framework_projects.clone();
@@ -49,7 +51,7 @@ impl<'a> ChangedScanEngine<'a> {
             return Ok(ChangedRepoContextStage {
                 repo_context,
                 coupling_graph,
-                context_graph: load.graph,
+                context_state: load.state,
                 cache_info: load.cache_info,
                 diagnostics,
                 elapsed_us: start.elapsed().as_micros() as u64,
@@ -69,11 +71,14 @@ impl<'a> ChangedScanEngine<'a> {
 
         let coupling_graph =
             relative_coupling_graph(build_coupling_graph(&repo_context, repo_root), repo_root);
-        let context_graph =
-            RepoContextGraph::from_scan_facts(&repo_context, repo_root, coupling_graph.clone());
+        let context_state = RepositoryContextState::from_scan_facts(
+            &repo_context,
+            repo_root,
+            coupling_graph.clone(),
+        );
         let mut cache_info =
             context_graph_cache_miss(repo_root, "missing-or-invalid-context-graph-cache");
-        match write_repo_context_graph(repo_root, &fingerprint, &context_graph) {
+        match write_repository_context_state(repo_root, &fingerprint, &context_state) {
             Ok(_) => {
                 cache_info.reason.push_str("; cache-updated");
             }
@@ -87,7 +92,7 @@ impl<'a> ChangedScanEngine<'a> {
         Ok(ChangedRepoContextStage {
             repo_context,
             coupling_graph,
-            context_graph,
+            context_state,
             cache_info,
             diagnostics,
             elapsed_us: start.elapsed().as_micros() as u64,

--- a/src/scan/scanner/changed/stages.rs
+++ b/src/scan/scanner/changed/stages.rs
@@ -1,6 +1,6 @@
 use crate::findings::types::Finding;
 use crate::graph::CouplingGraph;
-use crate::graph::context::{ContextGraphCacheInfo, RepoContextGraph};
+use crate::graph::context::{ContextGraphCacheInfo, RepositoryContextState};
 use crate::review::diff::ChangedFile;
 use crate::scan::cache::ScanCache;
 use crate::scan::facts::{FileFacts, ScanFacts};
@@ -30,7 +30,7 @@ pub(super) struct ChangedFileAnalysisStage {
 pub(super) struct ChangedRepoContextStage {
     pub repo_context: ScanFacts,
     pub coupling_graph: CouplingGraph,
-    pub context_graph: RepoContextGraph,
+    pub context_state: RepositoryContextState,
     pub cache_info: ContextGraphCacheInfo,
     pub diagnostics: Vec<ScanDiagnostic>,
     pub elapsed_us: u64,

--- a/src/scan/scanner/finalize.rs
+++ b/src/scan/scanner/finalize.rs
@@ -2,8 +2,8 @@ use super::summary::{ScanSummaryParts, build_scan_summary};
 use super::{full::ProjectAnalysisStage, full::ScanEngine, summary};
 use crate::findings::quality::SignalQualitySummary;
 use crate::graph::context::{
-    ContextGraphCacheInfo, ContextGraphSummary, RepoContextGraph, summarize_context_graph,
-    write_repo_context_graph,
+    ContextGraphCacheInfo, ContextGraphSummary, RepositoryContextState,
+    summarize_repository_context_state, write_repository_context_state,
 };
 use crate::scan::cache::config_fingerprint;
 use crate::scan::config::ScanConfig;
@@ -26,7 +26,7 @@ impl<'a> ScanEngine<'a> {
         signal_quality: SignalQualitySummary,
     ) -> ScanSummary {
         let finalization_start = Instant::now();
-        let context_graph = prepare_findings_and_context_graph(&mut project_stage);
+        let context_state = prepare_findings_and_context_state(&mut project_stage);
         let mut diagnostics = diagnostics;
         if crate::graph::was_cycle_detection_depth_exceeded() {
             diagnostics.push(ScanDiagnostic::warning(
@@ -37,7 +37,7 @@ impl<'a> ScanEngine<'a> {
         let context_graph_artifacts = build_context_graph_artifacts(
             &project_stage.facts.root_path,
             self.config,
-            &context_graph,
+            &context_state,
             &project_stage.findings,
             &mut diagnostics,
         );
@@ -56,12 +56,12 @@ impl<'a> ScanEngine<'a> {
     }
 }
 
-fn prepare_findings_and_context_graph(
+fn prepare_findings_and_context_state(
     project_stage: &mut ProjectAnalysisStage,
-) -> RepoContextGraph {
+) -> RepositoryContextState {
     summary::sort_findings(&mut project_stage.findings);
 
-    RepoContextGraph::from_scan_facts(
+    RepositoryContextState::from_scan_facts(
         &project_stage.facts,
         &project_stage.facts.root_path,
         project_stage.coupling_graph.clone(),
@@ -71,13 +71,13 @@ fn prepare_findings_and_context_graph(
 fn build_context_graph_artifacts(
     root_path: &Path,
     config: &ScanConfig,
-    context_graph: &RepoContextGraph,
+    context_state: &RepositoryContextState,
     findings: &[crate::findings::types::Finding],
     diagnostics: &mut Vec<ScanDiagnostic>,
 ) -> ContextGraphArtifacts {
-    let graph_summary = summarize_context_graph(context_graph, findings, &[]);
+    let graph_summary = summarize_repository_context_state(context_state, findings, &[]);
     let fingerprint = config_fingerprint(config);
-    let cache = match write_repo_context_graph(root_path, &fingerprint, context_graph) {
+    let cache = match write_repository_context_state(root_path, &fingerprint, context_state) {
         Ok(cache_info) => Some(cache_info),
         Err(error) => {
             diagnostics.push(cache_diagnostic(&error));

--- a/src/scan/scanner/summary.rs
+++ b/src/scan/scanner/summary.rs
@@ -2,7 +2,8 @@ use crate::findings::quality::SignalQualitySummary;
 use crate::findings::types::Finding;
 use crate::graph::CouplingGraph;
 use crate::graph::context::{
-    ContextGraphCacheInfo, ContextGraphSummary, RepoContextGraph, summarize_context_graph,
+    ContextGraphCacheInfo, ContextGraphSummary, RepositoryContextState,
+    summarize_repository_context_state,
 };
 use crate::scan::facts::ScanFacts;
 use crate::scan::types::LanguageSummary;
@@ -64,12 +65,12 @@ pub(super) fn build_scan_summary(
             .context_graph_summary
             .or_else(|| match parts.coupling_graph.as_ref() {
                 Some(coupling_graph) => {
-                    let graph = RepoContextGraph::from_scan_facts(
+                    let state = RepositoryContextState::from_scan_facts(
                         &facts,
                         &facts.root_path,
                         coupling_graph.clone(),
                     );
-                    Some(summarize_context_graph(&graph, &findings, &[]))
+                    Some(summarize_repository_context_state(&state, &findings, &[]))
                 }
                 None => None,
             });

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -811,11 +811,21 @@ fn force_context_graph_resolver(path: &Path, resolver_version: &str) {
 
 fn clear_context_graph_deferred_imports(path: &Path) {
     let mut value = read_json(path);
-    value["graph"]["deferred_edges"] = serde_json::json!({});
-    for node in value["graph"]["nodes"]
-        .as_array_mut()
-        .expect("context nodes")
-    {
+    let state = if value.get("state").is_some() {
+        &mut value["state"]
+    } else {
+        &mut value["graph"]
+    };
+    state["coupling"]["deferred_edges"] = serde_json::json!({});
+    if state.get("deferred_edges").is_some() {
+        state["deferred_edges"] = serde_json::json!({});
+    }
+    let files = if state.get("files").is_some() {
+        &mut state["files"]
+    } else {
+        &mut state["nodes"]
+    };
+    for node in files.as_array_mut().expect("context nodes") {
         node["deferred_imports"] = Value::Array(Vec::new());
     }
     write_json(path, &value);


### PR DESCRIPTION
## What changed

- move the bounded context-cycle projection onto graph v2 while preserving deferred-import, Rust module-containment, ordering, truncation, and depth-limit behavior;
- introduce an ordered internal `RepositoryContextState` and keep `RepoContextGraph` as a compatibility-only public view;
- migrate the repository context cache to schema v5 and make full and changed scans share the same state-to-analysis path;
- preserve public JSON, MCP, AI-context, findings, readiness, cache-info, and human report contracts;
- document the Phase A3 specification, implementation plan, and completed architecture state.

## Why

Graph-based rules, review impact, context metrics, and readiness already used graph v2, but changed scans still persisted and patched a separate compatibility graph. This left multiple sources of graph behavior and made invalidation and future repository-intelligence work harder to reason about.

Phase A3 makes source-derived context state the persistence boundary and graph v2 the single derived analysis path. Upgrading causes one expected internal cache rebuild; subsequent compatible changed scans continue to use warm cached context without rescanning unchanged source content.

## User and developer impact

- no public command or report schema change;
- more coherent full/changed graph analysis;
- deterministic cache schema migration;
- existing warm changed-scan behavior is retained;
- prepares the shared core for the broken-code evidence phase of v0.22.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` — 737 library tests, 55 binary tests, all integration/doc suites passed
- `python3 scripts/release-contract.py check`
- `npm run test:release-contract` — 42 tests passed
- `cargo run -- scan . --fail-on-priority p1` — PASS, P0 0, P1 0
- `cargo test --test perf_matrix -- --nocapture`
- `npm run review:performance` — changed/full ratio 0.346
- `npm run scan:performance` — medium warm full scan 569.35 ms; warm changed review 300.71 ms

The real-repository zoo was not cloned in this worktree, so no zoo measurement or reduction claim is included.
