### PR TITLE
feat: judge absence claims by per-language graph quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Absence-based graph claims are now judged per language rather than per
+  repository. "Nothing imports this file" only carries information when the
+  graph found most of the edges that exist, and resolution quality varies by
+  language inside one repository. When a language's unresolved internal imports
+  outnumber its resolved edges, the graph is not a usable map of it and the
+  claim is withdrawn under the new `graph.language-unmapped` reason code
+  instead of being reported at reduced confidence. Presence claims are never
+  gated: a resolved edge is proof on its own. `architecture.dead-module` drops
+  to zero findings on Now in Android and Spring PetClinic, whose JVM imports
+  largely do not resolve, and is unchanged everywhere else.
 - Resolve Java and Kotlin imports in multi-module builds. A JVM import names a
   type, not a path, and the resolver used to guess the module prefix from five
   fixed source roots — which resolves single-module Maven projects and nothing

--- a/docs/engineering/rule-scorecard.md
+++ b/docs/engineering/rule-scorecard.md
@@ -71,4 +71,4 @@ Rules that fire only in the strict profile are too numerous to label exhaustivel
 
 | Rule | Lifecycle | Sampled | Precision Estimate | False-Positive Debt |
 |---|---|---|---:|---:|
-| `architecture.dead-module` | experimental | 15 sampled across 5 repo(s) | 0.00 | 15 |
+| `architecture.dead-module` | experimental | 13 sampled across 4 repo(s) | 0.00 | 13 |

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -140,14 +140,21 @@ Current progress:
 - `architecture.dead-module` was the first rule measured, at 0.00 precision. Its
   entrypoint model now covers files reached without an import, and absence
   claims are restricted to languages whose imports the resolver maps to files.
-  The zoo population is down from 1762 to 498 strict findings. The sampled false
-  positives that remain name the next slices: test files under a singular
-  `test/` directory or a bare `tests.py`; multi-module Gradle projects, where
-  the JVM resolver probes five fixed source roots and misses
-  `<module>/src/main/kotlin` entirely; browser assets referenced by a
-  `<script>` tag or a bundler entry map; vendored third-party bundles;
+  Absence claims are also judged per language: JVM multi-module resolution
+  improved, and where a language's imports still mostly fail to resolve the
+  claim is withdrawn rather than demoted. The zoo population is down from 1762
+  to 321 strict findings. The sampled false positives that remain name the next
+  slices: test files under a singular `test/` directory or a bare `tests.py`
+  (now the dominant family); browser assets referenced by a `<script>` tag or a
+  bundler entry map; package `bin` entries; vendored third-party bundles;
   convention-loaded CLI command directories; and Python modules referenced by
   dotted string.
+- Known input weakness behind the language gate: an import counts as
+  repository-internal when its leading segment matches any directory name, and
+  in JVM projects `com` and `org` always do, so third-party imports inflate the
+  unresolved count. The inflation pushes the gate toward withdrawing claims,
+  which is the safe direction for an absence, but the classifier should become
+  path-aware and the gate re-measured after it does.
 
 Deliverables:
 

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -224,7 +224,15 @@ fn target_absence_readiness(
         .file_stem()
         .and_then(|stem| stem.to_str())
         .unwrap_or_default();
-    graph_readiness(capabilities, resolution, GraphClaim::TargetAbsence(stem))
+    let extension = info
+        .relative
+        .extension()
+        .and_then(|extension| extension.to_str());
+    graph_readiness(
+        capabilities,
+        resolution,
+        GraphClaim::TargetAbsence { stem, extension },
+    )
 }
 
 /// A production file importing a test or fixture file leaks test-only code into

--- a/src/graph/resolution_stats.rs
+++ b/src/graph/resolution_stats.rs
@@ -99,6 +99,24 @@ impl ImportResolutionStats {
             .sum()
     }
 
+    /// Unresolved internal imports written by files with this extension.
+    ///
+    /// Resolution quality is per language, not per repository: one project can
+    /// map its TypeScript perfectly while its Kotlin barely resolves, and an
+    /// absence claim about a Kotlin file must be judged on the Kotlin figure.
+    pub fn total_for_extension(&self, extension: &str) -> usize {
+        self.unresolved_internal_by_source
+            .iter()
+            .filter(|(source, _)| {
+                source
+                    .extension()
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|value| value == extension)
+            })
+            .map(|(_, evidence)| evidence.len())
+            .sum()
+    }
+
     /// True when any unresolved import could plausibly target a file named
     /// `stem`, so "nothing imports it" cannot be claimed for it. Both the last
     /// path segment (`./legacy/Utils.js` → `Utils`) and the last dotted segment

