### PR TITLE
fix: bound removed-export claims by re-export evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,16 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   Review JSON, console/Markdown output,
   `--fail-on-review definitely`, `repopilot_review_change`, and the existing
   `repopilot_explain_review_signal` replay tool project the same canonical
-  record. Path aliases and package imports, default/namespace imports,
-  re-exports, CommonJS/dynamic forms, file renames, and resolver selections
-  other than the changed exporter are intentionally omitted; `scan --changed`
-  parity is deferred to B2.2.
+  record. A name the post-change module no longer supplies under any symbol
+  kind is matched against every named import form, so a removed type export is
+  still proven broken for a caller that imports it without the `type` keyword.
+  A name that survives under the other kind stays limited to the kind that
+  disappeared. When the post-change module forwards the name through
+  `export { name } from "..."`, or can forward any name through
+  `export * from "..."`, no removal is claimed. Path aliases and package
+  imports, default/namespace imports, re-export sources, CommonJS/dynamic
+  forms, file renames, and resolver selections other than the changed exporter
+  are intentionally omitted; `scan --changed` parity is deferred to B2.2.
   RepoPilot does not run TypeScript, compiler, or build commands—the signal
   supplies a manual verification plan instead.
 - Add the first v0.22 broken-code detector,

--- a/docs/engineering/v0.22-removed-export-review-spec.md
+++ b/docs/engineering/v0.22-removed-export-review-spec.md
@@ -68,6 +68,9 @@ compatibility change even though serialized JSON remains compatible.
   - `import { loadUser } from "./api.ts"`;
   - `import { loadUser as load } from "./api.ts"`.
 - Type-only named imports when the matching type export is removed.
+- Any named import form of a name the post-change module no longer supplies
+  under either symbol kind, because such a name breaks the import however the
+  caller spelled it.
 - Explicit relative module specifiers whose existing resolver selects the
   changed module as its current target.
 - Modified exporter files where both pre-change and post-change source can be
@@ -80,7 +83,10 @@ compatibility change even though serialized JSON remains compatible.
 - Path aliases, workspace package imports, or root-absolute imports.
 - Default imports and default exports.
 - Namespace or wildcard imports.
-- Re-exports and barrel-mediated symbol flow.
+- Re-exports and barrel-mediated symbol flow. A post-change
+  `export { name } from "..."` is treated as still supplying that name, and a
+  post-change `export * from "..."` withdraws every removal claim about the
+  module, because the forwarded source is not analyzed.
 - Exporter file renames. The current review diff model does not retain the old
   path needed to load authoritative pre-change source, so B2.1 does not guess.
 - CommonJS destructuring, dynamic imports, computed property access, or runtime
@@ -119,12 +125,20 @@ For each modified supported module:
 
 1. load its pre-change and post-change `ReviewSource` using the selected
    `DiffTarget`;
-2. extract named exports from both sides;
-3. compute `removed = before - after` by exported name and symbol kind;
-4. stop when either side cannot be read or parsed.
+2. extract named exports from both sides, plus the names the post-change side
+   forwards through a sourced re-export;
+3. stop when the post-change side carries `export * from "..."`, which can
+   supply any name;
+4. compute `removed = before - after` by exported name and symbol kind, then
+   drop every name the post-change side forwards;
+5. record separately which removed names the post-change side no longer
+   supplies under either symbol kind;
+6. stop when either side cannot be read or parsed.
 
 A symbol moving from value export to type-only export, or the reverse, does not
-satisfy a caller of the old kind and remains eligible for confirmation.
+satisfy a caller of the old kind and remains eligible for confirmation. A name
+that disappeared under both kinds is matched against every named import form,
+because no spelling of the import can resolve it.
 
 ### 3. Bounded caller confirmation
 
@@ -137,7 +151,8 @@ the changed module. For each candidate:
 3. inventory file names from that same working-tree or selected-head target and
    use the existing local resolver to confirm that the import specifier targets
    the changed module;
-4. match the imported name and type/value kind against the removed export.
+4. match the imported name against the removed export, using the type/value
+   kind only when the name still exists under the other kind.
 
 The graph is a candidate index, not proof. A stale or incomplete graph can cause
 a bounded false negative, but it cannot create a signal because the AST import
@@ -224,10 +239,13 @@ removed symbols in one caller or the same symbol imported by two callers.
 
 - unsafe: removed named export with an unchanged direct caller;
 - unsafe: removed type export with a surviving type-only caller;
