### PR TITLE
feat: resolve JVM imports in multi-module builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,18 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Resolve Java and Kotlin imports in multi-module builds. A JVM import names a
+  type, not a path, and the resolver used to guess the module prefix from five
+  fixed source roots — which resolves single-module Maven projects and nothing
+  else. It now matches the package path against the tail of each scanned file,
+  so `<module>/src/main/kotlin` and Gradle product-flavor source sets resolve
+  like any other layout, and a member import such as
+  `Detector.Companion.ISSUE` finds its declaring type. Ambiguity is never
+  guessed: a type declared in two production source sets stays unresolved, and
+  a Kotlin top-level declaration in an arbitrarily named file stays unresolved
+  because no path convention can find it. Now in Android drops from 2058 to
+  1666 unresolved internal imports; every graph consumer — cycles, fan-out,
+  coupling, blast radius — reads the larger edge set.
 - `architecture.dead-module` now requires a language whose imports the resolver
   can map to repository files. C#, Swift, PHP, Dart, Scala, and the C family
   reference types through namespaces and headers that never become graph edges,

--- a/src/graph/resolver/jvm.rs
+++ b/src/graph/resolver/jvm.rs
@@ -1,37 +1,138 @@
 //! JVM (Java / Kotlin) import resolution from fully-qualified class names.
+//!
+//! A JVM import names a type, not a path: `com.example.Foo` says nothing about
+//! which module directory holds it. The mapping back to a file only works
+//! because Maven and Gradle both put sources under `<module>/src/<set>/<lang>/`
+//! and then mirror the package as directories. So the *tail* of the path is
+//! fully determined by the import, and only the module prefix is unknown.
+//!
+//! That is why this resolver matches on the path tail instead of guessing
+//! module prefixes. A fixed list of source roots resolves single-module
+//! projects and nothing else: Now in Android puts its code in 68 source roots
+//! like `core/data/src/main/kotlin` and `feature/foryou/impl/src/main/kotlin`,
+//! and a root-relative probe misses every one of them.
 
-use super::{normalize_path, probe};
+use super::normalize_path;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+/// How many trailing segments may be dropped while looking for the declaring
+/// file. `Detector.Companion.ISSUE` is three segments past `Detector.kt`, and
+/// two drops reach it; more would start matching packages instead of types.
+const MAX_MEMBER_SEGMENTS: usize = 2;
+
 /// Resolves a fully-qualified JVM class name (`com.example.Foo`) to a source
