### PR TITLE
feat(analysis): persist JavaScript symbol facts in parsed cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Move the existing conservative TypeScript/JavaScript export and named-import
+  facts into the shared analysis core and persist the complete typed payload,
+  including exact import spans, in parsed-facts cache schema v4. Older derived
+  cache entries are invalidated and rebuilt automatically from source; warm
+  changed scans restore the payload without reparsing unchanged files. Review
+  removed-export behavior and identity remain unchanged, and this internal
+  B2.2a foundation adds no public output field or new finding; `scan --changed`
+  removed-export parity remains the focused B2.2b follow-up.
 - Make JVM graph confidence path-aware without turning missing imports into
   false dead-code claims. An unresolved Java/Kotlin import now counts as
   repository-internal only when its package matches a scanned JVM package,

--- a/docs/engineering/v0.22-b2.2-symbol-fact-cache-plan.md
+++ b/docs/engineering/v0.22-b2.2-symbol-fact-cache-plan.md
@@ -1,0 +1,415 @@
+# B2.2a Persisted JavaScript Symbol Facts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the existing TypeScript/JavaScript symbol facts into the shared analysis core and preserve the complete typed payload through cold and warm parsed-cache paths.
+
+**Architecture:** A shared analysis module owns the current conservative AST walker and serializable symbol types. Scan and review pass their already-memoized syntax trees into the same extractor; `ParsedArtifact` and `ParsedFactsEntry` carry the optional payload without exposing it in public reports. Cache schema v4 invalidates older derived entries and rebuilds them from source.
+
+**Tech Stack:** Rust 2024, tree-sitter JavaScript/TypeScript grammars, serde JSON, existing `ParsedFile`, `ReviewSource`, `ParsedArtifact`, and `ParsedFactsCache`.
+
+**Spec:** `docs/engineering/v0.22-b2.2-symbol-fact-cache-spec.md`
+
+## Global Constraints
+
+- Implement B2.2a only; add no scan finding, review signal, rule ID, command, MCP tool, or public report field.
+- Support only `.ts`, `.tsx`, `.js`, and `.jsx` semantics already supported by B2.1.
+- Reject malformed/error-bearing trees; absence of a payload means facts were not proven.
+- Preserve B2.1 signal identity, confidence, gating, resolver behavior, and MCP explanation.
+- Keep `ParsedArtifact::exports` and `ParsedFactsEntry::exports` unchanged.
+- Invalidate old parsed-facts entries; do not migrate or infer missing symbol facts.
+- Reuse memoized syntax trees; never create a second parser pass for symbol extraction.
+- Keep output deterministic and local-only; no compiler, network, repository command, clock, or randomness.
+- Do not commit, push, or create a PR until the user explicitly requests publication.
+
+## File Structure
+
+- Create `src/analysis/symbols/mod.rs`: shared symbol namespace.
+- Create `src/analysis/symbols/javascript.rs`: serializable TS/JS facts and conservative AST walker moved from review.
+- Modify `src/analysis/mod.rs`: register the shared symbol module.
+- Delete `src/review/signals/api_contract/javascript.rs`: remove the review-owned duplicate after callers move.
+- Modify `src/review/signals/api_contract/mod.rs`: re-export shared types and adapt `ReviewSource` to the shared extractor interface.
+- Modify `src/review/signals/api_contract/detector.rs` and its tests only where import paths require it.
+- Modify `src/analysis/artifact.rs`: retain optional typed facts in source/current-cache artifacts.
+- Modify `src/scan/scanner/file_pipeline.rs` and `src/scan/scanner/file.rs`: extract once and carry facts through full/source collection.
+- Modify `src/scan/scanner/changed/file_analysis.rs`: restore facts on warm changed-cache hits.
+- Modify `src/scan/parsed_cache.rs`: serialize facts and bump schema/analysis versions.
+- Modify constructor call sites in `src/facts/from_scan.rs` and `src/scan/facts.rs` to pass `None` where no shared tree is available.
+- Modify `tests/scan_changed_cache_cli.rs`: pin on-disk payload, invalidation, and warm reuse telemetry.
+- Modify `CHANGELOG.md` and `docs/roadmap/v0.22.md`: record B2.2a behavior and B2.2b boundary.
+
+---
+
+### Task 1: Shared Symbol Contract and Review Parity
+
+**Files:**
+- Create: `src/analysis/symbols/mod.rs`
+- Create: `src/analysis/symbols/javascript.rs`
+- Modify: `src/analysis/mod.rs`
+- Modify: `src/review/signals/api_contract/mod.rs`
+- Modify: `src/review/signals/api_contract/detector.rs`
+- Delete: `src/review/signals/api_contract/javascript.rs`
+- Test: `src/review/signals/api_contract/tests/**`
+
+**Interfaces:**
+- Consumes: borrowed source text, RepoPilot language label, and a tree already owned by `ParsedFile` or `ReviewSource`.
+- Produces:
+
+```rust
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum SymbolKind {
+    Value,
+    Type,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ExportedSymbolFact {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub line_start: usize,
+    pub line_end: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ImportedSymbolFact {
+    pub imported_name: String,
+    pub local_name: String,
+    pub kind: SymbolKind,
+    pub module_specifier: String,
+    pub line_start: usize,
+    pub line_end: usize,
+    pub byte_start: usize,
+    pub byte_end: usize,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct JavaScriptSymbolFacts {
+    pub exports: Vec<ExportedSymbolFact>,
+    pub re_exports: Vec<String>,
+    pub wildcard_re_export: bool,
+    pub imports: Vec<ImportedSymbolFact>,
+}
+
+pub(crate) fn extract_javascript_symbol_facts(
+    content: &str,
+    language_label: Option<&str>,
+    tree: &tree_sitter::Tree,
+) -> Option<JavaScriptSymbolFacts>;
+```
+
+- [ ] **Step 1: Record the existing review characterization baseline**
+
+Run:
+
+```bash
+cargo test --lib review::signals::api_contract::tests
+cargo test --test removed_export_review
+cargo test --test removed_export_mcp
+```
+
+Expected: PASS before the ownership refactor. These tests pin malformed-AST rejection, direct program statements, kind semantics, re-export withdrawal, resolver matching, and exact occurrence IDs.
+
+- [ ] **Step 2: Add shared serialization coverage before moving callers**
+
+Add a focused test beside the new shared module using this literal source:
+
+```rust
+let source = concat!(
+    "export function loadUser() {}\n",
+    "export type UserId = string;\n",
+    "export { remote as forwarded } from './remote.ts';\n",
+    "import { loadUser as load, type UserId } from './api.ts';\n",
+);
+```
+
+Parse once with the TypeScript grammar, call the shared extractor, serialize with `serde_json`, deserialize, and assert equality plus these literal facts:
+
+```rust
+assert_eq!(facts.exports[0].name, "UserId");
+assert!(facts.exports.iter().any(|fact| {
+    fact.name == "loadUser" && fact.kind == SymbolKind::Value
+}));
+assert_eq!(facts.re_exports, vec!["forwarded"]);
+assert!(facts.imports.iter().any(|fact| {
+    fact.imported_name == "loadUser"
+        && fact.local_name == "load"
+        && fact.module_specifier == "./api.ts"
+        && fact.line_start == 4
+        && fact.byte_end > fact.byte_start
+}));
+```
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+
+```bash
+cargo test --lib analysis::symbols::javascript::tests::symbol_facts_round_trip_without_losing_spans -- --exact
+```
+
+Expected: FAIL to compile because the shared module and serializable shared types do not yet exist.
+
+- [ ] **Step 4: Move the extractor and adapt review without changing behavior**
+
+Move the current AST walker into `analysis::symbols::javascript`. Change only its boundary: replace `ReviewSource` access with the three explicit inputs above, keep the supported labels and `root.has_error()` guard, then sort/deduplicate every collection before returning.
+
+Keep the review-facing wrapper small and parser-neutral:
+
+```rust
+pub(crate) fn extract_javascript_symbol_facts(
+    source: &ReviewSource,
+) -> Option<JavaScriptSymbolFacts> {
+    crate::analysis::symbols::javascript::extract_javascript_symbol_facts(
+        source.content(),
+        source.language_label(),
+        source.tree()?,
+    )
+}
+```
+
+Re-export the shared fact types from `api_contract::mod` so detector/test imports remain focused. Delete the old review-owned implementation after `rg` shows no callers.
+
+- [ ] **Step 5: Verify GREEN and exact review parity**
+
+Run:
+
+```bash
+cargo test --lib analysis::symbols::javascript::tests
+cargo test --lib review::signals::api_contract::tests
+cargo test --test removed_export_review
+cargo test --test removed_export_mcp
+```
+
+Expected: serialization test and every existing B2.1 behavior test pass unchanged.
+
+- [ ] **Step 6: Review checkpoint**
+
+Run `git diff --check` and `rg -n "extract_javascript_symbol_facts" src`. Confirm one implementation lives under `analysis` and review contains only an adapter/callers.
+
+---
+
+### Task 2: Parsed Artifact and Source-Pipeline Facts
+
+**Files:**
+- Modify: `src/analysis/artifact.rs`
+- Modify: `src/scan/scanner/file_pipeline.rs`
+- Modify: `src/scan/scanner/file.rs`
+- Modify: `src/facts/from_scan.rs`
+- Modify: `src/scan/facts.rs`
+
+**Interfaces:**
+- Consumes: Task 1 `JavaScriptSymbolFacts` and `ParsedFile::tree()`.
+- Produces: `ParsedArtifact::javascript_symbols: Option<JavaScriptSymbolFacts>` and `FileAnalysisResult::javascript_symbols`.
+
+- [ ] **Step 1: Write the failing source-artifact test**
+
+Extend the scanner file-pipeline tests with a supported `FileFacts` whose content is:
+
+```typescript
+export type UserId = string;
+import { loadUser as load } from "./api.ts";
+```
+
+Run `analyze_file` with the normal empty/default audit set and assert:
+
+```rust
+let symbols = result.javascript_symbols.expect("supported symbol facts");
+assert_eq!(symbols.exports[0].name, "UserId");
+assert_eq!(symbols.imports[0].local_name, "load");
+assert_eq!(symbols.imports[0].module_specifier, "./api.ts");
+```
+
+Add a near-identical malformed source and assert `javascript_symbols.is_none()`.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo test --lib scan::scanner::file_pipeline::tests::source_analysis_retains_typed_javascript_symbols -- --exact
+```
+
+Expected: FAIL because `FileAnalysisResult` has no typed symbol payload.
+
+- [ ] **Step 3: Thread one memoized extraction through the source pipeline**
+
+Add `javascript_symbols` to `ParsedFileFacts` and `FileAnalysisResult`. In `extract_parsed_artifacts`, borrow the already-memoized tree and call Task 1's extractor:
+
+```rust
+let javascript_symbols = parsed.tree().and_then(|tree| {
+    extract_javascript_symbol_facts(parsed.content(), language, tree)
+});
+```
+
+Add the optional field to `ParsedArtifact`. Source/current-cache constructors accept it; `from_legacy_cache` always stores `None`. Pass the analyzed value from `scanner/file.rs`; pass `None` only at constructor sites that do not own complete parsed facts.
+
+- [ ] **Step 4: Verify GREEN and malformed guard**
+
+Run:
+
+```bash
+cargo test --lib scan::scanner::file_pipeline::tests
+cargo test --lib analysis::artifact::tests
+cargo test --lib scan::facts::tests
+```
+
+Expected: supported facts are present, malformed/unsupported facts are absent, and existing flat exports remain unchanged.
+
+- [ ] **Step 5: Review checkpoint**
+
+Run `git diff --check`. Confirm `ParsedFile::tree()` remains memoized and there is no call to `parse_label` or a new `Parser` in the source pipeline.
+
+---
+
+### Task 3: Persisted Cache and Warm Changed-Scan Reuse
+
+**Files:**
+- Modify: `src/scan/parsed_cache.rs`
+- Modify: `src/scan/scanner/file.rs`
+- Modify: `src/scan/scanner/changed/file_analysis.rs`
+- Modify: `tests/scan_changed_cache_cli.rs`
+
+**Interfaces:**
+- Consumes: Task 2 `ParsedArtifact::javascript_symbols`.
+- Produces: `ParsedFactsEntry::javascript_symbols: Option<JavaScriptSymbolFacts>`, schema version `4`, and analysis version `tree-sitter-imports-exports-symbols-spans-v3`.
+
+- [ ] **Step 1: Write the failing cache round-trip test**
+
+Create an artifact with one value export and one aliased named import whose byte span is `(42, 58)`. Convert it with `ParsedFactsEntry::from_artifact`, serialize/deserialize the entry, restore a current-cache artifact, and assert:
+
+```rust
+assert_eq!(restored.javascript_symbols, source.javascript_symbols);
+let import = &restored.javascript_symbols.as_ref().unwrap().imports[0];
+assert_eq!((import.byte_start, import.byte_end), (42, 58));
+assert_eq!(restored.origin, ArtifactOrigin::ParsedCacheV2);
+assert!(restored.has_complete_parsed_facts());
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo test --lib scan::parsed_cache::tests::typed_symbol_facts_survive_cache_round_trip -- --exact
+```
+
+Expected: FAIL because cache entries do not store typed facts.
+
+- [ ] **Step 3: Persist the payload and invalidate old entries**
+
+Add this field to `ParsedFactsEntry`:
+
+```rust
+#[serde(default)]
+pub javascript_symbols: Option<JavaScriptSymbolFacts>,
+```
+
+Copy it in `from_artifact`, full-scan cache restoration, and changed-scan cache restoration. Set:
+
+```rust
+const PARSED_FACTS_SCHEMA_VERSION: u32 = 4;
+const PARSED_FACTS_ANALYSIS_VERSION: &str =
+    "tree-sitter-imports-exports-symbols-spans-v3";
+```
+
+Keep `#[serde(default)]` so an old JSON file can be decoded and counted as a schema invalidation instead of a corruption; the version mismatch must still discard every old entry.
+
+- [ ] **Step 4: Add the changed-scan cold/warm integration test**
+
+Create a temporary Git repository containing `src/api.ts` and `src/caller.ts`, commit it, then modify the caller to add a named alias import. Run `scan --changed` and read `.repopilot/cache/parsed_facts_v2.json`.
+
+Assert the file reports schema `4`, the new analysis version, and at least one entry with:
+
+```json
+{
+  "javascript_symbols": {
+    "imports": [{
+      "imported_name": "loadUser",
+      "local_name": "load",
+      "module_specifier": "./api.ts"
+    }]
+  }
+}
+```
+
+Run the same changed scan again and assert:
+
+```rust
+assert!(cached["cache_telemetry"]["parsed_cache_hits"].as_u64().unwrap() > 0);
+assert_eq!(cached["cache_telemetry"]["parsed_cache_misses"], 0);
+```
+
+Extend the existing old-schema test to force schema `3`; assert the next scan records parsed-cache invalidation, rewrites schema `4`, and restores the typed payload from source.
+
+- [ ] **Step 5: Verify GREEN and cache regression safety**
+
+Run:
+
+```bash
+cargo test --lib scan::parsed_cache::tests
+cargo test --test scan_changed_cache_cli typed_symbol_facts
+cargo test --test scan_changed_cache_cli changed_scan_invalidates_old_cache_schema
+```
+
+Expected: exact symbol fields survive, warm telemetry proves reuse, and old entries rebuild rather than migrate.
+
+- [ ] **Step 6: Review checkpoint**
+
+Run `git diff --check`. Confirm atomic write/backup/entry-limit logic is unchanged and both full and changed cache restoration pass the optional payload into `ParsedArtifact`.
+
+---
+
+### Task 4: Documentation and Handoff Verification
+
+**Files:**
+- Modify: `docs/engineering/v0.22-b2.2-symbol-fact-cache-spec.md`
+- Modify: `docs/roadmap/v0.22.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: completed Tasks 1–3 and their measured test evidence.
+- Produces: an implemented B2.2a spec status and an explicit B2.2b next step.
+
+- [ ] **Step 1: Update tracked product documentation**
+
+Set the spec status to `implemented`. In the roadmap, replace the single B2.2 next line with:
+
+```markdown
+- B2.2a implemented: typed TypeScript/JavaScript symbol facts now live in the
+  shared analysis core and survive cold/warm parsed-cache paths.
+- Next: B2.2b `scan --changed` removed-export parity using the persisted facts.
+```
+
+Add an `[Unreleased]` changelog entry that states the schema invalidation, automatic cold rebuild, no public output change, and preserved B2.1 behavior.
+
+- [ ] **Step 2: Run focused verification**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --lib --tests -- -D warnings
+cargo test --lib analysis::symbols::javascript::tests
+cargo test --lib scan::parsed_cache::tests
+cargo test --test scan_changed_cache_cli
+cargo test --test removed_export_review
+cargo test --test removed_export_mcp
+git diff --check
+```
+
+Expected: all focused checks pass with no warnings or whitespace errors.
+
+- [ ] **Step 3: Run the one full pre-handoff gate**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+python3 scripts/release-contract.py check
+npm test
+cargo run -- scan . --fail-on-priority p1
+```
+
+Expected: every command exits `0`; self-scan reports `Decision: PASS`, P0 `0`, and P1 `0`.
+
+- [ ] **Step 4: Final review checkpoint**
+
+Run `git status --short --branch` and `git diff --stat`. Confirm only B2.2a source, tests, spec, roadmap, and changelog are changed. Do not commit, push, or create a PR until explicitly requested.

--- a/docs/engineering/v0.22-b2.2-symbol-fact-cache-spec.md
+++ b/docs/engineering/v0.22-b2.2-symbol-fact-cache-spec.md
@@ -1,0 +1,196 @@
+# v0.22 B2.2a — Persisted JavaScript Symbol Facts
+
+Status: implemented
+
+## Relationship to B2.2
+
+B2.2 is delivered as two focused changes:
+
+- B2.2a moves the existing TypeScript/JavaScript symbol facts into the shared
+  analysis core and persists them in the parsed-facts cache.
+- B2.2b consumes those facts from `scan --changed` and adds parity with the
+  existing review-first `behavioral.removed-export-still-imported` evidence.
+
+This specification covers B2.2a only. It deliberately adds no finding, review
+signal, command, MCP tool, or public report field.
+
+## Problem
+
+B2.1 extracts precise TypeScript/JavaScript export, re-export, and named-import
+facts inside the review subsystem. The scan pipeline separately stores only a
+flat exported-name list. That split has two costs:
+
+1. review and scan can drift because they do not share one typed symbol fact
+   contract;
+2. a warm changed scan cannot reuse the precise facts B2.2b needs, so adding
+   scan parity without first fixing the core would require a second parse.
+
+RepoPilot's release principles require a content identity to be parsed once and
+its facts reused across eligible consumers. B2.2a establishes that foundation
+without expanding the supported language or resolution boundary.
+
+## Outcome
+
+The shared analysis core owns one deterministic TypeScript/JavaScript symbol
+fact payload. Source analysis extracts it from the already-created syntax tree,
+`ParsedArtifact` retains it, and the parsed-facts cache serializes the identical
+payload. Review consumes the shared extractor and preserves B2.1 behavior.
+
+For an unchanged supported file, a warm `scan --changed` restores complete
+symbol facts from the cache without reconstructing its AST or repeating symbol
+extraction. Reading bytes to establish content identity remains part of cache
+validation. A cache entry without the new payload is incompatible and is
+rebuilt from source.
+
+## Decisions
+
+### Language boundary
+
+The payload remains explicitly TypeScript/JavaScript-specific. The existing
+`JavaScriptSymbolFacts`, `ExportedSymbolFact`, `ImportedSymbolFact`, and
+`SymbolKind` types move from `review` into `analysis` rather than being copied.
+
+No generic multilingual symbol model is introduced. Rust, Python, Go, Java,
+and Kotlin have different export and binding semantics and must not be forced
+into a JavaScript-shaped contract before a consumer needs them.
+
+### Compatibility
+
+The parsed-facts cache schema and analysis version are bumped. Older entries
+are invalidated and rebuilt automatically. There is no migration path because
+the cache is local, bounded, derived data, and an old record cannot synthesize
+the missing symbol kind, import binding, re-export, or byte-span evidence.
+
+The existing flat `exports: Vec<String>` remains in `ParsedArtifact` and the
+cache for this slice. Removing it or migrating its consumers is outside B2.2a.
+
+### Trust boundary
+
+Malformed or error-bearing syntax trees produce no typed symbol payload. An
+absent payload means that complete supported facts were not proven; it never
+means that the module has no imports or exports.
+
+## Architecture
+
+### Shared symbol module
+
+Add an analysis-owned TypeScript/JavaScript symbol module containing:
+
+- `SymbolKind::{Value, Type}`;
+- `ExportedSymbolFact` with name, kind, and line span;
+- `ImportedSymbolFact` with imported/local names, kind, module specifier, line
+  span, and exact byte span;
+- `JavaScriptSymbolFacts` with direct exports, named re-exports, wildcard
+  re-export state, and direct named imports;
+- the current conservative extractor over direct program statements.
+
+The types are deterministic, comparable, and serializable. Collections remain
+sorted and deduplicated before they enter an artifact or cache entry.
+
+The extractor accepts borrowed source content, a language label, and an
+already-created syntax tree. It owns no file loading or parser lifecycle, so
+both scan's `ParsedFile` and review's `ReviewSource` can pass their memoized
+tree without introducing a dependency between those subsystems or parsing a
+second time.
+
+### Parsed artifact
+
+`ParsedArtifact` gains an optional JavaScript symbol payload. Constructors for
+source and current parsed-cache artifacts accept and preserve it. Legacy or
+unsupported artifacts expose no payload and remain explicitly incomplete.
+
+The payload is internal analysis state. It is not projected into scan JSON,
+SARIF, MCP responses, or AI context in B2.2a.
+
+### Source pipeline
+
+For supported `.ts`, `.tsx`, `.js`, and `.jsx` content:
+
+1. create or reuse the existing `ParsedFile`;
+2. pass its content, language label, and memoized tree to the shared extractor;
+3. reject typed symbol extraction when its root has syntax errors;
+4. extract imports, spans, deferred imports, flat exports, syntax summary, and
+   typed symbol facts from that parse session;
+5. store the result in `ParsedArtifact`;
+6. derive the cache entry without parsing again.
+
+Unsupported languages and invalid trees keep the payload absent.
+
+### Parsed-facts cache
+
+`ParsedFactsEntry` stores the optional payload under the new schema. Cache
+lookup restores it into `ParsedArtifact` together with the existing parsed
+facts. Content hash, language, analysis version, and schema validation continue
+to govern reuse.
+
+The existing bounded entry limit, atomic temporary-file write, backup recovery,
+and telemetry behavior remain unchanged.
+
+### Review integration
+
+B2.1 imports the shared types and extractor from `analysis`. Its pre-change and
+post-change review sources keep their current loading and resolver behavior.
+No detector logic, signal identity, confidence, gating, or MCP explanation is
+changed in B2.2a.
+
+## Data Flow
+
+```text
+source content
+  -> shared ParsedFile/tree
+  -> shared JavaScript symbol extractor
+  -> ParsedArtifact.javascript_symbols
+  -> ParsedFactsEntry.javascript_symbols
+  -> warm changed-scan ParsedArtifact
+
+review source/memoized tree
+  -> same shared JavaScript symbol extractor interface
+  -> existing B2.1 detector
+```
+
+The persisted facts become a B2.2b input, but B2.2a adds no scan consumer.
+
+## Scope
+
+### In scope
+
+- Move the existing B2.1 symbol fact types and extraction into `analysis`.
+- Add serialization and parsed-artifact/cache storage.
+- Bump and test cache schema invalidation.
+- Preserve exact import byte spans and line spans through a warm cache hit.
+- Preserve B2.1 extraction and review behavior.
+- Update engineering documentation and the changelog.
+
+### Out of scope
+
+- A `scan --changed` removed-export finding or signal.
+- New public schemas, commands, MCP tools, or rule IDs.
+- Path aliases, workspace packages, default/namespace imports, or deeper
+  re-export propagation.
+- Symbol facts for languages other than TypeScript and JavaScript.
+- Removing the flat export list or redesigning the whole parsed cache.
+- Cache migration, network access, compiler execution, or repository commands.
+
+## Acceptance Criteria
+
+1. A supported source artifact contains the same typed facts B2.1 extracts for
+   direct named exports/imports, type/value kinds, aliases, and re-exports.
+2. An error-bearing AST produces no typed symbol payload.
+3. Serializing and loading a parsed-facts entry preserves every symbol field,
+   including exact byte and line spans.
+4. A cold changed scan writes the payload and an unchanged warm scan restores
+   it from cache without reconstructing an AST or repeating symbol extraction.
+5. A pre-B2.2a parsed cache is rejected and rebuilt automatically.
+6. Unsupported languages retain no JavaScript symbol payload.
+7. Existing flat exports and every B2.1 review signal remain unchanged.
+8. Deterministic ordering is identical across source extraction, serialization,
+   cache loading, and repeated runs.
+9. Targeted tests, formatting, Clippy, the full Rust suite, release contracts,
+   and RepoPilot's self-scan pass before handoff.
+
+## Follow-up: B2.2b
+
+B2.2b may begin only after B2.2a is merged. It will define how
+`scan --changed` compares pre-change and post-change typed facts, identifies
+resolved callers, emits canonical evidence, and proves cold/warm parity without
+expanding B2.1's conservative resolution boundary.

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -103,7 +103,9 @@ Current progress:
   that can still supply the name withdraws it.
   The verification plan is manual; RepoPilot does not run TypeScript,
   compiler, or build commands.
-- Next: B2.2 `scan --changed` parity and persisted symbol-fact caching.
+- B2.2a implemented: typed TypeScript/JavaScript symbol facts now live in the
+  shared analysis core and survive cold/warm parsed-cache paths.
+- Next: B2.2b `scan --changed` removed-export parity using the persisted facts.
 
 Initial evidence families:
 

--- a/src/analysis/artifact.rs
+++ b/src/analysis/artifact.rs
@@ -1,3 +1,4 @@
+use crate::analysis::symbols::JavaScriptSymbolFacts;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -46,13 +47,14 @@ pub struct ParsedArtifact {
     pub imports: Vec<String>,
     pub deferred_imports: Vec<String>,
     pub exports: Vec<String>,
+    pub(crate) javascript_symbols: Option<JavaScriptSymbolFacts>,
     pub context: FileContextFacts,
     pub syntax: SyntaxSummary,
     pub origin: ArtifactOrigin,
 }
 
 impl ParsedArtifact {
-    pub fn from_source(
+    pub(crate) fn from_source(
         path: PathBuf,
         language: Option<String>,
         imports: Vec<String>,
@@ -67,13 +69,14 @@ impl ParsedArtifact {
             imports,
             deferred_imports,
             exports,
+            javascript_symbols: None,
             context,
             syntax,
             origin: ArtifactOrigin::Source,
         }
     }
 
-    pub fn from_legacy_cache(
+    pub(crate) fn from_legacy_cache(
         path: PathBuf,
         language: Option<String>,
         imports: Vec<String>,
@@ -86,13 +89,14 @@ impl ParsedArtifact {
             imports,
             deferred_imports,
             exports: Vec::new(),
+            javascript_symbols: None,
             context,
             syntax: SyntaxSummary::unavailable(),
             origin: ArtifactOrigin::LegacyCache,
         }
     }
 
-    pub fn from_parsed_cache_v2(
+    pub(crate) fn from_parsed_cache_v2(
         path: PathBuf,
         language: Option<String>,
         imports: Vec<String>,
@@ -107,10 +111,19 @@ impl ParsedArtifact {
             imports,
             deferred_imports,
             exports,
+            javascript_symbols: None,
             context,
             syntax,
             origin: ArtifactOrigin::ParsedCacheV2,
         }
+    }
+
+    pub(crate) fn with_javascript_symbols(
+        mut self,
+        javascript_symbols: Option<JavaScriptSymbolFacts>,
+    ) -> Self {
+        self.javascript_symbols = javascript_symbols;
+        self
     }
 
     pub fn rebase_path(&mut self, path: PathBuf) {

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -4,6 +4,7 @@ mod model;
 #[doc(hidden)]
 pub mod parse;
 pub mod path_classifier;
+pub(crate) mod symbols;
 
 pub(crate) use artifact::{FileContextFacts, ParsedArtifact, RoleEvidenceFact, SyntaxSummary};
 pub use model::{ArchitectureContext, FileRole, LanguageFamily, ModuleKind};

--- a/src/analysis/symbols/javascript.rs
+++ b/src/analysis/symbols/javascript.rs
@@ -1,24 +1,24 @@
 use super::{ExportedSymbolFact, ImportedSymbolFact, JavaScriptSymbolFacts, SymbolKind};
 use crate::languages::import_support::extract_string_literal;
-use crate::review::signals::content::ReviewSource;
 use tree_sitter::Node;
 
-pub(super) fn extract_javascript_symbol_facts(
-    source: &ReviewSource,
+pub(crate) fn extract_javascript_symbol_facts(
+    content: &str,
+    language_label: Option<&str>,
+    tree: &tree_sitter::Tree,
 ) -> Option<JavaScriptSymbolFacts> {
     if !matches!(
-        source.language_label(),
+        language_label,
         Some("TypeScript" | "TypeScript React" | "JavaScript" | "JavaScript React")
     ) {
         return None;
     }
-    let tree = source.tree()?;
     let root = tree.root_node();
     if root.has_error() {
         return None;
     }
     let mut facts = JavaScriptSymbolFacts::default();
-    extract_program(root, source.content(), &mut facts);
+    extract_program(root, content, &mut facts);
     facts.exports.sort();
     facts.exports.dedup();
     facts.re_exports.sort();
@@ -291,3 +291,6 @@ fn semantic_field_text<'a>(node: Node<'_>, field: &str, content: &'a str) -> Opt
 fn span(node: Node<'_>) -> (usize, usize) {
     (node.start_position().row + 1, node.end_position().row + 1)
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/analysis/symbols/javascript/tests.rs
+++ b/src/analysis/symbols/javascript/tests.rs
@@ -1,0 +1,41 @@
+use super::extract_javascript_symbol_facts;
+use crate::analysis::symbols::{JavaScriptSymbolFacts, SymbolKind};
+use tree_sitter::Parser;
+
+#[test]
+fn symbol_facts_round_trip_without_losing_spans() {
+    let source = concat!(
+        "export function loadUser() {}\n",
+        "export type UserId = string;\n",
+        "export { remote as forwarded } from './remote.ts';\n",
+        "import { loadUser as load, type UserId } from './api.ts';\n",
+    );
+    let mut parser = Parser::new();
+    parser
+        .set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
+        .expect("TypeScript grammar");
+    let tree = parser.parse(source, None).expect("valid TypeScript tree");
+
+    let facts = extract_javascript_symbol_facts(source, Some("TypeScript"), &tree)
+        .expect("supported symbol facts");
+    let encoded = serde_json::to_string(&facts).expect("serialize symbol facts");
+    let decoded: JavaScriptSymbolFacts =
+        serde_json::from_str(&encoded).expect("deserialize symbol facts");
+
+    assert_eq!(decoded, facts);
+    assert_eq!(facts.exports[0].name, "UserId");
+    assert!(
+        facts
+            .exports
+            .iter()
+            .any(|fact| fact.name == "loadUser" && fact.kind == SymbolKind::Value)
+    );
+    assert_eq!(facts.re_exports, vec!["forwarded"]);
+    assert!(facts.imports.iter().any(|fact| {
+        fact.imported_name == "loadUser"
+            && fact.local_name == "load"
+            && fact.module_specifier == "./api.ts"
+            && fact.line_start == 4
+            && fact.byte_end > fact.byte_start
+    }));
+}

--- a/src/analysis/symbols/mod.rs
+++ b/src/analysis/symbols/mod.rs
@@ -1,0 +1,40 @@
+pub(crate) mod javascript;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum SymbolKind {
+    Value,
+    Type,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ExportedSymbolFact {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub line_start: usize,
+    pub line_end: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ImportedSymbolFact {
+    pub imported_name: String,
+    pub local_name: String,
+    pub kind: SymbolKind,
+    pub module_specifier: String,
+    pub line_start: usize,
+    pub line_end: usize,
+    pub byte_start: usize,
+    pub byte_end: usize,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct JavaScriptSymbolFacts {
+    pub exports: Vec<ExportedSymbolFact>,
+    /// Names forwarded by a sourced `export ... from "..."`. Their defining
+    /// module is not analyzed, so the symbol kind stays unknown.
+    pub re_exports: Vec<String>,
+    /// `export * from "..."` is present, so any name may still be supplied.
+    pub wildcard_re_export: bool,
+    pub imports: Vec<ImportedSymbolFact>,
+}

--- a/src/review/signals/api_contract/mod.rs
+++ b/src/review/signals/api_contract/mod.rs
@@ -1,49 +1,14 @@
 mod detector;
-mod javascript;
 
 use crate::review::diff::ChangedFile;
 use crate::review::diff::DiffTarget;
 use crate::scan::types::CouplingGraph;
 use std::path::PathBuf;
 
+pub(crate) use crate::analysis::symbols::{
+    ExportedSymbolFact, ImportedSymbolFact, JavaScriptSymbolFacts, SymbolKind,
+};
 use crate::review::signals::content::ReviewSource;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum SymbolKind {
-    Value,
-    Type,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct ExportedSymbolFact {
-    pub name: String,
-    pub kind: SymbolKind,
-    pub line_start: usize,
-    pub line_end: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct ImportedSymbolFact {
-    pub imported_name: String,
-    pub local_name: String,
-    pub kind: SymbolKind,
-    pub module_specifier: String,
-    pub line_start: usize,
-    pub line_end: usize,
-    pub byte_start: usize,
-    pub byte_end: usize,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub(crate) struct JavaScriptSymbolFacts {
-    pub exports: Vec<ExportedSymbolFact>,
-    /// Names forwarded by a sourced `export ... from "..."`. Their defining
-    /// module is not analyzed, so the symbol kind stays unknown.
-    pub re_exports: Vec<String>,
-    /// `export * from "..."` is present, so any name may still be supplied.
-    pub wildcard_re_export: bool,
-    pub imports: Vec<ImportedSymbolFact>,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct RemovedExportSignal {
@@ -77,7 +42,11 @@ pub(crate) fn detect_removed_export_imports(
 pub(crate) fn extract_javascript_symbol_facts(
     source: &ReviewSource,
 ) -> Option<JavaScriptSymbolFacts> {
-    javascript::extract_javascript_symbol_facts(source)
+    crate::analysis::symbols::javascript::extract_javascript_symbol_facts(
+        source.content(),
+        source.language_label(),
+        source.tree()?,
+    )
 }
 
 #[cfg(test)]

--- a/src/scan/parsed_cache.rs
+++ b/src/scan/parsed_cache.rs
@@ -1,3 +1,4 @@
+use crate::analysis::symbols::JavaScriptSymbolFacts;
 use crate::analysis::{ParsedArtifact, SyntaxSummary};
 use crate::scan::cache::{cache_dir, stable_hash_hex};
 use crate::scan::facts::FileFacts;
@@ -8,8 +9,8 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-const PARSED_FACTS_SCHEMA_VERSION: u32 = 3;
-const PARSED_FACTS_ANALYSIS_VERSION: &str = "tree-sitter-imports-exports-spans-v2";
+const PARSED_FACTS_SCHEMA_VERSION: u32 = 4;
+const PARSED_FACTS_ANALYSIS_VERSION: &str = "tree-sitter-imports-exports-symbols-spans-v3";
 const PARSED_FACTS_NAME: &str = "parsed_facts_v2.json";
 const PARSED_FACTS_BACKUP_NAME: &str = "parsed_facts_v2.backup.json";
 const PARSED_FACTS_TEMP_NAME: &str = "parsed_facts_v2.tmp.json";
@@ -34,6 +35,8 @@ pub struct ParsedFactsEntry {
     pub import_spans: BTreeMap<String, (usize, usize)>,
     pub deferred_imports: Vec<String>,
     pub exports: Vec<String>,
+    #[serde(default)]
+    pub(crate) javascript_symbols: Option<JavaScriptSymbolFacts>,
     pub syntax: CachedSyntaxSummary,
 }
 
@@ -219,6 +222,7 @@ impl ParsedFactsEntry {
             import_spans,
             deferred_imports: file.deferred_imports.clone(),
             exports: artifact.exports.clone(),
+            javascript_symbols: artifact.javascript_symbols.clone(),
             syntax: CachedSyntaxSummary::from(&artifact.syntax),
         }
     }
@@ -269,6 +273,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::analysis::artifact::ArtifactOrigin;
+    use crate::analysis::symbols::{
+        ExportedSymbolFact, ImportedSymbolFact, JavaScriptSymbolFacts, SymbolKind,
+    };
     use crate::analysis::{FileContextFacts, ParsedArtifact, SyntaxSummary};
     use std::path::PathBuf;
     use tempfile::tempdir;
@@ -317,6 +325,69 @@ mod tests {
         assert_eq!(entry.exports, vec!["run"]);
         assert_eq!(entry.syntax.root_kind.as_deref(), Some("source_file"));
         assert_eq!(loaded.telemetry().entries_loaded, 1);
+    }
+
+    #[test]
+    fn typed_symbol_facts_survive_cache_round_trip() {
+        let file = FileFacts {
+            path: PathBuf::from("src/api.ts"),
+            language: Some("TypeScript".to_string()),
+            imports: vec!["./caller.ts".to_string()],
+            ..FileFacts::default()
+        };
+        let source = ParsedArtifact::from_source(
+            file.path.clone(),
+            file.language.clone(),
+            file.imports.clone(),
+            Vec::new(),
+            vec!["loadUser".to_string()],
+            FileContextFacts::default(),
+            SyntaxSummary::default(),
+        )
+        .with_javascript_symbols(Some(JavaScriptSymbolFacts {
+            exports: vec![ExportedSymbolFact {
+                name: "loadUser".to_string(),
+                kind: SymbolKind::Value,
+                line_start: 1,
+                line_end: 1,
+            }],
+            imports: vec![ImportedSymbolFact {
+                imported_name: "loadUser".to_string(),
+                local_name: "load".to_string(),
+                kind: SymbolKind::Value,
+                module_specifier: "./api.ts".to_string(),
+                line_start: 2,
+                line_end: 2,
+                byte_start: 42,
+                byte_end: 58,
+            }],
+            ..JavaScriptSymbolFacts::default()
+        }));
+        let entry =
+            ParsedFactsEntry::from_artifact("hash".to_string(), &file, &source, BTreeMap::new());
+        let encoded = serde_json::to_string(&entry).expect("serialize cache entry");
+        let decoded: ParsedFactsEntry =
+            serde_json::from_str(&encoded).expect("deserialize cache entry");
+        let restored = ParsedArtifact::from_parsed_cache_v2(
+            file.path.clone(),
+            decoded.language.clone(),
+            decoded.imports.clone(),
+            decoded.deferred_imports.clone(),
+            decoded.exports.clone(),
+            FileContextFacts::default(),
+            (&decoded.syntax).into(),
+        )
+        .with_javascript_symbols(decoded.javascript_symbols.clone());
+
+        assert_eq!(restored.javascript_symbols, source.javascript_symbols);
+        let import = &restored
+            .javascript_symbols
+            .as_ref()
+            .expect("cached symbol facts")
+            .imports[0];
+        assert_eq!((import.byte_start, import.byte_end), (42, 58));
+        assert_eq!(restored.origin, ArtifactOrigin::ParsedCacheV2);
+        assert!(restored.has_complete_parsed_facts());
     }
 
     #[test]
@@ -385,6 +456,7 @@ mod tests {
                 import_spans: Default::default(),
                 deferred_imports: Vec::new(),
                 exports: Vec::new(),
+                javascript_symbols: None,
                 syntax: CachedSyntaxSummary::default(),
             }],
         };
@@ -427,6 +499,7 @@ mod tests {
             import_spans: Default::default(),
             deferred_imports: Vec::new(),
             exports: Vec::new(),
+            javascript_symbols: None,
             syntax: CachedSyntaxSummary::default(),
         }
     }

--- a/src/scan/scanner/changed/file_analysis.rs
+++ b/src/scan/scanner/changed/file_analysis.rs
@@ -353,6 +353,7 @@ impl<'a> ChangedScanEngine<'a> {
                     context.clone(),
                     (&entry.syntax).into(),
                 )
+                .with_javascript_symbols(entry.javascript_symbols.clone())
             })
             .unwrap_or_else(|| {
                 ParsedArtifact::from_legacy_cache(

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -1,5 +1,6 @@
 use crate::analysis::exports::extract_exports;
 use crate::analysis::parse::ParsedFile;
+use crate::analysis::symbols::javascript::extract_javascript_symbol_facts;
 use crate::analysis::{FileContextFacts, ParsedArtifact, RoleEvidenceFact};
 use crate::audits::code_quality::complexity::count_branches;
 use crate::audits::context::classify_file_with_evidence;
@@ -225,6 +226,7 @@ fn process_file_inner(
     let import_spans = analysis.import_spans;
     let deferred_imports = analysis.deferred_imports;
     let exports = analysis.exports;
+    let javascript_symbols = analysis.javascript_symbols;
     let syntax = analysis.syntax;
     full_facts.imports = imports;
     full_facts.deferred_imports = deferred_imports;
@@ -236,7 +238,8 @@ fn process_file_inner(
         exports,
         context,
         syntax,
-    );
+    )
+    .with_javascript_symbols(javascript_symbols);
 
     Ok(PerFileResult {
         file_facts: if retain_content {
@@ -304,30 +307,36 @@ fn collect_file_facts_inner(
     });
 
     let mut from_parsed_cache = false;
-    let (imports, import_spans, deferred_imports, exports, syntax) = if let Some(entry) = cached {
-        from_parsed_cache = true;
-        full_facts.branch_count = entry.branch_count;
-        full_facts.has_inline_tests = entry.has_inline_tests;
-        (
-            entry.imports,
-            entry.import_spans,
-            entry.deferred_imports,
-            entry.exports,
-            (&entry.syntax).into(),
-        )
-    } else {
-        // No audits run on this path, so the parse view is built solely to
-        // extract imports and syntax facts.
-        let parsed = ParsedFile::for_facts(&full_facts);
-        let lang = full_facts.language.as_deref();
-        (
-            extract_imports_from(&parsed, lang),
-            extract_import_spans_from(&parsed, lang),
-            extract_deferred_imports_from(&parsed, lang),
-            extract_exports(parsed.content(), lang),
-            parsed.syntax_summary(),
-        )
-    };
+    let (imports, import_spans, deferred_imports, exports, javascript_symbols, syntax) =
+        if let Some(entry) = cached {
+            from_parsed_cache = true;
+            full_facts.branch_count = entry.branch_count;
+            full_facts.has_inline_tests = entry.has_inline_tests;
+            (
+                entry.imports,
+                entry.import_spans,
+                entry.deferred_imports,
+                entry.exports,
+                entry.javascript_symbols,
+                (&entry.syntax).into(),
+            )
+        } else {
+            // No audits run on this path, so the parse view is built solely to
+            // extract imports and syntax facts.
+            let parsed = ParsedFile::for_facts(&full_facts);
+            let lang = full_facts.language.as_deref();
+            let javascript_symbols = parsed
+                .tree()
+                .and_then(|tree| extract_javascript_symbol_facts(parsed.content(), lang, tree));
+            (
+                extract_imports_from(&parsed, lang),
+                extract_import_spans_from(&parsed, lang),
+                extract_deferred_imports_from(&parsed, lang),
+                extract_exports(parsed.content(), lang),
+                javascript_symbols,
+                parsed.syntax_summary(),
+            )
+        };
     full_facts.imports = imports;
     full_facts.deferred_imports = deferred_imports;
     let artifact = if from_parsed_cache {
@@ -340,6 +349,7 @@ fn collect_file_facts_inner(
             context,
             syntax,
         )
+        .with_javascript_symbols(javascript_symbols)
     } else {
         ParsedArtifact::from_source(
             full_facts.path.clone(),
@@ -350,6 +360,7 @@ fn collect_file_facts_inner(
             context,
             syntax,
         )
+        .with_javascript_symbols(javascript_symbols)
     };
     if let (Some(cache), Some(hash)) = (parsed_cache.as_mut(), content_hash) {
         cache.insert(ParsedFactsEntry::from_artifact(

--- a/src/scan/scanner/file_pipeline.rs
+++ b/src/scan/scanner/file_pipeline.rs
@@ -1,6 +1,8 @@
 use crate::analysis::SyntaxSummary;
 use crate::analysis::exports::extract_exports;
 use crate::analysis::parse::ParsedFile;
+use crate::analysis::symbols::JavaScriptSymbolFacts;
+use crate::analysis::symbols::javascript::extract_javascript_symbol_facts;
 use crate::audits::pipeline::FileAuditRegistration;
 use crate::findings::types::Finding;
 use crate::graph::imports::{
@@ -16,6 +18,7 @@ pub(super) struct FileAnalysisResult {
     pub(super) import_spans: std::collections::BTreeMap<String, (usize, usize)>,
     pub(super) deferred_imports: Vec<String>,
     pub(super) exports: Vec<String>,
+    pub(super) javascript_symbols: Option<JavaScriptSymbolFacts>,
     pub(super) syntax: SyntaxSummary,
 }
 
@@ -24,6 +27,7 @@ struct ParsedFileFacts {
     import_spans: std::collections::BTreeMap<String, (usize, usize)>,
     deferred_imports: Vec<String>,
     exports: Vec<String>,
+    javascript_symbols: Option<JavaScriptSymbolFacts>,
     syntax: SyntaxSummary,
 }
 
@@ -58,6 +62,7 @@ pub(super) fn analyze_file(
         import_spans: parsed_facts.import_spans,
         deferred_imports: parsed_facts.deferred_imports,
         exports: parsed_facts.exports,
+        javascript_symbols: parsed_facts.javascript_symbols,
         syntax: parsed_facts.syntax,
     }
 }
@@ -96,12 +101,61 @@ fn extract_parsed_artifacts(parsed: &ParsedFile, language: Option<&str>) -> Pars
     let import_spans = extract_import_spans_from(parsed, language);
     let deferred_imports = extract_deferred_imports_from(parsed, language);
     let exports = extract_exports(parsed.content(), language);
+    let javascript_symbols = parsed
+        .tree()
+        .and_then(|tree| extract_javascript_symbol_facts(parsed.content(), language, tree));
     let syntax = parsed.syntax_summary();
     ParsedFileFacts {
         imports,
         import_spans,
         deferred_imports,
         exports,
+        javascript_symbols,
         syntax,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::analyze_file;
+    use crate::scan::config::ScanConfig;
+    use crate::scan::facts::FileFacts;
+    use std::path::PathBuf;
+
+    #[test]
+    fn source_analysis_retains_typed_javascript_symbols() {
+        let file = FileFacts {
+            path: PathBuf::from("src/user.ts"),
+            language: Some("TypeScript".to_string()),
+            content: Some(
+                concat!(
+                    "export type UserId = string;\n",
+                    "import { loadUser as load } from \"./api.ts\";\n",
+                )
+                .to_string(),
+            ),
+            ..FileFacts::default()
+        };
+
+        let result = analyze_file(&file, &[], &ScanConfig::default());
+        let symbols = result.javascript_symbols.expect("supported symbol facts");
+
+        assert_eq!(symbols.exports[0].name, "UserId");
+        assert_eq!(symbols.imports[0].local_name, "load");
+        assert_eq!(symbols.imports[0].module_specifier, "./api.ts");
+    }
+
+    #[test]
+    fn malformed_source_does_not_claim_typed_javascript_symbols() {
+        let file = FileFacts {
+            path: PathBuf::from("src/user.ts"),
+            language: Some("TypeScript".to_string()),
+            content: Some("export type UserId = ;".to_string()),
+            ..FileFacts::default()
+        };
+
+        let result = analyze_file(&file, &[], &ScanConfig::default());
+
+        assert!(result.javascript_symbols.is_none());
     }
 }

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -73,7 +73,7 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
     );
     assert_eq!(
         read_json(&cache_dir.join("parsed_facts_v2.json"))["analysis_version"],
-        "tree-sitter-imports-exports-spans-v2"
+        "tree-sitter-imports-exports-symbols-spans-v3"
     );
     assert_eq!(
         read_json(&cache_dir.join("parsed_facts_v2.json"))["entries"][0]["content_hash"]
@@ -127,6 +127,49 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
         first_finding_title(&invalidated),
         "Possible secret detected"
     );
+}
+
+#[test]
+fn typed_symbol_facts_are_persisted_and_reused_by_changed_scan() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(
+        temp.path().join("src/api.ts"),
+        "export function loadUser() {}\n",
+    );
+    write(temp.path().join("src/caller.ts"), "export {};\n");
+    commit_all(temp.path(), "initial");
+    write(
+        temp.path().join("src/caller.ts"),
+        "import { loadUser as load } from './api.ts';\nload();\n",
+    );
+
+    scan_changed_json(temp.path(), &["--changed"]);
+    let cache_path = temp.path().join(".repopilot/cache/parsed_facts_v2.json");
+    let cache = read_json(&cache_path);
+    assert_eq!(cache["schema_version"], 4);
+    assert_eq!(
+        cache["analysis_version"],
+        "tree-sitter-imports-exports-symbols-spans-v3"
+    );
+    let named_import = cache["entries"]
+        .as_array()
+        .expect("parsed cache entries")
+        .iter()
+        .filter_map(|entry| entry["javascript_symbols"]["imports"].as_array())
+        .flatten()
+        .find(|import| import["local_name"] == "load")
+        .expect("cached aliased import");
+    assert_eq!(named_import["imported_name"], "loadUser");
+    assert_eq!(named_import["module_specifier"], "./api.ts");
+
+    let cached = scan_changed_json(temp.path(), &["--changed"]);
+    assert!(
+        cached["cache_telemetry"]["parsed_cache_hits"]
+            .as_u64()
+            .is_some_and(|hits| hits > 0)
+    );
+    assert_eq!(cached["cache_telemetry"]["parsed_cache_misses"], 0);
 }
 
 #[test]
@@ -243,24 +286,50 @@ fn changed_scan_invalidates_cache_when_config_changes() {
 fn changed_scan_invalidates_old_cache_schema() {
     let temp = tempdir().expect("temp dir");
     init_repo(temp.path());
-    write(temp.path().join("src/lib.rs"), "pub fn live() {}\n");
+    write(
+        temp.path().join("src/api.ts"),
+        "export function loadUser() {}\n",
+    );
+    write(temp.path().join("src/caller.ts"), "export {};\n");
     commit_all(temp.path(), "initial");
     write(
-        temp.path().join("src/lib.rs"),
-        "pub fn live() {}\nconst API_KEY: &str = \"abc123xyz987\";\n",
+        temp.path().join("src/caller.ts"),
+        "import { loadUser as load } from './api.ts';\nload();\n",
     );
 
     scan_changed_json(temp.path(), &["--changed"]);
+    let cache_dir = temp.path().join(".repopilot/cache");
     for name in ["file_hashes.json", "file_roles.json", "findings.json"] {
         force_cache_schema(temp.path().join(".repopilot/cache").join(name).as_path(), 5);
     }
+    force_cache_schema(&cache_dir.join("parsed_facts_v2.json"), 3);
     let json = scan_changed_json(temp.path(), &["--changed"]);
 
     assert_eq!(json["cache_telemetry"]["hits"], 0);
     assert_eq!(json["cache_telemetry"]["misses"], 1);
+    assert!(
+        json["cache_telemetry"]["parsed_cache_invalidations"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    );
     assert_eq!(
         json["cache_telemetry"]["changed_files"][0]["cache_reason"],
         "missing-cache-entry"
+    );
+    let rebuilt = read_json(&cache_dir.join("parsed_facts_v2.json"));
+    assert_eq!(rebuilt["schema_version"], 4);
+    assert!(
+        rebuilt["entries"]
+            .as_array()
+            .expect("entries")
+            .iter()
+            .any(|entry| {
+                entry["javascript_symbols"]["imports"]
+                    .as_array()
+                    .is_some_and(|imports| {
+                        imports.iter().any(|import| import["local_name"] == "load")
+                    })
+            })
     );
 }
 


### PR DESCRIPTION
## Summary

This PR moves the existing conservative JS/TS export/import fact model out of the review subsystem and into the shared analysis core, then persists the complete typed payload through `ParsedArtifact` and parsed-facts cache schema v4.

Warm changed scans can now restore exact symbol facts including type/value kind, aliases, re-exports, line spans, and import byte spans without reparsing unchanged files. Existing B2.1 removed-export review behavior remains unchanged.

This is an internal analysis/cache foundation only: it adds no new finding, review signal, command, MCP tool, or public report field. `scan --changed` removed-export parity remains the B2.2b follow-up.

## Type of change

- [x] Feature
- [x] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- introduce analysis-owned `JavaScriptSymbolFacts`, `ExportedSymbolFact`, `ImportedSymbolFact`, and `SymbolKind` types;
- move the existing TypeScript/JavaScript symbol extractor from `review` into `analysis::symbols::javascript` while preserving its conservative AST semantics;
- make review consume the shared extractor instead of owning a duplicate implementation;
- retain optional JS/TS symbol facts on `ParsedArtifact` and thread them through the normal source-analysis pipeline;
- persist the typed payload in parsed-facts cache schema `4` with analysis version `tree-sitter-imports-exports-symbols-spans-v3`;
- invalidate older parsed-facts cache entries and rebuild them from source instead of attempting an unsafe migration;
- restore symbol facts on warm full/changed-cache paths without a second parser pass;
- add cache round-trip, malformed-tree, cold/warm changed-scan reuse, and old-schema invalidation coverage;
- document the B2.2a contract, implementation plan, roadmap status, and B2.2b boundary.

## Why

B2.1 already had precise TypeScript/JavaScript export, re-export, and named-import facts, but they lived inside the review subsystem while scan/cache retained only a flat export-name list.

That split created two architectural problems:

1. review and scan could drift because they did not share one typed symbol-fact contract;
2. implementing `scan --changed` removed-export parity would otherwise require reparsing unchanged files or duplicating extraction logic.

B2.2a fixes the ownership and reuse boundary first. A content identity is parsed once, the resulting typed facts are retained as shared analysis state, and eligible cold/warm consumers reuse the same deterministic payload.

## Analysis contract

For supported `.ts`, `.tsx`, `.js`, and `.jsx` files, the persisted payload preserves:

- direct named exports;
- `value` vs `type` symbol kind;
- named re-exports;
- wildcard re-export state;
- named imports and local aliases;
- module specifiers;
- exact line spans;
- exact import byte spans.

Malformed or error-bearing syntax trees produce no typed symbol payload. Absence therefore means "not proven", not "the module has no symbols".

The existing flat `exports` field remains intact for compatibility and is deliberately not removed in this slice.

## Cache behavior

Parsed-facts cache changes:

- schema: `3` → `4`;
- analysis version: `tree-sitter-imports-exports-spans-v2` → `tree-sitter-imports-exports-symbols-spans-v3`;
- old entries are invalidated and rebuilt automatically;
- warm changed scans restore typed facts from cache;
- cache telemetry confirms hits without reparsing unchanged files;
- atomic write, backup recovery, bounded retention, and content-hash validation remain unchanged.

## Contract and ownership

Subsystems affected:

- shared analysis core;
- JS/TS symbol extraction;
- parsed artifacts;
- parsed-facts cache;
- changed-scan cache restoration;
- review API-contract adapter.

Compatibility:

- [x] The change stays within a clear analysis/cache ownership boundary
- [x] No CLI command or flag changes
- [x] No scan/review JSON, SARIF, baseline, Action, MCP, or AI-context schema changes
- [x] No rule IDs, finding IDs, signal IDs, gate semantics, or exit-code changes
- [x] Existing B2.1 removed-export behavior and identity remain unchanged
- [x] Unsupported languages retain no JavaScript-shaped symbol payload
- [x] No second parser pass is introduced for symbol extraction
- [x] Cache invalidation is explicit rather than silently migrating incomplete facts

## Verification

Focused coverage includes:

```bash
cargo test --lib analysis::symbols::javascript::tests
cargo test --lib scan::parsed_cache::tests
cargo test --test scan_changed_cache_cli
cargo test --test removed_export_review
cargo test --test removed_export_mcp
```

Repository gate:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
npm test
cargo run -- scan . --fail-on-priority p1
```