+- unsafe: removed type export with a caller that omits the `type` keyword;
 - safe: export and all callers renamed together;
 - safe: removed unused export;
 - safe: same symbol imported from another module;
 - safe: existing export with an unchanged caller;
+- safe: implementation moved behind a sourced re-export of the same name;
+- safe: post-change `export * from "..."` withdraws the claim;
 - safe/limited: path alias, namespace import, re-export, and parse failure;
 - safe ownership: deleted module produces no B2.1 duplicate.
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -208,7 +208,9 @@ AST and target-matched resolver checks prove the relationship. It is review-only
 direct named `.ts`, `.tsx`, `.js`, and `.jsx` imports/exports; path aliases,
 package imports, default or namespace forms, re-exports, CommonJS/dynamic forms, and
 imports whose selected-target resolver selection is not the changed exporter are not
-reported as broken code. Its verification plan
+reported as broken code. A changed exporter that still forwards the name through
+`export { name } from "..."`, or that can forward any name through
+`export * from "..."`, is not reported either. Its verification plan
 asks the user to inspect the change and run the repository's declared
 type-check, build, or test command manually—RepoPilot does not execute those
 commands.

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -94,9 +94,13 @@ Current progress:
   It emits a High-confidence, definitely-sensitive
   `behavioral.removed-export-still-imported` signal at the caller import
   evidence (`path`) and identifies the changed exporter with `target_path`.
+  A name the changed exporter no longer supplies under either symbol kind is
+  matched against every named import form; a name that survives under the other
+  kind stays limited to the kind that disappeared.
   Default/namespace imports, re-exports, path aliases, package imports, renames,
   dynamic/CommonJS forms, and imports whose selected-target resolver selection is not
-  the changed exporter remain outside the claim.
+  the changed exporter remain outside the claim, and a post-change re-export
+  that can still supply the name withdraws it.
   The verification plan is manual; RepoPilot does not run TypeScript,
   compiler, or build commands.
 - Next: B2.2 `scan --changed` parity and persisted symbol-fact caching.

