### PR TITLE
feat(mcp): add configured review verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   both output streams, terminates managed process trees on timeout or
   cancellation, and blocks merge readiness for failed or revision-incompatible
   evidence. Review report schema advances to `0.25` with `0.24` retained.
+- **MCP parity for explicit review verification.** The existing
+  `repopilot_review_change` tool accepts an optional `verify` list of configured
+  check IDs and reuses the CLI verification policy, executor, redaction, and
+  readiness evidence. Its static annotations advertise potential local and
+  external effects; request cancellation terminates the managed process tree;
+  progress reports bounded analysis/check lifecycle events; and cancelled,
+  oversized, or revision-incompatible reviews cannot replace session state or
+  create replayable analysis handles. Calls without selected checks still spawn
+  no verification process, and no seventh MCP tool is added.
 - **Honest decision scores and progressive review disclosure.** Scan, baseline,
   workspace, receipt, JSON, MCP, console, Markdown, and HTML output now preserve
   the existing visible-profile `health_score` as `Visible health` and add a

--- a/docs/engineering/v0.22-d1-review-verification-plan.md
+++ b/docs/engineering/v0.22-d1-review-verification-plan.md
@@ -70,7 +70,7 @@
 - Produces: `select_checks(root: &Path, configured: &[VerificationCheckConfig], selected: &[String]) -> Result<Vec<ValidatedCheck>, VerificationPolicyError>`.
 - Consumes: existing `parse_config` and repository-root paths.
 
-- [ ] **Step 1: Write failing config and selection tests**
+- [x] **Step 1: Write failing config and selection tests**
 
 Add table-driven tests proving defaults, all four roles, duplicate/invalid IDs, unknown fields, invalid limits, absolute/traversing executable paths, traversal in `working_directory`, and unknown selected IDs. Include this positive assertion:
 
