### PR TITLE
feat(review): add explicit local verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **Explicit local verification for review.** Repositories can define bounded
+  test, build, type-check, and lint checks under `[[verification.checks]]` and
+  run only the allowlisted IDs selected with repeatable `review --verify`.
+  RepoPilot invokes programs directly without a shell, clears inherited
+  environment variables except a fixed portability set, bounds and redacts
+  both output streams, terminates managed process trees on timeout or
+  cancellation, and blocks merge readiness for failed or revision-incompatible
+  evidence. Review report schema advances to `0.25` with `0.24` retained.
 - **Honest decision scores and progressive review disclosure.** Scan, baseline,
   workspace, receipt, JSON, MCP, console, Markdown, and HTML output now preserve
   the existing visible-profile `health_score` as `Visible health` and add a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "globset",
  "ignore",
  "indicatif",
+ "libc",
  "proptest",
  "rayon",
  "serde",
@@ -892,6 +893,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ toml = "1.1.2"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,12 @@ tree-sitter-c-sharp = "0.23.5"
 tree-sitter-kotlin-ng = "1.1.0"
 toml = "1.1.2"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading"] }
+
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 proptest = "1.11.0"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -256,6 +256,7 @@ repopilot r [PATH] [OPTIONS]
 | `--base` | git ref | — | Base ref for the diff; without this, compares working tree to `HEAD` |
 | `--head` | git ref | `HEAD` | Head ref; requires `--base` |
 | `--since-snapshot` | flag | — | Review committed and uncommitted work since the last `repopilot snapshot` |
+| `--verify` | check ID | — | Run one configured local verification check; repeat to select more |
 | `--scope` | `changed\|full` | `changed` | Analyze changed files or retain full-repository findings |
 | `--profile` | `default\|strict` | scope-dependent | Finding visibility; changed defaults to default, full defaults to strict |
 | `--format` | `console\|json\|markdown` | `console` | Output format |
@@ -283,7 +284,7 @@ repopilot r [PATH] [OPTIONS]
 | Code | Meaning |
 |------|---------|
 | `0` | Success (no threshold breach) |
-| `1` | A finding gate or explicit review-signal gate failed |
+| `1` | A finding/review gate failed, or selected verification blocked readiness |
 | `2` | Invalid CLI/config/user input |
 | `3` | Runtime or environment failure |
 
@@ -320,7 +321,39 @@ repopilot review . --format json --output review.json
 
 # Focus on high-risk findings only
 repopilot review . --min-severity high