--- a/src/graph/v2/capabilities.rs
+++ b/src/graph/v2/capabilities.rs
@@ -8,6 +8,7 @@
 //! and has no command or report consumer yet — it does not add a public surface.
 
 use super::{GraphEdgeConfidence, GraphNodeKind, GraphSnapshot};
+use std::collections::BTreeMap;
 
 /// What dependency facts a snapshot provides. All counts are over dependency
 /// edges only (`Imports`/`ReExports`/`DependsOn`); structural edges such as
@@ -24,6 +25,13 @@ pub struct GraphCapabilities {
     pub external_dependency_edges: usize,
     /// Local imports that looked relative but resolved to nothing (low).
     pub unresolved_local_edges: usize,
+    /// Resolved dependency edges keyed by the importing file's extension.
+    ///
+    /// The graph maps some languages better than others in the same repository:
+    /// a Gradle project's TypeScript tooling can resolve cleanly while its
+    /// Kotlin barely resolves at all. A claim about one file needs to know how
+    /// well *its* language is mapped, not the repository average.
+    pub resolved_dependency_edges_by_extension: BTreeMap<String, usize>,
     /// Bounded diagnostics recorded while building the snapshot.
     pub diagnostics: usize,
 }
@@ -33,6 +41,14 @@ impl GraphCapabilities {
     /// the minimum for cycle, degree, and blast-radius analysis to mean anything.
     pub fn supports_dependency_analysis(&self) -> bool {
         self.resolved_dependency_edges > 0
+    }
+
+    /// Resolved dependency edges written by files with this extension.
+    pub fn resolved_edges_for_extension(&self, extension: &str) -> usize {
+        self.resolved_dependency_edges_by_extension
+            .get(extension)
+            .copied()
+            .unwrap_or(0)
     }
 }
 
@@ -44,11 +60,20 @@ pub fn graph_capabilities(snapshot: &GraphSnapshot) -> GraphCapabilities {
         ..GraphCapabilities::default()
     };
 
+    let mut extension_by_node = BTreeMap::new();
     for node in &snapshot.nodes {
         match node.kind {
             GraphNodeKind::File => capabilities.file_nodes += 1,
             GraphNodeKind::ExternalDependency => capabilities.external_nodes += 1,
             _ => {}
+        }
+        if let Some(extension) = node
+            .path
+            .as_ref()
+            .and_then(|path| path.extension())
+            .and_then(|extension| extension.to_str())
+        {
+            extension_by_node.insert(node.id.clone(), extension.to_string());
         }
     }
 
@@ -57,7 +82,15 @@ pub fn graph_capabilities(snapshot: &GraphSnapshot) -> GraphCapabilities {
             continue;
         }
         match edge.confidence {
-            GraphEdgeConfidence::High => capabilities.resolved_dependency_edges += 1,
+            GraphEdgeConfidence::High => {
+                capabilities.resolved_dependency_edges += 1;
+                if let Some(extension) = extension_by_node.get(&edge.from) {
+                    *capabilities
+                        .resolved_dependency_edges_by_extension
+                        .entry(extension.clone())
+                        .or_insert(0) += 1;
+                }
+            }
             GraphEdgeConfidence::Medium => capabilities.external_dependency_edges += 1,
             GraphEdgeConfidence::Low => capabilities.unresolved_local_edges += 1,
         }

