### PR TITLE
fix: stop calling non-imported entrypoints dead modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,20 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- `architecture.dead-module` no longer treats a file as dead when nothing
+  imports it *by design*. Executable tool configuration (`eslint.config.mjs`,
+  `.prettierrc.cjs`), build scripts (`settings.gradle.kts`, `gulpfile.js`),
+  framework-autoloaded Python modules (`management/commands/*`, `migrations/*`,
+  `conftest.py`, `wagtail_hooks.py`, Django app plumbing), file-system routes
+  (Next.js and Expo Router reserved names inside `app/`/`pages/`), documentation
+  and example sources, and standalone `scripts/` are all reached without an
+  import, so zero fan-in is their healthy state. Each recognizer names the
+  loader that reads the file, and reserved names apply only inside the directory
+  that reserves them, so an ordinary `page.tsx` or a CQRS `commands/` handler
+  stays eligible. Across the eleven zoo repositories this removes 1103 of 1762
+  strict findings (63%) with no change to any other rule and no change to the
+  default profile, which the rule never reached.
+
 - Preserve import source spans in parsed-facts cache schema v3 and
   repository-context cache schema v6. Full and warm changed scans now attach the
   same exact import-line evidence without reading or parsing files a second time.

--- a/docs/engineering/rule-scorecard.md
+++ b/docs/engineering/rule-scorecard.md
@@ -71,4 +71,4 @@ Rules that fire only in the strict profile are too numerous to label exhaustivel
 
 | Rule | Lifecycle | Sampled | Precision Estimate | False-Positive Debt |
 |---|---|---|---:|---:|
-| `architecture.dead-module` | experimental | 6 sampled across 5 repo(s) | 0.00 | 6 |
+| `architecture.dead-module` | experimental | 9 sampled across 5 repo(s) | 0.00 | 9 |

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -131,6 +131,21 @@ Definition of done:
 Turn isolated architecture and code-quality findings into a bounded maintainer
 view without inventing a second scoring system.
 