+
+# Run only explicitly selected repository checks
+repopilot review . --verify unit --verify lint
 ```
+
+### Explicit local verification
+
+Verification commands are repository policy, never call-time shell strings:
+
+```toml
+[[verification.checks]]
+id = "unit"
+role = "test"
+program = "cargo"
+args = ["test", "--all"]
+working_directory = "."
+timeout_seconds = 120
+max_output_bytes = 65536
+paths = ["src/**", "tests/**", "Cargo.toml", "Cargo.lock"]
+```
+
+Supported roles are `test`, `build`, `type-check`, and `lint`. A check runs only
+when its ID is selected. RepoPilot executes `program` directly with the exact
+configured argument vector, clears the child environment except for portability
+variables, applies an independent timeout and per-stream output bound, and
+redacts captured output before reporting it. This is not an operating-system
+sandbox: repository-controlled checks can access the same files as the user.
+
+For `--base/--head` review, verification requires `--head` to resolve to the
+current checkout and the checkout to be clean. This prevents a passing command
+from being attached to static evidence for different content. A failed,
+unavailable, timed-out, cancelled, or revision-changing check is reported first
+and then exits with code `1`.
 
 ---
 

--- a/docs/engineering/v0.22-d1-review-verification-plan.md
+++ b/docs/engineering/v0.22-d1-review-verification-plan.md
@@ -1,0 +1,524 @@
+# RepoPilot 0.22 D1 Review Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add explicit, allowlisted local checks to `repopilot review` and project their bounded outcomes into the canonical merge-readiness report.
+
+**Architecture:** A new `verification` library module owns the serializable model, validated policy, redaction, and a direct process executor. The CLI selects configured check IDs, executes applicable checks sequentially after static analysis, attaches outcomes to `ReviewReport`, and lets readiness/rendering consume that one evidence source.
+
+**Tech Stack:** Rust 2024, clap, serde/TOML, globset, standard process/thread primitives, `libc` on Unix, `windows-sys` Job Objects on Windows.
+
+**Spec:** `docs/engineering/v0.22-d1-review-verification-spec.md`
+
+## Global Constraints
+
+- Keep the existing top-level CLI surface; only add repeatable `review --verify <id>`.
+- Invoke `program` directly with configured `args`; never accept or invoke shell text.
+- IDs match `[a-z0-9][a-z0-9._-]{0,63}` and are unique.
+- Roles are exactly `test`, `build`, `type-check`, and `lint`.
+- `timeout_seconds` defaults to 300 and must be in `1..=1800`.
+- `max_output_bytes` defaults to 65,536 per stream and must be in `1..=1,048,576`.
+- Clear the child environment and restore only `PATH`, `HOME`, `USERPROFILE`, `SYSTEMROOT`, `TMPDIR`, `TEMP`, and `TMP` when present.
+- Checks run sequentially in lexicographic ID order; repeated selectors are deduplicated.
+- Raw child output must be bounded, redacted, and stripped of unsafe terminal controls before it enters any outcome or error.
+- A changed workspace revision invalidates the current outcome, skips remaining checks, and blocks readiness.
+- No selected checks means no child process and `verification_us == 0`.
+- D1 does not change SARIF, MCP, AI context, receipts, Action inputs, or static findings.
+- Keep files near 300 lines and functions near 50 lines; split platform process control into focused files.
+- During inline execution, do not commit or push until the user explicitly requests publication.
+
+---
+
+## File Structure
+
+- `src/verification/mod.rs`: public exports for the D1 verification boundary.
+- `src/verification/model.rs`: `VerificationRole`, `VerificationStatus`, `VerificationOutcome`, and cancellation token.
+- `src/verification/policy.rs`: semantic validation, deterministic selection, applicability globs, path confinement, and ref-target compatibility.
+- `src/verification/redaction.rs`: byte-bounded, terminal-safe, secret-masked excerpts.
+- `src/verification/executor.rs`: sequential orchestration, output readers, timeout/cancellation, revision checks.
+- `src/verification/executor/unix.rs`: Unix process-group creation and termination.
+- `src/verification/executor/windows.rs`: Windows Job Object ownership and termination.
+- `src/config/model.rs`: deserializable `VerificationSection` and `VerificationCheckConfig`.
+- `src/config/template.rs`: commented verification configuration example.
+- `src/cli/options/review.rs`: repeatable `--verify` selector.
+- `src/commands/review.rs`: D1 orchestration and exit semantics.
+- `src/review/model.rs`: canonical outcomes and verification timing on `ReviewReport`.
+- `src/review/report.rs`: initialize the new report field.
+- `src/review/readiness/{model.rs,derive.rs}`: verification reason codes, outcomes, verdict, and precise limitations.
+- `src/review/render/{console.rs,markdown.rs}`: bounded verification sections.
+- `src/report/schema/{mod.rs,review.rs}` and schema fixtures: schema `0.25` and canonical JSON projection.
+- `tests/verification_cli.rs`: end-to-end CLI selection, target compatibility, execution, rendering, and exit codes.
+- `tests/{config_loader.rs,review_readiness.rs,report_schema_contract.rs}`: focused public-contract coverage.
+- `docs/engineering/v0.22-d1-review-verification-spec.md`, `docs/rules-reference.md`, `CHANGELOG.md`: status and user-facing contract updates; regenerate only tracked generated files that the release contract requires.
+
+---
+
+### Task 1: Configuration Model and Semantic Validation
+
+**Files:**
+- Modify: `src/config/model.rs`
+- Modify: `src/config/template.rs`
+- Create: `src/verification/mod.rs`
+- Create: `src/verification/model.rs`
+- Create: `src/verification/policy.rs`
+- Modify: `src/lib.rs`
+- Test: `tests/config_loader.rs`
+
+**Interfaces:**
+- Produces: `VerificationCheckConfig { id, role, program, args, working_directory, timeout_seconds, max_output_bytes, paths }`.
+- Produces: `ValidatedCheck::try_from_config(root: &Path, config: &VerificationCheckConfig) -> Result<ValidatedCheck, VerificationPolicyError>`.
+- Produces: `select_checks(root: &Path, configured: &[VerificationCheckConfig], selected: &[String]) -> Result<Vec<ValidatedCheck>, VerificationPolicyError>`.
+- Consumes: existing `parse_config` and repository-root paths.
+
+- [ ] **Step 1: Write failing config and selection tests**
+
+Add table-driven tests proving defaults, all four roles, duplicate/invalid IDs, unknown fields, invalid limits, absolute/traversing executable paths, traversal in `working_directory`, and unknown selected IDs. Include this positive assertion:
+
+```rust
+let selected = select_checks(root, &config.verification.checks, &["lint".into(), "unit".into(), "lint".into()])?;
+assert_eq!(selected.iter().map(|check| check.id()).collect::<Vec<_>>(), ["lint", "unit"]);
+```
+
+- [ ] **Step 2: Run the focused tests and confirm RED**
+
+Run: `cargo test --test config_loader verification -- --nocapture`
+
+Expected: compilation fails because the verification config and policy API do not exist.
+
+- [ ] **Step 3: Add the typed configuration and policy errors**
+
+Implement these serialized enums and config defaults:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VerificationRole { Test, Build, TypeCheck, Lint }
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VerificationCheckConfig {
+    pub id: String,
+    pub role: VerificationRole,
+    pub program: PathBuf,
+    #[serde(default)] pub args: Vec<String>,
+    #[serde(default = "default_working_directory")] pub working_directory: PathBuf,
+    #[serde(default = "default_timeout_seconds")] pub timeout_seconds: u64,
+    #[serde(default = "default_max_output_bytes")] pub max_output_bytes: usize,
+    #[serde(default)] pub paths: Vec<String>,
+}
+```
+
+Add `verification: VerificationSection` to `RepoPilotConfig`. Validate all configured entries whenever any selection is requested, reject duplicates deterministically, deduplicate selected IDs with `BTreeSet`, and return checks sorted by ID.
+
+- [ ] **Step 4: Constrain paths and compile applicability globs**
+
+`ValidatedCheck` stores the canonical working directory, a direct executable (`Bare(String)` or `RepositoryRelative(PathBuf)`), and an optional `GlobSet`. Reject absolute paths, `..`, missing/non-directory working directories, symlink escapes, invalid globs, and repository-relative executable escapes. Bare programs contain exactly one normal path component.
+
+- [ ] **Step 5: Add a commented generated-config example**
+
+Place one commented `[[verification.checks]]` example in `generate_default_config()`; parsing the generated template must still yield defaults and no checks.
+
+- [ ] **Step 6: Run focused tests and confirm GREEN**
+
+Run: `cargo test --test config_loader verification -- --nocapture`
+
+Expected: all verification config and policy tests pass.
+
+- [ ] **Step 7: Publication checkpoint**
+
+When publication is authorized: `git add src/config src/verification src/lib.rs tests/config_loader.rs && git commit -m "feat: add review verification policy"`.
+
+---
+
+### Task 2: Applicability and Review-Target Compatibility
+
+**Files:**
+- Modify: `src/verification/policy.rs`
+- Test: `src/verification/policy.rs`
+- Test: `tests/verification_cli.rs`
+
+**Interfaces:**
+- Produces: `ValidatedCheck::is_applicable<'a>(&self, paths: impl IntoIterator<Item = &'a Path>) -> bool`.
+- Produces: `validate_review_target(root: &Path, target: &OwnedDiffTarget, ignored_paths: &[String]) -> Result<(), VerificationPolicyError>`.
+- Consumes: `ReviewReport.changed_files`, `ReviewReport.impact_paths`, and `OwnedDiffTarget`.
+
+- [ ] **Step 1: Write failing applicability tests**
+
+Cover always-applicable empty `paths`, matching a deleted changed path, matching only a transitive impacted path, non-match, slash normalization, and deterministic handling of duplicate paths.
+
+- [ ] **Step 2: Write failing ref compatibility tests**
+
+Create temporary Git repositories and prove that `WorkingTree` and `SinceRef` are accepted, while `Refs` rejects a head different from checkout `HEAD` and rejects dirty tracked, staged, or untracked source state. Ignored/cache-only changes remain compatible.
+
+- [ ] **Step 3: Run tests and confirm RED**
+
+Run: `cargo test verification::policy -- --nocapture && cargo test --test verification_cli ref_range -- --nocapture`
+
+Expected: failures identify missing applicability and target validation.
+
+- [ ] **Step 4: Implement path inventory and compatibility checks**
+
+Match repository-relative changed paths plus every direct/transitive impacted path. Resolve `Refs.head` and `HEAD` with direct Git invocations and compare object IDs. Parse porcelain `-z` status, apply RepoPilot built-in/config ignore semantics, and return one deterministic mismatch error before execution.
+
+- [ ] **Step 5: Run focused tests and confirm GREEN**
+
+Run: `cargo test verification::policy -- --nocapture && cargo test --test verification_cli ref_range -- --nocapture`
+
+Expected: all policy and target tests pass.
+
+- [ ] **Step 6: Publication checkpoint**
+
+When publication is authorized: `git add src/verification/policy.rs tests/verification_cli.rs && git commit -m "feat: validate verification applicability"`.
+
+---
+
+### Task 3: Bounded Redaction Pipeline
+
+**Files:**
+- Create: `src/verification/redaction.rs`
+- Modify: `src/verification/mod.rs`
+- Test: `src/verification/redaction.rs`
+
+**Interfaces:**
+- Produces: `CapturedStream { excerpt: String, truncated: bool }`.
+- Produces: `capture_and_redact(bytes: &[u8], observed_more: bool) -> CapturedStream`.
+- Consumes: already bounded bytes from executor readers.
+
+- [ ] **Step 1: Write failing redaction tests**
+
+Use only synthetic values and cover ANSI color/OSC escapes, C0/C1 controls except newline/tab, private-key blocks, JWT-shaped strings, provider-token shapes, `token=`, `password:`, `secret =`, `credential:` values, invalid UTF-8, and input that ends at the retention boundary.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+Run: `cargo test verification::redaction -- --nocapture`
+
+Expected: module/API is absent.
+
+- [ ] **Step 3: Implement one-way sanitization**
+
+Perform byte bounding before lossy UTF-8 conversion; strip terminal escapes and unsafe controls; replace secret values with `[REDACTED]`. Return only the sanitized excerpt and truncation flag. Do not retain the raw vector after outcome construction.
+
+- [ ] **Step 4: Run focused tests and secret-safety regression**
+
+Run: `cargo test verification::redaction -- --nocapture && cargo test --test fixture_secret_safety`
+
+Expected: all tests pass and no synthetic raw secret survives.
+
+- [ ] **Step 5: Publication checkpoint**
+
+When publication is authorized: `git add src/verification && git commit -m "feat: redact verification output"`.
+
+---
+
+### Task 4: Direct Executor, Bounded Pipes, Timeout, and Cancellation
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `Cargo.lock` through Cargo only
+- Create: `src/verification/executor.rs`
+- Create: `src/verification/executor/unix.rs`
+- Create: `src/verification/executor/windows.rs`
+- Modify: `src/verification/model.rs`
+- Modify: `src/verification/mod.rs`
+- Test: `src/verification/executor.rs`
+
+**Interfaces:**
+- Produces: `CancellationToken::new()`, `cancel()`, and `is_cancelled()` backed by `Arc<AtomicBool>`.
+- Produces: `execute_check(check: &ValidatedCheck, revision_before: &WorkspaceRevision, cancellation: &CancellationToken) -> VerificationOutcome`.
+- Produces: statuses `Passed`, `Failed`, `TimedOut`, `Unavailable`, `Cancelled`, `Skipped` serialized in kebab case.
+- Consumes: `capture_and_redact` and `WorkspaceRevision::capture`.
+
+- [ ] **Step 1: Write failing executor tests**
+
+Use repository-local fixture scripts/executables to prove literal argument delivery (`"a b"`, `"$(not-run)"`, `";"`), passed/failed/unavailable status, exact exit code, independent stdout/stderr truncation, concurrent high-volume output without deadlock, cancellation, timeout, and revision-before/after fields.
+
+- [ ] **Step 2: Write descendant-cleanup tests**
+
+Spawn a fixture that creates a long-lived descendant and writes its PID to a temp file. After timeout and cancellation, poll the PID for a bounded interval and assert the descendant no longer exists. Gate only the fixture syntax with `#[cfg(unix)]`/`#[cfg(windows)]`; do not weaken the executor assertion.
+
+- [ ] **Step 3: Run executor tests and confirm RED**
+
+Run: `cargo test verification::executor -- --nocapture`
+
+Expected: executor types/functions are absent.
+
+- [ ] **Step 4: Implement direct process execution**
+
+Build `std::process::Command` from the validated executable and exact argument vector, set the canonical working directory, call `env_clear`, restore the fixed portability keys, and pipe both streams. Two reader threads continuously drain each pipe while retaining at most the configured cap.
+
+- [ ] **Step 5: Implement portable process-tree ownership**
+
+On Unix, place the child in a new process group before exec and signal the group on timeout/cancel, escalating to kill after a short bounded grace period. On Windows, assign the child to a Job Object configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and terminate the job on timeout/cancel. Add target-specific `libc` and `windows-sys` dependencies only.
+
+- [ ] **Step 6: Finalize outcomes after readers join**
+
+Poll `try_wait` against the deadline and cancellation token, terminate when required, wait for the child, join both readers, redact both retained streams, capture `revision_after`, and set `revision_compatible = revision_before == revision_after`.
+
+- [ ] **Step 7: Run executor tests and confirm GREEN**
+
+Run: `cargo test verification::executor -- --nocapture`
+
+Expected: every status, pipe bound, direct-argument, and cleanup test passes.
+
+- [ ] **Step 8: Publication checkpoint**
+
+When publication is authorized: `git add Cargo.toml Cargo.lock src/verification && git commit -m "feat: execute bounded verification checks"`.
+
+---
+
+### Task 5: Sequential Verification Run and Revision Invalidation
+
+**Files:**
+- Modify: `src/verification/executor.rs`
+- Modify: `src/verification/model.rs`
+- Test: `src/verification/executor.rs`
+
+**Interfaces:**
+- Produces: `run_checks(checks: &[ValidatedCheck], evidence_paths: &[PathBuf], revision: &WorkspaceRevision, cancellation: &CancellationToken) -> Vec<VerificationOutcome>`.
+- Consumes: `ValidatedCheck::is_applicable` and `execute_check`.
+
+- [ ] **Step 1: Write failing orchestration tests**
+
+Prove lexicographic execution order, no spawn for inapplicable checks, `Skipped` with an applicability limitation, and that a check mutating the workspace marks itself incompatible and records every remaining check as skipped without spawning.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+Run: `cargo test verification::executor::tests::run_checks -- --nocapture`
+
+Expected: missing orchestration API.
+
+- [ ] **Step 3: Implement minimal sequential orchestration**
+
+For each already sorted check: emit `Skipped` when inapplicable; otherwise execute it. After any incompatible revision, append deterministic skipped outcomes for remaining checks with limitation `workspace revision changed before this check could run` and stop spawning.
+
+- [ ] **Step 4: Run tests and confirm GREEN**
+
+Run: `cargo test verification::executor -- --nocapture`
+
+Expected: orchestration and executor tests pass.
+
+- [ ] **Step 5: Publication checkpoint**
+
+When publication is authorized: `git add src/verification && git commit -m "feat: guard verification revisions"`.
+
+---
+
+### Task 6: Attach Canonical Outcomes to Review and Readiness
+
+**Files:**
+- Modify: `src/review/model.rs`
+- Modify: `src/review/report.rs`
+- Modify: every test helper constructing `ReviewReport`
+- Modify: `src/review/readiness/model.rs`
+- Modify: `src/review/readiness/derive.rs`
+- Test: `tests/review_readiness.rs`
+
+**Interfaces:**
+- Produces: `ReviewReport.verification: Vec<VerificationOutcome>` and `ReviewTimings.verification_us`.
+- Produces: `MergeReadinessRecord.verification: Vec<VerificationOutcome>` omitted when empty.
+- Produces reason codes: `VerificationFailed`, `VerificationTimedOut`, `VerificationUnavailable`, `VerificationCancelled`, `VerificationRevisionChanged`.
+- Consumes: one ordered outcome vector; renderers do not reinterpret status.
+
+- [ ] **Step 1: Write failing readiness tests**
+
+Add one case per blocking status and revision incompatibility, plus passed and skipped non-blocking cases. Assert that a passed check leaves existing finding/signal/ownership reasons intact and that readiness carries exactly the report outcomes.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+Run: `cargo test --test review_readiness verification -- --nocapture`
+
+Expected: missing report fields and reason codes.
+
+- [ ] **Step 3: Extend report construction and readiness projection**
+
+Initialize outcomes empty in `classify_findings`; update all literal `ReviewReport` builders. Clone the canonical outcomes into readiness with `skip_serializing_if = "Vec::is_empty"`. Add one stable reason per blocking category with deterministic count/message and include all verification reasons in the blocked verdict set.
+
+- [ ] **Step 4: Make limitations evidence-aware**
+
+Keep `RepoPilot did not execute tests` when outcomes are empty. Otherwise list selected check IDs and statuses, explicitly note skipped checks, and state that unselected checks and static semantics remain unverified. Do not claim a passed lint/build check executed tests.
+
+- [ ] **Step 5: Run focused tests and confirm GREEN**
+
+Run: `cargo test --test review_readiness verification -- --nocapture && cargo test review::readiness -- --nocapture`
+
+Expected: readiness is canonical, deterministic, and blocks only specified outcomes.
+
+- [ ] **Step 6: Publication checkpoint**
+
+When publication is authorized: `git add src/review tests && git commit -m "feat: project verification readiness"`.
+
+---
+
+### Task 7: Wire `review --verify` and Exit Semantics
+
+**Files:**
+- Modify: `src/cli/options/review.rs`
+- Modify: `src/commands/review.rs`
+- Test: `tests/verification_cli.rs`
+- Test: `tests/cli_stabilization.rs`
+
+**Interfaces:**
+- Produces: `ReviewOptions.verify: Vec<String>` using `#[arg(long, value_name = "ID", action = clap::ArgAction::Append)]`.
+- Consumes: configured policy, review target, changed/impact paths, scan-session revision, and `run_checks`.
+- Produces: usage exit 2 for policy/selection/target mismatch; findings exit 1 for blocking structured outcomes after rendering.
+
+- [ ] **Step 1: Write failing end-to-end CLI tests**
+
+Cover no-request/no-spawn, repeated selection dedupe, deterministic order, unknown ID exit 2 before spawn, selected pass exit 0, failed/unavailable/timeout exit 1 after JSON is written, applicability skip, and ref mismatch exit 2 before spawn.
+
+- [ ] **Step 2: Run CLI tests and confirm RED**
+
+Run: `cargo test --test verification_cli -- --nocapture`
+
+Expected: clap rejects `--verify` or output lacks outcomes.
+
+- [ ] **Step 3: Wire selection after configuration load**
+
+When `options.verify` is empty, bypass validation/execution entirely to preserve latency and behavior. Otherwise validate all configured checks and selected IDs, then validate target compatibility before any process spawn.
+
+- [ ] **Step 4: Execute after static report construction**
+
+Build a sorted, deduplicated evidence-path vector from changed files plus impact paths. Time only verification execution, attach outcomes to `review_report`, then evaluate existing finding/review gates and readiness against the enriched report.
+
+- [ ] **Step 5: Apply structured exit after writing reports**
+
+After console/Markdown/JSON and optional SARIF are written, return `CliExit { code: EXIT_FINDINGS, message: "RepoPilot verification blocked merge readiness" }` when any canonical verification reason blocks. Selection/config/target errors become `CliExit { code: EXIT_USAGE, ... }` before execution.
+
+- [ ] **Step 6: Run CLI and stabilization tests**
+
+Run: `cargo test --test verification_cli -- --nocapture && cargo test --test cli_stabilization`
+
+Expected: all tests pass and existing review flows remain stable.
+
+- [ ] **Step 7: Publication checkpoint**
+
+When publication is authorized: `git add src/cli/options/review.rs src/commands/review.rs tests && git commit -m "feat: run explicit review verification"`.
+
+---
+
+### Task 8: Human and JSON Output Contracts
+
+**Files:**
+- Modify: `src/review/render/console.rs`
+- Modify: `src/review/render/markdown.rs`
+- Modify: `src/report/schema.rs`
+- Modify: `src/report/schema/review.rs`
+- Modify: `tests/report_schema_contract.rs`
+- Create: `tests/fixtures/reports/scan-v025.json`
+- Modify: `tests/fixtures/golden/scan-json-schema.golden.json`
+- Modify: `tests/fixtures/golden/ai-context.json` only if the release contract requires the shared schema constant
+- Test: `tests/verification_cli.rs`
+- Test: `tests/review_console_detail.rs`
+
+**Interfaces:**
+- Consumes: `ReviewReport.verification` and `MergeReadinessRecord.verification`.
+- Produces: schema version `0.25`, while accepting `0.24` and existing supported versions.
+- Produces: bounded console and Markdown Verification sections after static evidence and before Next Action.
+
+- [ ] **Step 1: Write failing rendering and schema tests**
+
+Assert exact status labels, check IDs, duration, exit code, truncation marker, sanitized excerpts, revision incompatibility, empty omission, and that summary detail still includes blocking verification evidence. Assert SARIF contains no verification execution record.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+Run: `cargo test --test verification_cli rendering -- --nocapture && cargo test --test report_schema_contract`
+
+Expected: verification output/schema `0.25` is absent.
+
+- [ ] **Step 3: Render bounded human sections**
+
+Show one line per outcome in canonical order and at most the already bounded stdout/stderr excerpts. Use plain stable labels, never reconstruct configured arguments, and show revision incompatibility prominently. Render nothing when outcomes are empty.
+
+- [ ] **Step 4: Advance the additive schema**
+
+Set `SCAN_REPORT_SCHEMA_VERSION` to `0.25`, retain `0.24` in accepted versions, add the v0.25 fixture, and update exact schema/golden assertions. Serialize outcomes only under `merge_readiness.verification` and omit the field when empty.
+
+- [ ] **Step 5: Run output/schema tests and confirm GREEN**
+
+Run: `cargo test --test verification_cli rendering -- --nocapture && cargo test --test review_console_detail && cargo test --test report_schema_contract`
+
+Expected: console, Markdown, JSON, and compatibility tests pass; SARIF remains static.
+
+- [ ] **Step 6: Publication checkpoint**
+
+When publication is authorized: `git add src/review/render src/report tests && git commit -m "feat: report verification evidence"`.
+
+---
+
+### Task 9: Documentation, Generated Contracts, and No-Request Parity
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `README.md` or the existing review CLI guide selected by `rg -n "repopilot review" docs README.md`
+- Modify: `docs/engineering/v0.22-d1-review-verification-spec.md`
+- Modify: generated tracked artifacts reported by release-contract checks
+- Test: `tests/verification_cli.rs`
+
+**Interfaces:**
+- Consumes: final user-facing CLI/config/output behavior.
+- Produces: an accurate local-first security/trust explanation and D1/D2 boundary.
+
+- [ ] **Step 1: Add no-request parity assertions**
+
+Compare review JSON from a repository with no verification config and with a valid unselected check. Remove only the expected schema-version difference from the pre-D1 fixture and assert all remaining fields are identical; assert no marker file from the configured program exists.
+
+- [ ] **Step 2: Run parity test**
+
+Run: `cargo test --test verification_cli no_request -- --nocapture`
+
+Expected: PASS after Tasks 1–8.
+
+- [ ] **Step 3: Document the explicit trust boundary**
+
+Document configuration, `--verify`, limits, applicability, exit codes, clean-ref requirement, environment clearing, direct execution, and the fact that repository-controlled code is not sandboxed. Mark the spec `in-progress` during implementation and `done` only after the full gate.
+
+- [ ] **Step 4: Refresh required generated artifacts**
+
+Run: `python3 scripts/release-contract.py check`. If it reports a precise generator command, run that command and inspect the diff; do not manually edit generated output.
+
+- [ ] **Step 5: Publication checkpoint**
+
+When publication is authorized: `git add CHANGELOG.md README.md docs tests/verification_cli.rs && git commit -m "docs: explain explicit review verification"`.
+
+---
+
+### Task 10: Full Verification and Handoff
+
+**Files:**
+- Modify only files identified by failing gates; add regression tests before fixes.
+
+**Interfaces:**
+- Produces: a handoff-ready D1 slice with no known failing contract.
+
+- [ ] **Step 1: Run focused D1 suite**
+
+Run: `cargo test verification --all-targets -- --nocapture && cargo test --test verification_cli -- --nocapture && cargo test --test review_readiness && cargo test --test report_schema_contract`
+
+Expected: all pass.
+
+- [ ] **Step 2: Run the RepoPilot full gate**
+
+Use `source-command-rp-gate` so the frozen tree is checked with formatting, Clippy `-D warnings`, all Rust tests, Python and npm release contracts, and the priority-P1 self-scan.
+
+Expected: every gate passes on the same tree.
+
+- [ ] **Step 3: Run platform evidence available in CI**
+
+Confirm the PR matrix runs the descendant-cleanup executor tests on Linux, macOS, and Windows. A platform failure blocks handoff; do not waive it as platform-only.
+
+- [ ] **Step 4: Complete the spec and review the final diff**
+
+Set spec status to `done`, run `git diff --check`, inspect `git status --short`, and confirm there are no MCP/cache/scan-side verification changes and no raw synthetic secrets in tracked files.
+
+- [ ] **Step 5: Publication checkpoint**
+
+Only after explicit user authorization: create a focused commit set, push `feat/v0.22-explicit-verification-review`, and open a draft PR with what/why/tests and D2 explicitly deferred.
+
+---
+
+## Self-Review Result
+
+- Spec coverage: all 15 acceptance criteria map to Tasks 1–10; platform cleanup and no-request parity are explicit gates.
+- Placeholder scan: no implementation step delegates unspecified error handling, validation, or tests.
+- Type consistency: config feeds `ValidatedCheck`; executor produces `VerificationOutcome`; `ReviewReport` owns it; readiness and all renderers consume the same ordered vector.
+- Scope: CLI review only. MCP, caching, scan execution, Action inputs, and automatic static-reason satisfaction remain outside this plan.

