### PR TITLE
fix: recognize browser, binary, and vendored entries as reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- `architecture.dead-module` recognizes five more ways a file is reached
+  without an import: TypeScript declaration files, which carry no runtime code
+  at all; vendored third-party trees (`vendor/`, `node_modules/`,
+  `third_party/`); browser entries named by a bundler entry map, a `<script>`
+  tag, or a worker constructor (`entrypoints/`, `static_src/`, `*.worker.ts`);
+  a package's `bin` executable; and command modules in a package that declares
+  an executable, which the CLI dispatches by file name. The command case reuses
+  the existing `bin`-manifest evidence, so a CQRS `commands/` directory in a
+  library stays eligible. Across the zoo this takes the rule from 187 to 100
+  strict findings, with no other rule affected and no default-profile change.
 - Classify a singular `test/` directory as tests. The classifier recognized
   `tests/` but not `test/`, `src/test/java`, `src/androidTest`, or a bare
   `tests.py`, so Node, Maven, Gradle, and Django test trees carried

--- a/docs/engineering/rule-scorecard.md
+++ b/docs/engineering/rule-scorecard.md
@@ -71,4 +71,4 @@ Rules that fire only in the strict profile are too numerous to label exhaustivel
 
 | Rule | Lifecycle | Sampled | Precision Estimate | False-Positive Debt |
 |---|---|---|---:|---:|
-| `architecture.dead-module` | experimental | 7 sampled across 3 repo(s) | 0.00 | 7 |
+| `architecture.dead-module` | experimental | 3 sampled across 2 repo(s) | 0.00 | 3 |

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -142,14 +142,12 @@ Current progress:
   claims are restricted to languages whose imports the resolver maps to files.
   Absence claims are also judged per language: JVM multi-module resolution
   improved, and where a language's imports still mostly fail to resolve the
-  claim is withdrawn rather than demoted, and a singular `test/` directory is
-  classified as tests. The zoo population is down from 1762 to 187 strict
-  findings. The sampled false positives that remain name the next slices:
-  browser assets referenced by a `<script>` tag, a bundler entry map, or a
-  worker constructor; package `bin` entries; Django modules the app registry
-  imports (`models.py` and siblings); vendored third-party bundles;
-  convention-loaded CLI command directories; and Python modules referenced by
-  dotted string.
+  claim is withdrawn rather than demoted, a singular `test/` directory is
+  classified as tests, and browser, bundler, binary, and vendored entries are
+  recognized. The zoo population is down from 1762 to 100 strict findings — a
+  94% reduction driven entirely by measured evidence. What remains is mostly
+  Django modules the app registry imports (`models.py` and siblings) and Python
+  modules referenced by dotted string.
 - Known input weakness behind the language gate: an import counts as
   repository-internal when its leading segment matches any directory name, and
   in JVM projects `com` and `org` always do, so third-party imports inflate the

--- a/src/audits/architecture/graph_queries/entrypoints.rs
+++ b/src/audits/architecture/graph_queries/entrypoints.rs
@@ -41,15 +41,45 @@ pub(super) enum ReachedWithoutImport {
     DocumentationExample,
     /// A standalone script under `scripts/`, run by a person or a CI job.
     StandaloneScript,
+    /// A TypeScript declaration file. It carries no runtime code at all, so it
+    /// is never imported as a module and can never be dead.
+    TypeDeclaration,
+    /// Third-party code checked into the repository. Not project source.
+    VendoredCode,
+    /// Named by a bundler entry map, a `<script>` tag, or a worker constructor
+    /// rather than by an import in project code.
+    BrowserEntry,
+    /// A package's executable, named by `package.json`'s `bin` field.
+    PackageBinary,
+    /// A command module in a CLI package, dispatched by file name.
+    CommandModule,
 }
 
