### PR TITLE
feat: measure strict-only rules by deterministic sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   the explicit `from <package>.<module> import name` form, which never records
   the parent package, is claimed as a missing module. The rule now carries
   labeled zoo evidence.
+- Measure rules that only fire in the strict profile. `scripts/zoo.py sample
+  --rule <id>` draws a deterministic, evenly spread subset of one rule's zoo
+  findings to label, and the rule scorecard reports that sampled evidence in its
+  own table, separate from the exhaustive default-profile numbers. Strict
+  expectations now declare `evidence = "anchor"` (hand-picked recall pin, the
+  default) or `evidence = "sample"`, and only samples feed a precision estimate,
+  so a pinned known-good finding cannot be read as measurement. The first sample
+  records `architecture.dead-module` at 0.00 across six findings in five
+  repositories: tool configs, build scripts, framework-autoloaded modules,
+  runner-discovered tests, and dynamically imported documentation examples all
+  report zero fan-in without being dead.
 
 ### Changed
 

--- a/docs/engineering/rule-scorecard.md
+++ b/docs/engineering/rule-scorecard.md
@@ -5,6 +5,10 @@
 
 Per-rule signal quality derived from the real-repo validation zoo (`tests/zoo/expectations/*.toml`) and each rule's lifecycle (`docs/rules-reference.md`). Precision estimate is `(actionable + valid-but-accepted) / labeled` default-profile zoo findings — a proxy from human-reviewed dispositions, not measured precision. False-positive debt is the count of zoo findings a reviewer explicitly dispositioned `false-positive`; labels never suppress the finding, so debt reflects outstanding calibration work, not detector correctness at large.
 
+## Default-profile evidence
+
+Every default-visible zoo finding is labeled, so these rows are exhaustive for the pinned repositories. `no zoo evidence` means the rule never fired in the default profile on any of them — the rule is unmeasured, which is not the same as clean.
+
 | Rule | Lifecycle | Zoo Evidence | Precision Estimate | False-Positive Debt |
 |---|---|---|---:|---:|
 | `architecture.barrel-file-risk` | experimental | no zoo evidence | n/a | 0 |