+Current progress:
+
+- Signal-quality measurement is in place ahead of the health view. Rules that
+  only fire in the strict profile are measured by deterministic per-rule
+  sampling (`scripts/zoo.py sample`), so the catalog's unmeasured majority can
+  earn evidence without exhaustive labeling.
+- `architecture.dead-module` was the first rule measured, at 0.00 precision. Its
+  entrypoint model now covers files reached without an import, cutting the zoo
+  population from 1762 to 659 strict findings. The sampled false positives that
+  remain name the next slices: namespace-based languages (C#, Java, Kotlin)
+  where the file-import graph has no edges to count, test files under a singular
+  `test/` directory or a bare `tests.py`, vendored third-party bundles,
+  convention-loaded CLI command directories, and Python modules referenced by
+  dotted string.
+
 Deliverables:
 
 - graph-derived hotspots and cross-boundary coupling;

--- a/scripts/tests/test_zoo_sample.py
+++ b/scripts/tests/test_zoo_sample.py
@@ -8,7 +8,8 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
-import zoo_sample as zsam  # noqa: E402  (after the sys.path fix above)
+import zoo_expectations as ze  # noqa: E402  (after the sys.path fix above)
+import zoo_sample as zsam  # noqa: E402
 import zoo_triage as zt  # noqa: E402
 from zoo_expectations import LiveFinding  # noqa: E402
 
@@ -140,6 +141,39 @@ class SkeletonEvidenceTest(unittest.TestCase):
     def test_triage_skeletons_stay_unmarked(self):
         skeleton = zt.triage_skeleton(live("architecture.dead-module", "a.py", 3))
         self.assertNotIn("evidence", skeleton)
+
+
+class ResolvedSampleTest(unittest.TestCase):
+    def strict_expectation(self, evidence: str) -> ze.Expectation:
+        return ze.Expectation(
+            repo="repo-a",
+            schema_version=ze.SCHEMA_VERSION,
+            default_coverage="exhaustive",
+            strict_coverage="selective",
+            findings=(
+                ze.ExpectationFinding(
+                    profile="strict",
+                    finding_id="architecture.dead-module:a.py:dead",
+                    rule_id="architecture.dead-module",
+                    path="a.py",
+                    disposition="false-positive",
+                    reason="fixture reason",
+                    evidence=evidence,
+                ),
+            ),
+            source="repo-a.toml",
+        )
+
+    def test_a_fixed_sample_reads_as_resolved_not_as_a_lost_anchor(self):
+        # Catches telling a maintainer their recall anchor vanished when what
+        # actually happened is that the sampled false positive got fixed.
+        diags, _ = ze.match_repo("repo-a", self.strict_expectation("sample"), [], [])
+        self.assertEqual([d.kind for d in diags], [ze.RESOLVED_STRICT_SAMPLE])
+        self.assertIn("delete this entry and re-sample", diags[0].message)
+
+    def test_a_missing_anchor_still_reports_a_recall_regression(self):
+        diags, _ = ze.match_repo("repo-a", self.strict_expectation("anchor"), [], [])
+        self.assertEqual([d.kind for d in diags], [ze.MISSING_STRICT_RECALL_ANCHOR])
 
 
 if __name__ == "__main__":

--- a/scripts/zoo_expectations.py
+++ b/scripts/zoo_expectations.py
@@ -55,6 +55,7 @@ DUPLICATE_EXPECTATION = "DUPLICATE EXPECTATION"
 INVALID_EXPECTATION = "INVALID EXPECTATION"
 AMBIGUOUS_EXPECTATION = "AMBIGUOUS EXPECTATION"
 MISSING_STRICT_RECALL_ANCHOR = "MISSING STRICT RECALL ANCHOR"
+RESOLVED_STRICT_SAMPLE = "RESOLVED STRICT SAMPLE"
 MISSING_EXPECTATION_FILE = "MISSING EXPECTATION FILE"
 UNKNOWN_EXPECTATION_FILE = "UNKNOWN EXPECTATION FILE"
 KNOWN_FALSE_POSITIVE = "KNOWN FALSE POSITIVE"
@@ -70,6 +71,7 @@ DIAGNOSTIC_ORDER = (
     MISSING_EXPECTATION_FILE,
     UNKNOWN_EXPECTATION_FILE,
     MISSING_STRICT_RECALL_ANCHOR,
+    RESOLVED_STRICT_SAMPLE,
     KNOWN_FALSE_POSITIVE,
 )
 
@@ -408,8 +410,7 @@ def _match_profile(
     for exp in exps:
         matched = exp_matches[id(exp)]
         if len(matched) == 0:
-            kind = STALE_EXPECTATION if exhaustive else MISSING_STRICT_RECALL_ANCHOR
-            diags.append(Diagnostic(kind, repo, _describe_exp(exp)))
+            diags.append(Diagnostic(*_unmatched(repo, exp, exhaustive)))
         elif len(matched) > 1:
             diags.append(
                 Diagnostic(
@@ -457,6 +458,27 @@ def _count_disposition(
                 f"{exp.profile} {_describe_live(live)} — reviewed false positive: {exp.reason}",
             )
         )
+
+
+def _unmatched(repo: str, exp: ExpectationFinding, exhaustive: bool) -> tuple[str, str, str]:
+    """Classify an expectation whose finding is no longer emitted.
+
+    A recall *anchor* that stops matching is a regression: the downgraded signal
+    it pinned has gone missing from strict. A *sample* that stops matching is the
+    opposite — the sampled finding was fixed, which is the point of measuring it
+    — so it says to delete the entry and re-sample rather than reporting a lost
+    anchor a reader would go hunting for.
+    """
+    if exhaustive:
+        return (STALE_EXPECTATION, repo, _describe_exp(exp))
+    if exp.evidence == "sample":
+        return (
+            RESOLVED_STRICT_SAMPLE,
+            repo,
+            f"sampled finding is no longer emitted — delete this entry and re-sample "
+            f"the rule to measure current behavior: {_describe_exp(exp)}",
+        )
+    return (MISSING_STRICT_RECALL_ANCHOR, repo, _describe_exp(exp))
 
 
 def _describe_exp(exp: ExpectationFinding) -> str:

--- a/src/audits/architecture/graph_queries/entrypoints.rs
+++ b/src/audits/architecture/graph_queries/entrypoints.rs
@@ -1,0 +1,185 @@
+//! Files nothing imports *by design*, so zero fan-in is not evidence of death.
+//!
+//! `architecture.dead-module` reasons from an absence: no file imports this one.
+//! That inference only holds when being imported is how the file was ever meant
+//! to be reached. A large class of real files is reached another way — a tool
+//! reads them by name, a build system executes them, a framework discovers them
+//! by convention, a router maps them from their path — and their fan-in is zero
+//! in every healthy repository.
+//!
+//! Sampled zoo evidence put the rule at 0.00 precision, and every sampled
+//! finding was one of these: an ESLint flat config, a Gradle settings script, a
+//! Django management command, a Wagtail hooks module, and a documentation
+//! example. This module names those shapes so the rule stops claiming them.
+//!
+//! The recognizers are deliberately structural — a path convention a tool or
+//! framework actually implements — rather than a list of well-known filenames.
+//! A missed convention costs one false positive; an over-broad rule silently
+//! hides real dead code, so each entry below names the loader that reads it.
+
+use crate::audits::context::classify::helpers::path_contains_component;
+use std::path::Path;
+
+/// How a zero-fan-in file is reached when no import points at it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ReachedWithoutImport {
+    /// Read by name by a development tool (`eslint.config.mjs`, `.babelrc.js`).
+    ToolConfiguration,
+    /// Executed by a build system (`settings.gradle.kts`, `gulpfile.js`).
+    BuildScript,
+    /// Discovered by a framework convention (`management/commands/*.py`,
+    /// `wagtail_hooks.py`, `conftest.py`).
+    FrameworkAutoload,
+    /// Mapped from its path by a file-system router (Next.js `app/page.tsx`).
+    FileSystemRoute,
+    /// Example or documentation source, compiled or imported by name from docs
+    /// tooling and test suites rather than by a static import.
+    DocumentationExample,
+    /// A standalone script under `scripts/`, run by a person or a CI job.
+    StandaloneScript,
+}
+
+pub(super) fn reached_without_import(path: &Path) -> Option<ReachedWithoutImport> {
+    let name = file_name(path);
+    if is_documentation_example(path) {
+        return Some(ReachedWithoutImport::DocumentationExample);
+    }
+    if is_build_script(&name) {
+        return Some(ReachedWithoutImport::BuildScript);
+    }
+    if is_tool_configuration(&name) {
+        return Some(ReachedWithoutImport::ToolConfiguration);
+    }
+    if is_framework_autoload(path, &name) {
+        return Some(ReachedWithoutImport::FrameworkAutoload);
+    }
+    if is_file_system_route(path, &name) {
+        return Some(ReachedWithoutImport::FileSystemRoute);
+    }
+    if path_contains_component(path, &["scripts"]) {
+        return Some(ReachedWithoutImport::StandaloneScript);
+    }
+    None
+}
+
+fn file_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_lowercase()
+}
+
+/// `<tool>.config.<ext>` and `.<tool>rc.<ext>` — the two conventions the
+/// JavaScript ecosystem uses for executable configuration a tool loads by name.
+fn is_tool_configuration(name: &str) -> bool {
+    let Some(stem) = script_stem(name) else {
+        return false;
+    };
+    stem.ends_with(".config")
+        || stem.ends_with(".conf")
+        || (stem.starts_with('.') && stem.ends_with("rc"))
+}
+
+/// Scripts a build system executes directly. Gradle accepts both its Groovy and
+/// Kotlin DSL, and the JS task runners load their file by a fixed name.
+fn is_build_script(name: &str) -> bool {
+    if name.ends_with(".gradle") || name.ends_with(".gradle.kts") {
+        return true;
+    }
+    matches!(script_stem(name).as_deref(), Some("gulpfile" | "gruntfile"))
+}
+
+/// Conventions where a framework imports the module for you, by scanning a
+/// directory or by a fixed module name, so no source file names it.
+fn is_framework_autoload(path: &Path, name: &str) -> bool {
+    if !name.ends_with(".py") {
+        return false;
+    }
+    // Django loads every module under `<app>/management/commands/` and invokes
+    // it by command name; Django's migration runner does the same for
+    // `<app>/migrations/`.
+    if has_directory_pair(path, "management", "commands")
+        || path_contains_component(path, &["migrations"])
+    {
+        return true;
+    }
+    matches!(
+        name,
+        // pytest collects every conftest.py in the rootdir tree.
+        "conftest.py"
+            // Wagtail: `get_app_submodules("wagtail_hooks")` imports each app's
+            // hooks module dynamically.
+            | "wagtail_hooks.py"
+            // Django app plumbing, reached from settings strings and the app
+            // registry rather than from an import in project code.
+            | "apps.py"
+            | "admin.py"
+            | "urls.py"
+            | "wsgi.py"
+            | "asgi.py"
+    )
+}
+
+/// File-system routing: the framework derives the route from the path, so the
+/// module is never imported by name.
+///
+/// Next.js App Router, Next.js Pages Router, and Expo Router all reserve a
+/// small set of file names inside a routing directory.
+fn is_file_system_route(path: &Path, name: &str) -> bool {
+    let Some(stem) = script_stem(name) else {
+        return false;
+    };
+    let routed = matches!(
+        stem.as_str(),
+        "page"
+            | "layout"
+            | "_layout"
+            | "route"
+            | "template"
+            | "loading"
+            | "error"
+            | "not-found"
+            | "+not-found"
+            | "+html"
+            | "_app"
+            | "_document"
+    );
+    // These names are reserved only inside a router tree, so an unrelated
+    // `page.tsx` in `src/components/` still counts as importable.
+    routed && path_contains_component(path, &["app", "pages"])
+}
+
+/// Example and documentation source trees. Their files are compiled by docs
+/// tooling, run as standalone examples, or imported by name from a test
+/// parameter — never through a static import another module makes.
+fn is_documentation_example(path: &Path) -> bool {
+    path_contains_component(
+        path,
+        &[
+            "docs_src", "doc_src", "docs-src", "example", "examples", "sample", "samples",
+        ],
+    )
+}
+
+/// Two path components that must be adjacent, so an unrelated `commands/`
+/// directory does not read as Django's command loader.
+fn has_directory_pair(path: &Path, first: &str, second: &str) -> bool {
+    let text = path.to_string_lossy().replace('\\', "/").to_lowercase();
+    text.contains(&format!("/{first}/{second}/")) || text.starts_with(&format!("{first}/{second}/"))
+}
+
+/// The file name minus a single script extension, or `None` when the extension
+/// is not one these conventions use.
+fn script_stem(name: &str) -> Option<String> {
+    for extension in [
+        ".mts", ".cts", ".mjs", ".cjs", ".tsx", ".jsx", ".ts", ".js", ".kts",
+    ] {
+        if let Some(stem) = name.strip_suffix(extension) {
+            return Some(stem.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/audits/architecture/graph_queries/entrypoints/tests.rs
+++ b/src/audits/architecture/graph_queries/entrypoints/tests.rs
@@ -1,0 +1,160 @@
+use super::{ReachedWithoutImport, reached_without_import};
+use std::path::Path;
+
+fn reason(path: &str) -> Option<ReachedWithoutImport> {
+    reached_without_import(Path::new(path))
+}
+
+#[test]
+fn the_zoo_sampled_false_positives_are_all_recognized() {
+    // Catches losing any of the six findings that put this rule at 0.00
+    // precision in the first strict sample.
+    assert_eq!(
+        reason("eslint.config.mjs"),
+        Some(ReachedWithoutImport::ToolConfiguration)
+    );
+    assert_eq!(
+        reason("settings.gradle.kts"),
+        Some(ReachedWithoutImport::BuildScript)
+    );
+    assert_eq!(
+        reason("wagtail/management/commands/purge_revisions.py"),
+        Some(ReachedWithoutImport::FrameworkAutoload)
+    );
+    assert_eq!(
+        reason("wagtail/users/wagtail_hooks.py"),
+        Some(ReachedWithoutImport::FrameworkAutoload)
+    );
+    assert_eq!(
+        reason("docs_src/query_params_str_validations/tutorial008_an_py310.py"),
+        Some(ReachedWithoutImport::DocumentationExample)
+    );
+}
+
+#[test]
+fn executable_configuration_is_recognized_across_module_syntaxes() {
+    // Catches pinning the recognizer to one extension: the same tool config is
+    // written as .js, .cjs, .mjs, or .ts depending on the project's module mode.
+    for path in [
+        "vite.config.ts",
+        "jest.config.cjs",
+        "rollup.config.mjs",
+        "tailwind.config.js",
+        "karma.conf.js",
+        ".eslintrc.js",
+        ".prettierrc.cjs",
+    ] {
+        assert_eq!(
+            reason(path),
+            Some(ReachedWithoutImport::ToolConfiguration),
+            "{path}"
+        );
+    }
+}
+
+#[test]
+fn gradle_scripts_are_recognized_in_both_dsls() {
+    for path in ["settings.gradle", "build.gradle", "app/build.gradle.kts"] {
+        assert_eq!(
+            reason(path),
+            Some(ReachedWithoutImport::BuildScript),
+            "{path}"
+        );
+    }
+    assert_eq!(
+        reason("gulpfile.js"),
+        Some(ReachedWithoutImport::BuildScript)
+    );
+}
+
+#[test]
+fn django_command_loader_needs_both_path_components_in_order() {
+    // Catches matching any `commands/` directory: a CQRS command handler is
+    // ordinary importable code and must stay eligible for the rule.
+    assert_eq!(
+        reason("app/management/commands/sync.py"),
+        Some(ReachedWithoutImport::FrameworkAutoload)
+    );
+    assert_eq!(
+        reason("management/commands/sync.py"),
+        Some(ReachedWithoutImport::FrameworkAutoload)
+    );
+    assert_eq!(reason("app/domain/commands/create_order.py"), None);
+    assert_eq!(reason("app/commands/management/sync.py"), None);
+}
+
+#[test]
+fn file_system_routes_are_only_reserved_inside_a_router_tree() {
+    // Catches treating every `page.tsx` as routed: outside `app/` or `pages/`
+    // the name carries no framework meaning.
+    assert_eq!(
+        reason("app/dashboard/page.tsx"),
+        Some(ReachedWithoutImport::FileSystemRoute)
+    );
+    assert_eq!(
+        reason("pages/api/users.ts"),
+        None,
+        "an arbitrary module inside pages/ is still importable"
+    );
+    assert_eq!(reason("src/components/page.tsx"), None);
+}
+
+#[test]
+fn expo_and_next_router_names_are_recognized() {
+    // Catches covering only the Next.js App Router: Expo Router uses `_layout`
+    // and `+not-found`, and the Pages Router uses `_app`/`_document`.
+    for path in [
+        "boilerplate/src/app/_layout.tsx",
+        "src/app/+not-found.tsx",
+        "pages/_app.tsx",
+        "pages/_document.tsx",
+    ] {
+        assert_eq!(
+            reason(path),
+            Some(ReachedWithoutImport::FileSystemRoute),
+            "{path}"
+        );
+    }
+}
+
+#[test]
+fn standalone_scripts_are_run_not_imported() {
+    assert_eq!(
+        reason("scripts/get-translator-credits.py"),
+        Some(ReachedWithoutImport::StandaloneScript)
+    );
+    assert_eq!(
+        reason("tools/scripts/release.ts"),
+        Some(ReachedWithoutImport::StandaloneScript)
+    );
+    assert_eq!(reason("src/scripting/engine.ts"), None);
+}
+
+#[test]
+fn ordinary_source_files_stay_eligible_for_the_rule() {
+    // The false-negative guard: broadening any recognizer here silently hides
+    // real dead code, so the common shapes must keep returning None.
+    for path in [
+        "src/lib/user_service.ts",
+        "src/config.ts",
+        "src/config/database.ts",
+        "wagtail/models.py",
+        "wagtail/users/views.py",
+        "internal/server/handler.go",
+        "app/services/billing.rb",
+    ] {
+        assert_eq!(reason(path), None, "{path}");
+    }
+}
+
+#[test]
+fn python_autoload_names_do_not_leak_into_other_languages() {
+    // `urls`, `apps`, and `admin` are ordinary module names elsewhere; only the
+    // Python files carry Django's loader semantics.
+    assert_eq!(reason("src/urls.ts"), None);
+    assert_eq!(reason("src/admin.js"), None);
+    assert_eq!(
+        reason("project/urls.py"),
+        Some(ReachedWithoutImport::FrameworkAutoload)
+    );
+}

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -17,6 +17,7 @@ use crate::graph::v2::{
 use crate::scan::facts::FileFacts;
 
 mod edge_evidence;
+mod entrypoints;
 mod layers;
 mod packages;
 
@@ -171,6 +172,10 @@ fn dead_module_finding(
         || ctx.is_public_api
         || fan_in.unwrap_or(0) != 0
         || has_inline_tests
+        // A tool config, build script, framework-autoloaded module, routed
+        // file, or documentation example is reached without an import, so its
+        // fan-in is zero in every healthy repository.
+        || entrypoints::reached_without_import(&info.relative).is_some()
     {
         return None;
     }

--- a/tests/zoo/README.md
+++ b/tests/zoo/README.md
@@ -106,6 +106,12 @@ A strict entry declares *why* it exists through the optional `evidence` field:
 `sample` is strict-only: the default profile is already exhaustive, so a sample
 of it would be a coverage regression rather than new evidence.
 
+The two also fail differently when the finding stops being emitted. A missing
+anchor is `MISSING STRICT RECALL ANCHOR` — a downgraded signal disappeared from
+strict, which is a regression. A missing sample is `RESOLVED STRICT SAMPLE` —
+the sampled finding was fixed, so delete the entry and re-sample the rule to
+measure current behavior.
+
 Sampling is how a rule that never appears in the default profile earns measured
 evidence at all. `zoo.py sample` orders every matching finding by
 `(repo, path, line, id)` and picks `--limit` of them by even stride, so the

--- a/tests/zoo/expectations/changesets.toml
+++ b/tests/zoo/expectations/changesets.toml
@@ -18,13 +18,12 @@ rule_id = "architecture.circular-dependency"
 path = "packages/cli/src/commands/publish/npm-utils.ts"
 disposition = "actionable"
 reason = "Real two-node eager import cycle between npm-utils.ts and publishPackages.ts inside the publish command."
-
 [[finding]]
 profile = "strict"
-finding_id = "architecture.dead-module:eslint.config.mjs:b022a3e6e8b8daf1"
+finding_id = "architecture.dead-module:packages/apply-release-plan/src/test-utils/failing-functions.ts:b022a3e6e8b8daf1"
 rule_id = "architecture.dead-module"
-path = "eslint.config.mjs"
+path = "packages/apply-release-plan/src/test-utils/failing-functions.ts"
 line = 1
 evidence = "sample"
 disposition = "false-positive"
-reason = "ESLint flat config, loaded by the `eslint` binary declared in package.json — a tool entrypoint is never imported by project code, so zero fan-in is expected rather than dead."
+reason = "Imported by packages/apply-release-plan/src/index.test.ts through an extensionless specifier the resolver does not map to this file, so the edge exists in source but not in the graph."

--- a/tests/zoo/expectations/eshoponweb.toml
+++ b/tests/zoo/expectations/eshoponweb.toml
@@ -69,3 +69,23 @@ path = "src/Web/appsettings.Docker.json"
 line = 4
 disposition = "valid-but-accepted"
 reason = "IdentityConnection string with an embedded demo password for the Docker SQL container (Web)."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:src/BlazorShared/Models/LookupData.cs:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "src/BlazorShared/Models/LookupData.cs"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "C# references types through namespaces, not file paths, so the import graph has no file-to-file edge to count. Zero fan-in here means the language is unmodeled, not that nothing uses the type."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:src/Web/Pages/Basket/BasketItemViewModel.cs:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "src/Web/Pages/Basket/BasketItemViewModel.cs"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Same namespace-versus-path gap as LookupData.cs; the view model is used from Razor pages in the same namespace with no file import anywhere."

--- a/tests/zoo/expectations/express.toml
+++ b/tests/zoo/expectations/express.toml
@@ -14,3 +14,13 @@ line = 1
 evidence = "sample"
 disposition = "false-positive"
 reason = "A mocha test file under `test/`, discovered by the runner rather than imported. The finding also reports role=Production, so the role classifier missed the test directory."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:test/app.engine.js:5f75afc99cf552b5"
+rule_id = "architecture.dead-module"
+path = "test/app.engine.js"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Another mocha test under the singular `test/` directory classified role=Production. The test-file classifier recognizes `tests/` but not `test/`."

--- a/tests/zoo/expectations/fastapi.toml
+++ b/tests/zoo/expectations/fastapi.toml
@@ -27,13 +27,3 @@ path = "fastapi/applications.py"
 line = 926
 disposition = "valid-but-accepted"
 reason = "assert in a production path used as an internal precondition; downgraded to Low and retained as a strict recall anchor for the Python assert signal."
-
-[[finding]]
-profile = "strict"
-finding_id = "architecture.dead-module:docs_src/query_params_str_validations/tutorial008_an_py310.py:b022a3e6e8b8daf1"
-rule_id = "architecture.dead-module"
-path = "docs_src/query_params_str_validations/tutorial008_an_py310.py"
-line = 1
-evidence = "sample"
-disposition = "false-positive"
-reason = "Documentation example imported dynamically by tests/test_tutorial/test_query_params_str_validations/test_tutorial008.py, which names the module in a `pytest.param` string. No static edge exists to find."

--- a/tests/zoo/expectations/ignite.toml
+++ b/tests/zoo/expectations/ignite.toml
@@ -15,3 +15,13 @@ path = "src/commands/new.ts"
 line = 185
 disposition = "valid-but-accepted"
 reason = "CLI command handler that deliberately exits the process; downgraded to Low for cli-executable role and retained as a strict recall anchor."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:src/commands/issue.ts:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "src/commands/issue.ts"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "A gluegun CLI command module: the framework loads every file under its command directory by name and dispatches on the file name, so no source file imports it."

--- a/tests/zoo/expectations/nowinandroid.toml
+++ b/tests/zoo/expectations/nowinandroid.toml
@@ -10,13 +10,3 @@ rule_id = "language.managed.fatal-exception-risk"
 path = "feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt"
 disposition = "actionable"
 reason = "TODO() placeholder on the TopicUiState.Error branch will throw NotImplementedError at runtime if the error state is ever rendered; the rule correctly surfaces an unimplemented production path."
-
-[[finding]]
-profile = "strict"
-finding_id = "architecture.dead-module:settings.gradle.kts:b022a3e6e8b8daf1"
-rule_id = "architecture.dead-module"
-path = "settings.gradle.kts"
-line = 1
-evidence = "sample"
-disposition = "false-positive"
-reason = "Gradle settings script, executed by the build tool and never imported. The same scan reports 2058 unresolved internal imports in this repository, so absence of an edge proves nothing here."

--- a/tests/zoo/expectations/wagtail.toml
+++ b/tests/zoo/expectations/wagtail.toml
@@ -45,23 +45,32 @@ path = "wagtail/project_template/project_name/settings/production.py"
 line = 12
 disposition = "false-positive"
 reason = "Same guarded optional `from .local import *` override as dev.py; the import is wrapped in try/except ImportError."
-
 [[finding]]
 profile = "strict"
-finding_id = "architecture.dead-module:wagtail/management/commands/purge_revisions.py:b022a3e6e8b8daf1"
+finding_id = "architecture.dead-module:wagtail/admin/static_src/wagtailadmin/js/vendor/jquery-3.6.0.min.js:b022a3e6e8b8daf1"
 rule_id = "architecture.dead-module"
-path = "wagtail/management/commands/purge_revisions.py"
+path = "wagtail/admin/static_src/wagtailadmin/js/vendor/jquery-3.6.0.min.js"
 line = 1
 evidence = "sample"
 disposition = "false-positive"
-reason = "Django management command, discovered by convention from `management/commands/` and invoked by name. Commands are entrypoints, so zero fan-in is the expected shape."
+reason = "A vendored, minified third-party bundle under `vendor/`. It is not project source at all, so neither dead-module nor any other maintainability claim applies to it."
 
 [[finding]]
 profile = "strict"
-finding_id = "architecture.dead-module:wagtail/users/wagtail_hooks.py:b022a3e6e8b8daf1"
+finding_id = "architecture.dead-module:wagtail/project_template/home/tests.py:b022a3e6e8b8daf1"
 rule_id = "architecture.dead-module"
-path = "wagtail/users/wagtail_hooks.py"
+path = "wagtail/project_template/home/tests.py"
 line = 1
 evidence = "sample"
 disposition = "false-positive"
-reason = "Autoloaded by convention: wagtail/hooks.py calls `get_app_submodules(\"wagtail_hooks\")`, so every app's wagtail_hooks module is imported dynamically and never appears as a static edge."
+reason = "A test module named `tests.py`, collected by the runner. The test-file classifier recognizes a `tests/` directory and a `tests_` prefix but not the bare `tests.py` file name Django's template generates."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:wagtail/users/views/groups.py:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "wagtail/users/views/groups.py"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Referenced by dotted string from wagtail/users/apps.py (`group_viewset = \"wagtail.users.views.groups.GroupViewSet\"`), the Django pattern for late-bound references. No static import names the module."

--- a/tests/zoo/snapshots/changesets.json
+++ b/tests/zoo/snapshots/changesets.json
@@ -20,7 +20,7 @@
   "strict": {
     "by_rule": {
       "architecture.circular-dependency": 1,
-      "architecture.dead-module": 27,
+      "architecture.dead-module": 4,
       "architecture.large-file": 4,
       "code-marker.todo": 8,
       "code-quality.complex-file": 2,
@@ -30,6 +30,6 @@
       "language.javascript.runtime-exit-risk": 3,
       "testing.source-without-test": 28
     },
-    "visible_total": 118
+    "visible_total": 95
   }
 }

--- a/tests/zoo/snapshots/excalidraw.json
+++ b/tests/zoo/snapshots/excalidraw.json
@@ -24,7 +24,7 @@
     "by_rule": {
       "architecture.barrel-file-risk": 5,
       "architecture.circular-dependency": 6,
-      "architecture.dead-module": 62,
+      "architecture.dead-module": 36,
       "architecture.deep-relative-imports": 9,
       "architecture.excessive-fan-out": 23,
       "architecture.large-file": 83,
@@ -44,6 +44,6 @@
       "security.secret-candidate": 2,
       "testing.source-without-test": 374
     },
-    "visible_total": 1213
+    "visible_total": 1187
   }
 }

--- a/tests/zoo/snapshots/express.json
+++ b/tests/zoo/snapshots/express.json
@@ -11,12 +11,12 @@
   "sha": "18e5985b8a9d5e8423db0a9121f22bdaecd5b120",
   "strict": {
     "by_rule": {
-      "architecture.dead-module": 105,
+      "architecture.dead-module": 91,
       "architecture.large-file": 3,
       "code-quality.complex-function": 1,
       "code-quality.long-function": 6,
       "testing.source-without-test": 6
     },
-    "visible_total": 121
+    "visible_total": 107
   }
 }

--- a/tests/zoo/snapshots/fastapi.json
+++ b/tests/zoo/snapshots/fastapi.json
@@ -19,7 +19,7 @@
   "strict": {
     "by_rule": {
       "architecture.circular-dependency": 2,
-      "architecture.dead-module": 449,
+      "architecture.dead-module": 4,
       "architecture.large-file": 17,
       "architecture.too-many-modules": 3,
       "code-marker.todo": 17,
@@ -31,6 +31,6 @@
       "security.secret-candidate": 2,
       "testing.source-without-test": 36
     },
-    "visible_total": 765
+    "visible_total": 320
   }
 }

--- a/tests/zoo/snapshots/ignite.json
+++ b/tests/zoo/snapshots/ignite.json
@@ -12,7 +12,7 @@
   "strict": {
     "by_rule": {
       "architecture.barrel-file-risk": 1,
-      "architecture.dead-module": 33,
+      "architecture.dead-module": 26,
       "architecture.large-file": 13,
       "code-marker.todo": 4,
       "code-quality.complex-file": 1,
@@ -23,6 +23,6 @@
       "language.javascript.runtime-exit-risk": 12,
       "testing.source-without-test": 100
     },
-    "visible_total": 200
+    "visible_total": 193
   }
 }

--- a/tests/zoo/snapshots/nowinandroid.json
+++ b/tests/zoo/snapshots/nowinandroid.json
@@ -17,7 +17,7 @@
   "sha": "7d45eae4f8720a0c77f507712ba2437ff974b6ed",
   "strict": {
     "by_rule": {
-      "architecture.dead-module": 175,
+      "architecture.dead-module": 20,
       "architecture.deep-directory-nesting": 373,
       "architecture.large-file": 9,
       "code-marker.todo": 30,
@@ -26,6 +26,6 @@
       "language.managed.fatal-exception-risk": 6,
       "testing.source-without-test": 232
     },
-    "visible_total": 859
+    "visible_total": 704
   }
 }