-pub(super) fn reached_without_import(path: &Path) -> Option<ReachedWithoutImport> {
+pub(super) fn reached_without_import(
+    path: &Path,
+    in_executable_package: bool,
+) -> Option<ReachedWithoutImport> {
     let name = file_name(path);
+    if name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts") {
+        return Some(ReachedWithoutImport::TypeDeclaration);
+    }
+    if path_contains_component(path, &["vendor", "vendors", "node_modules", "third_party"]) {
+        return Some(ReachedWithoutImport::VendoredCode);
+    }
     if name == "__init__.py" {
         return Some(ReachedWithoutImport::PackageMarker);
     }
     if is_documentation_example(path) {
         return Some(ReachedWithoutImport::DocumentationExample);
+    }
+    if is_browser_entry(path, &name) {
+        return Some(ReachedWithoutImport::BrowserEntry);
+    }
+    if is_package_binary(path, &name) {
+        return Some(ReachedWithoutImport::PackageBinary);
+    }
+    if in_executable_package && path_contains_component(path, &["commands"]) {
+        return Some(ReachedWithoutImport::CommandModule);
     }
     if is_build_script(&name) {
         return Some(ReachedWithoutImport::BuildScript);
@@ -162,6 +192,27 @@ fn is_file_system_route(path: &Path, name: &str) -> bool {
     // These names are reserved only inside a router tree, so an unrelated
     // `page.tsx` in `src/components/` still counts as importable.
     routed && path_contains_component(path, &["app", "pages"])
+}
+
+/// Code the browser loads without any module importing it: a bundler names it
+/// in an entry map, a template names it in a `<script>` tag, or a worker
+/// constructor names it by URL.
+fn is_browser_entry(path: &Path, name: &str) -> bool {
+    if path_contains_component(path, &["entrypoints", "static_src", "static"]) {
+        return true;
+    }
+    // `subset-worker.chunk.ts`, `search.worker.ts` — a worker entry is loaded
+    // through `new Worker(url)`, never through an import.
+    script_stem(name).is_some_and(|stem| {
+        stem.split(['.', '-'])
+            .any(|token| token == "worker" || token == "sw")
+    })
+}
+
+/// A package's `bin` entry, run by npm rather than imported.
+fn is_package_binary(path: &Path, name: &str) -> bool {
+    path_contains_component(path, &["bin"])
+        || script_stem(name).is_some_and(|stem| stem == "bin" || stem == "cli")
 }
 
 /// Example and documentation source trees. Their files are compiled by docs

--- a/src/audits/architecture/graph_queries/entrypoints/tests.rs
+++ b/src/audits/architecture/graph_queries/entrypoints/tests.rs
@@ -2,7 +2,11 @@ use super::{ReachedWithoutImport, reached_without_import};
 use std::path::Path;
 
 fn reason(path: &str) -> Option<ReachedWithoutImport> {
-    reached_without_import(Path::new(path))
+    reached_without_import(Path::new(path), false)
+}
+
+fn reason_in_cli(path: &str) -> Option<ReachedWithoutImport> {
+    reached_without_import(Path::new(path), true)
 }
 
 #[test]
@@ -219,4 +223,92 @@ fn python_autoload_names_do_not_leak_into_other_languages() {
         reason("project/urls.py"),
         Some(ReachedWithoutImport::FrameworkAutoload)
     );
+}
+
+#[test]
+fn type_declarations_carry_no_runtime_code() {
+    // A `.d.ts` declares ambient types and compiles to nothing, so "no module
+    // imports it" says nothing about dead code.
+    for path in [
+        "client/src/custom.d.ts",
+        "client/storybook/stories.d.ts",
+        "types/global.d.mts",
+    ] {
+        assert_eq!(
+            reason(path),
+            Some(ReachedWithoutImport::TypeDeclaration),
+            "{path}"
+        );
+    }
+    assert_eq!(reason("client/src/custom.ts"), None);
+}
+
+#[test]
+fn vendored_third_party_code_is_not_project_source() {
+    for path in [
+        "wagtail/admin/static_src/js/vendor/bootstrap-modal.js",
+        "third_party/lib/parser.py",
+    ] {
+        assert_eq!(
+            reason(path),
+            Some(ReachedWithoutImport::VendoredCode),
+            "{path}"
+        );
+    }
+}
+
+#[test]
+fn browser_entries_are_named_by_a_bundler_template_or_worker() {
+    // wagtail's webpack config builds its entry map from
+    // `./client/src/entrypoints/${app}/${module}.js`, and its templates load
+    // `static_src` assets through a `{% versioned_static %}` script tag.
+    assert_eq!(
+        reason("client/src/entrypoints/admin/page-chooser.js"),
+        Some(ReachedWithoutImport::BrowserEntry)
+    );
+    assert_eq!(
+        reason("wagtail/images/static_src/wagtailimages/js/add-multiple.js"),
+        Some(ReachedWithoutImport::BrowserEntry)
+    );
+    assert_eq!(
+        reason("packages/excalidraw/subset/subset-worker.chunk.ts"),
+        Some(ReachedWithoutImport::BrowserEntry)
+    );
+    assert_eq!(
+        reason("src/search.worker.ts"),
+        Some(ReachedWithoutImport::BrowserEntry)
+    );
+    // A module that merely mentions the word is ordinary code.
+    assert_eq!(reason("src/workerPool.ts"), None);
+    assert_eq!(reason("src/staticData.ts"), None);
+}
+
+#[test]
+fn package_binaries_are_run_by_the_package_manager() {
+    assert_eq!(
+        reason("packages/cli/bin.js"),
+        Some(ReachedWithoutImport::PackageBinary)
+    );
+    assert_eq!(
+        reason("packages/cli/bin/run.js"),
+        Some(ReachedWithoutImport::PackageBinary)
+    );
+    assert_eq!(reason("src/binary_search.ts"), None);
+}
+
+#[test]
+fn command_modules_need_the_package_to_declare_an_executable() {
+    // The CQRS guard: a `commands/` directory in an ordinary library is
+    // importable code, and only a package that declares a `bin` dispatches its
+    // command modules by file name.
+    assert_eq!(
+        reason_in_cli("src/commands/cache.ts"),
+        Some(ReachedWithoutImport::CommandModule)
+    );
+    assert_eq!(
+        reason("src/commands/cache.ts"),
+        None,
+        "the same path in a library package stays eligible"
+    );
+    assert_eq!(reason_in_cli("src/domain/order.ts"), None);
 }

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -171,9 +171,13 @@ fn dead_module_finding(
         || fan_in.unwrap_or(0) != 0
         || has_inline_tests
         // A tool config, build script, framework-autoloaded module, routed
-        // file, or documentation example is reached without an import, so its
-        // fan-in is zero in every healthy repository.
-        || entrypoints::reached_without_import(&info.relative).is_some()
+        // file, browser entry, or documentation example is reached without an
+        // import, so its fan-in is zero in every healthy repository.
+        || entrypoints::reached_without_import(
+            &info.relative,
+            info.facts.is_some_and(|facts| facts.in_executable_package),
+        )
+        .is_some()
     {
         return None;
     }

--- a/tests/zoo/expectations/ignite.toml
+++ b/tests/zoo/expectations/ignite.toml
@@ -15,13 +15,3 @@ path = "src/commands/new.ts"
 line = 185
 disposition = "valid-but-accepted"
 reason = "CLI command handler that deliberately exits the process; downgraded to Low for cli-executable role and retained as a strict recall anchor."
-
-[[finding]]
-profile = "strict"
-finding_id = "architecture.dead-module:src/commands/issue.ts:b022a3e6e8b8daf1"
-rule_id = "architecture.dead-module"
-path = "src/commands/issue.ts"
-line = 1
-evidence = "sample"
-disposition = "false-positive"
-reason = "A gluegun CLI command module: the framework loads every file under its command directory by name and dispatches on the file name, so no source file imports it."

--- a/tests/zoo/expectations/wagtail.toml
+++ b/tests/zoo/expectations/wagtail.toml
@@ -47,16 +47,6 @@ disposition = "false-positive"
 reason = "Same guarded optional `from .local import *` override as dev.py; the import is wrapped in try/except ImportError."
 [[finding]]
 profile = "strict"
-finding_id = "architecture.dead-module:wagtail/admin/static_src/wagtailadmin/js/vendor/jquery-3.6.0.min.js:b022a3e6e8b8daf1"
-rule_id = "architecture.dead-module"
-path = "wagtail/admin/static_src/wagtailadmin/js/vendor/jquery-3.6.0.min.js"
-line = 1
-evidence = "sample"
-disposition = "false-positive"
-reason = "A vendored, minified third-party bundle under `vendor/`. It is not project source at all, so neither dead-module nor any other maintainability claim applies to it."
-
-[[finding]]
-profile = "strict"
 finding_id = "architecture.dead-module:wagtail/users/views/groups.py:b022a3e6e8b8daf1"
 rule_id = "architecture.dead-module"
 path = "wagtail/users/views/groups.py"
@@ -64,23 +54,3 @@ line = 1
 evidence = "sample"
 disposition = "false-positive"
 reason = "Referenced by dotted string from wagtail/users/apps.py (`group_viewset = \"wagtail.users.views.groups.GroupViewSet\"`), the Django pattern for late-bound references. No static import names the module."
-
-[[finding]]
-profile = "strict"
-finding_id = "architecture.dead-module:client/src/entrypoints/admin/page-chooser.js:b022a3e6e8b8daf1"
-rule_id = "architecture.dead-module"
-path = "client/src/entrypoints/admin/page-chooser.js"
-line = 1
-evidence = "sample"
-disposition = "false-positive"
-reason = "A webpack entry module: client/webpack.config.js builds its entry map from `./client/src/entrypoints/${appName}/${moduleName}.js`, so the bundler names it and no source file imports it."
-
-[[finding]]
-profile = "strict"
-finding_id = "architecture.dead-module:wagtail/images/static_src/wagtailimages/js/add-multiple.js:b022a3e6e8b8daf1"
-rule_id = "architecture.dead-module"
-path = "wagtail/images/static_src/wagtailimages/js/add-multiple.js"
-line = 1
-evidence = "sample"
-disposition = "false-positive"
-reason = "A browser asset loaded by a Django template tag: templates/wagtailimages/multiple/add.html has `<script src=\"{% versioned_static 'wagtailimages/js/add-multiple.js' %}\">`. Script-tag references are not imports."

--- a/tests/zoo/snapshots/changesets.json
+++ b/tests/zoo/snapshots/changesets.json
@@ -20,7 +20,7 @@
   "strict": {
     "by_rule": {
       "architecture.circular-dependency": 1,
-      "architecture.dead-module": 4,
+      "architecture.dead-module": 3,
       "architecture.large-file": 4,
       "code-marker.todo": 8,
       "code-quality.complex-file": 2,
@@ -30,6 +30,6 @@
       "language.javascript.runtime-exit-risk": 3,
       "testing.source-without-test": 28
     },
-    "visible_total": 95
+    "visible_total": 94
   }
 }

--- a/tests/zoo/snapshots/excalidraw.json
+++ b/tests/zoo/snapshots/excalidraw.json
@@ -24,7 +24,7 @@
     "by_rule": {
       "architecture.barrel-file-risk": 5,
       "architecture.circular-dependency": 6,
-      "architecture.dead-module": 36,
+      "architecture.dead-module": 22,
       "architecture.deep-relative-imports": 9,
       "architecture.excessive-fan-out": 23,
       "architecture.large-file": 83,
@@ -44,6 +44,6 @@
       "security.secret-candidate": 2,
       "testing.source-without-test": 374
     },
-    "visible_total": 1187
+    "visible_total": 1173
   }
 }

