### PR TITLE
fix: model guarded optional Python imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   disable/severity configuration, risk/CI gates, JSON and MCP scan output, and
   keeps full scans silent without an authoritative comparison revision. Cold
   and warm changed scans reuse the B2.2a symbol payload without rereading or
-  reparsing current callers; repository-context cache schema v7 adds only the
-  missing path-to-content-hash lookup key and invalidates older context entries.
+  reparsing current callers; repository-context cache schema v8 adds the
+  missing path-to-content-hash lookup key and guarded optional-import evidence,
+  and invalidates older context entries.
   `repopilot_explain_finding` preserves these Git-diff findings through its
   existing stored-only fallback rather than claiming a file-scoped live replay.
 - **Review-first removed-export evidence.** `repopilot review` now emits the
@@ -77,6 +78,18 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   repositories: tool configs, build scripts, framework-autoloaded modules,
   runner-discovered tests, and dynamically imported documentation examples all
   report zero fan-in without being dead.
+
+### Fixed
+
+- Stop `architecture.unresolved-local-import` from treating handled optional
+  Python dependencies as broken code. Imports in a `try` body guarded by an
+  absorbing `ImportError` or `ModuleNotFoundError` handler are excluded, while
+  unrelated handlers and bare re-raises retain the finding. The Python frontend
+  derives this internal fact from its existing syntax tree; parsed-facts cache
+  schema v5 and repository-context schema v8 preserve it across cold and warm
+  full/changed scans without rereading or reparsing source. The two historical
+  Wagtail false positives are removed, taking the reviewed default-visible zoo
+  false-positive debt from 2 to 0.
 
 ### Changed
 

--- a/docs/architecture-antipatterns.md
+++ b/docs/architecture-antipatterns.md
@@ -54,6 +54,13 @@ only:
 - Python relative modules such as `.payments` when neither the module file nor
   package initializer exists.
 
+Python imports inside a `try` body are not reported when an explicit
+`ImportError` or `ModuleNotFoundError` handler absorbs the failure. A handler
+that is broad or unrelated, or performs a bare re-raise, does not qualify and
+keeps the import required. This evidence comes from the same parsed syntax tree
+as the import graph and survives cold and warm changed scans; the audit does not
+reparse source text.
+
 RepoPilot checks every bounded candidate on disk before reporting, so a valid
 target omitted by ignore or scan-size policy remains quiet. Extensionless
 imports, path aliases, workspace packages, generated targets, Rust module forms,

--- a/docs/engineering/rule-scorecard.md
+++ b/docs/engineering/rule-scorecard.md
@@ -23,7 +23,7 @@ Every default-visible zoo finding is labeled, so these rows are exhaustive for t
 | `architecture.package-boundary-violation` | experimental | no zoo evidence | n/a | 0 |
 | `architecture.test-leak` | experimental | no zoo evidence | n/a | 0 |
 | `architecture.too-many-modules` | experimental | no zoo evidence | n/a | 0 |
-| `architecture.unresolved-local-import` | preview | 2 labeled across 1 repo(s) | 0.00 | 2 |
+| `architecture.unresolved-local-import` | preview | no zoo evidence | n/a | 0 |
 | `behavioral.removed-export-still-imported` | preview | no zoo evidence | n/a | 0 |
 | `code-marker.fixme` | experimental | no zoo evidence | n/a | 0 |
 | `code-marker.hack` | experimental | no zoo evidence | n/a | 0 |

--- a/docs/engineering/v0.22-broken-import-evidence-spec.md
+++ b/docs/engineering/v0.22-broken-import-evidence-spec.md
@@ -76,6 +76,44 @@ or explain the broken-code evidence.
 - An empty result means no supported broken local import was proven; it does not
   claim that every import or language semantic was evaluated.
 
+## Guarded optional Python imports
+
+Python code may deliberately probe for an optional local module:
+
+```python
+try:
+    from .local import *
+except ImportError:
+    pass
+```
+
+An absent target in this shape is handled repository behavior, not proven
+breakage. The Python frontend therefore records a crate-internal
+`guarded_optional_imports` fact from the same tree-sitter parse used for import
+extraction. A guarded import is eligible only when it is inside the body of a
+`try` statement with a matching `except ImportError` or
+`except ModuleNotFoundError` handler that absorbs the error. The standard names
+may appear directly or in a tuple; qualified attributes and arbitrary handler
+expressions do not qualify. A handler that contains a bare `raise` does not make
+the import optional.
+
+The fact is stored on `ParsedArtifact`, persisted in `ParsedFactsCache`, and
+projected into `ScanFacts` and `RepositoryContextState` with the other
+import-graph inputs required by repository-level audits. Both cache schemas are
+bumped, so warm changed scans cannot combine a new detector with context that
+predates the fact. It does not alter dependency edges or the existing
+deferred-import contract: an optional module still becomes a real dependency
+when it exists. The unresolved-import audit consults the fact before emitting a
+finding and otherwise preserves the existing proof, limitation, and diagnostic
+behavior.
+
+Malformed syntax, broad `except:`, unrelated exception types, string/comment
+lookalikes, imports outside the guarded `try` body, and imports deferred inside
+a function declared in that body do not enter this fact. The outer handler is
+not active when a deferred function body later runs. The cache schema and
+analysis version change conservatively so an older entry cannot silently omit
+the new fact.
+
 ## Acceptance criteria
 
 1. A TypeScript file importing `./missing.ts` produces exactly one
@@ -92,3 +130,19 @@ or explain the broken-code evidence.
    imports, including those too ambiguous for this detector.
 8. Targeted tests, rule fixture evaluation, formatting, clippy, the full Rust
    suite, release contracts, and RepoPilot's self-scan pass before handoff.
+9. A missing Python relative import guarded by an absorbing `ImportError` or
+   `ModuleNotFoundError` handler produces no finding on cold or warm scans.
+10. The same import guarded by an unrelated exception type still produces the
+    existing finding.
+11. A matching handler containing a bare `raise` still produces the finding.
+12. Guarded-import extraction reuses the frontend's existing parse and does not
+    add filesystem reads or a parser invocation inside the audit.
+13. Parsed-cache and repository-context round trips preserve the complete
+    guarded-import set; older schemas invalidate rather than appearing complete.
+14. Fresh Wagtail zoo output contains neither known optional-import false
+    positive, and the generated scorecard records no false-positive debt for
+    `architecture.unresolved-local-import`.
+15. A function-body import is not marked optional merely because the function
+    declaration appears inside a guarded `try` body.
+16. A qualified or computed exception expression containing the text
+    `ImportError` does not qualify as the standard exception type.

