### PR TITLE
feat: detect unresolved local imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,20 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- Add the first v0.22 broken-code detector,
+  `architecture.unresolved-local-import`. It reports only explicit local
+  TypeScript/JavaScript file imports and Python relative modules whose complete,
+  root-confined candidate set is absent. Ambiguous aliases, extensionless
+  imports, workspace packages, Rust module forms, and unsupported semantics stay
+  as bounded informational diagnostics instead of false broken-code claims.
+
 ### Changed
 
+- Preserve import source spans in parsed-facts cache schema v3 and
+  repository-context cache schema v6. Full and warm changed scans now attach the
+  same exact import-line evidence without reading or parsing files a second time.
 - Graph-based scan rules now share one graph-v2 snapshot and an internal
   available/limited/unavailable readiness policy. Absence claims are demoted or
   skipped when unresolved internal imports weaken them, while proven-edge

--- a/docs/architecture-antipatterns.md
+++ b/docs/architecture-antipatterns.md
@@ -41,6 +41,25 @@ from broad architecture structure heuristics.
 | `architecture.test-leak` | Does production code import a test or fixture file? | On by default; evidence cites the import line. |
 | `architecture.layer-violation` | Does a module import against the declared layer order? | Strictly opt-in via `[[architecture.layers]]`. |
 | `architecture.package-boundary-violation` | Does one package reach into another's internals instead of its public API? | Auto-enabled on a detected workspace (manifest boundaries → High confidence); also configurable via `[architecture] package_roots` (→ Medium). |
+| `architecture.unresolved-local-import` | Does a supported explicit local import point to a module that is absent? | High/High only for bounded TS/JS file candidates and Python relative modules; ambiguous semantics produce an informational limitation, not a finding. |
+
+## Broken local import boundary
+
+`architecture.unresolved-local-import` is a correctness-oriented graph rule in
+the existing architecture namespace. In its first conservative slice it reports
+only:
+
+- relative TypeScript/JavaScript imports with an explicit `.ts`, `.tsx`, `.js`,
+  or `.jsx` target; and
+- Python relative modules such as `.payments` when neither the module file nor
+  package initializer exists.
+
+RepoPilot checks every bounded candidate on disk before reporting, so a valid
+target omitted by ignore or scan-size policy remains quiet. Extensionless
+imports, path aliases, workspace packages, generated targets, Rust module forms,
+root escapes, and unsupported language semantics remain uncertainty. They are
+counted in an aggregated informational diagnostic and are never described as a
+proven build failure.
 
 ## Visibility guidance
 