--- a/tests/zoo/snapshots/ignite.json
+++ b/tests/zoo/snapshots/ignite.json
@@ -12,7 +12,7 @@
   "strict": {
     "by_rule": {
       "architecture.barrel-file-risk": 1,
-      "architecture.dead-module": 23,
+      "architecture.dead-module": 9,
       "architecture.large-file": 13,
       "code-marker.todo": 4,
       "code-quality.complex-file": 1,
@@ -23,6 +23,6 @@
       "language.javascript.runtime-exit-risk": 12,
       "testing.source-without-test": 100
     },
-    "visible_total": 190
+    "visible_total": 176
   }
 }

--- a/tests/zoo/snapshots/wagtail.json
+++ b/tests/zoo/snapshots/wagtail.json
@@ -25,7 +25,7 @@
   "strict": {
     "by_rule": {
       "architecture.circular-dependency": 11,
-      "architecture.dead-module": 106,
+      "architecture.dead-module": 48,
       "architecture.deep-directory-nesting": 1018,
       "architecture.deep-relative-imports": 33,
       "architecture.excessive-fan-out": 17,
@@ -47,6 +47,6 @@
       "language.python.exception-risk": 45,
       "testing.source-without-test": 668
     },
-    "visible_total": 2491
+    "visible_total": 2433
   }
 }


