### PR TITLE
fix: require file-resolvable imports before claiming a module is dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,26 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- `architecture.dead-module` now requires a language whose imports the resolver
+  can map to repository files. C#, Swift, PHP, Dart, Scala, and the C family
+  reference types through namespaces and headers that never become graph edges,
+  so every one of their files carries zero fan-in in a perfectly healthy
+  repository and the rule reported all of them. The check asks the resolver
+  itself which extensions it dispatches on, so it cannot drift from what the
+  graph can represent. eShopOnWeb drops from 208 to 2 findings.
+- Correct an over-broad example-tree recognizer shipped in the previous entry:
+  `examples`/`samples` were matched at any path depth, which silenced every
+  file under a package namespace containing those words — Spring PetClinic
+  (`org/springframework/samples/petclinic`) and Now in Android
+  (`com/google/samples/apps/nowinandroid`) lost their entire source trees. The
+  recognizer now only matches near a repository or package root, restoring 144
+  findings. Singular `example`/`sample` are no longer matched at all, since
+  `com/example` is the canonical Java package placeholder.
+- `architecture.dead-module` also stops reporting Python package markers
+  (`__init__.py`, executed whenever any module in the package is imported),
+  Storybook stories collected by glob, and Django template-tag libraries loaded
+  by `{% load %}` name.
+
 - `architecture.dead-module` no longer treats a file as dead when nothing
   imports it *by design*. Executable tool configuration (`eslint.config.mjs`,
   `.prettierrc.cjs`), build scripts (`settings.gradle.kts`, `gulpfile.js`),

--- a/docs/engineering/rule-scorecard.md
+++ b/docs/engineering/rule-scorecard.md
@@ -71,4 +71,4 @@ Rules that fire only in the strict profile are too numerous to label exhaustivel
 
 | Rule | Lifecycle | Sampled | Precision Estimate | False-Positive Debt |
 |---|---|---|---:|---:|
-| `architecture.dead-module` | experimental | 9 sampled across 5 repo(s) | 0.00 | 9 |
+| `architecture.dead-module` | experimental | 15 sampled across 5 repo(s) | 0.00 | 15 |

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -138,12 +138,15 @@ Current progress:
   sampling (`scripts/zoo.py sample`), so the catalog's unmeasured majority can
   earn evidence without exhaustive labeling.
 - `architecture.dead-module` was the first rule measured, at 0.00 precision. Its