--- a/docs/engineering/v0.22-optional-python-imports-plan.md
+++ b/docs/engineering/v0.22-optional-python-imports-plan.md
@@ -1,0 +1,111 @@
+# v0.22 Guarded Optional Python Imports Implementation Plan
+
+> **For agentic workers:** Execute inline with TDD. Do not commit, push, or open
+> a PR until the user requests handoff.
+
+**Goal:** Stop reporting handled optional Python imports as broken while
+preserving parse-once, cache parity, graph semantics, and conservative findings.
+
+**Architecture:** The Python frontend extracts a guarded-import set from its
+existing tree-sitter view. `ParsedArtifact` owns the internal fact,
+`ParsedFactsCache` persists it, `RepositoryContextState` carries its bounded
+graph-audit projection, and the unresolved-import audit checks it before
+projecting a finding. Dependency and deferred-edge behavior does not change.
+
+**Tech stack:** Rust 2024, tree-sitter-python, serde JSON, existing scan and zoo
+harnesses.
+
+**Spec:** `docs/engineering/v0.22-broken-import-evidence-spec.md`
+
+## Global constraints
+
+- Parse each source content identity once; the audit must not parse or reread.
+- Recognize only explicit `ImportError` and `ModuleNotFoundError` handlers.
+- A matching handler with a bare `raise` is not absorbing.
+- Keep the fact crate-internal and make no public report-schema change.
+- Invalidate old parsed-cache entries conservatively.
+- Preserve deterministic ordering and full/changed evidence parity.
+
+### Task 1: Frontend fact extraction
+
+**Files:**
+- Modify: `src/languages/mod.rs`
+- Modify: `src/languages/python/mod.rs`
+- Modify: `src/languages/python/imports.rs`
+- Add: `src/languages/python/imports/guarded.rs`
+- Test: `src/languages/python/imports/guarded.rs`
+
+**Interface:** Add
+`ImportExtractor::guarded_optional: Option<fn(&ParsedFile) -> HashSet<String>>`
+and `extract_guarded_optional_imports_from(&ParsedFile, Option<&str>) -> Vec<String>`.
+
+- [x] Add RED tests for `ImportError`, `ModuleNotFoundError`, unrelated
+  exceptions, a bare re-raise, nested imports, deferred function bodies,
+  malformed syntax, tuple handlers, qualified exception lookalikes, and
+  string/comment lookalikes.
+- [x] Run the exact Python import tests and confirm the guarded cases fail
+  because the fact does not exist.
+- [x] Traverse `try_statement` nodes from the existing `ParsedFile`; collect
+  imports in the `try` body only when an explicit matching handler absorbs the
+  exception.
+- [x] Run the exact frontend tests and confirm all eager/deferred behavior is
+  unchanged.
+
+### Task 2: Artifact and cache propagation
+
+**Files:**
+- Modify: `src/analysis/artifact.rs`
+- Modify: `src/scan/scanner/file_pipeline.rs`
+- Modify: `src/scan/scanner/file.rs`
+- Modify: `src/scan/scanner/changed/file_analysis.rs`
+- Modify: `src/scan/parsed_cache.rs`
+- Modify: `src/scan/facts.rs`
+- Modify: `src/graph/context.rs`
+- Modify: `src/graph/context/graph_impl.rs`
+- Modify: `src/graph/context/state.rs`
+- Test: the adjacent unit tests and `tests/scan_changed_cache_cli.rs`
+
+**Interface:** Add crate-internal
+`ParsedArtifact::guarded_optional_imports: Vec<String>` and a builder that
+normalizes ordering. Add the same serde-defaulted payload to `ParsedFactsEntry`,
+then bump parsed-cache schema `4 -> 5` and the analysis fingerprint to v4.
+Project the normalized set through `ScanFacts::guarded_optional_imports_by_file`
+and `RepoContextNode`, then bump repository-context schema `7 -> 8`.
+
+- [x] Add RED artifact/cache round-trip tests proving the set survives source,
+  serialization, and warm restoration.
+- [x] Thread the extractor result through source analysis, cached artifacts,
+  scan facts, and repository-context cold/warm paths.
+- [x] Extend old-schema invalidation coverage to schema 4.
+- [x] Run parsed-cache and changed-cache tests; inspect the JSON payload to
+  confirm the field is persisted and deterministic.
+
+### Task 3: Finding suppression and end-to-end parity
+
+**Files:**
+- Modify: `src/audits/architecture/unresolved_local_imports.rs`
+- Modify: `src/audits/architecture/unresolved_local_imports/tests.rs`
+- Modify: `tests/unresolved_local_import.rs`
+
+**Interface:** Before projecting a definitive missing-target finding, check the
+source artifact's guarded set for the exact raw import. Do not alter resolution
+statistics or limitation diagnostics.
+
+- [x] Add RED unit and CLI tests: absorbing handlers are silent; unrelated and
+  re-raising handlers retain the finding; cold and warm changed scans agree.
+- [x] Add the one exact guard at the audit boundary.
+- [x] Run the focused frontend, artifact, cache, audit, and CLI suites.
+
+### Task 4: Zoo evidence and handoff
+
+**Files:**
+- Update generated Wagtail zoo snapshot and expectation labels.
+- Regenerate: `docs/engineering/rule-scorecard.md`
+- Update: `CHANGELOG.md` under `[Unreleased]`
+
+- [x] Verify all 11 zoo pins, rescan Wagtail, and confirm both historical
+  optional-import findings disappear without new default-visible findings.
+- [x] Remove only the two stale Wagtail false-positive labels and regenerate the
+  scorecard.
+- [x] Run formatting, Clippy, focused tests, the full RepoPilot gate, and
+  self-scan before handoff.

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -85,8 +85,10 @@ Current progress:
 - B1 implemented: `architecture.unresolved-local-import` reuses typed graph
   evidence for explicit supported TS/JS and Python local imports, preserves
   exact source spans through cold/warm caches, and reports ambiguous semantics
-  as aggregated limitations. Safe/unsafe fixtures and full/changed parity pin
-  the trust boundary.
+  as aggregated limitations. Python imports guarded by an absorbing
+  `ImportError` or `ModuleNotFoundError` handler are excluded through a
+  parse-once fact that survives parsed-facts and repository-context caches.
+  Safe/unsafe fixtures and full/changed parity pin the trust boundary.
 - B2.1 implemented: `review` detects a removed direct named export that remains
   directly imported by a local `.ts`, `.tsx`, `.js`, or `.jsx` caller when the
   resolver selects the changed exporter from the selected review target's file
@@ -108,9 +110,9 @@ Current progress:
   `scan --changed` now consume one canonical removed-export detector and exact
   occurrence contract. Changed scan emits the canonical High-confidence,
   High-severity finding at the caller import, while full scan stays silent
-  without a comparison revision. Repository-context cache schema v7 persists
-  the path-to-content-hash lookup key needed to reuse unchanged caller facts
-  without rereading or reparsing current source.
+  without a comparison revision. Repository-context cache schema v8 persists
+  both the path-to-content-hash lookup key and guarded optional-import evidence
+  needed to reuse unchanged facts without rereading or reparsing current source.
 
 Initial evidence families:
 

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -218,7 +218,7 @@ A supported explicit local import does not resolve to any bounded source-file ca
 
 **Recommendation:** Restore the imported module, update the import path, or run the project compiler to confirm the intended generated target.
 
-**Known false positives:** Only explicit supported TypeScript/JavaScript file extensions and explicit Python relative modules are reported. Extensionless imports, aliases, workspace packages, Rust module forms, generated targets, and unsupported semantics remain limitations rather than findings.
+**Known false positives:** Only explicit supported TypeScript/JavaScript file extensions and explicit Python relative modules are reported. Python imports guarded by an absorbing ImportError or ModuleNotFoundError handler are excluded; broad or unrelated handlers and bare re-raises do not qualify. Extensionless imports, aliases, workspace packages, Rust module forms, generated targets, and unsupported semantics remain limitations rather than findings.
 
 **Reference:** <https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture>
 