@@ -60,3 +64,11 @@ Per-rule signal quality derived from the real-repo validation zoo (`tests/zoo/ex
 | `security.secret-candidate` | preview | 7 labeled across 1 repo(s) | 1.00 | 0 |
 | `testing.missing-test-folder` | experimental | no zoo evidence | n/a | 0 |
 | `testing.source-without-test` | experimental | no zoo evidence | n/a | 0 |
+
+## Strict-profile sampled evidence
+
+Rules that fire only in the strict profile are too numerous to label exhaustively. These rows come from deterministic per-rule samples (`python3 scripts/zoo.py sample --rule <id>`), so the precision estimate describes the sampled findings, not the rule's full strict-profile population. A rule missing from this table has no sampled evidence at all.
+
+| Rule | Lifecycle | Sampled | Precision Estimate | False-Positive Debt |
+|---|---|---|---:|---:|
+| `architecture.dead-module` | experimental | 6 sampled across 5 repo(s) | 0.00 | 6 |

--- a/scripts/tests/test_zoo_sample.py
+++ b/scripts/tests/test_zoo_sample.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import zoo_sample as zsam  # noqa: E402  (after the sys.path fix above)
+import zoo_triage as zt  # noqa: E402
+from zoo_expectations import LiveFinding  # noqa: E402
+
+
+def live(rule_id: str, path: str, line: int, finding_id: str | None = None) -> LiveFinding:
+    return LiveFinding(
+        profile="strict",
+        id=finding_id or f"{rule_id}:{path}:{line:04d}",
+        rule_id=rule_id,
+        path=path,
+        line=line,
+        line_end=line,
+        severity="LOW",
+        confidence="HIGH",
+        priority="P3",
+        title="title",
+        snippet="snippet",
+    )
+
+
+class EvenStrideTest(unittest.TestCase):
+    def test_spans_the_population_instead_of_taking_a_prefix(self):
+        # Catches a sampler that returns the alphabetically first N findings,
+        # which would let one crowded directory stand in for the whole zoo.
+        self.assertEqual(zsam.even_stride(100, 5), [0, 25, 50, 74, 99])
+        self.assertEqual(zsam.even_stride(10, 3), [0, 4, 9])
+
+    def test_returns_every_index_when_the_population_fits(self):
+        self.assertEqual(zsam.even_stride(3, 20), [0, 1, 2])
+        self.assertEqual(zsam.even_stride(4, 4), [0, 1, 2, 3])
+
+    def test_degenerate_inputs_are_empty_or_single(self):
+        self.assertEqual(zsam.even_stride(0, 5), [])
+        self.assertEqual(zsam.even_stride(5, 0), [])
+        self.assertEqual(zsam.even_stride(-1, 5), [])
+        self.assertEqual(zsam.even_stride(9, 1), [0])
+
+    def test_never_returns_a_duplicate_index(self):
+        # Rounding two strides onto the same index must not offer the same
+        # finding twice for labeling.
+        for population in range(1, 60):
+            for limit in range(1, 60):
+                indices = zsam.even_stride(population, limit)
+                self.assertEqual(len(indices), len(set(indices)), (population, limit))
+                self.assertTrue(all(0 <= i < population for i in indices), (population, limit))
+
+
+class BuildSampleTest(unittest.TestCase):
+    def setUp(self):
+        self.live_by_repo = {
+            "wagtail": [live("architecture.dead-module", f"w/{i}.py", i) for i in range(4)],
+            "excalidraw": [
+                live("architecture.dead-module", "e/a.ts", 1),
+                live("code-quality.long-function", "e/b.ts", 2),
+            ],
+        }
+
+    def test_only_the_requested_rule_is_sampled(self):
+        sample = zsam.build_sample(
+            "architecture.dead-module", "strict", self.live_by_repo, {}, limit=20
+        )
+        self.assertEqual(sample.population, 5)
+        self.assertTrue(all(c.finding.rule_id == "architecture.dead-module" for c in sample.selected))
+        self.assertEqual(sample.repos_with_findings, ("excalidraw", "wagtail"))
+
+    def test_ordering_is_stable_across_dict_iteration_order(self):
+        # Catches a sample that depends on repo insertion order, which would
+        # make the labeled evidence unreproducible on another machine.
+        reversed_input = dict(reversed(list(self.live_by_repo.items())))
+        first = zsam.build_sample("architecture.dead-module", "strict", self.live_by_repo, {}, limit=3)
+        second = zsam.build_sample("architecture.dead-module", "strict", reversed_input, {}, limit=3)
+        self.assertEqual(
+            [c.finding.id for c in first.selected],
+            [c.finding.id for c in second.selected],
+        )
+
+    def test_already_labeled_findings_are_excluded_and_counted(self):
+        # Re-running after a labeling pass must deepen coverage, not re-offer
+        # the same entries.
+        labeled = {"wagtail": {"architecture.dead-module:w/0.py:0000"}}
+        sample = zsam.build_sample(
+            "architecture.dead-module", "strict", self.live_by_repo, labeled, limit=20
+        )
+        self.assertEqual(sample.population, 4)
+        self.assertEqual(sample.already_labeled, 1)
+        self.assertNotIn(
+            "architecture.dead-module:w/0.py:0000", [c.finding.id for c in sample.selected]
+        )
+
+    def test_exhaustive_only_when_every_candidate_is_selected(self):
+        whole = zsam.build_sample("architecture.dead-module", "strict", self.live_by_repo, {}, limit=20)
+        self.assertTrue(whole.is_exhaustive)
+        subset = zsam.build_sample("architecture.dead-module", "strict", self.live_by_repo, {}, limit=2)
+        self.assertFalse(subset.is_exhaustive)
+
+    def test_unknown_rule_yields_an_empty_sample(self):
+        sample = zsam.build_sample("architecture.nope", "strict", self.live_by_repo, {}, limit=20)
+        self.assertEqual(sample.population, 0)
+        self.assertEqual(sample.selected, ())
+        self.assertIn("no strict-profile findings", zsam.render_frame(sample))
+
+
+class RenderFrameTest(unittest.TestCase):
+    def test_a_subset_is_labeled_as_a_sample(self):
+        # Catches a frame that lets a 20-of-1762 subset read as measured
+        # coverage of the rule.
+        live_by_repo = {"wagtail": [live("architecture.dead-module", f"w/{i}.py", i) for i in range(50)]}
+        frame = zsam.render_frame(
+            zsam.build_sample("architecture.dead-module", "strict", live_by_repo, {}, limit=5)
+        )
+        self.assertIn("SAMPLE, not exhaustive", frame)
+        self.assertIn("population:  50 unlabeled", frame)
+
+    def test_full_coverage_is_not_called_a_sample(self):
+        live_by_repo = {"wagtail": [live("architecture.dead-module", "w/0.py", 0)]}
+        frame = zsam.render_frame(
+            zsam.build_sample("architecture.dead-module", "strict", live_by_repo, {}, limit=5)
+        )
+        self.assertIn("exhaustive for the unlabeled population", frame)
+
+
+class SkeletonEvidenceTest(unittest.TestCase):
+    def test_sampler_skeletons_declare_the_sample_evidence_kind(self):
+        # Catches emitting a skeleton a maintainer would paste as an anchor,
+        # which would silently keep the rule out of the sampled scorecard.
+        skeleton = zt.triage_skeleton(live("architecture.dead-module", "a.py", 3), evidence="sample")
+        self.assertIn('evidence = "sample"', skeleton)
+
+    def test_triage_skeletons_stay_unmarked(self):
+        skeleton = zt.triage_skeleton(live("architecture.dead-module", "a.py", 3))
+        self.assertNotIn("evidence", skeleton)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_zoo_scorecard.py
+++ b/scripts/tests/test_zoo_scorecard.py
@@ -157,3 +157,88 @@ class RenderScorecardMarkdownTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def strict_toml(repo: str, entries: list[tuple[str, str, str, str]]) -> str:
+    """Expectation TOML for strict entries: (rule_id, disposition, path, evidence)."""
+    lines = [
+        "schema_version = 1",
+        f'repo = "{repo}"',
+        'default_coverage = "exhaustive"',
+        'strict_coverage = "selective"',
+        "",
+    ]
+    for rule_id, disposition, path, evidence in entries:
+        lines += [
+            "[[finding]]",
+            'profile = "strict"',
+            f'finding_id = "{rule_id}:{path}:deadbeef"',
+            f'rule_id = "{rule_id}"',
+            f'path = "{path}"',
+            f'evidence = "{evidence}"',
+            f'disposition = "{disposition}"',
+            'reason = "fixture reason"',
+            "",
+        ]
+    return "\n".join(lines)
+
+
+class StrictEvidenceKindTests(unittest.TestCase):
+    def test_hand_picked_anchors_are_excluded_from_sampled_precision(self) -> None:
+        # Catches counting recall anchors as measurement: an anchor is chosen
+        # *because* it is a known true positive, so aggregating it would report
+        # selection bias as a precision estimate.
+        with tempfile.TemporaryDirectory() as tmp:
+            expectation_dir = Path(tmp)
+            (expectation_dir / "repo-a.toml").write_text(
+                strict_toml(
+                    "repo-a",
+                    [
+                        ("architecture.dead-module", "actionable", "a.py", "anchor"),
+                        ("architecture.dead-module", "false-positive", "b.py", "sample"),
+                        ("architecture.dead-module", "actionable", "c.py", "sample"),
+                    ],
+                ),
+                encoding="utf-8",
+            )
+            manifest = [{"name": "repo-a"}]
+            sampled = zs.aggregate_rule_scores(manifest, expectation_dir, "strict", evidence="sample")
+            every_strict = zs.aggregate_rule_scores(manifest, expectation_dir, "strict")
+
+        self.assertEqual(sampled["architecture.dead-module"].labeled, 2)
+        self.assertAlmostEqual(sampled["architecture.dead-module"].precision_estimate, 0.5)
+        self.assertEqual(every_strict["architecture.dead-module"].labeled, 3)
+
+    def test_entries_default_to_anchor_when_evidence_is_omitted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            expectation_dir = Path(tmp)
+            (expectation_dir / "repo-a.toml").write_text(
+                expectation_toml("repo-a", [("strict", "architecture.dead-module", "actionable", "a.py")]),
+                encoding="utf-8",
+            )
+            manifest = [{"name": "repo-a"}]
+            sampled = zs.aggregate_rule_scores(manifest, expectation_dir, "strict", evidence="sample")
+        self.assertEqual(sampled, {}, "an unmarked strict entry is an anchor, not a sample")
+
+
+class StrictSampleSectionTests(unittest.TestCase):
+    def test_section_names_itself_a_sample_and_lists_only_sampled_rules(self) -> None:
+        scores = {
+            "architecture.dead-module": zs.RuleScore(
+                rule_id="architecture.dead-module",
+                labeled=20,
+                actionable=4,
+                valid_but_accepted=1,
+                false_positive=15,
+                repos={"repo-a", "repo-b"},
+            )
+        }
+        markdown = "\n".join(zs.render_strict_sample_section(scores, {"architecture.dead-module": "experimental"}))
+        self.assertIn("20 sampled across 2 repo(s)", markdown)
+        self.assertIn("0.25", markdown)
+        self.assertIn("not the rule's full", markdown)
+
+    def test_empty_section_says_so_instead_of_rendering_an_empty_table(self) -> None:
+        markdown = "\n".join(zs.render_strict_sample_section({}, {}))
+        self.assertIn("No rule has strict-profile sampled evidence yet.", markdown)
+        self.assertNotIn("|---|", markdown)

--- a/scripts/zoo.py
+++ b/scripts/zoo.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 import zoo_expectations as ze
+import zoo_sample as zsam
 import zoo_scorecard as zs
 import zoo_triage as zt
 from zoo_scanner import (
@@ -447,6 +448,51 @@ def cmd_triage(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_sample(args: argparse.Namespace) -> int:
+    if args.limit <= 0:
+        print("--limit must be positive", file=sys.stderr)
+        return 2
+    repos = select(load_manifest(), args.only)
+    try:
+        scanner = prepare_scanner(REPO_ROOT, args.repopilot, args.allow_version_mismatch)
+    except ScannerPreparationError as exc:
+        print(f"SCANNER PREPARATION FAILED\n{exc}", file=sys.stderr)
+        return 2
+    except ScannerProvenanceError as exc:
+        print(f"SCANNER PROVENANCE FAILED\n{exc}", file=sys.stderr)
+        return 3
+
+    print_scanner_provenance(scanner)
+    live_by_repo: dict[str, list[ze.LiveFinding]] = {}
+    labeled_by_repo: dict[str, set[str]] = {}
+    for repo in repos:
+        path = repo_path(repo)
+        if not path.exists():
+            print(f"  {repo['name']}: NOT CLONED (run `zoo.py clone`), skip")
+            continue
+        report = scan_repo(scanner, path, args.profile)
+        live_by_repo[repo["name"]] = ze.parse_live_findings(report, path, args.profile)
+        expectation, _ = ze.parse_expectation_file(expectation_path(repo["name"]), repo["name"])
+        labeled_by_repo[repo["name"]] = (
+            {finding.finding_id for finding in expectation.findings} if expectation else set()
+        )
+
+    sample = zsam.build_sample(args.rule, args.profile, live_by_repo, labeled_by_repo, args.limit)
+    print(f"\n===== sample =====\n\n{zsam.render_frame(sample)}\n")
+    if not sample.selected:
+        return 0
+    # Default-profile entries are exhaustive by contract and carry no evidence
+    # kind; only a strict entry needs to declare that it came from the sampler.
+    evidence_kind = "sample" if args.profile == "strict" else None
+    print(
+        "Paste the skeleton(s) below into the matching "
+        "tests/zoo/expectations/<repo>.toml and label each one.\n"
+    )
+    for candidate in sample.selected:
+        print(zt.render_triage_entry(candidate.repo, candidate.finding, evidence=evidence_kind))
+    return 0
+
+
 def select(repos: list[dict[str, Any]], only: str | None) -> list[dict[str, Any]]:
     if not only:
         return repos
@@ -498,6 +544,26 @@ def main() -> int:
         help="allow --repopilot to use a version that differs from this workspace",
     )
     p_triage.set_defaults(func=cmd_triage)
+
+    p_sample = sub.add_parser(
+        "sample", help="print a deterministic labelable sample of one rule's findings"
+    )
+    p_sample.add_argument("--rule", required=True, help="rule id to sample, e.g. architecture.dead-module")
+    p_sample.add_argument(
+        "--profile",
+        default="strict",
+        choices=("default", "strict"),
+        help="finding visibility profile to sample (default: strict)",
+    )
+    p_sample.add_argument("--limit", type=int, default=20, help="how many findings to select (default: 20)")
+    p_sample.add_argument("--only", help="comma-separated repo names")
+    p_sample.add_argument("--repopilot", help="explicit path to an external repopilot binary")
+    p_sample.add_argument(
+        "--allow-version-mismatch",
+        action="store_true",
+        help="allow --repopilot to use a version that differs from this workspace",
+    )
+    p_sample.set_defaults(func=cmd_sample)
 
     sub.add_parser("report", help="aggregate snapshots into a triage table").set_defaults(func=cmd_report)
 

--- a/scripts/zoo_expectations.py
+++ b/scripts/zoo_expectations.py
@@ -32,8 +32,16 @@ DISPOSITIONS = ("actionable", "valid-but-accepted", "false-positive")
 PROFILES = ("default", "strict")
 COVERAGE = ("exhaustive", "selective")
 
+# Why a strict entry exists. An `anchor` is hand-picked to prove one known
+# finding survives into strict, so its disposition says nothing about the rule's
+# precision. A `sample` is drawn by `zoo.py sample`, which selects without
+# looking at the finding, so those dispositions *can* be aggregated. Default
+# entries are exhaustive and carry the anchor default unused.
+EVIDENCE_KINDS = ("anchor", "sample")
+DEFAULT_EVIDENCE_KIND = "anchor"
+
 # Optional, never-required metadata fields a reviewer may attach to an entry.
-OPTIONAL_FINDING_KEYS = ("line", "line_end", "issue", "notes", "reviewed_by", "expires")
+OPTIONAL_FINDING_KEYS = ("line", "line_end", "issue", "notes", "reviewed_by", "expires", "evidence")
 REQUIRED_FINDING_KEYS = ("profile", "finding_id", "rule_id", "path", "disposition", "reason")
 ALLOWED_FINDING_KEYS = set(REQUIRED_FINDING_KEYS) | set(OPTIONAL_FINDING_KEYS)
 
@@ -88,6 +96,7 @@ class ExpectationFinding:
     notes: str | None = None
     reviewed_by: str | None = None
     expires: str | None = None
+    evidence: str = DEFAULT_EVIDENCE_KIND
     index: int = 0  # 1-based position in file, for diagnostics
 
     def identity(self) -> tuple[str, str, str, str, int | None, int | None]:
@@ -282,6 +291,12 @@ def _parse_finding(
         if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
             return fail(f"has a non-integer {key} {value!r}")
 
+    evidence = raw.get("evidence", DEFAULT_EVIDENCE_KIND)
+    if evidence not in EVIDENCE_KINDS:
+        return fail(f"has unknown evidence {evidence!r} (expected one of {EVIDENCE_KINDS})")
+    if evidence == "sample" and profile != "strict":
+        return fail("marks a default-profile entry as a sample; the default profile is labeled exhaustively")
+
     return (
         ExpectationFinding(
             profile=profile,
@@ -296,6 +311,7 @@ def _parse_finding(
             notes=raw.get("notes"),
             reviewed_by=raw.get("reviewed_by"),
             expires=raw.get("expires"),
+            evidence=evidence,
             index=position,
         ),
         [],

--- a/scripts/zoo_sample.py
+++ b/scripts/zoo_sample.py
@@ -1,0 +1,145 @@
+"""Deterministic per-rule sampling of zoo findings for precision measurement.
+
+The expectation layer labels the *default* profile exhaustively, which works
+because a healthy default profile is small. The strict profile is far too large
+to label that way, so today most of the rule catalog carries no measured
+evidence at all: a rule that only ever fires in strict can never earn a
+precision estimate.
+
+Sampling closes that gap. Given one rule, this module picks a fixed-size,
+reproducible subset of that rule's findings across the whole zoo, which a
+maintainer labels like any other expectation. The resulting numbers are a
+*sample*, never exhaustive coverage, and every caller is expected to say so.
+
+Two properties make the sample trustworthy:
+
+  * **Deterministic** — findings are ordered by `(repo, path, line, id)` and the
+    subset is chosen by even stride, so the same pinned zoo yields the same
+    sample on every machine and every re-run.
+  * **Spread** — even stride walks the whole ordered population instead of
+    taking the alphabetically first N, so one large repository or one crowded
+    directory cannot stand in for the rule's behavior everywhere.
+
+Already-labeled findings are excluded, so re-running after a labeling pass
+deepens coverage instead of re-offering the same entries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from zoo_expectations import LiveFinding
+
+
+@dataclass(frozen=True)
+class SampleCandidate:
+    """One finding eligible for labeling, tagged with the repo it came from."""
+
+    repo: str
+    finding: LiveFinding
+
+    @property
+    def sort_key(self) -> tuple[str, str, int, str]:
+        line = self.finding.line if self.finding.line is not None else -1
+        return (self.repo, self.finding.path, line, self.finding.id)
+
+
+@dataclass(frozen=True)
+class RuleSample:
+    """A reproducible subset of one rule's findings, plus its sampling frame."""
+
+    rule_id: str
+    profile: str
+    population: int
+    already_labeled: int
+    repos_with_findings: tuple[str, ...]
+    selected: tuple[SampleCandidate, ...]
+
+    @property
+    def is_exhaustive(self) -> bool:
+        """True when the sample is the whole eligible population, not a subset."""
+        return len(self.selected) == self.population
+
+
+def collect_candidates(
+    rule_id: str,
+    live_by_repo: dict[str, list[LiveFinding]],
+    labeled_ids_by_repo: dict[str, set[str]],
+) -> list[SampleCandidate]:
+    """Every unlabeled finding of `rule_id`, ordered deterministically.
+
+    `labeled_ids_by_repo` carries the finding ids a repo's expectation file
+    already dispositions, in any profile — re-labeling one is not useful work.
+    """
+    candidates = [
+        SampleCandidate(repo=repo, finding=finding)
+        for repo, findings in live_by_repo.items()
+        for finding in findings
+        if finding.rule_id == rule_id and finding.id not in labeled_ids_by_repo.get(repo, set())
+    ]
+    candidates.sort(key=lambda candidate: candidate.sort_key)
+    return candidates
+
+
+def even_stride(population: int, limit: int) -> list[int]:
+    """Indices of `limit` items spread evenly across `population` items.
+
+    The first and last items are always included when more than one is picked,
+    so the sample spans the full ordered population rather than clustering at
+    its start. Returns every index when the population is at or below `limit`.
+    """
+    if population <= 0 or limit <= 0:
+        return []
+    if population <= limit:
+        return list(range(population))
+    if limit == 1:
+        return [0]
+    step = (population - 1) / (limit - 1)
+    return sorted({round(index * step) for index in range(limit)})
+
+
+def build_sample(
+    rule_id: str,
+    profile: str,
+    live_by_repo: dict[str, list[LiveFinding]],
+    labeled_ids_by_repo: dict[str, set[str]],
+    limit: int,
+) -> RuleSample:
+    candidates = collect_candidates(rule_id, live_by_repo, labeled_ids_by_repo)
+    already_labeled = sum(
+        1
+        for repo, findings in live_by_repo.items()
+        for finding in findings
+        if finding.rule_id == rule_id and finding.id in labeled_ids_by_repo.get(repo, set())
+    )
+    repos = sorted({candidate.repo for candidate in candidates})
+    selected = tuple(candidates[index] for index in even_stride(len(candidates), limit))
+    return RuleSample(
+        rule_id=rule_id,
+        profile=profile,
+        population=len(candidates),
+        already_labeled=already_labeled,
+        repos_with_findings=tuple(repos),
+        selected=selected,
+    )
+
+
+def render_frame(sample: RuleSample) -> str:
+    """The sampling frame, printed above the entries so labels stay honest.
+
+    Anyone reading the resulting dispositions must be able to tell measured
+    coverage from a subset without re-deriving it.
+    """
+    if sample.population == 0 and sample.already_labeled == 0:
+        return f"rule `{sample.rule_id}` has no {sample.profile}-profile findings in the zoo"
+    coverage = "exhaustive for the unlabeled population" if sample.is_exhaustive else "SAMPLE, not exhaustive"
+    repos = ", ".join(sample.repos_with_findings) or "none"
+    return "\n".join(
+        [
+            f"rule:        {sample.rule_id}",
+            f"profile:     {sample.profile}",
+            f"population:  {sample.population} unlabeled ({sample.already_labeled} already labeled)",
+            f"repos:       {repos}",
+            f"selected:    {len(sample.selected)} by even stride — {coverage}",
+        ]
+    )

--- a/scripts/zoo_scorecard.py
+++ b/scripts/zoo_scorecard.py
@@ -66,8 +66,21 @@ def load_rule_lifecycles(rules_reference_path: Path) -> dict[str, str]:
     return lifecycles
 
 
-def aggregate_rule_scores(manifest: list[dict[str, Any]], expectation_dir: Path) -> dict[str, RuleScore]:
-    """Aggregate every committed expectation file's default-profile findings by rule_id."""
+def aggregate_rule_scores(
+    manifest: list[dict[str, Any]],
+    expectation_dir: Path,
+    profile: str = "default",
+    evidence: str | None = None,
+) -> dict[str, RuleScore]:
+    """Aggregate every committed expectation file's findings for one profile.
+
+    The two profiles are never mixed into one number: `default` labels are
+    exhaustive per repo, while `strict` labels cover only what a reviewer chose
+    to record, and averaging the two would present partial coverage as measured
+    coverage. Passing `evidence` narrows a strict aggregate to one kind — only
+    `sample` entries are drawn without looking at the finding, so only they can
+    support a precision estimate.
+    """
     scores: dict[str, RuleScore] = {}
     for repo in manifest:
         name = repo["name"]
@@ -75,7 +88,9 @@ def aggregate_rule_scores(manifest: list[dict[str, Any]], expectation_dir: Path)
         if expectation is None:
             continue
         for finding in expectation.findings:
-            if finding.profile != "default":
+            if finding.profile != profile:
+                continue
+            if evidence is not None and finding.evidence != evidence:
                 continue
             score = scores.setdefault(finding.rule_id, RuleScore(rule_id=finding.rule_id))
             score.labeled += 1
@@ -89,12 +104,56 @@ def aggregate_rule_scores(manifest: list[dict[str, Any]], expectation_dir: Path)
     return scores
 
 
-def render_scorecard_markdown(scores: dict[str, RuleScore], lifecycles: dict[str, str]) -> str:
+def render_strict_sample_section(scores: dict[str, RuleScore], lifecycles: dict[str, str]) -> list[str]:
+    """The strict-profile table: sampled evidence, listed apart from the default one.
+
+    Only rules a maintainer actually sampled appear here. A rule that fires
+    thousands of times in strict is unmeasurable by exhaustive labeling, so a
+    reproducible subset (`zoo.py sample --rule <id>`) is the only evidence it can
+    earn — and it must never be read as coverage of the whole population.
+    """
+    lines = [
+        "",
+        "## Strict-profile sampled evidence",
+        "",
+        "Rules that fire only in the strict profile are too numerous to label "
+        "exhaustively. These rows come from deterministic per-rule samples "
+        "(`python3 scripts/zoo.py sample --rule <id>`), so the precision "
+        "estimate describes the sampled findings, not the rule's full "
+        "strict-profile population. A rule missing from this table has no "
+        "sampled evidence at all.",
+        "",
+    ]
+    sampled = {rule_id: score for rule_id, score in scores.items() if score.labeled > 0}
+    if not sampled:
+        lines.append("No rule has strict-profile sampled evidence yet.")
+        lines.append("")
+        return lines
+    lines.append("| Rule | Lifecycle | Sampled | Precision Estimate | False-Positive Debt |")
+    lines.append("|---|---|---|---:|---:|")
+    for rule_id in sorted(sampled):
+        score = sampled[rule_id]
+        lifecycle = lifecycles.get(rule_id, "unknown")
+        sample = f"{score.labeled} sampled across {len(score.repos)} repo(s)"
+        lines.append(
+            f"| `{rule_id}` | {lifecycle} | {sample} | "
+            f"{score.precision_estimate:.2f} | {score.false_positive} |"
+        )
+    lines.append("")
+    return lines
+
+
+def render_scorecard_markdown(
+    scores: dict[str, RuleScore],
+    lifecycles: dict[str, str],
+    strict_scores: dict[str, RuleScore] | None = None,
+) -> str:
     """Render the deterministic committed rule scorecard.
 
     One row per rule known to either source, so a rule with zero zoo evidence
     still appears (a coverage gap is itself useful signal) and a stale
     expectation referencing a since-renamed rule doesn't silently vanish.
+    `strict_scores` adds the separate sampled-evidence table.
     """
     lines = [
         "# RepoPilot Rule Scorecard",
@@ -111,6 +170,13 @@ def render_scorecard_markdown(scores: dict[str, RuleScore], lifecycles: dict[str
         "suppress the finding, so debt reflects outstanding calibration work, "
         "not detector correctness at large.",
         "",
+        "## Default-profile evidence",
+        "",
+        "Every default-visible zoo finding is labeled, so these rows are "
+        "exhaustive for the pinned repositories. `no zoo evidence` means the "
+        "rule never fired in the default profile on any of them — the rule is "
+        "unmeasured, which is not the same as clean.",
+        "",
         "| Rule | Lifecycle | Zoo Evidence | Precision Estimate | False-Positive Debt |",
         "|---|---|---|---:|---:|",
     ]
@@ -124,12 +190,13 @@ def render_scorecard_markdown(scores: dict[str, RuleScore], lifecycles: dict[str
             precision = f"{score.precision_estimate:.2f}"
             debt = str(score.false_positive)
         lines.append(f"| `{rule_id}` | {lifecycle} | {evidence} | {precision} | {debt} |")
-    lines.append("")
+    lines += render_strict_sample_section(strict_scores or {}, lifecycles)
     return "\n".join(lines)
 
 
 def generate_scorecard(manifest: list[dict[str, Any]], expectation_dir: Path, rules_reference_path: Path) -> str:
     """Convenience wrapper: aggregate + parse lifecycles + render, in one call."""
-    scores = aggregate_rule_scores(manifest, expectation_dir)
+    scores = aggregate_rule_scores(manifest, expectation_dir, "default")
+    strict_scores = aggregate_rule_scores(manifest, expectation_dir, "strict", evidence="sample")
     lifecycles = load_rule_lifecycles(rules_reference_path)
-    return render_scorecard_markdown(scores, lifecycles)
+    return render_scorecard_markdown(scores, lifecycles, strict_scores)

--- a/scripts/zoo_triage.py
+++ b/scripts/zoo_triage.py
@@ -14,7 +14,7 @@ from zoo_expectations import SCHEMA_VERSION, LiveFinding
 REVIEW_REQUIRED = "REVIEW_REQUIRED"
 
 
-def triage_skeleton(live: LiveFinding) -> str:
+def triage_skeleton(live: LiveFinding, evidence: str | None = None) -> str:
     lines = [
         "[[finding]]",
         f'profile = "{live.profile}"',
@@ -24,12 +24,16 @@ def triage_skeleton(live: LiveFinding) -> str:
     ]
     if live.line is not None:
         lines.append(f"line = {live.line}")
+    # Only an entry the sampler drew may claim `sample`; a hand-picked strict
+    # anchor keeps the default kind, so aggregates stay free of selection bias.
+    if evidence is not None:
+        lines.append(f'evidence = "{evidence}"')
     lines.append(f'disposition = "{REVIEW_REQUIRED}"  # actionable | valid-but-accepted | false-positive')
     lines.append('reason = ""')
     return "\n".join(lines)
 
 
-def render_triage_entry(repo: str, live: LiveFinding) -> str:
+def render_triage_entry(repo: str, live: LiveFinding, evidence: str | None = None) -> str:
     line = f"{live.line}" if live.line is not None else "?"
     snippet = live.snippet.replace("\n", "\\n")
     if len(snippet) > 160:
@@ -46,7 +50,7 @@ def render_triage_entry(repo: str, live: LiveFinding) -> str:
         f"title:       {live.title}",
         f"evidence:    {snippet}",
     ]
-    return "\n".join(header) + "\n\n" + triage_skeleton(live) + "\n"
+    return "\n".join(header) + "\n\n" + triage_skeleton(live, evidence) + "\n"
 
 
 def skeleton_file_text(repo: str, lives: list[LiveFinding]) -> str:

--- a/tests/zoo/README.md
+++ b/tests/zoo/README.md
@@ -51,6 +51,10 @@ python3 scripts/zoo.py triage --only excalidraw
 
 # 5. Report: per-rule table + reviewed signal-quality summary.
 python3 scripts/zoo.py report
+
+# 6. Sample: measure a rule that only fires in strict, where exhaustive
+#    labeling is impossible. Deterministic, so the same pins give the same picks.
+python3 scripts/zoo.py sample --rule architecture.dead-module --limit 20
 ```
 
 Other helpers: `python3 scripts/zoo.py list` (manifest table),
@@ -87,6 +91,28 @@ share a stable id), plus free-form `issue`, `notes`, `reviewed_by`, `expires`.
   allowed. Anchors pin intentionally downgraded signals (e.g. the public Algolia
   DocSearch key, a test-support panic, a CLI command-handler `process.exit`, a
   Python `assert`) so a downgrade can never silently become a full suppression.