-/// file. Tries the standard Maven/Gradle source-root layout first, then falls
-/// back to bare `src/`.
+/// file whose path ends with that package path.
+///
+/// Ambiguity is not resolved by guessing. When a class name appears under two
+/// different source sets — the same type in `src/main` and `src/demo` product
+/// flavors, for instance — this returns `None` so the import is recorded as
+/// unresolved rather than wired to an arbitrary one of them.
 pub(super) fn resolve_jvm(
     raw: &str,
-    root: &Path,
     known_files: &HashSet<PathBuf>,
     extensions: &[&str],
 ) -> Option<PathBuf> {
-    let rel = raw.replace('.', "/");
-
-    const SOURCE_ROOTS: &[&str] = &[
-        "src/main/java",
-        "src/main/kotlin",
-        "src",
-        "app/src/main/java",
-        "app/src/main/kotlin",
-    ];
-
-    for src_root in SOURCE_ROOTS {
-        let base = normalize_path(&root.join(src_root).join(&rel));
-        let candidates: Vec<PathBuf> = extensions
+    for type_path in type_path_candidates(raw) {
+        // The file name is the cheap discriminator: it must equal the last
+        // package segment plus a source extension. Checking it first keeps the
+        // allocating full-path comparison off the overwhelming majority of
+        // files, which matters because most imports in a JVM project name a
+        // third-party type that no repository file declares.
+        let type_name = type_path.rsplit('/').next().unwrap_or(&type_path);
+        let mut matches = known_files
             .iter()
-            .map(|ext| base.with_extension(ext))
-            .collect();
-        if let Some(path) = probe(&candidates, known_files) {
-            return Some(path);
+            .filter(|path| file_name_declares(path, type_name, extensions))
+            .filter(|path| declares_type(path, &type_path, extensions))
+            .collect::<Vec<_>>();
+        if matches.is_empty() {
+            continue;
         }
+        // A test or fixture source set never shadows production code; only when
+        // every candidate is a test set does one of those stay eligible.
+        let production = matches
+            .iter()
+            .filter(|path| !is_test_source_set(path))
+            .count();
+        if production > 0 {
+            matches.retain(|path| !is_test_source_set(path));
+        }
+        if matches.len() == 1 {
+            return Some(normalize_path(matches[0]));
+        }
+        // Two source sets declare the same type; the build picks one by variant
+        // and this resolver cannot know which.
+        return None;
     }
     None
 }
+
+/// The package paths that could name the declaring file, longest first:
+/// the import itself, then the same import with trailing member segments
+/// dropped while the remaining tail still looks like a type name.
+fn type_path_candidates(raw: &str) -> Vec<String> {
+    let mut segments = raw.split('.').filter(|s| !s.is_empty()).collect::<Vec<_>>();
+    if segments.len() < 2 || segments.last().is_some_and(|last| *last == "*") {
+        return Vec::new();
+    }
+    let mut candidates = vec![segments.join("/")];
+    for _ in 0..MAX_MEMBER_SEGMENTS {
+        segments.pop();
+        match segments.last() {
+            Some(last) if starts_uppercase(last) && segments.len() >= 2 => {
+                candidates.push(segments.join("/"));
+            }
+            _ => break,
+        }
+    }
+    candidates
+}
+
+/// Allocation-free pre-filter: does this file's name match `<type_name>.<ext>`?
+fn file_name_declares(path: &Path, type_name: &str, extensions: &[&str]) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix(type_name))
+        .and_then(|rest| rest.strip_prefix('.'))
+        .is_some_and(|extension| extensions.contains(&extension))
+}
+
+/// Whether `path` is the file declaring `type_path`: its tail is exactly the
+/// package path plus a source extension, starting at a directory boundary.
+///
+/// `known_files` only ever holds scanned repository files, so matching the tail
+/// cannot reach outside the repository.
+fn declares_type(path: &Path, type_path: &str, extensions: &[&str]) -> bool {
+    let text = path.to_string_lossy().replace('\\', "/");
+    let Some(without_extension) = extensions
+        .iter()
+        .find_map(|extension| text.strip_suffix(&format!(".{extension}")))
+    else {
+        return false;
+    };
+    without_extension
+        .strip_suffix(type_path)
+        .is_some_and(|prefix| prefix.is_empty() || prefix.ends_with('/'))
+}
+
+/// Maven and Gradle name non-production source sets `src/test`, `src/androidTest`,
+/// and similar. Those hold their own copies of shared types.
+fn is_test_source_set(path: &Path) -> bool {
+    path.to_string_lossy()
+        .replace('\\', "/")
+        .split('/')
+        .any(|component| {
+            let lower = component.to_ascii_lowercase();
+            lower.ends_with("test") || lower.ends_with("tests")
+        })
+}
+
+fn starts_uppercase(segment: &str) -> bool {
+    segment
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_ascii_uppercase())
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/graph/resolver/jvm/tests.rs
+++ b/src/graph/resolver/jvm/tests.rs
@@ -1,0 +1,138 @@
+use super::{resolve_jvm, type_path_candidates};
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+fn files(paths: &[&str]) -> HashSet<PathBuf> {
+    paths.iter().map(PathBuf::from).collect()
+}
+
+#[test]
+fn a_single_module_maven_layout_still_resolves() {
+    // The layout the fixed source-root list used to handle must keep working.
+    let known =
+        files(&["/repo/src/main/java/org/springframework/samples/petclinic/owner/Owner.java"]);
+    assert_eq!(
+        resolve_jvm(
+            "org.springframework.samples.petclinic.owner.Owner",
+            &known,
+            &["java"]
+        ),
+        Some(PathBuf::from(
+            "/repo/src/main/java/org/springframework/samples/petclinic/owner/Owner.java"
+        ))
+    );
+}
+
+#[test]
+fn a_gradle_module_source_root_resolves() {
+    // Catches the regression this replaces: a root-relative probe misses every
+    // `<module>/src/main/kotlin` in a multi-module build.
+    let known = files(&[
+        "/repo/core/data/src/main/kotlin/com/google/samples/apps/nia/core/data/Repo.kt",
+        "/repo/feature/foryou/impl/src/main/kotlin/com/google/samples/apps/nia/feature/foryou/ForYouViewModel.kt",
+    ]);
+    assert_eq!(
+        resolve_jvm(
+            "com.google.samples.apps.nia.core.data.Repo",
+            &known,
+            &["kt", "java"]
+        ),
+        Some(PathBuf::from(
+            "/repo/core/data/src/main/kotlin/com/google/samples/apps/nia/core/data/Repo.kt"
+        ))
+    );
+}
+
+#[test]
+fn a_companion_member_import_resolves_to_its_declaring_type() {
+    let known = files(&["/repo/lint/src/main/kotlin/com/example/lint/DesignSystemDetector.kt"]);
+    assert_eq!(
+        resolve_jvm(
+            "com.example.lint.DesignSystemDetector.Companion.ISSUE",
+            &known,
+            &["kt", "java"]
+        ),
+        Some(PathBuf::from(
+            "/repo/lint/src/main/kotlin/com/example/lint/DesignSystemDetector.kt"
+        ))
+    );
+}
+
+#[test]
+fn a_top_level_declaration_in_an_unrelated_file_stays_unresolved() {
+    // Kotlin top-level functions do not have to live in a file named after
+    // them, so no path convention can find `followableTopicTestData`. Guessing
+    // would invent an edge.
+    let known = files(&["/repo/core/testing/src/main/kotlin/com/example/testing/data/TestData.kt"]);
+    assert_eq!(
+        resolve_jvm(
+            "com.example.testing.data.followableTopicTestData",
+            &known,
+            &["kt", "java"]
+        ),
+        None
+    );
+}
+
+#[test]
+fn production_source_sets_win_over_test_source_sets() {
+    let known = files(&[
+        "/repo/app/src/main/kotlin/com/example/app/Config.kt",
+        "/repo/app/src/test/kotlin/com/example/app/Config.kt",
+        "/repo/app/src/androidTest/kotlin/com/example/app/Config.kt",
+    ]);
+    assert_eq!(
+        resolve_jvm("com.example.app.Config", &known, &["kt", "java"]),
+        Some(PathBuf::from(
+            "/repo/app/src/main/kotlin/com/example/app/Config.kt"
+        ))
+    );
+}
+
+#[test]
+fn two_production_variants_of_one_type_stay_unresolved() {
+    // Gradle product flavors can declare the same type twice; which one the
+    // build picks is a variant decision this resolver cannot make, so the
+    // import is reported unresolved instead of wired arbitrarily.
+    let known = files(&[
+        "/repo/core/analytics/src/demo/kotlin/com/example/analytics/AnalyticsModule.kt",
+        "/repo/core/analytics/src/prod/kotlin/com/example/analytics/AnalyticsModule.kt",
+    ]);
+    assert_eq!(
+        resolve_jvm("com.example.analytics.AnalyticsModule", &known, &["kt"]),
+        None
+    );
+}
+
+#[test]
+fn a_package_path_must_start_at_a_directory_boundary() {
+    // `.../mycom/example/Foo.kt` must not satisfy an import of `com.example.Foo`.
+    let known = files(&["/repo/src/main/kotlin/mycom/example/Foo.kt"]);
+    assert_eq!(resolve_jvm("com.example.Foo", &known, &["kt"]), None);
+}
+
+#[test]
+fn star_imports_and_bare_names_resolve_nothing() {
+    let known = files(&["/repo/src/main/kotlin/com/example/Foo.kt"]);
+    assert_eq!(resolve_jvm("com.example.*", &known, &["kt"]), None);
+    assert_eq!(resolve_jvm("Foo", &known, &["kt"]), None);
+}
+
+#[test]
+fn member_stripping_stops_before_it_reaches_a_package() {
+    // Catches dropping so many segments that a package directory name is
+    // treated as a type and matched against an unrelated file.
+    assert_eq!(
+        type_path_candidates("com.example.Detector.Companion.ISSUE"),
+        vec![
+            "com/example/Detector/Companion/ISSUE",
+            "com/example/Detector/Companion",
+            "com/example/Detector",
+        ]
+    );
+    assert_eq!(
+        type_path_candidates("com.example.data.helper"),
+        vec!["com/example/data/helper"],
+        "a lowercase tail is not a type, so nothing is stripped"
+    );
+}