--- a/src/analysis/artifact.rs
+++ b/src/analysis/artifact.rs
@@ -46,6 +46,7 @@ pub struct ParsedArtifact {
     pub language: Option<String>,
     pub imports: Vec<String>,
     pub deferred_imports: Vec<String>,
+    pub(crate) guarded_optional_imports: Vec<String>,
     pub exports: Vec<String>,
     pub(crate) javascript_symbols: Option<JavaScriptSymbolFacts>,
     pub context: FileContextFacts,
@@ -68,6 +69,7 @@ impl ParsedArtifact {
             language,
             imports,
             deferred_imports,
+            guarded_optional_imports: Vec::new(),
             exports,
             javascript_symbols: None,
             context,
@@ -88,6 +90,7 @@ impl ParsedArtifact {
             language,
             imports,
             deferred_imports,
+            guarded_optional_imports: Vec::new(),
             exports: Vec::new(),
             javascript_symbols: None,
             context,
@@ -110,6 +113,7 @@ impl ParsedArtifact {
             language,
             imports,
             deferred_imports,
+            guarded_optional_imports: Vec::new(),
             exports,
             javascript_symbols: None,
             context,
@@ -123,6 +127,13 @@ impl ParsedArtifact {
         javascript_symbols: Option<JavaScriptSymbolFacts>,
     ) -> Self {
         self.javascript_symbols = javascript_symbols;
+        self
+    }
+
+    pub(crate) fn with_guarded_optional_imports(mut self, mut imports: Vec<String>) -> Self {
+        imports.sort();
+        imports.dedup();
+        self.guarded_optional_imports = imports;
         self
     }
 
@@ -218,5 +229,28 @@ mod tests {
         assert!(artifact.is_source_origin());
         assert!(artifact.is_complete_source_artifact());
         assert!(artifact.has_complete_parsed_facts());
+    }
+
+    #[test]
+    fn guarded_optional_imports_are_normalized_and_queryable() {
+        let artifact = ParsedArtifact::from_source(
+            PathBuf::from("pkg/settings.py"),
+            Some("Python".to_string()),
+            vec![".local".to_string(), ".plugin".to_string()],
+            Vec::new(),
+            Vec::new(),
+            FileContextFacts::default(),
+            SyntaxSummary::default(),
+        )
+        .with_guarded_optional_imports(vec![
+            ".plugin".to_string(),
+            ".local".to_string(),
+            ".local".to_string(),
+        ]);
+
+        assert_eq!(
+            artifact.guarded_optional_imports,
+            vec![".local".to_string(), ".plugin".to_string()]
+        );
     }
 }

--- a/src/audits/architecture/unresolved_local_imports.rs
+++ b/src/audits/architecture/unresolved_local_imports.rs
@@ -20,6 +20,9 @@ pub(crate) fn analyze_unresolved_local_imports(
     let mut findings = Vec::new();
     let mut limitations = BTreeMap::new();
     for unresolved in context.resolution.evidence() {
+        if is_guarded_optional_import(unresolved, context) {
+            continue;
+        }
         if is_shadowed_python_submodule(unresolved, context.resolution) {
             continue;
         }
@@ -46,6 +49,39 @@ pub(crate) fn analyze_unresolved_local_imports(
         findings,
         diagnostics: limitation_diagnostics(limitations),
     }
+}
+
+fn is_guarded_optional_import(
+    unresolved: &crate::graph::UnresolvedImportEvidence,
+    context: &GraphAuditContext<'_>,
+) -> bool {
+    if unresolved
+        .source
+        .extension()
+        .and_then(|value| value.to_str())
+        != Some("py")
+    {
+        return false;
+    }
+    path_keyed_value(
+        &context.facts.guarded_optional_imports_by_file,
+        &unresolved.source,
+    )
+    .is_some_and(|imports| {
+        imports
+            .binary_search_by(|candidate| candidate.as_str().cmp(&unresolved.raw_import))
+            .is_ok()
+    })
+}
+
+fn path_keyed_value<'a, T>(values: &'a BTreeMap<PathBuf, T>, path: &Path) -> Option<&'a T> {
+    values.get(path).or_else(|| {
+        let normalized = crate::graph::resolver::normalize_path(path);
+        values
+            .iter()
+            .find(|(candidate, _)| crate::graph::resolver::normalize_path(candidate) == normalized)
+            .map(|(_, value)| value)
+    })
 }
 
 fn source_facts<'a>(
@@ -90,15 +126,7 @@ fn missing_import_finding(
 ) -> Finding {
     let path = relative_path(&unresolved.source, context.root);
     let source_facts = source_facts(context, unresolved);
-    let stored_spans = context
-        .facts
-        .import_spans_by_file
-        .iter()
-        .find(|(path, _)| {
-            crate::graph::resolver::normalize_path(path)
-                == crate::graph::resolver::normalize_path(&unresolved.source)
-        })
-        .map(|(_, spans)| spans);
+    let stored_spans = path_keyed_value(&context.facts.import_spans_by_file, &unresolved.source);
     let (line_start, line_end) = import_span(source_facts, stored_spans, &unresolved.raw_import);
     Finding {
         id: String::new(),

--- a/src/audits/architecture/unresolved_local_imports/tests.rs
+++ b/src/audits/architecture/unresolved_local_imports/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::analysis::{FileContextFacts, ParsedArtifact, SyntaxSummary};
 use crate::audits::architecture::graph_context::GraphAuditContext;
 use crate::findings::types::{Confidence, Severity};
 use crate::graph::v2::build_coupling_graph_snapshot;
@@ -88,6 +89,34 @@ fn missing_explicit_python_relative_module_emits_finding() {
     assert_eq!(result.findings.len(), 1);
     assert_eq!(result.findings[0].evidence[0].line_start, 1);
     assert!(result.findings[0].description.contains(".missing"));
+}
+
+#[test]
+fn guarded_optional_python_import_is_not_reported_as_broken() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let source = root.join("pkg/settings.py");
+    let content = "try:\n    from .local import *\nexcept ImportError:\n    pass\n";
+    let mut facts = facts(source.clone(), "Python", content, &[".local"]);
+    facts.insert_artifact(
+        ParsedArtifact::from_source(
+            source.clone(),
+            Some("Python".to_string()),
+            vec![".local".to_string()],
+            Vec::new(),
+            Vec::new(),
+            FileContextFacts::default(),
+            SyntaxSummary::default(),
+        )
+        .with_guarded_optional_imports(vec![".local".to_string()]),
+    );
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record_classified(&source, ".local", root);
+
+    let result = analyze(root, &facts, &resolution);
+
+    assert!(result.findings.is_empty(), "{:#?}", result.findings);
+    assert!(result.diagnostics.is_empty());
 }
 
 #[test]

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -14,7 +14,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 pub const CONTEXT_GRAPH_CACHE_NAME: &str = "repo_context.json";
-pub const CONTEXT_GRAPH_SCHEMA_VERSION: u32 = 7;
+pub const CONTEXT_GRAPH_SCHEMA_VERSION: u32 = 8;
 pub const CONTEXT_GRAPH_RESOLVER_VERSION: &str = "context-state-v1";
 pub const MAX_CONTEXT_GRAPH_CYCLES: usize = 20;
 pub const MAX_CONTEXT_GRAPH_METRICS: usize = 10;
@@ -66,6 +66,8 @@ pub struct RepoContextNode {
     pub import_spans: BTreeMap<String, (usize, usize)>,
     #[serde(default)]
     pub deferred_imports: Vec<String>,
+    #[serde(default)]
+    pub guarded_optional_imports: Vec<String>,
     pub is_test: bool,
     pub is_generated: bool,
     pub is_config: bool,

--- a/src/graph/context/analysis.rs
+++ b/src/graph/context/analysis.rs
@@ -245,6 +245,7 @@ mod tests {
             imports: Vec::new(),
             import_spans: Default::default(),
             deferred_imports: Vec::new(),
+            guarded_optional_imports: Vec::new(),
             is_test: false,
             is_generated: false,
             is_config: false,

--- a/src/graph/context/graph_impl.rs
+++ b/src/graph/context/graph_impl.rs
@@ -16,6 +16,7 @@ impl RepoContextGraph {
                         root,
                         facts.import_spans_by_file.get(&file.path),
                         facts.parsed_content_hashes.get(&file.path),
+                        facts.guarded_optional_imports_by_file.get(&file.path),
                     )
                 })
                 .collect(),
@@ -54,6 +55,12 @@ impl RepoContextGraph {
             .iter()
             .filter_map(|node| Some((node.path.clone(), node.content_hash.as_ref()?.clone())))
             .collect();
+        let guarded_optional_imports_by_file = self
+            .nodes
+            .iter()
+            .filter(|node| !node.guarded_optional_imports.is_empty())
+            .map(|node| (node.path.clone(), node.guarded_optional_imports.clone()))
+            .collect();
 
         ScanFacts {
             root_path: self.root_path.clone(),
@@ -65,6 +72,7 @@ impl RepoContextGraph {
             files,
             parsed_content_hashes,
             import_spans_by_file,
+            guarded_optional_imports_by_file,
             detected_frameworks: self.detected_frameworks.clone(),
             framework_projects: self.framework_projects.clone(),
             react_native: self.react_native.clone(),
@@ -103,6 +111,7 @@ impl RepoContextGraph {
             patch_files,
             &BTreeMap::new(),
             &BTreeMap::new(),
+            &BTreeMap::new(),
         );
     }
 
@@ -113,6 +122,7 @@ impl RepoContextGraph {
         patch_files: &[FileFacts],
         patch_import_spans: &BTreeMap<PathBuf, BTreeMap<String, (usize, usize)>>,
         patch_content_hashes: &BTreeMap<PathBuf, String>,
+        patch_guarded_optional_imports: &BTreeMap<PathBuf, Vec<String>>,
     ) {
         let removed = changed_files
             .iter()
@@ -129,6 +139,7 @@ impl RepoContextGraph {
                 repo_root,
                 patch_import_spans.get(&file.path),
                 patch_content_hashes.get(&file.path),
+                patch_guarded_optional_imports.get(&file.path),
             )
         }));
         self.nodes.sort_by(|left, right| left.path.cmp(&right.path));
@@ -181,6 +192,7 @@ impl RepoContextNode {
         root: &Path,
         import_spans: Option<&BTreeMap<String, (usize, usize)>>,
         content_hash: Option<&String>,
+        guarded_optional_imports: Option<&Vec<String>>,
     ) -> Self {
         let context = classify_file(file);
         let roles = context.role_ids().into_iter().map(str::to_string).collect();
@@ -215,6 +227,7 @@ impl RepoContextNode {
             imports: file.imports.clone(),
             import_spans: import_spans.cloned().unwrap_or_default(),
             deferred_imports: file.deferred_imports.clone(),
+            guarded_optional_imports: guarded_optional_imports.cloned().unwrap_or_default(),
             is_test: context.is_test,
             is_generated,
             is_config,

--- a/src/graph/context/state.rs
+++ b/src/graph/context/state.rs
@@ -67,6 +67,7 @@ impl RepositoryContextState {
         patch_files: &[FileFacts],
         patch_import_spans: &BTreeMap<PathBuf, BTreeMap<String, (usize, usize)>>,
         patch_content_hashes: &BTreeMap<PathBuf, String>,
+        patch_guarded_optional_imports: &BTreeMap<PathBuf, Vec<String>>,
     ) {
         let mut graph = self.to_compat();
         graph.apply_changed_facts_with_spans(
@@ -75,6 +76,7 @@ impl RepositoryContextState {
             patch_files,
             patch_import_spans,
             patch_content_hashes,
+            patch_guarded_optional_imports,
         );
         *self = Self::from_compat(graph);
     }

--- a/src/graph/context/tests.rs
+++ b/src/graph/context/tests.rs
@@ -28,6 +28,25 @@ fn repository_context_state_round_trips_the_compatibility_view() {
 }
 
 #[test]
+fn repository_context_state_round_trips_guarded_optional_imports() {
+    let root = Path::new("/repo");
+    let mut facts = scan_facts(root, vec![file_fact("plugin.py", &[".adapter"])]);
+    facts
+        .guarded_optional_imports_by_file
+        .insert(PathBuf::from("plugin.py"), vec![".adapter".to_string()]);
+    let coupling = build_coupling_graph(&facts, root);
+
+    let restored = RepositoryContextState::from_scan_facts(&facts, root, coupling).to_scan_facts();
+
+    assert_eq!(
+        restored
+            .guarded_optional_imports_by_file
+            .get(Path::new("plugin.py")),
+        Some(&vec![".adapter".to_string()])
+    );
+}
+
+#[test]
 fn repository_context_state_sorts_file_records_by_relative_path() {
     let root = Path::new("/repo");
     let facts = scan_facts(root, vec![file_fact("b.rs", &[]), file_fact("a.rs", &[])]);
@@ -72,7 +91,14 @@ fn repository_context_state_patch_removes_deleted_targets() {
         hunks: Vec::new(),
     };
 
-    state.apply_changed_facts_with_spans(root, &[deleted], &[], &BTreeMap::new(), &BTreeMap::new());
+    state.apply_changed_facts_with_spans(
+        root,
+        &[deleted],
+        &[],
+        &BTreeMap::new(),
+        &BTreeMap::new(),
+        &BTreeMap::new(),
+    );
 
     let graph = state.coupling_graph();
     assert!(!graph.nodes.contains(Path::new("b.rs")));
@@ -442,6 +468,7 @@ fn node(path: &Path) -> RepoContextNode {
         imports: Vec::new(),
         import_spans: Default::default(),
         deferred_imports: Vec::new(),
+        guarded_optional_imports: Vec::new(),
         is_test: false,
         is_generated: false,
         is_config: false,

--- a/src/graph/imports.rs
+++ b/src/graph/imports.rs
@@ -62,6 +62,23 @@ pub(crate) fn extract_deferred_imports_from(
     }
 }
 
+/// Imports whose absence is explicitly handled by the language construct that
+/// contains them. These remain dependency edges when the target exists.
+pub(crate) fn extract_guarded_optional_imports_from(
+    parsed: &ParsedFile,
+    language: Option<&str>,
+) -> Vec<String> {
+    let mut imports = match language
+        .and_then(imports_for_label)
+        .and_then(|extractor| extractor.guarded_optional)
+    {
+        Some(guarded) => guarded(parsed).into_iter().collect(),
+        None => Vec::new(),
+    };
+    imports.sort();
+    imports
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/languages/csharp/mod.rs
+++ b/src/languages/csharp/mod.rs
@@ -13,6 +13,7 @@ use crate::review::signals::tables::{
 static CSHARP_IMPORTS: ImportExtractor = ImportExtractor {
     eager: imports::eager,
     deferred: None,
+    guarded_optional: None,
     spans: imports::spans,
 };
 

--- a/src/languages/go/mod.rs
+++ b/src/languages/go/mod.rs
@@ -12,6 +12,7 @@ use super::ImportExtractor;
 static GO_IMPORTS: ImportExtractor = ImportExtractor {
     eager: imports::eager,
     deferred: None,
+    guarded_optional: None,
     spans: imports::spans,
 };
 

--- a/src/languages/java/mod.rs
+++ b/src/languages/java/mod.rs
@@ -12,6 +12,7 @@ use super::ImportExtractor;
 static JAVA_IMPORTS: ImportExtractor = ImportExtractor {
     eager: imports::eager,
     deferred: None,
+    guarded_optional: None,
     spans: imports::spans,
 };
 

--- a/src/languages/javascript/mod.rs
+++ b/src/languages/javascript/mod.rs
@@ -15,6 +15,7 @@ use super::ImportExtractor;
 static JS_FAMILY_IMPORTS: ImportExtractor = ImportExtractor {
     eager: imports::eager,
     deferred: Some(imports::deferred),
+    guarded_optional: None,
     spans: imports::spans,
 };
 

--- a/src/languages/kotlin/mod.rs
+++ b/src/languages/kotlin/mod.rs
@@ -12,6 +12,7 @@ use super::ImportExtractor;
 static KOTLIN_IMPORTS: ImportExtractor = ImportExtractor {
     eager: imports::eager,
     deferred: None,
+    guarded_optional: None,
     spans: imports::spans,
 };
 

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -75,6 +75,10 @@ pub struct ImportExtractor {
     /// dependency (Python function-body imports, TS type-only imports);
     /// cycle detection subtracts them. `None` when the language has none.
     pub(crate) deferred: Option<fn(&ParsedFile) -> HashSet<String>>,
+    /// Imports whose absence is explicitly absorbed by language-level error
+    /// handling. They remain graph edges when present, but absence-based
+    /// broken-import rules must not claim they are required.
+    pub(crate) guarded_optional: Option<fn(&ParsedFile) -> HashSet<String>>,
     /// 1-indexed line spans per imported specifier, for edge evidence.
     pub(crate) spans: fn(&ParsedFile) -> BTreeMap<String, (usize, usize)>,
 }

--- a/src/languages/python/imports.rs
+++ b/src/languages/python/imports.rs
@@ -2,6 +2,9 @@ use crate::analysis::parse::ParsedFile;
 use std::collections::{BTreeMap, HashSet};
 use tree_sitter::{Node, Tree};
 
+mod guarded;
+pub(super) use guarded::guarded_optional;
+
 pub(super) fn eager(parsed: &ParsedFile) -> HashSet<String> {
     parsed
         .tree()

--- a/src/languages/python/imports/guarded.rs
+++ b/src/languages/python/imports/guarded.rs
@@ -1,0 +1,209 @@
+use super::{from_import_modules, import_statement_modules};
+use crate::analysis::parse::ParsedFile;
+use std::collections::HashSet;
+use tree_sitter::Node;
+
+pub(in crate::languages::python) fn guarded_optional(parsed: &ParsedFile) -> HashSet<String> {
+    let mut imports = HashSet::new();
+    if let Some(tree) = parsed.tree()
+        && !tree.root_node().has_error()
+    {
+        collect_guarded_optional(tree.root_node(), parsed.content(), &mut imports);
+    }
+    imports
+}
+
+fn collect_guarded_optional(node: Node<'_>, content: &str, imports: &mut HashSet<String>) {
+    if node.kind() == "try_statement"
+        && try_absorbs_missing_import(node, content)
+        && let Some(body) = node.child_by_field_name("body")
+    {
+        collect_imports(body, content, imports);
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_guarded_optional(child, content, imports);
+    }
+}
+
+fn try_absorbs_missing_import(node: Node<'_>, content: &str) -> bool {
+    let mut cursor = node.walk();
+    for handler in node
+        .named_children(&mut cursor)
+        .filter(|child| child.kind() == "except_clause")
+    {
+        let Some(value) = handler.child_by_field_name("value") else {
+            return false;
+        };
+        let caught = exception_names(value, content);
+        if caught
+            .iter()
+            .any(|name| matches!(name.as_str(), "Exception" | "BaseException"))
+        {
+            return false;
+        }
+        if caught
+            .iter()
+            .any(|name| matches!(name.as_str(), "ImportError" | "ModuleNotFoundError"))
+        {
+            return handler_body(handler).is_some_and(|body| !contains_bare_raise(body, content));
+        }
+    }
+    false
+}
+
+fn exception_names(node: Node<'_>, content: &str) -> Vec<String> {
+    if node.kind() == "identifier" {
+        return node
+            .utf8_text(content.as_bytes())
+            .ok()
+            .map(str::to_string)
+            .into_iter()
+            .collect();
+    }
+    if node.kind() != "tuple" {
+        return Vec::new();
+    }
+
+    let mut names = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        names.extend(exception_names(child, content));
+    }
+    names
+}
+
+fn handler_body(handler: Node<'_>) -> Option<Node<'_>> {
+    let mut cursor = handler.walk();
+    handler
+        .named_children(&mut cursor)
+        .find(|child| child.kind() == "block")
+}
+
+fn contains_bare_raise(node: Node<'_>, content: &str) -> bool {
+    if node.kind() == "raise_statement"
+        && node
+            .utf8_text(content.as_bytes())
+            .is_ok_and(|text| text.trim() == "raise")
+    {
+        return true;
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .any(|child| contains_bare_raise(child, content))
+}
+
+fn collect_imports(node: Node<'_>, content: &str, imports: &mut HashSet<String>) {
+    if node.kind() == "function_definition" {
+        return;
+    }
+    let modules = match node.kind() {
+        "import_statement" => node
+            .utf8_text(content.as_bytes())
+            .ok()
+            .map(import_statement_modules),
+        "import_from_statement" => node
+            .utf8_text(content.as_bytes())
+            .ok()
+            .map(from_import_modules),
+        _ => None,
+    };
+    imports.extend(modules.into_iter().flatten());
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_imports(child, content, imports);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn guarded(content: &str) -> Vec<String> {
+        let parsed = ParsedFile::new(content, Some("Python"));
+        let mut imports: Vec<_> = guarded_optional(&parsed).into_iter().collect();
+        imports.sort();
+        imports
+    }
+
+    #[test]
+    fn import_error_handler_marks_try_body_import_as_optional() {
+        let content = "try:\n    from .local import *\nexcept ImportError:\n    pass\n";
+        assert_eq!(guarded(content), vec![".local"]);
+    }
+
+    #[test]
+    fn module_not_found_handler_marks_nested_try_body_import_as_optional() {
+        let content = concat!(
+            "if enabled:\n",
+            "    try:\n",
+            "        from .plugin import load\n",
+            "    except ModuleNotFoundError:\n",
+            "        fallback = None\n",
+        );
+        assert_eq!(guarded(content), vec![".plugin", ".plugin.load"]);
+    }
+
+    #[test]
+    fn unrelated_exception_handler_does_not_mark_import_as_optional() {
+        let content = "try:\n    from .missing import run\nexcept ValueError:\n    pass\n";
+        assert!(guarded(content).is_empty());
+    }
+
+    #[test]
+    fn bare_reraise_keeps_guarded_import_required() {
+        let content = "try:\n    from .missing import run\nexcept ImportError:\n    raise\n";
+        assert!(guarded(content).is_empty());
+    }
+
+    #[test]
+    fn comments_and_strings_do_not_create_guarded_import_facts() {
+        let content = concat!(
+            "text = 'try: from .fake import value except ImportError: pass'\n",
+            "# try: from .comment import value\n",
+        );
+        assert!(guarded(content).is_empty());
+    }
+
+    #[test]
+    fn tuple_handler_marks_guarded_import_as_optional() {
+        let content = concat!(
+            "try:\n",
+            "    from .adapter import load\n",
+            "except (ImportError, ModuleNotFoundError):\n",
+            "    fallback = None\n",
+        );
+        assert_eq!(guarded(content), vec![".adapter", ".adapter.load"]);
+    }
+
+    #[test]
+    fn malformed_syntax_does_not_create_guarded_import_facts() {
+        let content = "try:\n    from .missing import run\nexcept ImportError\n    pass\n";
+        assert!(guarded(content).is_empty());
+    }
+
+    #[test]
+    fn deferred_function_import_is_not_guarded_by_outer_try() {
+        let content = concat!(
+            "try:\n",
+            "    def load():\n",
+            "        from .missing import run\n",
+            "except ImportError:\n",
+            "    pass\n",
+        );
+        assert!(guarded(content).is_empty());
+    }
+
+    #[test]
+    fn qualified_exception_named_import_error_does_not_qualify() {
+        let content = concat!(
+            "try:\n",
+            "    from .missing import run\n",
+            "except errors.ImportError:\n",
+            "    pass\n",
+        );
+        assert!(guarded(content).is_empty());
+    }
+}

--- a/src/languages/python/mod.rs
+++ b/src/languages/python/mod.rs
@@ -12,6 +12,7 @@ use super::ImportExtractor;
 static PYTHON_IMPORTS: ImportExtractor = ImportExtractor {
     eager: imports::eager,
     deferred: Some(imports::deferred),
+    guarded_optional: Some(imports::guarded_optional),
     spans: imports::spans,
 };
 

--- a/src/languages/rust/mod.rs
+++ b/src/languages/rust/mod.rs
@@ -11,6 +11,7 @@ use super::ImportExtractor;
 static RUST_IMPORTS: ImportExtractor = ImportExtractor {
     eager: imports::eager,
     deferred: None,
+    guarded_optional: None,
     spans: imports::spans,
 };
 

--- a/src/rules/registry/architecture.rs
+++ b/src/rules/registry/architecture.rs
@@ -130,7 +130,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
             "Restore the imported module, update the import path, or run the project compiler to confirm the intended generated target.",
         ),
         false_positive_notes: Some(
-            "Only explicit supported TypeScript/JavaScript file extensions and explicit Python relative modules are reported. Extensionless imports, aliases, workspace packages, Rust module forms, generated targets, and unsupported semantics remain limitations rather than findings.",
+            "Only explicit supported TypeScript/JavaScript file extensions and explicit Python relative modules are reported. Python imports guarded by an absorbing ImportError or ModuleNotFoundError handler are excluded; broad or unrelated handlers and bare re-raises do not qualify. Extensionless imports, aliases, workspace packages, Rust module forms, generated targets, and unsupported semantics remain limitations rather than findings.",
         ),
         ..RuleMetadata::DEFAULT
     },

--- a/src/scan/facts.rs
+++ b/src/scan/facts.rs
@@ -29,6 +29,10 @@ pub struct ScanFacts {
     /// Kept outside `FileFacts` so evidence-only parser metadata does not expand
     /// the stable per-file facts contract.
     pub import_spans_by_file: BTreeMap<PathBuf, BTreeMap<String, (usize, usize)>>,
+    /// Missing imports whose absence is explicitly absorbed by language-level
+    /// error handling. Repository graph audits consume this bounded projection
+    /// without reparsing source.
+    pub guarded_optional_imports_by_file: BTreeMap<PathBuf, Vec<String>>,
     pub detected_frameworks: Vec<DetectedFramework>,
     pub framework_projects: Vec<FrameworkProject>,
     pub react_native: Option<ReactNativeArchitectureProfile>,
@@ -41,6 +45,14 @@ pub type FactStore = ScanFacts;
 
 impl ScanFacts {
     pub fn insert_artifact(&mut self, artifact: ParsedArtifact) {
+        if artifact.guarded_optional_imports.is_empty() {
+            self.guarded_optional_imports_by_file.remove(&artifact.path);
+        } else {
+            self.guarded_optional_imports_by_file.insert(
+                artifact.path.clone(),
+                artifact.guarded_optional_imports.clone(),
+            );
+        }
         self.artifacts.insert(artifact.path.clone(), artifact);
     }
 

--- a/src/scan/parsed_cache.rs
+++ b/src/scan/parsed_cache.rs
@@ -9,8 +9,8 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-const PARSED_FACTS_SCHEMA_VERSION: u32 = 4;
-const PARSED_FACTS_ANALYSIS_VERSION: &str = "tree-sitter-imports-exports-symbols-spans-v3";
+const PARSED_FACTS_SCHEMA_VERSION: u32 = 5;
+const PARSED_FACTS_ANALYSIS_VERSION: &str = "tree-sitter-imports-exports-symbols-spans-guarded-v4";
 const PARSED_FACTS_NAME: &str = "parsed_facts_v2.json";
 const PARSED_FACTS_BACKUP_NAME: &str = "parsed_facts_v2.backup.json";
 const PARSED_FACTS_TEMP_NAME: &str = "parsed_facts_v2.tmp.json";
@@ -34,6 +34,8 @@ pub struct ParsedFactsEntry {
     #[serde(default)]
     pub import_spans: BTreeMap<String, (usize, usize)>,
     pub deferred_imports: Vec<String>,
+    #[serde(default)]
+    pub(crate) guarded_optional_imports: Vec<String>,
     pub exports: Vec<String>,
     #[serde(default)]
     pub(crate) javascript_symbols: Option<JavaScriptSymbolFacts>,
@@ -230,6 +232,7 @@ impl ParsedFactsEntry {
             imports: file.imports.clone(),
             import_spans,
             deferred_imports: file.deferred_imports.clone(),
+            guarded_optional_imports: artifact.guarded_optional_imports.clone(),
             exports: artifact.exports.clone(),
             javascript_symbols: artifact.javascript_symbols.clone(),
             syntax: CachedSyntaxSummary::from(&artifact.syntax),
@@ -400,6 +403,46 @@ mod tests {
     }
 
     #[test]
+    fn guarded_optional_imports_survive_cache_round_trip() {
+        let file = FileFacts {
+            path: PathBuf::from("pkg/settings.py"),
+            language: Some("Python".to_string()),
+            imports: vec![".local".to_string()],
+            ..FileFacts::default()
+        };
+        let source = ParsedArtifact::from_source(
+            file.path.clone(),
+            file.language.clone(),
+            file.imports.clone(),
+            Vec::new(),
+            Vec::new(),
+            FileContextFacts::default(),
+            SyntaxSummary::default(),
+        )
+        .with_guarded_optional_imports(vec![".local".to_string()]);
+
+        let entry =
+            ParsedFactsEntry::from_artifact("hash".to_string(), &file, &source, BTreeMap::new());
+        let encoded = serde_json::to_string(&entry).expect("serialize cache entry");
+        let decoded: ParsedFactsEntry =
+            serde_json::from_str(&encoded).expect("deserialize cache entry");
+        let restored = ParsedArtifact::from_parsed_cache_v2(
+            file.path.clone(),
+            decoded.language.clone(),
+            decoded.imports.clone(),
+            decoded.deferred_imports.clone(),
+            decoded.exports.clone(),
+            FileContextFacts::default(),
+            (&decoded.syntax).into(),
+        )
+        .with_guarded_optional_imports(decoded.guarded_optional_imports.clone());
+
+        assert_eq!(decoded.guarded_optional_imports, vec![".local"]);
+        assert_eq!(restored.guarded_optional_imports, vec![".local"]);
+        assert_eq!(restored.origin, ArtifactOrigin::ParsedCacheV2);
+    }
+
+    #[test]
     fn corrupt_parsed_facts_cache_is_discarded() {
         let temp = tempdir().expect("temp dir");
         let cache_root = cache_dir(temp.path());
@@ -464,6 +507,7 @@ mod tests {
                 imports: Vec::new(),
                 import_spans: Default::default(),
                 deferred_imports: Vec::new(),
+                guarded_optional_imports: Vec::new(),
                 exports: Vec::new(),
                 javascript_symbols: None,
                 syntax: CachedSyntaxSummary::default(),
@@ -507,6 +551,7 @@ mod tests {
             imports: Vec::new(),
             import_spans: Default::default(),
             deferred_imports: Vec::new(),
+            guarded_optional_imports: Vec::new(),
             exports: Vec::new(),
             javascript_symbols: None,
             syntax: CachedSyntaxSummary::default(),

--- a/src/scan/scanner/changed/file_analysis.rs
+++ b/src/scan/scanner/changed/file_analysis.rs
@@ -356,6 +356,7 @@ impl<'a> ChangedScanEngine<'a> {
                     context.clone(),
                     (&entry.syntax).into(),
                 )
+                .with_guarded_optional_imports(entry.guarded_optional_imports.clone())
                 .with_javascript_symbols(entry.javascript_symbols.clone())
             })
             .unwrap_or_else(|| {

--- a/src/scan/scanner/changed/repo_context.rs
+++ b/src/scan/scanner/changed/repo_context.rs
@@ -40,6 +40,7 @@ impl<'a> ChangedScanEngine<'a> {
                 graph_patch_files,
                 &facts.import_spans_by_file,
                 &facts.parsed_content_hashes,
+                &facts.guarded_optional_imports_by_file,
             );
             if let Err(error) = write_repository_context_state(repo_root, &fingerprint, &load.state)
             {

--- a/src/scan/scanner/file.rs
+++ b/src/scan/scanner/file.rs
@@ -225,6 +225,7 @@ fn process_file_inner(
     let imports = analysis.imports;
     let import_spans = analysis.import_spans;
     let deferred_imports = analysis.deferred_imports;
+    let guarded_optional_imports = analysis.guarded_optional_imports;
     let exports = analysis.exports;
     let javascript_symbols = analysis.javascript_symbols;
     let syntax = analysis.syntax;
@@ -239,6 +240,7 @@ fn process_file_inner(
         context,
         syntax,
     )
+    .with_guarded_optional_imports(guarded_optional_imports)
     .with_javascript_symbols(javascript_symbols);
 
     Ok(PerFileResult {
@@ -312,36 +314,45 @@ fn collect_file_facts_inner(
     });
 
     let mut from_parsed_cache = false;
-    let (imports, import_spans, deferred_imports, exports, javascript_symbols, syntax) =
-        if let Some(entry) = cached {
-            from_parsed_cache = true;
-            full_facts.branch_count = entry.branch_count;
-            full_facts.has_inline_tests = entry.has_inline_tests;
-            (
-                entry.imports,
-                entry.import_spans,
-                entry.deferred_imports,
-                entry.exports,
-                entry.javascript_symbols,
-                (&entry.syntax).into(),
-            )
-        } else {
-            // No audits run on this path, so the parse view is built solely to
-            // extract imports and syntax facts.
-            let parsed = ParsedFile::for_facts(&full_facts);
-            let lang = full_facts.language.as_deref();
-            let javascript_symbols = parsed
-                .tree()
-                .and_then(|tree| extract_javascript_symbol_facts(parsed.content(), lang, tree));
-            (
-                extract_imports_from(&parsed, lang),
-                extract_import_spans_from(&parsed, lang),
-                extract_deferred_imports_from(&parsed, lang),
-                extract_exports(parsed.content(), lang),
-                javascript_symbols,
-                parsed.syntax_summary(),
-            )
-        };
+    let (
+        imports,
+        import_spans,
+        deferred_imports,
+        guarded_optional_imports,
+        exports,
+        javascript_symbols,
+        syntax,
+    ) = if let Some(entry) = cached {
+        from_parsed_cache = true;
+        full_facts.branch_count = entry.branch_count;
+        full_facts.has_inline_tests = entry.has_inline_tests;
+        (
+            entry.imports,
+            entry.import_spans,
+            entry.deferred_imports,
+            entry.guarded_optional_imports,
+            entry.exports,
+            entry.javascript_symbols,
+            (&entry.syntax).into(),
+        )
+    } else {
+        // No audits run on this path, so the parse view is built solely to
+        // extract imports and syntax facts.
+        let parsed = ParsedFile::for_facts(&full_facts);
+        let lang = full_facts.language.as_deref();
+        let javascript_symbols = parsed
+            .tree()
+            .and_then(|tree| extract_javascript_symbol_facts(parsed.content(), lang, tree));
+        (
+            extract_imports_from(&parsed, lang),
+            extract_import_spans_from(&parsed, lang),
+            extract_deferred_imports_from(&parsed, lang),
+            crate::graph::imports::extract_guarded_optional_imports_from(&parsed, lang),
+            extract_exports(parsed.content(), lang),
+            javascript_symbols,
+            parsed.syntax_summary(),
+        )
+    };
     full_facts.imports = imports;
     full_facts.deferred_imports = deferred_imports;
     let artifact = if from_parsed_cache {
@@ -354,6 +365,7 @@ fn collect_file_facts_inner(
             context,
             syntax,
         )
+        .with_guarded_optional_imports(guarded_optional_imports)
         .with_javascript_symbols(javascript_symbols)
     } else {
         ParsedArtifact::from_source(
@@ -365,6 +377,7 @@ fn collect_file_facts_inner(
             context,
             syntax,
         )
+        .with_guarded_optional_imports(guarded_optional_imports)
         .with_javascript_symbols(javascript_symbols)
     };
     if let (Some(cache), Some(hash)) = (parsed_cache.as_mut(), content_hash) {

--- a/src/scan/scanner/file_pipeline.rs
+++ b/src/scan/scanner/file_pipeline.rs
@@ -6,7 +6,8 @@ use crate::analysis::symbols::javascript::extract_javascript_symbol_facts;
 use crate::audits::pipeline::FileAuditRegistration;
 use crate::findings::types::Finding;
 use crate::graph::imports::{
-    extract_deferred_imports_from, extract_import_spans_from, extract_imports_from,
+    extract_deferred_imports_from, extract_guarded_optional_imports_from,
+    extract_import_spans_from, extract_imports_from,
 };
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::FileFacts;
@@ -17,6 +18,7 @@ pub(super) struct FileAnalysisResult {
     pub(super) imports: Vec<String>,
     pub(super) import_spans: std::collections::BTreeMap<String, (usize, usize)>,
     pub(super) deferred_imports: Vec<String>,
+    pub(super) guarded_optional_imports: Vec<String>,
     pub(super) exports: Vec<String>,
     pub(super) javascript_symbols: Option<JavaScriptSymbolFacts>,
     pub(super) syntax: SyntaxSummary,
@@ -26,6 +28,7 @@ struct ParsedFileFacts {
     imports: Vec<String>,
     import_spans: std::collections::BTreeMap<String, (usize, usize)>,
     deferred_imports: Vec<String>,
+    guarded_optional_imports: Vec<String>,
     exports: Vec<String>,
     javascript_symbols: Option<JavaScriptSymbolFacts>,
     syntax: SyntaxSummary,
@@ -61,6 +64,7 @@ pub(super) fn analyze_file(
         imports: parsed_facts.imports,
         import_spans: parsed_facts.import_spans,
         deferred_imports: parsed_facts.deferred_imports,
+        guarded_optional_imports: parsed_facts.guarded_optional_imports,
         exports: parsed_facts.exports,
         javascript_symbols: parsed_facts.javascript_symbols,
         syntax: parsed_facts.syntax,
@@ -100,6 +104,7 @@ fn extract_parsed_artifacts(parsed: &ParsedFile, language: Option<&str>) -> Pars
     let imports = extract_imports_from(parsed, language);
     let import_spans = extract_import_spans_from(parsed, language);
     let deferred_imports = extract_deferred_imports_from(parsed, language);
+    let guarded_optional_imports = extract_guarded_optional_imports_from(parsed, language);
     let exports = extract_exports(parsed.content(), language);
     let javascript_symbols = parsed
         .tree()
@@ -109,6 +114,7 @@ fn extract_parsed_artifacts(parsed: &ParsedFile, language: Option<&str>) -> Pars
         imports,
         import_spans,
         deferred_imports,
+        guarded_optional_imports,
         exports,
         javascript_symbols,
         syntax,

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -73,7 +73,7 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
     );
     assert_eq!(
         read_json(&cache_dir.join("parsed_facts_v2.json"))["analysis_version"],
-        "tree-sitter-imports-exports-symbols-spans-v3"
+        "tree-sitter-imports-exports-symbols-spans-guarded-v4"
     );
     assert_eq!(
         read_json(&cache_dir.join("parsed_facts_v2.json"))["entries"][0]["content_hash"]
@@ -147,10 +147,10 @@ fn typed_symbol_facts_are_persisted_and_reused_by_changed_scan() {
     scan_changed_json(temp.path(), &["--changed"]);
     let cache_path = temp.path().join(".repopilot/cache/parsed_facts_v2.json");
     let cache = read_json(&cache_path);
-    assert_eq!(cache["schema_version"], 4);
+    assert_eq!(cache["schema_version"], 5);
     assert_eq!(
         cache["analysis_version"],
-        "tree-sitter-imports-exports-symbols-spans-v3"
+        "tree-sitter-imports-exports-symbols-spans-guarded-v4"
     );
     let named_import = cache["entries"]
         .as_array()
@@ -302,7 +302,7 @@ fn changed_scan_invalidates_old_cache_schema() {
     for name in ["file_hashes.json", "file_roles.json", "findings.json"] {
         force_cache_schema(temp.path().join(".repopilot/cache").join(name).as_path(), 5);
     }
-    force_cache_schema(&cache_dir.join("parsed_facts_v2.json"), 3);
+    force_cache_schema(&cache_dir.join("parsed_facts_v2.json"), 4);
     let json = scan_changed_json(temp.path(), &["--changed"]);
 
     assert_eq!(json["cache_telemetry"]["hits"], 0);
@@ -317,7 +317,7 @@ fn changed_scan_invalidates_old_cache_schema() {
         "missing-cache-entry"
     );
     let rebuilt = read_json(&cache_dir.join("parsed_facts_v2.json"));
-    assert_eq!(rebuilt["schema_version"], 4);
+    assert_eq!(rebuilt["schema_version"], 5);
     assert!(
         rebuilt["entries"]
             .as_array()

--- a/tests/unresolved_local_import.rs
+++ b/tests/unresolved_local_import.rs
@@ -39,6 +39,51 @@ fn full_and_warm_changed_scans_preserve_broken_import_evidence() {
     assert_eq!(full_finding["id"], changed_finding["id"]);
 }
 
+#[test]
+fn full_and_warm_changed_scans_ignore_guarded_optional_python_import() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(&temp.path().join("pkg/__init__.py"), "");
+    write(&temp.path().join("pkg/settings.py"), "VALUE = 1\n");
+    commit_all(temp.path(), "initial");
+    write(
+        &temp.path().join("pkg/settings.py"),
+        "try:\n    from .local import *\nexcept ImportError:\n    pass\nVALUE = 1\n",
+    );
+
+    let full = scan_json(temp.path(), &[]);
+    let cold_changed = scan_json(temp.path(), &["--changed"]);
+    let warm_changed = scan_json(temp.path(), &["--changed"]);
+
+    assert_rule_absent(&full);
+    assert_rule_absent(&cold_changed);
+    assert_rule_absent(&warm_changed);
+    assert!(
+        warm_changed["cache_telemetry"]["parsed_cache_hits"]
+            .as_u64()
+            .is_some_and(|hits| hits > 0),
+        "warm changed scan should restore guarded facts from cache: {warm_changed:#?}"
+    );
+}
+
+#[test]
+fn reraising_import_error_keeps_missing_python_import_finding() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(&temp.path().join("pkg/__init__.py"), "");
+    write(
+        &temp.path().join("pkg/settings.py"),
+        "try:\n    from .missing import run\nexcept ImportError:\n    raise\n",
+    );
+
+    let full = scan_json(temp.path(), &[]);
+
+    assert_eq!(
+        rule_finding(&full)["evidence"][0]["path"],
+        "pkg/settings.py"
+    );
+}
+
 fn scan_json(root: &Path, extra: &[&str]) -> Value {
     let output = Command::new(env!("CARGO_BIN_EXE_repopilot"))
         .arg("scan")
@@ -62,6 +107,17 @@ fn rule_finding(report: &Value) -> &Value {
         .iter()
         .find(|finding| finding["rule_id"] == RULE_ID)
         .expect("broken local import finding")
+}
+
+fn assert_rule_absent(report: &Value) {
+    assert!(
+        report["findings"]
+            .as_array()
+            .expect("findings array")
+            .iter()
+            .all(|finding| finding["rule_id"] != RULE_ID),
+        "guarded optional import should not produce {RULE_ID}: {report:#?}"
+    );
 }
 
 fn init_repo(root: &Path) {

--- a/tests/zoo/expectations/wagtail.toml
+++ b/tests/zoo/expectations/wagtail.toml
@@ -29,23 +29,6 @@ disposition = "valid-but-accepted"
 reason = "Bare `except:` carrying an explicit `# noqa:B901,E722`; upstream has knowingly accepted the broad handler."
 
 [[finding]]
-profile = "default"
-finding_id = "architecture.unresolved-local-import:wagtail/project_template/project_name/settings/dev.py:11ea2da70fd5eb9f"
-rule_id = "architecture.unresolved-local-import"
-path = "wagtail/project_template/project_name/settings/dev.py"
-line = 16
-disposition = "false-positive"
-reason = "`try: from .local import * except ImportError: pass` — the Django settings idiom for an optional, git-ignored local override. The absence is deliberate and handled, so it is not broken code. Guarded optional imports are not modeled yet."
-
-[[finding]]
-profile = "default"
-finding_id = "architecture.unresolved-local-import:wagtail/project_template/project_name/settings/production.py:11ea2da70fd5eb9f"
-rule_id = "architecture.unresolved-local-import"
-path = "wagtail/project_template/project_name/settings/production.py"
-line = 12
-disposition = "false-positive"
-reason = "Same guarded optional `from .local import *` override as dev.py; the import is wrapped in try/except ImportError."
-[[finding]]
 profile = "strict"
 finding_id = "architecture.dead-module:wagtail/users/views/groups.py:b022a3e6e8b8daf1"
 rule_id = "architecture.dead-module"

--- a/tests/zoo/snapshots/wagtail.json
+++ b/tests/zoo/snapshots/wagtail.json
@@ -1,22 +1,19 @@
 {
   "default": {
     "by_priority": {
-      "P0": 4,
+      "P0": 2,
       "P1": 1
     },
     "by_rule": {
       "architecture.circular-dependency": 2,
-      "architecture.unresolved-local-import": 2,
       "language.python.exception-risk": 1
     },
     "fingerprints": [
       "architecture.circular-dependency:wagtail/actions/publish_revision.py:0da7c5453404677e",
       "architecture.circular-dependency:wagtail/admin/views/bulk_action/__init__.py:a2ca81903a3ef0d5",
-      "architecture.unresolved-local-import:wagtail/project_template/project_name/settings/dev.py:11ea2da70fd5eb9f",
-      "architecture.unresolved-local-import:wagtail/project_template/project_name/settings/production.py:11ea2da70fd5eb9f",
       "language.python.exception-risk:wagtail/images/models.py:b3686c8d8679d8e4"
     ],
-    "visible_total": 5
+    "visible_total": 3
   },
   "framework": "django",
   "language": "python",
@@ -32,7 +29,6 @@
       "architecture.large-file": 85,
       "architecture.test-leak": 2,
       "architecture.too-many-modules": 8,
-      "architecture.unresolved-local-import": 2,
       "code-marker.fixme": 3,
       "code-marker.hack": 3,
       "code-marker.todo": 19,
@@ -47,6 +43,6 @@
       "language.python.exception-risk": 45,
       "testing.source-without-test": 668
     },
-    "visible_total": 2433
+    "visible_total": 2431
   }
 }


### PR DESCRIPTION
## Summary

Treat Python relative imports guarded by an absorbing ImportError or ModuleNotFoundError handler as optional instead of proven broken code. The evidence is derived once from the existing tree-sitter parse and survives full, changed, cold, and warm scan paths.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- add a conservative guarded-import AST fact with exact identifier and tuple handling, malformed-tree rejection, bare re-raise protection, and deferred-function boundaries
- persist the fact through parsed-facts schema v5 and repository-context schema v8 without changing dependency edges or public report schemas
- remove two reviewed Wagtail false positives and regenerate the rule scorecard, registry reference, roadmap, spec, and changelog

## Why

Optional local overrides are a normal Python pattern. Reporting their handled absence as broken code damages trust, while reparsing text or adding string heuristics would create architectural debt. This change keeps one parse-once evidence path and preserves conservative behavior for broad, unrelated, qualified, or re-raising handlers.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

## Changelog

- [x] CHANGELOG.md updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
npm run test:release-contract
cargo run -- scan . --fail-on-priority p1
python3 scripts/zoo.py scan --only wagtail --repopilot target/debug/repopilot
```

All six pre-handoff gates passed. The focused Wagtail scan retained 3 expected default-visible findings and removed the 2 guarded optional-import false positives.