+
+## Anchors vs. samples
+
+A strict entry declares *why* it exists through the optional `evidence` field:
+
+- **`anchor`** (the default) — hand-picked to prove one known finding survives
+  into strict. It is chosen *because* of what it is, so its disposition says
+  nothing about how often the rule is right.
+- **`sample`** — drawn by `zoo.py sample`, which selects by position in a sorted
+  population without looking at the finding. Only these feed the scorecard's
+  strict precision estimate.
+
+`sample` is strict-only: the default profile is already exhaustive, so a sample
+of it would be a coverage regression rather than new evidence.
+
+Sampling is how a rule that never appears in the default profile earns measured
+evidence at all. `zoo.py sample` orders every matching finding by
+`(repo, path, line, id)` and picks `--limit` of them by even stride, so the
+selection spans the whole population, reproduces on any machine, and skips
+entries already labeled — re-running after a labeling pass deepens coverage
+instead of re-offering the same rows. The numbers it produces describe the
+sample, never the rule's full strict population, and the scorecard says so.
 
 ## Common tasks
 

--- a/tests/zoo/expectations/changesets.toml
+++ b/tests/zoo/expectations/changesets.toml
@@ -18,3 +18,13 @@ rule_id = "architecture.circular-dependency"
 path = "packages/cli/src/commands/publish/npm-utils.ts"
 disposition = "actionable"
 reason = "Real two-node eager import cycle between npm-utils.ts and publishPackages.ts inside the publish command."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:eslint.config.mjs:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "eslint.config.mjs"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "ESLint flat config, loaded by the `eslint` binary declared in package.json — a tool entrypoint is never imported by project code, so zero fan-in is expected rather than dead."