--- a/src/review/signals/api_contract/detector.rs
+++ b/src/review/signals/api_contract/detector.rs
@@ -20,6 +20,11 @@ pub(crate) fn detect_removed_export_imports(
     let Some(graph) = graph else {
         return Vec::new();
     };
+    if !changed_sources.iter().any(is_supported_modification) {
+        // Nothing can be proven, so the file inventory and the reverse importer
+        // index are not worth building for this review.
+        return Vec::new();
+    }
     let importers = build_importers_by_target(graph, repo_root);
     let Some(known_files) = target_file_inventory(repo_root, target) else {
         return Vec::new();
@@ -56,20 +61,28 @@ fn removed_export_delta(
     sources: &ChangedReviewSources<'_>,
     repo_root: &Path,
     caller_facts: &mut CallerFactCache<'_, '_, '_>,
-) -> Option<(PathBuf, BTreeSet<(String, SymbolKind)>)> {
-    if sources.file.status != ChangeStatus::Modified || !is_supported_path(&sources.file.path) {
+) -> Option<(PathBuf, RemovedExports)> {
+    if !is_supported_modification(sources) {
         return None;
     }
     let pre_facts = extract_javascript_symbol_facts(sources.pre?)?;
     let exporter = normalized_review_path(&sources.file.path, repo_root);
     let post_facts = caller_facts.facts_for(&exporter)?;
-    let removed = removed_symbols(&pre_facts.exports, &post_facts.exports);
+    if post_facts.wildcard_re_export {
+        // A star re-export can still supply every name, so no removal is proven.
+        return None;
+    }
+    let removed = removed_symbols(&pre_facts.exports, &post_facts);
     (!removed.is_empty()).then_some((exporter, removed))
+}
+
+fn is_supported_modification(sources: &ChangedReviewSources<'_>) -> bool {
+    sources.file.status == ChangeStatus::Modified && is_supported_path(&sources.file.path)
 }
 
 fn confirm_callers(
     exporter: &Path,
-    removed: &BTreeSet<(String, SymbolKind)>,
+    removed: &RemovedExports,
     candidates: &BTreeSet<PathBuf>,
     known_files: &HashSet<PathBuf>,
     caller_facts: &mut CallerFactCache<'_, '_, '_>,
@@ -97,12 +110,12 @@ fn confirmed_occurrence(
     import: &ImportedSymbolFact,
     importer: &Path,
     exporter: &Path,
-    removed: &BTreeSet<(String, SymbolKind)>,
+    removed: &RemovedExports,
     repo_root: &Path,
     known_files: &HashSet<PathBuf>,
 ) -> Option<RemovedExportSignal> {
     if !import.module_specifier.starts_with('.')
-        || !removed.contains(&(import.imported_name.clone(), import.kind))
+        || !removed.matches(&import.imported_name, import.kind)
     {
         return None;
     }
@@ -130,18 +143,58 @@ fn confirmed_occurrence(
     })
 }
 
+/// Named exports the change dropped from one module.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct RemovedExports {
+    /// Exact `(name, kind)` pairs the post-change module no longer declares.
+    pairs: BTreeSet<(String, SymbolKind)>,
+    /// Names the post-change module no longer supplies under any kind. Such a
+    /// name breaks every named import of it, however the caller spelled the
+    /// import, so the kind is not part of the match.
+    vanished: BTreeSet<String>,
+}
+
+impl RemovedExports {
+    fn matches(&self, name: &str, kind: SymbolKind) -> bool {
+        self.vanished.contains(name) || self.pairs.contains(&(name.to_string(), kind))
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pairs.is_empty()
+    }
+}
+
 fn removed_symbols(
     pre: &[super::ExportedSymbolFact],
-    post: &[super::ExportedSymbolFact],
-) -> BTreeSet<(String, SymbolKind)> {
-    let after = post
+    post: &JavaScriptSymbolFacts,
+) -> RemovedExports {
+    let after_pairs = post
+        .exports
         .iter()
         .map(|fact| (fact.name.clone(), fact.kind))
         .collect::<BTreeSet<_>>();
-    pre.iter()
+    let after_names = post
+        .exports
+        .iter()
+        .map(|fact| fact.name.as_str())
+        .collect::<HashSet<_>>();
+    let forwarded = post
+        .re_exports
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    let pairs = pre
+        .iter()
         .map(|fact| (fact.name.clone(), fact.kind))
-        .filter(|symbol| !after.contains(symbol))
-        .collect()
+        .filter(|(name, _)| !forwarded.contains(name.as_str()))
+        .filter(|symbol| !after_pairs.contains(symbol))
+        .collect::<BTreeSet<_>>();
+    let vanished = pairs
+        .iter()
+        .map(|(name, _)| name.clone())
+        .filter(|name| !after_names.contains(name.as_str()))
+        .collect();
+    RemovedExports { pairs, vanished }
 }
 
 struct CallerFactCache<'root, 'target, 'source> {

--- a/src/review/signals/api_contract/javascript.rs
+++ b/src/review/signals/api_contract/javascript.rs
@@ -21,6 +21,8 @@ pub(super) fn extract_javascript_symbol_facts(
     extract_program(root, source.content(), &mut facts);
     facts.exports.sort();
     facts.exports.dedup();
+    facts.re_exports.sort();
+    facts.re_exports.dedup();
     facts.imports.sort();
     facts.imports.dedup();
     Some(facts)
@@ -38,7 +40,11 @@ fn extract_program(program: Node<'_>, content: &str, facts: &mut JavaScriptSymbo
 }
 
 fn extract_export(node: Node<'_>, content: &str, facts: &mut JavaScriptSymbolFacts) {
-    if node.child_by_field_name("source").is_some() || has_direct_kind(node, "default") {
+    if node.child_by_field_name("source").is_some() {
+        extract_re_export(node, content, facts);
+        return;
+    }
+    if has_direct_kind(node, "default") {
         return;
     }
     let statement_kind = if has_direct_type_modifier(node) {
@@ -60,6 +66,62 @@ fn extract_export(node: Node<'_>, content: &str, facts: &mut JavaScriptSymbolFac
                 push_declaration(child, content, SymbolKind::Type, facts)
             }
             _ => {}
+        }
+    }
+}
+
+/// Records what a sourced `export ... from "..."` statement can still supply.
+///
+/// The forwarded symbols live in another module, so their kind is unknown here.
+/// A bare `export * from "..."` can supply any name, which makes every removal
+/// claim about this module unprovable.
+fn extract_re_export(node: Node<'_>, content: &str, facts: &mut JavaScriptSymbolFacts) {
+    let mut cursor = node.walk();
+    let mut forwards_named_symbols = false;
+    for child in node.named_children(&mut cursor) {
+        match child.kind() {
+            "export_clause" => {
+                forwards_named_symbols = true;
+                collect_re_exported_names(child, content, facts);
+            }
+            "namespace_export" => {
+                forwards_named_symbols = true;
+                record_namespace_export(child, content, facts);
+            }
+            _ => {}
+        }
+    }
+    if !forwards_named_symbols {
+        facts.wildcard_re_export = true;
+    }
+}
+
+/// `export * as api from "..."` supplies only the alias it binds.
+fn record_namespace_export(node: Node<'_>, content: &str, facts: &mut JavaScriptSymbolFacts) {
+    match node.named_child(0).and_then(|alias| {
+        alias
+            .utf8_text(content.as_bytes())
+            .ok()
+            .filter(|text| !text.is_empty())
+    }) {
+        Some(alias) => facts.re_exports.push(alias.to_string()),
+        // An unreadable alias is treated as an unbounded forward.
+        None => facts.wildcard_re_export = true,
+    }
+}
+
+fn collect_re_exported_names(clause: Node<'_>, content: &str, facts: &mut JavaScriptSymbolFacts) {
+    let mut cursor = clause.walk();
+    for specifier in clause.named_children(&mut cursor) {
+        if specifier.kind() != "export_specifier" {
+            continue;
+        }
+        // `export { default as loadUser } from "..."` still supplies `loadUser`,
+        // so only the exported side is checked for the `default` name.
+        let name = semantic_field_text(specifier, "alias", content)
+            .or_else(|| semantic_field_text(specifier, "name", content));
+        if let Some(name) = name.filter(|name| *name != "default") {
+            facts.re_exports.push(name.to_string());
         }
     }
 }

--- a/src/review/signals/api_contract/mod.rs
+++ b/src/review/signals/api_contract/mod.rs
@@ -37,6 +37,11 @@ pub(crate) struct ImportedSymbolFact {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct JavaScriptSymbolFacts {
     pub exports: Vec<ExportedSymbolFact>,
+    /// Names forwarded by a sourced `export ... from "..."`. Their defining
+    /// module is not analyzed, so the symbol kind stays unknown.
+    pub re_exports: Vec<String>,
+    /// `export * from "..."` is present, so any name may still be supplied.
+    pub wildcard_re_export: bool,
     pub imports: Vec<ImportedSymbolFact>,
 }
 

--- a/src/review/signals/api_contract/tests.rs
+++ b/src/review/signals/api_contract/tests.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
 
+mod re_exports;
 mod robustness;
 
 #[test]
@@ -218,8 +219,9 @@ fn unsupported_mjs_or_cjs_exporter_or_importer_is_not_reported() {
     }
 }
 #[test]
-fn removed_exports_require_a_surviving_direct_resolved_value_import() {
-    // Catches graph-only, alias, name-only, or type/value mismatches.
+fn removed_exports_require_a_surviving_direct_resolved_import() {
+    // Catches graph-only, alias, or name-only matches. Symbol-kind handling is
+    // pinned separately in `re_exports`.
     assert_no_removed_export(
         "import { saveUser } from \"./api.ts\";\n",
         &[("src/caller.ts", "src/api.ts")],
@@ -268,30 +270,6 @@ fn removed_exports_require_a_surviving_direct_resolved_value_import() {
             true,
         );
     }
-
-    let temp = TempDir::new().expect("temp dir");
-    let root = temp.path();
-    init_repo(root);
-    write(root, "src/api.ts", "export type User = string;\n");
-    write(
-        root,
-        "src/caller.ts",
-        "import { User } from \"./api.ts\";\n",
-    );
-    let api = changed("src/api.ts", ChangeStatus::Modified);
-    let pre = source("export type User = string;\n");
-    let post = source("export type Other = string;\n");
-    let signals = detect_removed_export_imports(
-        root,
-        DiffTarget::WorkingTree,
-        &[ChangedReviewSources {
-            file: &api,
-            pre: Some(&pre),
-            post: Some(&post),
-        }],
-        Some(&coupling_graph(&[("src/caller.ts", "src/api.ts")])),
-    );
-    assert!(signals.is_empty());
 }
 fn assert_no_removed_export(
     caller_source: &str,

--- a/src/review/signals/api_contract/tests/re_exports.rs
+++ b/src/review/signals/api_contract/tests/re_exports.rs
@@ -1,0 +1,131 @@
+use super::{changed, coupling_graph, init_repo, source, write};
+use crate::review::diff::{ChangeStatus, DiffTarget};
+use crate::review::signals::api_contract::{
+    ChangedReviewSources, RemovedExportSignal, SymbolKind, detect_removed_export_imports,
+    extract_javascript_symbol_facts,
+};
+use tempfile::TempDir;
+
+#[test]
+fn sourced_re_export_of_the_same_name_is_not_a_removed_export() {
+    // Catches claiming a break when the change only moved the implementation
+    // and kept the name reachable through `export { name } from "..."`.
+    let signals = detect(
+        "export function loadUser() {}\n",
+        "export { loadUser } from \"./users.ts\";\n",
+        "import { loadUser } from \"./api.ts\";\n",
+    );
+
+    assert!(signals.is_empty(), "{signals:#?}");
+}
+
+#[test]
+fn forwarded_default_alias_supplies_the_named_export() {
+    // Catches dropping `default as name` forwards, whose exported side is the
+    // alias and not the excluded `default` name.
+    let signals = detect(
+        "export function loadUser() {}\n",
+        "export { default as loadUser } from \"./users.ts\";\n",
+        "import { loadUser } from \"./api.ts\";\n",
+    );
+
+    assert!(signals.is_empty(), "{signals:#?}");
+}
+
+#[test]
+fn star_re_export_suppresses_every_removal_claim() {
+    // Catches proving a removal against a module that can still forward any
+    // name from an unanalyzed source.
+    let signals = detect(
+        "export function loadUser() {}\n",
+        "export * from \"./users.ts\";\n",
+        "import { loadUser } from \"./api.ts\";\n",
+    );
+
+    assert!(signals.is_empty(), "{signals:#?}");
+}
+
+#[test]
+fn namespace_re_export_supplies_only_its_own_alias() {
+    // Catches widening `export * as alias from "..."` into an unbounded
+    // forward, which would silence every real removal in the module.
+    let facts = extract_javascript_symbol_facts(&source(
+        "export * as api from \"./users.ts\";\nexport { helper as tool } from \"./util.ts\";\n",
+    ))
+    .expect("supported TypeScript source");
+    assert!(!facts.wildcard_re_export, "{facts:#?}");
+    assert_eq!(
+        facts.re_exports,
+        vec!["api".to_string(), "tool".to_string()]
+    );
+
+    let signals = detect(
+        "export function loadUser() {}\n",
+        "export * as api from \"./users.ts\";\n",
+        "import { loadUser } from \"./api.ts\";\n",
+    );
+    assert_eq!(signals.len(), 1, "{signals:#?}");
+}
+
+#[test]
+fn a_name_removed_under_every_kind_matches_any_caller_import_form() {
+    // Catches matching the caller's import kind against the pre-change export
+    // kind, which misses `import { Type }` and `import type { value }`.
+    let type_export = detect(
+        "export type UserRecord = { id: string };\n",
+        "export type AccountRecord = { id: string };\n",
+        "import { UserRecord } from \"./api.ts\";\n",
+    );
+    assert_eq!(type_export.len(), 1, "{type_export:#?}");
+    assert_eq!(type_export[0].exported_name, "UserRecord");
+    assert_eq!(type_export[0].symbol_kind, SymbolKind::Value);
+
+    let value_export = detect(
+        "export function loadUser() {}\n",
+        "export function saveUser() {}\n",
+        "import type { loadUser } from \"./api.ts\";\n",
+    );
+    assert_eq!(value_export.len(), 1, "{value_export:#?}");
+    assert_eq!(value_export[0].symbol_kind, SymbolKind::Type);
+}
+
+#[test]
+fn a_surviving_name_is_only_claimed_for_the_kind_that_disappeared() {
+    // Catches turning the kind-agnostic match into a blanket one: a name that
+    // still exists as a type satisfies a type-only caller.
+    let value_caller = detect(
+        "export const Money = 1;\n",
+        "export type Money = number;\n",
+        "import { Money } from \"./api.ts\";\n",
+    );
+    assert_eq!(value_caller.len(), 1, "{value_caller:#?}");
+
+    let type_caller = detect(
+        "export const Money = 1;\n",
+        "export type Money = number;\n",
+        "import type { Money } from \"./api.ts\";\n",
+    );
+    assert!(type_caller.is_empty(), "{type_caller:#?}");
+}
+
+fn detect(pre_source: &str, post_source: &str, caller_source: &str) -> Vec<RemovedExportSignal> {
+    let temp = TempDir::new().expect("temp dir");
+    let root = temp.path();
+    init_repo(root);
+    write(root, "src/api.ts", post_source);
+    write(root, "src/caller.ts", caller_source);
+    let api = changed("src/api.ts", ChangeStatus::Modified);
+    let pre = source(pre_source);
+    let post = source(post_source);
+
+    detect_removed_export_imports(
+        root,
+        DiffTarget::WorkingTree,
+        &[ChangedReviewSources {
+            file: &api,
+            pre: Some(&pre),
+            post: Some(&post),
+        }],
+        Some(&coupling_graph(&[("src/caller.ts", "src/api.ts")])),
+    )
+}

--- a/tests/fixtures/review/api-contract/moved-behind-re-export/after/src/api.ts
+++ b/tests/fixtures/review/api-contract/moved-behind-re-export/after/src/api.ts
@@ -1,0 +1,1 @@
+export { loadUser } from "./users.ts";

--- a/tests/fixtures/review/api-contract/moved-behind-re-export/after/src/users.ts
+++ b/tests/fixtures/review/api-contract/moved-behind-re-export/after/src/users.ts
@@ -1,0 +1,3 @@
+export function loadUser() {
+  return { id: "user-1" };
+}

--- a/tests/fixtures/review/api-contract/moved-behind-re-export/before/src/api.ts
+++ b/tests/fixtures/review/api-contract/moved-behind-re-export/before/src/api.ts
@@ -1,0 +1,3 @@
+export function loadUser() {
+  return { id: "user-1" };
+}

--- a/tests/fixtures/review/api-contract/moved-behind-re-export/before/src/caller.ts
+++ b/tests/fixtures/review/api-contract/moved-behind-re-export/before/src/caller.ts
@@ -1,0 +1,3 @@
+import { loadUser } from "./api.ts";
+
+export const currentUser = loadUser();

--- a/tests/fixtures/review/api-contract/moved-behind-re-export/expected.json
+++ b/tests/fixtures/review/api-contract/moved-behind-re-export/expected.json
@@ -1,0 +1,8 @@
+{
+  "description": "Moving an implementation behind a sourced re-export keeps the named export reachable, so the surviving caller import is not broken.",
+  "label": "expected_true_negative",
+  "expect": [],
+  "forbid": [
+    { "kind": "behavioral.removed-export-still-imported" }
+  ]
+}

--- a/tests/fixtures/review/api-contract/star-re-export-fallback/after/src/api.ts
+++ b/tests/fixtures/review/api-contract/star-re-export-fallback/after/src/api.ts
@@ -1,0 +1,1 @@
+export * from "./users.ts";

--- a/tests/fixtures/review/api-contract/star-re-export-fallback/after/src/users.ts
+++ b/tests/fixtures/review/api-contract/star-re-export-fallback/after/src/users.ts
@@ -1,0 +1,3 @@
+export function loadUser() {
+  return { id: "user-1" };
+}

--- a/tests/fixtures/review/api-contract/star-re-export-fallback/before/src/api.ts
+++ b/tests/fixtures/review/api-contract/star-re-export-fallback/before/src/api.ts
@@ -1,0 +1,3 @@
+export function loadUser() {
+  return { id: "user-1" };
+}

--- a/tests/fixtures/review/api-contract/star-re-export-fallback/before/src/caller.ts
+++ b/tests/fixtures/review/api-contract/star-re-export-fallback/before/src/caller.ts
@@ -1,0 +1,3 @@
+import { loadUser } from "./api.ts";
+
+export const currentUser = loadUser();

--- a/tests/fixtures/review/api-contract/star-re-export-fallback/expected.json
+++ b/tests/fixtures/review/api-contract/star-re-export-fallback/expected.json
@@ -1,0 +1,8 @@
+{
+  "description": "A star re-export added by the change can still supply the name, so the removed direct export is not proven broken.",
+  "label": "expected_true_negative",
+  "expect": [],
+  "forbid": [
+    { "kind": "behavioral.removed-export-still-imported" }
+  ]
+}

--- a/tests/fixtures/review/api-contract/type-import-without-type-keyword/after/src/api.ts
+++ b/tests/fixtures/review/api-contract/type-import-without-type-keyword/after/src/api.ts
@@ -1,0 +1,1 @@
+export type AccountRecord = { id: string };

--- a/tests/fixtures/review/api-contract/type-import-without-type-keyword/before/src/api.ts
+++ b/tests/fixtures/review/api-contract/type-import-without-type-keyword/before/src/api.ts
@@ -1,0 +1,1 @@
+export type UserRecord = { id: string };

--- a/tests/fixtures/review/api-contract/type-import-without-type-keyword/before/src/caller.ts
+++ b/tests/fixtures/review/api-contract/type-import-without-type-keyword/before/src/caller.ts
@@ -1,0 +1,3 @@
+import { UserRecord } from "./api.ts";
+
+export const currentUser: UserRecord = { id: "user-1" };

--- a/tests/fixtures/review/api-contract/type-import-without-type-keyword/expected.json
+++ b/tests/fixtures/review/api-contract/type-import-without-type-keyword/expected.json
@@ -1,0 +1,15 @@
+{
+  "description": "A removed type export stays broken for a caller that imports the name without the `type` keyword.",
+  "label": "expected_true_positive",
+  "expect": [
+    {
+      "bucket": "definitely",
+      "family": "behavioral",
+      "kind": "behavioral.removed-export-still-imported",
+      "path": "src/caller.ts",
+      "target_path": "src/api.ts",
+      "headline": "removed export is still imported"
+    }
+  ],
+  "forbid": []
+}


### PR DESCRIPTION
## Summary

Corrects the B2.1 `behavioral.removed-export-still-imported` evidence boundary:
a re-export in the post-change module now withdraws the removal claim, and a
name that disappeared under every symbol kind is matched against any named
import form.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- The TS/JS symbol extractor records sourced re-exports separately from directly
  declared exports: `export { name } from "..."` (including `default as name`)
  and `export * as alias from "..."` contribute forwarded names, while a bare
  `export * from "..."` sets a wildcard flag.
- The detector drops every forwarded name from the removal delta and returns no
  claim at all for a module carrying a wildcard re-export.
- The removal delta now also records which names the post-change module no
  longer supplies under *either* kind. Those match any named import form; a name
  that survives under the other kind stays limited to the kind that disappeared.
- Detection returns before building the target file inventory and the reverse
  importer index when no changed file is a modified `.ts`/`.tsx`/`.js`/`.jsx`
  module.
- Three review golden fixtures (two safe, one unsafe) and six detector unit
  tests in a new `tests/re_exports.rs`; the superseded kind-mismatch assertion
  was removed from `tests.rs`.

## Why

Moving an implementation into a new module and keeping a barrel re-export is a
routine refactor. Before this change it produced a High-confidence,
definitely-sensitive signal against an unchanged caller — a false positive that
`--fail-on-review definitely` would block on. Both new safe fixtures fail on
`main`.

The kind comparison was the mirror problem: `import { UserRecord }` without the
`type` keyword is the common way to import a type, and removing
`export type UserRecord` left it unreported. The unsafe fixture for that case
also fails on `main`.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

Subsystem: `src/review/signals/api_contract`. No public schema, signal kind,
severity, or output-ordering change — B2.1 is still unreleased, so the
`[Unreleased]` entry was corrected in place rather than adding a `Fixed` note
for behavior no user has seen. Recall is not reduced: the wildcard withdrawal
is the only suppression, and it is the case where no local evidence can prove
the name is gone.

## Changelog

- [x] `CHANGELOG.md` updated (skip for CI-only or doc changes with no user-visible effect)

Also updated: `docs/reports.md`, `docs/roadmap/v0.22.md`, and the B2.1 spec
(`docs/engineering/v0.22-removed-export-review-spec.md`).

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan . --fail-on-priority p1
```

All green: 99 test binaries, 0 failures; self-scan 0 visible findings; dogfood
`review` reports no signal on this diff.

`python3 scripts/release-contract.py check` fails locally on a **pre-existing**
wagtail zoo snapshot drift from `architecture.unresolved-local-import` (#365).
Verified by stashing this branch and re-running on `main` — same failure, same
seven findings. Not touched here; it needs its own triage and expectation
labels.