--- a/src/graph/v2/mod.rs
+++ b/src/graph/v2/mod.rs
@@ -124,7 +124,10 @@ mod tests {
             graph_readiness(
                 &capabilities,
                 &resolution,
-                GraphClaim::TargetAbsence("orphan")
+                GraphClaim::TargetAbsence {
+                    stem: "orphan",
+                    extension: None,
+                }
             ),
             GraphReadiness::Unavailable {
                 unresolved_internal: 1,

--- a/src/graph/v2/readiness.rs
+++ b/src/graph/v2/readiness.rs
@@ -7,7 +7,12 @@ use crate::graph::ImportResolutionStats;
 pub enum GraphClaim<'a> {
     Presence,
     RepositoryAbsence,
-    TargetAbsence(&'a str),
+    /// Nothing in the repository points at this file. `stem` is its file stem
+    /// and `extension` its language, which decides how well the graph maps it.
+    TargetAbsence {
+        stem: &'a str,
+        extension: Option<&'a str>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -26,6 +31,9 @@ pub enum GraphReadiness {
 pub enum GraphReadinessReason {
     NoFileGraph,
     UnresolvedTarget,
+    /// More of this language's internal imports failed to resolve than
+    /// succeeded, so the graph is not a usable map of it.
+    LanguageUnmapped,
 }
 
 impl GraphReadiness {
@@ -41,8 +49,31 @@ impl GraphReadiness {
                 reason: GraphReadinessReason::UnresolvedTarget,
                 ..
             } => "graph.unresolved-target",
+            Self::Unavailable {
+                reason: GraphReadinessReason::LanguageUnmapped,
+                ..
+            } => "graph.language-unmapped",
         }
     }
+}
+
+/// Whether the graph maps this language well enough to reason from an absence.
+///
+/// An absence claim says "no edge points here". That is only information when
+/// the graph found most of the edges that exist. Comparing a language's
+/// resolved edges against its unresolved internal imports gives that directly:
+/// when more of its imports failed than succeeded, the map has more holes than
+/// roads, and a missing edge says nothing about the code.
+///
+/// No unresolved imports means nothing failed, so a language with few edges is
+/// still fully mapped — sparse is not the same as unmapped.
+fn language_is_mapped(
+    capabilities: &GraphCapabilities,
+    resolution: &ImportResolutionStats,
+    extension: &str,
+) -> bool {
+    let unresolved = resolution.total_for_extension(extension);
+    unresolved == 0 || capabilities.resolved_edges_for_extension(extension) >= unresolved
 }
 
 pub fn graph_readiness(
@@ -62,13 +93,21 @@ pub fn graph_readiness(
         };
     }
 
-    if let GraphClaim::TargetAbsence(stem) = claim
-        && resolution.could_target_stem(stem)
-    {
-        return GraphReadiness::Unavailable {
-            unresolved_internal,
-            reason: GraphReadinessReason::UnresolvedTarget,
-        };
+    if let GraphClaim::TargetAbsence { stem, extension } = claim {
+        if resolution.could_target_stem(stem) {
+            return GraphReadiness::Unavailable {
+                unresolved_internal,
+                reason: GraphReadinessReason::UnresolvedTarget,
+            };
+        }
+        if let Some(extension) = extension
+            && !language_is_mapped(capabilities, resolution, extension)
+        {
+            return GraphReadiness::Unavailable {
+                unresolved_internal,
+                reason: GraphReadinessReason::LanguageUnmapped,
+            };
+        }
     }
 
     if unresolved_internal > 0 {
@@ -77,5 +116,121 @@ pub fn graph_readiness(
         }
     } else {
         GraphReadiness::Available
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::ImportResolutionStats;
+    use std::path::Path;
+
+    fn capabilities(resolved_by_extension: &[(&str, usize)]) -> GraphCapabilities {
+        GraphCapabilities {
+            file_nodes: 1,
+            resolved_dependency_edges: resolved_by_extension.iter().map(|(_, n)| n).sum(),
+            resolved_dependency_edges_by_extension: resolved_by_extension
+                .iter()
+                .map(|(extension, count)| ((*extension).to_string(), *count))
+                .collect(),
+            ..GraphCapabilities::default()
+        }
+    }
+
+    fn unresolved(entries: &[(&str, usize)]) -> ImportResolutionStats {
+        let mut resolution = ImportResolutionStats::default();
+        for (source, count) in entries {
+            for index in 0..*count {
+                resolution.record(Path::new(source), &format!("./missing-{index}"));
+            }
+        }
+        resolution
+    }
+
+    fn absence(extension: &str) -> GraphClaim<'_> {
+        GraphClaim::TargetAbsence {
+            stem: "unrelated",
+            extension: Some(extension),
+        }
+    }
+
+    #[test]
+    fn a_language_with_more_holes_than_roads_cannot_support_an_absence_claim() {
+        // Now in Android's shape: Kotlin resolves a minority of its imports, so
+        // "nothing imports this file" carries no information about Kotlin.
+        let capabilities = capabilities(&[("kt", 400)]);
+        let resolution = unresolved(&[("app/Main.kt", 1666)]);
+
+        assert_eq!(
+            graph_readiness(&capabilities, &resolution, absence("kt")),
+            GraphReadiness::Unavailable {
+                unresolved_internal: 1666,
+                reason: GraphReadinessReason::LanguageUnmapped,
+            }
+        );
+        assert_eq!(
+            GraphReadiness::Unavailable {
+                unresolved_internal: 1666,
+                reason: GraphReadinessReason::LanguageUnmapped,
+            }
+            .reason_code(),
+            "graph.language-unmapped"
+        );
+    }
+
+    #[test]
+    fn one_unmapped_language_does_not_silence_another_in_the_same_repository() {
+        // The false-negative guard: a Gradle project's TypeScript tooling can
+        // resolve cleanly while its Kotlin does not.
+        let capabilities = capabilities(&[("kt", 10), ("ts", 500)]);
+        let resolution = unresolved(&[("app/Main.kt", 900), ("web/app.ts", 3)]);
+
+        assert!(matches!(
+            graph_readiness(&capabilities, &resolution, absence("kt")),
+            GraphReadiness::Unavailable {
+                reason: GraphReadinessReason::LanguageUnmapped,
+                ..
+            }
+        ));
+        assert!(matches!(
+            graph_readiness(&capabilities, &resolution, absence("ts")),
+            GraphReadiness::Limited { .. }
+        ));
+    }
+
+    #[test]
+    fn a_language_that_never_failed_to_resolve_stays_mapped_even_with_few_edges() {
+        // Sparse is not unmapped: a Go package importing only the standard
+        // library has no internal imports to fail.
+        let capabilities = capabilities(&[("go", 0)]);
+        let resolution = unresolved(&[("web/app.ts", 5)]);
+
+        assert!(matches!(
+            graph_readiness(&capabilities, &resolution, absence("go")),
+            GraphReadiness::Limited { .. }
+        ));
+    }
+
+    #[test]
+    fn a_language_resolving_at_least_as_much_as_it_misses_stays_mapped() {
+        let capabilities = capabilities(&[("py", 50)]);
+        let resolution = unresolved(&[("pkg/app.py", 50)]);
+
+        assert!(matches!(
+            graph_readiness(&capabilities, &resolution, absence("py")),
+            GraphReadiness::Limited { .. }
+        ));
+    }
+
+    #[test]
+    fn presence_claims_are_never_gated_on_resolution_quality() {
+        // A resolved edge is proof on its own; only absence needs a good map.
+        let capabilities = capabilities(&[("kt", 1)]);
+        let resolution = unresolved(&[("app/Main.kt", 5000)]);
+
+        assert_eq!(
+            graph_readiness(&capabilities, &resolution, GraphClaim::Presence),
+            GraphReadiness::Available
+        );
     }
 }

--- a/tests/zoo/expectations/nowinandroid.toml
+++ b/tests/zoo/expectations/nowinandroid.toml
@@ -10,22 +10,3 @@ rule_id = "language.managed.fatal-exception-risk"
 path = "feature/topic/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/topic/impl/TopicScreen.kt"
 disposition = "actionable"
 reason = "TODO() placeholder on the TopicUiState.Error branch will throw NotImplementedError at runtime if the error state is ever rendered; the rule correctly surfaces an unimplemented production path."
-[[finding]]
-profile = "strict"
-finding_id = "architecture.dead-module:core/analytics/src/demo/kotlin/com/google/samples/apps/nowinandroid/core/analytics/AnalyticsModule.kt:b022a3e6e8b8daf1"
-rule_id = "architecture.dead-module"
-path = "core/analytics/src/demo/kotlin/com/google/samples/apps/nowinandroid/core/analytics/AnalyticsModule.kt"
-line = 1
-evidence = "sample"
-disposition = "false-positive"
-reason = "A Hilt module in the Gradle `demo` product-flavor source set (`src/demo/kotlin`), wired by annotation processing. The JVM resolver only knows the five fixed source roots, so no import in this multi-module build resolves to it."
-
-[[finding]]
-profile = "strict"
-finding_id = "architecture.dead-module:feature/foryou/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/impl/ForYouViewModel.kt:b022a3e6e8b8daf1"
-rule_id = "architecture.dead-module"
-path = "feature/foryou/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/impl/ForYouViewModel.kt"
-line = 1
-evidence = "sample"
-disposition = "false-positive"
-reason = "Kotlin in a multi-module Gradle project: the JVM resolver probes only `src/main/kotlin` and four other fixed roots relative to the repository root, never a per-module `<module>/src/main/kotlin`, so this repository resolves almost no internal imports."

--- a/tests/zoo/snapshots/nowinandroid.json
+++ b/tests/zoo/snapshots/nowinandroid.json
@@ -17,7 +17,6 @@
   "sha": "7d45eae4f8720a0c77f507712ba2437ff974b6ed",
   "strict": {
     "by_rule": {
-      "architecture.dead-module": 137,
       "architecture.deep-directory-nesting": 373,
       "architecture.large-file": 9,
       "code-marker.todo": 30,
@@ -26,6 +25,6 @@
       "language.managed.fatal-exception-risk": 6,
       "testing.source-without-test": 232
     },
-    "visible_total": 821
+    "visible_total": 684
   }
 }

--- a/tests/zoo/snapshots/spring-petclinic.json
+++ b/tests/zoo/snapshots/spring-petclinic.json
@@ -11,11 +11,10 @@
   "sha": "a2c2ef994340d3970eb6db51247456a51bb161f8",
   "strict": {
     "by_rule": {
-      "architecture.dead-module": 28,
       "architecture.deep-directory-nesting": 46,
       "language.managed.fatal-exception-risk": 1,
       "testing.source-without-test": 30
     },
-    "visible_total": 105
+    "visible_total": 77
   }
 }