--- a/tests/zoo/expectations/express.toml
+++ b/tests/zoo/expectations/express.toml
@@ -4,3 +4,13 @@ default_coverage = "exhaustive"
 strict_coverage = "selective"
 
 # express emits no default-visible findings at the pinned SHA.
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:test/app.render.js:5f75afc99cf552b5"
+rule_id = "architecture.dead-module"
+path = "test/app.render.js"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "A mocha test file under `test/`, discovered by the runner rather than imported. The finding also reports role=Production, so the role classifier missed the test directory."

--- a/tests/zoo/expectations/fastapi.toml
+++ b/tests/zoo/expectations/fastapi.toml
@@ -27,3 +27,13 @@ path = "fastapi/applications.py"
 line = 926
 disposition = "valid-but-accepted"
 reason = "assert in a production path used as an internal precondition; downgraded to Low and retained as a strict recall anchor for the Python assert signal."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:docs_src/query_params_str_validations/tutorial008_an_py310.py:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "docs_src/query_params_str_validations/tutorial008_an_py310.py"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Documentation example imported dynamically by tests/test_tutorial/test_query_params_str_validations/test_tutorial008.py, which names the module in a `pytest.param` string. No static edge exists to find."

--- a/tests/zoo/expectations/nowinandroid.toml
+++ b/tests/zoo/expectations/nowinandroid.toml
@@ -10,3 +10,13 @@ rule_id = "language.managed.fatal-exception-risk"
 path = "feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt"
 disposition = "actionable"
 reason = "TODO() placeholder on the TopicUiState.Error branch will throw NotImplementedError at runtime if the error state is ever rendered; the rule correctly surfaces an unimplemented production path."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:settings.gradle.kts:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "settings.gradle.kts"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Gradle settings script, executed by the build tool and never imported. The same scan reports 2058 unresolved internal imports in this repository, so absence of an edge proves nothing here."