-  entrypoint model now covers files reached without an import, cutting the zoo
-  population from 1762 to 659 strict findings. The sampled false positives that
-  remain name the next slices: namespace-based languages (C#, Java, Kotlin)
-  where the file-import graph has no edges to count, test files under a singular
-  `test/` directory or a bare `tests.py`, vendored third-party bundles,
-  convention-loaded CLI command directories, and Python modules referenced by
+  entrypoint model now covers files reached without an import, and absence
+  claims are restricted to languages whose imports the resolver maps to files.
+  The zoo population is down from 1762 to 498 strict findings. The sampled false
+  positives that remain name the next slices: test files under a singular
+  `test/` directory or a bare `tests.py`; multi-module Gradle projects, where
+  the JVM resolver probes five fixed source roots and misses
+  `<module>/src/main/kotlin` entirely; browser assets referenced by a
+  `<script>` tag or a bundler entry map; vendored third-party bundles;
+  convention-loaded CLI command directories; and Python modules referenced by
   dotted string.
 
 Deliverables:

--- a/src/audits/architecture/graph_queries/entrypoints.rs
+++ b/src/audits/architecture/graph_queries/entrypoints.rs
@@ -27,9 +27,13 @@ pub(super) enum ReachedWithoutImport {
     ToolConfiguration,
     /// Executed by a build system (`settings.gradle.kts`, `gulpfile.js`).
     BuildScript,
-    /// Discovered by a framework convention (`management/commands/*.py`,
-    /// `wagtail_hooks.py`, `conftest.py`).
+    /// Discovered by a framework or tool convention — a directory scan, a glob,
+    /// or a fixed module name (`management/commands/*.py`, `wagtail_hooks.py`,
+    /// `conftest.py`, `*.stories.tsx`).
     FrameworkAutoload,
+    /// A Python package's `__init__.py`, executed whenever any module inside the
+    /// package is imported, with no edge pointing at it.
+    PackageMarker,
     /// Mapped from its path by a file-system router (Next.js `app/page.tsx`).
     FileSystemRoute,
     /// Example or documentation source, compiled or imported by name from docs
@@ -41,6 +45,9 @@ pub(super) enum ReachedWithoutImport {
 
 pub(super) fn reached_without_import(path: &Path) -> Option<ReachedWithoutImport> {
     let name = file_name(path);
+    if name == "__init__.py" {
+        return Some(ReachedWithoutImport::PackageMarker);
+    }
     if is_documentation_example(path) {
         return Some(ReachedWithoutImport::DocumentationExample);
     }
@@ -89,17 +96,25 @@ fn is_build_script(name: &str) -> bool {
     matches!(script_stem(name).as_deref(), Some("gulpfile" | "gruntfile"))
 }
 
-/// Conventions where a framework imports the module for you, by scanning a
-/// directory or by a fixed module name, so no source file names it.
+/// Conventions where a framework or tool imports the module for you — a
+/// directory scan, a glob, or a fixed module name — so no source file names it.
 fn is_framework_autoload(path: &Path, name: &str) -> bool {
+    // Storybook and its ecosystem collect `*.stories.*` by glob from a
+    // configured directory; nothing in the application imports a story.
+    if let Some(stem) = script_stem(name)
+        && (stem.ends_with(".stories") || stem.ends_with(".story"))
+    {
+        return true;
+    }
     if !name.ends_with(".py") {
         return false;
     }
     // Django loads every module under `<app>/management/commands/` and invokes
-    // it by command name; Django's migration runner does the same for
+    // it by command name; the template engine loads `<app>/templatetags/` by
+    // library name from `{% load %}`; the migration runner does the same for
     // `<app>/migrations/`.
     if has_directory_pair(path, "management", "commands")
-        || path_contains_component(path, &["migrations"])
+        || path_contains_component(path, &["migrations", "templatetags"])
     {
         return true;
     }
@@ -152,13 +167,21 @@ fn is_file_system_route(path: &Path, name: &str) -> bool {
 /// Example and documentation source trees. Their files are compiled by docs
 /// tooling, run as standalone examples, or imported by name from a test
 /// parameter — never through a static import another module makes.
+///
+/// Such a tree sits near the repository or package root. Deeper down, the same
+/// words are ordinary namespace segments — `com/example/...` is the canonical
+/// Java package placeholder and Spring's PetClinic lives under
+/// `org/springframework/samples/petclinic/` — so matching at any depth would
+/// silence a whole application's worth of real source.
+const EXAMPLE_TREE_MAX_DEPTH: usize = 2;
+
 fn is_documentation_example(path: &Path) -> bool {
-    path_contains_component(
-        path,
-        &[
-            "docs_src", "doc_src", "docs-src", "example", "examples", "sample", "samples",
-        ],
-    )
+    const EXAMPLE_DIRECTORIES: &[&str] =
+        &["docs_src", "doc_src", "docs-src", "examples", "samples"];
+    path.to_string_lossy()
+        .split(['/', '\\'])
+        .take(EXAMPLE_TREE_MAX_DEPTH + 1)
+        .any(|component| EXAMPLE_DIRECTORIES.contains(&component.to_lowercase().as_str()))
 }
 
 /// Two path components that must be adjacent, so an unrelated `commands/`

--- a/src/audits/architecture/graph_queries/entrypoints/tests.rs
+++ b/src/audits/architecture/graph_queries/entrypoints/tests.rs
@@ -84,6 +84,17 @@ fn django_command_loader_needs_both_path_components_in_order() {
 }
 
 #[test]
+fn django_template_tag_libraries_are_loaded_by_name() {
+    // `{% load wagtailusers_tags %}` names the library, not a module path, so
+    // no Python file imports it.
+    assert_eq!(
+        reason("wagtail/users/templatetags/wagtailusers_tags.py"),
+        Some(ReachedWithoutImport::FrameworkAutoload)
+    );
+    assert_eq!(reason("wagtail/users/views/groups.py"), None);
+}
+
+#[test]
 fn file_system_routes_are_only_reserved_inside_a_router_tree() {
     // Catches treating every `page.tsx` as routed: outside `app/` or `pages/`
     // the name carries no framework meaning.
@@ -114,6 +125,57 @@ fn expo_and_next_router_names_are_recognized() {
             Some(ReachedWithoutImport::FileSystemRoute),
             "{path}"
         );
+    }
+}
+
+#[test]
+fn a_python_package_marker_is_never_dead() {
+    // Importing `pkg.sub` executes `pkg/__init__.py` without any edge pointing
+    // at it, so zero fan-in there proves nothing.
+    assert_eq!(
+        reason("wagtail/users/views/__init__.py"),
+        Some(ReachedWithoutImport::PackageMarker)
+    );
+    assert_eq!(reason("wagtail/users/views/groups.py"), None);
+}
+
+#[test]
+fn storybook_stories_are_collected_by_glob() {
+    for path in [
+        "wagtail/admin/templates/shared/status_tag.stories.tsx",
+        "src/components/Button.stories.ts",
+        "src/components/Button.story.jsx",
+    ] {
+        assert_eq!(
+            reason(path),
+            Some(ReachedWithoutImport::FrameworkAutoload),
+            "{path}"
+        );
+    }
+    assert_eq!(reason("src/components/Button.tsx"), None);
+}
+
+#[test]
+fn example_trees_are_recognized_only_near_a_root() {
+    // Catches matching `examples`/`samples` at any depth: those words are
+    // ordinary namespace segments inside a package path, and suppressing there
+    // hides an entire application's source.
+    for path in [
+        "docs_src/tutorial.py",
+        "examples/basic.rs",
+        "packages/core/examples/usage.ts",
+    ] {
+        assert_eq!(
+            reason(path),
+            Some(ReachedWithoutImport::DocumentationExample),
+            "{path}"
+        );
+    }
+    for path in [
+        "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+        "src/main/java/com/example/app/Service.java",
+    ] {
+        assert_eq!(reason(path), None, "{path}");
     }
 }
 

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -8,7 +8,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use crate::analysis::{ArchitectureClassifier, ArchitectureContext, FileRole, LanguageFamily};
+use crate::analysis::{ArchitectureClassifier, ArchitectureContext, FileRole};
 use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use crate::graph::ImportResolutionStats;
 use crate::graph::v2::{
@@ -150,16 +150,14 @@ fn dead_module_finding(
     readiness: GraphReadiness,
 ) -> Option<Finding> {
     let ctx = &info.context;
-    // "Dead module" only means something for files that participate in the
-    // import graph. Docs, config, stylesheets, lockfiles, images, and shell
-    // scripts (Markup / Shell / Unknown families) are never "imported", so they
-    // always have fan_in=0 and would otherwise all be flagged — e.g. every
-    // `.claude/*.md`, `*.css`, `*.json`, or lockfile in a repo. Restrict to
-    // languages the resolver actually wires up.
-    let is_importable_code = matches!(
-        ctx.language_family,
-        LanguageFamily::CurlyBrace | LanguageFamily::Python | LanguageFamily::Go
-    );
+    // "Nothing imports this" is only evidence when an import could have become
+    // an edge. Docs, stylesheets, and lockfiles are never imported, and neither
+    // are C#, Swift, PHP, or C++ sources as far as this graph is concerned:
+    // they reference types through namespaces and headers the resolver does not
+    // map to files, so every one of their files carries fan_in=0 in a perfectly
+    // healthy repository. Ask the resolver itself which languages it wires up,
+    // so this cannot drift from what the graph can actually represent.
+    let is_importable_code = crate::graph::resolver::resolves_file_imports(&info.relative);
     // A file that carries its own tests is exercised by the suite, and its only
     // importer is often a `#[cfg(test)] mod ...;` declaration, whose edge is
     // intentionally excluded from the production import graph. Treating such a

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -59,6 +59,45 @@ fn dead_module_ignores_non_code_files() {
 }
 
 #[test]
+fn dead_module_is_silent_for_languages_the_resolver_cannot_wire_up() {
+    // C#, Swift, PHP, and the C family reference types through namespaces and
+    // headers no resolver maps to a file, so every one of their files has
+    // fan_in=0 even when heavily used. Zero fan-in there means "unmodeled", and
+    // an absence claim built on it is unsound rather than merely noisy.
+    for relative in [
+        "src/Web/Services/CatalogItemViewModelService.cs",
+        "Sources/App/Model.swift",
+        "src/Controller/HomeController.php",
+        "src/engine/renderer.cpp",
+    ] {
+        assert!(
+            dead_module_finding(&prod(relative), Some(0), GraphReadiness::Available).is_none(),
+            "{relative}"
+        );
+    }
+}
+
+#[test]
+fn dead_module_still_covers_every_language_the_resolver_wires_up() {
+    // The false-negative guard for the language gate.
+    for relative in [
+        "src/orphan.ts",
+        "src/orphan.tsx",
+        "src/orphan.js",
+        "pkg/orphan.py",
+        "internal/orphan.go",
+        "src/orphan.rs",
+        "src/main/java/com/example/Orphan.java",
+        "core/src/main/kotlin/com/example/Orphan.kt",
+    ] {
+        assert!(
+            dead_module_finding(&prod(relative), Some(0), GraphReadiness::Available).is_some(),
+            "{relative}"
+        );
+    }
+}
+
+#[test]
 fn dead_module_exempts_entrypoints_public_api_and_imported_files() {
     let readiness = GraphReadiness::Available;
     assert!(

--- a/src/graph/resolver/mod.rs
+++ b/src/graph/resolver/mod.rs
@@ -14,6 +14,28 @@ mod ts;
 use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
 
+/// Extensions [`resolve_import`] dispatches on. Every other language extracts
+/// imports but has no way to turn one into a repository path, so its files hold
+/// no outgoing edges at all.
+const FILE_RESOLVED_EXTENSIONS: &[&str] = &[
+    "rs", "ts", "tsx", "js", "jsx", "mjs", "cjs", "py", "go", "java", "kt", "kts",
+];
+
+/// Whether this file's imports can become graph edges.
+///
+/// A claim built on the *absence* of edges — nothing imports this file, nothing
+/// reaches this code — is only meaningful when edges could have existed. C#,
+/// Swift, PHP, Dart, Scala, and the C family reference types through namespaces
+/// or headers that [`resolve_import`] never maps to a file, so every one of
+/// their files has zero fan-in in a healthy repository. Callers that reason from
+/// absence must consult this first; callers that reason from a present edge do
+/// not need to, because a resolved edge is proof on its own.
+pub fn resolves_file_imports(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| FILE_RESOLVED_EXTENSIONS.contains(&extension))
+}
+
 /// Resolves a raw import string extracted from `from_file` to a concrete path
 /// under `root`. Returns a path only when it exists in `known_files`.
 pub fn resolve_import(
@@ -183,5 +205,55 @@ mod definitive_candidates_tests {
             ),
             None
         );
+    }
+}
+
+#[cfg(test)]
+mod file_resolution_support_tests {
+    use super::*;
+
+    #[test]
+    fn every_declared_extension_reaches_a_language_resolver() {
+        // Catches the predicate drifting from `resolve_import`'s dispatch: an
+        // extension listed here but missing from the match would claim edges
+        // are possible when none can ever be produced.
+        let root = Path::new("/repo");
+        for extension in FILE_RESOLVED_EXTENSIONS {
+            let source = PathBuf::from(format!("/repo/src/app.{extension}"));
+            assert!(resolves_file_imports(&source), "{extension}");
+            // A resolver ran if it probed at all; the empty file set makes every
+            // probe miss, so the observable contract is "did not panic and
+            // returned None" — the dispatch arm exists.
+            assert_eq!(
+                resolve_import("./sibling", &source, root, &HashSet::new()),
+                None,
+                "{extension}"
+            );
+        }
+    }
+
+    #[test]
+    fn namespace_and_header_languages_have_no_file_resolution() {
+        // These are the languages whose zero fan-in means "unmodeled", not
+        // "unreferenced" — the distinction absence-based rules depend on.
+        for extension in ["cs", "swift", "php", "dart", "scala", "cpp", "h", "rb"] {
+            let source = PathBuf::from(format!("/repo/src/app.{extension}"));
+            assert!(!resolves_file_imports(&source), "{extension}");
+            assert_eq!(
+                resolve_import(
+                    "Some.Namespace.Type",
+                    &source,
+                    Path::new("/repo"),
+                    &HashSet::new()
+                ),
+                None,
+                "{extension}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_file_without_an_extension_resolves_nothing() {
+        assert!(!resolves_file_imports(Path::new("/repo/Makefile")));
     }
 }

--- a/tests/zoo/expectations/changesets.toml
+++ b/tests/zoo/expectations/changesets.toml
@@ -27,3 +27,13 @@ line = 1
 evidence = "sample"
 disposition = "false-positive"
 reason = "Imported by packages/apply-release-plan/src/index.test.ts through an extensionless specifier the resolver does not map to this file, so the edge exists in source but not in the graph."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:packages/assemble-release-plan/src/test-utils.ts:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "packages/assemble-release-plan/src/test-utils.ts"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Test helper imported by sibling test files through an extensionless specifier the resolver does not map, so the edge exists in source but not in the graph."

--- a/tests/zoo/expectations/eshoponweb.toml
+++ b/tests/zoo/expectations/eshoponweb.toml
@@ -69,23 +69,3 @@ path = "src/Web/appsettings.Docker.json"
 line = 4
 disposition = "valid-but-accepted"
 reason = "IdentityConnection string with an embedded demo password for the Docker SQL container (Web)."
-
-[[finding]]
-profile = "strict"
-finding_id = "architecture.dead-module:src/BlazorShared/Models/LookupData.cs:b022a3e6e8b8daf1"
-rule_id = "architecture.dead-module"
-path = "src/BlazorShared/Models/LookupData.cs"
-line = 1
-evidence = "sample"
-disposition = "false-positive"
-reason = "C# references types through namespaces, not file paths, so the import graph has no file-to-file edge to count. Zero fan-in here means the language is unmodeled, not that nothing uses the type."
-
-[[finding]]
-profile = "strict"
-finding_id = "architecture.dead-module:src/Web/Pages/Basket/BasketItemViewModel.cs:b022a3e6e8b8daf1"
-rule_id = "architecture.dead-module"
-path = "src/Web/Pages/Basket/BasketItemViewModel.cs"
-line = 1
-evidence = "sample"
-disposition = "false-positive"
-reason = "Same namespace-versus-path gap as LookupData.cs; the view model is used from Razor pages in the same namespace with no file import anywhere."

--- a/tests/zoo/expectations/express.toml
+++ b/tests/zoo/expectations/express.toml
@@ -24,3 +24,23 @@ line = 1
 evidence = "sample"
 disposition = "false-positive"
 reason = "Another mocha test under the singular `test/` directory classified role=Production. The test-file classifier recognizes `tests/` but not `test/`."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:test/acceptance/route-map.js:5f75afc99cf552b5"
+rule_id = "architecture.dead-module"
+path = "test/acceptance/route-map.js"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Acceptance test under the singular `test/` directory, classified role=Production because the test-file classifier only recognizes `tests/`."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:test/support/tmpl.js:5f75afc99cf552b5"
+rule_id = "architecture.dead-module"
+path = "test/support/tmpl.js"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Test support helper under the singular `test/` directory; same classifier gap as test/acceptance/route-map.js."

--- a/tests/zoo/expectations/nowinandroid.toml
+++ b/tests/zoo/expectations/nowinandroid.toml
@@ -10,3 +10,22 @@ rule_id = "language.managed.fatal-exception-risk"
 path = "feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt"
 disposition = "actionable"
 reason = "TODO() placeholder on the TopicUiState.Error branch will throw NotImplementedError at runtime if the error state is ever rendered; the rule correctly surfaces an unimplemented production path."
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:core/analytics/src/demo/kotlin/com/google/samples/apps/nowinandroid/core/analytics/AnalyticsModule.kt:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "core/analytics/src/demo/kotlin/com/google/samples/apps/nowinandroid/core/analytics/AnalyticsModule.kt"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "A Hilt module in the Gradle `demo` product-flavor source set (`src/demo/kotlin`), wired by annotation processing. The JVM resolver only knows the five fixed source roots, so no import in this multi-module build resolves to it."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:feature/foryou/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/impl/ForYouViewModel.kt:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "feature/foryou/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/impl/ForYouViewModel.kt"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Kotlin in a multi-module Gradle project: the JVM resolver probes only `src/main/kotlin` and four other fixed roots relative to the repository root, never a per-module `<module>/src/main/kotlin`, so this repository resolves almost no internal imports."

--- a/tests/zoo/expectations/wagtail.toml
+++ b/tests/zoo/expectations/wagtail.toml
@@ -74,3 +74,33 @@ line = 1
 evidence = "sample"
 disposition = "false-positive"
 reason = "Referenced by dotted string from wagtail/users/apps.py (`group_viewset = \"wagtail.users.views.groups.GroupViewSet\"`), the Django pattern for late-bound references. No static import names the module."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:client/src/entrypoints/admin/page-chooser.js:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "client/src/entrypoints/admin/page-chooser.js"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "A webpack entry module: client/webpack.config.js builds its entry map from `./client/src/entrypoints/${appName}/${moduleName}.js`, so the bundler names it and no source file imports it."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:wagtail/images/static_src/wagtailimages/js/add-multiple.js:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "wagtail/images/static_src/wagtailimages/js/add-multiple.js"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "A browser asset loaded by a Django template tag: templates/wagtailimages/multiple/add.html has `<script src=\"{% versioned_static 'wagtailimages/js/add-multiple.js' %}\">`. Script-tag references are not imports."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.dead-module:wagtail/test/utils/wagtail_tests.py:b022a3e6e8b8daf1"
+rule_id = "architecture.dead-module"
+path = "wagtail/test/utils/wagtail_tests.py"
+line = 1
+evidence = "sample"
+disposition = "false-positive"
+reason = "Test utilities under a singular `test/` directory, classified role=Production for the same reason as express's `test/` tree."

--- a/tests/zoo/snapshots/eshoponweb.json
+++ b/tests/zoo/snapshots/eshoponweb.json
@@ -24,7 +24,7 @@
   "sha": "4da8212117e87d808d4bbc7da6286fd2147ce606",
   "strict": {
     "by_rule": {
-      "architecture.dead-module": 208,
+      "architecture.dead-module": 2,
       "architecture.deep-directory-nesting": 30,
       "architecture.large-file": 1,
       "code-marker.todo": 9,
@@ -33,6 +33,6 @@
       "security.secret-candidate": 7,
       "testing.source-without-test": 2
     },
-    "visible_total": 268
+    "visible_total": 62
   }
 }

--- a/tests/zoo/snapshots/fastapi.json
+++ b/tests/zoo/snapshots/fastapi.json
@@ -19,7 +19,7 @@
   "strict": {
     "by_rule": {
       "architecture.circular-dependency": 2,
-      "architecture.dead-module": 4,
+      "architecture.dead-module": 1,
       "architecture.large-file": 17,
       "architecture.too-many-modules": 3,
       "code-marker.todo": 17,
@@ -31,6 +31,6 @@
       "security.secret-candidate": 2,
       "testing.source-without-test": 36
     },
-    "visible_total": 320
+    "visible_total": 317
   }
 }

--- a/tests/zoo/snapshots/nowinandroid.json
+++ b/tests/zoo/snapshots/nowinandroid.json
@@ -17,7 +17,7 @@
   "sha": "7d45eae4f8720a0c77f507712ba2437ff974b6ed",
   "strict": {
     "by_rule": {
-      "architecture.dead-module": 20,
+      "architecture.dead-module": 136,
       "architecture.deep-directory-nesting": 373,
       "architecture.large-file": 9,
       "code-marker.todo": 30,
@@ -26,6 +26,6 @@
       "language.managed.fatal-exception-risk": 6,
       "testing.source-without-test": 232
     },
-    "visible_total": 704
+    "visible_total": 820
   }
 }

--- a/tests/zoo/snapshots/spring-petclinic.json
+++ b/tests/zoo/snapshots/spring-petclinic.json
@@ -11,10 +11,11 @@
   "sha": "a2c2ef994340d3970eb6db51247456a51bb161f8",
   "strict": {
     "by_rule": {
+      "architecture.dead-module": 28,
       "architecture.deep-directory-nesting": 46,
       "language.managed.fatal-exception-risk": 1,
       "testing.source-without-test": 30
     },
-    "visible_total": 77
+    "visible_total": 105
   }
 }

--- a/tests/zoo/snapshots/wagtail.json
+++ b/tests/zoo/snapshots/wagtail.json
@@ -25,7 +25,7 @@
   "strict": {
     "by_rule": {
       "architecture.circular-dependency": 11,
-      "architecture.dead-module": 255,
+      "architecture.dead-module": 159,
       "architecture.deep-directory-nesting": 1019,
       "architecture.deep-relative-imports": 33,
       "architecture.excessive-fan-out": 17,
@@ -47,6 +47,6 @@
       "language.python.exception-risk": 45,
       "testing.source-without-test": 668
     },
-    "visible_total": 2640
+    "visible_total": 2544
   }
 }


### PR DESCRIPTION
## Summary

An absence claim only carries information when the thing could have been present. `architecture.dead-module` now requires a language whose imports the resolver can turn into edges, which removes 206 unsound C# findings - and, along the way, corrects an over-broad recognizer from #370 that was hiding 144 real ones.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- `graph::resolver::resolves_file_imports(path)` - a public predicate backed by the same extension list `resolve_import` dispatches on, so the two cannot drift. A test walks every declared extension into its resolver arm and asserts the namespace/header languages resolve nothing.
- `dead_module_finding` uses it instead of the `LanguageFamily::CurlyBrace` check, which lumped C#, Swift, PHP, Dart, Scala, and the C family together with Rust and TypeScript.
- **Correction to #370:** `examples`/`samples` were matched at any path depth. They are now matched only within two components of a root, and singular `example`/`sample` not at all.
- Three shapes added to the entrypoint model: Python `__init__.py` package markers, Storybook `*.stories.*` collected by glob, and Django `templatetags/` libraries loaded by `{% load %}` name.
- 6 new unit tests, including a false-negative guard listing every language the rule must still cover.
- Zoo snapshots re-blessed; two resolved sample labels deleted, eight new ones labeled.

## Why

C# has no resolver arm at all. `using Microsoft.eShopWeb.Web.Interfaces` never becomes an edge, so *every* `.cs` file in every repository has zero fan-in, and the rule flagged all 208 in eShopOnWeb. Two of them were in the previous sample, and verifying them showed the shape: `CatalogItemViewModelService.cs` is referenced from `ConfigureWebServices.cs` and a Razor page, and `BasketItemConfiguration.cs` is loaded by `ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly())`. Both are heavily used. The graph simply has nothing to say about them, and "no evidence" must not render as "dead".

## Correcting the previous slice

Worth stating plainly: #370 shipped a recognizer that matched `samples` anywhere in a path. Spring PetClinic's package is `org.springframework.samples.petclinic` and Now in Android's is `com.google.samples.apps.nowinandroid`, so both had their entire source trees suppressed as "documentation examples" - PetClinic's 28 findings went to 0 for the wrong reason. The depth limit restores 144 findings. Whether those are themselves precise is a separate question the new sample answers below; hiding them was not the way to find out.

## Measurement

```
repo                #370   this PR
eshoponweb           208         2     ← C# language gate
wagtail              255       159     ← __init__.py, stories, templatetags
fastapi                4         1     ← __init__.py
nowinandroid          20       136     ← restored (samples/ depth fix)
spring-petclinic       0        28     ← restored (samples/ depth fix)
                    ----      ----
TOTAL                659       498
```

Across both slices: **1762 → 498 (−72%)**. No other strict rule's count moved in any repository, and every default profile is unchanged - this rule is strict-only.

## What the rule still gets wrong

Eight newly sampled findings, all labeled with verified reasons, in three families:

1. **Singular `test/` trees** (express ×2, wagtail) - `is_test_file` recognizes `tests/` and a `tests_` prefix but not `test/`, `src/test/java`, or a bare tests.py`, so those files classify as `role=Production`.
2. **Multi-module Gradle builds** (nowinandroid ×2) - `jvm.rs` probes five fixed source roots relative to the repository root and never `<module>/src/main/kotlin`, so this build resolves almost nothing. One of the two is also in a `src/demo/kotlin` product-flavor source set.
3. **Browser assets** (wagtail ×2) - one is named by webpack's entry map (`./client/src/entrypoints/${appName}/${moduleName}.js`), the other by a Django template tag (`<script src="{% versioned_static ... %}">`). Neither is an import.

Plus the carried-over extensionless test-helper case in changesets. Family 2 is the interesting one: fixing JVM resolution would improve cycles, fan-out, and coupling too, not just this rule.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 -m unittest discover -s scripts/tests -p 'test_*.py'
python3 scripts/release-contract.py check
cargo run -- scan . --fail-on-priority p1
```
