### PR TITLE
fix(graph): prevent false JVM dead-module claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,15 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Make JVM graph confidence path-aware without turning missing imports into
+  false dead-code claims. An unresolved Java/Kotlin import now counts as
+  repository-internal only when its package matches a scanned JVM package,
+  rather than whenever a generic directory such as `com` or `org` exists. The
+  package suffix index is built once per scan and queried in constant time.
+  Java and Kotlin import edges remain available to coupling, cycles, fan-out,
+  and blast-radius analysis, but `architecture.dead-module` is withheld for
+  those languages: same-package types can be referenced without an import, so
+  an import-only graph cannot prove that zero fan-in means unused code.
 - `architecture.dead-module` recognizes five more ways a file is reached
   without an import: TypeScript declaration files, which carry no runtime code
   at all; vendored third-party trees (`vendor/`, `node_modules/`,
@@ -107,7 +116,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   so every one of their files carries zero fan-in in a perfectly healthy
   repository and the rule reported all of them. The check asks the resolver
   itself which extensions it dispatches on, so it cannot drift from what the
-  graph can represent. eShopOnWeb drops from 208 to 2 findings.
+  graph can represent. Java and Kotlin are also withheld from this absence
+  claim because same-package references do not create import edges, while their
+  present edges remain available to every presence-based graph consumer.
+  eShopOnWeb drops from 208 to 2 findings.
 - Correct an over-broad example-tree recognizer shipped in the previous entry:
   `examples`/`samples` were matched at any path depth, which silenced every
   file under a package namespace containing those words — Spring PetClinic

--- a/docs/architecture-antipatterns.md
+++ b/docs/architecture-antipatterns.md
@@ -37,7 +37,7 @@ from broad architecture structure heuristics.
 | `architecture.import-coupling` | Is a file coupled to too many internal modules? | Should prefer source code over generated/test corpora. |
 | `architecture.deep-relative-imports` | Are imports crossing too many directory levels? | Should focus on maintainability of production imports. |
 | `architecture.barrel-file-risk` | Is a barrel file hiding coupling or unstable public boundaries? | Should explain why the barrel is risky, not merely that it exists. |
-| `architecture.dead-module` | Is a production file imported by nothing and not an entrypoint? | Demoted/suppressed when unresolved imports make the graph incomplete. |
+| `architecture.dead-module` | Is a production file imported by nothing and not an entrypoint? | Demoted/suppressed when unresolved imports make the graph incomplete; withheld for Java/Kotlin until same-package references are modeled. |
 | `architecture.test-leak` | Does production code import a test or fixture file? | On by default; evidence cites the import line. |
 | `architecture.layer-violation` | Does a module import against the declared layer order? | Strictly opt-in via `[[architecture.layers]]`. |
 | `architecture.package-boundary-violation` | Does one package reach into another's internals instead of its public API? | Auto-enabled on a detected workspace (manifest boundaries → High confidence); also configurable via `[architecture] package_roots` (→ Medium). |

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -139,21 +139,23 @@ Current progress:
   earn evidence without exhaustive labeling.
 - `architecture.dead-module` was the first rule measured, at 0.00 precision. Its
   entrypoint model now covers files reached without an import, and absence
-  claims are restricted to languages whose imports the resolver maps to files.
-  Absence claims are also judged per language: JVM multi-module resolution
-  improved, and where a language's imports still mostly fail to resolve the
+  claims are restricted to languages whose import-only graph can prove file
+  reachability. Java and Kotlin keep their resolved edges for presence-based
+  analysis but are excluded from dead-module absence claims because same-package
+  type references need no import. Absence claims are also judged per language:
+  JVM multi-module resolution improved, and where a language's imports still
+  mostly fail to resolve the
   claim is withdrawn rather than demoted, a singular `test/` directory is
   classified as tests, and browser, bundler, binary, and vendored entries are
   recognized. The zoo population is down from 1762 to 100 strict findings — a
   94% reduction driven entirely by measured evidence. What remains is mostly
   Django modules the app registry imports (`models.py` and siblings) and Python
   modules referenced by dotted string.
-- Known input weakness behind the language gate: an import counts as
-  repository-internal when its leading segment matches any directory name, and
-  in JVM projects `com` and `org` always do, so third-party imports inflate the
-  unresolved count. The inflation pushes the gate toward withdrawing claims,
-  which is the safe direction for an absence, but the classifier should become
-  path-aware and the gate re-measured after it does.
+- JVM unresolved-import classification is now path-aware: a package must match
+  a scanned JVM package suffix, so generic `com` and `org` directories no longer
+  turn third-party imports into repository holes. Re-measurement exposed the
+  deeper same-package-reference limitation above; a future JVM symbol/reference
+  graph can restore dead-module coverage without relying on missing imports.
 
 Deliverables:
 

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -56,7 +56,7 @@ This production file is not imported by any other project file and is not a know
 
 **Recommendation:** Remove the file if it is no longer used, or ensure it is exported in the package's public API.
 
-**Known false positives:** Dynamic imports, dependency injection, and build-tool aliases create importers the graph cannot see. When the repository contains unresolved internal imports (relative paths, aliases, or workspace-package imports the resolver cannot wire up — common in monorepos) the finding is reported at Low confidence, and it is suppressed when an unresolved import matches the candidate file's name.
+**Known false positives:** Dynamic imports, dependency injection, and build-tool aliases create importers the graph cannot see. Java and Kotlin are excluded because same-package type references need no import and are invisible to the import graph. When the repository contains unresolved internal imports (relative paths, aliases, or workspace-package imports the resolver cannot wire up — common in monorepos) the finding is reported at Low confidence, and it is suppressed when an unresolved import matches the candidate file's name.
 
 ### `architecture.deep-directory-nesting` — Deep directory nesting detected
 

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -154,10 +154,10 @@ fn dead_module_finding(
     // an edge. Docs, stylesheets, and lockfiles are never imported, and neither
     // are C#, Swift, PHP, or C++ sources as far as this graph is concerned:
     // they reference types through namespaces and headers the resolver does not
-    // map to files, so every one of their files carries fan_in=0 in a perfectly
-    // healthy repository. Ask the resolver itself which languages it wires up,
-    // so this cannot drift from what the graph can actually represent.
-    let is_importable_code = crate::graph::resolver::resolves_file_imports(&info.relative);
+    // map to files. Java and Kotlin do produce import edges, but same-package
+    // references need no import and are invisible here. Ask the resolver which
+    // languages support absence claims so this cannot drift from graph semantics.
+    let supports_absence = crate::graph::resolver::supports_file_absence_claims(&info.relative);
     // A file that carries its own tests is exercised by the suite, and its only
     // importer is often a `#[cfg(test)] mod ...;` declaration, whose edge is
     // intentionally excluded from the production import graph. Treating such a
@@ -165,7 +165,7 @@ fn dead_module_finding(
     // only under `cfg(test)`), so exempt files with inline tests.
     let has_inline_tests = info.facts.is_some_and(|facts| facts.has_inline_tests);
     if ctx.file_role != FileRole::Production
-        || !is_importable_code
+        || !supports_absence
         || ctx.is_entrypoint
         || ctx.is_public_api
         || fan_in.unwrap_or(0) != 0

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -87,11 +87,25 @@ fn dead_module_still_covers_every_language_the_resolver_wires_up() {
         "pkg/orphan.py",
         "internal/orphan.go",
         "src/orphan.rs",
-        "src/main/java/com/example/Orphan.java",
-        "core/src/main/kotlin/com/example/Orphan.kt",
     ] {
         assert!(
             dead_module_finding(&prod(relative), Some(0), GraphReadiness::Available).is_some(),
+            "{relative}"
+        );
+    }
+}
+
+#[test]
+fn dead_module_is_silent_when_jvm_same_package_references_are_unmodeled() {
+    // Java and Kotlin can reference types from the same package without an
+    // import. The import graph cannot see those uses, so zero fan-in is not
+    // evidence that the target file is dead.
+    for relative in [
+        "src/main/java/com/example/UsedWithoutImport.java",
+        "core/src/main/kotlin/com/example/UsedWithoutImport.kt",
+    ] {
+        assert!(
+            dead_module_finding(&prod(relative), Some(0), GraphReadiness::Available).is_none(),
             "{relative}"
         );
     }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -53,6 +53,9 @@ pub fn build_coupling_graph_with_resolution(
     let known_files: HashSet<PathBuf> = known_file_by_normalized.keys().cloned().collect();
     let repo_dirs =
         resolution_stats::repo_directory_names(facts.files.iter().map(|file| file.path.as_path()));
+    let repo_jvm_packages = resolution_stats::repo_jvm_package_suffixes(
+        facts.files.iter().map(|file| file.path.as_path()),
+    );
 
     let mut edges: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
     let mut deferred_edges: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
@@ -86,7 +89,12 @@ pub fn build_coupling_graph_with_resolution(
                 Some(_) => {}
                 None => {
                     let raw = raw.trim();
-                    if resolution_stats::is_unresolved_internal_import(raw, &repo_dirs) {
+                    if resolution_stats::is_unresolved_internal_import(
+                        raw,
+                        &source,
+                        &repo_jvm_packages,
+                        &repo_dirs,
+                    ) {
                         resolution.record_classified(&source, raw, root);
                     }
                 }
@@ -402,10 +410,10 @@ mod tests {
     use super::*;
     use crate::scan::facts::{FileFacts, ScanFacts};
 
-    fn py(path: &str, imports: &[&str]) -> FileFacts {
+    fn file(path: &str, language: &str, imports: &[&str]) -> FileFacts {
         FileFacts {
             path: PathBuf::from(path),
-            language: Some("Python".to_string()),
+            language: Some(language.to_string()),
             non_empty_lines: 0,
             branch_count: 0,
             imports: imports.iter().map(|value| (*value).to_string()).collect(),
@@ -416,6 +424,10 @@ mod tests {
         }
     }
 
+    fn py(path: &str, imports: &[&str]) -> FileFacts {
+        file(path, "Python", imports)
+    }
+
     #[test]
     fn records_unresolved_workspace_import_but_not_third_party() {
         // A monorepo package import (`app.*` where `app/` is a real directory)
@@ -423,8 +435,9 @@ mod tests {
         // absence claim is demoted; a genuine third-party import must not be.
         let facts = ScanFacts {
             root_path: PathBuf::from("/repo"),
-            files: vec![py(
+            files: vec![file(
                 "apps/ml/app/api.py",
+                "Python",
                 &["app.enrichment.contract", "numpy", "fastapi"],
             )],
             ..ScanFacts::default()
@@ -438,6 +451,36 @@ mod tests {
             "only the internal workspace import should be recorded"
         );
         assert!(resolution.could_target_stem("contract"));
+    }
+
+    #[test]
+    fn jvm_unresolved_imports_require_a_matching_local_package() {
+        let facts = ScanFacts {
+            root_path: PathBuf::from("/repo"),
+            files: vec![
+                file(
+                    "app/src/main/java/com/acme/App.java",
+                    "Java",
+                    &["com.google.gson.Gson", "com.acme.service.Missing"],
+                ),
+                file(
+                    "app/src/main/java/com/acme/service/Existing.java",
+                    "Java",
+                    &[],
+                ),
+            ],
+            ..ScanFacts::default()
+        };
+
+        let (_graph, resolution) = build_coupling_graph_with_resolution(&facts, Path::new("/repo"));
+
+        assert_eq!(
+            resolution.total(),
+            1,
+            "only the import whose package exists in this repository is internal"
+        );
+        assert!(resolution.could_target_stem("Missing"));
+        assert!(!resolution.could_target_stem("Gson"));
     }
 
     fn graph_from_edges(edges: &[(&str, &str)]) -> CouplingGraph {

--- a/src/graph/resolution_stats.rs
+++ b/src/graph/resolution_stats.rs
@@ -183,10 +183,14 @@ pub(crate) fn is_relative_import(import: &str) -> bool {
 
 /// Whether an unresolved import should weaken absence claims (dead module,
 /// instability). Relative imports and recognizable local path aliases always
-/// count; a bare import counts only when its leading segment names a directory
-/// that exists in `repo_dirs` — i.e. an internal monorepo/workspace package the
-/// resolver did not wire up — which keeps genuine third-party packages out.
-pub(crate) fn is_unresolved_internal_import(import: &str, repo_dirs: &HashSet<String>) -> bool {
+/// count. JVM imports require a matching local package; other bare imports count
+/// when their leading segment names a repository directory.
+pub(crate) fn is_unresolved_internal_import(
+    import: &str,
+    source: &Path,
+    repo_jvm_packages: &HashSet<PathBuf>,
+    repo_dirs: &HashSet<String>,
+) -> bool {
     let import = import.trim();
     if import.is_empty() {
         return false;
@@ -198,7 +202,61 @@ pub(crate) fn is_unresolved_internal_import(import: &str, repo_dirs: &HashSet<St
     if import.starts_with("@/") || import.starts_with("~/") || import == "~" {
         return true;
     }
+    if source
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "java" | "kt" | "kts"))
+    {
+        return jvm_import_has_local_package(import, repo_jvm_packages);
+    }
     leading_segment(import).is_some_and(|segment| repo_dirs.contains(segment))
+}
+
+fn jvm_import_has_local_package(import: &str, repo_jvm_packages: &HashSet<PathBuf>) -> bool {
+    let segments = import
+        .split('.')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+
+    (1..=3).any(|trailing_segments| {
+        let Some(package_segments) =
+            segments.get(..segments.len().saturating_sub(trailing_segments))
+        else {
+            return false;
+        };
+        if package_segments.len() < 2 {
+            return false;
+        }
+        let package = package_segments.iter().collect::<PathBuf>();
+        repo_jvm_packages.contains(&package)
+    })
+}
+
+/// Every two-or-more-component directory suffix that contains a JVM source
+/// file. Built once per scan so unresolved imports can test local package
+/// evidence without walking every known file.
+pub(crate) fn repo_jvm_package_suffixes<'a, I>(paths: I) -> HashSet<PathBuf>
+where
+    I: IntoIterator<Item = &'a Path>,
+{
+    let mut packages = HashSet::new();
+    for path in paths {
+        if !path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| matches!(extension, "java" | "kt" | "kts"))
+        {
+            continue;
+        }
+        let Some(parent) = path.parent() else {
+            continue;
+        };
+        let components = parent.components().collect::<Vec<_>>();
+        for start in 0..components.len().saturating_sub(1) {
+            packages.insert(components[start..].iter().collect());
+        }
+    }
+    packages
 }
 
 /// The first non-empty segment of an import, splitting on every path/module

--- a/src/graph/resolution_stats/tests.rs
+++ b/src/graph/resolution_stats/tests.rs
@@ -70,25 +70,20 @@ fn internal_import_classifier_separates_workspace_from_third_party() {
         .into_iter()
         .map(String::from)
         .collect();
+    let source = Path::new("src/app.py");
+    let repo_jvm_packages = HashSet::new();
+    let classify =
+        |import| is_unresolved_internal_import(import, source, &repo_jvm_packages, &repo_dirs);
 
-    assert!(is_unresolved_internal_import("./helper", &repo_dirs));
-    assert!(is_unresolved_internal_import(
-        "@/components/Button",
-        &repo_dirs
-    ));
-    assert!(is_unresolved_internal_import("~/lib/util", &repo_dirs));
-    assert!(is_unresolved_internal_import("app.ml.train", &repo_dirs));
-    assert!(is_unresolved_internal_import(
-        "components/Button",
-        &repo_dirs
-    ));
-    assert!(!is_unresolved_internal_import("react", &repo_dirs));
-    assert!(!is_unresolved_internal_import("@angular/core", &repo_dirs));
-    assert!(!is_unresolved_internal_import("numpy", &repo_dirs));
-    assert!(!is_unresolved_internal_import(
-        "django.db.models",
-        &repo_dirs
-    ));
+    assert!(classify("./helper"));
+    assert!(classify("@/components/Button"));
+    assert!(classify("~/lib/util"));
+    assert!(classify("app.ml.train"));
+    assert!(classify("components/Button"));
+    assert!(!classify("react"));
+    assert!(!classify("@angular/core"));
+    assert!(!classify("numpy"));
+    assert!(!classify("django.db.models"));
 }
 
 #[test]

--- a/src/graph/resolver/mod.rs
+++ b/src/graph/resolver/mod.rs
@@ -36,6 +36,20 @@ pub fn resolves_file_imports(path: &Path) -> bool {
         .is_some_and(|extension| FILE_RESOLVED_EXTENSIONS.contains(&extension))
 }
 
+/// Whether an import-only graph can support claims based on a file having no
+/// incoming edges.
+///
+/// Java and Kotlin imports resolve to files, but types in the same package can
+/// be referenced without an import. Their present edges remain useful while a
+/// missing edge cannot prove that a file is unused.
+pub fn supports_file_absence_claims(path: &Path) -> bool {
+    resolves_file_imports(path)
+        && !path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| matches!(extension, "java" | "kt" | "kts"))
+}
+
 /// Resolves a raw import string extracted from `from_file` to a concrete path
 /// under `root`. Returns a path only when it exists in `known_files`.
 pub fn resolve_import(

--- a/src/rules/registry/architecture.rs
+++ b/src/rules/registry/architecture.rs
@@ -201,7 +201,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
             "Remove the file if it is no longer used, or ensure it is exported in the package's public API.",
         ),
         false_positive_notes: Some(
-            "Dynamic imports, dependency injection, and build-tool aliases create importers the graph cannot see. When the repository contains unresolved internal imports (relative paths, aliases, or workspace-package imports the resolver cannot wire up — common in monorepos) the finding is reported at Low confidence, and it is suppressed when an unresolved import matches the candidate file's name.",
+            "Dynamic imports, dependency injection, and build-tool aliases create importers the graph cannot see. Java and Kotlin are excluded because same-package type references need no import and are invisible to the import graph. When the repository contains unresolved internal imports (relative paths, aliases, or workspace-package imports the resolver cannot wire up — common in monorepos) the finding is reported at Low confidence, and it is suppressed when an unresolved import matches the candidate file's name.",
         ),
         ..RuleMetadata::DEFAULT
     },


### PR DESCRIPTION
## Summary

Make JVM graph confidence match what RepoPilot's import-only dependency graph can actually prove.

This fixes two related sources of false `architecture.dead-module` evidence:

1. unresolved Java/Kotlin imports are now treated as repository-internal only when their package matches a scanned JVM package, instead of being inferred from generic top-level directories such as `com` or `org`;
2. `architecture.dead-module` is withheld for Java/Kotlin because same-package types can be referenced without an import, so zero import fan-in is not sufficient evidence that a JVM file is unused.

Resolved Java/Kotlin edges remain available to presence-based graph consumers such as coupling, cycle detection, fan-out, blast radius, and impact analysis.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- build a JVM package-suffix index once per graph build and use it to classify unresolved Java/Kotlin imports against actual repository package evidence;
- add `supports_file_absence_claims(...)` so the resolver explicitly distinguishes languages that can resolve present edges from languages where missing edges can support absence claims;
- keep Java/Kotlin import resolution enabled for presence-based graph analysis while suppressing `architecture.dead-module` for JVM files until same-package references are modeled;
- add focused regression coverage for third-party-vs-local JVM imports and same-package dead-module false positives;
- update the changelog, architecture anti-pattern guidance, v0.22 roadmap, and generated rule reference to document the precision boundary.

## Why

The previous unresolved-import classifier could mistake third-party JVM imports for repository-local holes whenever a broad directory such as `com` or `org` existed in the repository. That made graph completeness look worse than it really was.

More importantly, Java and Kotlin allow code in the same package to reference types without an import statement. Because RepoPilot's current JVM dependency graph is import-based, a file can have zero observed fan-in while still being used by neighboring same-package code. Emitting `architecture.dead-module` from that absence was therefore stronger than the available evidence justified.

The safe contract is now explicit: JVM edges that RepoPilot can prove are retained, while JVM absence claims are withheld until a symbol/reference graph can model same-package usage.

## Contract and ownership

Subsystems affected:

- graph construction and unresolved-import classification;
- resolver capability semantics;
- `architecture.dead-module` evidence policy.

Compatibility:

- [x] The change stays within a clear graph/architecture ownership boundary
- [x] No CLI command, flag, JSON, SARIF, baseline, Action, or MCP schema changes
- [x] No rule IDs, finding IDs, gate semantics, or exit-code behavior changed
- [x] New behavior is covered by deterministic regression tests
- [x] Noise reduction preserves resolved JVM graph edges for presence-based consumers
- [x] No unrelated refactor or generated-file churn is included

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
npm run release:contract
./scripts/smoke-product.sh
```