--- a/src/graph/resolver/mod.rs
+++ b/src/graph/resolver/mod.rs
@@ -53,8 +53,8 @@ pub fn resolve_import(
         }
         "py" => python::resolve_python(raw_import, from_file, root, known_files),
         "go" => go::resolve_go(raw_import, root, known_files),
-        "java" => jvm::resolve_jvm(raw_import, root, known_files, &["java"]),
-        "kt" | "kts" => jvm::resolve_jvm(raw_import, root, known_files, &["kt", "java"]),
+        "java" => jvm::resolve_jvm(raw_import, known_files, &["java"]),
+        "kt" | "kts" => jvm::resolve_jvm(raw_import, known_files, &["kt", "java"]),
         _ => None,
     }
 }

--- a/tests/zoo/snapshots/nowinandroid.json
+++ b/tests/zoo/snapshots/nowinandroid.json
@@ -17,7 +17,7 @@
   "sha": "7d45eae4f8720a0c77f507712ba2437ff974b6ed",
   "strict": {
     "by_rule": {
-      "architecture.dead-module": 136,
+      "architecture.dead-module": 137,
       "architecture.deep-directory-nesting": 373,
       "architecture.large-file": 9,
       "code-marker.todo": 30,
@@ -26,6 +26,6 @@
       "language.managed.fatal-exception-risk": 6,
       "testing.source-without-test": 232
     },
-    "visible_total": 820
+    "visible_total": 821
   }
 }


