### PR TITLE
fix: stop claiming Python package members are missing modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   root-confined candidate set is absent. Ambiguous aliases, extensionless
   imports, workspace packages, Rust module forms, and unsupported semantics stay
   as bounded informational diagnostics instead of false broken-code claims.
+  A Python `from <package> import name` candidate is one of those bounded
+  limitations: `name` may be a submodule or a member defined in the package's
+  `__init__.py`, and the two are indistinguishable from the import alone. Only
+  the explicit `from <package>.<module> import name` form, which never records
+  the parent package, is claimed as a missing module. The rule now carries
+  labeled zoo evidence.
 
 ### Changed
 

--- a/docs/engineering/rule-scorecard.md
+++ b/docs/engineering/rule-scorecard.md
@@ -19,7 +19,7 @@ Per-rule signal quality derived from the real-repo validation zoo (`tests/zoo/ex
 | `architecture.package-boundary-violation` | experimental | no zoo evidence | n/a | 0 |
 | `architecture.test-leak` | experimental | no zoo evidence | n/a | 0 |
 | `architecture.too-many-modules` | experimental | no zoo evidence | n/a | 0 |
-| `architecture.unresolved-local-import` | preview | no zoo evidence | n/a | 0 |
+| `architecture.unresolved-local-import` | preview | 2 labeled across 1 repo(s) | 0.00 | 2 |
 | `code-marker.fixme` | experimental | no zoo evidence | n/a | 0 |
 | `code-marker.hack` | experimental | no zoo evidence | n/a | 0 |
 | `code-marker.todo` | experimental | no zoo evidence | n/a | 0 |

--- a/src/audits/architecture/unresolved_local_imports.rs
+++ b/src/audits/architecture/unresolved_local_imports.rs
@@ -23,6 +23,12 @@ pub(crate) fn analyze_unresolved_local_imports(
         if is_shadowed_python_submodule(unresolved, context.resolution) {
             continue;
         }
+        if speculation::is_python_package_member(unresolved, source_facts(context, unresolved)) {
+            *limitations
+                .entry(UnresolvedImportLimitation::PythonPackageMember)
+                .or_insert(0usize) += 1;
+            continue;
+        }
         match &unresolved.proof {
             UnresolvedImportProof::DefinitiveLocalCandidates(candidates)
                 if !candidates.iter().any(|candidate| candidate.is_file()) =>
@@ -40,6 +46,16 @@ pub(crate) fn analyze_unresolved_local_imports(
         findings,
         diagnostics: limitation_diagnostics(limitations),
     }
+}
+
+fn source_facts<'a>(
+    context: &'a GraphAuditContext<'_>,
+    unresolved: &crate::graph::UnresolvedImportEvidence,
+) -> Option<&'a FileFacts> {
+    context.facts.files.iter().find(|file| {
+        crate::graph::resolver::normalize_path(&file.path)
+            == crate::graph::resolver::normalize_path(&unresolved.source)
+    })
 }
 
 fn is_shadowed_python_submodule(
@@ -73,10 +89,7 @@ fn missing_import_finding(
     candidates: &[PathBuf],
 ) -> Finding {
     let path = relative_path(&unresolved.source, context.root);
-    let source_facts = context.facts.files.iter().find(|file| {
-        crate::graph::resolver::normalize_path(&file.path)
-            == crate::graph::resolver::normalize_path(&unresolved.source)
-    });
+    let source_facts = source_facts(context, unresolved);
     let stored_spans = context
         .facts
         .import_spans_by_file
@@ -163,6 +176,8 @@ fn relative_path(path: &Path, root: &Path) -> PathBuf {
         .map(Path::to_path_buf)
         .unwrap_or_else(|_| path.to_path_buf())
 }
+
+mod speculation;
 
 #[cfg(test)]
 mod tests;

--- a/src/audits/architecture/unresolved_local_imports/speculation.rs
+++ b/src/audits/architecture/unresolved_local_imports/speculation.rs
@@ -1,0 +1,69 @@
+//! Tells a Python import that names a module apart from one that only *might*.
+//!
+//! `from . import get_document_model` is recorded as two imports: the package
+//! `.` and the derived candidate `.get_document_model`. The derived candidate
+//! is a guess — `get_document_model` is just as likely a function defined in the
+//! package's `__init__.py`. Only the explicit form `from .get_document_model
+//! import x` proves a module was meant, and it never records the parent.
+//!
+//! So a derived candidate is exactly a candidate whose strict parent prefix the
+//! same file also imports, which is what this module detects.
+
+use crate::graph::UnresolvedImportEvidence;
+use crate::scan::facts::FileFacts;
+
+pub(super) fn is_python_package_member(
+    unresolved: &UnresolvedImportEvidence,
+    source_facts: Option<&FileFacts>,
+) -> bool {
+    if unresolved
+        .source
+        .extension()
+        .and_then(|extension| extension.to_str())
+        != Some("py")
+    {
+        return false;
+    }
+    let Some(parent) = parent_module(&unresolved.raw_import) else {
+        return false;
+    };
+    source_facts.is_some_and(|facts| facts.imports.iter().any(|import| import == parent))
+}
+
+/// The module a derived candidate would have been derived from: everything
+/// before the last dotted segment, keeping the leading relative dots.
+///
+/// `.a` → `.`, `..a` → `..`, `.a.b` → `.a`, `pkg.a` → `pkg`. A bare `.` or `..`
+/// has no parent to check.
+fn parent_module(raw_import: &str) -> Option<&str> {
+    let leading_dots = raw_import.len() - raw_import.trim_start_matches('.').len();
+    let (dots, rest) = raw_import.split_at(leading_dots);
+    if rest.is_empty() {
+        return None;
+    }
+    match rest.rfind('.') {
+        Some(index) => Some(&raw_import[..leading_dots + index]),
+        // A single segment after the dots: the parent is the relative package
+        // itself, and an absolute `name` has no local parent to import.
+        None => (!dots.is_empty()).then_some(dots),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parent_module;
+
+    #[test]
+    fn parent_module_keeps_relative_depth_and_stops_at_the_package() {
+        // Catches a parent that loses relative depth, which would compare the
+        // candidate against an import the file never made.
+        assert_eq!(parent_module(".get_document_model"), Some("."));
+        assert_eq!(parent_module("..get_document_model"), Some(".."));
+        assert_eq!(parent_module("...views"), Some("..."));
+        assert_eq!(parent_module(".settings.local"), Some(".settings"));
+        assert_eq!(parent_module("wagtail.documents"), Some("wagtail"));
+        assert_eq!(parent_module("."), None);
+        assert_eq!(parent_module(".."), None);
+        assert_eq!(parent_module("settings"), None);
+    }
+}

--- a/src/audits/architecture/unresolved_local_imports/tests.rs
+++ b/src/audits/architecture/unresolved_local_imports/tests.rs
@@ -137,3 +137,78 @@ fn ambiguous_imports_are_aggregated_into_one_info_diagnostic() {
     assert_eq!(result.diagnostics[0].severity, DiagnosticSeverity::Info);
     assert!(result.diagnostics[0].message.contains('2'));
 }
+
+#[test]
+fn python_package_member_import_is_a_limitation_not_a_missing_module() {
+    // Catches claiming `from . import name` is broken code: `name` may be a
+    // function defined in the package's `__init__.py`.
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    fs::create_dir_all(root.join("pkg")).unwrap();
+    fs::write(
+        root.join("pkg/__init__.py"),
+        "def get_model():\n    return 1\n",
+    )
+    .unwrap();
+    let source = root.join("pkg/app.py");
+    let facts = facts(
+        source.clone(),
+        "Python",
+        "from . import get_model\n\nget_model()\n",
+        &[".", ".get_model"],
+    );
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record_classified(&source, ".get_model", root);
+
+    let result = analyze(root, &facts, &resolution);
+
+    assert!(result.findings.is_empty(), "{:#?}", result.findings);
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(
+        result.diagnostics[0].code,
+        "analysis.unresolved-local-import-limited"
+    );
+}
+
+#[test]
+fn an_explicit_submodule_import_keeps_its_missing_module_finding() {
+    // Catches widening the package-member guard into every dotted import: only
+    // a candidate whose parent the same file also imports is speculative.
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let source = root.join("pkg/app.py");
+    let facts = facts(
+        source.clone(),
+        "Python",
+        "from .get_model import build\n\nbuild()\n",
+        &[".get_model"],
+    );
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record_classified(&source, ".get_model", root);
+
+    let result = analyze(root, &facts, &resolution);
+
+    assert_eq!(result.findings.len(), 1, "{:#?}", result.findings);
+    assert!(result.findings[0].description.contains(".get_model"));
+}
+
+#[test]
+fn the_package_member_guard_is_python_only() {
+    // Catches applying Python package semantics to path-based imports, where
+    // `./a/b` is never derived from `./a`.
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let source = root.join("src/app.ts");
+    let facts = facts(
+        source.clone(),
+        "TypeScript",
+        "import a from \"./lib\";\nimport b from \"./lib/missing.ts\";\n",
+        &["./lib", "./lib/missing.ts"],
+    );
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record_classified(&source, "./lib/missing.ts", root);
+
+    let result = analyze(root, &facts, &resolution);
+
+    assert_eq!(result.findings.len(), 1, "{:#?}", result.findings);
+}

--- a/src/graph/resolution_stats.rs
+++ b/src/graph/resolution_stats.rs
@@ -24,6 +24,10 @@ pub enum UnresolvedImportKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum UnresolvedImportLimitation {
     AmbiguousTarget,
+    /// A Python `from <package> import name` candidate. `name` may be a
+    /// submodule or a symbol defined in the package, and the two forms are
+    /// indistinguishable from the import text alone.
+    PythonPackageMember,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/tests/fixtures/rules/architecture.unresolved-local-import/expected.json
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/expected.json
@@ -19,6 +19,10 @@
     {
       "path": "false_positive_ambiguous",
       "expected_rule_ids": []
+    },
+    {
+      "path": "false_positive_package_member",
+      "expected_rule_ids": []
     }
   ]
 }

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_package_member/pkg/__init__.py
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_package_member/pkg/__init__.py
@@ -1,0 +1,3 @@
+def get_document_model():
+    """A package member, not a submodule file."""
+    return "Document"

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_package_member/pkg/app.py
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_package_member/pkg/app.py
@@ -1,0 +1,5 @@
+# `from <package> import name` may import a submodule or a package member, so
+# the derived `.get_document_model` candidate is not proof of a missing module.
+from . import get_document_model
+
+model = get_document_model()

--- a/tests/zoo/expectations/wagtail.toml
+++ b/tests/zoo/expectations/wagtail.toml
@@ -27,3 +27,21 @@ path = "wagtail/images/models.py"
 line = 868
 disposition = "valid-but-accepted"
 reason = "Bare `except:` carrying an explicit `# noqa:B901,E722`; upstream has knowingly accepted the broad handler."
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.unresolved-local-import:wagtail/project_template/project_name/settings/dev.py:11ea2da70fd5eb9f"
+rule_id = "architecture.unresolved-local-import"
+path = "wagtail/project_template/project_name/settings/dev.py"
+line = 16
+disposition = "false-positive"
+reason = "`try: from .local import * except ImportError: pass` — the Django settings idiom for an optional, git-ignored local override. The absence is deliberate and handled, so it is not broken code. Guarded optional imports are not modeled yet."
+
+[[finding]]
+profile = "default"
+finding_id = "architecture.unresolved-local-import:wagtail/project_template/project_name/settings/production.py:11ea2da70fd5eb9f"
+rule_id = "architecture.unresolved-local-import"
+path = "wagtail/project_template/project_name/settings/production.py"
+line = 12
+disposition = "false-positive"
+reason = "Same guarded optional `from .local import *` override as dev.py; the import is wrapped in try/except ImportError."

--- a/tests/zoo/snapshots/wagtail.json
+++ b/tests/zoo/snapshots/wagtail.json
@@ -1,19 +1,22 @@
 {
   "default": {
     "by_priority": {
-      "P0": 2,
+      "P0": 4,
       "P1": 1
     },
     "by_rule": {
       "architecture.circular-dependency": 2,
+      "architecture.unresolved-local-import": 2,
       "language.python.exception-risk": 1
     },
     "fingerprints": [
       "architecture.circular-dependency:wagtail/actions/publish_revision.py:0da7c5453404677e",
       "architecture.circular-dependency:wagtail/admin/views/bulk_action/__init__.py:a2ca81903a3ef0d5",
+      "architecture.unresolved-local-import:wagtail/project_template/project_name/settings/dev.py:11ea2da70fd5eb9f",
+      "architecture.unresolved-local-import:wagtail/project_template/project_name/settings/production.py:11ea2da70fd5eb9f",
       "language.python.exception-risk:wagtail/images/models.py:b3686c8d8679d8e4"
     ],
-    "visible_total": 3
+    "visible_total": 5
   },
   "framework": "django",
   "language": "python",
@@ -29,6 +32,7 @@
       "architecture.large-file": 85,
       "architecture.test-leak": 1,
       "architecture.too-many-modules": 8,
+      "architecture.unresolved-local-import": 2,
       "code-marker.fixme": 3,
       "code-marker.hack": 3,
       "code-marker.todo": 19,
@@ -43,6 +47,6 @@
       "language.python.exception-risk": 45,
       "testing.source-without-test": 668
     },
-    "visible_total": 3040
+    "visible_total": 3042
   }
 }