--- a/docs/engineering/rule-scorecard.md
+++ b/docs/engineering/rule-scorecard.md
@@ -19,6 +19,7 @@ Per-rule signal quality derived from the real-repo validation zoo (`tests/zoo/ex
 | `architecture.package-boundary-violation` | experimental | no zoo evidence | n/a | 0 |
 | `architecture.test-leak` | experimental | no zoo evidence | n/a | 0 |
 | `architecture.too-many-modules` | experimental | no zoo evidence | n/a | 0 |
+| `architecture.unresolved-local-import` | preview | no zoo evidence | n/a | 0 |
 | `code-marker.fixme` | experimental | no zoo evidence | n/a | 0 |
 | `code-marker.hack` | experimental | no zoo evidence | n/a | 0 |
 | `code-marker.todo` | experimental | no zoo evidence | n/a | 0 |

--- a/docs/engineering/v0.22-broken-import-evidence-spec.md
+++ b/docs/engineering/v0.22-broken-import-evidence-spec.md
@@ -1,0 +1,94 @@
+# v0.22 Broken Local Import Evidence
+
+Status: approved
+
+## Problem
+
+RepoPilot already records imports that the repository graph cannot resolve, but
+it treats every unresolved import as the same raw string. That is sufficient to
+weaken absence-based architecture claims, but it cannot distinguish a provably
+missing local module from an alias, generated target, workspace package, or
+language form that RepoPilot does not fully understand. Surfacing all unresolved
+imports as broken code would therefore create false positives.
+
+## Outcome
+
+Add the first conservative Phase B detector: `architecture.unresolved-local-import`.
+It reports a default-visible finding only when RepoPilot can derive a bounded set
+of local candidate paths using supported language semantics and none of those
+paths exists. Every other unresolved internal import remains uncertainty and is
+summarized as a bounded informational diagnostic rather than stated as broken.
+
+The rule stays in the existing `architecture` namespace for this slice because
+`FindingCategory` is part of the public report contract and does not yet expose a
+`correctness` category. A separate category migration is not required to deliver
+or explain the broken-code evidence.
+
+## Scope
+
+### In scope
+
+- Replace raw unresolved-import strings with deterministic typed evidence that
+  preserves source path, import text, target kind, proof state, and candidate
+  paths where a definitive local lookup is supported.
+- Reuse the existing import extraction and graph construction pass. The detector
+  must not reread or reparse the repository as a second analysis pipeline.
+- Treat these forms as eligible for definitive missing-target evidence:
+  - relative TypeScript/JavaScript imports with an explicit supported code
+    extension (`.ts`, `.tsx`, `.js`, or `.jsx`), using the same candidate rules
+    as the current resolver;
+  - explicit Python relative modules with a non-empty module name, using the
+    same module/package candidates as the current resolver.
+- Before emitting a finding, verify that no candidate exists on disk, including
+  candidates omitted from the scan by ignore or size policy.
+- Keep aliases, workspace packages, extensionless JS/TS imports, Rust module
+  forms, unsupported languages, targets outside the repository root, and other
+  ambiguous cases as limited evidence only.
+- Emit one High-severity, High-confidence finding per unresolved source/import
+  occurrence, with the source line, import text, impact, and verification
+  guidance.
+- Aggregate non-definitive evidence into deterministic informational diagnostics
+  by limitation reason; do not emit one diagnostic per import.
+- Preserve identical rule evidence for full scans and changed scans after the
+  repository-context cache is warm.
+- Add unsafe and near-identical safe fixtures, targeted unit/integration tests,
+  rule metadata/reference updates, changelog notes, and user documentation.
+
+### Out of scope
+
+- Missing exported-symbol analysis, compiler/type-checker execution, manifest
+  dependency mismatch, generated-code discovery, or alias inference beyond the
+  resolver's current configuration support.
+- Treating extensionless JavaScript/TypeScript imports or Rust `mod`/`use`
+  statements as definitive failures.
+- Adding a new top-level command, a new public finding category, or a second
+  health score.
+- Network access, clock-dependent output, randomness, or unbounded diagnostics.
+
+## Trust contract
+
+- A finding means all supported local candidates were enumerated, remained
+  inside the repository root, and did not exist at analysis time.
+- Unsupported or ambiguous resolution never becomes a default-visible finding.
+- Findings and diagnostics are sorted deterministically.
+- Candidate paths and snippets pass through the existing finding/report
+  redaction and root-relative normalization paths.
+- An empty result means no supported broken local import was proven; it does not
+  claim that every import or language semantic was evaluated.
+
+## Acceptance criteria
+
+1. A TypeScript file importing `./missing.ts` produces exactly one
+   `architecture.unresolved-local-import` finding at the import line.
+2. Adding the matching `missing.ts` file removes that finding.
+3. A Python file importing `.missing` produces the finding when neither
+   `missing.py` nor `missing/__init__.py` exists.
+4. Extensionless JS/TS, configured/local aliases, workspace packages, Rust
+   module syntax, and paths escaping the root produce no broken-code finding.
+5. An existing candidate excluded from scanning produces no finding.
+6. Full and changed scans produce the same occurrence identity and evidence for
+   the same repository state.
+7. Existing graph readiness behavior continues to count all unresolved internal
+   imports, including those too ambiguous for this detector.
+8. Targeted tests, rule fixture evaluation, formatting, clippy, the full Rust
+   suite, release contracts, and RepoPilot's self-scan pass before handoff.

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -80,6 +80,16 @@ Definition of done:
 Add conservative detectors for failures RepoPilot can prove from local static
 facts rather than attempting to replace compilers or type checkers.
 
+Current progress:
+
+- B1 implemented: `architecture.unresolved-local-import` reuses typed graph
+  evidence for explicit supported TS/JS and Python local imports, preserves
+  exact source spans through cold/warm caches, and reports ambiguous semantics
+  as aggregated limitations. Safe/unsafe fixtures and full/changed parity pin
+  the trust boundary.
+- Next: deleted or renamed exported symbols still referenced inside supported
+  local analysis boundaries.
+
 Initial evidence families:
 
 - unresolved local imports and modules with language-aware confidence;

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -3,7 +3,7 @@
 <!-- @generated from the rule registry — do not edit by hand. -->
 <!-- Regenerate with `REPOPILOT_BLESS=1 cargo test --test rules_reference_doc`. -->
 
-RepoPilot ships 52 rules across 5 categories. Every finding traces back to one of these rules. Severity and confidence below are the registry defaults: context (audit tiers, knowledge packs) may lower them, or raise them up to a rule's declared ceiling, but never past it.
+RepoPilot ships 53 rules across 5 categories. Every finding traces back to one of these rules. Severity and confidence below are the registry defaults: context (audit tiers, knowledge packs) may lower them, or raise them up to a rule's declared ceiling, but never past it.
 
 ## Architecture
 
@@ -202,6 +202,25 @@ A production module imports a test or fixture module.
 A directory contains more files than the configured threshold, suggesting it may need to be broken into sub-packages.
 
 **Recommendation:** Group related files into sub-directories. Adjust `max_directory_modules` in repopilot.toml if the current threshold is too strict.
+
+### `architecture.unresolved-local-import` — Local import target is missing
+
+- **Severity:** HIGH
+- **Confidence:** HIGH
+- **Lifecycle:** preview
+- **Signal source:** import-graph
+- **Execution scope:** repository
+- **Required facts:** imports, exports, file-context, dependency-graph, workspace-metadata
+- **Cache policy:** per-workspace-revision
+- **Produces:** finding
+
+A supported explicit local import does not resolve to any bounded source-file candidate inside the repository.
+
+**Recommendation:** Restore the imported module, update the import path, or run the project compiler to confirm the intended generated target.
+
+**Known false positives:** Only explicit supported TypeScript/JavaScript file extensions and explicit Python relative modules are reported. Extensionless imports, aliases, workspace packages, Rust module forms, generated targets, and unsupported semantics remain limitations rather than findings.
+
+**Reference:** <https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture>
 
 ## Code quality
 

--- a/src/audits/architecture/graph_analysis.rs
+++ b/src/audits/architecture/graph_analysis.rs
@@ -1,16 +1,20 @@
 use super::graph_context::GraphAuditContext;
 use super::graph_queries::GraphQueriesAudit;
 use super::import_coupling::ImportCouplingAudit;
+use super::unresolved_local_imports::analyze_unresolved_local_imports;
 use crate::findings::types::Finding;
 use crate::graph::v2::build_coupling_graph_snapshot;
 use crate::graph::{CouplingGraph, build_coupling_graph_with_resolution};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
+use crate::scan::types::ScanDiagnostic;
 use std::path::Path;
 
 pub(crate) struct GraphAnalysisResult {
     pub(crate) coupling_findings: Vec<Finding>,
     pub(crate) query_findings: Vec<Finding>,
+    pub(crate) broken_import_findings: Vec<Finding>,
+    pub(crate) diagnostics: Vec<ScanDiagnostic>,
     pub(crate) graph: CouplingGraph,
 }
 
@@ -32,10 +36,13 @@ pub(crate) fn run_graph_analysis(
     };
     let coupling_findings = ImportCouplingAudit.audit(&context);
     let query_findings = GraphQueriesAudit.audit(&context);
+    let broken_import_analysis = analyze_unresolved_local_imports(&context);
 
     GraphAnalysisResult {
         coupling_findings,
         query_findings,
+        broken_import_findings: broken_import_analysis.findings,
+        diagnostics: broken_import_analysis.diagnostics,
         graph,
     }
 }

--- a/src/audits/architecture/mod.rs
+++ b/src/audits/architecture/mod.rs
@@ -7,3 +7,4 @@ pub mod graph_queries;
 pub mod import_coupling;
 pub mod large_file;
 pub mod too_many_modules;
+pub(crate) mod unresolved_local_imports;

--- a/src/audits/architecture/unresolved_local_imports.rs
+++ b/src/audits/architecture/unresolved_local_imports.rs
@@ -1,0 +1,168 @@
+use super::graph_context::GraphAuditContext;
+use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
+use crate::graph::imports::lines::import_line_spans;
+use crate::graph::{UnresolvedImportLimitation, UnresolvedImportProof};
+use crate::scan::facts::FileFacts;
+use crate::scan::types::{DiagnosticSeverity, ScanDiagnostic};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+const RULE_ID: &str = "architecture.unresolved-local-import";
+
+pub(crate) struct UnresolvedLocalImportAnalysis {
+    pub(crate) findings: Vec<Finding>,
+    pub(crate) diagnostics: Vec<ScanDiagnostic>,
+}
+
+pub(crate) fn analyze_unresolved_local_imports(
+    context: &GraphAuditContext<'_>,
+) -> UnresolvedLocalImportAnalysis {
+    let mut findings = Vec::new();
+    let mut limitations = BTreeMap::new();
+    for unresolved in context.resolution.evidence() {
+        if is_shadowed_python_submodule(unresolved, context.resolution) {
+            continue;
+        }
+        match &unresolved.proof {
+            UnresolvedImportProof::DefinitiveLocalCandidates(candidates)
+                if !candidates.iter().any(|candidate| candidate.is_file()) =>
+            {
+                findings.push(missing_import_finding(context, unresolved, candidates));
+            }
+            UnresolvedImportProof::DefinitiveLocalCandidates(_) => {}
+            UnresolvedImportProof::Limited(reason) => {
+                *limitations.entry(*reason).or_insert(0usize) += 1;
+            }
+        }
+    }
+    findings.sort_by(|left, right| left.evidence[0].path.cmp(&right.evidence[0].path));
+    UnresolvedLocalImportAnalysis {
+        findings,
+        diagnostics: limitation_diagnostics(limitations),
+    }
+}
+
+fn is_shadowed_python_submodule(
+    unresolved: &crate::graph::UnresolvedImportEvidence,
+    resolution: &crate::graph::ImportResolutionStats,
+) -> bool {
+    if unresolved
+        .source
+        .extension()
+        .and_then(|value| value.to_str())
+        != Some("py")
+    {
+        return false;
+    }
+    resolution.evidence().any(|parent| {
+        parent.source == unresolved.source
+            && matches!(
+                parent.proof,
+                UnresolvedImportProof::DefinitiveLocalCandidates(_)
+            )
+            && unresolved
+                .raw_import
+                .strip_prefix(&parent.raw_import)
+                .is_some_and(|suffix| suffix.starts_with('.') && suffix.len() > 1)
+    })
+}
+
+fn missing_import_finding(
+    context: &GraphAuditContext<'_>,
+    unresolved: &crate::graph::UnresolvedImportEvidence,
+    candidates: &[PathBuf],
+) -> Finding {
+    let path = relative_path(&unresolved.source, context.root);
+    let source_facts = context.facts.files.iter().find(|file| {
+        crate::graph::resolver::normalize_path(&file.path)
+            == crate::graph::resolver::normalize_path(&unresolved.source)
+    });
+    let stored_spans = context
+        .facts
+        .import_spans_by_file
+        .iter()
+        .find(|(path, _)| {
+            crate::graph::resolver::normalize_path(path)
+                == crate::graph::resolver::normalize_path(&unresolved.source)
+        })
+        .map(|(_, spans)| spans);
+    let (line_start, line_end) = import_span(source_facts, stored_spans, &unresolved.raw_import);
+    Finding {
+        id: String::new(),
+        rule_id: RULE_ID.to_string(),
+        title: "Local import target is missing".to_string(),
+        description: format!(
+            "The local import `{}` does not resolve to any supported source file candidate.",
+            unresolved.raw_import
+        ),
+        recommendation: "Restore the imported module, update the import path, or run the project compiler to confirm the intended generated target.".to_string(),
+        category: FindingCategory::Architecture,
+        severity: Severity::High,
+        confidence: Confidence::High,
+        evidence: vec![Evidence {
+            path,
+            line_start,
+            line_end,
+            snippet: candidate_snippet(&unresolved.raw_import, candidates, context.root),
+        }],
+        workspace_package: None,
+        docs_url: None,
+        provenance: Default::default(),
+        risk: Default::default(),
+    }
+}
+
+fn import_span(
+    file: Option<&FileFacts>,
+    stored_spans: Option<&BTreeMap<String, (usize, usize)>>,
+    raw_import: &str,
+) -> (usize, Option<usize>) {
+    if let Some(&(start, end)) = stored_spans.and_then(|spans| spans.get(raw_import)) {
+        return (start, (end > start).then_some(end));
+    }
+    let Some(file) = file else {
+        return (1, None);
+    };
+    let Some(content) = file.content.as_deref() else {
+        return (1, None);
+    };
+    import_line_spans(content, file.language.as_deref(), &[raw_import.to_string()])
+        .get(raw_import)
+        .copied()
+        .map(|(start, end)| (start, (end > start).then_some(end)))
+        .unwrap_or((1, None))
+}
+
+fn candidate_snippet(raw_import: &str, candidates: &[PathBuf], root: &Path) -> String {
+    let checked = candidates
+        .iter()
+        .map(|candidate| relative_path(candidate, root).display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("unresolved local import `{raw_import}`; checked: {checked}")
+}
+
+fn limitation_diagnostics(
+    limitations: BTreeMap<UnresolvedImportLimitation, usize>,
+) -> Vec<ScanDiagnostic> {
+    limitations
+        .into_values()
+        .map(|count| ScanDiagnostic {
+            code: "analysis.unresolved-local-import-limited".to_string(),
+            severity: DiagnosticSeverity::Info,
+            message: format!(
+                "{count} unresolved internal import(s) used ambiguous or unsupported resolution semantics and were not reported as broken code."
+            ),
+            path: None,
+        })
+        .collect()
+}
+
+fn relative_path(path: &Path, root: &Path) -> PathBuf {
+    path.strip_prefix(root)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/audits/architecture/unresolved_local_imports/tests.rs
+++ b/src/audits/architecture/unresolved_local_imports/tests.rs
@@ -1,0 +1,139 @@
+use super::*;
+use crate::audits::architecture::graph_context::GraphAuditContext;
+use crate::findings::types::{Confidence, Severity};
+use crate::graph::v2::build_coupling_graph_snapshot;
+use crate::graph::{CouplingGraph, ImportResolutionStats};
+use crate::scan::config::ScanConfig;
+use crate::scan::facts::{FileFacts, ScanFacts};
+use crate::scan::types::DiagnosticSeverity;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn analyze(
+    root: &Path,
+    facts: &ScanFacts,
+    resolution: &ImportResolutionStats,
+) -> UnresolvedLocalImportAnalysis {
+    let graph = CouplingGraph::default();
+    let (snapshot, path_by_id) = build_coupling_graph_snapshot(&graph);
+    let context = GraphAuditContext {
+        facts,
+        config: &ScanConfig::default(),
+        root,
+        graph: &graph,
+        resolution,
+        snapshot: &snapshot,
+        path_by_id: &path_by_id,
+    };
+    analyze_unresolved_local_imports(&context)
+}
+
+fn facts(path: PathBuf, language: &str, content: &str, imports: &[&str]) -> ScanFacts {
+    ScanFacts {
+        files: vec![FileFacts {
+            path,
+            language: Some(language.to_string()),
+            content: Some(content.to_string()),
+            imports: imports.iter().map(|value| (*value).to_string()).collect(),
+            ..FileFacts::default()
+        }],
+        ..ScanFacts::default()
+    }
+}
+
+#[test]
+fn missing_explicit_typescript_target_emits_high_confidence_finding_at_import_line() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let source = root.join("src/app.ts");
+    let facts = facts(
+        source.clone(),
+        "TypeScript",
+        "// application entry\nimport { run } from \"./missing.ts\";\nrun();\n",
+        &["./missing.ts"],
+    );
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record_classified(&source, "./missing.ts", root);
+
+    let result = analyze(root, &facts, &resolution);
+
+    assert_eq!(result.findings.len(), 1);
+    let finding = &result.findings[0];
+    assert_eq!(finding.rule_id, "architecture.unresolved-local-import");
+    assert_eq!(finding.severity, Severity::High);
+    assert_eq!(finding.confidence, Confidence::High);
+    assert_eq!(finding.evidence[0].path, PathBuf::from("src/app.ts"));
+    assert_eq!(finding.evidence[0].line_start, 2);
+    assert!(finding.evidence[0].snippet.contains("./missing.ts"));
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn missing_explicit_python_relative_module_emits_finding() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let source = root.join("pkg/app.py");
+    let facts = facts(
+        source.clone(),
+        "Python",
+        "from .missing import run\n\nrun()\n",
+        &[".missing"],
+    );
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record_classified(&source, ".missing", root);
+    resolution.record_classified(&source, ".missing.run", root);
+
+    let result = analyze(root, &facts, &resolution);
+
+    assert_eq!(result.findings.len(), 1);
+    assert_eq!(result.findings[0].evidence[0].line_start, 1);
+    assert!(result.findings[0].description.contains(".missing"));
+}
+
+#[test]
+fn candidate_present_on_disk_but_absent_from_scan_is_not_reported() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/present.ts"), "export const value = 1;\n").unwrap();
+    let source = root.join("src/app.ts");
+    let facts = facts(
+        source.clone(),
+        "TypeScript",
+        "import { value } from \"./present.ts\";\n",
+        &["./present.ts"],
+    );
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record_classified(&source, "./present.ts", root);
+
+    let result = analyze(root, &facts, &resolution);
+
+    assert!(result.findings.is_empty());
+}
+
+#[test]
+fn ambiguous_imports_are_aggregated_into_one_info_diagnostic() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let source = root.join("src/app.ts");
+    let facts = facts(
+        source.clone(),
+        "TypeScript",
+        "import a from \"./generated-a\";\nimport b from \"./generated-b\";\n",
+        &["./generated-a", "./generated-b"],
+    );
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record_classified(&source, "./generated-a", root);
+    resolution.record_classified(&source, "./generated-b", root);
+
+    let result = analyze(root, &facts, &resolution);
+
+    assert!(result.findings.is_empty());
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(
+        result.diagnostics[0].code,
+        "analysis.unresolved-local-import-limited"
+    );
+    assert_eq!(result.diagnostics[0].severity, DiagnosticSeverity::Info);
+    assert!(result.diagnostics[0].message.contains('2'));
+}

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -14,7 +14,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 pub const CONTEXT_GRAPH_CACHE_NAME: &str = "repo_context.json";
-pub const CONTEXT_GRAPH_SCHEMA_VERSION: u32 = 5;
+pub const CONTEXT_GRAPH_SCHEMA_VERSION: u32 = 6;
 pub const CONTEXT_GRAPH_RESOLVER_VERSION: &str = "context-state-v1";
 pub const MAX_CONTEXT_GRAPH_CYCLES: usize = 20;
 pub const MAX_CONTEXT_GRAPH_METRICS: usize = 10;
@@ -60,6 +60,8 @@ pub struct RepoContextNode {
     pub non_empty_lines: usize,
     #[serde(default)]
     pub imports: Vec<String>,
+    #[serde(default)]
+    pub import_spans: BTreeMap<String, (usize, usize)>,
     #[serde(default)]
     pub deferred_imports: Vec<String>,
     pub is_test: bool,

--- a/src/graph/context/analysis.rs
+++ b/src/graph/context/analysis.rs
@@ -242,6 +242,7 @@ mod tests {
             workspace_package: None,
             non_empty_lines: 1,
             imports: Vec::new(),
+            import_spans: Default::default(),
             deferred_imports: Vec::new(),
             is_test: false,
             is_generated: false,

--- a/src/graph/context/cache.rs
+++ b/src/graph/context/cache.rs
@@ -243,6 +243,7 @@ fn stable_node_inputs(graph: &RepoContextGraph) -> Vec<serde_json::Value> {
                 "workspace_package": &node.workspace_package,
                 "non_empty_lines": node.non_empty_lines,
                 "imports": sorted_strings(&node.imports),
+                "import_spans": &node.import_spans,
                 "deferred_imports": sorted_strings(&node.deferred_imports),
                 "is_test": node.is_test,
                 "is_generated": node.is_generated,

--- a/src/graph/context/graph_impl.rs
+++ b/src/graph/context/graph_impl.rs
@@ -10,7 +10,13 @@ impl RepoContextGraph {
             nodes: facts
                 .files
                 .iter()
-                .map(|file| RepoContextNode::from_file(file, root))
+                .map(|file| {
+                    RepoContextNode::from_file(
+                        file,
+                        root,
+                        facts.import_spans_by_file.get(&file.path),
+                    )
+                })
                 .collect(),
             edges: relative_edges(coupling_graph.edges, root),
             deferred_edges: relative_edges(coupling_graph.deferred_edges, root),
@@ -36,6 +42,13 @@ impl RepoContextGraph {
             }
         }
 
+        let import_spans_by_file = self
+            .nodes
+            .iter()
+            .filter(|node| !node.import_spans.is_empty())
+            .map(|node| (node.path.clone(), node.import_spans.clone()))
+            .collect();
+
         ScanFacts {
             root_path: self.root_path.clone(),
             files_discovered: files.len(),
@@ -44,6 +57,7 @@ impl RepoContextGraph {
             non_empty_lines,
             languages: build_language_summary(languages),
             files,
+            import_spans_by_file,
             detected_frameworks: self.detected_frameworks.clone(),
             framework_projects: self.framework_projects.clone(),
             react_native: self.react_native.clone(),
@@ -76,6 +90,21 @@ impl RepoContextGraph {
         changed_files: &[ChangedFile],
         patch_files: &[FileFacts],
     ) {
+        self.apply_changed_facts_with_spans(
+            repo_root,
+            changed_files,
+            patch_files,
+            &BTreeMap::new(),
+        );
+    }
+
+    pub(crate) fn apply_changed_facts_with_spans(
+        &mut self,
+        repo_root: &Path,
+        changed_files: &[ChangedFile],
+        patch_files: &[FileFacts],
+        patch_import_spans: &BTreeMap<PathBuf, BTreeMap<String, (usize, usize)>>,
+    ) {
         let removed = changed_files
             .iter()
             .filter(|file| file.status == ChangeStatus::Deleted)
@@ -85,11 +114,9 @@ impl RepoContextGraph {
         self.nodes.retain(|node| !removed.contains(&node.path));
         self.nodes
             .retain(|node| !patch_files.iter().any(|file| file.path == node.path));
-        self.nodes.extend(
-            patch_files
-                .iter()
-                .map(|file| RepoContextNode::from_file(file, repo_root)),
-        );
+        self.nodes.extend(patch_files.iter().map(|file| {
+            RepoContextNode::from_file(file, repo_root, patch_import_spans.get(&file.path))
+        }));
         self.nodes.sort_by(|left, right| left.path.cmp(&right.path));
 
         let known_file_set_changed = changed_files.iter().any(|file| {
@@ -135,7 +162,11 @@ impl RepoContextGraph {
 }
 
 impl RepoContextNode {
-    fn from_file(file: &FileFacts, root: &Path) -> Self {
+    fn from_file(
+        file: &FileFacts,
+        root: &Path,
+        import_spans: Option<&BTreeMap<String, (usize, usize)>>,
+    ) -> Self {
         let context = classify_file(file);
         let roles = context.role_ids().into_iter().map(str::to_string).collect();
         let frameworks = context
@@ -166,6 +197,7 @@ impl RepoContextNode {
             workspace_package: None,
             non_empty_lines: file.non_empty_lines,
             imports: file.imports.clone(),
+            import_spans: import_spans.cloned().unwrap_or_default(),
             deferred_imports: file.deferred_imports.clone(),
             is_test: context.is_test,
             is_generated,

--- a/src/graph/context/state.rs
+++ b/src/graph/context/state.rs
@@ -4,6 +4,7 @@ use crate::graph::CouplingGraph;
 use crate::review::diff::ChangedFile;
 use crate::scan::facts::{FileFacts, ScanFacts};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -59,14 +60,15 @@ impl RepositoryContextState {
         self.to_compat().to_scan_facts()
     }
 
-    pub(crate) fn apply_changed_facts(
+    pub(crate) fn apply_changed_facts_with_spans(
         &mut self,
         root: &Path,
         changed_files: &[ChangedFile],
         patch_files: &[FileFacts],
+        patch_import_spans: &BTreeMap<PathBuf, BTreeMap<String, (usize, usize)>>,
     ) {
         let mut graph = self.to_compat();
-        graph.apply_changed_facts(root, changed_files, patch_files);
+        graph.apply_changed_facts_with_spans(root, changed_files, patch_files, patch_import_spans);
         *self = Self::from_compat(graph);
     }
 }

--- a/src/graph/context/tests.rs
+++ b/src/graph/context/tests.rs
@@ -72,7 +72,7 @@ fn repository_context_state_patch_removes_deleted_targets() {
         hunks: Vec::new(),
     };
 
-    state.apply_changed_facts(root, &[deleted], &[]);
+    state.apply_changed_facts_with_spans(root, &[deleted], &[], &BTreeMap::new());
 
     let graph = state.coupling_graph();
     assert!(!graph.nodes.contains(Path::new("b.rs")));
@@ -439,6 +439,7 @@ fn node(path: &Path) -> RepoContextNode {
         workspace_package: None,
         non_empty_lines: 1,
         imports: Vec::new(),
+        import_spans: Default::default(),
         deferred_imports: Vec::new(),
         is_test: false,
         is_generated: false,

--- a/src/graph/imports.rs
+++ b/src/graph/imports.rs
@@ -1,5 +1,6 @@
 use crate::analysis::parse::ParsedFile;
 use crate::languages::imports_for_label;
+use std::collections::BTreeMap;
 
 pub mod lines;
 
@@ -25,6 +26,17 @@ pub(crate) fn extract_imports_from(parsed: &ParsedFile, language: Option<&str>) 
         Some(extractor) => (extractor.eager)(parsed).into_iter().collect(),
         None => Vec::new(),
     }
+}
+
+/// Extracts 1-indexed source spans from the same shared parse view as imports.
+pub(crate) fn extract_import_spans_from(
+    parsed: &ParsedFile,
+    language: Option<&str>,
+) -> BTreeMap<String, (usize, usize)> {
+    language
+        .and_then(imports_for_label)
+        .map(|extractor| (extractor.spans)(parsed))
+        .unwrap_or_default()
 }
 
 /// Imports that are real edges in the coupling graph but must be subtracted by

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -9,7 +9,10 @@ mod resolution_stats;
 pub use coupling_metrics::coupling_file_metrics;
 pub(crate) use coupling_metrics::coupling_file_metrics_from_snapshot;
 pub use imports::extract_imports;
-pub use resolution_stats::ImportResolutionStats;
+pub use resolution_stats::{
+    ImportResolutionStats, UnresolvedImportEvidence, UnresolvedImportKind,
+    UnresolvedImportLimitation, UnresolvedImportProof,
+};
 pub use resolver::resolve_import;
 
 use crate::scan::facts::ScanFacts;
@@ -84,7 +87,7 @@ pub fn build_coupling_graph_with_resolution(
                 None => {
                     let raw = raw.trim();
                     if resolution_stats::is_unresolved_internal_import(raw, &repo_dirs) {
-                        resolution.record(&source, raw);
+                        resolution.record_classified(&source, raw, root);
                     }
                 }
             }

--- a/src/graph/resolution_stats.rs
+++ b/src/graph/resolution_stats.rs
@@ -14,18 +14,74 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum UnresolvedImportKind {
+    RelativePath,
+    LocalAlias,
+    WorkspacePackage,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum UnresolvedImportLimitation {
+    AmbiguousTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum UnresolvedImportProof {
+    DefinitiveLocalCandidates(Vec<PathBuf>),
+    Limited(UnresolvedImportLimitation),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UnresolvedImportEvidence {
+    pub source: PathBuf,
+    pub raw_import: String,
+    pub kind: UnresolvedImportKind,
+    pub proof: UnresolvedImportProof,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ImportResolutionStats {
     /// Unresolved internal imports keyed by the importing file.
-    pub unresolved_internal_by_source: BTreeMap<PathBuf, Vec<String>>,
+    pub unresolved_internal_by_source: BTreeMap<PathBuf, Vec<UnresolvedImportEvidence>>,
 }
 
 impl ImportResolutionStats {
     pub fn record(&mut self, source: &Path, raw_import: &str) {
-        self.unresolved_internal_by_source
-            .entry(source.to_path_buf())
-            .or_default()
-            .push(raw_import.to_string());
+        self.insert(UnresolvedImportEvidence {
+            source: source.to_path_buf(),
+            raw_import: raw_import.to_string(),
+            kind: unresolved_import_kind(raw_import),
+            proof: UnresolvedImportProof::Limited(UnresolvedImportLimitation::AmbiguousTarget),
+        });
+    }
+
+    pub fn record_classified(&mut self, source: &Path, raw_import: &str, root: &Path) {
+        let proof = crate::graph::resolver::definitive_local_candidates(raw_import, source, root)
+            .map(UnresolvedImportProof::DefinitiveLocalCandidates)
+            .unwrap_or(UnresolvedImportProof::Limited(
+                UnresolvedImportLimitation::AmbiguousTarget,
+            ));
+        self.insert(UnresolvedImportEvidence {
+            source: source.to_path_buf(),
+            raw_import: raw_import.to_string(),
+            kind: unresolved_import_kind(raw_import),
+            proof,
+        });
+    }
+
+    fn insert(&mut self, evidence: UnresolvedImportEvidence) {
+        let entries = self
+            .unresolved_internal_by_source
+            .entry(evidence.source.clone())
+            .or_default();
+        entries.push(evidence);
+        entries.sort();
+        entries.dedup();
+    }
+
+    pub fn evidence(&self) -> impl Iterator<Item = &UnresolvedImportEvidence> {
+        self.unresolved_internal_by_source.values().flatten()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -51,13 +107,26 @@ impl ImportResolutionStats {
         self.unresolved_internal_by_source
             .values()
             .flatten()
-            .any(|import| {
-                import_target_stems(import)
+            .any(|evidence| {
+                import_target_stems(&evidence.raw_import)
                     .iter()
                     .any(|candidate| candidate.eq_ignore_ascii_case(stem))
             })
     }
 }
+
+fn unresolved_import_kind(raw_import: &str) -> UnresolvedImportKind {
+    if raw_import.starts_with('.') {
+        UnresolvedImportKind::RelativePath
+    } else if raw_import.starts_with("@/") || raw_import.starts_with("~/") || raw_import == "~" {
+        UnresolvedImportKind::LocalAlias
+    } else {
+        UnresolvedImportKind::WorkspacePackage
+    }
+}
+
+#[cfg(test)]
+mod tests;
 
 /// Candidate file stems an import could be referring to. A path import's target
 /// is its last `/`-segment with the extension stripped; a dotted module import's
@@ -87,7 +156,7 @@ fn import_target_stems(raw_import: &str) -> Vec<String> {
 }
 
 pub(crate) fn is_relative_import(import: &str) -> bool {
-    import.starts_with("./") || import.starts_with("../")
+    import.starts_with('.')
 }
 
 /// Whether an unresolved import should weaken absence claims (dead module,
@@ -138,100 +207,4 @@ where
         }
     }
     dirs
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn records_and_counts_unresolved_imports_per_source() {
-        let mut stats = ImportResolutionStats::default();
-        assert!(stats.is_empty());
-
-        stats.record(Path::new("src/a.ts"), "./missing");
-        stats.record(Path::new("src/a.ts"), "../gone/helper");
-        stats.record(Path::new("src/b.ts"), "./missing");
-
-        assert!(!stats.is_empty());
-        assert_eq!(stats.total(), 3);
-        assert_eq!(stats.unresolved_internal_by_source.len(), 2);
-    }
-
-    #[test]
-    fn could_target_stem_matches_final_segment_without_extension() {
-        let mut stats = ImportResolutionStats::default();
-        stats.record(Path::new("src/a.ts"), "../legacy/Utils.js");
-
-        assert!(stats.could_target_stem("utils"));
-        assert!(stats.could_target_stem("Utils"));
-        assert!(!stats.could_target_stem("legacy"));
-        assert!(!stats.could_target_stem(""));
-    }
-
-    #[test]
-    fn could_target_stem_matches_last_dotted_module_segment() {
-        let mut stats = ImportResolutionStats::default();
-        stats.record(Path::new("apps/web/main.py"), "app.services.foo");
-
-        assert!(stats.could_target_stem("foo"));
-        assert!(stats.could_target_stem("app"));
-        assert!(!stats.could_target_stem("services"));
-    }
-
-    #[test]
-    fn relative_import_detection_matches_dot_prefixes_only() {
-        assert!(is_relative_import("./a"));
-        assert!(is_relative_import("../a"));
-        assert!(!is_relative_import("react"));
-        assert!(!is_relative_import("@scope/pkg"));
-    }
-
-    #[test]
-    fn internal_import_classifier_separates_workspace_from_third_party() {
-        let repo_dirs: HashSet<String> = ["app", "components", "ml"]
-            .into_iter()
-            .map(String::from)
-            .collect();
-
-        // Relative and aliased imports are always internal.
-        assert!(is_unresolved_internal_import("./helper", &repo_dirs));
-        assert!(is_unresolved_internal_import(
-            "@/components/Button",
-            &repo_dirs
-        ));
-        assert!(is_unresolved_internal_import("~/lib/util", &repo_dirs));
-        // Bare imports whose leading segment is a repo directory are internal.
-        assert!(is_unresolved_internal_import("app.ml.train", &repo_dirs));
-        assert!(is_unresolved_internal_import(
-            "components/Button",
-            &repo_dirs
-        ));
-        // Genuine third-party packages stay out.
-        assert!(!is_unresolved_internal_import("react", &repo_dirs));
-        assert!(!is_unresolved_internal_import("@angular/core", &repo_dirs));
-        assert!(!is_unresolved_internal_import("numpy", &repo_dirs));
-        assert!(!is_unresolved_internal_import(
-            "django.db.models",
-            &repo_dirs
-        ));
-    }
-
-    #[test]
-    fn repo_directory_names_collects_parent_segments_only() {
-        let paths = [
-            Path::new("apps/ml/app/train.py"),
-            Path::new("apps/web/src/index.ts"),
-        ];
-        let dirs = repo_directory_names(paths);
-
-        assert!(dirs.contains("apps"));
-        assert!(dirs.contains("ml"));
-        assert!(dirs.contains("app"));
-        assert!(dirs.contains("web"));
-        assert!(dirs.contains("src"));
-        // File names are not directories.
-        assert!(!dirs.contains("train"));
-        assert!(!dirs.contains("index"));
-    }
 }

--- a/src/graph/resolution_stats/tests.rs
+++ b/src/graph/resolution_stats/tests.rs
@@ -1,0 +1,107 @@
+use super::*;
+
+#[test]
+fn records_and_counts_unresolved_imports_per_source() {
+    let mut stats = ImportResolutionStats::default();
+    assert!(stats.is_empty());
+
+    stats.record(Path::new("src/a.ts"), "./missing");
+    stats.record(Path::new("src/a.ts"), "../gone/helper");
+    stats.record(Path::new("src/b.ts"), "./missing");
+
+    assert!(!stats.is_empty());
+    assert_eq!(stats.total(), 3);
+    assert_eq!(stats.unresolved_internal_by_source.len(), 2);
+}
+
+#[test]
+fn typed_evidence_preserves_definitive_candidates_and_limited_imports() {
+    let root = Path::new("/repo");
+    let mut stats = ImportResolutionStats::default();
+    stats.record_classified(Path::new("/repo/src/app.ts"), "./missing.ts", root);
+    stats.record_classified(Path::new("/repo/src/app.ts"), "./generated-client", root);
+
+    let evidence = stats.evidence().collect::<Vec<_>>();
+    assert_eq!(evidence.len(), 2);
+    assert_eq!(evidence[0].raw_import, "./generated-client");
+    assert_eq!(evidence[0].kind, UnresolvedImportKind::RelativePath);
+    assert_eq!(
+        evidence[0].proof,
+        UnresolvedImportProof::Limited(UnresolvedImportLimitation::AmbiguousTarget)
+    );
+    assert_eq!(evidence[1].raw_import, "./missing.ts");
+    assert!(matches!(
+        &evidence[1].proof,
+        UnresolvedImportProof::DefinitiveLocalCandidates(candidates)
+            if candidates == &vec![
+                PathBuf::from("/repo/src/missing.ts"),
+                PathBuf::from("/repo/src/missing.tsx"),
+                PathBuf::from("/repo/src/missing.js"),
+                PathBuf::from("/repo/src/missing.jsx"),
+            ]
+    ));
+}
+
+#[test]
+fn could_target_stem_matches_path_and_dotted_module_segments() {
+    let mut stats = ImportResolutionStats::default();
+    stats.record(Path::new("src/a.ts"), "../legacy/Utils.js");
+    stats.record(Path::new("apps/web/main.py"), "app.services.foo");
+
+    assert!(stats.could_target_stem("utils"));
+    assert!(stats.could_target_stem("foo"));
+    assert!(stats.could_target_stem("app"));
+    assert!(!stats.could_target_stem("services"));
+    assert!(!stats.could_target_stem(""));
+}
+
+#[test]
+fn relative_import_detection_matches_dot_prefixes_only() {
+    assert!(is_relative_import("./a"));
+    assert!(is_relative_import("../a"));
+    assert!(is_relative_import(".python_module"));
+    assert!(!is_relative_import("react"));
+    assert!(!is_relative_import("@scope/pkg"));
+}
+
+#[test]
+fn internal_import_classifier_separates_workspace_from_third_party() {
+    let repo_dirs: HashSet<String> = ["app", "components", "ml"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+    assert!(is_unresolved_internal_import("./helper", &repo_dirs));
+    assert!(is_unresolved_internal_import(
+        "@/components/Button",
+        &repo_dirs
+    ));
+    assert!(is_unresolved_internal_import("~/lib/util", &repo_dirs));
+    assert!(is_unresolved_internal_import("app.ml.train", &repo_dirs));
+    assert!(is_unresolved_internal_import(
+        "components/Button",
+        &repo_dirs
+    ));
+    assert!(!is_unresolved_internal_import("react", &repo_dirs));
+    assert!(!is_unresolved_internal_import("@angular/core", &repo_dirs));
+    assert!(!is_unresolved_internal_import("numpy", &repo_dirs));
+    assert!(!is_unresolved_internal_import(
+        "django.db.models",
+        &repo_dirs
+    ));
+}
+
+#[test]
+fn repo_directory_names_collects_parent_segments_only() {
+    let paths = [
+        Path::new("apps/ml/app/train.py"),
+        Path::new("apps/web/src/index.ts"),
+    ];
+    let dirs = repo_directory_names(paths);
+
+    for expected in ["apps", "ml", "app", "web", "src"] {
+        assert!(dirs.contains(expected));
+    }
+    assert!(!dirs.contains("train"));
+    assert!(!dirs.contains("index"));
+}

--- a/src/graph/resolver/mod.rs
+++ b/src/graph/resolver/mod.rs
@@ -37,6 +37,37 @@ pub fn resolve_import(
     }
 }
 
+/// Enumerates every local file candidate only for language forms whose lookup
+/// semantics are bounded enough for a missing-target claim.
+pub(crate) fn definitive_local_candidates(
+    raw_import: &str,
+    from_file: &Path,
+    root: &Path,
+) -> Option<Vec<PathBuf>> {
+    let root = normalize_path(root);
+    let normalized_source = normalize_path(from_file);
+    let source = if from_file.is_absolute() || normalized_source.starts_with(&root) {
+        normalized_source
+    } else {
+        normalize_path(&root.join(normalized_source))
+    };
+    let ext = source.extension().and_then(|value| value.to_str())?;
+    let candidates = match ext {
+        "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs" => {
+            ts::definitive_relative_candidates(raw_import, &source)?
+        }
+        "py" => python::definitive_relative_candidates(raw_import, &source)?,
+        _ => return None,
+    };
+    let candidates = candidates
+        .into_iter()
+        .map(|candidate| normalize_path(&candidate))
+        .collect::<Vec<_>>();
+
+    (!candidates.is_empty() && candidates.iter().all(|path| path.starts_with(&root)))
+        .then_some(candidates)
+}
+
 /// Returns the first candidate that exists in `known_files`, after normalizing
 /// `.`/`..` components. Shared by every language resolver.
 fn probe(candidates: &[PathBuf], known_files: &HashSet<PathBuf>) -> Option<PathBuf> {
@@ -62,4 +93,95 @@ pub(crate) fn normalize_path(path: &Path) -> PathBuf {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod definitive_candidates_tests {
+    use super::*;
+
+    #[test]
+    fn explicit_typescript_relative_import_has_bounded_local_candidates() {
+        let candidates = definitive_local_candidates(
+            "./missing.ts",
+            Path::new("/repo/src/app.ts"),
+            Path::new("/repo"),
+        )
+        .expect("explicit supported TypeScript import should be definitive");
+
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("/repo/src/missing.ts"),
+                PathBuf::from("/repo/src/missing.tsx"),
+                PathBuf::from("/repo/src/missing.js"),
+                PathBuf::from("/repo/src/missing.jsx"),
+            ]
+        );
+    }
+
+    #[test]
+    fn relative_source_already_rooted_under_relative_scan_path_is_not_prefixed_twice() {
+        let candidates = definitive_local_candidates(
+            "./missing.ts",
+            Path::new("project/src/app.ts"),
+            Path::new("project"),
+        )
+        .expect("relative rooted source should be definitive");
+
+        assert_eq!(candidates[0], PathBuf::from("project/src/missing.ts"));
+    }
+
+    #[test]
+    fn extensionless_typescript_import_is_not_claimed_as_definitive() {
+        assert_eq!(
+            definitive_local_candidates(
+                "./generated-client",
+                Path::new("/repo/src/app.ts"),
+                Path::new("/repo"),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn explicit_python_relative_module_has_module_and_package_candidates() {
+        let candidates = definitive_local_candidates(
+            ".missing",
+            Path::new("/repo/pkg/app.py"),
+            Path::new("/repo"),
+        )
+        .expect("explicit Python relative module should be definitive");
+
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("/repo/pkg/missing.py"),
+                PathBuf::from("/repo/pkg/missing/__init__.py"),
+            ]
+        );
+    }
+
+    #[test]
+    fn candidates_that_escape_the_repository_are_not_definitive() {
+        assert_eq!(
+            definitive_local_candidates(
+                "../../outside.ts",
+                Path::new("/repo/src/app.ts"),
+                Path::new("/repo"),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn rust_module_semantics_remain_limited_in_first_slice() {
+        assert_eq!(
+            definitive_local_candidates(
+                "mod::missing",
+                Path::new("/repo/src/lib.rs"),
+                Path::new("/repo"),
+            ),
+            None
+        );
+    }
 }

--- a/src/graph/resolver/python.rs
+++ b/src/graph/resolver/python.rs
@@ -19,11 +19,11 @@ pub(super) fn resolve_python(
             dir = dir.parent().unwrap_or(dir);
         }
 
-        return resolve_python_module_from_base(dir, module, known_files);
+        return probe(&python_module_candidates(dir, module), known_files);
     }
 
     for base in [root.to_path_buf(), root.join("src")] {
-        if let Some(path) = resolve_python_module_from_base(&base, raw, known_files) {
+        if let Some(path) = probe(&python_module_candidates(&base, raw), known_files) {
             return Some(path);
         }
     }
@@ -31,13 +31,9 @@ pub(super) fn resolve_python(
     None
 }
 
-fn resolve_python_module_from_base(
-    base_dir: &Path,
-    module: &str,
-    known_files: &HashSet<PathBuf>,
-) -> Option<PathBuf> {
+fn python_module_candidates(base_dir: &Path, module: &str) -> Vec<PathBuf> {
     if module.is_empty() {
-        return probe(&[base_dir.join("__init__.py")], known_files);
+        return vec![base_dir.join("__init__.py")];
     }
 
     let segments = module
@@ -45,17 +41,26 @@ fn resolve_python_module_from_base(
         .filter(|segment| !segment.is_empty())
         .collect::<Vec<_>>();
 
+    let mut candidates = Vec::new();
     for end in (1..=segments.len()).rev() {
         let base = segments[..end]
             .iter()
             .fold(base_dir.to_path_buf(), |path, segment| path.join(segment));
-        if let Some(path) = probe(
-            &[base.with_extension("py"), base.join("__init__.py")],
-            known_files,
-        ) {
-            return Some(path);
-        }
+        candidates.push(base.with_extension("py"));
+        candidates.push(base.join("__init__.py"));
     }
+    candidates
+}
 
-    None
+pub(super) fn definitive_relative_candidates(raw: &str, from_file: &Path) -> Option<Vec<PathBuf>> {
+    let dots = raw.chars().take_while(|value| *value == '.').count();
+    let module = raw.get(dots..)?;
+    if dots == 0 || module.is_empty() {
+        return None;
+    }
+    let mut dir = from_file.parent()?;
+    for _ in 0..dots.saturating_sub(1) {
+        dir = dir.parent()?;
+    }
+    Some(python_module_candidates(dir, module))
 }

--- a/src/graph/resolver/ts.rs
+++ b/src/graph/resolver/ts.rs
@@ -15,12 +15,12 @@ pub(super) fn resolve_ts(
     if raw.starts_with('.') {
         let dir = from_file.parent()?;
         let base = normalize_path(&dir.join(raw));
-        return probe_ts_extensions(&base, known_files);
+        return probe_ts_extensions(&base, raw, known_files);
     }
 
     if raw.starts_with('/') {
         let base = normalize_path(&root.join(raw.trim_start_matches('/')));
-        if let Some(path) = probe_ts_extensions(&base, known_files) {
+        if let Some(path) = probe_ts_extensions(&base, raw, known_files) {
             return Some(path);
         }
     }
@@ -29,16 +29,36 @@ pub(super) fn resolve_ts(
     resolve_ts_alias(raw, &aliases, known_files)
 }
 
-fn probe_ts_extensions(base: &Path, known_files: &HashSet<PathBuf>) -> Option<PathBuf> {
+fn probe_ts_extensions(base: &Path, raw: &str, known_files: &HashSet<PathBuf>) -> Option<PathBuf> {
+    probe(&ts_candidates(base, raw), known_files)
+}
+
+fn ts_candidates(base: &Path, raw: &str) -> Vec<PathBuf> {
     const EXTS: &[&str] = &["ts", "tsx", "js", "jsx"];
     let mut candidates: Vec<PathBuf> = Vec::new();
     for ext in EXTS {
         candidates.push(base.with_extension(ext));
     }
-    for ext in EXTS {
-        candidates.push(base.join(format!("index.{ext}")));
+    if Path::new(raw).extension().is_none() {
+        for ext in EXTS {
+            candidates.push(base.join(format!("index.{ext}")));
+        }
     }
-    probe(&candidates, known_files)
+    candidates
+}
+
+pub(super) fn definitive_relative_candidates(raw: &str, from_file: &Path) -> Option<Vec<PathBuf>> {
+    const SUPPORTED_EXTS: &[&str] = &["ts", "tsx", "js", "jsx"];
+    if !raw.starts_with('.')
+        || !Path::new(raw)
+            .extension()
+            .and_then(|value| value.to_str())
+            .is_some_and(|extension| SUPPORTED_EXTS.contains(&extension))
+    {
+        return None;
+    }
+    let base = normalize_path(&from_file.parent()?.join(raw));
+    Some(ts_candidates(&base, raw))
 }
 
 #[derive(Clone)]
@@ -175,7 +195,7 @@ fn resolve_ts_alias(
     for alias in aliases {
         if alias.prefix.is_empty() {
             let base = normalize_path(&alias.roots[0].join(raw));
-            if let Some(path) = probe_ts_extensions(&base, known_files) {
+            if let Some(path) = probe_ts_extensions(&base, raw, known_files) {
                 return Some(path);
             }
             continue;
@@ -189,13 +209,13 @@ fn resolve_ts_alias(
 
             for root in &alias.roots {
                 let base = normalize_path(&root.join(tail));
-                if let Some(path) = probe_ts_extensions(&base, known_files) {
+                if let Some(path) = probe_ts_extensions(&base, tail, known_files) {
                     return Some(path);
                 }
             }
         } else if raw == alias.prefix {
             for root in &alias.roots {
-                if let Some(path) = probe_ts_extensions(root, known_files) {
+                if let Some(path) = probe_ts_extensions(root, raw, known_files) {
                     return Some(path);
                 }
             }

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -792,6 +792,14 @@ suppress_generated = true
 risk = { id = "knowledge.circular-dependency", label = "cycle risk", weight = 6, reason = "dependency cycles make local changes harder to isolate and review" }
 
 [[rules]]
+rule_id = "architecture.unresolved-local-import"
+minimum_support = "rule-aware"
+languages = ["python", "typescript", "typescript-react", "javascript", "javascript-react"]
+suppress_low_signal = true
+suppress_generated = true
+risk = { id = "knowledge.unresolved-local-import", label = "broken local import", weight = 8, reason = "a proven missing local module prevents the importing source from loading or compiling" }
+
+[[rules]]
 rule_id = "architecture.excessive-fan-out"
 minimum_support = "rule-aware"
 languages = ["rust", "go", "python", "typescript", "typescript-react", "javascript", "javascript-react", "java", "kotlin"]

--- a/src/rules/registry/architecture.rs
+++ b/src/rules/registry/architecture.rs
@@ -113,6 +113,28 @@ pub(super) static RULES: &[RuleMetadata] = &[
         ..RuleMetadata::DEFAULT
     },
     RuleMetadata {
+        rule_id: "architecture.unresolved-local-import",
+        title: "Local import target is missing",
+        category: FindingCategory::Architecture,
+        default_severity: Severity::High,
+        default_confidence: Confidence::High,
+        lifecycle: RuleLifecycle::Preview,
+        signal_source: SignalSource::ImportGraph,
+
+        requirements: RuleRequirements::repository_graph(RuleLifecycle::Preview),
+        docs_url: Some(
+            "https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture",
+        ),
+        description: "A supported explicit local import does not resolve to any bounded source-file candidate inside the repository.",
+        recommendation: Some(
+            "Restore the imported module, update the import path, or run the project compiler to confirm the intended generated target.",
+        ),
+        false_positive_notes: Some(
+            "Only explicit supported TypeScript/JavaScript file extensions and explicit Python relative modules are reported. Extensionless imports, aliases, workspace packages, Rust module forms, generated targets, and unsupported semantics remain limitations rather than findings.",
+        ),
+        ..RuleMetadata::DEFAULT
+    },
+    RuleMetadata {
         rule_id: "architecture.excessive-fan-out",
         title: "File imports too many project-internal modules",
         category: FindingCategory::Architecture,

--- a/src/scan/facts.rs
+++ b/src/scan/facts.rs
@@ -22,6 +22,10 @@ pub struct ScanFacts {
     pub languages: Vec<LanguageSummary>,
     pub files: Vec<FileFacts>,
     pub artifacts: BTreeMap<PathBuf, ParsedArtifact>,
+    /// 1-indexed source spans keyed first by file path, then import specifier.
+    /// Kept outside `FileFacts` so evidence-only parser metadata does not expand
+    /// the stable per-file facts contract.
+    pub import_spans_by_file: BTreeMap<PathBuf, BTreeMap<String, (usize, usize)>>,
     pub detected_frameworks: Vec<DetectedFramework>,
     pub framework_projects: Vec<FrameworkProject>,
     pub react_native: Option<ReactNativeArchitectureProfile>,

--- a/src/scan/parsed_cache.rs
+++ b/src/scan/parsed_cache.rs
@@ -8,8 +8,8 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-const PARSED_FACTS_SCHEMA_VERSION: u32 = 2;
-const PARSED_FACTS_ANALYSIS_VERSION: &str = "tree-sitter-imports-exports-v1";
+const PARSED_FACTS_SCHEMA_VERSION: u32 = 3;
+const PARSED_FACTS_ANALYSIS_VERSION: &str = "tree-sitter-imports-exports-spans-v2";
 const PARSED_FACTS_NAME: &str = "parsed_facts_v2.json";
 const PARSED_FACTS_BACKUP_NAME: &str = "parsed_facts_v2.backup.json";
 const PARSED_FACTS_TEMP_NAME: &str = "parsed_facts_v2.tmp.json";
@@ -30,6 +30,8 @@ pub struct ParsedFactsEntry {
     pub branch_count: usize,
     pub has_inline_tests: bool,
     pub imports: Vec<String>,
+    #[serde(default)]
+    pub import_spans: BTreeMap<String, (usize, usize)>,
     pub deferred_imports: Vec<String>,
     pub exports: Vec<String>,
     pub syntax: CachedSyntaxSummary,
@@ -205,6 +207,7 @@ impl ParsedFactsEntry {
         content_hash: String,
         file: &FileFacts,
         artifact: &ParsedArtifact,
+        import_spans: BTreeMap<String, (usize, usize)>,
     ) -> Self {
         Self {
             content_hash,
@@ -213,6 +216,7 @@ impl ParsedFactsEntry {
             branch_count: file.branch_count,
             has_inline_tests: file.has_inline_tests,
             imports: file.imports.clone(),
+            import_spans,
             deferred_imports: file.deferred_imports.clone(),
             exports: artifact.exports.clone(),
             syntax: CachedSyntaxSummary::from(&artifact.syntax),
@@ -302,6 +306,7 @@ mod tests {
             "hash".to_string(),
             &file,
             &artifact,
+            BTreeMap::new(),
         ));
         cache.write(temp.path()).expect("write parsed facts cache");
 
@@ -377,6 +382,7 @@ mod tests {
                 branch_count: 0,
                 has_inline_tests: false,
                 imports: Vec::new(),
+                import_spans: Default::default(),
                 deferred_imports: Vec::new(),
                 exports: Vec::new(),
                 syntax: CachedSyntaxSummary::default(),
@@ -418,6 +424,7 @@ mod tests {
             branch_count: 0,
             has_inline_tests: false,
             imports: Vec::new(),
+            import_spans: Default::default(),
             deferred_imports: Vec::new(),
             exports: Vec::new(),
             syntax: CachedSyntaxSummary::default(),

--- a/src/scan/scanner/changed.rs
+++ b/src/scan/scanner/changed.rs
@@ -125,12 +125,21 @@ impl<'a> ChangedScanEngine<'a> {
         );
         let query_findings =
             stamp_findings_analysis_scope(graph_analysis.query_findings, AnalysisScope::Repository);
+        let broken_import_findings = stamp_findings_analysis_scope(
+            graph_analysis.broken_import_findings,
+            AnalysisScope::Repository,
+        );
+        let graph_diagnostics = graph_analysis.diagnostics;
 
         file_stage.findings.extend(project_findings);
         file_stage.findings.extend(framework_findings);
         file_stage.findings.extend(apply_project_decisions(
             &repo_stage.repo_context,
             coupling_findings,
+        ));
+        file_stage.findings.extend(apply_project_decisions(
+            &repo_stage.repo_context,
+            broken_import_findings,
         ));
         file_stage.findings.extend(query_findings);
         let post_scan_audits_us = project_start.elapsed().as_micros() as u64;
@@ -144,7 +153,8 @@ impl<'a> ChangedScanEngine<'a> {
             &file_stage.findings,
             contract_stage.report.violations.len(),
         );
-        let mut diagnostics = contract_stage.diagnostics;
+        let mut diagnostics = graph_diagnostics;
+        diagnostics.extend(contract_stage.diagnostics);
         diagnostics.extend(rule_config_diagnostics(self.config));
         let finding_pipeline = ChangedFindingPipelineStage {
             post_scan_audits_us,

--- a/src/scan/scanner/changed/file_analysis.rs
+++ b/src/scan/scanner/changed/file_analysis.rs
@@ -242,6 +242,7 @@ impl<'a> ChangedScanEngine<'a> {
                             content_hash(content),
                             &per_file.file_facts,
                             artifact,
+                            per_file.import_spans.clone(),
                         ));
                     }
                 }
@@ -259,6 +260,12 @@ impl<'a> ChangedScanEngine<'a> {
                 let mut graph_file = per_file.file_facts.clone();
                 graph_file.content = None;
                 graph_patch_files.push(graph_file);
+
+                if !per_file.import_spans.is_empty() {
+                    facts
+                        .import_spans_by_file
+                        .insert(per_file.file_facts.path.clone(), per_file.import_spans);
+                }
 
                 if let Some(artifact) = per_file.artifact {
                     facts.insert_artifact(artifact);
@@ -330,8 +337,12 @@ impl<'a> ChangedScanEngine<'a> {
             paradigms: role_entry.paradigms.clone(),
             is_test: role_entry.is_test,
         };
-        let artifact = parsed_cache
-            .lookup(&role_entry.hash, role_entry.language.as_deref())
+        let cached_parsed = parsed_cache.lookup(&role_entry.hash, role_entry.language.as_deref());
+        let import_spans = cached_parsed
+            .as_ref()
+            .map(|entry| entry.import_spans.clone())
+            .unwrap_or_default();
+        let artifact = cached_parsed
             .map(|entry| {
                 ParsedArtifact::from_parsed_cache_v2(
                     PathBuf::from(&role_entry.path),
@@ -353,6 +364,11 @@ impl<'a> ChangedScanEngine<'a> {
                 )
             });
         let mut graph_file = record_cached_file(facts, languages, &role_entry);
+        if !import_spans.is_empty() {
+            facts
+                .import_spans_by_file
+                .insert(graph_file.path.clone(), import_spans);
+        }
         facts.insert_artifact(artifact);
         graph_file.content = None;
         graph_patch_files.push(graph_file);

--- a/src/scan/scanner/changed/repo_context.rs
+++ b/src/scan/scanner/changed/repo_context.rs
@@ -34,8 +34,12 @@ impl<'a> ChangedScanEngine<'a> {
         let fingerprint = config_fingerprint(self.config);
 
         if let Some(mut load) = load_repository_context_state(repo_root, &fingerprint) {
-            load.state
-                .apply_changed_facts(repo_root, &discovery.changed_files, graph_patch_files);
+            load.state.apply_changed_facts_with_spans(
+                repo_root,
+                &discovery.changed_files,
+                graph_patch_files,
+                &facts.import_spans_by_file,
+            );
             if let Err(error) = write_repository_context_state(repo_root, &fingerprint, &load.state)
             {
                 diagnostics.push(cache_diagnostic(&error));

--- a/src/scan/scanner/collection.rs
+++ b/src/scan/scanner/collection.rs
@@ -99,6 +99,11 @@ pub(super) fn analyze_discovered_files(
         if let Some(artifact) = per_file.artifact {
             facts.insert_artifact(artifact);
         }
+        if !per_file.import_spans.is_empty() {
+            facts
+                .import_spans_by_file
+                .insert(per_file.file_facts.path.clone(), per_file.import_spans);
+        }
         facts.files.push(per_file.file_facts);
         findings.extend(per_file.findings);
     }

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -5,14 +5,16 @@ use crate::audits::code_quality::complexity::count_branches;
 use crate::audits::context::classify_file_with_evidence;
 use crate::audits::pipeline::FileAuditRegistration;
 use crate::findings::types::Finding;
-use crate::graph::imports::{extract_deferred_imports_from, extract_imports_from};
+use crate::graph::imports::{
+    extract_deferred_imports_from, extract_import_spans_from, extract_imports_from,
+};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::{FileFacts, ScanFacts};
 use crate::scan::language::detect_language;
 use crate::scan::parsed_cache::{ParsedFactsCache, ParsedFactsEntry, content_hash};
 use crate::scan::path_classification::is_low_signal_audit_path;
 use crate::scan::workspace::{PackageRoot, path_in_executable_package};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -24,6 +26,7 @@ pub(super) struct PerFileResult {
     pub(super) findings: Vec<Finding>,
     pub(super) language: Option<String>,
     pub(super) artifact: Option<ParsedArtifact>,
+    pub(super) import_spans: BTreeMap<String, (usize, usize)>,
     pub(super) skip_reason: SkipReason,
     pub(super) skipped_bytes: u64,
 }
@@ -219,6 +222,7 @@ fn process_file_inner(
     let analysis = analyze_file(&full_facts, file_audits, config);
     let findings = analysis.findings;
     let imports = analysis.imports;
+    let import_spans = analysis.import_spans;
     let deferred_imports = analysis.deferred_imports;
     let exports = analysis.exports;
     let syntax = analysis.syntax;
@@ -243,6 +247,7 @@ fn process_file_inner(
         findings,
         language,
         artifact: Some(artifact),
+        import_spans,
         skip_reason: SkipReason::None,
         skipped_bytes: 0,
     })
@@ -299,12 +304,13 @@ fn collect_file_facts_inner(
     });
 
     let mut from_parsed_cache = false;
-    let (imports, deferred_imports, exports, syntax) = if let Some(entry) = cached {
+    let (imports, import_spans, deferred_imports, exports, syntax) = if let Some(entry) = cached {
         from_parsed_cache = true;
         full_facts.branch_count = entry.branch_count;
         full_facts.has_inline_tests = entry.has_inline_tests;
         (
             entry.imports,
+            entry.import_spans,
             entry.deferred_imports,
             entry.exports,
             (&entry.syntax).into(),
@@ -316,6 +322,7 @@ fn collect_file_facts_inner(
         let lang = full_facts.language.as_deref();
         (
             extract_imports_from(&parsed, lang),
+            extract_import_spans_from(&parsed, lang),
             extract_deferred_imports_from(&parsed, lang),
             extract_exports(parsed.content(), lang),
             parsed.syntax_summary(),
@@ -349,10 +356,14 @@ fn collect_file_facts_inner(
             hash,
             &full_facts,
             &artifact,
+            import_spans.clone(),
         ));
     }
 
     record_analyzed_file(facts, languages, &full_facts);
+    facts
+        .import_spans_by_file
+        .insert(full_facts.path.clone(), import_spans);
     facts.insert_artifact(artifact);
     facts.files.push(full_facts);
 
@@ -427,6 +438,7 @@ fn skipped_result(
         findings: Vec::new(),
         language,
         artifact: None,
+        import_spans: BTreeMap::new(),
         skip_reason,
         skipped_bytes,
     }

--- a/src/scan/scanner/file_pipeline.rs
+++ b/src/scan/scanner/file_pipeline.rs
@@ -3,7 +3,9 @@ use crate::analysis::exports::extract_exports;
 use crate::analysis::parse::ParsedFile;
 use crate::audits::pipeline::FileAuditRegistration;
 use crate::findings::types::Finding;
-use crate::graph::imports::{extract_deferred_imports_from, extract_imports_from};
+use crate::graph::imports::{
+    extract_deferred_imports_from, extract_import_spans_from, extract_imports_from,
+};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
 use rayon::prelude::*;
@@ -11,9 +13,18 @@ use rayon::prelude::*;
 pub(super) struct FileAnalysisResult {
     pub(super) findings: Vec<Finding>,
     pub(super) imports: Vec<String>,
+    pub(super) import_spans: std::collections::BTreeMap<String, (usize, usize)>,
     pub(super) deferred_imports: Vec<String>,
     pub(super) exports: Vec<String>,
     pub(super) syntax: SyntaxSummary,
+}
+
+struct ParsedFileFacts {
+    imports: Vec<String>,
+    import_spans: std::collections::BTreeMap<String, (usize, usize)>,
+    deferred_imports: Vec<String>,
+    exports: Vec<String>,
+    syntax: SyntaxSummary,
 }
 
 pub(super) fn analyze_file(
@@ -27,27 +38,27 @@ pub(super) fn analyze_file(
         .partition(|registration| registration.requires_parsed_syntax());
 
     let mut findings = run_file_audits(file, config, &text_only);
-    let (parsed_findings, (imports, deferred_imports, exports, syntax)) =
-        if parsed_required.is_empty() {
-            (
-                Vec::new(),
-                extract_parsed_artifacts(&parsed, file.language.as_deref()),
-            )
-        } else {
-            rayon::join(
-                || run_parsed_file_audits(file, &parsed, config, &parsed_required),
-                || extract_parsed_artifacts(&parsed, file.language.as_deref()),
-            )
-        };
+    let (parsed_findings, parsed_facts) = if parsed_required.is_empty() {
+        (
+            Vec::new(),
+            extract_parsed_artifacts(&parsed, file.language.as_deref()),
+        )
+    } else {
+        rayon::join(
+            || run_parsed_file_audits(file, &parsed, config, &parsed_required),
+            || extract_parsed_artifacts(&parsed, file.language.as_deref()),
+        )
+    };
 
     findings.extend(parsed_findings);
 
     FileAnalysisResult {
         findings,
-        imports,
-        deferred_imports,
-        exports,
-        syntax,
+        imports: parsed_facts.imports,
+        import_spans: parsed_facts.import_spans,
+        deferred_imports: parsed_facts.deferred_imports,
+        exports: parsed_facts.exports,
+        syntax: parsed_facts.syntax,
     }
 }
 
@@ -80,13 +91,17 @@ fn run_parsed_file_audits(
         .collect()
 }
 
-fn extract_parsed_artifacts(
-    parsed: &ParsedFile,
-    language: Option<&str>,
-) -> (Vec<String>, Vec<String>, Vec<String>, SyntaxSummary) {
+fn extract_parsed_artifacts(parsed: &ParsedFile, language: Option<&str>) -> ParsedFileFacts {
     let imports = extract_imports_from(parsed, language);
+    let import_spans = extract_import_spans_from(parsed, language);
     let deferred_imports = extract_deferred_imports_from(parsed, language);
     let exports = extract_exports(parsed.content(), language);
     let syntax = parsed.syntax_summary();
-    (imports, deferred_imports, exports, syntax)
+    ParsedFileFacts {
+        imports,
+        import_spans,
+        deferred_imports,
+        exports,
+        syntax,
+    }
 }

--- a/src/scan/scanner/full.rs
+++ b/src/scan/scanner/full.rs
@@ -20,7 +20,7 @@ use crate::risk::{apply_cluster_overlay, apply_graph_overlay, assess_findings};
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::ScanFacts;
 use crate::scan::session::AnalysisSession;
-use crate::scan::types::{ScanSummary, ScanTimings};
+use crate::scan::types::{ScanDiagnostic, ScanSummary, ScanTimings};
 use std::io;
 use std::path::Path;
 use std::time::Instant;
@@ -77,6 +77,7 @@ pub(super) struct ProjectAnalysisStage {
     pub(super) findings: Vec<Finding>,
     pub(super) coupling_graph: CouplingGraph,
     pub(super) elapsed_us: u64,
+    pub(super) diagnostics: Vec<ScanDiagnostic>,
 }
 
 impl<'a> ScanEngine<'a> {
@@ -142,7 +143,8 @@ impl<'a> ScanEngine<'a> {
         };
 
         let sidecar = build_sidecar(&project_stage.facts);
-        let mut diagnostics = contract_stage.diagnostics;
+        let mut diagnostics = std::mem::take(&mut project_stage.diagnostics);
+        diagnostics.extend(contract_stage.diagnostics);
         diagnostics.extend(rule_config_diagnostics(self.config));
         let summary = self.finalize_report(
             project_stage,
@@ -225,6 +227,10 @@ impl<'a> ScanEngine<'a> {
         );
         let query_findings =
             stamp_findings_analysis_scope(graph_analysis.query_findings, AnalysisScope::Repository);
+        let broken_import_findings = stamp_findings_analysis_scope(
+            graph_analysis.broken_import_findings,
+            AnalysisScope::Repository,
+        );
 
         let coupling_findings = stamp_findings_analysis_scope(
             graph_analysis.coupling_findings,
@@ -234,6 +240,7 @@ impl<'a> ScanEngine<'a> {
         findings.extend(project_findings);
         findings.extend(framework_findings);
         findings.extend(apply_project_decisions(&facts, coupling_findings));
+        findings.extend(apply_project_decisions(&facts, broken_import_findings));
         findings.extend(query_findings);
 
         ProjectAnalysisStage {
@@ -241,6 +248,7 @@ impl<'a> ScanEngine<'a> {
             findings,
             coupling_graph: graph_analysis.graph,
             elapsed_us: start.elapsed().as_micros() as u64,
+            diagnostics: graph_analysis.diagnostics,
         }
     }
 

--- a/tests/fixtures/rules/architecture.unresolved-local-import/expected.json
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/expected.json
@@ -1,0 +1,24 @@
+{
+  "fixtures": [
+    {
+      "path": "true_positive_ts",
+      "expected_rule_ids": [
+        "architecture.unresolved-local-import"
+      ]
+    },
+    {
+      "path": "true_positive_python",
+      "expected_rule_ids": [
+        "architecture.unresolved-local-import"
+      ]
+    },
+    {
+      "path": "false_positive_existing",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "false_positive_ambiguous",
+      "expected_rule_ids": []
+    }
+  ]
+}

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_ambiguous/src/app.ts
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_ambiguous/src/app.ts
@@ -1,0 +1,5 @@
+// Extensionless imports can be generated or resolved by unsupported tooling,
+// so the first conservative slice records a limitation instead of a finding.
+import { client } from "./generated-client";
+
+client();

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_existing/src/app.ts
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_existing/src/app.ts
@@ -1,0 +1,3 @@
+import { value } from "./present.ts";
+
+console.log(value);

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_existing/src/present.ts
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_existing/src/present.ts
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/tests/fixtures/rules/architecture.unresolved-local-import/true_positive_python/pkg/app.py
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/true_positive_python/pkg/app.py
@@ -1,0 +1,3 @@
+from .missing import run
+
+run()

--- a/tests/fixtures/rules/architecture.unresolved-local-import/true_positive_ts/src/app.ts
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/true_positive_ts/src/app.ts
@@ -1,0 +1,3 @@
+import { run } from "./missing.ts";
+
+run();

--- a/tests/rule_eval_fixture_coverage.rs
+++ b/tests/rule_eval_fixture_coverage.rs
@@ -27,6 +27,7 @@ const SECURITY_RULES_WITH_FIXTURES: &[&str] = &[
 
 const IMPORT_GRAPH_RULES_WITH_FIXTURES: &[&str] = &[
     "architecture.circular-dependency",
+    "architecture.unresolved-local-import",
     "architecture.excessive-fan-out",
     "architecture.high-instability-hub",
     "architecture.dead-module",

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -73,7 +73,7 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
     );
     assert_eq!(
         read_json(&cache_dir.join("parsed_facts_v2.json"))["analysis_version"],
-        "tree-sitter-imports-exports-v1"
+        "tree-sitter-imports-exports-spans-v2"
     );
     assert_eq!(
         read_json(&cache_dir.join("parsed_facts_v2.json"))["entries"][0]["content_hash"]

--- a/tests/unresolved_local_import.rs
+++ b/tests/unresolved_local_import.rs
@@ -1,0 +1,90 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+const RULE_ID: &str = "architecture.unresolved-local-import";
+
+#[test]
+fn full_and_warm_changed_scans_preserve_broken_import_evidence() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(
+        &temp.path().join("src/app.ts"),
+        "// application entry\nimport { run } from \"./present.ts\";\nrun();\n",
+    );
+    write(
+        &temp.path().join("src/present.ts"),
+        "export function run() {}\n",
+    );
+    commit_all(temp.path(), "initial");
+    write(
+        &temp.path().join("src/app.ts"),
+        "// application entry\nimport { run } from \"./missing.ts\";\nrun();\n",
+    );
+
+    let full = scan_json(temp.path(), &[]);
+    let _cold_changed = scan_json(temp.path(), &["--changed"]);
+    let warm_changed = scan_json(temp.path(), &["--changed"]);
+    let full_finding = rule_finding(&full);
+    let changed_finding = rule_finding(&warm_changed);
+
+    assert_eq!(full_finding["rule_id"], RULE_ID);
+    assert_eq!(full_finding["severity"], "HIGH");
+    assert_eq!(full_finding["confidence"], "HIGH");
+    assert_eq!(full_finding["evidence"][0]["path"], "src/app.ts");
+    assert_eq!(full_finding["evidence"][0]["line_start"], 2);
+    assert_eq!(full_finding["evidence"][0], changed_finding["evidence"][0]);
+    assert_eq!(full_finding["id"], changed_finding["id"]);
+}
+
+fn scan_json(root: &Path, extra: &[&str]) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_repopilot"))
+        .arg("scan")
+        .arg(root)
+        .args(extra)
+        .args(["--format", "json"])
+        .output()
+        .expect("run RepoPilot scan");
+    assert!(
+        output.status.success(),
+        "scan failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("valid JSON scan report")
+}
+
+fn rule_finding(report: &Value) -> &Value {
+    report["findings"]
+        .as_array()
+        .expect("findings array")
+        .iter()
+        .find(|finding| finding["rule_id"] == RULE_ID)
+        .expect("broken local import finding")
+}
+
+fn init_repo(root: &Path) {
+    run_git(root, &["init", "-q"]);
+    run_git(root, &["config", "user.email", "test@example.com"]);
+    run_git(root, &["config", "user.name", "RepoPilot Test"]);
+}
+
+fn commit_all(root: &Path, message: &str) {
+    run_git(root, &["add", "."]);
+    run_git(root, &["commit", "-q", "-m", message]);
+}
+
+fn run_git(root: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git command failed: {args:?}");
+}
+
+fn write(path: &Path, content: &str) {
+    fs::create_dir_all(path.parent().expect("file parent")).unwrap();
+    fs::write(path, content).unwrap();
+}


### PR DESCRIPTION
## Summary

Add the first conservative v0.22 broken-code detector for provably missing local imports while preserving uncertainty for ambiguous resolution semantics.

## Type of change

- [x] Feature
- [x] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- Added the preview `architecture.unresolved-local-import` rule for explicit supported TypeScript/JavaScript and Python relative imports.
- Replaced raw unresolved-import strings with typed, deterministic evidence and bounded candidate proofs shared with the existing graph resolver.
- Preserved exact import-line evidence across full, cold changed, and warm changed scans through parsed-facts and repository-context caches.
- Added safe/unsafe rule fixtures, cold/warm parity coverage, registry/knowledge metadata, generated references, and the approved B1 specification.

## Why

RepoPilot already knew when an internal graph edge could not be resolved, but it could not distinguish a genuinely missing local module from aliases, generated targets, workspace packages, or unsupported language semantics. Reporting every unresolved import would create false positives.

This slice only emits a High-confidence finding when RepoPilot can enumerate every supported local candidate, all candidates remain inside the repository, and none exists on disk. Ambiguous cases remain non-finding informational diagnostics.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

The rule remains in the existing `architecture` category. No top-level command or report category was added. Existing candidates excluded by ignore or size policy are checked on disk before a finding is emitted.

## Changelog

- [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
npm run test:release-contract
cargo run -- scan . --fail-on-priority p1
```