### PR DESCRIPTION
## Summary

Clustering all 187 surviving `architecture.dead-module` findings showed five shapes, not a long tail. Recognizing them takes the rule to **100, from 1762** at the start of this series - a 94% reduction, every step of it measured.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

Five recognizers, each naming what reaches the file:

| Shape | Reached by |
|---|---|
| `*.d.ts` / `.d.mts` / `.d.cts` | nothing — a declaration file compiles to no runtime code |
| `vendor/`, `node_modules/`, `third_party/` | not project source |
| `entrypoints/`, `static_src/`, `static/`, `*.worker.ts` | a bundler entry map, a `<script>` tag, or `new Worker(url)` |
| `bin.js`, `bin/` | the package manager, via `package.json`'s `bin` |
| `commands/` **in a package that declares an executable** | the CLI, dispatching by file name |

The command case reuses `FileFacts::in_executable_package`, the `bin`-manifest evidence already threaded through for the CLI-executable role, so a CQRS `commands/` directory in a library package stays eligible. Both sides are pinned by a guard test.

## Why

Rather than sample-and-guess again, I dumped every remaining finding and clustered by path:

```
  33  entrypoints/          16  *.d.ts            15  vendor/
  12  src/commands/ (CLI)    6  static_src/        2  worker
   2  bin
```

That is 86 of 187 in five families, all verifiable from the repository itself - wagtail's `client/webpack.config.js` names its entry map, its templates load `static_src` through `{% versioned_static %}`, and ignite's package declares a `bin`.

## Measurement

```
repo          before  after
wagtail          106     48
excalidraw        36     22
ignite            23      9
changesets         4      3
(others)     unchanged
              ------  -----
TOTAL            187    100
```

No other rule's count moved in any repository, and no default profile changed.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
cargo run -- scan . --fail-on-priority p1
```