--- a/docs/engineering/v0.22-d1-review-verification-spec.md
+++ b/docs/engineering/v0.22-d1-review-verification-spec.md
@@ -1,0 +1,320 @@
+# RepoPilot 0.22 D1 — Explicit Review Verification
+
+Status: in-progress
+
+## Purpose
+
+RepoPilot already recommends deterministic verification steps, but it cannot
+execute a repository-defined test, build, type-check, or lint check. The first
+Phase D slice adds explicit execution to the existing `review` workflow without
+adding a command, accepting call-time shell text, or creating a second readiness
+model.
+
+The product flow becomes:
+
+```text
+static review evidence
+  -> explicitly selected configured checks
+  -> bounded verification outcomes
+  -> one canonical merge-readiness record
+```
+
+This slice is review-first. Scan execution, MCP execution, verification caching,
+and automatic satisfaction of static reasons remain separate follow-ups.
+
+## Product Contract
+
+### Configuration
+
+Checks are repository policy in `repopilot.toml`:
+
+```toml
+[[verification.checks]]
+id = "unit"
+role = "test"
+program = "cargo"
+args = ["test", "--all"]
+working_directory = "."
+timeout_seconds = 120
+max_output_bytes = 65536
+paths = ["src/**", "tests/**", "Cargo.toml", "Cargo.lock"]
+```
+
+The supported roles are `test`, `build`, `type-check`, and `lint`. Check IDs are
+unique and match `[a-z0-9][a-z0-9._-]{0,63}`. Check entries reject unknown
+fields. `args` is an array, never a shell string.
+`working_directory` is repository-relative and defaults to `.`. `paths` is an
+optional set of repository-relative globs; an empty set means always applicable.
+
+`timeout_seconds` defaults to 300 and must be between 1 and 1800.
+`max_output_bytes` defaults to 65,536 per stream and must be between 1 and
+1,048,576. A repository may choose stricter values but cannot configure an
+unbounded process or response.
+
+The generated config contains only a commented example. No check runs merely
+because configuration exists.
+
+### CLI
+
+`review` gains a repeatable explicit selector:
+
+```text
+repopilot review . --verify unit --verify lint
+```
+
+There is no `--verify-all` in D1. Selected IDs are deduplicated and executed in
+lexicographic ID order so config declaration order cannot affect output.
+
+An unknown selected ID or an invalid/duplicate configured check fails before
+execution with the existing usage exit code. Repeating the same valid CLI ID is
+harmless and is deduplicated. A review without `--verify` and with a valid
+configuration preserves current behavior, latency, output, and exit codes.
+
+### Applicability
+
+A check with no `paths` is applicable. Otherwise it is applicable when at least
+one changed or transitively impacted repository-relative path matches one of its
+globs. Deleted paths participate. Matching reuses the project glob semantics and
+is deterministic.
+
+An explicitly selected but inapplicable check produces a `skipped` outcome. It
+does not spawn a process and does not block readiness.
+
+### Review target compatibility
+
+Working-tree and `--since-snapshot` reviews execute against the same working
+tree they analyze. A ref-range review may execute only when its selected head
+resolves to the current checkout `HEAD` and the worktree has no tracked,
+staged, or untracked source changes outside ignored/cache paths. Otherwise the
+static review remains valid, but an explicit verification request fails closed
+before spawning because it would verify different content.
+
+## Execution and Security Contract
+
+### No shell boundary
+
+RepoPilot invokes `program` directly with the configured `args`. It never
+passes the check through `sh`, `bash`, PowerShell, `cmd.exe`, or an equivalent
+shell. CLI and MCP callers cannot add or replace arguments.
+
+`program` may be a bare executable resolved through `PATH` or a
+repository-relative executable. Absolute paths, parent traversal, and a
+repository-relative executable whose canonical target escapes the repository
+are rejected.
+
+Arguments are trusted repository policy: RepoPilot does not claim to sandbox
+repository-controlled code. The safety boundary prevents call-time command
+injection and accidental path escape; it is not an OS security sandbox.
+
+### Working directory
+
+The repository root is resolved before execution. The configured working
+directory is joined to it, canonicalized, and required to remain inside it.
+Missing directories, symlink escapes, and non-directory targets are invalid.
+
+### Environment
+
+The child environment is cleared. D1 restores only a fixed portability set
+when present: `PATH`, `HOME`, `USERPROFILE`, `SYSTEMROOT`, `TMPDIR`, `TEMP`, and
+`TMP`. The config cannot add environment variables in this slice. RepoPilot
+does not copy environment values into reports.
+
+This limits accidental secret inheritance but does not sandbox filesystem
+access by repository code.
+
+### Process lifetime
+
+Checks execute sequentially. Each check has an independent timeout. Timeout or
+RepoPilot cancellation terminates the managed process tree rather than only the
+immediate child: a process group on Unix and a job/process-tree equivalent on
+Windows. Reader tasks are joined before the outcome is finalized, so no output
+pipe or child is left behind.
+
+D1 enforces the configured timeout in the CLI flow. The executor accepts a
+cancellation token and records `cancelled` so the same engine can be reused by
+MCP D2. D1 tests that executor contract directly; portable interactive signal
+wiring and MCP request cancellation belong to D2.
+
+### Output bounds and redaction
+
+Stdout and stderr are drained concurrently to prevent pipe deadlocks. Each
+stream retains at most `max_output_bytes`; excess bytes are drained and
+discarded, and the outcome records truncation. Invalid UTF-8 is represented
+lossily after byte bounding.
+
+Before storage or rendering, output passes through a verification-specific
+central redactor that:
+
+- strips ANSI escapes and unsafe control characters;
+- masks private-key blocks, JWT-shaped values, and provider-token shapes shared
+  with RepoPilot security evidence;
+- masks assignment values for sensitive key names such as token, password,
+  secret, and credential;
+- never includes inherited environment values merely to explain execution.
+
+Tests use synthetic secret shapes only. Raw child output never enters a report,
+history receipt, or error string before this redaction step.
+
+## Canonical Evidence Model
+
+The library owns one internal/publicly serializable verification model reused by
+review and later MCP consumers:
+
+```text
+VerificationOutcome
+  check_id
+  role
+  status
+  duration_ms
+  exit_code?
+  working_directory
+  stdout_excerpt
+  stderr_excerpt
+  stdout_truncated
+  stderr_truncated
+  revision_before
+  revision_after
+  revision_compatible
+  limitations[]
+```
+
+Statuses are `passed`, `failed`, `timed-out`, `unavailable`, `cancelled`, and
+`skipped`. Outcomes are ordered by check ID. Durations are measurements and do
+not participate in policy identity, readiness ordering, or future cache keys.
+
+The workspace revision used by static analysis is captured before the first
+check and recomputed after every check through the existing session revision
+contract. If a check changes that revision, its evidence is marked
+incompatible, the remaining selected checks are recorded as skipped, and
+readiness blocks with a stable revision-changed reason. A passed command against
+changed content therefore cannot be presented as verification of the static
+report.
+
+The exact configured arguments are not copied into the report. The check ID is
+the stable policy reference; the repository config remains the authoritative
+command definition.
+
+`ReviewReport` owns the outcomes. `derive_readiness` projects the same outcomes
+into `MergeReadinessRecord`; renderers do not recompute or reinterpret process
+results.
+
+## Readiness and Exit Semantics
+
+D1 adds stable reason codes for failed, timed-out, unavailable, cancelled, and
+revision-incompatible selected checks. Any of these conditions makes readiness
+`blocked` and causes the existing findings/gate exit code `1` after the report
+is rendered. A passed revision-compatible check and a skipped inapplicable check
+add evidence but no blocking reason.
+
+A passed check does not remove findings, review signals, ownership reasons,
+boundary reasons, or static limitations. D1 has no deterministic mapping from a
+check to a particular static reason, so claiming that a pass resolves one would
+be false confidence.
+
+The current static-only limitation is replaced conditionally:
+
+- no checks requested: keep the existing statement that RepoPilot did not
+  execute tests;
+- checks requested: state exactly which configured checks ran or were skipped,
+  while preserving limitations for checks not selected and static semantics not
+  verified.
+
+Configuration/selection errors use exit `2`. Failures to spawn are structured
+`unavailable` evidence and use exit `1`, not an unstructured runtime crash.
+
+## Output Contract
+
+Console and Markdown add a bounded `Verification` section after static evidence
+and before the next action. JSON adds verification outcomes through the
+canonical merge-readiness record and advances the additive review/scan report
+schema from `0.24` to `0.25`, retaining `0.24` compatibility. The empty outcome
+list is omitted, so a no-request review changes only the schema version.
+
+SARIF remains static-finding focused and does not represent repository-scoped
+process executions in D1. AI context, receipts, Action inputs, and MCP static
+calls remain unchanged.
+
+`ReviewTimings` adds `verification_us`. It is zero when no check is requested.
+
+## Architecture Boundary
+
+The implementation should introduce a focused `verification` library module:
+
+- `model` — configuration-independent roles, statuses, and outcomes;
+- `policy` — semantic config validation, selection, applicability, and path
+  confinement;
+- `executor` — direct process execution, timeout/cancellation, bounded capture,
+  and process-tree termination;
+- `redaction` — centralized output sanitization.
+
+CLI code only coordinates selection and attaches outcomes to `ReviewReport`.
+Readiness and output layers consume canonical outcomes. No renderer spawns,
+loads config, reads source, or applies policy.
+
+Files stay within RepoPilot size limits and platform-specific process control is
+isolated behind a small executor boundary.
+
+## Alternatives Rejected
+
+1. **A new `verify` top-level command.** Rejected because it creates a separate
+   product workflow and contradicts the stable CLI surface.
+2. **A shell command string in config or CLI.** Rejected because quoting,
+   injection, and cross-platform behavior become unbounded.
+3. **Policy-only foundation with no user flow.** Rejected because it adds dead
+   architecture without proving integration.
+4. **CLI and MCP execution in one PR.** Rejected because cancellation,
+   side-effect annotations, request schemas, and session caching deserve a
+   separate review boundary.
+5. **Passing checks automatically suppress findings.** Rejected because a
+   generic test or lint pass does not deterministically disprove static
+   evidence.
+6. **Parallel checks.** Rejected in D1 because sequential execution is easier to
+   bound, cancel, explain, and reproduce.
+
+## Deferred to D2 and Later
+
+- MCP selection and honest write/execute annotations;
+- MCP cancellation wiring and progress events;
+- revision-aware verification cache;
+- scan-side verification;
+- GitHub Action inputs;
+- configurable environment inheritance;
+- parallel scheduling;
+- deterministic mappings that allow a passed check to satisfy a specific
+  readiness requirement.
+
+## Acceptance Criteria
+
+1. A review without `--verify` preserves all existing JSON fields, omits the
+   empty outcome list, changes only the schema version, and does not spawn a
+   process.
+2. `--verify <id>` can select only a valid configured check and cannot alter its
+   program, arguments, directory, environment, timeout, or output limit.
+3. Commands execute directly without a shell and in deterministic check-ID
+   order.
+4. Working-directory traversal, symlink escape, invalid executable paths,
+   duplicate IDs, unsupported roles, zero/unbounded limits, and unknown selected
+   IDs fail closed before execution.
+5. Ref-range verification cannot run against content different from the
+   selected review head.
+6. Applicability globs use changed and impacted paths; an inapplicable selected
+   check produces `skipped` without spawning.
+7. Passed, failed, timed-out, unavailable, cancelled, and skipped outcomes have
+   deterministic serialization and bounded redacted output.
+8. Timeout and cancellation leave no managed child or descendant process
+   running on Linux, macOS, or Windows.
+9. Large stdout and stderr cannot deadlock or exceed the configured retained
+   bytes per stream; truncation is explicit.
+10. Synthetic secrets and ANSI/control sequences never appear raw in console,
+    Markdown, JSON, errors, or snapshots.
+11. Failed, timed-out, unavailable, cancelled, and revision-incompatible checks
+    block readiness and exit `1` only after the report is emitted.
+12. Passed checks never remove or downgrade static evidence in D1.
+13. Console, Markdown, and JSON consume the same ordered outcomes; SARIF and
+    static MCP behavior remain unchanged.
+14. Focused unit/integration tests cover config validation, root confinement,
+    direct argument passing, applicability, every outcome status, redaction,
+    truncation, timeout cleanup, ref mismatch, mid-check revision change,
+    readiness, rendering, schema compatibility, and no-request parity.
+15. Full formatting, Clippy, all tests, release contracts, platform smoke tests,
+    and self-scan pass before handoff.