@@ -79,13 +79,13 @@ let selected = select_checks(root, &config.verification.checks, &["lint".into(),
 assert_eq!(selected.iter().map(|check| check.id()).collect::<Vec<_>>(), ["lint", "unit"]);
 ```
 
-- [ ] **Step 2: Run the focused tests and confirm RED**
+- [x] **Step 2: Run the focused tests and confirm RED**
 
 Run: `cargo test --test config_loader verification -- --nocapture`
 
 Expected: compilation fails because the verification config and policy API do not exist.
 
-- [ ] **Step 3: Add the typed configuration and policy errors**
+- [x] **Step 3: Add the typed configuration and policy errors**
 
 Implement these serialized enums and config defaults:
 
@@ -110,21 +110,21 @@ pub struct VerificationCheckConfig {
 
 Add `verification: VerificationSection` to `RepoPilotConfig`. Validate all configured entries whenever any selection is requested, reject duplicates deterministically, deduplicate selected IDs with `BTreeSet`, and return checks sorted by ID.
 
-- [ ] **Step 4: Constrain paths and compile applicability globs**
+- [x] **Step 4: Constrain paths and compile applicability globs**
 
 `ValidatedCheck` stores the canonical working directory, a direct executable (`Bare(String)` or `RepositoryRelative(PathBuf)`), and an optional `GlobSet`. Reject absolute paths, `..`, missing/non-directory working directories, symlink escapes, invalid globs, and repository-relative executable escapes. Bare programs contain exactly one normal path component.
 
-- [ ] **Step 5: Add a commented generated-config example**
+- [x] **Step 5: Add a commented generated-config example**
 
 Place one commented `[[verification.checks]]` example in `generate_default_config()`; parsing the generated template must still yield defaults and no checks.
 
-- [ ] **Step 6: Run focused tests and confirm GREEN**
+- [x] **Step 6: Run focused tests and confirm GREEN**
 
 Run: `cargo test --test config_loader verification -- --nocapture`
 
 Expected: all verification config and policy tests pass.
 
-- [ ] **Step 7: Publication checkpoint**
+- [x] **Step 7: Publication checkpoint**
 
 When publication is authorized: `git add src/config src/verification src/lib.rs tests/config_loader.rs && git commit -m "feat: add review verification policy"`.
 
@@ -142,31 +142,31 @@ When publication is authorized: `git add src/config src/verification src/lib.rs 
 - Produces: `validate_review_target(root: &Path, target: &OwnedDiffTarget, ignored_paths: &[String]) -> Result<(), VerificationPolicyError>`.
 - Consumes: `ReviewReport.changed_files`, `ReviewReport.impact_paths`, and `OwnedDiffTarget`.
 
-- [ ] **Step 1: Write failing applicability tests**
+- [x] **Step 1: Write failing applicability tests**
 
 Cover always-applicable empty `paths`, matching a deleted changed path, matching only a transitive impacted path, non-match, slash normalization, and deterministic handling of duplicate paths.
 
-- [ ] **Step 2: Write failing ref compatibility tests**
+- [x] **Step 2: Write failing ref compatibility tests**
 
 Create temporary Git repositories and prove that `WorkingTree` and `SinceRef` are accepted, while `Refs` rejects a head different from checkout `HEAD` and rejects dirty tracked, staged, or untracked source state. Ignored/cache-only changes remain compatible.
 
-- [ ] **Step 3: Run tests and confirm RED**
+- [x] **Step 3: Run tests and confirm RED**
 
 Run: `cargo test verification::policy -- --nocapture && cargo test --test verification_cli ref_range -- --nocapture`
 
 Expected: failures identify missing applicability and target validation.
 
-- [ ] **Step 4: Implement path inventory and compatibility checks**
+- [x] **Step 4: Implement path inventory and compatibility checks**
 
 Match repository-relative changed paths plus every direct/transitive impacted path. Resolve `Refs.head` and `HEAD` with direct Git invocations and compare object IDs. Parse porcelain `-z` status, apply RepoPilot built-in/config ignore semantics, and return one deterministic mismatch error before execution.
 
-- [ ] **Step 5: Run focused tests and confirm GREEN**
+- [x] **Step 5: Run focused tests and confirm GREEN**
 
 Run: `cargo test verification::policy -- --nocapture && cargo test --test verification_cli ref_range -- --nocapture`
 
 Expected: all policy and target tests pass.
 
-- [ ] **Step 6: Publication checkpoint**
+- [x] **Step 6: Publication checkpoint**
 
 When publication is authorized: `git add src/verification/policy.rs tests/verification_cli.rs && git commit -m "feat: validate verification applicability"`.
 
@@ -184,27 +184,27 @@ When publication is authorized: `git add src/verification/policy.rs tests/verifi
 - Produces: `capture_and_redact(bytes: &[u8], observed_more: bool) -> CapturedStream`.
 - Consumes: already bounded bytes from executor readers.
 
-- [ ] **Step 1: Write failing redaction tests**
+- [x] **Step 1: Write failing redaction tests**
 
 Use only synthetic values and cover ANSI color/OSC escapes, C0/C1 controls except newline/tab, private-key blocks, JWT-shaped strings, provider-token shapes, `token=`, `password:`, `secret =`, `credential:` values, invalid UTF-8, and input that ends at the retention boundary.
 
-- [ ] **Step 2: Run tests and confirm RED**
+- [x] **Step 2: Run tests and confirm RED**
 
 Run: `cargo test verification::redaction -- --nocapture`
 
 Expected: module/API is absent.
 
-- [ ] **Step 3: Implement one-way sanitization**
+- [x] **Step 3: Implement one-way sanitization**
 
 Perform byte bounding before lossy UTF-8 conversion; strip terminal escapes and unsafe controls; replace secret values with `[REDACTED]`. Return only the sanitized excerpt and truncation flag. Do not retain the raw vector after outcome construction.
 
-- [ ] **Step 4: Run focused tests and secret-safety regression**
+- [x] **Step 4: Run focused tests and secret-safety regression**
 
 Run: `cargo test verification::redaction -- --nocapture && cargo test --test fixture_secret_safety`
 
 Expected: all tests pass and no synthetic raw secret survives.
 
-- [ ] **Step 5: Publication checkpoint**
+- [x] **Step 5: Publication checkpoint**
 
 When publication is authorized: `git add src/verification && git commit -m "feat: redact verification output"`.
 
@@ -228,39 +228,39 @@ When publication is authorized: `git add src/verification && git commit -m "feat
 - Produces: statuses `Passed`, `Failed`, `TimedOut`, `Unavailable`, `Cancelled`, `Skipped` serialized in kebab case.
 - Consumes: `capture_and_redact` and `WorkspaceRevision::capture`.
 
-- [ ] **Step 1: Write failing executor tests**
+- [x] **Step 1: Write failing executor tests**
 
 Use repository-local fixture scripts/executables to prove literal argument delivery (`"a b"`, `"$(not-run)"`, `";"`), passed/failed/unavailable status, exact exit code, independent stdout/stderr truncation, concurrent high-volume output without deadlock, cancellation, timeout, and revision-before/after fields.
 
-- [ ] **Step 2: Write descendant-cleanup tests**
+- [x] **Step 2: Write descendant-cleanup tests**
 
 Spawn a fixture that creates a long-lived descendant and writes its PID to a temp file. After timeout and cancellation, poll the PID for a bounded interval and assert the descendant no longer exists. Gate only the fixture syntax with `#[cfg(unix)]`/`#[cfg(windows)]`; do not weaken the executor assertion.
 
-- [ ] **Step 3: Run executor tests and confirm RED**
+- [x] **Step 3: Run executor tests and confirm RED**
 
 Run: `cargo test verification::executor -- --nocapture`
 
 Expected: executor types/functions are absent.
 
-- [ ] **Step 4: Implement direct process execution**
+- [x] **Step 4: Implement direct process execution**
 
 Build `std::process::Command` from the validated executable and exact argument vector, set the canonical working directory, call `env_clear`, restore the fixed portability keys, and pipe both streams. Two reader threads continuously drain each pipe while retaining at most the configured cap.
 
-- [ ] **Step 5: Implement portable process-tree ownership**
+- [x] **Step 5: Implement portable process-tree ownership**
 
 On Unix, place the child in a new process group before exec and signal the group on timeout/cancel, escalating to kill after a short bounded grace period. On Windows, assign the child to a Job Object configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and terminate the job on timeout/cancel. Add target-specific `libc` and `windows-sys` dependencies only.
 
-- [ ] **Step 6: Finalize outcomes after readers join**
+- [x] **Step 6: Finalize outcomes after readers join**
 
 Poll `try_wait` against the deadline and cancellation token, terminate when required, wait for the child, join both readers, redact both retained streams, capture `revision_after`, and set `revision_compatible = revision_before == revision_after`.
 
-- [ ] **Step 7: Run executor tests and confirm GREEN**
+- [x] **Step 7: Run executor tests and confirm GREEN**
 
 Run: `cargo test verification::executor -- --nocapture`
 
 Expected: every status, pipe bound, direct-argument, and cleanup test passes.
 
-- [ ] **Step 8: Publication checkpoint**
+- [x] **Step 8: Publication checkpoint**
 
 When publication is authorized: `git add Cargo.toml Cargo.lock src/verification && git commit -m "feat: execute bounded verification checks"`.
 
@@ -277,27 +277,27 @@ When publication is authorized: `git add Cargo.toml Cargo.lock src/verification 
 - Produces: `run_checks(checks: &[ValidatedCheck], evidence_paths: &[PathBuf], revision: &WorkspaceRevision, cancellation: &CancellationToken) -> Vec<VerificationOutcome>`.
 - Consumes: `ValidatedCheck::is_applicable` and `execute_check`.
 
-- [ ] **Step 1: Write failing orchestration tests**
+- [x] **Step 1: Write failing orchestration tests**
 
 Prove lexicographic execution order, no spawn for inapplicable checks, `Skipped` with an applicability limitation, and that a check mutating the workspace marks itself incompatible and records every remaining check as skipped without spawning.
 
-- [ ] **Step 2: Run tests and confirm RED**
+- [x] **Step 2: Run tests and confirm RED**
 
 Run: `cargo test verification::executor::tests::run_checks -- --nocapture`
 
 Expected: missing orchestration API.
 
-- [ ] **Step 3: Implement minimal sequential orchestration**
+- [x] **Step 3: Implement minimal sequential orchestration**
 
 For each already sorted check: emit `Skipped` when inapplicable; otherwise execute it. After any incompatible revision, append deterministic skipped outcomes for remaining checks with limitation `workspace revision changed before this check could run` and stop spawning.
 
-- [ ] **Step 4: Run tests and confirm GREEN**
+- [x] **Step 4: Run tests and confirm GREEN**
 
 Run: `cargo test verification::executor -- --nocapture`
 
 Expected: orchestration and executor tests pass.
 
-- [ ] **Step 5: Publication checkpoint**
+- [x] **Step 5: Publication checkpoint**
 
 When publication is authorized: `git add src/verification && git commit -m "feat: guard verification revisions"`.
 
@@ -319,31 +319,31 @@ When publication is authorized: `git add src/verification && git commit -m "feat
 - Produces reason codes: `VerificationFailed`, `VerificationTimedOut`, `VerificationUnavailable`, `VerificationCancelled`, `VerificationRevisionChanged`.
 - Consumes: one ordered outcome vector; renderers do not reinterpret status.
 
-- [ ] **Step 1: Write failing readiness tests**
+- [x] **Step 1: Write failing readiness tests**
 
 Add one case per blocking status and revision incompatibility, plus passed and skipped non-blocking cases. Assert that a passed check leaves existing finding/signal/ownership reasons intact and that readiness carries exactly the report outcomes.
 
-- [ ] **Step 2: Run tests and confirm RED**
+- [x] **Step 2: Run tests and confirm RED**
 
 Run: `cargo test --test review_readiness verification -- --nocapture`
 
 Expected: missing report fields and reason codes.
 
-- [ ] **Step 3: Extend report construction and readiness projection**
+- [x] **Step 3: Extend report construction and readiness projection**
 
 Initialize outcomes empty in `classify_findings`; update all literal `ReviewReport` builders. Clone the canonical outcomes into readiness with `skip_serializing_if = "Vec::is_empty"`. Add one stable reason per blocking category with deterministic count/message and include all verification reasons in the blocked verdict set.
 
-- [ ] **Step 4: Make limitations evidence-aware**
+- [x] **Step 4: Make limitations evidence-aware**
 
 Keep `RepoPilot did not execute tests` when outcomes are empty. Otherwise list selected check IDs and statuses, explicitly note skipped checks, and state that unselected checks and static semantics remain unverified. Do not claim a passed lint/build check executed tests.
 
-- [ ] **Step 5: Run focused tests and confirm GREEN**
+- [x] **Step 5: Run focused tests and confirm GREEN**
 
 Run: `cargo test --test review_readiness verification -- --nocapture && cargo test review::readiness -- --nocapture`
 
 Expected: readiness is canonical, deterministic, and blocks only specified outcomes.
 
-- [ ] **Step 6: Publication checkpoint**
+- [x] **Step 6: Publication checkpoint**
 
 When publication is authorized: `git add src/review tests && git commit -m "feat: project verification readiness"`.
 
@@ -362,35 +362,35 @@ When publication is authorized: `git add src/review tests && git commit -m "feat
 - Consumes: configured policy, review target, changed/impact paths, scan-session revision, and `run_checks`.
 - Produces: usage exit 2 for policy/selection/target mismatch; findings exit 1 for blocking structured outcomes after rendering.
 
-- [ ] **Step 1: Write failing end-to-end CLI tests**
+- [x] **Step 1: Write failing end-to-end CLI tests**
 
 Cover no-request/no-spawn, repeated selection dedupe, deterministic order, unknown ID exit 2 before spawn, selected pass exit 0, failed/unavailable/timeout exit 1 after JSON is written, applicability skip, and ref mismatch exit 2 before spawn.
 
-- [ ] **Step 2: Run CLI tests and confirm RED**
+- [x] **Step 2: Run CLI tests and confirm RED**
 
 Run: `cargo test --test verification_cli -- --nocapture`
 
 Expected: clap rejects `--verify` or output lacks outcomes.
 
-- [ ] **Step 3: Wire selection after configuration load**
+- [x] **Step 3: Wire selection after configuration load**
 
 When `options.verify` is empty, bypass validation/execution entirely to preserve latency and behavior. Otherwise validate all configured checks and selected IDs, then validate target compatibility before any process spawn.
 
-- [ ] **Step 4: Execute after static report construction**
+- [x] **Step 4: Execute after static report construction**
 
 Build a sorted, deduplicated evidence-path vector from changed files plus impact paths. Time only verification execution, attach outcomes to `review_report`, then evaluate existing finding/review gates and readiness against the enriched report.
 
-- [ ] **Step 5: Apply structured exit after writing reports**
+- [x] **Step 5: Apply structured exit after writing reports**
 
 After console/Markdown/JSON and optional SARIF are written, return `CliExit { code: EXIT_FINDINGS, message: "RepoPilot verification blocked merge readiness" }` when any canonical verification reason blocks. Selection/config/target errors become `CliExit { code: EXIT_USAGE, ... }` before execution.
 
-- [ ] **Step 6: Run CLI and stabilization tests**
+- [x] **Step 6: Run CLI and stabilization tests**
 
 Run: `cargo test --test verification_cli -- --nocapture && cargo test --test cli_stabilization`
 
 Expected: all tests pass and existing review flows remain stable.
 
-- [ ] **Step 7: Publication checkpoint**
+- [x] **Step 7: Publication checkpoint**
 
 When publication is authorized: `git add src/cli/options/review.rs src/commands/review.rs tests && git commit -m "feat: run explicit review verification"`.
 
@@ -415,31 +415,31 @@ When publication is authorized: `git add src/cli/options/review.rs src/commands/
 - Produces: schema version `0.25`, while accepting `0.24` and existing supported versions.
 - Produces: bounded console and Markdown Verification sections after static evidence and before Next Action.
 
-- [ ] **Step 1: Write failing rendering and schema tests**
+- [x] **Step 1: Write failing rendering and schema tests**
 
 Assert exact status labels, check IDs, duration, exit code, truncation marker, sanitized excerpts, revision incompatibility, empty omission, and that summary detail still includes blocking verification evidence. Assert SARIF contains no verification execution record.
 
-- [ ] **Step 2: Run tests and confirm RED**
+- [x] **Step 2: Run tests and confirm RED**
 
 Run: `cargo test --test verification_cli rendering -- --nocapture && cargo test --test report_schema_contract`
 
 Expected: verification output/schema `0.25` is absent.
 
-- [ ] **Step 3: Render bounded human sections**
+- [x] **Step 3: Render bounded human sections**
 
 Show one line per outcome in canonical order and at most the already bounded stdout/stderr excerpts. Use plain stable labels, never reconstruct configured arguments, and show revision incompatibility prominently. Render nothing when outcomes are empty.
 
-- [ ] **Step 4: Advance the additive schema**
+- [x] **Step 4: Advance the additive schema**
 
 Set `SCAN_REPORT_SCHEMA_VERSION` to `0.25`, retain `0.24` in accepted versions, add the v0.25 fixture, and update exact schema/golden assertions. Serialize outcomes only under `merge_readiness.verification` and omit the field when empty.
 
-- [ ] **Step 5: Run output/schema tests and confirm GREEN**
+- [x] **Step 5: Run output/schema tests and confirm GREEN**
 
 Run: `cargo test --test verification_cli rendering -- --nocapture && cargo test --test review_console_detail && cargo test --test report_schema_contract`
 
 Expected: console, Markdown, JSON, and compatibility tests pass; SARIF remains static.
 
-- [ ] **Step 6: Publication checkpoint**
+- [x] **Step 6: Publication checkpoint**
 
 When publication is authorized: `git add src/review/render src/report tests && git commit -m "feat: report verification evidence"`.
 
@@ -458,25 +458,25 @@ When publication is authorized: `git add src/review/render src/report tests && g
 - Consumes: final user-facing CLI/config/output behavior.
 - Produces: an accurate local-first security/trust explanation and D1/D2 boundary.
 
-- [ ] **Step 1: Add no-request parity assertions**
+- [x] **Step 1: Add no-request parity assertions**
 
 Compare review JSON from a repository with no verification config and with a valid unselected check. Remove only the expected schema-version difference from the pre-D1 fixture and assert all remaining fields are identical; assert no marker file from the configured program exists.
 
-- [ ] **Step 2: Run parity test**
+- [x] **Step 2: Run parity test**
 
 Run: `cargo test --test verification_cli no_request -- --nocapture`
 
 Expected: PASS after Tasks 1–8.
 
-- [ ] **Step 3: Document the explicit trust boundary**
+- [x] **Step 3: Document the explicit trust boundary**
 
 Document configuration, `--verify`, limits, applicability, exit codes, clean-ref requirement, environment clearing, direct execution, and the fact that repository-controlled code is not sandboxed. Mark the spec `in-progress` during implementation and `done` only after the full gate.
 
-- [ ] **Step 4: Refresh required generated artifacts**
+- [x] **Step 4: Refresh required generated artifacts**
 
 Run: `python3 scripts/release-contract.py check`. If it reports a precise generator command, run that command and inspect the diff; do not manually edit generated output.
 
-- [ ] **Step 5: Publication checkpoint**
+- [x] **Step 5: Publication checkpoint**
 
 When publication is authorized: `git add CHANGELOG.md README.md docs tests/verification_cli.rs && git commit -m "docs: explain explicit review verification"`.
 
@@ -490,27 +490,27 @@ When publication is authorized: `git add CHANGELOG.md README.md docs tests/verif
 **Interfaces:**
 - Produces: a handoff-ready D1 slice with no known failing contract.
 
-- [ ] **Step 1: Run focused D1 suite**
+- [x] **Step 1: Run focused D1 suite**
 
 Run: `cargo test verification --all-targets -- --nocapture && cargo test --test verification_cli -- --nocapture && cargo test --test review_readiness && cargo test --test report_schema_contract`
 
 Expected: all pass.
 
-- [ ] **Step 2: Run the RepoPilot full gate**
+- [x] **Step 2: Run the RepoPilot full gate**
 
 Use `source-command-rp-gate` so the frozen tree is checked with formatting, Clippy `-D warnings`, all Rust tests, Python and npm release contracts, and the priority-P1 self-scan.
 
 Expected: every gate passes on the same tree.
 
-- [ ] **Step 3: Run platform evidence available in CI**
+- [x] **Step 3: Run platform evidence available in CI**
 
 Confirm the PR matrix runs the descendant-cleanup executor tests on Linux, macOS, and Windows. A platform failure blocks handoff; do not waive it as platform-only.
 
-- [ ] **Step 4: Complete the spec and review the final diff**
+- [x] **Step 4: Complete the spec and review the final diff**
 
 Set spec status to `done`, run `git diff --check`, inspect `git status --short`, and confirm there are no MCP/cache/scan-side verification changes and no raw synthetic secrets in tracked files.
 
-- [ ] **Step 5: Publication checkpoint**
+- [x] **Step 5: Publication checkpoint**
 
 Only after explicit user authorization: create a focused commit set, push `feat/v0.22-explicit-verification-review`, and open a draft PR with what/why/tests and D2 explicitly deferred.
 

--- a/docs/engineering/v0.22-d1-review-verification-spec.md
+++ b/docs/engineering/v0.22-d1-review-verification-spec.md
@@ -1,6 +1,6 @@
 # RepoPilot 0.22 D1 — Explicit Review Verification
 
-Status: in-progress
+Status: done
 
 ## Purpose
 

--- a/docs/engineering/v0.22-d2-mcp-verification-plan.md
+++ b/docs/engineering/v0.22-d2-mcp-verification-plan.md
@@ -1,0 +1,598 @@
+# RepoPilot 0.22 D2 MCP Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose D1's explicit repository-defined verification through `repopilot_review_change` with honest MCP effects, live cancellation, bounded progress, and transactional session publication.
+
+**Architecture:** Keep one verification policy and executor. Generalize the command adapter so CLI and MCP supply their own cancellation token and lifecycle observer, split MCP request lifecycle code out of the oversized server module, and defer analysis-store mutation until the final response is valid, bounded, uncancelled, and revision-compatible.
+
+**Tech Stack:** Rust 2024, serde/serde_json, stdio JSON-RPC MCP, standard-library threads/channels, the existing `AnalysisSession`, verification executor, and platform process-tree controls.
+
+**Spec:** `docs/engineering/v0.22-d2-mcp-verification-spec.md`
+
+## Global Constraints
+
+- Extend `repopilot_review_change`; do not add a seventh MCP tool or a new CLI command.
+- Accept only configured check IDs through optional `verify: string[]`; never accept commands, arguments, environment, paths, timeouts, or limits at call time.
+- Missing and empty `verify` must spawn no process and preserve the existing report shape.
+- Reuse D1 validation, applicability, ordering, executor, redaction, revision, outcome, readiness, and rendering behavior.
+- Tool annotations are static and conservative: `readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=false`, `openWorldHint=true`.
+- Cancellation must prevent later process starts and terminate the active managed process tree.
+- Cancelled and revision-incompatible calls must not create a handle or replace `last_review`.
+- Failed but revision-compatible checks are valid evidence and may be published.
+- Progress payloads contain lifecycle state and check IDs only; never command text, arguments, environment, stdout, or stderr.
+- Verification remains sequential and deterministic; D2 adds no cache or parallel scheduling.
+- Keep touched Rust source files near 300 lines and functions near 50 lines; split focused modules instead of extending `src/commands/mcp/mod.rs`.
+- Do not commit or push any checkpoint until the user explicitly authorizes publication.
+
+---
+
+### Task 1: Add observable execution to the shared verification core
+
+**Files:**
+- Modify: `src/verification/executor.rs`
+- Modify: `src/verification/mod.rs`
+- Modify: `src/verification/executor/tests.rs`
+
+**Interfaces:**
+- Produces: `VerificationExecutionEvent::{Started, Completed}` carrying `check_id`, one-based `index`, `total`, and completion `VerificationStatus`.
+- Produces: `run_checks_observed(..., observer: &mut dyn FnMut(VerificationExecutionEvent)) -> Vec<VerificationOutcome>`.
+- Preserves: `run_checks(...) -> Vec<VerificationOutcome>` as a no-observer wrapper for all existing callers.
+
+- [x] **Step 1: Write failing ordering and cancellation tests**
+
+Add executor tests that capture events and assert this exact sequence for two checks:
+
+```rust
+assert_eq!(events, vec![
+    VerificationExecutionEvent::Started { check_id: "lint".into(), index: 1, total: 2 },
+    VerificationExecutionEvent::Completed { check_id: "lint".into(), index: 1, total: 2, status: VerificationStatus::Passed },
+    VerificationExecutionEvent::Started { check_id: "unit".into(), index: 2, total: 2 },
+    VerificationExecutionEvent::Completed { check_id: "unit".into(), index: 2, total: 2, status: VerificationStatus::Passed },
+]);
+```
+
+Add a second test whose observer cancels after the first completion and assert that the second executable never creates its marker file.
+
+- [x] **Step 2: Prove the tests fail for the missing API**
+
+Run:
+
+```bash
+cargo test verification::executor::tests::observed_checks_emit_ordered_lifecycle
+cargo test verification::executor::tests::observer_cancellation_prevents_next_spawn
+```
+
+Expected: compile failure because `VerificationExecutionEvent` and `run_checks_observed` do not exist.
+
+- [x] **Step 3: Implement the minimal observer API**
+
+Define the event beside executor behavior and make the current entry point delegate to the observed variant:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationExecutionEvent {
+    Started { check_id: String, index: usize, total: usize },
+    Completed {
+        check_id: String,
+        index: usize,
+        total: usize,
+        status: VerificationStatus,
+    },
+}
+
+pub fn run_checks(/* existing arguments */) -> Vec<VerificationOutcome> {
+    run_checks_observed(/* existing arguments */, &mut |_| {})
+}
+```
+
+Emit `Started` immediately before `execute_check`, emit `Completed` immediately after its bounded outcome exists, and retain the existing revision-change and cancellation breaks.
+
+- [x] **Step 4: Run focused verification tests**
+
+Run:
+
+```bash
+cargo test verification::executor
+```
+
+Expected: all executor tests pass, including unchanged D1 timeout, redaction, revision, and process-tree tests.
+
+- [x] **Step 5: Publication checkpoint**
+
+Review `git diff --check` and the focused diff. If publication has been explicitly authorized, commit only these files as `refactor(verification): expose execution lifecycle`.
+
+---
+
+### Task 2: Generalize the D1 command adapter without changing CLI behavior
+
+**Files:**
+- Modify: `src/commands/review_verification.rs`
+- Modify: `src/commands/review.rs`
+- Create: `src/commands/review_verification/tests.rs`
+
+**Interfaces:**
+- Consumes: `run_checks_observed` and `VerificationExecutionEvent` from Task 1.
+- Produces: `ReviewVerificationEvent::{Started, Completed}` with the same safe fields.
+- Produces: `run_selected_with_context(selected, session, target, report, cancellation, observer) -> Result<(), Box<dyn Error>>`.
+- Produces: `run_selected(selected, session, target, report)` as the CLI wrapper that uses a fresh token and a no-op observer; `review.rs` stops passing its separately loaded config copy.
+
+- [x] **Step 1: Split and add failing adapter tests**
+
+Move inline unit tests into `src/commands/review_verification/tests.rs`. Add tests that:
+
+```rust
+let token = CancellationToken::new();
+let mut events = Vec::new();
+run_selected_with_context(
+    &["unit".into()],
+    &session,
+    &target,
+    &mut report,
+    &token,
+    &mut |event| events.push(event),
+)?;
+assert_eq!(events.len(), 2);
+assert_eq!(report.verification.len(), 1);
+```
+
+Add a no-selector test asserting the observer is untouched and `report.verification` stays empty.
+
+- [x] **Step 2: Prove the adapter tests fail**
+
+Run:
+
+```bash
+cargo test commands::review_verification::tests
+```
+
+Expected: compile failure because the context-aware function and event type are absent.
+
+- [x] **Step 3: Implement the shared adapter**
+
+Change the implementation to read policy from `session.repo_config()` so CLI and MCP cannot supply mismatched configuration:
+
+```rust
+pub(super) fn run_selected_with_context(
+    selected: &[String],
+    session: &AnalysisSession,
+    target: &OwnedDiffTarget,
+    report: &mut ReviewReport,
+    cancellation: &CancellationToken,
+    observer: &mut dyn FnMut(ReviewVerificationEvent),
+) -> Result<(), Box<dyn std::error::Error>>
+```
+
+Keep evidence-path collection, timing, target validation, selection, and outcome attachment in this one adapter. Keep `run_selected` as the unchanged CLI-facing wrapper.
+
+- [x] **Step 4: Run CLI and adapter regressions**
+
+Run:
+
+```bash
+cargo test commands::review_verification::tests
+cargo test --test cli_stabilization
+cargo test --test review_readiness
+```
+
+Expected: all pass and existing CLI JSON/readiness behavior remains unchanged.
+
+- [x] **Step 5: Publication checkpoint**
+
+Run `git diff --check`. If publication has been explicitly authorized, commit this slice as `refactor(review): share verification call context`.
+
+---
+
+### Task 3: Add the explicit MCP input and typed review result
+
+**Files:**
+- Modify: `src/commands/mcp/review_change.rs`
+- Create: `src/commands/mcp/review_change/tests.rs`
+- Modify: `src/commands/mcp/tests.rs`
+
+**Interfaces:**
+- Consumes: `run_selected_with_context` from Task 2.
+- Produces: `ReviewCallContext<'a> { cancellation: &'a CancellationToken, observer: &'a mut dyn FnMut(ReviewVerificationEvent) }`.
+- Produces: `ReviewCallResult { rendered: String }`; Task 5 adds revision metadata together with its first consumer so no dead fields are introduced.
+- Produces: `ReviewCallError::{Cancelled, Message(String)}` so cancellation is not flattened into a tool-content error.
+
+- [x] **Step 1: Add failing schema, annotation, and no-request tests**
+
+Assert the tool definition contains:
+
+```rust
+assert_eq!(review["inputSchema"]["properties"]["verify"]["uniqueItems"], true);
+assert_eq!(review["annotations"]["readOnlyHint"], false);
+assert_eq!(review["annotations"]["destructiveHint"], true);
+assert_eq!(review["annotations"]["idempotentHint"], false);
+assert_eq!(review["annotations"]["openWorldHint"], true);
+```
+
+Add review-call tests showing missing and empty `verify` produce identical JSON and never invoke the observer.
+
+- [x] **Step 2: Prove the MCP review tests fail**
+
+Run:
+
+```bash
+cargo test commands::mcp::review_change::tests
+cargo test commands::mcp::tests::lists_supported_tools
+```
+
+Expected: failures on the missing schema and old read-only annotations.
+
+- [x] **Step 3: Implement parsing and typed execution**
+
+Parse `verify` with an explicit type check:
+
+```rust
+fn verification_ids(arguments: &Value) -> Result<Vec<String>, ReviewCallError>
+```
+
+Reject non-arrays and non-string elements before scanning. After `build_review_report_from_session`, check cancellation, call the shared adapter, and render the canonical report. Task 5 retains the session revision and computes:
+
+```rust
+let revision_compatible = review_report
+    .verification
+    .iter()
+    .all(|outcome| outcome.revision_compatible);
+```
+
+Keep full/compact projection outside the canonical report construction.
+Update the tool description to state that non-empty `verify` runs only configured
+local checks, may modify workspace files or contact external systems, and returns
+bounded redacted evidence.
+
+- [x] **Step 4: Run review and MCP definition tests**
+
+Run:
+
+```bash
+cargo test commands::mcp::review_change
+cargo test commands::mcp::tests
+```
+
+Expected: the review schema/effect tests pass and the tool list still contains exactly six tools.
+
+- [x] **Step 5: Publication checkpoint**
+
+Run `git diff --check`. If authorized, commit this slice as `feat(mcp): accept configured review checks`.
+
+---
+
+### Task 4: Replace cancellation markers with a request registry
+
+**Files:**
+- Create: `src/commands/mcp/request_registry.rs`
+- Create: `src/commands/mcp/request_registry/tests.rs`
+- Create: `src/commands/mcp/worker.rs`
+- Modify: `src/commands/mcp/mod.rs`
+- Modify: `src/commands/mcp/tool_call.rs`
+
+**Interfaces:**
+- Produces: `RequestRegistry` with `register(key, token)`, `cancel(key)`, and `finish(key)`.
+- Produces: `ToolJob { id, params, progress_token, cancellation }`.
+- Changes: `handle_tools_call(..., cancellation: &CancellationToken, observer: &mut dyn FnMut(ReviewVerificationEvent))`.
+- Preserves: one worker thread and newline-delimited stdio JSON-RPC.
+
+- [x] **Step 1: Add failing registry state-machine tests**
+
+Cover these transitions independently:
+
+```text
+cancel before register -> pending marker -> registered token already cancelled
+register then cancel -> active token cancelled
+repeated cancel -> idempotent
+finish -> no pending marker and no active token
+```
+
+Also assert a reused request ID receives a fresh uncancelled token after `finish`.
+Add a worker test with a failing writer and assert registry cleanup still occurs.
+
+- [x] **Step 2: Prove registry tests fail**
+
+Run:
+
+```bash
+cargo test commands::mcp::request_registry::tests
+```
+
+Expected: compile failure because `RequestRegistry` is absent.
+
+- [x] **Step 3: Implement the registry and split the worker**
+
+Use focused state:
+
+```rust
+#[derive(Default)]
+pub(super) struct RequestRegistry {
+    pending: HashSet<String>,
+    active: HashMap<String, CancellationToken>,
+}
+```
+
+At tool-call acceptance create/register the token before enqueueing. On cancellation call `token.cancel()` when active, otherwise retain a pending marker. Move `ToolJob`, `run_tool_worker`, and progress writing from `mod.rs` into `worker.rs`; use a scope guard or single exit path so `finish` runs on every worker outcome.
+
+- [x] **Step 4: Wire typed cancellation through review execution**
+
+Check the token before dispatch, between analysis and verification, and before publication. Convert `ReviewCallError::Cancelled` to JSON-RPC error `-32800`; keep check failures as normal MCP tool results.
+
+- [x] **Step 5: Run lifecycle regressions**
+
+Run:
+
+```bash
+cargo test commands::mcp::request_registry
+cargo test commands::mcp::tests
+cargo test --test mcp_cli mcp_server_cancels_background_tool_calls
+```
+
+Expected: all pass; cancellation remains responsive while the worker holds `ServerState`.
+
+- [x] **Step 6: Publication checkpoint**
+
+Confirm `src/commands/mcp/mod.rs` is reduced toward the 300-line project limit and run `git diff --check`. If authorized, commit as `refactor(mcp): own active request cancellation`.
+
+---
+
+### Task 5: Make analysis publication transactional and revision-aware
+
+**Files:**
+- Modify: `src/commands/mcp/analysis_store.rs`
+- Modify: `src/commands/mcp/tool_call.rs`
+- Modify: `src/commands/mcp/tests.rs`
+- Modify: `src/commands/mcp/workspace_freshness_tests.rs`
+
+**Interfaces:**
+- Produces: `AnalysisStore::prospective_handle(kind, report, workspace_revision) -> String` without mutation.
+- Produces: `AnalysisStore::publish(kind, report, workspace_revision) -> String` with the same deterministic handle.
+- Extends: `ReviewCallResult` with `analysis_revision: String` and `revision_compatible: bool`, immediately consumed by publication policy.
+- Changes: response compaction, pagination, and size validation complete before `publish` and `last_review` mutation.
+
+- [x] **Step 1: Add failing transactional-publication tests**
+
+Add tests proving each condition leaves `analyses` and `last_review` unchanged:
+
+```text
+cancelled after analysis
+revision-incompatible verification outcome
+workspace revision changed after analysis
+pagination/compaction error
+response larger than max_response_bytes
+```
+
+Add the positive guard: a failed check with `revision_compatible=true` is published and replayable.
+
+- [x] **Step 2: Prove the tests expose current premature mutation**
+
+Run:
+
+```bash
+cargo test commands::mcp::tests::review_publication
+cargo test commands::mcp::workspace_freshness_tests
+```
+
+Expected: at least the oversized/late-cancellation cases fail because current code inserts before final response validation.
+
+- [x] **Step 3: Separate preparation from commit**
+
+Create a private prepared value:
+
+```rust
+struct PreparedAnalysis {
+    result: Value,
+    kind: AnalysisKind,
+    full_report: String,
+    client_report: String,
+    workspace_revision: String,
+}
+```
+
+Build and bound `result` with a prospective handle, then publish only if the cancellation token is still clear and review metadata says the analysis revision equals the captured response revision and all outcomes are revision-compatible. Oversized errors must contain no handle that was not stored.
+
+- [x] **Step 4: Run handle, pagination, and freshness suites**
+
+Run:
+
+```bash
+cargo test commands::mcp::analysis_store
+cargo test commands::mcp::tests
+cargo test commands::mcp::workspace_freshness_tests
+cargo test --test removed_export_mcp
+```
+
+Expected: existing handle formats remain stable and all new no-publication guarantees pass.
+
+- [x] **Step 5: Publication checkpoint**
+
+Run `git diff --check`. If authorized, commit as `fix(mcp): publish only valid review analyses`.
+
+---
+
+### Task 6: Emit bounded check-aware MCP progress
+
+**Files:**
+- Create: `src/commands/mcp/progress.rs`
+- Create: `src/commands/mcp/progress/tests.rs`
+- Modify: `src/commands/mcp/worker.rs`
+- Modify: `src/commands/mcp/tool_call.rs`
+- Modify: `tests/mcp_cli.rs`
+
+**Interfaces:**
+- Produces: `ProgressReporter` that owns only the optional MCP progress token and bounded notification sink.
+- Consumes: `ReviewVerificationEvent` from Task 2.
+- Preserves: the existing two-notification `total=1` sequence for non-review tools; review uses the D2 `N + 2` work model even when `N=0`.
+
+- [x] **Step 1: Add failing progress-sequence tests**
+
+For two checks, assert monotonic work units with `total=4`:
+
+```text
+0 analysis started
+1 analysis complete
+1 lint started
+2 lint passed
+2 unit started
+3 unit failed
+4 review complete
+```
+
+For review without checks, assert `0 analysis started`, `1 analysis complete`,
+and `2 review complete` with `total=2`. Keep the existing scan progress test at
+two notifications with `total=1`.
+
+Assert messages include check IDs and statuses but exclude a configured secret argument and captured child output. Add cancellation coverage asserting no event follows acknowledgement.
+
+- [x] **Step 2: Prove progress tests fail**
+
+Run:
+
+```bash
+cargo test commands::mcp::progress::tests
+cargo test --test mcp_cli mcp_server_emits_progress_for_tool_calls
+```
+
+Expected: new multi-check tests fail because current progress supports only analysis start/completion.
+
+- [x] **Step 3: Implement the bounded reporter**
+
+Encode notifications in `progress.rs`. Derive `total = selected_check_count + 2`; treat each completed or skipped check as one unit. Emit lifecycle text from fixed templates plus validated check ID and `VerificationStatus`, never child evidence.
+
+- [x] **Step 4: Wire progress without changing no-token results**
+
+Pass the reporter callback through `worker -> tool_call -> review_change -> review_verification`. Stop emission when cancellation is observed. An omitted token uses a no-op sink and produces the identical final tool result.
+
+- [x] **Step 5: Run progress and response-bound tests**
+
+Run:
+
+```bash
+cargo test commands::mcp::progress
+cargo test --test mcp_cli mcp_server_emits_progress_for_tool_calls
+cargo test --test mcp_cli
+```
+
+Expected: progress is monotonic/bounded and response limiting remains unchanged.
+
+- [x] **Step 6: Publication checkpoint**
+
+Run `git diff --check`. If authorized, commit as `feat(mcp): report verification progress`.
+
+---
+
+### Task 7: Prove end-to-end trust, cancellation, and compatibility
+
+**Files:**
+- Create: `tests/mcp_verification.rs`
+- Modify: `tests/mcp_cli.rs`
+- Modify: `docs/roadmap/v0.22.md`
+- Modify: `docs/engineering/v0.22-d2-mcp-verification-spec.md`
+- Modify: `CHANGELOG.md`
+- Modify if generated output changes: `docs/rules-reference.md`
+
+**Interfaces:**
+- Exercises the public stdio MCP contract only.
+- Produces no new runtime API.
+
+- [x] **Step 1: Add end-to-end fixture helpers**
+
+Create temporary Git repositories and repository-local `repopilot.toml` checks using platform-neutral Rust test helpers. Record process execution with marker files; use the existing platform process-tree fixture pattern for long-running cancellation.
+
+- [x] **Step 2: Add the acceptance matrix**
+
+Cover:
+
+```text
+missing/empty verify -> no marker
+selected configured ID -> exactly one marker and one canonical outcome
+duplicate IDs -> deterministic single execution
+unknown ID/invalid policy -> isError before marker
+failed/timeout/unavailable -> blocked inspectable report
+cancel active check -> JSON-RPC -32800 and descendant termination
+cancel before/during analysis -> no verification marker
+cancel/revision mismatch -> previous last_review and handles unchanged
+revision-compatible failure -> stored and explainable
+root escape/ref-range incompatibility -> bounded error before spawn
+secret-like stdout/stderr -> redacted report and progress
+```
+
+- [x] **Step 3: Run the end-to-end MCP verification suite**
+
+Run:
+
+```bash
+cargo test --test mcp_verification
+cargo test --test mcp_cli
+```
+
+Expected: every acceptance case passes on the current platform.
+
+- [x] **Step 4: Update user-facing documentation**
+
+Document the optional `verify` array, explicit local effect boundary, cancellation behavior, and lack of caching. Mark D2 roadmap items complete only for behavior proven by tests. Add one concise `[Unreleased]` changelog entry.
+
+- [x] **Step 5: Refresh generated artifacts only when required**
+
+Run:
+
+```bash
+cargo test --test rules_reference_doc
+```
+
+Expected: PASS with no rules-reference change because D2 adds no rule. If the
+drift guard fails for a legitimate registry change, regenerate with
+`REPOPILOT_BLESS=1 cargo test --test rules_reference_doc` and explain why that
+unrelated-looking generated diff is required.
+
+- [x] **Step 6: Publication checkpoint**
+
+Run `git diff --check`. If authorized, commit tests and docs as `test(mcp): prove explicit review verification`.
+
+---
+
+### Task 8: Run release-quality verification and close D2
+
+**Files:**
+- Modify: `docs/engineering/v0.22-d2-mcp-verification-spec.md`
+- Modify: `docs/engineering/v0.22-d2-mcp-verification-plan.md`
+
+**Interfaces:**
+- Verifies the complete D2 contract; adds no product API.
+
+- [x] **Step 1: Run focused D2 suites**
+
+Run:
+
+```bash
+cargo test verification::executor
+cargo test commands::review_verification
+cargo test commands::mcp
+cargo test --test mcp_verification
+cargo test --test mcp_cli
+cargo test --test cli_stabilization
+cargo test --test review_readiness
+```
+
+Expected: all pass.
+
+- [x] **Step 2: Run the full RepoPilot handoff gate**
+
+Follow `.agents/skills/source-command-rp-gate/SKILL.md`, including formatting, Clippy, all tests, release contract, review performance, and self-scan.
+
+Expected: every gate passes without waived warnings.
+
+- [ ] **Step 3: Confirm platform evidence**
+
+Push only after explicit authorization, then require Linux, macOS, and Windows CI smoke to pass. Confirm the Windows Job Object path terminates verification descendants and no platform-specific shell assumption entered the MCP tests.
+
+- [x] **Step 4: Check no-verification performance**
+
+Run the existing review performance command from `package.json` against the same baseline and candidate inputs. The no-`verify` scenario must remain within the spec's 10% regression ceiling.
+
+- [ ] **Step 5: Close the documents truthfully**
+
+After all local and platform evidence is green, set the spec status to `done`, mark only completed plan boxes, run `git diff --check`, and inspect the final diff for secrets, unrelated changes, duplicated verification logic, and source files still materially above project size limits.
+
+- [ ] **Step 6: Final publication checkpoint**
+
+When explicitly requested, commit remaining status updates, push `feat/v0.22-mcp-verification`, and open a draft PR with what/why/tests/risks. Do not merge automatically.

--- a/docs/engineering/v0.22-d2-mcp-verification-spec.md
+++ b/docs/engineering/v0.22-d2-mcp-verification-spec.md
@@ -1,0 +1,333 @@
+# RepoPilot 0.22 D2 — Explicit MCP Verification
+
+Status: in-progress
+
+**Parent:** [RepoPilot 0.22 roadmap](../roadmap/v0.22.md)
+**Predecessor:** [D1 explicit review verification](v0.22-d1-review-verification-spec.md)
+
+## Purpose
+
+D1 made repository-defined checks executable through an explicit CLI request and
+projected their outcomes into the canonical review-readiness record. D2 exposes
+that same capability through the existing `repopilot_review_change` MCP tool
+without adding a seventh tool, accepting call-time commands, or creating a
+second verification implementation.
+
+The product flow becomes:
+
+```text
+agent selects configured check IDs
+  -> MCP validates the effectful request
+  -> shared review analysis runs
+  -> shared D1 verifier executes selected checks
+  -> one canonical readiness report is returned
+```
+
+This slice is MCP parity only. Verification caching, `scan` execution, GitHub
+Action inputs, parallel checks, and automatic satisfaction of static reasons
+remain separate follow-ups.
+
+## Product Decisions
+
+1. Extend `repopilot_review_change`; do not add a new MCP tool.
+2. Accept only configured check IDs through a `verify` array.
+3. Treat absent and empty `verify` identically: no process is spawned and the
+   report omits empty verification outcomes.
+4. Reuse the D1 policy, executor, redaction, outcome, readiness, and rendering
+   contracts unchanged.
+5. Advertise the review tool as potentially effectful because MCP annotations
+   are static and cannot vary by arguments.
+6. Map an MCP cancellation notification to the shared verification
+   `CancellationToken` so an active child process and its descendants terminate.
+7. Do not publish cancelled or revision-incompatible reviews into MCP session
+   state.
+8. Keep the single-worker execution model; D2 adds no parallel tool or check
+   scheduling.
+
+## MCP Input Contract
+
+`repopilot_review_change` gains one optional property:
+
+```json
+{
+  "verify": ["unit", "lint"]
+}
+```
+
+The schema is:
+
+```json
+{
+  "type": "array",
+  "items": { "type": "string" },
+  "uniqueItems": true,
+  "description": "Configured local verification check IDs to run explicitly."
+}
+```
+
+Runtime behavior remains deterministic even if a client ignores
+`uniqueItems`: IDs are deduplicated and executed in lexicographic order by the
+shared D1 selection policy.
+
+The request cannot provide:
+
+- a program or shell command;
+- arguments;
+- a working directory;
+- environment variables;
+- a timeout or output limit;
+- applicability paths;
+- an execution order.
+
+All of those values remain repository policy loaded from the same
+`repopilot.toml` selected by the existing MCP `config` argument. Unknown IDs,
+invalid verification configuration, root escapes, and incompatible ref-range
+targets return an MCP tool error before any verification process starts.
+
+Check failures, timeouts, and unavailable executables are evidence, not protocol
+failures. They return a successful MCP tool result containing the blocked
+canonical readiness report. This lets the agent inspect the failure instead of
+losing it behind a transport error.
+
+## Effect and Trust Contract
+
+The `repopilot_review_change` definition uses conservative, call-independent
+annotations:
+
+```json
+{
+  "readOnlyHint": false,
+  "destructiveHint": true,
+  "idempotentHint": false,
+  "openWorldHint": true
+}
+```
+
+This is intentionally stricter than the no-`verify` path. Configured build,
+test, lint, and type-check commands may create or modify local artifacts, and
+MCP annotations cannot describe conditional effects. `openWorldHint` is true
+because a repository-defined executable may contact external systems even
+though RepoPilot itself performs no network operation and grants no additional
+network authority. The server cannot prove the configured command is local-only.
+
+The tool description must state that:
+
+- verification runs only when `verify` is explicitly present and non-empty;
+- only repository-configured IDs are accepted;
+- selected checks execute local processes and may change workspace files;
+- stdout and stderr are bounded and redacted before projection.
+
+No secret-bearing command, argument, environment value, or raw child output is
+included in progress notifications, transport errors, analysis summaries, or
+handles.
+
+## Shared Execution Boundary
+
+D2 generalizes the command-side D1 adapter rather than duplicating it. The
+shared adapter receives:
+
+- selected check IDs;
+- the immutable `AnalysisSession` and its repository configuration;
+- the selected review target;
+- the canonical `ReviewReport` under construction;
+- a caller-owned `CancellationToken`;
+- an optional progress observer.
+
+The CLI supplies a fresh uncancelled token and no MCP observer, preserving D1
+behavior. MCP supplies the request token and a bounded observer. Policy
+validation, evidence-path collection, execution ordering, revision checks, and
+outcome attachment remain one implementation.
+
+The observer reports structured lifecycle events only:
+
+```text
+analysis-started
+analysis-complete
+verification-started(check_id, index, total)
+verification-complete(check_id, index, total, status)
+review-complete
+```
+
+It never receives or emits command text, arguments, environment, stdout, or
+stderr. CLI progress rendering and MCP JSON-RPC encoding remain adapters outside
+the verification core.
+
+## Cancellation Lifecycle
+
+The MCP server replaces its cancellation-only `HashSet` with a focused request
+registry that owns pending cancellation markers and active tokens.
+
+```text
+tools/call accepted
+  -> create token
+  -> register request ID + token
+  -> enqueue worker job
+
+notifications/cancelled
+  -> find active token and cancel it
+  -> or retain a pending marker if the job has not started
+
+worker completion
+  -> remove token and pending marker
+```
+
+Required semantics:
+
+- cancellation before the worker starts prevents analysis and verification;
+- cancellation during static analysis prevents verification from starting and
+  returns JSON-RPC error `-32800` after the current non-cooperative analysis
+  boundary finishes;
+- cancellation during a verification check causes the D1 executor to terminate
+  the complete managed process tree;
+- cancellation between checks prevents the next check from spawning;
+- a cancelled call returns JSON-RPC error `-32800`, not a normal readiness
+  report;
+- a cancelled call creates no analysis handle and does not replace
+  `last_review`;
+- registry cleanup happens on success, tool error, cancellation, writer error,
+  and worker shutdown.
+
+D2 does not thread cooperative cancellation through every scan rule. That is a
+separate engine concern; the promise in this slice is immediate cancellation of
+verification processes and no new process after cancellation.
+
+## Progress Contract
+
+When the client supplies an MCP progress token, notifications are monotonic and
+bounded. The server reports analysis start/completion, each selected check
+start/completion, and final review completion. Each notification includes
+`progress`, `total`, and a stable human-readable message.
+
+For `N` selected checks, total work units are `N + 2`: one analysis unit, `N`
+verification units, and one finalization unit. Inapplicable checks still consume
+their verification unit and report `skipped`. Without selected checks, the
+existing analysis start/completion behavior remains compatible.
+
+No progress notification is emitted after cancellation is acknowledged. A
+client that omits a progress token receives the same final result without
+notifications.
+
+## Report and Session-State Contract
+
+MCP returns the same JSON review projection as CLI D1, including ordered
+verification outcomes and canonical readiness reasons. Response bounding and
+finding pagination continue to use the existing MCP result layer.
+
+A result may update `last_review` and create an `analysis_handle` only when:
+
+- the tool call was not cancelled;
+- report construction and compaction succeeded;
+- every emitted verification outcome is revision-compatible;
+- the workspace revision captured for the analysis still matches the revision
+  used for the stored handle.
+
+A verification failure with a compatible revision is still stored: it is valid
+evidence. A revision-incompatible review is returned to the caller as a blocked
+report but receives no handle and does not replace the previous `last_review`.
+This prevents stale static evidence from becoming replayable under a new
+workspace revision.
+
+Unknown IDs and policy errors return `isError: true`, create no handle, and leave
+the previous session state unchanged.
+
+## Error Handling
+
+| Condition | MCP result | Process | Session state |
+|---|---|---|---|
+| no `verify` / empty array | normal report | none | stored normally |
+| unknown or invalid check policy | tool error | none | unchanged |
+| check failed / timed out / unavailable | blocked normal report | terminated | stored if revision-compatible |
+| check cancelled | JSON-RPC `-32800` | process tree terminated | unchanged |
+| workspace changed during verification | blocked normal report | remaining checks skipped | unchanged |
+| response too large | existing bounded MCP error | already complete | no partial publication |
+
+All tool errors remain bounded and must not include child output or secret-like
+configuration values.
+
+## Compatibility
+
+- No new top-level CLI command or MCP tool is added.
+- CLI `review --verify` behavior and schema v0.25 remain unchanged.
+- Static `repopilot_scan`, context, and explain tools remain read-only.
+- Review calls without `verify` preserve their runtime and report behavior; only
+  the static tool annotations become conservatively effectful.
+- SARIF, scan reports, baselines, receipts, history, AI context, and GitHub
+  Action inputs do not change.
+- The existing MCP protocol versions, response limit, root confinement,
+  pagination, and analysis-handle formats remain stable.
+
+## Performance Contract
+
+- A review without `verify` adds no process, filesystem walk, or config reload
+  beyond constant-time cancellation-context setup.
+- Verification remains sequential and deterministic.
+- Progress reporting performs bounded writes and never buffers child output.
+- D2 adds no verification cache and makes no cached-result claim.
+- Existing review performance budgets must not regress by more than 10% in the
+  no-verification scenario.
+
+## Test Strategy
+
+Focused unit tests cover:
+
+- request-registry pending, active, repeated, and cleanup transitions;
+- shared adapter use by CLI and MCP callers;
+- progress ordering, totals, and redaction-safe payloads;
+- session publication decisions for success, failure, cancellation, and
+  revision change;
+- conservative MCP annotations and the `verify` input schema.
+
+End-to-end MCP tests cover:
+
+- no-request parity and no process spawn;
+- one selected configured check running exactly once;
+- duplicate selectors remaining deterministic;
+- unknown IDs and invalid policy failing before spawn;
+- failed checks returning inspectable blocked readiness evidence;
+- cancellation terminating a long-running child and descendants;
+- cancellation leaving the prior `last_review` and handles unchanged;
+- monotonic progress across analysis and multiple checks;
+- output redaction and response bounds;
+- revision mutation returning blocked evidence without reusable state;
+- ref-range incompatibility and workspace-root confinement.
+
+Existing CLI verification, MCP freshness, handle, pagination, cancellation,
+progress, release-contract, and platform-smoke suites remain regression gates.
+
+## Out of Scope
+
+- Verification result caching or cache telemetry.
+- Verification through `repopilot_scan`.
+- GitHub Action verification inputs.
+- Parallel check execution.
+- Client-supplied commands, arguments, environment, limits, or paths.
+- Per-rule automatic satisfaction from a passed check.
+- Cooperative cancellation inside every static scan/audit loop.
+- A new MCP tool or protocol version.
+
+## Acceptance Criteria
+
+1. `repopilot_review_change` accepts an optional `verify` array and no other
+   call-time execution policy.
+2. Missing or empty `verify` spawns no process and preserves report parity.
+3. Selected IDs use the same D1 validation, applicability, ordering, executor,
+   redaction, and readiness code as CLI review.
+4. Unknown IDs and invalid policy produce a bounded MCP tool error before spawn.
+5. Failed, timed-out, unavailable, and skipped checks return inspectable
+   canonical outcomes rather than protocol failure.
+6. MCP cancellation terminates the active verification process tree and returns
+   JSON-RPC `-32800`.
+7. Cancellation before or during analysis prevents verification from starting.
+8. Cancelled calls create no handle and do not replace `last_review`.
+9. Revision-incompatible reports are returned blocked but are not stored or
+   replayable.
+10. Compatible failed verification reports may be stored because they are valid
+    evidence.
+11. Progress is monotonic, bounded, check-aware, and free of command/output
+    secrets.
+12. Tool annotations conservatively advertise potential local effects.
+13. Static MCP tools remain read-only and no seventh tool is introduced.
+14. CLI, SARIF, scan, Action, history, receipt, baseline, and AI-context
+    contracts remain unchanged.
+15. Focused tests, the full RepoPilot gate, no-verification performance gate,
+    and Linux/macOS/Windows platform smoke pass before handoff.

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -219,6 +219,16 @@ Definition of done:
 - fixtures cover success, failure, timeout, excessive output, missing executable,
   stale cache, redaction, and disabled execution.
 
+Delivery slices:
+
+- D1 delivers explicit CLI `review --verify` execution and canonical readiness
+  evidence;
+- D2 delivers the same configured checks through `repopilot_review_change`,
+  including honest effects, process-tree cancellation, bounded progress, and
+  revision-safe session publication;
+- verification-result caching remains a later Phase D slice and must satisfy
+  the cache-key and stale-evidence requirements above before Phase D is complete.
+
 ### Phase E — Product Convergence and Release Evidence
 
 Make the new core coherent across all supported product surfaces and validate it

--- a/src/commands/mcp/analysis_store.rs
+++ b/src/commands/mcp/analysis_store.rs
@@ -35,13 +35,22 @@ pub struct AnalysisStore {
 }
 
 impl AnalysisStore {
-    pub fn insert(
+    pub fn prospective_handle(
+        &self,
+        kind: AnalysisKind,
+        report: &str,
+        workspace_revision: &str,
+    ) -> String {
+        analysis_handle(kind, report, workspace_revision)
+    }
+
+    pub fn publish(
         &mut self,
         kind: AnalysisKind,
         report: String,
         workspace_revision: &str,
     ) -> String {
-        let handle = analysis_handle(kind, &report, workspace_revision);
+        let handle = self.prospective_handle(kind, &report, workspace_revision);
         if !self.records.contains_key(&handle) {
             self.order.push_back(handle.clone());
         }
@@ -109,12 +118,12 @@ mod summary_tests {
     #[test]
     fn summaries_are_newest_first_and_count_analysis_contents() {
         let mut store = AnalysisStore::default();
-        let scan = store.insert(
+        let scan = store.publish(
             AnalysisKind::Scan,
             json!({ "findings": [{ "id": "one" }] }).to_string(),
             "revision-1",
         );
-        let review = store.insert(
+        let review = store.publish(
             AnalysisKind::Review,
             json!({
                 "findings": [],
@@ -129,6 +138,19 @@ mod summary_tests {
         assert_eq!(summaries[0]["review_signals"], 2);
         assert_eq!(summaries[1]["analysis_handle"], scan);
         assert_eq!(summaries[1]["findings"], 1);
+    }
+
+    #[test]
+    fn prospective_handle_does_not_publish_until_commit() {
+        let mut store = AnalysisStore::default();
+        let report = json!({ "findings": [] }).to_string();
+
+        let prospective = store.prospective_handle(AnalysisKind::Review, &report, "revision-1");
+
+        assert!(store.get(&prospective).is_none());
+        let published = store.publish(AnalysisKind::Review, report, "revision-1");
+        assert_eq!(published, prospective);
+        assert!(store.get(&published).is_some());
     }
 }
 
@@ -227,9 +249,9 @@ mod tests {
     #[test]
     fn store_evicts_old_handles() {
         let mut store = AnalysisStore::default();
-        let first = store.insert(AnalysisKind::Scan, "first".into(), "r1");
+        let first = store.publish(AnalysisKind::Scan, "first".into(), "r1");
         for index in 0..MAX_STORED_ANALYSES {
-            store.insert(AnalysisKind::Scan, format!("report-{index}"), "r1");
+            store.publish(AnalysisKind::Scan, format!("report-{index}"), "r1");
         }
         assert!(store.get(&first).is_none());
     }

--- a/src/commands/mcp/catalog.rs
+++ b/src/commands/mcp/catalog.rs
@@ -1,0 +1,141 @@
+use super::{
+    ServerState, context, explain_file, explain_finding, explain_review_signal, review_change, scan,
+};
+use crate::commands::mcp::jsonrpc::Response;
+use serde_json::{Value, json};
+
+pub(super) fn tools_list_result() -> Value {
+    json!({
+        "tools": [
+            review_change::definition(),
+            scan::definition(),
+            context::definition(),
+            explain_file::definition(),
+            explain_finding::definition(),
+            explain_review_signal::definition(),
+        ]
+    })
+}
+
+pub(super) fn resources_list_result(state: &ServerState) -> Value {
+    let mut resources = vec![
+        json!({
+            "uri": "repopilot://rules",
+            "name": "RepoPilot rule catalog",
+            "mimeType": "application/json"
+        }),
+        json!({
+            "uri": "repopilot://repository-summary",
+            "name": "RepoPilot repository summary",
+            "mimeType": "application/json"
+        }),
+        json!({
+            "uri": "repopilot://analyses",
+            "name": "Available RepoPilot analysis handles",
+            "mimeType": "application/json"
+        }),
+    ];
+    if state.last_scan.is_some() {
+        resources.push(json!({
+            "uri": "repopilot://last-scan",
+            "name": "Last RepoPilot scan",
+            "mimeType": "application/json"
+        }));
+    }
+    if state.last_review.is_some() {
+        resources.push(json!({
+            "uri": "repopilot://last-review",
+            "name": "Last RepoPilot review",
+            "mimeType": "application/json"
+        }));
+    }
+    json!({ "resources": resources })
+}
+
+pub(super) fn handle_resource_read(id: Value, params: &Value, state: &ServerState) -> Response {
+    let uri = params
+        .get("uri")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let text = match uri {
+        "repopilot://analyses" => serde_json::to_string_pretty(&state.analyses.summaries())
+            .unwrap_or_else(|_| "[]".to_string()),
+        "repopilot://rules" => {
+            let rules = repopilot::rules::all_rule_metadata()
+                .map(|rule| {
+                    json!({
+                        "rule_id": rule.rule_id,
+                        "title": rule.title,
+                        "category": rule.category.label(),
+                        "severity": rule.default_severity.label(),
+                        "max_severity": rule.severity_ceiling().label(),
+                        "confidence": rule.default_confidence.label(),
+                        "max_confidence": rule.confidence_ceiling().label(),
+                        "lifecycle": rule.lifecycle.label(),
+                        "signal_source": rule.signal_source.label(),
+                        "docs_url": rule.docs_url
+                    })
+                })
+                .collect::<Vec<_>>();
+            serde_json::to_string_pretty(&rules).unwrap_or_else(|_| "[]".to_string())
+        }
+        "repopilot://last-scan" => state.last_scan.clone().unwrap_or_default(),
+        "repopilot://last-review" => state.last_review.clone().unwrap_or_default(),
+        "repopilot://repository-summary" => serde_json::to_string_pretty(&json!({
+            "root": state.root.to_string_lossy(),
+            "git_repository": state.root.join(".git").exists(),
+            "config_present": state.root.join("repopilot.toml").is_file(),
+            "baseline_present": state.root.join(".repopilot/baseline.json").is_file(),
+            "feedback_present": state.root.join(".repopilot/feedback.yml").is_file(),
+            "last_scan_available": state.last_scan.is_some(),
+            "last_review_available": state.last_review.is_some()
+        }))
+        .unwrap_or_else(|_| "{}".to_string()),
+        _ => return Response::error(id, -32002, format!("resource not found: {uri}")),
+    };
+    Response::success(
+        id,
+        json!({ "contents": [{ "uri": uri, "mimeType": "application/json", "text": text }] }),
+    )
+}
+
+pub(super) fn prompts_list_result() -> Value {
+    json!({
+        "prompts": [
+            {
+                "name": "review-change",
+                "description": "Review the current change with RepoPilot evidence."
+            },
+            {
+                "name": "fix-top-risk",
+                "description": "Plan the smallest fix for the highest-priority RepoPilot risk."
+            }
+        ]
+    })
+}
+
+pub(super) fn handle_prompt_get(id: Value, params: &Value) -> Response {
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let text = match name {
+        "review-change" => {
+            "Call repopilot_review_change, inspect definitely-sensitive signals first, and report evidence without claiming the change is safe."
+        }
+        "fix-top-risk" => {
+            "Call repopilot_scan, select the highest-priority evidence-backed finding, and propose the smallest verified remediation."
+        }
+        _ => return Response::error(id, -32602, format!("unknown prompt: {name}")),
+    };
+    Response::success(
+        id,
+        json!({
+            "description": text,
+            "messages": [{
+                "role": "user",
+                "content": { "type": "text", "text": text }
+            }]
+        }),
+    )
+}

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -7,15 +7,21 @@
 //! service is called).
 
 mod analysis_store;
+mod catalog;
 mod context;
 mod explain_file;
 mod explain_finding;
 mod explain_review_signal;
 mod jsonrpc;
+mod progress;
+mod publication;
+mod request_registry;
 mod review_change;
+mod review_projection;
 mod scan;
 mod scan_cache;
 mod tool_call;
+mod worker;
 
 #[cfg(test)]
 mod tests;
@@ -24,16 +30,20 @@ mod workspace_freshness_tests;
 
 use crate::cli::McpOptions;
 use analysis_store::AnalysisStore;
+use catalog::{
+    handle_prompt_get, handle_resource_read, prompts_list_result, resources_list_result,
+    tools_list_result,
+};
 use jsonrpc::{METHOD_NOT_FOUND, Request, Response};
-use serde::Serialize;
+#[cfg(test)]
+use publication::tool_result;
+use request_registry::RequestRegistry;
 use serde_json::{Value, json};
-use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, mpsc};
 use tool_call::handle_tools_call;
-#[cfg(test)]
-use tool_call::tool_result;
+use worker::{ToolJob, run_tool_worker, write_message};
 
 const SERVER_NAME: &str = "repopilot";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -102,16 +112,16 @@ fn serve_with_options<R: BufRead, W: Write + Send>(
         max_response_bytes,
         ..ServerState::default()
     }));
-    let cancelled = Arc::new(Mutex::new(HashSet::<String>::new()));
+    let registry = Arc::new(Mutex::new(RequestRegistry::default()));
     let writer = Arc::new(Mutex::new(&mut writer));
     let (jobs_tx, jobs_rx) = mpsc::channel::<ToolJob>();
 
     std::thread::scope(|scope| -> std::io::Result<()> {
         let worker_state = Arc::clone(&state);
-        let worker_cancelled = Arc::clone(&cancelled);
+        let worker_registry = Arc::clone(&registry);
         let worker_writer = Arc::clone(&writer);
         let worker = scope.spawn(move || {
-            run_tool_worker(jobs_rx, &worker_state, &worker_cancelled, &worker_writer)
+            run_tool_worker(jobs_rx, &worker_state, &worker_registry, &worker_writer)
         });
 
         for line in reader.lines() {
@@ -130,10 +140,10 @@ fn serve_with_options<R: BufRead, W: Write + Send>(
 
             if request.method == "notifications/cancelled" {
                 if let Some(request_id) = cancellation_request_id(&request.params) {
-                    cancelled
+                    registry
                         .lock()
                         .map_err(lock_error)?
-                        .insert(request_key(&request_id));
+                        .cancel(&request_key(&request_id));
                 }
                 continue;
             }
@@ -154,18 +164,27 @@ fn serve_with_options<R: BufRead, W: Write + Send>(
                     .get("_meta")
                     .and_then(|meta| meta.get("progressToken"))
                     .cloned();
-                jobs_tx
+                let key = request_key(&id);
+                let cancellation = repopilot::verification::CancellationToken::new();
+                registry
+                    .lock()
+                    .map_err(lock_error)?
+                    .register(key.clone(), cancellation.clone());
+                if jobs_tx
                     .send(ToolJob {
                         id,
                         params: request.params,
                         progress_token,
+                        cancellation,
                     })
-                    .map_err(|_| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::BrokenPipe,
-                            "MCP tool worker stopped",
-                        )
-                    })?;
+                    .is_err()
+                {
+                    registry.lock().map_err(lock_error)?.finish(&key);
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        "MCP tool worker stopped",
+                    ));
+                }
                 continue;
             }
 
@@ -183,74 +202,6 @@ fn serve_with_options<R: BufRead, W: Write + Send>(
             .join()
             .map_err(|_| std::io::Error::other("MCP tool worker panicked"))??;
         Ok(())
-    })
-}
-
-struct ToolJob {
-    id: Value,
-    params: Value,
-    progress_token: Option<Value>,
-}
-
-fn write_message<W: Write, T: Serialize>(
-    writer: &Arc<Mutex<&mut W>>,
-    message: &T,
-) -> std::io::Result<()> {
-    let encoded = serde_json::to_string(message)?;
-    let mut writer = writer.lock().map_err(lock_error)?;
-    writer.write_all(encoded.as_bytes())?;
-    writer.write_all(b"\n")?;
-    writer.flush()
-}
-
-fn run_tool_worker<W: Write>(
-    jobs: mpsc::Receiver<ToolJob>,
-    state: &Arc<Mutex<ServerState>>,
-    cancelled: &Arc<Mutex<HashSet<String>>>,
-    writer: &Arc<Mutex<&mut W>>,
-) -> std::io::Result<()> {
-    for job in jobs {
-        let key = request_key(&job.id);
-        if cancelled.lock().map_err(lock_error)?.contains(&key) {
-            write_message(
-                writer,
-                &Response::error(job.id, -32800, "request cancelled"),
-            )?;
-            continue;
-        }
-
-        if let Some(token) = &job.progress_token {
-            write_message(writer, &progress_notification(token, 0, "analysis started"))?;
-        }
-
-        let mut response = {
-            let mut state = state.lock().map_err(lock_error)?;
-            handle_tools_call(job.id.clone(), &job.params, &mut state)
-        };
-
-        if cancelled.lock().map_err(lock_error)?.remove(&key) {
-            response = Response::error(job.id, -32800, "request cancelled");
-        } else if let Some(token) = &job.progress_token {
-            write_message(
-                writer,
-                &progress_notification(token, 1, "analysis complete"),
-            )?;
-        }
-        write_message(writer, &response)?;
-    }
-    Ok(())
-}
-
-fn progress_notification(token: &Value, progress: u8, message: &str) -> Value {
-    json!({
-        "jsonrpc": "2.0",
-        "method": "notifications/progress",
-        "params": {
-            "progressToken": token,
-            "progress": progress,
-            "total": 1,
-            "message": message
-        }
     })
 }
 
@@ -323,142 +274,4 @@ fn initialize_result(params: &Value) -> Value {
         },
         "serverInfo": { "name": SERVER_NAME, "version": SERVER_VERSION }
     })
-}
-
-fn tools_list_result() -> Value {
-    json!({
-        "tools": [
-            review_change::definition(),
-            scan::definition(),
-            context::definition(),
-            explain_file::definition(),
-            explain_finding::definition(),
-            explain_review_signal::definition(),
-        ]
-    })
-}
-
-fn resources_list_result(state: &ServerState) -> Value {
-    let mut resources = vec![
-        json!({
-            "uri": "repopilot://rules",
-            "name": "RepoPilot rule catalog",
-            "mimeType": "application/json"
-        }),
-        json!({
-            "uri": "repopilot://repository-summary",
-            "name": "RepoPilot repository summary",
-            "mimeType": "application/json"
-        }),
-        json!({
-            "uri": "repopilot://analyses",
-            "name": "Available RepoPilot analysis handles",
-            "mimeType": "application/json"
-        }),
-    ];
-    if state.last_scan.is_some() {
-        resources.push(json!({
-            "uri": "repopilot://last-scan",
-            "name": "Last RepoPilot scan",
-            "mimeType": "application/json"
-        }));
-    }
-    if state.last_review.is_some() {
-        resources.push(json!({
-            "uri": "repopilot://last-review",
-            "name": "Last RepoPilot review",
-            "mimeType": "application/json"
-        }));
-    }
-    json!({ "resources": resources })
-}
-
-fn handle_resource_read(id: Value, params: &Value, state: &ServerState) -> Response {
-    let uri = params
-        .get("uri")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    let text = match uri {
-        "repopilot://analyses" => serde_json::to_string_pretty(&state.analyses.summaries())
-            .unwrap_or_else(|_| "[]".to_string()),
-        "repopilot://rules" => {
-            let rules = repopilot::rules::all_rule_metadata()
-                .map(|rule| {
-                    json!({
-                        "rule_id": rule.rule_id,
-                        "title": rule.title,
-                        "category": rule.category.label(),
-                        "severity": rule.default_severity.label(),
-                        "max_severity": rule.severity_ceiling().label(),
-                        "confidence": rule.default_confidence.label(),
-                        "max_confidence": rule.confidence_ceiling().label(),
-                        "lifecycle": rule.lifecycle.label(),
-                        "signal_source": rule.signal_source.label(),
-                        "docs_url": rule.docs_url
-                    })
-                })
-                .collect::<Vec<_>>();
-            serde_json::to_string_pretty(&rules).unwrap_or_else(|_| "[]".to_string())
-        }
-        "repopilot://last-scan" => state.last_scan.clone().unwrap_or_default(),
-        "repopilot://last-review" => state.last_review.clone().unwrap_or_default(),
-        "repopilot://repository-summary" => serde_json::to_string_pretty(&json!({
-            "root": state.root.to_string_lossy(),
-            "git_repository": state.root.join(".git").exists(),
-            "config_present": state.root.join("repopilot.toml").is_file(),
-            "baseline_present": state.root.join(".repopilot/baseline.json").is_file(),
-            "feedback_present": state.root.join(".repopilot/feedback.yml").is_file(),
-            "last_scan_available": state.last_scan.is_some(),
-            "last_review_available": state.last_review.is_some()
-        }))
-        .unwrap_or_else(|_| "{}".to_string()),
-        _ => {
-            return Response::error(id, -32002, format!("resource not found: {uri}"));
-        }
-    };
-    Response::success(
-        id,
-        json!({ "contents": [{ "uri": uri, "mimeType": "application/json", "text": text }] }),
-    )
-}
-
-fn prompts_list_result() -> Value {
-    json!({
-        "prompts": [
-            {
-                "name": "review-change",
-                "description": "Review the current change with RepoPilot evidence."
-            },
-            {
-                "name": "fix-top-risk",
-                "description": "Plan the smallest fix for the highest-priority RepoPilot risk."
-            }
-        ]
-    })
-}
-
-fn handle_prompt_get(id: Value, params: &Value) -> Response {
-    let name = params
-        .get("name")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    let text = match name {
-        "review-change" => {
-            "Call repopilot_review_change, inspect definitely-sensitive signals first, and report evidence without claiming the change is safe."
-        }
-        "fix-top-risk" => {
-            "Call repopilot_scan, select the highest-priority evidence-backed finding, and propose the smallest verified remediation."
-        }
-        _ => return Response::error(id, -32602, format!("unknown prompt: {name}")),
-    };
-    Response::success(
-        id,
-        json!({
-            "description": text,
-            "messages": [{
-                "role": "user",
-                "content": { "type": "text", "text": text }
-            }]
-        }),
-    )
 }

--- a/src/commands/mcp/progress.rs
+++ b/src/commands/mcp/progress.rs
@@ -1,0 +1,150 @@
+use crate::commands::review_verification::ReviewVerificationEvent;
+use repopilot::verification::{CancellationToken, VerificationStatus};
+use serde_json::{Value, json};
+use std::collections::BTreeSet;
+use std::io;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProgressMode {
+    Tool,
+    Review { checks: usize },
+}
+
+pub(super) fn mode_for_tool_call(params: &Value) -> ProgressMode {
+    if params.get("name").and_then(Value::as_str) != Some(super::review_change::TOOL_NAME) {
+        return ProgressMode::Tool;
+    }
+    let checks = params
+        .get("arguments")
+        .and_then(|arguments| arguments.get("verify"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect::<BTreeSet<_>>()
+        .len();
+    ProgressMode::Review { checks }
+}
+
+pub(super) struct ProgressReporter<'a> {
+    token: Option<Value>,
+    mode: ProgressMode,
+    cancellation: &'a CancellationToken,
+    sink: &'a mut dyn FnMut(Value) -> io::Result<()>,
+    analysis_complete: bool,
+    error: Option<io::Error>,
+}
+
+impl<'a> ProgressReporter<'a> {
+    pub(super) fn new(
+        token: Option<Value>,
+        mode: ProgressMode,
+        cancellation: &'a CancellationToken,
+        sink: &'a mut dyn FnMut(Value) -> io::Result<()>,
+    ) -> Self {
+        Self {
+            token,
+            mode,
+            cancellation,
+            sink,
+            analysis_complete: false,
+            error: None,
+        }
+    }
+
+    pub(super) fn analysis_started(&mut self) {
+        self.emit(0, self.total(), "analysis started".to_string());
+    }
+
+    pub(super) fn verification(&mut self, event: ReviewVerificationEvent) {
+        self.ensure_analysis_complete();
+        match event {
+            ReviewVerificationEvent::Started {
+                check_id, index, ..
+            } => self.emit(
+                index,
+                self.total(),
+                format!("verification {check_id} started"),
+            ),
+            ReviewVerificationEvent::Completed {
+                check_id,
+                index,
+                status,
+                ..
+            } => self.emit(
+                index + 1,
+                self.total(),
+                format!("verification {check_id} {}", status_label(status)),
+            ),
+        }
+    }
+
+    pub(super) fn finish_success(&mut self) {
+        match self.mode {
+            ProgressMode::Tool => {
+                self.analysis_complete = true;
+                self.emit(1, 1, "analysis complete".to_string());
+            }
+            ProgressMode::Review { checks } => {
+                self.ensure_analysis_complete();
+                self.emit(checks + 2, checks + 2, "review complete".to_string());
+            }
+        }
+    }
+
+    pub(super) fn has_error(&self) -> bool {
+        self.error.is_some()
+    }
+
+    pub(super) fn into_result(self) -> io::Result<()> {
+        self.error.map_or(Ok(()), Err)
+    }
+
+    fn ensure_analysis_complete(&mut self) {
+        if self.analysis_complete {
+            return;
+        }
+        self.analysis_complete = true;
+        self.emit(1, self.total(), "analysis complete".to_string());
+    }
+
+    fn total(&self) -> usize {
+        match self.mode {
+            ProgressMode::Tool => 1,
+            ProgressMode::Review { checks } => checks + 2,
+        }
+    }
+
+    fn emit(&mut self, progress: usize, total: usize, message: String) {
+        if self.token.is_none() || self.cancellation.is_cancelled() || self.error.is_some() {
+            return;
+        }
+        let notification = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/progress",
+            "params": {
+                "progressToken": self.token.as_ref().expect("checked progress token"),
+                "progress": progress,
+                "total": total,
+                "message": message
+            }
+        });
+        if let Err(error) = (self.sink)(notification) {
+            self.error = Some(error);
+        }
+    }
+}
+
+fn status_label(status: VerificationStatus) -> &'static str {
+    match status {
+        VerificationStatus::Passed => "passed",
+        VerificationStatus::Failed => "failed",
+        VerificationStatus::TimedOut => "timed out",
+        VerificationStatus::Unavailable => "unavailable",
+        VerificationStatus::Cancelled => "cancelled",
+        VerificationStatus::Skipped => "skipped",
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/commands/mcp/progress/tests.rs
+++ b/src/commands/mcp/progress/tests.rs
@@ -1,0 +1,165 @@
+use super::{ProgressMode, ProgressReporter, mode_for_tool_call};
+use crate::commands::review_verification::ReviewVerificationEvent;
+use repopilot::verification::{CancellationToken, VerificationStatus};
+use serde_json::{Value, json};
+use std::io;
+
+#[test]
+fn review_progress_is_monotonic_and_check_aware() {
+    let cancellation = CancellationToken::new();
+    let notifications = capture(
+        ProgressMode::Review { checks: 2 },
+        &cancellation,
+        |reporter| {
+            reporter.analysis_started();
+            reporter.verification(ReviewVerificationEvent::Started {
+                check_id: "lint".into(),
+                index: 1,
+                total: 2,
+            });
+            reporter.verification(ReviewVerificationEvent::Completed {
+                check_id: "lint".into(),
+                index: 1,
+                total: 2,
+                status: VerificationStatus::Passed,
+            });
+            reporter.verification(ReviewVerificationEvent::Started {
+                check_id: "unit".into(),
+                index: 2,
+                total: 2,
+            });
+            reporter.verification(ReviewVerificationEvent::Completed {
+                check_id: "unit".into(),
+                index: 2,
+                total: 2,
+                status: VerificationStatus::Failed,
+            });
+            reporter.finish_success();
+        },
+    );
+
+    assert_eq!(
+        progress_messages(&notifications),
+        vec![
+            (0, 4, "analysis started"),
+            (1, 4, "analysis complete"),
+            (1, 4, "verification lint started"),
+            (2, 4, "verification lint passed"),
+            (2, 4, "verification unit started"),
+            (3, 4, "verification unit failed"),
+            (4, 4, "review complete"),
+        ]
+    );
+}
+
+#[test]
+fn review_without_checks_has_analysis_and_finalization_units() {
+    let cancellation = CancellationToken::new();
+    let notifications = capture(
+        ProgressMode::Review { checks: 0 },
+        &cancellation,
+        |reporter| {
+            reporter.analysis_started();
+            reporter.finish_success();
+        },
+    );
+
+    assert_eq!(
+        progress_messages(&notifications),
+        vec![
+            (0, 2, "analysis started"),
+            (1, 2, "analysis complete"),
+            (2, 2, "review complete"),
+        ]
+    );
+}
+
+#[test]
+fn non_review_tool_keeps_existing_two_notification_contract() {
+    let cancellation = CancellationToken::new();
+    let notifications = capture(ProgressMode::Tool, &cancellation, |reporter| {
+        reporter.analysis_started();
+        reporter.finish_success();
+    });
+
+    assert_eq!(
+        progress_messages(&notifications),
+        vec![(0, 1, "analysis started"), (1, 1, "analysis complete")]
+    );
+}
+
+#[test]
+fn cancellation_suppresses_all_later_notifications() {
+    let cancellation = CancellationToken::new();
+    let observer_token = cancellation.clone();
+    let notifications = capture(
+        ProgressMode::Review { checks: 1 },
+        &cancellation,
+        |reporter| {
+            reporter.analysis_started();
+            observer_token.cancel();
+            reporter.verification(ReviewVerificationEvent::Started {
+                check_id: "unit".into(),
+                index: 1,
+                total: 1,
+            });
+            reporter.finish_success();
+        },
+    );
+
+    assert_eq!(
+        progress_messages(&notifications),
+        vec![(0, 3, "analysis started")]
+    );
+}
+
+#[test]
+fn review_mode_counts_unique_string_selectors() {
+    assert_eq!(
+        mode_for_tool_call(&json!({
+            "name": "repopilot_review_change",
+            "arguments": { "verify": ["unit", "lint", "unit"] }
+        })),
+        ProgressMode::Review { checks: 2 }
+    );
+    assert_eq!(
+        mode_for_tool_call(&json!({
+            "name": "repopilot_scan",
+            "arguments": { "verify": ["ignored"] }
+        })),
+        ProgressMode::Tool
+    );
+}
+
+fn capture(
+    mode: ProgressMode,
+    cancellation: &CancellationToken,
+    run: impl FnOnce(&mut ProgressReporter<'_>),
+) -> Vec<Value> {
+    let mut notifications = Vec::new();
+    {
+        let mut sink = |value: Value| -> io::Result<()> {
+            notifications.push(value);
+            Ok(())
+        };
+        let mut reporter =
+            ProgressReporter::new(Some(json!("token")), mode, cancellation, &mut sink);
+        run(&mut reporter);
+        reporter.into_result().expect("progress sink");
+    }
+    notifications
+}
+
+fn progress_messages(notifications: &[Value]) -> Vec<(u64, u64, &str)> {
+    notifications
+        .iter()
+        .map(|notification| {
+            let params = &notification["params"];
+            (
+                params["progress"].as_u64().expect("progress"),
+                params["total"].as_u64().expect("total"),
+                params["message"].as_str().expect("message"),
+            )
+        })
+        .collect()
+}

--- a/src/commands/mcp/publication.rs
+++ b/src/commands/mcp/publication.rs
@@ -1,0 +1,199 @@
+use super::analysis_store::{self, AnalysisKind};
+use super::{ServerState, context, review_change, review_projection, scan};
+use serde_json::{Value, json};
+
+pub(super) struct PreparedToolResult {
+    pub result: Value,
+    publication: Option<AnalysisPublication>,
+}
+
+struct AnalysisPublication {
+    kind: AnalysisKind,
+    full_report: String,
+    client_report: String,
+    workspace_revision: String,
+}
+
+impl PreparedToolResult {
+    pub(super) fn publish(self, state: &mut ServerState) -> Value {
+        let Some(publication) = self.publication else {
+            return self.result;
+        };
+        state.analyses.publish(
+            publication.kind,
+            publication.full_report,
+            &publication.workspace_revision,
+        );
+        match publication.kind {
+            AnalysisKind::Scan => state.last_scan = Some(publication.client_report),
+            AnalysisKind::Review => state.last_review = Some(publication.client_report),
+        }
+        self.result
+    }
+}
+
+pub(super) fn prepare_tool_result(
+    name: &str,
+    outcome: Result<String, String>,
+    arguments: &Value,
+    state: &ServerState,
+    workspace_revision: &str,
+    publishable: bool,
+) -> PreparedToolResult {
+    let kind = match name {
+        scan::TOOL_NAME => Some(AnalysisKind::Scan),
+        review_change::TOOL_NAME => Some(AnalysisKind::Review),
+        _ => None,
+    };
+    let Some(kind) = kind else {
+        return PreparedToolResult {
+            result: tool_result(
+                name,
+                outcome,
+                workspace_revision,
+                None,
+                None,
+                state.max_response_bytes,
+            ),
+            publication: None,
+        };
+    };
+    let full_report = match outcome {
+        Ok(report) => report,
+        Err(message) => {
+            return error_result(name, message, workspace_revision, state.max_response_bytes);
+        }
+    };
+    let client_report = match compact_review_for_client(kind, full_report.clone(), arguments) {
+        Ok(report) => report,
+        Err(message) => {
+            return error_result(name, message, workspace_revision, state.max_response_bytes);
+        }
+    };
+    let page = match analysis_store::paginate_findings(&client_report, arguments) {
+        Ok(page) => page,
+        Err(message) => {
+            return error_result(name, message, workspace_revision, state.max_response_bytes);
+        }
+    };
+    let handle = publishable.then(|| {
+        state
+            .analyses
+            .prospective_handle(kind, &full_report, workspace_revision)
+    });
+    let result = tool_result(
+        name,
+        Ok(page.text.clone()),
+        workspace_revision,
+        handle.as_deref(),
+        page.metadata,
+        state.max_response_bytes,
+    );
+    if result["isError"] == true {
+        return PreparedToolResult {
+            result,
+            publication: None,
+        };
+    }
+    PreparedToolResult {
+        result,
+        publication: publishable.then_some(AnalysisPublication {
+            kind,
+            full_report,
+            client_report: page.text,
+            workspace_revision: workspace_revision.to_string(),
+        }),
+    }
+}
+
+fn error_result(
+    name: &str,
+    message: String,
+    workspace_revision: &str,
+    max_response_bytes: usize,
+) -> PreparedToolResult {
+    PreparedToolResult {
+        result: tool_result(
+            name,
+            Err(message),
+            workspace_revision,
+            None,
+            None,
+            max_response_bytes,
+        ),
+        publication: None,
+    }
+}
+
+fn compact_review_for_client(
+    kind: AnalysisKind,
+    full_report: String,
+    arguments: &Value,
+) -> Result<String, String> {
+    if kind == AnalysisKind::Review
+        && arguments.get("offset").is_none()
+        && arguments.get("limit").is_none()
+        && arguments.get("detail").and_then(Value::as_str) != Some("full")
+    {
+        review_projection::compact_review_json(&full_report)
+    } else {
+        Ok(full_report)
+    }
+}
+
+pub(super) fn tool_result(
+    name: &str,
+    outcome: Result<String, String>,
+    workspace_revision: &str,
+    analysis_handle: Option<&str>,
+    pagination: Option<Value>,
+    max_response_bytes: usize,
+) -> Value {
+    let mut result = match outcome {
+        Ok(text) => success_result(name, text),
+        Err(message) => {
+            json!({ "content": [{ "type": "text", "text": message }], "isError": true })
+        }
+    };
+    result["workspaceRevision"] = json!(workspace_revision);
+    if let Some(handle) = analysis_handle {
+        result["analysisHandle"] = json!(handle);
+    }
+    if let Some(pagination) = pagination {
+        result["pagination"] = pagination;
+    }
+    if serde_json::to_vec(&result).is_ok_and(|encoded| encoded.len() <= max_response_bytes) {
+        return result;
+    }
+    oversized_result(workspace_revision, max_response_bytes)
+}
+
+fn success_result(name: &str, text: String) -> Value {
+    let structured = serde_json::from_str::<Value>(&text).unwrap_or_else(|_| {
+        if name == context::TOOL_NAME {
+            json!({ "markdown": text })
+        } else {
+            json!({ "text": text })
+        }
+    });
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "structuredContent": structured,
+        "isError": false
+    })
+}
+
+fn oversized_result(workspace_revision: &str, max_response_bytes: usize) -> Value {
+    json!({
+        "content": [{
+            "type": "text",
+            "text": format!(
+                "MCP tool result exceeded the configured {max_response_bytes}-byte limit; use filters, offset/limit, detail=compact, or a smaller context budget"
+            )
+        }],
+        "isError": true,
+        "workspaceRevision": workspace_revision,
+        "responseTruncated": true,
+        "responseLimitBytes": max_response_bytes
+    })
+}

--- a/src/commands/mcp/request_registry.rs
+++ b/src/commands/mcp/request_registry.rs
@@ -1,0 +1,35 @@
+use repopilot::verification::CancellationToken;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Default)]
+pub(super) struct RequestRegistry {
+    pending: HashSet<String>,
+    active: HashMap<String, CancellationToken>,
+}
+
+impl RequestRegistry {
+    pub(super) fn register(&mut self, key: String, token: CancellationToken) {
+        if self.pending.remove(&key) {
+            token.cancel();
+        }
+        if let Some(replaced) = self.active.insert(key, token) {
+            replaced.cancel();
+        }
+    }
+
+    pub(super) fn cancel(&mut self, key: &str) {
+        if let Some(token) = self.active.get(key) {
+            token.cancel();
+        } else {
+            self.pending.insert(key.to_string());
+        }
+    }
+
+    pub(super) fn finish(&mut self, key: &str) {
+        self.pending.remove(key);
+        self.active.remove(key);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/commands/mcp/request_registry/tests.rs
+++ b/src/commands/mcp/request_registry/tests.rs
@@ -1,0 +1,51 @@
+use super::RequestRegistry;
+use repopilot::verification::CancellationToken;
+
+#[test]
+fn pending_cancellation_applies_when_request_registers() {
+    let mut registry = RequestRegistry::default();
+    registry.cancel("7");
+    let token = CancellationToken::new();
+
+    registry.register("7".to_string(), token.clone());
+
+    assert!(token.is_cancelled());
+    registry.finish("7");
+    let reused = CancellationToken::new();
+    registry.register("7".to_string(), reused.clone());
+    assert!(!reused.is_cancelled());
+}
+
+#[test]
+fn active_and_repeated_cancellation_are_idempotent() {
+    let mut registry = RequestRegistry::default();
+    let token = CancellationToken::new();
+    registry.register("active".to_string(), token.clone());
+
+    registry.cancel("active");
+    registry.cancel("active");
+
+    assert!(token.is_cancelled());
+    registry.finish("active");
+    let reused = CancellationToken::new();
+    registry.register("active".to_string(), reused.clone());
+    assert!(!reused.is_cancelled());
+}
+
+#[test]
+fn finish_clears_pending_and_active_state() {
+    let mut registry = RequestRegistry::default();
+    registry.cancel("pending");
+    registry.finish("pending");
+    let pending_reuse = CancellationToken::new();
+    registry.register("pending".to_string(), pending_reuse.clone());
+    assert!(!pending_reuse.is_cancelled());
+
+    let active = CancellationToken::new();
+    registry.register("active".to_string(), active);
+    registry.finish("active");
+    registry.cancel("active");
+    let active_reuse = CancellationToken::new();
+    registry.register("active".to_string(), active_reuse.clone());
+    assert!(active_reuse.is_cancelled());
+}

--- a/src/commands/mcp/review_change.rs
+++ b/src/commands/mcp/review_change.rs
@@ -1,7 +1,9 @@
 //! The `repopilot_review_change` MCP tool: the local "is this change risky?"
 //! audit, wrapping the same scan + review pipeline the `review` command uses.
 
+use crate::commands::mcp::review_projection::compact_review_json;
 use crate::commands::product_scan::{ProductScanMode, ProductScanRequest, run_product_scan};
+use crate::commands::review_verification::{ReviewVerificationEvent, run_selected_with_context};
 use crate::commands::scan_config::ScanConfigOverrides;
 use repopilot::baseline::reader::read_baseline;
 use repopilot::findings::filter::FindingFilter;
@@ -12,17 +14,51 @@ use repopilot::review::{
     ReviewSignalGatePolicy, ReviewSignalGateResult, build_review_report_from_session,
     load_review_input,
 };
+use repopilot::verification::CancellationToken;
 use serde_json::{Value, json};
+use std::fmt;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 pub const TOOL_NAME: &str = "repopilot_review_change";
 
+pub(super) struct ReviewCallContext<'a> {
+    pub cancellation: &'a CancellationToken,
+    pub observer: &'a mut dyn FnMut(ReviewVerificationEvent),
+}
+
+pub(super) struct ReviewCallResult {
+    pub rendered: String,
+    pub analysis_revision: String,
+    pub revision_compatible: bool,
+}
+
+#[derive(Debug)]
+pub(super) enum ReviewCallError {
+    Cancelled,
+    Message(String),
+}
+
+impl fmt::Display for ReviewCallError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cancelled => formatter.write_str("request cancelled"),
+            Self::Message(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl From<String> for ReviewCallError {
+    fn from(message: String) -> Self {
+        Self::Message(message)
+    }
+}
+
 /// The `tools/list` descriptor for this tool.
 pub fn definition() -> Value {
     json!({
         "name": TOOL_NAME,
-        "description": "Audit the current Git changes locally. Scans the repository, splits findings into those touching changed diff lines vs the rest, and reports blast radius (files that import the changed files). Also surfaces deterministic change signals grouped by confidence tier (definitely-sensitive / maybe-sensitive / large-diff-or-noise) on `tiered_signals`: security-boundary changes (auth, CORS, CI, dependency manifests, committed .env), behavioral changes (network/subprocess/filesystem/env/dependency/migration/raw-SQL added; error-handling, auth-check, or test removed; removed named TypeScript/JavaScript export that a resolved local caller still imports), algorithmic changes (control-flow nesting deeper, nested loop introduced, function grew, recursion introduced), and taint-lite reachability (HTTP request or process arguments reaching SQL, exec, filesystem-write, or outbound-network sinks within a changed function). These flag, they do not judge. Runs entirely on disk — nothing is uploaded. Returns a JSON review report.",
+        "description": "Audit the current Git changes locally. Scans the repository, splits findings into those touching changed diff lines vs the rest, and reports blast radius (files that import the changed files). Also surfaces deterministic change signals grouped by confidence tier (definitely-sensitive / maybe-sensitive / large-diff-or-noise) on `tiered_signals`: security-boundary changes (auth, CORS, CI, dependency manifests, committed .env), behavioral changes (network/subprocess/filesystem/env/dependency/migration/raw-SQL added; error-handling, auth-check, or test removed; removed named TypeScript/JavaScript export that a resolved local caller still imports), algorithmic changes (control-flow nesting deeper, nested loop introduced, function grew, recursion introduced), and taint-lite reachability (HTTP request or process arguments reaching SQL, exec, filesystem-write, or outbound-network sinks within a changed function). These flag, they do not judge. An explicit non-empty `verify` array runs only configured local checks; those processes may modify workspace files or contact external systems. Captured output is bounded and redacted. RepoPilot itself uploads nothing. Returns a JSON review report.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -46,6 +82,12 @@ pub fn definition() -> Value {
                 "detail": { "type": "string", "enum": ["compact", "full"], "default": "compact" },
                 "offset": { "type": "integer", "minimum": 0, "description": "Zero-based finding offset." },
                 "limit": { "type": "integer", "minimum": 1, "maximum": 1000, "description": "Maximum findings to return." },
+                "verify": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "uniqueItems": true,
+                    "description": "Configured local verification check IDs to run explicitly."
+                },
                 "filters": {
                     "type": "object",
                     "properties": {
@@ -61,17 +103,24 @@ pub fn definition() -> Value {
         },
         "outputSchema": { "type": "object", "additionalProperties": true },
         "annotations": {
-            "readOnlyHint": true,
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": false
+            "readOnlyHint": false,
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true
         }
     })
 }
 
 /// Runs the review for a `tools/call`, returning the JSON report on success or a
 /// human-readable message on failure (surfaced to the agent as an error result).
-pub fn call(arguments: &Value) -> Result<String, String> {
+pub(super) fn call_with_context(
+    arguments: &Value,
+    context: ReviewCallContext<'_>,
+) -> Result<ReviewCallResult, ReviewCallError> {
+    let selected_checks = verification_ids(arguments)?;
+    if context.cancellation.is_cancelled() {
+        return Err(ReviewCallError::Cancelled);
+    }
     let path = PathBuf::from(arguments.get("path").and_then(Value::as_str).unwrap_or("."));
     let base = arguments.get("base").and_then(Value::as_str);
     let head = arguments.get("head").and_then(Value::as_str);
@@ -85,12 +134,15 @@ pub fn call(arguments: &Value) -> Result<String, String> {
         .map(PathBuf::from);
 
     if base.is_none() && head.is_some() {
-        return Err("`head` requires `base`".to_string());
+        return Err(ReviewCallError::Message(
+            "`head` requires `base`".to_string(),
+        ));
     }
 
     let diff_started = Instant::now();
     let input =
         load_review_input(&path, base, head).map_err(|error| format!("review failed: {error}"))?;
+    let review_target = input.target.clone();
     let diff_loading_us = duration_us(diff_started.elapsed());
     let scope = arguments
         .get("scope")
@@ -99,7 +151,7 @@ pub fn call(arguments: &Value) -> Result<String, String> {
     let visibility_profile = match arguments.get("profile").and_then(Value::as_str) {
         Some("strict") => FindingVisibilityProfile::Strict,
         Some("default") | None => FindingVisibilityProfile::Default,
-        Some(other) => return Err(format!("invalid profile: {other}")),
+        Some(other) => return Err(format!("invalid profile: {other}").into()),
     };
     let mode = match scope {
         "changed" => ProductScanMode::ResolvedChanged {
@@ -107,7 +159,7 @@ pub fn call(arguments: &Value) -> Result<String, String> {
             base_ref: input.target.base_ref().map(str::to_string),
         },
         "full" => ProductScanMode::Full,
-        other => return Err(format!("invalid scope: {other}")),
+        other => return Err(format!("invalid scope: {other}").into()),
     };
     let filter = super::scan::parse_filters(arguments)?;
 
@@ -147,6 +199,7 @@ pub fn call(arguments: &Value) -> Result<String, String> {
         &scan_result.session,
     )
     .map_err(|error| format!("review failed: {error}"))?;
+    let analysis_revision = scan_result.session.revision().id().to_string();
     review_report.timings.diff_loading_us = diff_loading_us;
     review_report.timings.review_signals_us = duration_us(review_started.elapsed());
     if scope == "changed" {
@@ -158,6 +211,21 @@ pub fn call(arguments: &Value) -> Result<String, String> {
             ..FindingFilter::default()
         });
     }
+    if context.cancellation.is_cancelled() {
+        return Err(ReviewCallError::Cancelled);
+    }
+    run_selected_with_context(
+        &selected_checks,
+        &scan_result.session,
+        &review_target,
+        &mut review_report,
+        context.cancellation,
+        context.observer,
+    )
+    .map_err(|error| ReviewCallError::Message(error.to_string()))?;
+    if context.cancellation.is_cancelled() {
+        return Err(ReviewCallError::Cancelled);
+    }
     let gate_policy = match arguments
         .get("fail_on_review")
         .and_then(Value::as_str)
@@ -165,7 +233,7 @@ pub fn call(arguments: &Value) -> Result<String, String> {
     {
         "none" => ReviewSignalGatePolicy::None,
         "definitely" => ReviewSignalGatePolicy::Definitely,
-        other => return Err(format!("invalid fail_on_review: {other}")),
+        other => return Err(format!("invalid fail_on_review: {other}").into()),
     };
     let gating_started = Instant::now();
     let review_gate = ReviewSignalGateResult::evaluate(&review_report, gate_policy);
@@ -177,37 +245,45 @@ pub fn call(arguments: &Value) -> Result<String, String> {
     let rendered = render(&review_report, OutputFormat::Json, None, Some(&review_gate))
         .map_err(|error| format!("render failed: {error}"))?;
 
-    if arguments
+    let rendered = if arguments
         .get("detail")
         .and_then(Value::as_str)
         .is_some_and(|detail| detail == "full")
     {
-        return Ok(rendered);
-    }
-    compact_review_json(&rendered)
+        rendered
+    } else {
+        compact_review_json(&rendered)?
+    };
+    Ok(ReviewCallResult {
+        rendered,
+        analysis_revision,
+        revision_compatible: review_report
+            .verification
+            .iter()
+            .all(|outcome| outcome.revision_compatible),
+    })
+}
+
+fn verification_ids(arguments: &Value) -> Result<Vec<String>, ReviewCallError> {
+    let Some(value) = arguments.get("verify") else {
+        return Ok(Vec::new());
+    };
+    let values = value.as_array().ok_or_else(|| {
+        ReviewCallError::Message("`verify` must be an array of strings".to_string())
+    })?;
+    values
+        .iter()
+        .map(|value| {
+            value.as_str().map(str::to_string).ok_or_else(|| {
+                ReviewCallError::Message("`verify` must be an array of strings".to_string())
+            })
+        })
+        .collect()
 }
 
 fn duration_us(duration: Duration) -> u64 {
     duration.as_micros().min(u128::from(u64::MAX)) as u64
 }
 
-pub(super) fn compact_review_json(rendered: &str) -> Result<String, String> {
-    const LIMIT: usize = 20;
-    let mut value: Value =
-        serde_json::from_str(rendered).map_err(|error| format!("compact failed: {error}"))?;
-    if let Some(findings) = value.get_mut("findings").and_then(Value::as_array_mut) {
-        findings.truncate(LIMIT);
-    }
-    let mut remaining = LIMIT;
-    for tier in ["definitely", "maybe", "noise"] {
-        if let Some(signals) = value
-            .get_mut("tiered_signals")
-            .and_then(|tiered| tiered.get_mut(tier))
-            .and_then(Value::as_array_mut)
-        {
-            signals.truncate(remaining);
-            remaining = remaining.saturating_sub(signals.len());
-        }
-    }
-    serde_json::to_string_pretty(&value).map_err(|error| format!("compact failed: {error}"))
-}
+#[cfg(test)]
+mod tests;

--- a/src/commands/mcp/review_change/tests.rs
+++ b/src/commands/mcp/review_change/tests.rs
@@ -1,0 +1,18 @@
+use super::verification_ids;
+use serde_json::json;
+
+#[test]
+fn missing_and_empty_verification_selectors_are_equivalent() {
+    assert_eq!(
+        verification_ids(&json!({})).expect("missing selector"),
+        verification_ids(&json!({ "verify": [] })).expect("empty selector")
+    );
+}
+
+#[test]
+fn verification_selectors_must_be_strings() {
+    let error = verification_ids(&json!({ "verify": ["unit", 7] }))
+        .expect_err("non-string selector must fail");
+
+    assert!(error.to_string().contains("array of strings"));
+}

--- a/src/commands/mcp/review_projection.rs
+++ b/src/commands/mcp/review_projection.rs
@@ -1,0 +1,22 @@
+use serde_json::Value;
+
+pub(super) fn compact_review_json(rendered: &str) -> Result<String, String> {
+    const LIMIT: usize = 20;
+    let mut value: Value =
+        serde_json::from_str(rendered).map_err(|error| format!("compact failed: {error}"))?;
+    if let Some(findings) = value.get_mut("findings").and_then(Value::as_array_mut) {
+        findings.truncate(LIMIT);
+    }
+    let mut remaining = LIMIT;
+    for tier in ["definitely", "maybe", "noise"] {
+        if let Some(signals) = value
+            .get_mut("tiered_signals")
+            .and_then(|tiered| tiered.get_mut(tier))
+            .and_then(Value::as_array_mut)
+        {
+            signals.truncate(remaining);
+            remaining = remaining.saturating_sub(signals.len());
+        }
+    }
+    serde_json::to_string_pretty(&value).map_err(|error| format!("compact failed: {error}"))
+}

--- a/src/commands/mcp/tests.rs
+++ b/src/commands/mcp/tests.rs
@@ -99,7 +99,8 @@ fn tools_list_advertises_all_tools_with_schemas() {
         ]
     );
 
-    // Every advertised tool exposes an object input schema.
+    // Every advertised tool exposes an object input schema. Static tools stay
+    // read-only; review advertises the worst-case effects of explicit checks.
     for tool in tools {
         assert_eq!(
             tool["inputSchema"]["type"], "object",
@@ -107,13 +108,29 @@ fn tools_list_advertises_all_tools_with_schemas() {
             tool["name"]
         );
         assert!(tool["outputSchema"].is_object());
-        assert_eq!(tool["annotations"]["readOnlyHint"], true);
+        if tool["name"] != "repopilot_review_change" {
+            assert_eq!(tool["annotations"]["readOnlyHint"], true);
+        }
     }
 
-    let review_description = tools
+    let review = tools
         .iter()
         .find(|tool| tool["name"] == "repopilot_review_change")
-        .and_then(|tool| tool["description"].as_str())
+        .expect("review tool");
+    assert_eq!(
+        review["inputSchema"]["properties"]["verify"]["type"],
+        "array"
+    );
+    assert_eq!(
+        review["inputSchema"]["properties"]["verify"]["uniqueItems"],
+        true
+    );
+    assert_eq!(review["annotations"]["readOnlyHint"], false);
+    assert_eq!(review["annotations"]["destructiveHint"], true);
+    assert_eq!(review["annotations"]["idempotentHint"], false);
+    assert_eq!(review["annotations"]["openWorldHint"], true);
+    let review_description = review["description"]
+        .as_str()
         .expect("review tool description");
     assert!(
         review_description.contains(
@@ -121,6 +138,8 @@ fn tools_list_advertises_all_tools_with_schemas() {
         ),
         "{review_description}"
     );
+    assert!(review_description.contains("configured local checks"));
+    assert!(review_description.contains("bounded and redacted"));
 }
 
 #[test]
@@ -553,4 +572,66 @@ fn oversized_tool_result_is_replaced_by_a_bounded_error() {
     assert_eq!(result["isError"], true);
     assert_eq!(result["responseTruncated"], true);
     assert!(serde_json::to_vec(&result).expect("serialize").len() <= 1024);
+}
+
+#[test]
+fn oversized_analysis_is_not_published() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    std::fs::write(
+        temp.path().join("lib.rs"),
+        "pub fn value() -> usize { 1 }\n",
+    )
+    .expect("source");
+    let mut state = ServerState {
+        root: temp.path().canonicalize().expect("canonical root"),
+        initialized: true,
+        max_response_bytes: 1024,
+        ..ServerState::default()
+    };
+
+    let response = handle_tools_call(
+        json!(30),
+        &json!({
+            "name": scan::TOOL_NAME,
+            "arguments": { "path": ".", "detail": "full" }
+        }),
+        &mut state,
+    );
+    let result = response.result.expect("tool result");
+
+    assert_eq!(result["isError"], true);
+    assert_eq!(result["responseTruncated"], true);
+    assert!(result.get("analysisHandle").is_none());
+    assert!(state.analyses.summaries().is_empty());
+    assert!(state.last_scan.is_none());
+}
+
+#[test]
+fn pagination_error_does_not_publish_analysis() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    std::fs::write(
+        temp.path().join("lib.rs"),
+        "pub fn value() -> usize { 1 }\n",
+    )
+    .expect("source");
+    let mut state = ServerState {
+        root: temp.path().canonicalize().expect("canonical root"),
+        initialized: true,
+        ..ServerState::default()
+    };
+
+    let response = handle_tools_call(
+        json!(31),
+        &json!({
+            "name": scan::TOOL_NAME,
+            "arguments": { "path": ".", "limit": 0 }
+        }),
+        &mut state,
+    );
+    let result = response.result.expect("tool result");
+
+    assert_eq!(result["isError"], true);
+    assert!(result.get("analysisHandle").is_none());
+    assert!(state.analyses.summaries().is_empty());
+    assert!(state.last_scan.is_none());
 }

--- a/src/commands/mcp/tool_call.rs
+++ b/src/commands/mcp/tool_call.rs
@@ -1,13 +1,26 @@
-use super::analysis_store::{self, AnalysisKind, AnalysisRecord};
+use super::analysis_store::{AnalysisKind, AnalysisRecord};
+use super::publication::{prepare_tool_result, tool_result};
 use super::{
     ServerState, context, explain_file, explain_finding, explain_review_signal, review_change, scan,
 };
 use crate::commands::mcp::jsonrpc::Response;
+use crate::commands::review_verification::ReviewVerificationEvent;
 use repopilot::scan::session::WorkspaceRevision;
+use repopilot::verification::CancellationToken;
 use serde_json::{Value, json};
 use std::path::Path;
 
 pub(super) fn handle_tools_call(id: Value, params: &Value, state: &mut ServerState) -> Response {
+    handle_tools_call_with_context(id, params, state, &CancellationToken::new(), &mut |_| {})
+}
+
+pub(super) fn handle_tools_call_with_context(
+    id: Value,
+    params: &Value,
+    state: &mut ServerState,
+    cancellation: &CancellationToken,
+    observer: &mut dyn FnMut(ReviewVerificationEvent),
+) -> Response {
     let name = params
         .get("name")
         .and_then(Value::as_str)
@@ -25,24 +38,48 @@ pub(super) fn handle_tools_call(id: Value, params: &Value, state: &mut ServerSta
         Ok(record) => record,
         Err(message) => return tool_response(id, name, Err(message), &current_revision, state),
     };
-    let outcome = dispatch_tool(name, &arguments, state, referenced.as_ref());
+    let outcome = match dispatch_tool(
+        name,
+        &arguments,
+        state,
+        referenced.as_ref(),
+        cancellation,
+        observer,
+    ) {
+        Ok(outcome) => Ok(outcome),
+        Err(DispatchError::Message(message)) => Err(message),
+        Err(DispatchError::Cancelled) => {
+            return Response::error(id, -32800, "request cancelled");
+        }
+    };
+    if cancellation.is_cancelled() {
+        return Response::error(id, -32800, "request cancelled");
+    }
 
     // Analysis may update RepoPilot-owned cache files. Capture the revision at
     // response time so a handle never becomes stale because of its own call.
     let workspace_revision = WorkspaceRevision::capture(&state.root).id().to_string();
-    let (outcome, analysis_handle, pagination) =
-        prepare_analysis_result(name, outcome, &arguments, state, &workspace_revision);
-    Response::success(
-        id,
-        tool_result(
-            name,
-            outcome,
-            &workspace_revision,
-            analysis_handle.as_deref(),
-            pagination,
-            state.max_response_bytes,
-        ),
-    )
+    let (outcome, publishable) = match outcome {
+        Ok(execution) => {
+            let publishable = execution.review_revision.as_ref().is_none_or(|revision| {
+                revision.revision_compatible && revision.analysis_revision == workspace_revision
+            });
+            (Ok(execution.rendered), publishable)
+        }
+        Err(message) => (Err(message), false),
+    };
+    let prepared = prepare_tool_result(
+        name,
+        outcome,
+        &arguments,
+        state,
+        &workspace_revision,
+        publishable,
+    );
+    if cancellation.is_cancelled() {
+        return Response::error(id, -32800, "request cancelled");
+    }
+    Response::success(id, prepared.publish(state))
 }
 
 fn tool_response(
@@ -70,26 +107,79 @@ fn dispatch_tool(
     arguments: &Value,
     state: &ServerState,
     referenced: Option<&AnalysisRecord>,
-) -> Result<String, String> {
+    cancellation: &CancellationToken,
+    observer: &mut dyn FnMut(ReviewVerificationEvent),
+) -> Result<ToolExecution, DispatchError> {
     match name {
         review_change::TOOL_NAME => {
             let mut full_arguments = arguments.clone();
             full_arguments["detail"] = json!("full");
-            review_change::call(&full_arguments)
+            review_change::call_with_context(
+                &full_arguments,
+                review_change::ReviewCallContext {
+                    cancellation,
+                    observer,
+                },
+            )
+            .map(|result| ToolExecution {
+                rendered: result.rendered,
+                review_revision: Some(ReviewRevision {
+                    analysis_revision: result.analysis_revision,
+                    revision_compatible: result.revision_compatible,
+                }),
+            })
+            .map_err(|error| match error {
+                review_change::ReviewCallError::Cancelled => DispatchError::Cancelled,
+                review_change::ReviewCallError::Message(message) => DispatchError::Message(message),
+            })
         }
-        scan::TOOL_NAME => scan::call(arguments),
-        context::TOOL_NAME => context::call(arguments),
-        explain_file::TOOL_NAME => explain_file::call(arguments, &state.root),
-        explain_finding::TOOL_NAME => call_explain_finding(arguments, state, referenced),
+        scan::TOOL_NAME => scan::call(arguments)
+            .map(ToolExecution::plain)
+            .map_err(DispatchError::Message),
+        context::TOOL_NAME => context::call(arguments)
+            .map(ToolExecution::plain)
+            .map_err(DispatchError::Message),
+        explain_file::TOOL_NAME => explain_file::call(arguments, &state.root)
+            .map(ToolExecution::plain)
+            .map_err(DispatchError::Message),
+        explain_finding::TOOL_NAME => call_explain_finding(arguments, state, referenced)
+            .map(ToolExecution::plain)
+            .map_err(DispatchError::Message),
         explain_review_signal::TOOL_NAME => {
             let report = referenced
                 .filter(|record| record.kind == AnalysisKind::Review)
                 .map(|record| record.report.as_str())
                 .or(state.last_review.as_deref());
             explain_review_signal::call(arguments, report)
+                .map(ToolExecution::plain)
+                .map_err(DispatchError::Message)
         }
-        other => Err(format!("unknown tool: {other}")),
+        other => Err(DispatchError::Message(format!("unknown tool: {other}"))),
     }
+}
+
+enum DispatchError {
+    Cancelled,
+    Message(String),
+}
+
+struct ToolExecution {
+    rendered: String,
+    review_revision: Option<ReviewRevision>,
+}
+
+impl ToolExecution {
+    fn plain(rendered: String) -> Self {
+        Self {
+            rendered,
+            review_revision: None,
+        }
+    }
+}
+
+struct ReviewRevision {
+    analysis_revision: String,
+    revision_compatible: bool,
 }
 
 fn referenced_analysis(
@@ -146,123 +236,6 @@ fn call_explain_finding(
         state.last_scan.as_deref(),
         state.last_review.as_deref(),
     )
-}
-
-fn prepare_analysis_result(
-    name: &str,
-    outcome: Result<String, String>,
-    arguments: &Value,
-    state: &mut ServerState,
-    workspace_revision: &str,
-) -> (Result<String, String>, Option<String>, Option<Value>) {
-    let kind = match name {
-        scan::TOOL_NAME => Some(AnalysisKind::Scan),
-        review_change::TOOL_NAME => Some(AnalysisKind::Review),
-        _ => None,
-    };
-    let Some(kind) = kind else {
-        return (outcome, None, None);
-    };
-    let full_report = match outcome {
-        Ok(report) => report,
-        Err(message) => return (Err(message), None, None),
-    };
-    let handle = state
-        .analyses
-        .insert(kind, full_report.clone(), workspace_revision);
-    let client_report = compact_review_for_client(kind, full_report, arguments);
-    let client_report = match client_report {
-        Ok(report) => report,
-        Err(message) => return (Err(message), Some(handle), None),
-    };
-    match analysis_store::paginate_findings(&client_report, arguments) {
-        Ok(page) => {
-            match kind {
-                AnalysisKind::Scan => state.last_scan = Some(page.text.clone()),
-                AnalysisKind::Review => state.last_review = Some(page.text.clone()),
-            }
-            (Ok(page.text), Some(handle), page.metadata)
-        }
-        Err(message) => (Err(message), Some(handle), None),
-    }
-}
-
-fn compact_review_for_client(
-    kind: AnalysisKind,
-    full_report: String,
-    arguments: &Value,
-) -> Result<String, String> {
-    if kind == AnalysisKind::Review
-        && arguments.get("offset").is_none()
-        && arguments.get("limit").is_none()
-        && arguments.get("detail").and_then(Value::as_str) != Some("full")
-    {
-        review_change::compact_review_json(&full_report)
-    } else {
-        Ok(full_report)
-    }
-}
-
-pub(super) fn tool_result(
-    name: &str,
-    outcome: Result<String, String>,
-    workspace_revision: &str,
-    analysis_handle: Option<&str>,
-    pagination: Option<Value>,
-    max_response_bytes: usize,
-) -> Value {
-    let mut result = match outcome {
-        Ok(text) => success_result(name, text),
-        Err(message) => {
-            json!({ "content": [{ "type": "text", "text": message }], "isError": true })
-        }
-    };
-    result["workspaceRevision"] = json!(workspace_revision);
-    if let Some(handle) = analysis_handle {
-        result["analysisHandle"] = json!(handle);
-    }
-    if let Some(pagination) = pagination {
-        result["pagination"] = pagination;
-    }
-    if serde_json::to_vec(&result).is_ok_and(|encoded| encoded.len() <= max_response_bytes) {
-        return result;
-    }
-    oversized_result(workspace_revision, analysis_handle, max_response_bytes)
-}
-
-fn success_result(name: &str, text: String) -> Value {
-    let structured = serde_json::from_str::<Value>(&text).unwrap_or_else(|_| {
-        if name == context::TOOL_NAME {
-            json!({ "markdown": text })
-        } else {
-            json!({ "text": text })
-        }
-    });
-    json!({
-        "content": [{ "type": "text", "text": text }],
-        "structuredContent": structured,
-        "isError": false
-    })
-}
-
-fn oversized_result(
-    workspace_revision: &str,
-    analysis_handle: Option<&str>,
-    max_response_bytes: usize,
-) -> Value {
-    json!({
-        "content": [{
-            "type": "text",
-            "text": format!(
-                "MCP tool result exceeded the configured {max_response_bytes}-byte limit; use filters, offset/limit, detail=compact, or a smaller context budget"
-            )
-        }],
-        "isError": true,
-        "workspaceRevision": workspace_revision,
-        "analysisHandle": analysis_handle,
-        "responseTruncated": true,
-        "responseLimitBytes": max_response_bytes
-    })
 }
 
 fn resolve_tool_paths(arguments: &mut Value, root: &Path) -> Result<(), String> {

--- a/src/commands/mcp/worker.rs
+++ b/src/commands/mcp/worker.rs
@@ -1,0 +1,94 @@
+use super::jsonrpc::Response;
+use super::progress::{ProgressReporter, mode_for_tool_call};
+use super::request_registry::RequestRegistry;
+use super::{ServerState, lock_error, request_key};
+use crate::commands::mcp::tool_call::handle_tools_call_with_context;
+use repopilot::verification::CancellationToken;
+use serde::Serialize;
+use serde_json::Value;
+use std::io::Write;
+use std::sync::{Arc, Mutex, mpsc};
+
+pub(super) struct ToolJob {
+    pub id: Value,
+    pub params: Value,
+    pub progress_token: Option<Value>,
+    pub cancellation: CancellationToken,
+}
+
+pub(super) fn write_message<W: Write, T: Serialize>(
+    writer: &Arc<Mutex<&mut W>>,
+    message: &T,
+) -> std::io::Result<()> {
+    let encoded = serde_json::to_string(message)?;
+    let mut writer = writer.lock().map_err(lock_error)?;
+    writer.write_all(encoded.as_bytes())?;
+    writer.write_all(b"\n")?;
+    writer.flush()
+}
+
+pub(super) fn run_tool_worker<W: Write>(
+    jobs: mpsc::Receiver<ToolJob>,
+    state: &Arc<Mutex<ServerState>>,
+    registry: &Arc<Mutex<RequestRegistry>>,
+    writer: &Arc<Mutex<&mut W>>,
+) -> std::io::Result<()> {
+    for job in jobs {
+        let key = request_key(&job.id);
+        let result = process_job(job, state, writer);
+        registry.lock().map_err(lock_error)?.finish(&key);
+        result?;
+    }
+    Ok(())
+}
+
+fn process_job<W: Write>(
+    job: ToolJob,
+    state: &Arc<Mutex<ServerState>>,
+    writer: &Arc<Mutex<&mut W>>,
+) -> std::io::Result<()> {
+    if job.cancellation.is_cancelled() {
+        return write_message(
+            writer,
+            &Response::error(job.id, -32800, "request cancelled"),
+        );
+    }
+
+    let mode = mode_for_tool_call(&job.params);
+    let mut sink = |notification| write_message(writer, &notification);
+    let mut reporter = ProgressReporter::new(
+        job.progress_token.clone(),
+        mode,
+        &job.cancellation,
+        &mut sink,
+    );
+    reporter.analysis_started();
+    if reporter.has_error() {
+        return reporter.into_result();
+    }
+
+    let response = {
+        let mut state = state.lock().map_err(lock_error)?;
+        handle_tools_call_with_context(
+            job.id.clone(),
+            &job.params,
+            &mut state,
+            &job.cancellation,
+            &mut |event| reporter.verification(event),
+        )
+    };
+
+    if response.error.is_none()
+        && response
+            .result
+            .as_ref()
+            .is_some_and(|result| result["isError"] != true)
+    {
+        reporter.finish_success();
+    }
+    reporter.into_result()?;
+    write_message(writer, &response)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/commands/mcp/worker/tests.rs
+++ b/src/commands/mcp/worker/tests.rs
@@ -1,0 +1,56 @@
+use super::{ToolJob, run_tool_worker};
+use crate::commands::mcp::ServerState;
+use crate::commands::mcp::request_registry::RequestRegistry;
+use repopilot::verification::CancellationToken;
+use serde_json::json;
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex, mpsc};
+
+struct FailingWriter;
+
+impl Write for FailingWriter {
+    fn write(&mut self, _buffer: &[u8]) -> io::Result<usize> {
+        Err(io::Error::new(io::ErrorKind::BrokenPipe, "writer closed"))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn writer_failure_still_cleans_request_registry() {
+    let registry = Arc::new(Mutex::new(RequestRegistry::default()));
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    registry
+        .lock()
+        .expect("registry")
+        .register("41".to_string(), cancellation.clone());
+    let (sender, receiver) = mpsc::channel();
+    sender
+        .send(ToolJob {
+            id: json!(41),
+            params: json!({}),
+            progress_token: None,
+            cancellation,
+        })
+        .expect("job");
+    drop(sender);
+    let state = Arc::new(Mutex::new(ServerState::default()));
+    let mut output = FailingWriter;
+    let writer = Arc::new(Mutex::new(&mut output));
+
+    let error =
+        run_tool_worker(receiver, &state, &registry, &writer).expect_err("closed writer must fail");
+
+    assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+    let reused = CancellationToken::new();
+    let mut registry = registry.lock().expect("registry");
+    registry.cancel("41");
+    registry.register("41".to_string(), reused.clone());
+    assert!(
+        reused.is_cancelled(),
+        "completed request remained active after writer failure"
+    );
+}

--- a/src/commands/mcp/workspace_freshness_tests.rs
+++ b/src/commands/mcp/workspace_freshness_tests.rs
@@ -1,4 +1,7 @@
 use super::{ServerState, context, explain_file, handle_tools_call, review_change, scan};
+use crate::commands::mcp::tool_call::handle_tools_call_with_context;
+use crate::commands::review_verification::ReviewVerificationEvent;
+use repopilot::verification::CancellationToken;
 use serde_json::{Value, json};
 use std::fs;
 use std::path::Path;
@@ -193,4 +196,122 @@ fn explain_file_observes_manifest_changes_after_the_first_call() {
             .as_array()
             .is_some_and(|roles| roles.iter().any(|role| role == "cli-executable"))
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn revision_incompatible_review_is_returned_but_not_published() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    setup_verification_review_repo(temp.path(), "printf changed > verification-mutated.txt");
+    let mut state = state(temp.path());
+    state.last_review = Some("previous review".to_string());
+
+    let response = handle_tools_call(
+        json!(20),
+        &json!({
+            "name": review_change::TOOL_NAME,
+            "arguments": {
+                "path": ".",
+                "config": "repopilot.toml",
+                "detail": "full",
+                "verify": ["unit"]
+            }
+        }),
+        &mut state,
+    );
+    let result = response.result.expect("review result");
+
+    assert_eq!(result["isError"], false, "review failed: {result}");
+    assert_eq!(
+        result["structuredContent"]["merge_readiness"]["verification"][0]["revision_compatible"],
+        false
+    );
+    assert!(result.get("analysisHandle").is_none());
+    assert!(state.analyses.summaries().is_empty());
+    assert_eq!(state.last_review.as_deref(), Some("previous review"));
+}
+
+#[cfg(unix)]
+#[test]
+fn revision_compatible_failed_review_is_published() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    setup_verification_review_repo(temp.path(), "exit 7");
+    let mut state = state(temp.path());
+
+    let response = handle_tools_call(
+        json!(21),
+        &json!({
+            "name": review_change::TOOL_NAME,
+            "arguments": {
+                "path": ".",
+                "config": "repopilot.toml",
+                "detail": "full",
+                "verify": ["unit"]
+            }
+        }),
+        &mut state,
+    );
+    let result = response.result.expect("review result");
+
+    assert_eq!(result["isError"], false, "review failed: {result}");
+    assert_eq!(
+        result["structuredContent"]["merge_readiness"]["verification"][0]["status"],
+        "failed"
+    );
+    assert!(result["analysisHandle"].is_string());
+    assert_eq!(state.analyses.summaries().len(), 1);
+    assert!(state.last_review.is_some());
+}
+
+#[cfg(unix)]
+#[test]
+fn cancellation_after_verification_leaves_previous_review_unchanged() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    setup_verification_review_repo(temp.path(), "exit 7");
+    let mut state = state(temp.path());
+    state.last_review = Some("previous review".to_string());
+    let cancellation = CancellationToken::new();
+    let observer_token = cancellation.clone();
+
+    let response = handle_tools_call_with_context(
+        json!(22),
+        &json!({
+            "name": review_change::TOOL_NAME,
+            "arguments": {
+                "path": ".",
+                "config": "repopilot.toml",
+                "detail": "full",
+                "verify": ["unit"]
+            }
+        }),
+        &mut state,
+        &cancellation,
+        &mut |event| {
+            if matches!(event, ReviewVerificationEvent::Completed { .. }) {
+                observer_token.cancel();
+            }
+        },
+    );
+
+    assert_eq!(response.error.expect("cancelled response").code, -32800);
+    assert!(state.analyses.summaries().is_empty());
+    assert_eq!(state.last_review.as_deref(), Some("previous review"));
+}
+
+#[cfg(unix)]
+fn setup_verification_review_repo(root: &Path, shell_command: &str) {
+    git(root, &["init", "-q"]);
+    git(root, &["config", "user.email", "t@example.com"]);
+    git(root, &["config", "user.name", "Test"]);
+    fs::write(root.join("lib.rs"), "pub fn live() -> i32 { 1 }\n").expect("source");
+    fs::write(
+        root.join("repopilot.toml"),
+        format!(
+            "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"sh\"\nargs = [\"-c\", {shell_command:?}]\n"
+        ),
+    )
+    .expect("config");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-qm", "initial"]);
+    fs::write(root.join("lib.rs"), "pub fn live() -> i32 { 2 }\n").expect("change");
 }

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -135,7 +135,6 @@ pub fn run(options: ReviewOptions) -> Result<(), Box<dyn std::error::Error>> {
 
     crate::commands::review_verification::run_selected(
         &options.verify,
-        &configured,
         &scan_result.session,
         &history_target,
         &mut review_report,

--- a/src/commands/review_verification.rs
+++ b/src/commands/review_verification.rs
@@ -1,23 +1,56 @@
 use crate::commands::{CliExit, EXIT_USAGE};
-use repopilot::config::model::RepoPilotConfig;
 use repopilot::review::diff::OwnedDiffTarget;
 use repopilot::review::model::ReviewReport;
 use repopilot::scan::session::AnalysisSession;
 use repopilot::verification::{
-    CancellationToken, run_checks, select_checks, validate_review_target,
+    CancellationToken, VerificationExecutionEvent, VerificationStatus, run_checks_observed,
+    select_checks, validate_review_target,
 };
 use std::time::Instant;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ReviewVerificationEvent {
+    Started {
+        check_id: String,
+        index: usize,
+        total: usize,
+    },
+    Completed {
+        check_id: String,
+        index: usize,
+        total: usize,
+        status: VerificationStatus,
+    },
+}
+
 pub(super) fn run_selected(
     selected: &[String],
-    config: &RepoPilotConfig,
     session: &AnalysisSession,
     target: &OwnedDiffTarget,
     report: &mut ReviewReport,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    run_selected_with_context(
+        selected,
+        session,
+        target,
+        report,
+        &CancellationToken::new(),
+        &mut |_| {},
+    )
+}
+
+pub(super) fn run_selected_with_context(
+    selected: &[String],
+    session: &AnalysisSession,
+    target: &OwnedDiffTarget,
+    report: &mut ReviewReport,
+    cancellation: &CancellationToken,
+    observer: &mut dyn FnMut(ReviewVerificationEvent),
+) -> Result<(), Box<dyn std::error::Error>> {
     if selected.is_empty() {
         return Ok(());
     }
+    let config = session.repo_config();
     validate_review_target(session.workspace_root(), target, &config.scan.ignore)
         .map_err(usage_error)?;
     let checks = select_checks(
@@ -40,14 +73,40 @@ pub(super) fn run_selected(
     evidence_paths.dedup();
 
     let started = Instant::now();
-    report.verification = run_checks(
+    report.verification = run_checks_observed(
         &checks,
         &evidence_paths,
         session.revision(),
-        &CancellationToken::new(),
+        cancellation,
+        &mut |event| observer(map_event(event)),
     );
     report.timings.verification_us = started.elapsed().as_micros().min(u128::from(u64::MAX)) as u64;
     Ok(())
+}
+
+fn map_event(event: VerificationExecutionEvent) -> ReviewVerificationEvent {
+    match event {
+        VerificationExecutionEvent::Started {
+            check_id,
+            index,
+            total,
+        } => ReviewVerificationEvent::Started {
+            check_id,
+            index,
+            total,
+        },
+        VerificationExecutionEvent::Completed {
+            check_id,
+            index,
+            total,
+            status,
+        } => ReviewVerificationEvent::Completed {
+            check_id,
+            index,
+            total,
+            status,
+        },
+    }
 }
 
 fn usage_error(error: impl std::fmt::Display) -> Box<dyn std::error::Error> {
@@ -56,3 +115,6 @@ fn usage_error(error: impl std::fmt::Display) -> Box<dyn std::error::Error> {
         message: error.to_string(),
     })
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/commands/review_verification/tests.rs
+++ b/src/commands/review_verification/tests.rs
@@ -1,0 +1,109 @@
+use super::{ReviewVerificationEvent, run_selected_with_context};
+use repopilot::config::loader::parse_config;
+use repopilot::findings::visibility::FindingVisibilityProfile;
+use repopilot::review::diff::OwnedDiffTarget;
+use repopilot::review::model::ReviewReport;
+use repopilot::scan::config::ScanConfig;
+use repopilot::scan::session::AnalysisSession;
+use repopilot::scan::types::ScanSummary;
+use repopilot::verification::{CancellationToken, VerificationStatus};
+use tempfile::tempdir;
+
+#[test]
+fn context_adapter_attaches_outcome_and_emits_safe_lifecycle() {
+    let temp = tempdir().expect("temp dir");
+    let config = parse_config(
+        r#"[[verification.checks]]
+id = "unit"
+role = "test"
+program = "repopilot-missing-unit-program"
+"#,
+        None,
+    )
+    .expect("valid config");
+    let session = AnalysisSession::new(
+        temp.path().to_path_buf(),
+        config,
+        ScanConfig::default(),
+        FindingVisibilityProfile::Default,
+    );
+    let mut report = empty_report(temp.path());
+    let mut events = Vec::new();
+
+    run_selected_with_context(
+        &["unit".into()],
+        &session,
+        &OwnedDiffTarget::WorkingTree,
+        &mut report,
+        &CancellationToken::new(),
+        &mut |event| events.push(event),
+    )
+    .expect("verification outcome");
+
+    assert_eq!(report.verification.len(), 1);
+    assert_eq!(
+        report.verification[0].status,
+        VerificationStatus::Unavailable
+    );
+    assert_eq!(
+        events,
+        vec![
+            ReviewVerificationEvent::Started {
+                check_id: "unit".into(),
+                index: 1,
+                total: 1,
+            },
+            ReviewVerificationEvent::Completed {
+                check_id: "unit".into(),
+                index: 1,
+                total: 1,
+                status: VerificationStatus::Unavailable,
+            },
+        ]
+    );
+}
+
+#[test]
+fn empty_selection_does_not_touch_report_or_observer() {
+    let temp = tempdir().expect("temp dir");
+    let session = AnalysisSession::new(
+        temp.path().to_path_buf(),
+        Default::default(),
+        ScanConfig::default(),
+        FindingVisibilityProfile::Default,
+    );
+    let mut report = empty_report(temp.path());
+    let mut events = Vec::new();
+
+    run_selected_with_context(
+        &[],
+        &session,
+        &OwnedDiffTarget::WorkingTree,
+        &mut report,
+        &CancellationToken::new(),
+        &mut |event| events.push(event),
+    )
+    .expect("empty selection");
+
+    assert!(report.verification.is_empty());
+    assert!(events.is_empty());
+}
+
+fn empty_report(root: &std::path::Path) -> ReviewReport {
+    ReviewReport {
+        summary: ScanSummary::default(),
+        repo_root: root.to_path_buf(),
+        baseline_path: None,
+        changed_files: Vec::new(),
+        blast_radius: Vec::new(),
+        impact_paths: Default::default(),
+        ownership: Default::default(),
+        ownership_diagnostics: Vec::new(),
+        boundary_signals: Vec::new(),
+        boundary_missing_test: false,
+        tiered_signals: Default::default(),
+        timings: Default::default(),
+        verification: Vec::new(),
+        findings: Vec::new(),
+    }
+}

--- a/src/verification/executor.rs
+++ b/src/verification/executor.rs
@@ -1,5 +1,7 @@
 use crate::scan::session::WorkspaceRevision;
-use crate::verification::model::{CancellationToken, VerificationOutcome, VerificationStatus};
+use crate::verification::model::{
+    CancellationToken, VerificationExecutionEvent, VerificationOutcome, VerificationStatus,
+};
 use crate::verification::policy::{ValidatedCheck, ValidatedProgram};
 use crate::verification::redaction::{CapturedStream, capture_and_redact};
 use std::io::Read;
@@ -27,27 +29,51 @@ pub fn run_checks(
     revision: &WorkspaceRevision,
     cancellation: &CancellationToken,
 ) -> Vec<VerificationOutcome> {
+    run_checks_observed(checks, evidence_paths, revision, cancellation, &mut |_| {})
+}
+
+pub fn run_checks_observed(
+    checks: &[ValidatedCheck],
+    evidence_paths: &[std::path::PathBuf],
+    revision: &WorkspaceRevision,
+    cancellation: &CancellationToken,
+    observer: &mut dyn FnMut(VerificationExecutionEvent),
+) -> Vec<VerificationOutcome> {
     let mut outcomes = Vec::with_capacity(checks.len());
     let mut revision_changed = false;
-    for check in checks {
-        if revision_changed {
-            outcomes.push(skipped_outcome(
+    let total = checks.len();
+    for (offset, check) in checks.iter().enumerate() {
+        if cancellation.is_cancelled() {
+            break;
+        }
+        let index = offset + 1;
+        observer(VerificationExecutionEvent::Started {
+            check_id: check.id().to_string(),
+            index,
+            total,
+        });
+        let outcome = if revision_changed {
+            skipped_outcome(
                 check,
                 revision,
                 "workspace revision changed before this check could run",
-            ));
-            continue;
-        }
-        if !check.is_applicable(evidence_paths.iter().map(std::path::PathBuf::as_path)) {
-            outcomes.push(skipped_outcome(
+            )
+        } else if !check.is_applicable(evidence_paths.iter().map(std::path::PathBuf::as_path)) {
+            skipped_outcome(
                 check,
                 revision,
                 "no changed or impacted path matched this check",
-            ));
-            continue;
-        }
-        let outcome = execute_check(check, revision, cancellation);
+            )
+        } else {
+            execute_check(check, revision, cancellation)
+        };
         revision_changed = !outcome.revision_compatible;
+        observer(VerificationExecutionEvent::Completed {
+            check_id: check.id().to_string(),
+            index,
+            total,
+            status: outcome.status,
+        });
         outcomes.push(outcome);
     }
     outcomes
@@ -59,6 +85,9 @@ pub fn execute_check(
     cancellation: &CancellationToken,
 ) -> VerificationOutcome {
     let started = Instant::now();
+    if cancellation.is_cancelled() {
+        return cancelled_outcome(check, revision_before, started);
+    }
     let mut command = command_for(check);
     let mut child = match command.spawn() {
         Ok(child) => child,
@@ -203,6 +232,29 @@ fn unavailable_outcome(
         revision_after: revision.id().to_string(),
         revision_compatible: true,
         limitations: vec!["configured program could not be started".to_string()],
+    }
+}
+
+fn cancelled_outcome(
+    check: &ValidatedCheck,
+    revision: &WorkspaceRevision,
+    started: Instant,
+) -> VerificationOutcome {
+    VerificationOutcome {
+        check_id: check.id().to_string(),
+        role: check.role,
+        status: VerificationStatus::Cancelled,
+        duration_ms: duration_ms(started.elapsed()),
+        exit_code: None,
+        working_directory: check.working_directory_label.clone(),
+        stdout_excerpt: String::new(),
+        stderr_excerpt: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+        revision_before: revision.id().to_string(),
+        revision_after: revision.id().to_string(),
+        revision_compatible: true,
+        limitations: vec!["verification was cancelled before the check started".to_string()],
     }
 }
 

--- a/src/verification/executor/tests.rs
+++ b/src/verification/executor/tests.rs
@@ -1,4 +1,4 @@
-use super::{execute_check, run_checks};
+use super::{VerificationExecutionEvent, execute_check, run_checks, run_checks_observed};
 use crate::config::loader::parse_config;
 use crate::scan::session::WorkspaceRevision;
 use crate::verification::{CancellationToken, VerificationStatus, select_checks};
@@ -9,6 +9,116 @@ fn check(root: &std::path::Path, toml: &str, id: &str) -> crate::verification::V
     select_checks(root, &config.verification.checks, &[id.into()])
         .expect("valid selection")
         .remove(0)
+}
+
+#[test]
+fn observed_checks_emit_ordered_lifecycle() {
+    let temp = tempdir().expect("temp dir");
+    let config = parse_config(
+        r#"[[verification.checks]]
+id = "unit"
+role = "test"
+program = "repopilot-missing-unit-program"
+[[verification.checks]]
+id = "lint"
+role = "lint"
+program = "repopilot-missing-lint-program"
+"#,
+        None,
+    )
+    .expect("valid config");
+    let checks = select_checks(
+        temp.path(),
+        &config.verification.checks,
+        &["unit".into(), "lint".into()],
+    )
+    .expect("valid selection");
+    let mut events = Vec::new();
+
+    let outcomes = run_checks_observed(
+        &checks,
+        &[],
+        &WorkspaceRevision::capture(temp.path()),
+        &CancellationToken::new(),
+        &mut |event| events.push(event),
+    );
+
+    assert_eq!(outcomes.len(), 2);
+    assert_eq!(
+        events,
+        vec![
+            VerificationExecutionEvent::Started {
+                check_id: "lint".into(),
+                index: 1,
+                total: 2,
+            },
+            VerificationExecutionEvent::Completed {
+                check_id: "lint".into(),
+                index: 1,
+                total: 2,
+                status: VerificationStatus::Unavailable,
+            },
+            VerificationExecutionEvent::Started {
+                check_id: "unit".into(),
+                index: 2,
+                total: 2,
+            },
+            VerificationExecutionEvent::Completed {
+                check_id: "unit".into(),
+                index: 2,
+                total: 2,
+                status: VerificationStatus::Unavailable,
+            },
+        ]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn observer_cancellation_prevents_next_spawn() {
+    let temp = tempdir().expect("temp dir");
+    let config = parse_config(
+        r#"[[verification.checks]]
+id = "first"
+role = "test"
+program = "sh"
+args = ["-c", "true"]
+[[verification.checks]]
+id = "second"
+role = "lint"
+program = "sh"
+args = ["-c", "printf spawned > second.txt"]
+"#,
+        None,
+    )
+    .expect("valid config");
+    let checks = select_checks(
+        temp.path(),
+        &config.verification.checks,
+        &["first".into(), "second".into()],
+    )
+    .expect("valid selection");
+    let cancellation = CancellationToken::new();
+    let observer_token = cancellation.clone();
+
+    let outcomes = run_checks_observed(
+        &checks,
+        &[],
+        &WorkspaceRevision::capture(temp.path()),
+        &cancellation,
+        &mut |event| {
+            if matches!(
+                event,
+                VerificationExecutionEvent::Completed { ref check_id, .. }
+                    if check_id == "first"
+            ) {
+                observer_token.cancel();
+            }
+        },
+    );
+
+    assert_eq!(outcomes.len(), 1);
+    assert!(!temp.path().join("second.txt").exists());
 }
 
 #[cfg(unix)]

--- a/src/verification/mod.rs
+++ b/src/verification/mod.rs
@@ -3,6 +3,9 @@ mod model;
 mod policy;
 mod redaction;
 
-pub use executor::{execute_check, run_checks};
-pub use model::{CancellationToken, VerificationOutcome, VerificationRole, VerificationStatus};
+pub use executor::{execute_check, run_checks, run_checks_observed};
+pub use model::{
+    CancellationToken, VerificationExecutionEvent, VerificationOutcome, VerificationRole,
+    VerificationStatus,
+};
 pub use policy::{ValidatedCheck, VerificationPolicyError, select_checks, validate_review_target};

--- a/src/verification/model.rs
+++ b/src/verification/model.rs
@@ -22,6 +22,21 @@ pub enum VerificationStatus {
     Skipped,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationExecutionEvent {
+    Started {
+        check_id: String,
+        index: usize,
+        total: usize,
+    },
+    Completed {
+        check_id: String,
+        index: usize,
+        total: usize,
+        status: VerificationStatus,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct VerificationOutcome {
     pub check_id: String,

--- a/tests/mcp_cli.rs
+++ b/tests/mcp_cli.rs
@@ -395,6 +395,83 @@ fn mcp_server_emits_progress_for_tool_calls() {
     assert!(responses.iter().any(|message| message["id"] == 7));
 }
 
+#[cfg(unix)]
+#[test]
+fn mcp_review_emits_check_aware_redaction_safe_progress() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    git(temp.path(), &["init", "-q"]);
+    git(temp.path(), &["config", "user.email", "test@example.com"]);
+    git(temp.path(), &["config", "user.name", "Test"]);
+    fs::write(
+        temp.path().join("lib.rs"),
+        "pub fn value() -> usize { 1 }\n",
+    )
+    .expect("source");
+    fs::write(
+        temp.path().join("repopilot.toml"),
+        r#"[[verification.checks]]
+id = "lint"
+role = "lint"
+program = "sh"
+args = ["-c", "printf 'token=progress-secret'; exit 0"]
+[[verification.checks]]
+id = "unit"
+role = "test"
+program = "sh"
+args = ["-c", "printf 'token=progress-secret' >&2; exit 7"]
+"#,
+    )
+    .expect("config");
+    git(temp.path(), &["add", "."]);
+    git(temp.path(), &["commit", "-qm", "initial"]);
+    fs::write(
+        temp.path().join("lib.rs"),
+        "pub fn value() -> usize { 2 }\n",
+    )
+    .expect("change");
+
+    let responses = run_mcp(
+        &[
+            r#"{"jsonrpc":"2.0","id":"init","method":"initialize","params":{"protocolVersion":"2025-11-25"}}"#,
+            r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+            r#"{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"repopilot_review_change","arguments":{"path":".","verify":["unit","lint"]},"_meta":{"progressToken":"review-8"}}}"#,
+        ],
+        temp.path(),
+    );
+    let progress = responses
+        .iter()
+        .filter(|message| message["method"] == "notifications/progress")
+        .collect::<Vec<_>>();
+    let sequence = progress
+        .iter()
+        .map(|message| {
+            (
+                message["params"]["progress"].as_u64().expect("progress"),
+                message["params"]["total"].as_u64().expect("total"),
+                message["params"]["message"]
+                    .as_str()
+                    .expect("message")
+                    .to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        sequence,
+        vec![
+            (0, 4, "analysis started".to_string()),
+            (1, 4, "analysis complete".to_string()),
+            (1, 4, "verification lint started".to_string()),
+            (2, 4, "verification lint passed".to_string()),
+            (2, 4, "verification unit started".to_string()),
+            (3, 4, "verification unit failed".to_string()),
+            (4, 4, "review complete".to_string()),
+        ]
+    );
+    let encoded = serde_json::to_string(&responses).expect("responses");
+    assert!(!encoded.contains("progress-secret"));
+}
+
 #[test]
 fn mcp_server_cancels_background_tool_calls() {
     let temp = tempfile::tempdir().expect("temp dir");
@@ -422,6 +499,81 @@ fn mcp_server_cancels_background_tool_calls() {
         .find(|message| message["id"] == 9)
         .expect("cancelled response");
     assert_eq!(cancelled["error"]["code"], -32800);
+}
+
+#[cfg(unix)]
+#[test]
+fn mcp_cancellation_stops_active_verification() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    git(temp.path(), &["init", "-q"]);
+    git(temp.path(), &["config", "user.email", "test@example.com"]);
+    git(temp.path(), &["config", "user.name", "Test"]);
+    fs::write(
+        temp.path().join("lib.rs"),
+        "pub fn value() -> usize { 1 }\n",
+    )
+    .expect("source");
+    fs::write(
+        temp.path().join("repopilot.toml"),
+        r#"[[verification.checks]]
+id = "slow"
+role = "test"
+program = "sh"
+args = ["-c", "printf started > verification-started; sleep 30"]
+timeout_seconds = 2
+"#,
+    )
+    .expect("config");
+    git(temp.path(), &["add", "."]);
+    git(temp.path(), &["commit", "-qm", "initial"]);
+    fs::write(
+        temp.path().join("lib.rs"),
+        "pub fn value() -> usize { 2 }\n",
+    )
+    .expect("change");
+
+    let (mut child, mut stdin, mut stdout) = start_mcp(temp.path());
+    initialize_mcp(&mut stdin, &mut stdout);
+    send_mcp(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 17,
+            "method": "tools/call",
+            "params": {
+                "name": "repopilot_review_change",
+                "arguments": { "path": ".", "verify": ["slow"] }
+            }
+        }),
+    );
+    let marker = temp.path().join("verification-started");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !marker.exists() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(marker.exists(), "verification process did not start");
+
+    let cancelled_at = std::time::Instant::now();
+    send_mcp(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/cancelled",
+            "params": { "requestId": 17, "reason": "test active cancellation" }
+        }),
+    );
+    let response = receive_mcp(&mut stdout);
+    let cancellation_latency = cancelled_at.elapsed();
+    drop(stdin);
+    let status = child.wait().expect("MCP server exits");
+
+    assert!(status.success());
+    assert_eq!(response["id"], 17);
+    assert_eq!(response["error"]["code"], -32800);
+    assert!(
+        cancellation_latency < std::time::Duration::from_secs(1),
+        "active cancellation took {cancellation_latency:?}"
+    );
 }
 
 fn git(root: &Path, args: &[&str]) {

--- a/tests/mcp_verification.rs
+++ b/tests/mcp_verification.rs
@@ -1,0 +1,213 @@
+#![cfg(unix)]
+
+use serde_json::{Value, json};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+#[test]
+fn absent_empty_and_duplicate_selection_preserve_explicit_execution() {
+    let temp = verification_repo(
+        r#"[[verification.checks]]
+id = "unit"
+role = "test"
+program = "sh"
+args = ["-c", "printf x >> verification-runs"]
+"#,
+    );
+    let responses = run_mcp(
+        temp.path(),
+        vec![
+            tool_call(1, json!({ "path": ".", "detail": "full" })),
+            tool_call(2, json!({ "path": ".", "detail": "full", "verify": [] })),
+            tool_call(
+                3,
+                json!({
+                    "path": ".",
+                    "detail": "full",
+                    "verify": ["unit", "unit"]
+                }),
+            ),
+        ],
+    );
+
+    for id in [1, 2] {
+        let result = result_for(&responses, id);
+        assert_eq!(result["isError"], false);
+        assert!(
+            result["structuredContent"]["merge_readiness"]
+                .get("verification")
+                .is_none()
+        );
+    }
+    let selected = result_for(&responses, 3);
+    assert_eq!(
+        selected["structuredContent"]["merge_readiness"]["verification"]
+            .as_array()
+            .expect("verification outcomes")
+            .len(),
+        1
+    );
+    assert_eq!(
+        fs::read_to_string(temp.path().join("verification-runs")).expect("marker"),
+        "x"
+    );
+}
+
+#[test]
+fn unknown_selector_fails_before_spawn_and_publication() {
+    let temp = verification_repo(
+        r#"[[verification.checks]]
+id = "known"
+role = "test"
+program = "sh"
+args = ["-c", "printf spawned > should-not-exist"]
+"#,
+    );
+    let responses = run_mcp(
+        temp.path(),
+        vec![
+            tool_call(4, json!({ "path": ".", "verify": ["unknown"] })),
+            json!({
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "resources/read",
+                "params": { "uri": "repopilot://analyses" }
+            }),
+        ],
+    );
+
+    let result = result_for(&responses, 4);
+    assert_eq!(result["isError"], true);
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .expect("error")
+            .contains("unknown verification check id")
+    );
+    assert!(!temp.path().join("should-not-exist").exists());
+    assert_eq!(result_for(&responses, 5)["contents"][0]["text"], "[]");
+}
+
+#[test]
+fn failed_check_is_blocked_publishable_evidence() {
+    let temp = verification_repo(
+        r#"[[verification.checks]]
+id = "unit"
+role = "test"
+program = "sh"
+args = ["-c", "printf failure >&2; exit 7"]
+"#,
+    );
+    let responses = run_mcp(
+        temp.path(),
+        vec![tool_call(
+            6,
+            json!({ "path": ".", "detail": "full", "verify": ["unit"] }),
+        )],
+    );
+
+    let result = result_for(&responses, 6);
+    assert_eq!(result["isError"], false);
+    assert_eq!(
+        result["structuredContent"]["merge_readiness"]["verification"][0]["status"],
+        "failed"
+    );
+    assert_eq!(
+        result["structuredContent"]["merge_readiness"]["verdict"],
+        "blocked"
+    );
+    assert!(result["analysisHandle"].is_string());
+}
+
+fn verification_repo(config: &str) -> tempfile::TempDir {
+    let temp = tempfile::tempdir().expect("temp dir");
+    git(temp.path(), &["init", "-q"]);
+    git(temp.path(), &["config", "user.email", "test@example.com"]);
+    git(temp.path(), &["config", "user.name", "Test"]);
+    fs::write(
+        temp.path().join("lib.rs"),
+        "pub fn value() -> usize { 1 }\n",
+    )
+    .expect("source");
+    fs::write(temp.path().join("repopilot.toml"), config).expect("config");
+    git(temp.path(), &["add", "."]);
+    git(temp.path(), &["commit", "-qm", "initial"]);
+    fs::write(
+        temp.path().join("lib.rs"),
+        "pub fn value() -> usize { 2 }\n",
+    )
+    .expect("change");
+    temp
+}
+
+fn tool_call(id: u64, arguments: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": { "name": "repopilot_review_change", "arguments": arguments }
+    })
+}
+
+fn run_mcp(root: &Path, requests: Vec<Value>) -> Vec<Value> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_repopilot"))
+        .arg("mcp")
+        .current_dir(root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn MCP server");
+    let mut stdin = child.stdin.take().expect("stdin");
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": "init",
+            "method": "initialize",
+            "params": { "protocolVersion": "2025-11-25" }
+        })
+    )
+    .expect("initialize");
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        })
+    )
+    .expect("initialized");
+    for request in requests {
+        writeln!(stdin, "{request}").expect("request");
+    }
+    drop(stdin);
+
+    let output = child.wait_with_output().expect("MCP output");
+    assert!(output.status.success(), "MCP server failed");
+    String::from_utf8(output.stdout)
+        .expect("UTF-8")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("JSON response"))
+        .collect()
+}
+
+fn result_for(responses: &[Value], id: u64) -> &Value {
+    &responses
+        .iter()
+        .find(|response| response["id"] == id)
+        .unwrap_or_else(|| panic!("missing response {id}"))["result"]
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git");
+    assert!(output.status.success(), "git {args:?} failed");
+}


### PR DESCRIPTION
## Summary

Adds configured local verification parity to `repopilot_review_change` while preserving the existing no-verification MCP behavior.

## Type of change

- [x] Feature
- [x] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- accepts an explicit `verify` array of repository-configured check IDs; arbitrary call-time commands remain impossible
- shares the canonical review verification adapter across CLI and MCP
- adds active process-tree cancellation, bounded redaction-safe progress, and transactional revision-safe analysis publication
- splits MCP worker, progress, catalog, request registry, projection, and publication ownership into focused modules
- adds unit, lifecycle, freshness, and end-to-end stdio acceptance coverage

## Why

D1 made local verification part of the canonical CLI readiness record. D2 gives agents the same controlled capability through MCP without introducing a parallel execution or decision path.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

No zoo reduction is claimed; `.zoo/` was unavailable locally.

## Changelog

- [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
cargo run -- scan . --fail-on-priority p1
npm run review:performance
```