### PR DESCRIPTION
## Summary

`architecture.unresolved-local-import` reported the Python
`from <package> import name` idiom as broken code. The derived candidate is now a bounded limitation, and the wagtail zoo snapshot - which has been drifting since the rule landed in #365 - is re-blessed with reviewed labels.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- New `speculation` submodule under the audit: a Python candidate is speculative when the same file also imports its strict parent prefix (`.get_document_model` alongside `.`). Those candidates count as `UnresolvedImportLimitation::PythonPackageMember` and feed the existing  aggregate info diagnostic instead of producing a finding.
- Extracted the duplicated `source_facts` lookup in the audit.
- New rule fixture `false_positive_package_member`, plus three unit tests: the limitation, the false-negative guard (`from .module import name` still reports), and the Python-only boundary.
- `tests/zoo/expectations/wagtail.toml`, `tests/zoo/snapshots/wagtail.json`, and  the generated `docs/engineering/rule-scorecard.md` re-blessed.

## Why

`from . import get_document_model` records two imports — the package `.` and a derived `.get_document_model`. The derived one is a guess: the name is just as likely a function in the package's `__init__.py`, which is exactly what it is in wagtail. The rule claimed a missing module at P0/High on five wagtail files.

The discriminator is structural, not textual: only `from . import name` records the parent package, so a candidate whose parent the same file also imports is derived, and the explicit `from .module import name` form is untouched.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
cargo run -- scan . --fail-on-priority p1
```