--- a/src/cli/options/review.rs
+++ b/src/cli/options/review.rs
@@ -24,6 +24,10 @@ pub struct ReviewOptions {
     #[arg(long, conflicts_with_all = ["base", "head"])]
     pub since_snapshot: bool,
 
+    /// Run an allowlisted verification check configured in repopilot.toml (repeatable)
+    #[arg(long, value_name = "ID", action = clap::ArgAction::Append)]
+    pub verify: Vec<String>,
+
     /// Review only changed files (default) or include full-repository findings
     #[arg(long, value_enum)]
     pub scope: Option<ReviewScopeArg>,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod mcp;
 pub(crate) mod product_scan;
 mod progress;
 pub mod review;
+mod review_verification;
 pub mod scan;
 pub(crate) mod scan_config;
 pub mod snapshot;

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -19,6 +19,7 @@ use repopilot::review::{
     ReviewSignalGatePolicy, ReviewSignalGateResult, build_review_report_from_session,
     load_review_input, load_review_input_since, review_report_for_ci,
 };
+use repopilot::verification::VerificationStatus;
 use std::time::{Duration, Instant};
 
 pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
@@ -132,6 +133,14 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
         review_report.apply_filter(&priority_filter);
     }
 
+    crate::commands::review_verification::run_selected(
+        &options.verify,
+        &configured,
+        &scan_result.session,
+        &history_target,
+        &mut review_report,
+    )?;
+
     let gating_started = Instant::now();
     let ci_report = review_report_for_ci(&review_report);
     let ci_gate = options
@@ -215,6 +224,21 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
                 "RepoPilot review gate failed: {} definitely-sensitive signal(s)",
                 review_gate.failed_signals
             ),
+        }));
+    }
+    if review_report.verification.iter().any(|outcome| {
+        !outcome.revision_compatible
+            || matches!(
+                outcome.status,
+                VerificationStatus::Failed
+                    | VerificationStatus::TimedOut
+                    | VerificationStatus::Unavailable
+                    | VerificationStatus::Cancelled
+            )
+    }) {
+        return Err(Box::new(CliExit {
+            code: EXIT_FINDINGS,
+            message: "RepoPilot verification blocked merge readiness".to_string(),
         }));
     }
 

--- a/src/commands/review_verification.rs
+++ b/src/commands/review_verification.rs
@@ -1,0 +1,58 @@
+use crate::commands::{CliExit, EXIT_USAGE};
+use repopilot::config::model::RepoPilotConfig;
+use repopilot::review::diff::OwnedDiffTarget;
+use repopilot::review::model::ReviewReport;
+use repopilot::scan::session::AnalysisSession;
+use repopilot::verification::{
+    CancellationToken, run_checks, select_checks, validate_review_target,
+};
+use std::time::Instant;
+
+pub(super) fn run_selected(
+    selected: &[String],
+    config: &RepoPilotConfig,
+    session: &AnalysisSession,
+    target: &OwnedDiffTarget,
+    report: &mut ReviewReport,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if selected.is_empty() {
+        return Ok(());
+    }
+    validate_review_target(session.workspace_root(), target, &config.scan.ignore)
+        .map_err(usage_error)?;
+    let checks = select_checks(
+        session.workspace_root(),
+        &config.verification.checks,
+        selected,
+    )
+    .map_err(usage_error)?;
+    let mut evidence_paths = report
+        .changed_files
+        .iter()
+        .map(|file| file.path.clone())
+        .collect::<Vec<_>>();
+    for impact in &report.impact_paths.files {
+        evidence_paths.push(impact.path.clone());
+        evidence_paths.extend(impact.direct_dependents.iter().cloned());
+        evidence_paths.extend(impact.transitive_dependents.iter().cloned());
+    }
+    evidence_paths.sort();
+    evidence_paths.dedup();
+
+    let started = Instant::now();
+    report.verification = run_checks(
+        &checks,
+        &evidence_paths,
+        session.revision(),
+        &CancellationToken::new(),
+    );
+    report.timings.verification_us = started.elapsed().as_micros().min(u128::from(u64::MAX)) as u64;
+    Ok(())
+}
+
+fn usage_error(error: impl std::fmt::Display) -> Box<dyn std::error::Error> {
+    Box::new(CliExit {
+        code: EXIT_USAGE,
+        message: error.to_string(),
+    })
+}

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -8,7 +8,9 @@ use crate::config::defaults::{
 };
 use crate::output::OutputFormat;
 use crate::scan::config::ScanConfig;
+use crate::verification::VerificationRole;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default)]
@@ -26,6 +28,7 @@ pub struct RepoPilotConfig {
     pub taint: TaintSection,
     pub output: OutputSection,
     pub history: HistorySection,
+    pub verification: VerificationSection,
 }
 
 /// Per-rule configuration: turn individual rules off or pin their severity.