--- a/tests/zoo/snapshots/ripgrep.json
+++ b/tests/zoo/snapshots/ripgrep.json
@@ -20,7 +20,7 @@
   "sha": "82313cf95849bfe425109ad9506a52154879b1b1",
   "strict": {
     "by_rule": {
-      "architecture.dead-module": 5,
+      "architecture.dead-module": 2,
       "architecture.large-file": 33,
       "code-marker.fixme": 4,
       "code-marker.todo": 4,
@@ -30,6 +30,6 @@
       "language.rust.panic-risk": 97,
       "testing.source-without-test": 27
     },
-    "visible_total": 254
+    "visible_total": 251
   }
 }

--- a/tests/zoo/snapshots/spring-petclinic.json
+++ b/tests/zoo/snapshots/spring-petclinic.json
@@ -11,11 +11,10 @@
   "sha": "a2c2ef994340d3970eb6db51247456a51bb161f8",
   "strict": {
     "by_rule": {
-      "architecture.dead-module": 28,
       "architecture.deep-directory-nesting": 46,
       "language.managed.fatal-exception-risk": 1,
       "testing.source-without-test": 30
     },
-    "visible_total": 105
+    "visible_total": 77
   }
 }

--- a/tests/zoo/snapshots/wagtail.json
+++ b/tests/zoo/snapshots/wagtail.json
@@ -25,7 +25,7 @@
   "strict": {
     "by_rule": {
       "architecture.circular-dependency": 11,
-      "architecture.dead-module": 657,
+      "architecture.dead-module": 255,
       "architecture.deep-directory-nesting": 1019,
       "architecture.deep-relative-imports": 33,
       "architecture.excessive-fan-out": 17,
@@ -47,6 +47,6 @@
       "language.python.exception-risk": 45,
       "testing.source-without-test": 668
     },
-    "visible_total": 3042
+    "visible_total": 2640
   }
 }