### PR DESCRIPTION
## Summary

A JVM import names a type, not a path. The resolver bridged that gap with five fixed source roots, which resolves single-module Maven projects and nothing else. It now matches the package path against the tail of each scanned file, so multi-module Gradle builds resolve too - Now in Android goes from 2058 to 1666 unresolved internal imports.

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- `resolve_jvm` matches `com/example/Foo` against the tail of every scanned path, requiring the package to start at a directory boundary, instead of probing `<root>/src/main/{java,kotlin}` and three siblings.
- Member imports resolve to their declaring type: `Detector.Companion.ISSUE` drops up to two trailing segments while the remaining tail still looks like a type name.
- File name is an allocation-free pre-filter, so the common case (an import of a third-party type no repository file declares) costs one comparison per file instead of a path normalization.
- 9 unit tests covering both layouts, member imports, source-set precedence, ambiguity, boundary matching, and star imports.

## Why

Now in Android keeps its code in 68 source roots (`core/data/src/main/kotlin`, `feature/foryou/impl/src/main/kotlin`, …). A root-relative probe misses every one, so the whole repository had almost no Kotlin edges — which is what made `architecture.dead-module` unusable there, and equally starved cycles, fan-out, coupling, and blast radius.

## Measurement

| | before | after |
|---|---:|---:|
| nowinandroid unresolved internal imports | 2058 | 1666 |
| nowinandroid `architecture.dead-module` | 136 | 137 |

Finding counts barely move, and that is worth stating plainly rather than dressing up. The extra 392 edges mostly land on files that already had an importer. Three findings changed, all verified by hand:

- `core/common/.../NiaDispatchers.kt` gains a real importer and is no longer reported;
- `core/data/.../model/NewsResource.kt` and `Topic.kt` are now reported, and correctly — nothing in the repository imports `core.data.model.NewsResource` or `core.data.model.Topic` by name; they hold top-level extension functions callers import individually.

No other repository's snapshot moved, and no default profile changed.

The value here is graph accuracy, not this rule's count. The remaining Kotlin noise is the top-level-declaration case, which no amount of resolution fixes - it needs a per-language readiness gate, which is the next slice.

## Performance

Path matching is per-import, so this was measured rather than assumed:

```
nowinandroid strict scan   1.405s → 1.175s   (baseline → this branch, warm)
npm run review:performance changed/full ratio 0.381 (budget 0.6)
npm run scan:performance   per-file median 0.49ms (budget 6000ms)
                           changed_review_medium_1000 warm 260ms (budget 1500ms)
```

The first draft without the file-name pre-filter ran at 2.4s; that is what the pre-filter exists for.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
npm run review:performance
npm run scan:performance
cargo run -- scan . --fail-on-priority p1
```