--- a/tests/zoo/expectations/wagtail.toml
+++ b/tests/zoo/expectations/wagtail.toml
@@ -45,3 +45,23 @@ path = "wagtail/project_template/project_name/settings/production.py"
 line = 12
 disposition = "false-positive"
 reason = "Same guarded optional `from .local import *` override as dev.py; the import is wrapped in try/except ImportError."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:wagtail/management/commands/purge_revisions.py:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "wagtail/management/commands/purge_revisions.py"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Django management command, discovered by convention from `management/commands/` and invoked by name. Commands are entrypoints, so zero fan-in is the expected shape."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:wagtail/users/wagtail_hooks.py:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "wagtail/users/wagtail_hooks.py"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Autoloaded by convention: wagtail/hooks.py calls `get_app_submodules(\"wagtail_hooks\")`, so every app's wagtail_hooks module is imported dynamically and never appears as a static edge."

--- a/tests/zoo_runner_contract.rs
+++ b/tests/zoo_runner_contract.rs
@@ -31,6 +31,7 @@ impl Harness {
         copy_script(&root, "zoo.py");
         copy_script(&root, "zoo_scanner.py");
         copy_script(&root, "zoo_expectations.py");
+        copy_script(&root, "zoo_sample.py");
         copy_script(&root, "zoo_scorecard.py");
         copy_script(&root, "zoo_triage.py");
         fs::write(root.join("Cargo.toml"), CARGO_TOML).expect("Cargo.toml");


### PR DESCRIPTION
## Summary

Makes strict-only rules measurable. `zoo.py sample --rule <id>` draws a deterministic, evenly spread subset of one rule's findings to label, and the scorecard reports that sampled evidence in its own table. First measured rule: `architecture.dead-module`, 6 sampled across 5 repos, 6 false positives.

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- New `scripts/zoo_sample.py`: `even_stride` selection over a population ordered by `(repo, path, line, id)`, exclusion of already-labeled findings, and a printed sampling frame that names a subset a SAMPLE.
- New `zoo.py sample` subcommand (`--rule`, `--profile`, `--limit`, `--only`), emitting labelable TOML skeletons through the existing triage renderer.
- Expectation schema: optional `evidence = "anchor" | "sample"` on a finding,  defaulting to `anchor`. `sample` is rejected on default-profile entries.
- `zoo_scorecard.py`: `aggregate_rule_scores` takes a profile and an optional evidence kind; a second table renders strict sampled evidence, and the default table gained a heading explaining that `no zoo evidence` means unmeasured.
- 12 new Python tests; `zoo_runner_contract.rs` copies the new module.
- First labeled sample: 6 `architecture.dead-module` findings across changesets, express, fastapi, nowinandroid, and wagtail.

## Why

The release contract requires labeled real-repository evidence before a rule can become stable or affect the default verdict. Today 46 of 53 rules have none - including 4 of the 5 stable ones  and that is structural, not neglect:
`default_coverage` is exhaustive but the default profile only produces 27 findings across the whole zoo, while strict produces 7001. A rule that never fires in default can never be labeled, so it can never be measured, so Phase C's
"stable and default-visible rules have labeled zoo evidence" is unreachable.

Sampling is the only way to attach a number to a 1762-finding rule. It has to be deterministic, or the evidence is not reproducible; it has to spread across the ordered population, or one crowded directory speaks for the rule everywhere; and it has to be distinguishable from a hand-picked anchor, or selection bias gets reported as precision. All three are enforced by tests.

## What the first sample found

`architecture.dead-module` — 1762 strict findings, the largest rule in the catalog — scored **0.00 over 6 sampled findings**. All six are entrypoints the import graph cannot see:

| Repo | Path | Why it is not dead |
|---|---|---|
| changesets | `eslint.config.mjs` | flat config loaded by the `eslint` binary |
| express | `test/app.render.js` | mocha-discovered test, also misclassified `role=Production` |
| fastapi | `docs_src/.../tutorial008_an_py310.py` | imported by a `pytest.param` string |
| nowinandroid | `settings.gradle.kts` | Gradle build script |
| wagtail | `management/commands/purge_revisions.py` | Django management command |
| wagtail | `users/wagtail_hooks.py` | autoloaded via `get_app_submodules("wagtail_hooks")` |

nowinandroid also reports 2058 unresolved internal imports in the same scan, so an absence claim there rests on a graph that resolved almost nothing.

This does not change the rule — expectations never suppress. It records the debt so the fix can be scoped against evidence.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

Subsystem: the zoo evidence layer (`scripts/zoo*`, `tests/zoo/`). No analyzer, rule, finding, or public schema change - RepoPilot's output is byte-identical. The expectation schema change is additive with a default, so every existing file stays valid at `schema_version = 1`. No claim here exceeds its evidence: six labeled findings are reported as six, in a table that says it is a sample.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 -m unittest discover -s scripts/tests -p 'test_*.py'
python3 scripts/release-contract.py check
cargo run -- scan . --fail-on-priority p1
```