### PR DESCRIPTION
## Summary

Acts on the first sampled measurement: `architecture.dead-module` scored 0.00, and every sampled finding was a file nothing imports *by design*. The rule now recognizes those shapes and drops 1103 of 1762 strict zoo findings (63%) with no other rule affected.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- New `graph_queries/entrypoints.rs` recognizing six ways a file is reached without an import, each documented with the loader that reads it:
  - **tool configuration** — `<tool>.config.<ext>`, `<tool>.conf.<ext>`, `.<tool>rc.<ext>` across `.js/.cjs/.mjs/.ts/.mts/.cts`;
  - **build scripts** — `*.gradle`, `*.gradle.kts`, `gulpfile.*`, `gruntfile.*`;
  - **framework autoload** — Django `management/commands/` and `migrations/`, pytest `conftest.py`, `wagtail_hooks.py`, and Django app plumbing (`apps.py`, `admin.py`, `urls.py`, `wsgi.py`, `asgi.py`);
  - **file-system routes** — Next.js App/Pages Router and Expo Router reserved names, only inside an `app/` or `pages/` tree;
  - **documentation and example sources** — `docs_src/`, `examples/`, `samples/`;
  - **standalone scripts** — anything under `scripts/`.
- `dead_module_finding` skips a node when any recognizer matches.
- 9 unit tests, including a false-negative guard that pins ordinary source shapes as still eligible.
- Zoo snapshots re-blessed; the five resolved sample labels deleted and a fresh sample of eight labeled in their place.
- A sampled entry that stops matching now reports `RESOLVED STRICT SAMPLE` ("delete this entry and re-sample") instead of `MISSING STRICT RECALL ANCHOR`. An anchor going missing is a recall regression; a sample going missing is the fix landing, and sending a maintainer hunting for it would be wrong.
- Roadmap Phase C gains a "Current progress" note; `CHANGELOG.md` updated.