### PR DESCRIPTION
## Summary

Resolution quality is a per-language property, not a repository average. A target-absence claim about a file whose language the graph maps poorly is now withdrawn rather than reported at reduced confidence. `architecture.dead-module` goes to zero on Now in Android and Spring PetClinic and is unchanged elsewhere - 499 → 334 strict findings, and **1762 → 321** across the whole slice.

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- `GraphCapabilities` counts resolved dependency edges keyed by the importing file's extension.
- `ImportResolutionStats::total_for_extension` counts unresolved internal imports the same way.
- `GraphClaim::TargetAbsence` carries the target's extension alongside its stem.
- `graph_readiness` withdraws the claim when a language's unresolved imports outnumber its resolved edges, under a new `graph.language-unmapped` reason code.
- 5 unit tests on the policy, including the false-negative guard that one unmapped language must not silence another in the same repository.

## Why

The previous slice showed the limit of resolution work. Kotlin top-level declarations can live in a file named anything, so no path convention finds them - Now in Android keeps 1666 unresolved internal imports even after
multi-module resolution landed, and its 137 dead-module findings were almost all false. More resolver work cannot fix that; the honest answer is to stop making claims the graph cannot support.

The rule is deliberately a comparison rather than a tuned threshold: when a language's imports fail more often than they succeed, the map has more holes than roads. Two guards keep it from over-firing - a language that never failed to resolve stays mapped however few edges it has (sparse ≠ unmapped), and presence claims are never gated, because a resolved edge is proof on its own.