@@ -82,6 +85,42 @@ impl Default for ReviewSection {
             impact_path_depth: DEFAULT_IMPACT_PATH_DEPTH,
         }
     }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct VerificationSection {
+    pub checks: Vec<VerificationCheckConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VerificationCheckConfig {
+    pub id: String,
+    pub role: VerificationRole,
+    pub program: PathBuf,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default = "default_verification_working_directory")]
+    pub working_directory: PathBuf,
+    #[serde(default = "default_verification_timeout_seconds")]
+    pub timeout_seconds: u64,
+    #[serde(default = "default_verification_max_output_bytes")]
+    pub max_output_bytes: usize,
+    #[serde(default)]
+    pub paths: Vec<String>,
+}
+
+fn default_verification_working_directory() -> PathBuf {
+    PathBuf::from(".")
+}
+
+fn default_verification_timeout_seconds() -> u64 {
+    300
+}
+
+fn default_verification_max_output_bytes() -> usize {
+    65_536
 }
 
 impl RepoPilotConfig {

--- a/src/config/template.rs
+++ b/src/config/template.rs
@@ -29,6 +29,17 @@ scope = "changed"
 # Review signals are advisory unless explicitly enabled as a gate.
 fail_on = "none"
 
+# Explicit local checks run only when selected with `repopilot review --verify <id>`.
+# [[verification.checks]]
+# id = "unit"
+# role = "test"
+# program = "cargo"
+# args = ["test", "--all"]
+# working_directory = "."
+# timeout_seconds = 120
+# max_output_bytes = 65536
+# paths = ["src/**", "tests/**", "Cargo.toml", "Cargo.lock"]
+
 [architecture]
 max_file_lines = {DEFAULT_MAX_FILE_LINES}
 huge_file_lines = {DEFAULT_HUGE_FILE_LINES}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,3 +58,5 @@ pub mod risk;
 pub mod rules;
 #[doc(hidden)]
 pub mod scan;
+#[doc(hidden)]
+pub mod verification;

--- a/src/report/schema.rs
+++ b/src/report/schema.rs
@@ -18,7 +18,7 @@ use serde_json::Value;
 use std::io;
 use std::path::PathBuf;
 
-pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.24";
+pub const SCAN_REPORT_SCHEMA_VERSION: &str = "0.25";
 const ACCEPTED_SCAN_REPORT_SCHEMA_VERSIONS: &[&str] = &[
     "0.16",
     "0.17",
@@ -28,6 +28,7 @@ const ACCEPTED_SCAN_REPORT_SCHEMA_VERSIONS: &[&str] = &[
     "0.21",
     "0.22",
     "0.23",
+    "0.24",
     SCAN_REPORT_SCHEMA_VERSION,
 ];
 pub const REPOPILOT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -287,7 +288,7 @@ mod tests {
 
     #[test]
     fn schema_version_tracks_review_signal_verification_contract() {
-        assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.24");
+        assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.25");
     }
 
     #[test]

--- a/src/review/model.rs
+++ b/src/review/model.rs
@@ -7,6 +7,7 @@ use crate::review::ownership::{OwnershipDiagnostic, OwnershipSummary};
 use crate::review::signals::BoundarySignal;
 use crate::review::signals::tiered::TieredSignals;
 use crate::scan::types::ScanSummary;
+use crate::verification::VerificationOutcome;
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -16,6 +17,7 @@ pub struct ReviewTimings {
     pub review_signals_us: u64,
     pub gating_us: u64,
     pub rendering_us: u64,
+    pub verification_us: u64,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -34,6 +36,7 @@ pub struct ReviewReport {
     /// Boundary + behavioral + algorithmic + taint signals by confidence tier.
     pub tiered_signals: TieredSignals,
     pub timings: ReviewTimings,
+    pub verification: Vec<VerificationOutcome>,
     pub findings: Vec<ReviewFindingStatus>,
 }
 

--- a/src/review/readiness/derive.rs
+++ b/src/review/readiness/derive.rs
@@ -6,6 +6,7 @@ use crate::history::RiskDelta;
 use crate::review::gate::ReviewSignalGateResult;
 use crate::review::model::ReviewReport;
 use crate::risk::RiskPriority;
+use crate::verification::VerificationStatus;
 use std::collections::BTreeSet;
 
 pub fn derive_readiness(
@@ -101,6 +102,49 @@ pub fn derive_readiness(
         ReadinessReasonCode::UnownedSurface,
         "Changed or impacted path(s) have no named owner.",
     );
+    for (status, code, message) in [
+        (
+            VerificationStatus::Failed,
+            ReadinessReasonCode::VerificationFailed,
+            "Selected verification check(s) failed.",
+        ),
+        (
+            VerificationStatus::TimedOut,
+            ReadinessReasonCode::VerificationTimedOut,
+            "Selected verification check(s) timed out.",
+        ),
+        (
+            VerificationStatus::Unavailable,
+            ReadinessReasonCode::VerificationUnavailable,
+            "Selected verification check(s) could not start.",
+        ),
+        (
+            VerificationStatus::Cancelled,
+            ReadinessReasonCode::VerificationCancelled,
+            "Selected verification check(s) were cancelled.",
+        ),
+    ] {
+        push_count(
+            &mut reasons,
+            report
+                .verification
+                .iter()
+                .filter(|outcome| outcome.status == status)
+                .count(),
+            code,
+            message,
+        );
+    }
+    push_count(
+        &mut reasons,
+        report
+            .verification
+            .iter()
+            .filter(|outcome| !outcome.revision_compatible)
+            .count(),
+        ReadinessReasonCode::VerificationRevisionChanged,
+        "Workspace revision changed during verification.",
+    );
     reasons.sort_by_key(|reason| reason.code);
 
     MergeReadinessRecord {
@@ -109,6 +153,7 @@ pub fn derive_readiness(
         impact: report.impact_paths.clone(),
         ownership: report.ownership.clone(),
         verification_steps: verification_steps(report),
+        verification: report.verification.clone(),
         limitations: limitations(report),
         risk_delta: risk_delta.cloned(),
     }
@@ -122,6 +167,11 @@ fn verdict(reasons: &[ReadinessReason]) -> ReadinessVerdict {
                 | ReadinessReasonCode::FindingGateFailed
                 | ReadinessReasonCode::ReviewSignalGateFailed
                 | ReadinessReasonCode::PriorityP0
+                | ReadinessReasonCode::VerificationFailed
+                | ReadinessReasonCode::VerificationTimedOut
+                | ReadinessReasonCode::VerificationUnavailable
+                | ReadinessReasonCode::VerificationCancelled
+                | ReadinessReasonCode::VerificationRevisionChanged
         )
     }) {
         ReadinessVerdict::Blocked
@@ -146,10 +196,15 @@ fn verification_steps(report: &ReviewReport) -> Vec<String> {
 }
 
 fn limitations(report: &ReviewReport) -> Vec<String> {
-    let mut limitations = vec![
-        "Readiness is derived from static local evidence; RepoPilot does not execute tests."
-            .to_string(),
-    ];
+    let mut limitations = if report.verification.is_empty() {
+        vec![
+            "Readiness is derived from static local evidence; RepoPilot does not execute tests."
+                .to_string(),
+        ]
+    } else {
+        vec!["Selected local checks do not resolve or suppress static evidence; unselected checks remain unverified."
+            .to_string()]
+    };
     if !report.ownership.unowned_paths.is_empty() {
         limitations.push(
             "Unowned paths use package or directory boundaries, not inferred people.".to_string(),

--- a/src/review/readiness/model.rs
+++ b/src/review/readiness/model.rs
@@ -1,6 +1,7 @@
 use crate::history::RiskDelta;
 use crate::review::ImpactPaths;
 use crate::review::ownership::OwnershipSummary;
+use crate::verification::VerificationOutcome;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -34,6 +35,11 @@ pub enum ReadinessReasonCode {
     BoundaryMissingTest,
     VisibleFinding,
     UnownedSurface,
+    VerificationFailed,
+    VerificationTimedOut,
+    VerificationUnavailable,
+    VerificationCancelled,
+    VerificationRevisionChanged,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -50,6 +56,8 @@ pub struct MergeReadinessRecord {
     pub impact: ImpactPaths,
     pub ownership: OwnershipSummary,
     pub verification_steps: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub verification: Vec<VerificationOutcome>,
     pub limitations: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub risk_delta: Option<RiskDelta>,

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -7,6 +7,7 @@ use crate::review::derive_readiness;
 use crate::review::model::ReviewReport;
 use crate::review::render::ReviewRenderOptions;
 use crate::review::signals::tiered::ReviewSignal;
+use crate::verification::VerificationStatus;
 
 const REVIEW_SIGNAL_DETAIL_LIMIT: usize = 20;
 
@@ -134,9 +135,52 @@ pub fn render_console_with_options(
         );
     }
 
+    render_verification(&mut output, report);
+
     inventory::render_next_action(&mut output, report, options.detail);
 
     output
+}
+
+fn render_verification(output: &mut String, report: &ReviewReport) {
+    if report.verification.is_empty() {
+        return;
+    }
+    output.push_str("\nVerification:\n");
+    for outcome in &report.verification {
+        output.push_str(&format!(
+            "  - {}: {} ({} ms)\n",
+            outcome.check_id,
+            verification_status_label(outcome.status),
+            outcome.duration_ms
+        ));
+        if !outcome.stdout_excerpt.is_empty() {
+            output.push_str(&format!(
+                "    stdout: {}\n",
+                outcome.stdout_excerpt.trim_end()
+            ));
+        }
+        if !outcome.stderr_excerpt.is_empty() {
+            output.push_str(&format!(
+                "    stderr: {}\n",
+                outcome.stderr_excerpt.trim_end()
+            ));
+        }
+        if !outcome.revision_compatible {
+            output.push_str("    workspace revision changed; evidence is incompatible\n");
+        }
+    }
+}
+
+fn verification_status_label(status: VerificationStatus) -> &'static str {
+    match status {
+        VerificationStatus::Passed => "PASSED",
+        VerificationStatus::Failed => "FAILED",
+        VerificationStatus::TimedOut => "TIMED OUT",
+        VerificationStatus::Unavailable => "UNAVAILABLE",
+        VerificationStatus::Cancelled => "CANCELLED",
+        VerificationStatus::Skipped => "SKIPPED",
+    }
 }
 
 fn render_blast_radius(output: &mut String, report: &ReviewReport) {

--- a/src/review/render/markdown.rs
+++ b/src/review/render/markdown.rs
@@ -115,6 +115,7 @@ pub fn render_markdown_with_gates(
     render_markdown_blast_radius(&mut output, report);
     render_markdown_impact_paths(&mut output, report);
     render_markdown_tiered_signals(&mut output, report);
+    render_markdown_verification(&mut output, report);
     render_markdown_findings_group(
         &mut output,
         "In-Diff Findings",
@@ -137,6 +138,26 @@ pub fn render_markdown_with_gates(
     );
 
     output
+}
+
+fn render_markdown_verification(output: &mut String, report: &ReviewReport) {
+    if report.verification.is_empty() {
+        return;
+    }
+    output.push_str("## Verification\n\n");
+    output.push_str("| Check | Status | Duration | Exit |\n| --- | --- | ---: | ---: |\n");
+    for outcome in &report.verification {
+        output.push_str(&format!(
+            "| `{}` | `{:?}` | {} ms | {} |\n",
+            outcome.check_id,
+            outcome.status,
+            outcome.duration_ms,
+            outcome
+                .exit_code
+                .map_or_else(|| "-".to_string(), |code| code.to_string())
+        ));
+    }
+    output.push('\n');
 }
 
 fn render_markdown_blast_radius(output: &mut String, report: &ReviewReport) {

--- a/src/review/report.rs
+++ b/src/review/report.rs
@@ -215,6 +215,7 @@ fn classify_findings(
         boundary_missing_test,
         tiered_signals,
         timings: Default::default(),
+        verification: Vec::new(),
         findings,
     }
 }

--- a/src/verification/executor.rs
+++ b/src/verification/executor.rs
@@ -1,0 +1,237 @@
+use crate::scan::session::WorkspaceRevision;
+use crate::verification::model::{CancellationToken, VerificationOutcome, VerificationStatus};
+use crate::verification::policy::{ValidatedCheck, ValidatedProgram};
+use crate::verification::redaction::{CapturedStream, capture_and_redact};
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+mod platform;
+use platform::{ProcessTree, configure_process_tree};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const PORTABLE_ENV_KEYS: &[&str] = &[
+    "PATH",
+    "HOME",
+    "USERPROFILE",
+    "SYSTEMROOT",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+];
+
+pub fn run_checks(
+    checks: &[ValidatedCheck],
+    evidence_paths: &[std::path::PathBuf],
+    revision: &WorkspaceRevision,
+    cancellation: &CancellationToken,
+) -> Vec<VerificationOutcome> {
+    let mut outcomes = Vec::with_capacity(checks.len());
+    let mut revision_changed = false;
+    for check in checks {
+        if revision_changed {
+            outcomes.push(skipped_outcome(
+                check,
+                revision,
+                "workspace revision changed before this check could run",
+            ));
+            continue;
+        }
+        if !check.is_applicable(evidence_paths.iter().map(std::path::PathBuf::as_path)) {
+            outcomes.push(skipped_outcome(
+                check,
+                revision,
+                "no changed or impacted path matched this check",
+            ));
+            continue;
+        }
+        let outcome = execute_check(check, revision, cancellation);
+        revision_changed = !outcome.revision_compatible;
+        outcomes.push(outcome);
+    }
+    outcomes
+}
+
+pub fn execute_check(
+    check: &ValidatedCheck,
+    revision_before: &WorkspaceRevision,
+    cancellation: &CancellationToken,
+) -> VerificationOutcome {
+    let started = Instant::now();
+    let mut command = command_for(check);
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            return unavailable_outcome(check, revision_before, started, error.to_string());
+        }
+    };
+    let process_tree = match ProcessTree::attach(&child) {
+        Ok(tree) => tree,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return unavailable_outcome(check, revision_before, started, error);
+        }
+    };
+    let stdout = spawn_reader(child.stdout.take(), check.max_output_bytes);
+    let stderr = spawn_reader(child.stderr.take(), check.max_output_bytes);
+    let deadline = started + Duration::from_secs(check.timeout_seconds);
+    let mut forced_status = None;
+
+    let exit = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) if cancellation.is_cancelled() => {
+                forced_status = Some(VerificationStatus::Cancelled);
+                process_tree.terminate(&mut child);
+                break child.wait().ok();
+            }
+            Ok(None) if Instant::now() >= deadline => {
+                forced_status = Some(VerificationStatus::TimedOut);
+                process_tree.terminate(&mut child);
+                break child.wait().ok();
+            }
+            Ok(None) => thread::sleep(POLL_INTERVAL),
+            Err(_) => {
+                process_tree.terminate(&mut child);
+                break child.wait().ok();
+            }
+        }
+    };
+
+    let stdout = join_reader(stdout);
+    let stderr = join_reader(stderr);
+    let revision_after = WorkspaceRevision::capture(&check.working_directory);
+    let status = forced_status.unwrap_or_else(|| {
+        if exit.is_some_and(|status| status.success()) {
+            VerificationStatus::Passed
+        } else {
+            VerificationStatus::Failed
+        }
+    });
+    VerificationOutcome {
+        check_id: check.id().to_string(),
+        role: check.role,
+        status,
+        duration_ms: duration_ms(started.elapsed()),
+        exit_code: exit.and_then(|status| status.code()),
+        working_directory: check.working_directory_label.clone(),
+        stdout_excerpt: stdout.excerpt,
+        stderr_excerpt: stderr.excerpt,
+        stdout_truncated: stdout.truncated,
+        stderr_truncated: stderr.truncated,
+        revision_before: revision_before.id().to_string(),
+        revision_after: revision_after.id().to_string(),
+        revision_compatible: revision_before == &revision_after,
+        limitations: Vec::new(),
+    }
+}
+
+fn command_for(check: &ValidatedCheck) -> Command {
+    let mut command = match &check.program {
+        ValidatedProgram::Bare(program) => Command::new(program),
+        ValidatedProgram::RepositoryRelative(program) => Command::new(program),
+    };
+    command
+        .args(&check.args)
+        .current_dir(&check.working_directory)
+        .env_clear()
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for key in PORTABLE_ENV_KEYS {
+        if let Some(value) = std::env::var_os(key) {
+            command.env(key, value);
+        }
+    }
+    configure_process_tree(&mut command);
+    command
+}
+
+fn spawn_reader(
+    stream: Option<impl Read + Send + 'static>,
+    limit: usize,
+) -> thread::JoinHandle<CapturedStream> {
+    thread::spawn(move || {
+        let Some(mut stream) = stream else {
+            return capture_and_redact(&[], false);
+        };
+        let mut retained = Vec::with_capacity(limit.min(8_192));
+        let mut buffer = [0_u8; 8_192];
+        let mut observed_more = false;
+        loop {
+            match stream.read(&mut buffer) {
+                Ok(0) | Err(_) => break,
+                Ok(read) => {
+                    let available = limit.saturating_sub(retained.len());
+                    let keep = available.min(read);
+                    retained.extend_from_slice(&buffer[..keep]);
+                    observed_more |= keep < read;
+                }
+            }
+        }
+        capture_and_redact(&retained, observed_more)
+    })
+}
+
+fn join_reader(reader: thread::JoinHandle<CapturedStream>) -> CapturedStream {
+    reader
+        .join()
+        .unwrap_or_else(|_| capture_and_redact(&[], true))
+}
+
+fn unavailable_outcome(
+    check: &ValidatedCheck,
+    revision: &WorkspaceRevision,
+    started: Instant,
+    error: String,
+) -> VerificationOutcome {
+    let error = capture_and_redact(error.as_bytes(), false);
+    VerificationOutcome {
+        check_id: check.id().to_string(),
+        role: check.role,
+        status: VerificationStatus::Unavailable,
+        duration_ms: duration_ms(started.elapsed()),
+        exit_code: None,
+        working_directory: check.working_directory_label.clone(),
+        stdout_excerpt: String::new(),
+        stderr_excerpt: error.excerpt,
+        stdout_truncated: false,
+        stderr_truncated: error.truncated,
+        revision_before: revision.id().to_string(),
+        revision_after: revision.id().to_string(),
+        revision_compatible: true,
+        limitations: vec!["configured program could not be started".to_string()],
+    }
+}
+
+fn skipped_outcome(
+    check: &ValidatedCheck,
+    revision: &WorkspaceRevision,
+    limitation: &str,
+) -> VerificationOutcome {
+    VerificationOutcome {
+        check_id: check.id().to_string(),
+        role: check.role,
+        status: VerificationStatus::Skipped,
+        duration_ms: 0,
+        exit_code: None,
+        working_directory: check.working_directory_label.clone(),
+        stdout_excerpt: String::new(),
+        stderr_excerpt: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+        revision_before: revision.id().to_string(),
+        revision_after: revision.id().to_string(),
+        revision_compatible: true,
+        limitations: vec![limitation.to_string()],
+    }
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/verification/executor/platform.rs
+++ b/src/verification/executor/platform.rs
@@ -1,0 +1,78 @@
+use std::process::{Child, Command};
+
+#[cfg(unix)]
+pub(super) fn configure_process_tree(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    command.process_group(0);
+}
+
+#[cfg(windows)]
+pub(super) fn configure_process_tree(_command: &mut Command) {}
+
+#[cfg(unix)]
+pub(super) struct ProcessTree;
+
+#[cfg(unix)]
+impl ProcessTree {
+    pub(super) fn attach(_child: &Child) -> Result<Self, String> {
+        Ok(Self)
+    }
+
+    pub(super) fn terminate(&self, child: &mut Child) {
+        let pid = child.id();
+        // The child is the leader of a dedicated process group.
+        unsafe {
+            libc::kill(-(pid as i32), libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(windows)]
+pub(super) struct ProcessTree(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl ProcessTree {
+    pub(super) fn attach(child: &Child) -> Result<Self, String> {
+        use std::mem::{size_of, zeroed};
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::System::JobObjects::*;
+        unsafe {
+            let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if job.is_null() {
+                return Err("failed to create Windows verification job object".to_string());
+            }
+            let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = zeroed();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            if SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                &limits as *const _ as *const _,
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            ) == 0
+                || AssignProcessToJobObject(job, child.as_raw_handle() as _) == 0
+            {
+                windows_sys::Win32::Foundation::CloseHandle(job);
+                return Err(
+                    "failed to attach verification process to Windows job object".to_string(),
+                );
+            }
+            Ok(Self(job))
+        }
+    }
+
+    pub(super) fn terminate(&self, child: &mut Child) {
+        unsafe {
+            windows_sys::Win32::System::JobObjects::TerminateJobObject(self.0, 1);
+        }
+        let _ = child.kill();
+    }
+}
+
+#[cfg(windows)]
+impl Drop for ProcessTree {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}

--- a/src/verification/executor/tests.rs
+++ b/src/verification/executor/tests.rs
@@ -1,0 +1,135 @@
+use super::{execute_check, run_checks};
+use crate::config::loader::parse_config;
+use crate::scan::session::WorkspaceRevision;
+use crate::verification::{CancellationToken, VerificationStatus, select_checks};
+use tempfile::tempdir;
+
+fn check(root: &std::path::Path, toml: &str, id: &str) -> crate::verification::ValidatedCheck {
+    let config = parse_config(toml, None).expect("valid config");
+    select_checks(root, &config.verification.checks, &[id.into()])
+        .expect("valid selection")
+        .remove(0)
+}
+
+#[cfg(unix)]
+#[test]
+fn records_pass_failure_and_bounded_redacted_streams() {
+    let temp = tempdir().expect("temp dir");
+    let check = check(
+        temp.path(),
+        r#"[[verification.checks]]
+id = "unit"
+role = "test"
+program = "sh"
+args = ["-c", "printf '\\033[31mok\\033[0m\\ntoken=fake-secret\\n'; printf 'err' >&2; exit 7"]
+max_output_bytes = 20
+"#,
+        "unit",
+    );
+    let outcome = execute_check(
+        &check,
+        &WorkspaceRevision::capture(temp.path()),
+        &CancellationToken::new(),
+    );
+    assert_eq!(outcome.status, VerificationStatus::Failed);
+    assert_eq!(outcome.exit_code, Some(7));
+    assert!(outcome.stdout_excerpt.contains("ok"));
+    assert!(!outcome.stdout_excerpt.contains("fake-secret"));
+    assert_eq!(outcome.stderr_excerpt, "err");
+    assert!(outcome.stdout_truncated);
+}
+
+#[test]
+fn unavailable_program_is_structured_evidence() {
+    let temp = tempdir().expect("temp dir");
+    let check = check(
+        temp.path(),
+        "[[verification.checks]]\nid = \"missing\"\nrole = \"build\"\nprogram = \"repopilot-program-that-does-not-exist\"\n",
+        "missing",
+    );
+    let outcome = execute_check(
+        &check,
+        &WorkspaceRevision::capture(temp.path()),
+        &CancellationToken::new(),
+    );
+    assert_eq!(outcome.status, VerificationStatus::Unavailable);
+    assert_eq!(outcome.exit_code, None);
+    assert!(!outcome.stderr_excerpt.is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn timeout_returns_without_leaving_the_child_running() {
+    let temp = tempdir().expect("temp dir");
+    let check = check(
+        temp.path(),
+        "[[verification.checks]]\nid = \"slow\"\nrole = \"test\"\nprogram = \"sh\"\nargs = [\"-c\", \"sleep 30\"]\ntimeout_seconds = 1\n",
+        "slow",
+    );
+    let started = std::time::Instant::now();
+    let outcome = execute_check(
+        &check,
+        &WorkspaceRevision::capture(temp.path()),
+        &CancellationToken::new(),
+    );
+    assert_eq!(outcome.status, VerificationStatus::TimedOut);
+    assert!(started.elapsed() < std::time::Duration::from_secs(5));
+}
+
+#[cfg(unix)]
+#[test]
+fn cancellation_is_structured_and_bounded() {
+    let temp = tempdir().expect("temp dir");
+    let check = check(
+        temp.path(),
+        "[[verification.checks]]\nid = \"slow\"\nrole = \"test\"\nprogram = \"sh\"\nargs = [\"-c\", \"sleep 30\"]\n",
+        "slow",
+    );
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let outcome = execute_check(
+        &check,
+        &WorkspaceRevision::capture(temp.path()),
+        &cancellation,
+    );
+    assert_eq!(outcome.status, VerificationStatus::Cancelled);
+}
+
+#[cfg(unix)]
+#[test]
+fn revision_change_skips_remaining_checks() {
+    let temp = tempdir().expect("temp dir");
+    std::fs::write(temp.path().join("tracked.txt"), "before").expect("seed file");
+    let config = parse_config(
+        r#"[[verification.checks]]
+id = "mutate"
+role = "test"
+program = "sh"
+args = ["-c", "printf after > tracked.txt"]
+[[verification.checks]]
+id = "second"
+role = "lint"
+program = "sh"
+args = ["-c", "printf spawned > second.txt"]
+"#,
+        None,
+    )
+    .expect("valid config");
+    let checks = select_checks(
+        temp.path(),
+        &config.verification.checks,
+        &["second".into(), "mutate".into()],
+    )
+    .expect("valid selection");
+    let revision = WorkspaceRevision::capture(temp.path());
+    let outcomes = run_checks(
+        &checks,
+        &["tracked.txt".into()],
+        &revision,
+        &CancellationToken::new(),
+    );
+    assert_eq!(outcomes[0].check_id, "mutate");
+    assert!(!outcomes[0].revision_compatible);
+    assert_eq!(outcomes[1].status, VerificationStatus::Skipped);
+    assert!(!temp.path().join("second.txt").exists());
+}

--- a/src/verification/mod.rs
+++ b/src/verification/mod.rs
@@ -1,0 +1,8 @@
+mod executor;
+mod model;
+mod policy;
+mod redaction;
+
+pub use executor::{execute_check, run_checks};
+pub use model::{CancellationToken, VerificationOutcome, VerificationRole, VerificationStatus};
+pub use policy::{ValidatedCheck, VerificationPolicyError, select_checks, validate_review_target};

--- a/src/verification/model.rs
+++ b/src/verification/model.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VerificationRole {
+    Test,
+    Build,
+    TypeCheck,
+    Lint,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VerificationStatus {
+    Passed,
+    Failed,
+    TimedOut,
+    Unavailable,
+    Cancelled,
+    Skipped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct VerificationOutcome {
+    pub check_id: String,
+    pub role: VerificationRole,
+    pub status: VerificationStatus,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub working_directory: String,
+    pub stdout_excerpt: String,
+    pub stderr_excerpt: String,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+    pub revision_before: String,
+    pub revision_after: String,
+    pub revision_compatible: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub limitations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CancellationToken(Arc<AtomicBool>);
+
+impl CancellationToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}

--- a/src/verification/policy.rs
+++ b/src/verification/policy.rs
@@ -1,0 +1,299 @@
+use crate::config::model::VerificationCheckConfig;
+use crate::review::diff::OwnedDiffTarget;
+use crate::verification::VerificationRole;
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+const MAX_TIMEOUT_SECONDS: u64 = 1_800;
+const MAX_OUTPUT_BYTES: usize = 1_048_576;
+
+#[derive(Debug)]
+pub struct ValidatedCheck {
+    id: String,
+    pub(crate) role: VerificationRole,
+    pub(crate) program: ValidatedProgram,
+    pub(crate) args: Vec<String>,
+    pub(crate) working_directory: PathBuf,
+    pub(crate) working_directory_label: String,
+    pub(crate) timeout_seconds: u64,
+    pub(crate) max_output_bytes: usize,
+    pub(crate) paths: Option<GlobSet>,
+}
+
+impl ValidatedCheck {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn is_applicable<'a>(&self, paths: impl IntoIterator<Item = &'a Path>) -> bool {
+        let Some(patterns) = &self.paths else {
+            return true;
+        };
+        paths.into_iter().any(|path| {
+            let normalized = path.to_string_lossy().replace('\\', "/");
+            patterns.is_match(normalized)
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ValidatedProgram {
+    Bare(String),
+    RepositoryRelative(PathBuf),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerificationPolicyError(String);
+
+impl fmt::Display for VerificationPolicyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for VerificationPolicyError {}
+
+pub fn select_checks(
+    root: &Path,
+    configured: &[VerificationCheckConfig],
+    selected: &[String],
+) -> Result<Vec<ValidatedCheck>, VerificationPolicyError> {
+    let root = root.canonicalize().map_err(|error| {
+        VerificationPolicyError(format!("failed to resolve repository root: {error}"))
+    })?;
+    let mut checks = BTreeMap::new();
+    for config in configured {
+        if checks.contains_key(&config.id) {
+            return Err(VerificationPolicyError(format!(
+                "duplicate verification check id `{}`",
+                config.id
+            )));
+        }
+        checks.insert(config.id.clone(), validate_check(&root, config)?);
+    }
+
+    let selected = selected.iter().collect::<BTreeSet<_>>();
+    let mut result = Vec::with_capacity(selected.len());
+    for id in selected {
+        let check = checks.remove(id).ok_or_else(|| {
+            VerificationPolicyError(format!("unknown verification check id `{id}`"))
+        })?;
+        result.push(check);
+    }
+    Ok(result)
+}
+
+pub fn validate_review_target(
+    root: &Path,
+    target: &OwnedDiffTarget,
+    ignored_paths: &[String],
+) -> Result<(), VerificationPolicyError> {
+    let OwnedDiffTarget::Refs { head, .. } = target else {
+        return Ok(());
+    };
+    let selected = git_text(root, &["rev-parse", "--verify", head])?;
+    let checkout = git_text(root, &["rev-parse", "--verify", "HEAD"])?;
+    if selected != checkout {
+        return Err(VerificationPolicyError(format!(
+            "verification head `{head}` does not match the current checkout HEAD"
+        )));
+    }
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["status", "--porcelain=v1", "-z", "-uall"])
+        .output()
+        .map_err(|error| {
+            VerificationPolicyError(format!("failed to inspect checkout state: {error}"))
+        })?;
+    if !status.status.success() {
+        return Err(VerificationPolicyError(
+            "failed to inspect checkout state".to_string(),
+        ));
+    }
+    let ignored = compile_ignored_paths(ignored_paths)?;
+    let dirty = status
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty())
+        .any(|entry| {
+            let path = String::from_utf8_lossy(entry.get(3..).unwrap_or_default());
+            path != ".repopilot/cache"
+                && !path.starts_with(".repopilot/cache/")
+                && !ignored.is_match(path.as_ref())
+        });
+    if dirty {
+        return Err(VerificationPolicyError(
+            "ref-range verification requires a clean current checkout".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn compile_ignored_paths(paths: &[String]) -> Result<GlobSet, VerificationPolicyError> {
+    let mut builder = GlobSetBuilder::new();
+    for path in paths {
+        let normalized = path.trim_matches('/');
+        for pattern in [normalized.to_string(), format!("{normalized}/**")] {
+            builder.add(Glob::new(&pattern).map_err(|error| {
+                VerificationPolicyError(format!("invalid configured ignore `{path}`: {error}"))
+            })?);
+        }
+    }
+    builder
+        .build()
+        .map_err(|error| VerificationPolicyError(format!("invalid configured ignores: {error}")))
+}
+
+fn git_text(root: &Path, args: &[&str]) -> Result<String, VerificationPolicyError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .map_err(|error| VerificationPolicyError(format!("failed to run git: {error}")))?;
+    if !output.status.success() {
+        return Err(VerificationPolicyError(format!(
+            "git could not resolve verification target: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn validate_check(
+    root: &Path,
+    config: &VerificationCheckConfig,
+) -> Result<ValidatedCheck, VerificationPolicyError> {
+    validate_id(&config.id)?;
+    if !(1..=MAX_TIMEOUT_SECONDS).contains(&config.timeout_seconds) {
+        return Err(VerificationPolicyError(format!(
+            "verification check `{}` timeout_seconds must be between 1 and {MAX_TIMEOUT_SECONDS}",
+            config.id
+        )));
+    }
+    if !(1..=MAX_OUTPUT_BYTES).contains(&config.max_output_bytes) {
+        return Err(VerificationPolicyError(format!(
+            "verification check `{}` max_output_bytes must be between 1 and {MAX_OUTPUT_BYTES}",
+            config.id
+        )));
+    }
+
+    Ok(ValidatedCheck {
+        id: config.id.clone(),
+        role: config.role,
+        program: validate_program(root, &config.id, &config.program)?,
+        args: config.args.clone(),
+        working_directory: confined_directory(root, &config.id, &config.working_directory)?,
+        working_directory_label: normalized_label(&config.working_directory),
+        timeout_seconds: config.timeout_seconds,
+        max_output_bytes: config.max_output_bytes,
+        paths: compile_paths(&config.id, &config.paths)?,
+    })
+}
+
+fn validate_id(id: &str) -> Result<(), VerificationPolicyError> {
+    let mut chars = id.chars();
+    let valid = id.len() <= 64
+        && chars
+            .next()
+            .is_some_and(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit())
+        && chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || "._-".contains(ch));
+    if valid {
+        Ok(())
+    } else {
+        Err(VerificationPolicyError(format!(
+            "invalid verification check id `{id}`"
+        )))
+    }
+}
+
+fn validate_program(
+    root: &Path,
+    id: &str,
+    program: &Path,
+) -> Result<ValidatedProgram, VerificationPolicyError> {
+    if program.is_absolute() || has_parent_component(program) {
+        return Err(VerificationPolicyError(format!(
+            "verification check `{id}` program must be a bare or repository-relative executable"
+        )));
+    }
+    let components = program.components().collect::<Vec<_>>();
+    if components.len() == 1 && matches!(components[0], Component::Normal(_)) {
+        return Ok(ValidatedProgram::Bare(
+            program.to_string_lossy().into_owned(),
+        ));
+    }
+    let resolved = root.join(program).canonicalize().map_err(|error| {
+        VerificationPolicyError(format!(
+            "verification check `{id}` program {} cannot be resolved: {error}",
+            program.display()
+        ))
+    })?;
+    if !resolved.starts_with(root) || !resolved.is_file() {
+        return Err(VerificationPolicyError(format!(
+            "verification check `{id}` program must resolve to a file inside the repository"
+        )));
+    }
+    Ok(ValidatedProgram::RepositoryRelative(resolved))
+}
+
+fn confined_directory(
+    root: &Path,
+    id: &str,
+    relative: &Path,
+) -> Result<PathBuf, VerificationPolicyError> {
+    if relative.is_absolute() || has_parent_component(relative) {
+        return Err(VerificationPolicyError(format!(
+            "verification check `{id}` working_directory must be repository-relative"
+        )));
+    }
+    let resolved = root.join(relative).canonicalize().map_err(|error| {
+        VerificationPolicyError(format!(
+            "verification check `{id}` working_directory {} cannot be resolved: {error}",
+            relative.display()
+        ))
+    })?;
+    if !resolved.starts_with(root) || !resolved.is_dir() {
+        return Err(VerificationPolicyError(format!(
+            "verification check `{id}` working_directory must resolve to a directory inside the repository"
+        )));
+    }
+    Ok(resolved)
+}
+
+fn compile_paths(id: &str, paths: &[String]) -> Result<Option<GlobSet>, VerificationPolicyError> {
+    if paths.is_empty() {
+        return Ok(None);
+    }
+    let mut builder = GlobSetBuilder::new();
+    for pattern in paths {
+        builder.add(Glob::new(pattern).map_err(|error| {
+            VerificationPolicyError(format!(
+                "verification check `{id}` has invalid path glob `{pattern}`: {error}"
+            ))
+        })?);
+    }
+    builder.build().map(Some).map_err(|error| {
+        VerificationPolicyError(format!(
+            "verification check `{id}` path globs cannot be compiled: {error}"
+        ))
+    })
+}
+
+fn has_parent_component(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::ParentDir))
+}
+
+fn normalized_label(path: &Path) -> String {
+    let label = path.to_string_lossy().replace('\\', "/");
+    if label.is_empty() {
+        ".".to_string()
+    } else {
+        label
+    }
+}

--- a/src/verification/redaction.rs
+++ b/src/verification/redaction.rs
@@ -1,0 +1,185 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CapturedStream {
+    pub excerpt: String,
+    pub truncated: bool,
+}
+
+pub(crate) fn capture_and_redact(bytes: &[u8], observed_more: bool) -> CapturedStream {
+    let text = String::from_utf8_lossy(bytes);
+    let terminal_safe = strip_terminal_sequences(&text);
+    let mut excerpt = String::new();
+    let mut inside_private_key = false;
+
+    for segment in terminal_safe.split_inclusive('\n') {
+        let has_newline = segment.ends_with('\n');
+        let line = segment.trim_end_matches('\n');
+        if line.contains("-----BEGIN ") && line.contains("PRIVATE KEY-----") {
+            inside_private_key = true;
+            excerpt.push_str("[REDACTED PRIVATE KEY]");
+        } else if inside_private_key {
+            if line.contains("-----END ") && line.contains("PRIVATE KEY-----") {
+                inside_private_key = false;
+            }
+        } else {
+            excerpt.push_str(&redact_line(line));
+        }
+        if has_newline && !inside_private_key {
+            excerpt.push('\n');
+        }
+    }
+
+    CapturedStream {
+        excerpt,
+        truncated: observed_more,
+    }
+}
+
+fn redact_line(line: &str) -> String {
+    if let Some((prefix, _)) = sensitive_assignment(line) {
+        return format!("{prefix}[REDACTED]");
+    }
+    line.split_whitespace()
+        .map(|token| {
+            let candidate = token.trim_matches(|ch: char| {
+                !ch.is_ascii_alphanumeric() && ch != '.' && ch != '_' && ch != '-'
+            });
+            if is_jwt(candidate) {
+                "[REDACTED JWT]"
+            } else if is_provider_token(candidate) {
+                "[REDACTED TOKEN]"
+            } else {
+                token
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn sensitive_assignment(line: &str) -> Option<(&str, &str)> {
+    for (separator, _) in line.match_indices(['=', ':']) {
+        let before = line[..separator].trim_end();
+        let key_start = before
+            .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '-'))
+            .map_or(0, |index| index + 1);
+        let key = before[key_start..].to_ascii_lowercase();
+        let sensitive = ["token", "password", "secret", "credential"]
+            .iter()
+            .any(|word| {
+                key == *word
+                    || key.ends_with(&format!("_{word}"))
+                    || key.ends_with(&format!("-{word}"))
+            });
+        if sensitive {
+            let value_start = line[separator + 1..]
+                .find(|ch: char| !ch.is_whitespace())
+                .map_or(line.len(), |offset| separator + 1 + offset);
+            return Some(line.split_at(value_start));
+        }
+    }
+    None
+}
+
+fn is_jwt(token: &str) -> bool {
+    let parts = token.split('.').collect::<Vec<_>>();
+    parts.len() == 3
+        && parts.iter().all(|part| {
+            part.len() >= 4
+                && part
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+        })
+}
+
+fn is_provider_token(token: &str) -> bool {
+    (token.starts_with("ghp_") && token.len() >= 24)
+        || (token.starts_with("github_pat_") && token.len() >= 32)
+        || (token.starts_with("sk-") && token.len() >= 24)
+        || (token.starts_with("AKIA") && token.len() == 20)
+}
+
+fn strip_terminal_sequences(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            match chars.next() {
+                Some('[') => {
+                    for next in chars.by_ref() {
+                        if ('@'..='~').contains(&next) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    let mut previous_escape = false;
+                    for next in chars.by_ref() {
+                        if next == '\u{7}' || (previous_escape && next == '\\') {
+                            break;
+                        }
+                        previous_escape = next == '\u{1b}';
+                    }
+                }
+                Some(_) | None => {}
+            }
+        } else if ch == '\n' || ch == '\t' || (!ch.is_control() && ch != '\u{7f}') {
+            output.push(ch);
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::capture_and_redact;
+
+    #[test]
+    fn strips_terminal_controls_and_masks_sensitive_assignments() {
+        let captured = capture_and_redact(
+            b"\x1b[31mfailed\x1b[0m\x07\ntoken=synthetic-secret\npassword: fake-password\n",
+            false,
+        );
+
+        assert_eq!(
+            captured.excerpt,
+            "failed\ntoken=[REDACTED]\npassword: [REDACTED]\n"
+        );
+        assert!(!captured.truncated);
+    }
+
+    #[test]
+    fn masks_private_keys_and_jwt_shapes() {
+        let captured = capture_and_redact(
+            b"-----BEGIN PRIVATE KEY-----\nZmFrZQ==\n-----END PRIVATE KEY-----\neyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmYWtlIn0.c2lnbmF0dXJl\n",
+            false,
+        );
+
+        assert!(!captured.excerpt.contains("ZmFrZQ"));
+        assert!(!captured.excerpt.contains("eyJhbGci"));
+        assert!(captured.excerpt.contains("[REDACTED PRIVATE KEY]"));
+        assert!(captured.excerpt.contains("[REDACTED JWT]"));
+    }
+
+    #[test]
+    fn converts_invalid_utf8_only_after_bounding() {
+        let captured = capture_and_redact(&[b'o', b'k', 0xff], true);
+
+        assert_eq!(captured.excerpt, "ok\u{fffd}");
+        assert!(captured.truncated);
+    }
+
+    #[test]
+    fn masks_provider_token_shapes_without_literal_secret_fixtures() {
+        let synthetic = format!("{}{}", "ghp_", "A".repeat(36));
+        let captured = capture_and_redact(format!("provider {synthetic}\n").as_bytes(), false);
+
+        assert_eq!(captured.excerpt, "provider [REDACTED TOKEN]\n");
+        assert!(!captured.excerpt.contains(&synthetic));
+    }
+
+    #[test]
+    fn masks_sensitive_assignment_embedded_in_a_log_prefix() {
+        let captured = capture_and_redact(b"error: API_TOKEN = synthetic-secret\n", false);
+
+        assert_eq!(captured.excerpt, "error: API_TOKEN = [REDACTED]\n");
+    }
+}

--- a/tests/config_loader.rs
+++ b/tests/config_loader.rs
@@ -1,10 +1,226 @@
 use repopilot::config::loader::{discover_config_path, load_optional_config, parse_config};
 use repopilot::config::model::RepoPilotConfig;
 use repopilot::output::OutputFormat;
+use repopilot::verification::select_checks;
 use std::fs;
 use tempfile::tempdir;
 
 const CONFIG_FILE_NAME: &str = "repopilot.toml";
+
+#[test]
+fn verification_checks_parse_with_bounded_defaults() {
+    let config = parse_config(
+        r#"
+        [[verification.checks]]
+        id = "unit"
+        role = "test"
+        program = "cargo"
+        args = ["test", "--all"]
+        paths = ["src/**", "tests/**"]
+        "#,
+        None,
+    )
+    .expect("verification config should parse");
+
+    let check = &config.verification.checks[0];
+    assert_eq!(check.id, "unit");
+    assert_eq!(check.program, std::path::PathBuf::from("cargo"));
+    assert_eq!(check.args, ["test", "--all"]);
+    assert_eq!(check.working_directory, std::path::PathBuf::from("."));
+    assert_eq!(check.timeout_seconds, 300);
+    assert_eq!(check.max_output_bytes, 65_536);
+    assert_eq!(check.paths, ["src/**", "tests/**"]);
+}
+
+#[test]
+fn verification_check_rejects_unknown_fields() {
+    let error = parse_config(
+        r#"
+        [[verification.checks]]
+        id = "unit"
+        role = "test"
+        program = "cargo"
+        shell = true
+        "#,
+        None,
+    )
+    .expect_err("unknown verification fields must fail closed");
+
+    assert!(error.to_string().contains("unknown field `shell`"));
+}
+
+#[test]
+fn verification_check_rejects_unsupported_role() {
+    let error = parse_config(
+        r#"
+        [[verification.checks]]
+        id = "unit"
+        role = "deploy"
+        program = "cargo"
+        "#,
+        None,
+    )
+    .expect_err("unsupported verification roles must fail closed");
+
+    assert!(error.to_string().contains("unknown variant `deploy`"));
+}
+
+#[test]
+fn verification_selection_is_deduplicated_and_sorted() {
+    let temp = tempdir().expect("temp dir");
+    let config = parse_config(
+        r#"
+        [[verification.checks]]
+        id = "unit"
+        role = "test"
+        program = "cargo"
+
+        [[verification.checks]]
+        id = "lint"
+        role = "lint"
+        program = "cargo"
+        "#,
+        None,
+    )
+    .expect("valid config");
+
+    let selected = select_checks(
+        temp.path(),
+        &config.verification.checks,
+        &["unit".into(), "lint".into(), "unit".into()],
+    )
+    .expect("selection should be valid");
+
+    assert_eq!(
+        selected.iter().map(|check| check.id()).collect::<Vec<_>>(),
+        ["lint", "unit"]
+    );
+}
+
+#[test]
+fn verification_selection_rejects_invalid_policy_before_execution() {
+    let temp = tempdir().expect("temp dir");
+    for (body, expected) in [
+        (
+            "id = \"Upper\"\nrole = \"test\"\nprogram = \"cargo\"",
+            "invalid verification check id `Upper`",
+        ),
+        (
+            "id = \"unit\"\nrole = \"test\"\nprogram = \"cargo\"\ntimeout_seconds = 0",
+            "timeout_seconds must be between 1 and 1800",
+        ),
+        (
+            "id = \"unit\"\nrole = \"test\"\nprogram = \"cargo\"\nmax_output_bytes = 1048577",
+            "max_output_bytes must be between 1 and 1048576",
+        ),
+    ] {
+        let config = parse_config(&format!("[[verification.checks]]\n{body}\n"), None)
+            .expect("syntax should parse before semantic validation");
+        let error = select_checks(temp.path(), &config.verification.checks, &["unit".into()])
+            .expect_err("invalid verification policy must fail closed");
+        assert!(error.to_string().contains(expected), "{error}");
+    }
+}
+
+#[test]
+fn verification_selection_rejects_duplicate_ids_and_unknown_selection() {
+    let temp = tempdir().expect("temp dir");
+    let duplicate = parse_config(
+        r#"
+        [[verification.checks]]
+        id = "unit"
+        role = "test"
+        program = "cargo"
+        [[verification.checks]]
+        id = "unit"
+        role = "lint"
+        program = "cargo"
+        "#,
+        None,
+    )
+    .expect("valid TOML");
+    let error = select_checks(
+        temp.path(),
+        &duplicate.verification.checks,
+        &["unit".into()],
+    )
+    .expect_err("duplicate IDs must fail closed");
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate verification check id `unit`")
+    );
+
+    let valid = parse_config(
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"cargo\"\n",
+        None,
+    )
+    .expect("valid TOML");
+    let error = select_checks(temp.path(), &valid.verification.checks, &["missing".into()])
+        .expect_err("unknown selected IDs must fail closed");
+    assert!(
+        error
+            .to_string()
+            .contains("unknown verification check id `missing`")
+    );
+}
+
+#[test]
+fn verification_paths_match_changed_or_impacted_files() {
+    let temp = tempdir().expect("temp dir");
+    let config = parse_config(
+        r#"
+        [[verification.checks]]
+        id = "unit"
+        role = "test"
+        program = "cargo"
+        paths = ["src/**", "Cargo.toml"]
+        "#,
+        None,
+    )
+    .expect("valid config");
+    let checks = select_checks(temp.path(), &config.verification.checks, &["unit".into()])
+        .expect("valid selection");
+
+    assert!(checks[0].is_applicable([std::path::Path::new("src/deleted.rs")]));
+    assert!(checks[0].is_applicable([std::path::Path::new("Cargo.toml")]));
+    assert!(!checks[0].is_applicable([std::path::Path::new("docs/guide.md")]));
+}
+
+#[test]
+fn verification_without_paths_is_always_applicable() {
+    let temp = tempdir().expect("temp dir");
+    let config = parse_config(
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"cargo\"\n",
+        None,
+    )
+    .expect("valid config");
+    let checks = select_checks(temp.path(), &config.verification.checks, &["unit".into()])
+        .expect("valid selection");
+
+    assert!(checks[0].is_applicable(std::iter::empty::<&std::path::Path>()));
+}
+
+#[test]
+fn verification_paths_reject_repository_escape() {
+    let temp = tempdir().expect("temp dir");
+    let outside = tempdir().expect("outside dir");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(outside.path(), temp.path().join("escape")).expect("create symlink");
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(outside.path(), temp.path().join("escape"))
+        .expect("create symlink");
+
+    let config = parse_config(
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"cargo\"\nworking_directory = \"escape\"\n",
+        None,
+    )
+    .expect("valid TOML");
+    let error = select_checks(temp.path(), &config.verification.checks, &["unit".into()])
+        .expect_err("symlink escape must fail closed");
+
+    assert!(error.to_string().contains("inside the repository"));
+}
 
 #[test]
 fn missing_config_returns_defaults() {

--- a/tests/fixtures/golden/ai-context.json
+++ b/tests/fixtures/golden/ai-context.json
@@ -4,7 +4,7 @@
     "kind": "repopilot-analysis",
     "version": 1,
     "source": "ai-context",
-    "report_schema_version": "0.24",
+    "report_schema_version": "0.25",
     "repopilot_version": "{{VERSION}}"
   },
   "project": "ai-context-sample",

--- a/tests/fixtures/golden/scan-json-schema.golden.json
+++ b/tests/fixtures/golden/scan-json-schema.golden.json
@@ -1,9 +1,9 @@
 {
-  "schema_version": "0.24",
+  "schema_version": "0.25",
   "repopilot_version": "{{VERSION}}",
   "report": {
     "kind": "scan",
-    "schema_version": "0.24",
+    "schema_version": "0.25",
     "repopilot_version": "{{VERSION}}"
   },
   "root_path": "demo-project",

--- a/tests/fixtures/reports/scan-v025.json
+++ b/tests/fixtures/reports/scan-v025.json
@@ -1,0 +1,113 @@
+{
+  "schema_version": "0.25",
+  "repopilot_version": "0.19.0",
+  "report": {
+    "kind": "scan",
+    "schema_version": "0.25",
+    "repopilot_version": "0.19.0"
+  },
+  "root_path": ".",
+  "mode": "full",
+  "changed_files_count": 0,
+  "repo_level_rules_included": true,
+  "files_discovered": 2,
+  "files_analyzed": 2,
+  "directories_count": 1,
+  "non_empty_lines": 12,
+  "large_files_skipped": 0,
+  "files_skipped_low_signal": 0,
+  "binary_files_skipped": 0,
+  "skipped_bytes": 0,
+  "languages": [],
+  "findings": [],
+  "detected_frameworks": [],
+  "framework_projects": [],
+  "coupling_graph": null,
+  "context_graph_summary": {
+    "files": 2,
+    "import_edges": 0
+  },
+  "context_graph_cache": {
+    "status": "write",
+    "reason": "context-graph-cache-updated",
+    "cache_path": ".repopilot/cache/repo_context.json"
+  },
+  "scan_duration_us": 100,
+  "health_score": 100,
+  "maintainability_score": 100,
+  "raw_findings_count": 0,
+  "visible_findings_count": 0,
+  "hidden_suggestions_count": 0,
+  "files_skipped_by_limit": 0,
+  "files_skipped_repopilotignore": 0,
+  "diagnostics": [
+    {
+      "code": "workspace.package-scan-failed",
+      "severity": "warning",
+      "message": "Package scan failed; results are partial.",
+      "path": "packages/api"
+    }
+  ],
+  "risk_summary": {
+    "total": 0,
+    "average_score": 0,
+    "counts": { "p0": 0, "p1": 0, "p2": 0, "p3": 0 }
+  },
+  "raw_signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  },
+  "visible_signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  },
+  "signal_quality": {
+    "findings_total": 0,
+    "by_confidence": { "low": 0, "medium": 0, "high": 0 },
+    "by_lifecycle": { "experimental": 0, "preview": 0, "stable": 0, "deprecated": 0 },
+    "by_signal_source": {
+      "text_heuristic": 0,
+      "ast": 0,
+      "config_file": 0,
+      "dependency_manifest": 0,
+      "import_graph": 0,
+      "framework_detector": 0,
+      "git_diff": 0,
+      "mixed": 0
+    },
+    "evidence_coverage_percent": 100,
+    "recommendation_coverage_percent": 100,
+    "docs_coverage_for_high_risk_percent": 100,
+    "contract_violations": 0
+  }
+}

--- a/tests/report_schema_contract.rs
+++ b/tests/report_schema_contract.rs
@@ -5,11 +5,11 @@ use serde_json::Value;
 
 #[test]
 fn current_schema_fixture_documents_scan_report_contract() {
-    let current_text = include_str!("fixtures/reports/scan-v024.json");
+    let current_text = include_str!("fixtures/reports/scan-v025.json");
     let current: Value =
         serde_json::from_str(current_text).expect("current report fixture should be valid JSON");
 
-    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.24");
+    assert_eq!(SCAN_REPORT_SCHEMA_VERSION, "0.25");
     assert_eq!(current["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
     assert_eq!(current["report"]["kind"], "scan");
     assert_eq!(
@@ -36,7 +36,7 @@ fn current_schema_fixture_documents_scan_report_contract() {
 
 #[test]
 fn strict_reader_accepts_current_scan_report_shape() {
-    let current_text = include_str!("fixtures/reports/scan-v024.json");
+    let current_text = include_str!("fixtures/reports/scan-v025.json");
     let current = parse_scan_summary_json(current_text)
         .expect("current report should parse into ScanSummary");
 
@@ -69,8 +69,10 @@ fn strict_reader_accepts_current_scan_report_shape() {
 
 #[test]
 fn strict_reader_accepts_previous_scan_report_shapes() {
+    let previous_v024 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v024.json"))
+        .expect("0.24 report should parse during 0.25 transition");
     let previous_v023 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v023.json"))
-        .expect("0.23 report should parse during 0.24 transition");
+        .expect("0.23 report should parse during 0.25 transition");
     let previous_v022 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v022.json"))
         .expect("0.22 report should parse during 0.24 transition");
     let previous_v021 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v021.json"))
@@ -86,6 +88,7 @@ fn strict_reader_accepts_previous_scan_report_shapes() {
     let previous_v016 = parse_scan_summary_json(include_str!("fixtures/reports/scan-v016.json"))
         .expect("0.16 report should parse during 0.24 transition");
 
+    assert_eq!(previous_v024.metrics.files_discovered, 2);
     assert_eq!(previous_v023.metrics.files_discovered, 2);
     assert_eq!(previous_v023.metrics.maintainability_score, 100);
     assert_eq!(previous_v022.metrics.files_discovered, 2);

--- a/tests/review_blast_radius.rs
+++ b/tests/review_blast_radius.rs
@@ -157,6 +157,7 @@ fn render_console_includes_blast_radius_section_when_present() {
         boundary_missing_test: false,
         tiered_signals: TieredSignals::default(),
         timings: Default::default(),
+        verification: Vec::new(),
         findings: vec![],
     };
 

--- a/tests/review_console_detail.rs
+++ b/tests/review_console_detail.rs
@@ -99,6 +99,7 @@ fn report_with_changed_files() -> ReviewReport {
         boundary_missing_test: false,
         tiered_signals: Default::default(),
         timings: Default::default(),
+        verification: Vec::new(),
         findings: Vec::new(),
     }
 }

--- a/tests/review_readiness.rs
+++ b/tests/review_readiness.rs
@@ -6,6 +6,7 @@ use repopilot::review::{
     MergeReadinessRecord, OwnershipSummary, ReadinessReasonCode, ReadinessVerdict, derive_readiness,
 };
 use repopilot::scan::types::ScanSummary;
+use repopilot::verification::{VerificationOutcome, VerificationRole, VerificationStatus};
 use std::path::PathBuf;
 
 #[test]
@@ -97,6 +98,58 @@ fn human_reports_project_readiness_and_owners() {
     assert!(markdown.contains("**Suggested owners:** `@team`"));
 }
 
+#[test]
+fn failed_verification_blocks_canonical_readiness() {
+    let mut report = report_with_ownership(OwnershipSummary::default());
+    report.verification = vec![verification_outcome(VerificationStatus::Failed, true)];
+
+    let readiness = derive_readiness(&report, None, None, None);
+
+    assert_eq!(readiness.verdict, ReadinessVerdict::Blocked);
+    assert!(readiness.reasons.iter().any(|reason| {
+        reason.code == ReadinessReasonCode::VerificationFailed && reason.count == 1
+    }));
+    assert_eq!(readiness.verification, report.verification);
+}
+
+#[test]
+fn revision_incompatible_pass_blocks_readiness() {
+    let mut report = report_with_ownership(OwnershipSummary::default());
+    report.verification = vec![verification_outcome(VerificationStatus::Passed, false)];
+
+    let readiness = derive_readiness(&report, None, None, None);
+
+    assert_eq!(readiness.verdict, ReadinessVerdict::Blocked);
+    assert!(
+        readiness
+            .reasons
+            .iter()
+            .any(|reason| { reason.code == ReadinessReasonCode::VerificationRevisionChanged })
+    );
+}
+
+fn verification_outcome(
+    status: VerificationStatus,
+    revision_compatible: bool,
+) -> VerificationOutcome {
+    VerificationOutcome {
+        check_id: "unit".to_string(),
+        role: VerificationRole::Test,
+        status,
+        duration_ms: 10,
+        exit_code: Some(1),
+        working_directory: ".".to_string(),
+        stdout_excerpt: String::new(),
+        stderr_excerpt: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+        revision_before: "before".to_string(),
+        revision_after: "after".to_string(),
+        revision_compatible,
+        limitations: Vec::new(),
+    }
+}
+
 fn report_with_ownership(ownership: OwnershipSummary) -> ReviewReport {
     ReviewReport {
         summary: ScanSummary::default(),
@@ -116,6 +169,7 @@ fn report_with_ownership(ownership: OwnershipSummary) -> ReviewReport {
         boundary_missing_test: false,
         tiered_signals: Default::default(),
         timings: Default::default(),
+        verification: Vec::new(),
         findings: Vec::new(),
     }
 }

--- a/tests/verification_cli.rs
+++ b/tests/verification_cli.rs
@@ -1,0 +1,253 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+#[cfg(unix)]
+#[test]
+fn selected_check_runs_and_is_reported_once() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    fs::create_dir_all(temp.path().join("src")).expect("src");
+    fs::write(temp.path().join("src/lib.rs"), "pub fn before() {}\n").expect("source");
+    fs::write(
+        temp.path().join("repopilot.toml"),
+        r#"
+        [[verification.checks]]
+        id = "unit"
+        role = "test"
+        program = "sh"
+        args = ["-c", "printf verified"]
+        "#,
+    )
+    .expect("config");
+    commit_all(temp.path(), "initial");
+    fs::write(temp.path().join("src/lib.rs"), "pub fn after() {}\n").expect("change");
+
+    let output = repopilot()
+        .args([
+            "review", ".", "--format", "json", "--verify", "unit", "--verify", "unit",
+        ])
+        .current_dir(temp.path())
+        .output()
+        .expect("review");
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("JSON report");
+    let outcomes = json["merge_readiness"]["verification"]
+        .as_array()
+        .expect("outcomes");
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(outcomes[0]["check_id"], "unit");
+    assert_eq!(outcomes[0]["status"], "passed");
+    assert_eq!(outcomes[0]["working_directory"], ".");
+    assert_eq!(outcomes[0]["stdout_excerpt"], "verified");
+}
+
+#[test]
+fn unknown_selected_check_exits_with_usage_code() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    fs::write(temp.path().join("README.md"), "before\n").expect("source");
+    commit_all(temp.path(), "initial");
+    fs::write(temp.path().join("README.md"), "after\n").expect("change");
+
+    let output = repopilot()
+        .args(["review", ".", "--verify", "missing"])
+        .current_dir(temp.path())
+        .output()
+        .expect("review");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unknown verification check id `missing`")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn console_renders_verification_evidence() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    fs::write(temp.path().join("README.md"), "before\n").expect("source");
+    fs::write(
+        temp.path().join("repopilot.toml"),
+        "[[verification.checks]]\nid = \"lint\"\nrole = \"lint\"\nprogram = \"sh\"\nargs = [\"-c\", \"printf clean\"]\n",
+    )
+    .expect("config");
+    commit_all(temp.path(), "initial");
+    fs::write(temp.path().join("README.md"), "after\n").expect("change");
+
+    let output = repopilot()
+        .args(["review", ".", "--verify", "lint"])
+        .current_dir(temp.path())
+        .output()
+        .expect("review");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success());
+    assert!(stdout.contains("Verification:\n"));
+    assert!(stdout.contains("lint: PASSED"));
+    assert!(stdout.contains("clean"));
+}
+
+#[cfg(unix)]
+#[test]
+fn ref_range_verification_rejects_a_non_checkout_head() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    fs::write(temp.path().join("README.md"), "one\n").expect("source");
+    fs::write(
+        temp.path().join("repopilot.toml"),
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"sh\"\nargs = [\"-c\", \"printf should-not-run > marker\"]\n",
+    )
+    .expect("config");
+    commit_all(temp.path(), "first");
+    fs::write(temp.path().join("README.md"), "two\n").expect("change");
+    commit_all(temp.path(), "second");
+
+    let output = repopilot()
+        .args([
+            "review", ".", "--base", "HEAD~1", "--head", "HEAD~1", "--verify", "unit",
+        ])
+        .current_dir(temp.path())
+        .output()
+        .expect("review");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(!temp.path().join("marker").exists());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("does not match the current checkout")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn ref_range_allows_changes_covered_by_configured_ignores() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    fs::write(temp.path().join("README.md"), "one\n").expect("source");
+    fs::write(
+        temp.path().join("repopilot.toml"),
+        "[scan]\nignore = [\"generated\"]\n[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"sh\"\nargs = [\"-c\", \"printf ok\"]\n",
+    )
+    .expect("config");
+    commit_all(temp.path(), "first");
+    fs::write(temp.path().join("README.md"), "two\n").expect("change");
+    commit_all(temp.path(), "second");
+    fs::create_dir_all(temp.path().join("generated")).expect("generated dir");
+    fs::write(temp.path().join("generated/output.txt"), "ignored\n").expect("ignored file");
+
+    let output = repopilot()
+        .args([
+            "review", ".", "--base", "HEAD~1", "--head", "HEAD", "--verify", "unit",
+        ])
+        .current_dir(temp.path())
+        .output()
+        .expect("review");
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn configured_check_does_not_run_without_explicit_selection() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    fs::write(temp.path().join("README.md"), "before\n").expect("source");
+    fs::write(
+        temp.path().join("repopilot.toml"),
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"sh\"\nargs = [\"-c\", \"printf spawned > marker\"]\n",
+    )
+    .expect("config");
+    commit_all(temp.path(), "initial");
+    fs::write(temp.path().join("README.md"), "after\n").expect("change");
+
+    let output = repopilot()
+        .args(["review", ".", "--format", "json"])
+        .current_dir(temp.path())
+        .output()
+        .expect("review");
+    let json: Value = serde_json::from_slice(&output.stdout).expect("JSON report");
+
+    assert!(output.status.success());
+    assert!(!temp.path().join("marker").exists());
+    assert!(json["merge_readiness"].get("verification").is_none());
+}
+
+#[cfg(unix)]
+#[test]
+fn failed_check_writes_report_before_exit_one() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    fs::write(temp.path().join("README.md"), "before\n").expect("source");
+    fs::write(
+        temp.path().join("repopilot.toml"),
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"sh\"\nargs = [\"-c\", \"printf failed >&2; exit 7\"]\n",
+    )
+    .expect("config");
+    commit_all(temp.path(), "initial");
+    fs::write(temp.path().join("README.md"), "after\n").expect("change");
+    let report = temp.path().join("review.json");
+
+    let output = repopilot()
+        .args([
+            "review",
+            ".",
+            "--format",
+            "json",
+            "--output",
+            report.to_str().unwrap(),
+            "--verify",
+            "unit",
+        ])
+        .current_dir(temp.path())
+        .output()
+        .expect("review");
+    let json: Value =
+        serde_json::from_slice(&fs::read(report).expect("written report")).expect("JSON report");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        json["merge_readiness"]["verification"][0]["status"],
+        "failed"
+    );
+    assert_eq!(json["merge_readiness"]["verification"][0]["exit_code"], 7);
+}
+
+fn init_repo(root: &Path) {
+    git(root, &["init"]);
+    git(root, &["config", "user.email", "repopilot@example.invalid"]);
+    git(root, &["config", "user.name", "RepoPilot Test"]);
+}
+
+fn commit_all(root: &Path, message: &str) {
+    git(root, &["add", "."]);
+    git(root, &["commit", "-m", message]);
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

Add the v0.22 D1 opt-in local verification layer to `repopilot review`, so users can run explicitly configured test, build, type-check, and lint checks and receive canonical readiness evidence without introducing implicit command execution.

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- Added typed `[verification]` configuration and repeatable `review --verify <id>` selection with strict path, executable, revision, timeout, output, and workspace-confinement policy.
- Added direct process execution, cancellation and timeout handling, bounded/redacted output, Unix process-group cleanup, and Windows Job Object cleanup.
- Projected verification outcomes into canonical merge readiness, console/Markdown/JSON reports, schema v0.25, docs, and focused integration coverage.

## Why

RepoPilot should move from only recommending checks to recording trustworthy local verification evidence. This slice keeps execution explicit and deterministic while making failed, unavailable, cancelled, timed-out, or revision-incompatible checks block readiness with stable reason codes.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

SARIF remains unchanged. MCP, Action, scan integration, verification caching, and MCP progress/cancellation selection are intentionally deferred to the next slice.

## Changelog

- [x] `CHANGELOG.md` updated (skip for CI-only or doc changes with no user-visible effect)

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
npm run test:release-contract
cargo run -- scan . --fail-on-priority p1
```

All six pre-handoff gates passed on the frozen tree. A fresh post-review `cargo test --all` also passed, including 853 library tests, 55 CLI unit tests, and all integration/doc suites.

## Platform note

The Windows executor uses a kill-on-close Job Object. Local cross-compilation on macOS could not compile the C-backed parser dependencies because an MSVC C toolchain/headers are unavailable, so Windows CI is the required final platform/runtime proof before this draft is ready to merge.