## Why

Sampling `architecture.dead-module` — 1762 findings, the largest rule in the catalog — returned six false positives out of six. The failure was not a bug in the fan-in computation; it was the premise. "No file imports this" only implies
"dead" when being imported is how the file was meant to be reached, and a large class of real files is reached by a loader instead.

Precision is the whole point of this rule: a maintainer who sees a dead-module list that is mostly config files stops reading the list.

## Measurement

```
repo                before  after
changesets              27      4
excalidraw              62     36
express                105     91
fastapi                449      4
ignite                  33     26
nowinandroid           175     20
ripgrep                  5      2
spring-petclinic        28      0
wagtail                657    255
                    ------  -----
TOTAL                 1762    659   (1103 removed, 63%)
```

Verified as zero-collateral: no other strict rule's count moved in any repo, and every repository's default profile is byte-identical - this rule is strict-only and never reached the default verdict.

## What the rule still gets wrong

Re-sampling the smaller population gives eight new false positives, all labeled with reasons. They are distinct families, and each is its own slice:

1. **Namespace-based languages** (eshoponweb ×2) - C#, Java, and Kotlin reference types through namespaces, so the file-import graph has no edges to count. Zero fan-in there means *unmodeled*, not *unreferenced*.
2. **Test files** (express, wagtail) - the classifier knows `tests/` and the `tests_` prefix but not a singular `test/` directory or a bare `tests.py`.
3. **Vendored bundles** (wagtail) - `vendor/jquery-3.6.0.min.js` is not project source at all.
4. **Convention-loaded command directories** (ignite) - gluegun dispatches CLI commands by file name.
5. **Dotted-string references** (wagtail) — `"wagtail.users.views.groups.GroupViewSet"`  in `apps.py` is a real reference the graph cannot see.
6. **Unresolved specifier** (changesets) — a test imports the module through an extensionless specifier the resolver does not map.

So the scorecard still reads 0.00 for this rule. That is correct and worth stating plainly: the sample measures the precision of what remains, not the volume removed. Both numbers matter, and they live in different places - the scorecard and the snapshots.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 -m unittest discover -s scripts/tests -p 'test_*.py'
python3 scripts/release-contract.py check
cargo run -- scan . --fail-on-priority p1
```