## Measurement

```
repo                dead-module before  after
nowinandroid                       137      0
spring-petclinic                    28      0
(nine others)                   unchanged
                                 -----   ----
TOTAL                              499    334
```

Across the whole dead-module effort: **1762 → 321 (−82%)**. No other rule moved in any repository and no default profile changed.

Both suppressed repositories are JVM projects whose imports largely do not resolve, which is exactly the case the gate exists for.

## A weakness in the gate's input, stated rather than hidden

`is_unresolved_internal_import` treats a dotted import as repository-internal when its leading segment matches any directory name in the repository. In JVM projects `com` and `org` are always directory names, so `org.springframework.boot.SpringApplication` counts as an unresolved *internal* import in Spring PetClinic. That inflates the unresolved side and is part of why PetClinic trips the gate.

The inflation pushes toward withdrawing claims, which is the safe direction for an absence, so this is not a correctness hazard today. But the classifier should become path-aware - does the package chain exist as a directory chain? - and this gate must be re-measured when it does, because PetClinic's 28 findings may come back and will then need the Spring dependency-injection question answered.
Recorded in the roadmap.

## What the remaining population looks like

A fresh draw of 6 from the 321 survivors shows the same families as before, with one shift: **three of six are now the singular `test/` case** (`test/`, `src/test/java`, bare `tests.py`), which makes it the dominant remaining family
and the natural next slice. The others are a package `bin` entry, a webpack entry module, and a Python module referenced by dotted string. No new families appeared, so no new labels were added this round; the two nowinandroid sample labels whose findings the gate resolved were deleted.

## Performance

`total_for_extension` walks the unresolved map per candidate node, so this was measured:

```
wagtail strict scan      3.622s → 3.145s
excalidraw strict scan   1.203s → 1.302s
review:performance       changed/full ratio 0.357 (budget 0.6)
```

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

Subsystem: `src/graph/v2` capability and readiness policy, consumed by `graph_queries`. The new reason code is internal - readiness has no public report consumer yet. No rule id, severity, or schema change.

On recall: this withdraws strict findings, which normally preserves everything. It is the same justification as the language gate in #371 - these are not downgraded signals but claims the graph cannot support, and the release contract asks for bounded limitations over facts stated without evidence.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
npm run review:performance
cargo run -- scan . --fail-on-priority p1
```
