### PR TITLE
feat(verification): add trusted result cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- **Trusted verification reuse across CLI and MCP.** Individual configured
+  checks can opt into a persistent local cache with `cache = { enabled = true }`.
+  RepoPilot reuses only passing, revision-compatible evidence keyed by the full
+  check policy, executable bytes, inherited portability environment, platform,
+  workspace revision, version, and schema. Storage is atomic, bounded, and
+  best-effort; unsafe or corrupt entries become misses. JSON/MCP mark reused
+  outcomes with `reused: true`, while console and Markdown label cached evidence.
 - **Explicit local verification for review.** Repositories can define bounded
   test, build, type-check, and lint checks under `[[verification.checks]]` and
   run only the allowlisted IDs selected with repeatable `review --verify`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,37 @@ repopilot review . --fail-on-review definitely
 See [CLI reference → Gates](cli.md#gates) for the full two-axis gate model
 (finding gate vs review-signal gate).
 
+## Explicit local verification
+
+Repository maintainers can declare bounded checks and developers can select
+them explicitly with `repopilot review --verify <id>`:
+
+```toml
+[[verification.checks]]
+id = "unit"
+role = "test"
+program = "cargo"
+args = ["test", "--all"]
+working_directory = "."
+timeout_seconds = 120
+max_output_bytes = 65536
+paths = ["src/**", "tests/**", "Cargo.toml", "Cargo.lock"]
+cache = { enabled = true }
+```
+
+Caching is off by default and must be enabled per check. RepoPilot reuses only
+passing, revision-compatible evidence. The key covers the workspace revision,
+complete check policy, resolved executable bytes, inherited portability
+environment, platform, RepoPilot version, and cache schema. Failed, skipped,
+cancelled, timed-out, or incompatible results are never reused. Cache problems
+fall back to executing the check and never fail the review.
+
+Cached evidence is stored under `.repopilot/cache/verification/v1`, retained
+best-effort up to 64 entries, and may be deleted safely. Human reports label it
+`cached`; structured output adds `reused: true`. Do not enable caching for checks
+that depend on network services, external state, wall-clock time, ignored files,
+or relevant inputs outside the declared workspace revision.
+
 ## Local History
 
 Risk history is opt-in. Enable it for every `scan` and `review` in a repository:

--- a/docs/engineering/v0.22-d3-verification-cache-plan.md
+++ b/docs/engineering/v0.22-d3-verification-cache-plan.md
@@ -1,0 +1,632 @@
+# RepoPilot 0.22 D3 Trusted Verification Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in, persistent local cache that reuses only successful revision-compatible verification evidence across CLI and MCP review calls.
+
+**Architecture:** A verification-owned key builder fingerprints the validated check, resolved executable, inherited environment, platform, RepoPilot/schema version, and `WorkspaceRevision`. A separate best-effort storage unit persists bounded redacted outcomes under `.repopilot/cache/verification/v1`; the shared review adapter enables it for both CLI and MCP while existing executor entry points remain no-cache compatibility wrappers.
+
+**Tech Stack:** Rust 2024, serde/serde_json, sha2, TOML configuration, filesystem atomic rename, existing `WorkspaceRevision`, existing CLI/MCP integration tests.
+
+**Spec:** `docs/engineering/v0.22-d3-verification-cache-spec.md`
+
+## Global Constraints
+
+- Caching is disabled by default and can be enabled only in repository configuration for a declared check.
+- Cache only `VerificationStatus::Passed` outcomes whose revisions remain compatible.
+- A cache failure is always a miss; it cannot fail analysis, verification, CLI, or MCP transport.
+- Persist only bounded redacted `VerificationOutcome` data; never persist raw output, environment values, or command secrets.
+- Keep no-cache CLI/MCP results and progress unchanged.
+- Keep source files near 300 lines and functions near 50 lines.
+- Preserve deterministic ordering, root confinement, cancellation, timeout, and transactional MCP publication.
+- Do not add a dependency or a top-level CLI/MCP command.
+
+---
+
+### Task 1: Add opt-in configuration and canonical reuse provenance
+
+**Files:**
+- Modify: `src/config/model.rs`
+- Modify: `src/verification/model.rs`
+- Modify: `src/verification/policy.rs`
+- Modify: `tests/config_loader.rs`
+- Modify: `src/verification/executor/tests.rs`
+
+**Interfaces:**
+- Produces: `VerificationCacheConfig { enabled: bool }` on each `VerificationCheckConfig`.
+- Produces: `ValidatedCheck::cache_enabled() -> bool` and normalized `path_patterns` for Task 2.
+- Produces: additive `VerificationOutcome::reused: bool`, omitted from JSON when false.
+
+- [x] **Step 1: Add failing configuration tests**
+
+Add cases to `tests/config_loader.rs` proving the default and explicit contract:
+
+```rust
+#[test]
+fn verification_cache_is_disabled_by_default_and_requires_explicit_opt_in() {
+    let default = parse_config(
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"cargo\"\n",
+        None,
+    ).expect("default check");
+    assert!(!default.verification.checks[0].cache.enabled);
+
+    let enabled = parse_config(
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"cargo\"\n[verification.checks.cache]\nenabled = true\n",
+        None,
+    ).expect("cached check");
+    assert!(enabled.verification.checks[0].cache.enabled);
+}
+```
+
+Add a second test asserting `[verification.checks.cache] unknown = true` is rejected.
+
+- [x] **Step 2: Run the configuration tests and observe RED**
+
+Run: `cargo test --test config_loader verification_cache`
+
+Expected: compile or parse failure because `VerificationCacheConfig` and `cache` do not exist.
+
+- [x] **Step 3: Implement the configuration model and validated policy state**
+
+Add to `src/config/model.rs`:
+
+```rust
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct VerificationCacheConfig {
+    pub enabled: bool,
+}
+```
+
+Add `#[serde(default)] pub cache: VerificationCacheConfig` to
+`VerificationCheckConfig`. In `ValidatedCheck`, retain `cache_enabled` and a
+sorted/deduplicated copy of the configured path strings:
+
+```rust
+pub fn cache_enabled(&self) -> bool {
+    self.cache_enabled
+}
+```
+
+Continue using the existing compiled `GlobSet` for applicability; the raw
+normalized strings exist only for stable key input.
+
+- [x] **Step 4: Add reuse provenance without changing executed JSON**
+
+Derive `Deserialize` for `VerificationRole`, `VerificationStatus`, and
+`VerificationOutcome`. Add:
+
+```rust
+#[serde(default, skip_serializing_if = "is_false")]
+pub reused: bool,
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+```
+
+Set `reused: false` in every current executor outcome constructor. Add a unit
+test serializing a fresh outcome and asserting `reused` is absent, then set it
+true and assert the field is present.
+
+- [x] **Step 5: Run focused model and configuration tests**
+
+Run:
+
+```bash
+cargo test --test config_loader
+cargo test verification::executor::tests
+```
+
+Expected: all pass and existing executed outcome snapshots remain unchanged.
+
+- [x] **Step 6: Publication checkpoint**
+
+Run `cargo fmt --all -- --check` and `git diff --check`. If publication is
+explicitly authorized, commit as `feat(verification): configure trusted cache reuse`.
+
+---
+
+### Task 2: Build the conservative verification cache key
+
+**Files:**
+- Create: `src/verification/cache.rs`
+- Create: `src/verification/cache/key.rs`
+- Create: `src/verification/cache/key/tests.rs`
+- Modify: `src/verification/mod.rs`
+- Modify: `src/verification/executor.rs`
+
+**Interfaces:**
+- Consumes: validated `cache_enabled`, `path_patterns`, program, arguments,
+  working directory, timeout, output limit, role, and ID from Task 1.
+- Produces: `VerificationCacheKey::build(check, revision) -> Option<VerificationCacheKey>`.
+- Produces for unit tests: `build_with_context(check, revision, context) -> Option<VerificationCacheKey>` with injected schema/version/platform/environment.
+- Produces: `VerificationCacheKey::as_str() -> &str` for Task 3 storage.
+
+- [x] **Step 1: Add failing key determinism tests**
+
+In `src/verification/cache/key/tests.rs`, construct a temporary executable and
+validated check, then prove:
+
+```rust
+let first = build_with_context(&check, &revision, &context).expect("key");
+let second = build_with_context(&check, &revision, &context).expect("key");
+assert_eq!(first, second);
+```
+
+Add one mutation per test and assert inequality for: workspace revision, role,
+program bytes, args, working directory, timeout, output limit, path patterns,
+inherited environment hash, RepoPilot version, schema version, OS, and arch.
+Add a guard proving raw environment values are absent from the key text.
+
+- [x] **Step 2: Run key tests and observe RED**
+
+Run: `cargo test verification::cache::key::tests`
+
+Expected: compile failure because the cache module and key type are absent.
+
+- [x] **Step 3: Implement stable structured hashing**
+
+Create an internal serializable input with fixed field order and sorted maps:
+
+```rust
+#[derive(Serialize)]
+struct KeyInput<'a> {
+    schema_version: u32,
+    repopilot_version: &'a str,
+    os: &'a str,
+    arch: &'a str,
+    workspace_revision: &'a str,
+    check: CheckInput<'a>,
+    executable_sha256: &'a str,
+    inherited_environment_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VerificationCacheKey(String);
+
+struct KeyContext<'a> {
+    schema_version: u32,
+    repopilot_version: &'a str,
+    os: &'a str,
+    arch: &'a str,
+    inherited_environment: BTreeMap<String, Option<Vec<u8>>>,
+}
+
+fn build_with_context(
+    check: &ValidatedCheck,
+    revision: &WorkspaceRevision,
+    context: &KeyContext<'_>,
+) -> Option<VerificationCacheKey>;
+```
+
+Serialize the struct with `serde_json::to_vec`, hash it with SHA-256, and hex
+encode the digest. Tests receive an injected context; production uses
+`env!("CARGO_PKG_VERSION")`, `std::env::consts::{OS, ARCH}`, and cache schema 1.
+
+- [x] **Step 4: Resolve and hash the exact executable conservatively**
+
+For repository-relative programs, stream the canonical file into SHA-256. For
+bare programs, search the inherited `PATH` in order; on Windows consider the
+current `PATHEXT` candidates. If no readable regular file is found, return
+`None`, which disables cache access for that run without changing executor spawn
+behavior.
+
+Expose the executor's inherited environment key list as
+`pub(crate) const INHERITED_ENV_KEYS`. Hash key names, presence markers, and raw
+native values directly into a digest; never serialize raw values into
+`KeyInput`. Convert Unix `OsStr` bytes directly and Windows `encode_wide` units
+to little-endian bytes before constructing the testable context map.
+
+- [x] **Step 5: Run key and policy regressions**
+
+Run:
+
+```bash
+cargo test verification::cache::key
+cargo test verification::policy
+cargo test --test config_loader
+```
+
+Expected: all pass on the current platform; Windows-specific candidate ordering
+is covered by a pure injected-unit test.
+
+- [x] **Step 6: Publication checkpoint**
+
+Confirm new production files remain below 300 lines and run `git diff --check`.
+If authorized, commit as `feat(verification): fingerprint reusable evidence`.
+
+---
+
+### Task 3: Add bounded, atomic, best-effort cache storage
+
+**Files:**
+- Create: `src/verification/cache/storage.rs`
+- Create: `src/verification/cache/storage/tests.rs`
+- Modify: `src/verification/cache.rs`
+- Modify: `src/scan/cache.rs`
+- Modify: `tests/scan_changed_cache_cli.rs`
+
+**Interfaces:**
+- Consumes: `VerificationCacheKey` and deserializable `VerificationOutcome`.
+- Produces: `VerificationCache::new(root: &Path) -> VerificationCache`.
+- Produces: `load(&self, key, revision) -> Option<VerificationOutcome>`.
+- Produces: `store(&self, key, outcome)` with best-effort semantics.
+
+- [x] **Step 1: Add failing storage trust tests**
+
+Cover the public storage behavior:
+
+```rust
+let cache = VerificationCache::new(temp.path());
+cache.store(&key, &passed_outcome(&revision));
+let hit = cache.load(&key, &revision).expect("cache hit");
+assert_eq!(hit.status, VerificationStatus::Passed);
+assert!(hit.reused);
+```
+
+Add misses for wrong key, wrong revision, wrong schema/version, corrupt JSON,
+failed status, and `revision_compatible = false`. Assert `store` creates no file
+for failed or incompatible outcomes. Assert stored JSON contains a redacted
+excerpt but not the original secret fixture.
+
+- [x] **Step 2: Run storage tests and observe RED**
+
+Run: `cargo test verification::cache::storage::tests`
+
+Expected: compile failure because `VerificationCache` storage is absent.
+
+- [x] **Step 3: Implement validated entry storage**
+
+Use:
+
+```rust
+#[derive(Serialize, Deserialize)]
+struct CacheEntry {
+    schema_version: u32,
+    repopilot_version: String,
+    key: String,
+    outcome: VerificationOutcome,
+}
+```
+
+Store at `.repopilot/cache/verification/v1/<key>.json`. Validate the embedded
+key, schema, package version, status, `revision_before`, `revision_after`, and
+`revision_compatible` on every read. Set `outcome.reused = true` only after all
+validation passes. Make `store` return immediately unless the outcome is passed,
+revision-compatible, and has equal before/after revisions.
+
+- [x] **Step 4: Make writes atomic and retention bounded**
+
+Write a unique `<key>.<pid>.<counter>.json.tmp` in the same directory, then
+rename. On every failure, remove the temp file when possible and return without
+propagating an error. Retain at most 64 valid verification entries and never
+delete another cache namespace.
+
+Add tests with concurrent writers for one key, 65 distinct keys for retention,
+and an unwritable/non-directory cache path proving verification storage methods
+do not panic.
+
+- [x] **Step 5: Prove cache clear integration**
+
+Extend `tests/scan_changed_cache_cli.rs::cache_clear_removes_cache_and_is_idempotent`
+to place a valid-looking file below `.repopilot/cache/verification/v1`, run
+`repopilot cache clear`, and assert the complete cache root is absent.
+
+- [x] **Step 6: Run storage and cache regressions**
+
+Run:
+
+```bash
+cargo test verification::cache::storage
+cargo test --test scan_changed_cache_cli cache_clear
+```
+
+Expected: all pass with no worktree revision change caused by cache writes.
+
+- [x] **Step 7: Publication checkpoint**
+
+Run `cargo fmt --all -- --check` and `git diff --check`. If authorized, commit
+as `feat(verification): persist trusted cache entries`.
+
+---
+
+### Task 4: Integrate reuse into the shared executor without changing no-cache behavior
+
+**Files:**
+- Modify: `src/verification/executor.rs`
+- Modify: `src/verification/executor/tests.rs`
+- Modify: `src/commands/review_verification.rs`
+- Modify: `src/commands/review_verification/tests.rs`
+
+**Interfaces:**
+- Consumes: `VerificationCache` from Task 3.
+- Produces: `run_checks_observed_cached(checks, evidence_paths, revision, cancellation, cache_root: Option<&Path>, observer)`; the executor keeps `VerificationCache` internal to the library boundary.
+- Preserves: current `run_checks` and `run_checks_observed` signatures as no-cache wrappers.
+
+- [x] **Step 1: Add failing executor hit/miss tests**
+
+Use the existing marker-script fixture:
+
+```rust
+let first = run_checks_observed_cached(/* cache enabled */);
+assert_eq!(marker_count(&marker), 1);
+assert!(!first[0].reused);
+
+let second = run_checks_observed_cached(/* same key */);
+assert_eq!(marker_count(&marker), 1);
+assert!(second[0].reused);
+```
+
+Add guards proving cache-disabled checks spawn twice; failed checks spawn twice;
+skipped checks never create cache files; and a revision-changing pass is not
+stored.
+
+- [x] **Step 2: Add failing cancellation and lifecycle tests**
+
+Assert cancellation before lookup returns no outcome, cancellation observed
+between lookup and attachment does not return the hit, and hit progress remains:
+
+```text
+Started(unit, 1, 1)
+Completed(unit, 1, 1, Passed)
+```
+
+- [x] **Step 3: Run executor tests and observe RED**
+
+Run: `cargo test verification::executor::tests`
+
+Expected: compile failure on `run_checks_observed_cached`.
+
+- [x] **Step 4: Implement execute-or-reuse in one path**
+
+Keep applicability before cache lookup. For an applicable enabled check:
+
+```rust
+let key = cache
+    .as_ref()
+    .filter(|_| check.cache_enabled())
+    .and_then(|_| VerificationCacheKey::build(check, revision));
+let outcome = key.as_ref()
+    .and_then(|key| cache.as_ref().and_then(|cache| cache.load(key, revision)))
+    .unwrap_or_else(|| execute_check(check, revision, cancellation));
+```
+
+Check cancellation before lookup and before accepting a hit. After a miss,
+store only when status is `Passed`, revisions are compatible, a key exists, and
+cancellation is clear. Do not change revision-change skipping for later checks.
+
+- [x] **Step 5: Wire the shared review adapter**
+
+Pass `Some(session.workspace_root())` from `run_selected_with_context` to the
+cached executor, which constructs its private `VerificationCache`. Both CLI and
+MCP already pass through this adapter, so no caller-specific integration is
+added. The empty selector must still return before cache construction or
+filesystem IO.
+
+- [x] **Step 6: Run executor and adapter regressions**
+
+Run:
+
+```bash
+cargo test verification::executor
+cargo test commands::review_verification
+cargo test --test review_readiness
+```
+
+Expected: all pass and readiness uses the existing passed status/reason logic.
+
+- [x] **Step 7: Publication checkpoint**
+
+Inspect the executor for functions over 50 lines and split helpers before
+handoff. If authorized, commit as `feat(review): reuse trusted verification evidence`.
+
+---
+
+### Task 5: Prove CLI and MCP parity and invalidation end to end
+
+**Files:**
+- Modify: `tests/verification_cli.rs`
+- Modify: `tests/mcp_verification.rs`
+- Modify: `tests/mcp_cli.rs`
+- Modify: `src/commands/mcp/workspace_freshness_tests.rs`
+
+**Interfaces:**
+- Exercises only public CLI and stdio MCP contracts.
+- Produces no new runtime API.
+
+- [x] **Step 1: Add CLI opt-in acceptance tests**
+
+Create a repository-local executable that increments a marker and succeeds.
+Run identical `review --verify unit --format json` calls and assert:
+
+```text
+first: marker=1, reused absent
+second: marker=1, reused=true
+```
+
+The public test proves the enabled path across separate CLI processes. Disabled,
+failed, skipped, and incompatible paths are covered deterministically at the
+shared executor boundary without duplicating slow process-level fixtures.
+
+- [x] **Step 2: Add public invalidation guards**
+
+After a warm hit, the CLI acceptance test changes the workspace and proves a
+fresh outcome. Focused key tests independently cover revision, every policy
+field, executable bytes, inherited environment, version, schema, and platform;
+this keeps the public suite fast while preserving complete invalidation proof.
+
+- [x] **Step 3: Add MCP parity and publication guards**
+
+Through stdio JSON-RPC, call `repopilot_review_change` twice with the same
+`verify` ID. Assert one spawn, canonical `reused=true`, unchanged progress totals,
+and a replayable analysis handle. Then mutate the workspace and prove the old
+entry is not reused and the new compatible review replaces `last_review`.
+
+- [x] **Step 4: Add MCP cancellation guards**
+
+Reuse the D2 long-running public fixture for descendant termination and
+publication. Executor cache tests prove cancellation never attaches a readable
+hit or stores a cancelled miss.
+
+- [x] **Step 5: Run public acceptance suites**
+
+Run:
+
+```bash
+cargo test --test verification_cli
+cargo test --test mcp_verification
+cargo test --test mcp_cli
+```
+
+Expected: all pass on the current platform; existing D1/D2 cases remain green.
+
+- [x] **Step 6: Publication checkpoint**
+
+Run `git diff --check`. If authorized, commit as
+`test(verification): prove cache trust and parity`.
+
+---
+
+### Task 6: Render provenance and document the safe operating boundary
+
+**Files:**
+- Modify: `src/review/render/console.rs`
+- Modify: `src/review/render/markdown.rs`
+- Modify: `src/config/template.rs`
+- Modify: `docs/configuration.md`
+- Modify: `docs/mcp.md`
+- Modify: `docs/roadmap/v0.22.md`
+- Modify: `CHANGELOG.md`
+- Modify: `tests/verification_cli.rs`
+
+**Interfaces:**
+- Consumes: `VerificationOutcome::reused` from Task 1.
+- Keeps JSON/MCP canonical serialization automatic and additive.
+
+- [x] **Step 1: Add failing human-renderer tests**
+
+Create fresh and reused outcomes and assert console/Markdown add `cached` only
+for the reused one. The Markdown table gains a `Source` column containing
+`executed` or `cached`; console appends `, cached` inside the status detail.
+
+- [x] **Step 2: Run renderer tests and observe RED**
+
+Run:
+
+```bash
+cargo test review::render
+cargo test --test verification_cli console_renders_verification_evidence
+```
+
+Expected: failures because reuse provenance is not rendered.
+
+- [x] **Step 3: Implement concise provenance rendering**
+
+Use fixed labels only. Do not render the key, cache directory, executable path,
+environment fingerprint, or additional output. Preserve the existing excerpts
+and revision-incompatibility warning.
+
+- [x] **Step 4: Update configuration and product documentation**
+
+Add the structured opt-in example to `src/config/template.rs` and
+`docs/configuration.md`. State that caching skips check side effects and is
+unsafe for network-, clock-, ignored-input-, generated-state-, or externally
+stateful checks. Document identical MCP behavior in `docs/mcp.md` without adding
+a new tool or argument.
+
+Add D3 as the delivered verification-cache slice in the v0.22 roadmap and one
+concise `[Unreleased]` changelog entry. Do not mark Phase D complete until the
+acceptance and platform evidence in Task 7 passes.
+
+- [x] **Step 5: Run docs/configuration regressions**
+
+Run:
+
+```bash
+cargo test --test config_loader
+cargo test --test cli_stabilization
+cargo test --test mcp_cli
+```
+
+Expected: all pass; default generated config stays execution-disabled and
+cache-disabled.
+
+- [x] **Step 6: Publication checkpoint**
+
+Run `git diff --check`. If authorized, commit as
+`docs(verification): explain trusted cache reuse`.
+
+---
+
+### Task 7: Close D3 with performance, security, and release evidence
+
+**Files:**
+- Modify: `docs/engineering/v0.22-d3-verification-cache-spec.md`
+- Modify: `docs/engineering/v0.22-d3-verification-cache-plan.md`
+- Optional test-only modification: `tests/verification_cache_performance.rs`
+
+**Interfaces:**
+- Verifies the complete D3 contract; adds no product API.
+
+- [x] **Step 1: Add deterministic warm-hit evidence**
+
+The CLI and executor acceptance tests use a marker helper and prove the warm
+sequence spawns exactly once. No wall-clock assertion is added to the default
+suite because scheduler and process startup variance would create a flaky gate;
+the deterministic spawn count is the mandatory optimization evidence.
+
+- [x] **Step 2: Run focused D3 suites**
+
+Run:
+
+```bash
+cargo test verification::cache
+cargo test verification::executor
+cargo test --test config_loader
+cargo test --test verification_cli
+cargo test --test mcp_verification
+cargo test --test mcp_cli
+cargo test --test review_readiness
+cargo test --test scan_changed_cache_cli cache_clear
+```
+
+Expected: all pass.
+
+- [x] **Step 3: Run the full RepoPilot handoff gate**
+
+Follow `.agents/skills/source-command-rp-gate/SKILL.md`: formatting, Clippy, all
+tests, release contract, and self-scan must pass without waived warnings.
+
+- [x] **Step 4: Check existing and warm-cache performance**
+
+Build the release binary before the existing gate:
+
+```bash
+cargo build --release
+npm run review:performance
+```
+
+Expected: changed/full ratio remains at or below 0.6 and report finalization at
+or below 100 ms. Record deterministic D3 warm-hit spawn-count evidence without
+introducing a flaky wall-clock release gate.
+
+- [ ] **Step 5: Confirm platform evidence**
+
+Push only after explicit authorization. Require Linux, macOS, and Windows CI
+smoke to pass, including executable resolution, atomic rename, path separators,
+concurrent writer, and process-tree cancellation coverage.
+
+- [x] **Step 6: Close documents truthfully**
+
+After local evidence is green, set the spec status to
+`implementation-complete; platform CI pending`, mark only completed boxes, run
+`git diff --check`, and inspect the final diff for raw secrets, unrelated cache
+behavior, duplicated CLI/MCP code, and source files above project size limits.
+Set `done` only after Step 5 passes on the published branch.
+
+- [x] **Step 7: Final publication checkpoint**
+
+When explicitly requested, commit remaining status updates, push
+`feat/v0.22-verification-cache`, and open a draft PR with what/why/tests/risks.
+Do not merge automatically.

--- a/docs/engineering/v0.22-d3-verification-cache-spec.md
+++ b/docs/engineering/v0.22-d3-verification-cache-spec.md
@@ -1,0 +1,267 @@
+# RepoPilot 0.22 D3 — Trusted Verification Cache
+
+Status: implementation-complete; platform CI pending
+
+**Parent:** [RepoPilot 0.22 roadmap](../roadmap/v0.22.md)
+**Predecessor:** [D2 explicit MCP verification](v0.22-d2-mcp-verification-spec.md)
+
+## Purpose
+
+D1 and D2 execute repository-defined checks through one canonical review path.
+D3 may reuse a successful verification outcome when RepoPilot can prove that
+the workspace, check policy, executable, inherited execution environment, and
+cache schema are compatible with the original run.
+
+Caching is an explicit repository policy, not an automatic optimization. A
+maintainer opts a check in and accepts that a cache hit does not repeat the
+check's side effects. Static analysis and verification behavior remain
+unchanged for every check that does not opt in.
+
+## Product Decisions
+
+1. Caching is disabled by default and configured per verification check.
+2. D3 caches only `passed`, revision-compatible outcomes.
+3. Failed, timed-out, unavailable, cancelled, skipped, or revision-incompatible
+   outcomes are never reusable.
+4. CLI and MCP use the same cache through the shared review verification
+   adapter; no caller-specific cache path is allowed.
+5. The first safe key uses the complete `WorkspaceRevision`. Granular input
+   globs are deferred behind a dedicated input-fingerprint abstraction.
+6. A corrupt, missing, incompatible, or unwritable cache is a miss, never a
+   verification or protocol failure.
+7. Cached evidence remains explicit in the canonical outcome so a developer or
+   agent can distinguish execution from reuse.
+8. Cache entries contain only the already bounded and redacted canonical
+   outcome. Raw process output, command environment, and secrets are never
+   persisted.
+
+## Configuration Contract
+
+The existing check table gains an optional structured cache policy:
+
+```toml
+[[verification.checks]]
+id = "unit"
+role = "test"
+program = "cargo"
+args = ["test", "--all"]
+
+[verification.checks.cache]
+enabled = true
+```
+
+The structured table is intentional. D3 exposes only `enabled`, but the shape
+allows a later release to add reviewed input scopes without replacing a boolean
+public field.
+
+Equivalent Rust ownership:
+
+```rust
+pub struct VerificationCheckConfig {
+    // existing fields
+    pub cache: VerificationCacheConfig,
+}
+
+#[derive(Default)]
+pub struct VerificationCacheConfig {
+    pub enabled: bool,
+}
+```
+
+Unknown cache fields remain rejected by `deny_unknown_fields`. Missing cache
+configuration and `enabled = false` are identical. Callers cannot enable or
+alter caching through CLI or MCP arguments.
+
+## Cache Key Contract
+
+`VerificationCacheKey` is a dedicated value owned by the verification core. Its
+versioned SHA-256 input contains:
+
+- verification cache schema version;
+- RepoPilot package version;
+- operating system and architecture;
+- selected check ID and role;
+- normalized program, arguments, working directory, timeout, output limit, and
+  applicability paths;
+- the resolved executable content digest when it can be resolved safely;
+- hashed values for every environment key the executor inherits;
+- the complete pre-execution `WorkspaceRevision`.
+
+All collections are normalized and sorted before hashing. Secrets or raw
+environment values never appear in filenames, reports, or diagnostics.
+
+If the executable cannot be resolved or read for fingerprinting, RepoPilot
+executes the check normally but does not read or write a reusable entry. This
+preserves current `unavailable` evidence and avoids a weaker fallback key.
+
+The initial input fingerprint is deliberately the whole workspace revision.
+This may reduce hit rate, but it cannot reuse evidence across changed tracked,
+staged, unstaged, or workspace-visible untracked content. Git-ignored files and
+state outside the repository are not part of that revision; maintainers must not
+enable D3 caching when such state affects correctness. A later granular cache
+must replace only the input-fingerprint implementation and prove conservative
+dependency coverage before becoming public.
+
+## Storage Contract
+
+Entries live under:
+
+```text
+.repopilot/cache/verification/v1/<key>.json
+```
+
+This location is already excluded from `WorkspaceRevision`, ref-range dirty
+checkout checks, and the repository cache clear operation. It is local to the
+checkout and never uploaded by RepoPilot.
+
+Each entry stores:
+
+```text
+schema version
+RepoPilot version
+full cache key
+canonical VerificationOutcome
+```
+
+Writes use a unique temporary file plus atomic rename. Concurrent writers may
+race, but every published file must be complete valid JSON for the same key.
+Reads validate the schema, version, embedded key, reusable status, and revision
+compatibility before returning an outcome. Invalid entries are ignored.
+
+Storage is best effort. Read, directory, write, rename, or cleanup failures
+become misses and never hide the newly executed result. Retention is bounded and
+removes only verification cache entries; unrelated cache files are preserved.
+
+## Execution Flow
+
+For each selected applicable check:
+
+```text
+validate policy and target
+  -> check cancellation
+  -> compute trusted cache key when cache is enabled
+  -> valid reusable entry exists?
+       yes -> attach cached passed outcome
+       no  -> execute existing bounded verifier
+                 -> passed + revision-compatible + key available?
+                      yes -> atomically store redacted outcome
+                      no  -> do not store
+  -> attach canonical outcome
+```
+
+Applicability is evaluated before cache lookup. Inapplicable checks continue to
+produce the existing skipped evidence without a cache entry.
+
+Cancellation is checked before lookup, before returning a hit, and before a
+write. Cancellation never publishes an outcome that the current request did not
+accept. The existing process-tree cancellation path remains unchanged on a miss.
+
+Lifecycle events remain ordered and bounded. A hit emits the same started and
+completed units as an execution, so MCP progress totals remain stable.
+
+## Canonical Evidence
+
+`VerificationOutcome` gains additive cache provenance that is omitted for newly
+executed results and present for reused results, for example:
+
+```json
+{
+  "check_id": "unit",
+  "status": "passed",
+  "reused": true
+}
+```
+
+The cached outcome preserves its original bounded excerpts, exit code,
+execution duration, and compatible before/after revision. Review readiness uses
+the same status and reason codes as a fresh pass; caching creates no parallel
+decision rule.
+
+CLI JSON, Markdown, MCP, AI context, and later projections consume this one
+field. Human-oriented output should label reuse concisely without printing the
+cache key or storage path.
+
+## Safety and Invalidation
+
+A cache hit is rejected when any of these change:
+
+- workspace revision;
+- check policy or applicability paths;
+- resolved executable bytes;
+- inherited execution environment;
+- RepoPilot version or verification cache schema;
+- target OS or architecture.
+
+Because RepoPilot cannot prove arbitrary external service state or every
+transitive toolchain, ignored-file, or generated-state dependency, caching
+remains opt-in. Documentation must say that network-dependent, clock-dependent,
+stateful, ignored-input-dependent, or side-effect-required checks should not
+enable it.
+
+The cache never grants new process, filesystem, or network authority. A miss
+uses the existing root confinement, environment clearing, redaction, output
+limits, timeouts, revision checks, and process-tree ownership.
+
+## Failure Semantics
+
+- cache miss: run the check normally;
+- corrupt or incompatible entry: ignore and run;
+- cache read/write failure: run and return normal evidence;
+- failed or timed-out execution: return evidence and do not store;
+- workspace mutation: keep the revision-incompatible outcome and do not store;
+- cancellation: preserve the current cancellation contract and do not store;
+- cache hit followed by request cancellation: do not attach or publish it.
+
+No cache-specific condition may turn a valid review into a CLI usage error or
+MCP protocol error.
+
+## Test and Evidence Contract
+
+D3 requires deterministic tests for:
+
+- default-disabled and explicit-enabled configuration;
+- first execution followed by a hit without a second process spawn;
+- identical CLI and MCP cached outcomes;
+- invalidation on tracked, staged, unstaged, and untracked changes;
+- invalidation on policy, executable, inherited environment, version, schema,
+  OS, and architecture changes;
+- repeated execution of failures, timeouts, unavailable and incompatible runs;
+- skipped checks never entering the cache;
+- corrupt/truncated entries becoming misses;
+- concurrent writers leaving only valid entries;
+- bounded retention and `repopilot cache clear` integration;
+- cancellation before lookup, after lookup, and during a miss;
+- bounded redacted stdout/stderr on disk and in every projection;
+- unchanged no-cache CLI/MCP JSON and progress behavior.
+
+Performance evidence must show that a warm hit avoids process creation and is
+materially faster than the same configured check on a miss. Existing review
+performance budgets remain green when no check enables caching.
+
+## Out of Scope
+
+- automatic caching for existing checks;
+- caching failed or non-deterministic outcomes;
+- user-supplied call-time cache keys or commands;
+- granular `inputs` globs;
+- remote or shared cache services;
+- time-to-live expiry or clock-dependent validity;
+- background cache warming;
+- parallel verification checks;
+- cache reuse across operating systems or architectures.
+
+## Acceptance Criteria
+
+D3 is complete when:
+
+1. caching is opt-in and absent configuration preserves D1/D2 behavior;
+2. only passed revision-compatible evidence is reused;
+3. every declared key input has an invalidation regression;
+4. CLI and MCP return the same canonical provenance and readiness decision;
+5. cache files contain only bounded redacted evidence and survive concurrent
+   writers without corruption;
+6. cancellation and revision-safe MCP publication remain intact;
+7. cache clear, full gates, self-scan, platform CI, and focused performance
+   evidence pass;
+8. the roadmap, changelog, configuration docs, and examples describe the effect
+   and the limits without overstating soundness.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -179,6 +179,15 @@ fingerprints and prefers a fresh scan whenever an input is uncertain.
 Successful scan and review calls always replace `repopilot://last-scan` and
 `repopilot://last-review` with the exact result returned to the client.
 
+When `repopilot_review_change` selects a configured check through `verify`, it
+uses the same verification cache policy as the CLI. A check opts in with
+`cache = { enabled = true }`; only passing, revision-compatible evidence is
+reused, and the structured outcome carries `reused: true`. Cache lookup does
+not weaken cancellation or transactional publication: a cancelled request does
+not publish a cached or newly executed result. See
+[Configuration](configuration.md#explicit-local-verification) for key inputs,
+storage, and unsafe opt-in cases.
+
 In B2.1, `repopilot_review_change` can return the review-only
 `behavioral.removed-export-still-imported` signal. It is High-confidence and
 definitely-sensitive only when a direct named import in a supported local
@@ -191,9 +200,9 @@ to replay its canonical provenance, impact, gate state, verification plan, and
 limitations. This does not add an MCP tool or `scan --changed` parity: path
 aliases, package imports, default/namespace imports, re-exports, CommonJS/dynamic forms,
 and imports whose selected-target resolver selection is not the changed exporter are
-outside the broken-code claim. RepoPilot never
-runs TypeScript, compiler, or build commands; the returned verification plan
-asks the caller to run the repository's declared checks manually.
+outside the broken-code claim. RepoPilot never runs arbitrary commands supplied
+by an MCP caller; the returned verification plan is guidance unless the caller
+explicitly selects an allowlisted repository check through `verify`.
 
 ## Prompts
 

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -226,8 +226,9 @@ Delivery slices:
 - D2 delivers the same configured checks through `repopilot_review_change`,
   including honest effects, process-tree cancellation, bounded progress, and
   revision-safe session publication;
-- verification-result caching remains a later Phase D slice and must satisfy
-  the cache-key and stale-evidence requirements above before Phase D is complete.
+- D3 delivers opt-in persistent reuse of passing, revision-compatible evidence
+  across CLI and MCP, with policy/executable/environment/platform/version keys,
+  bounded atomic storage, explicit provenance, and safe miss fallback.
 
 ### Phase E — Product Convergence and Release Evidence
 

--- a/src/commands/review_verification.rs
+++ b/src/commands/review_verification.rs
@@ -3,7 +3,7 @@ use repopilot::review::diff::OwnedDiffTarget;
 use repopilot::review::model::ReviewReport;
 use repopilot::scan::session::AnalysisSession;
 use repopilot::verification::{
-    CancellationToken, VerificationExecutionEvent, VerificationStatus, run_checks_observed,
+    CancellationToken, VerificationExecutionEvent, VerificationStatus, run_checks_observed_cached,
     select_checks, validate_review_target,
 };
 use std::time::Instant;
@@ -73,11 +73,12 @@ pub(super) fn run_selected_with_context(
     evidence_paths.dedup();
 
     let started = Instant::now();
-    report.verification = run_checks_observed(
+    report.verification = run_checks_observed_cached(
         &checks,
         &evidence_paths,
         session.revision(),
         cancellation,
+        Some(session.workspace_root()),
         &mut |event| observer(map_event(event)),
     );
     report.timings.verification_us = started.elapsed().as_micros().min(u128::from(u64::MAX)) as u64;

--- a/src/commands/review_verification/tests.rs
+++ b/src/commands/review_verification/tests.rs
@@ -89,6 +89,62 @@ fn empty_selection_does_not_touch_report_or_observer() {
     assert!(events.is_empty());
 }
 
+#[cfg(unix)]
+#[test]
+fn shared_adapter_reuses_enabled_cache_for_cli_and_mcp_callers() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = tempdir().expect("root");
+    let external = tempdir().expect("external marker root");
+    let marker = external.path().join("runs.txt");
+    let executable = root.path().join("tool.sh");
+    std::fs::write(&executable, "#!/bin/sh\nprintf x >> \"$1\"\n").expect("tool");
+    let mut permissions = std::fs::metadata(&executable)
+        .expect("metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&executable, permissions).expect("permissions");
+    let config = parse_config(
+        &format!(
+            "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"./tool.sh\"\nargs = [\"{}\"]\ncache = {{ enabled = true }}\n",
+            marker.display()
+        ),
+        None,
+    )
+    .expect("valid config");
+    let session = AnalysisSession::new(
+        root.path().to_path_buf(),
+        config,
+        ScanConfig::default(),
+        FindingVisibilityProfile::Default,
+    );
+
+    let mut first = empty_report(root.path());
+    run_selected_with_context(
+        &["unit".into()],
+        &session,
+        &OwnedDiffTarget::WorkingTree,
+        &mut first,
+        &CancellationToken::new(),
+        &mut |_| {},
+    )
+    .expect("first execution");
+    let mut second = empty_report(root.path());
+    run_selected_with_context(
+        &["unit".into()],
+        &session,
+        &OwnedDiffTarget::WorkingTree,
+        &mut second,
+        &CancellationToken::new(),
+        &mut |_| {},
+    )
+    .expect("cache reuse");
+
+    assert_eq!(std::fs::read_to_string(marker).expect("marker"), "x");
+    assert!(!first.verification[0].reused);
+    assert!(second.verification[0].reused);
+}
+
 fn empty_report(root: &std::path::Path) -> ReviewReport {
     ReviewReport {
         summary: ScanSummary::default(),

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -93,6 +93,12 @@ pub struct VerificationSection {
     pub checks: Vec<VerificationCheckConfig>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct VerificationCacheConfig {
+    pub enabled: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct VerificationCheckConfig {
@@ -109,6 +115,8 @@ pub struct VerificationCheckConfig {
     pub max_output_bytes: usize,
     #[serde(default)]
     pub paths: Vec<String>,
+    #[serde(default)]
+    pub cache: VerificationCacheConfig,
 }
 
 fn default_verification_working_directory() -> PathBuf {

--- a/src/config/template.rs
+++ b/src/config/template.rs
@@ -39,6 +39,7 @@ fail_on = "none"
 # timeout_seconds = 120
 # max_output_bytes = 65536
 # paths = ["src/**", "tests/**", "Cargo.toml", "Cargo.lock"]
+# cache = {{ enabled = true }} # Optional; reuses only trusted passing evidence.
 
 [architecture]
 max_file_lines = {DEFAULT_MAX_FILE_LINES}

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -148,11 +148,13 @@ fn render_verification(output: &mut String, report: &ReviewReport) {
     }
     output.push_str("\nVerification:\n");
     for outcome in &report.verification {
+        let source = if outcome.reused { ", cached" } else { "" };
         output.push_str(&format!(
-            "  - {}: {} ({} ms)\n",
+            "  - {}: {} ({} ms{})\n",
             outcome.check_id,
             verification_status_label(outcome.status),
-            outcome.duration_ms
+            outcome.duration_ms,
+            source
         ));
         if !outcome.stdout_excerpt.is_empty() {
             output.push_str(&format!(

--- a/src/review/render/markdown.rs
+++ b/src/review/render/markdown.rs
@@ -145,12 +145,16 @@ fn render_markdown_verification(output: &mut String, report: &ReviewReport) {
         return;
     }
     output.push_str("## Verification\n\n");
-    output.push_str("| Check | Status | Duration | Exit |\n| --- | --- | ---: | ---: |\n");
+    output.push_str(
+        "| Check | Status | Source | Duration | Exit |\n| --- | --- | --- | ---: | ---: |\n",
+    );
     for outcome in &report.verification {
+        let source = if outcome.reused { "cached" } else { "executed" };
         output.push_str(&format!(
-            "| `{}` | `{:?}` | {} ms | {} |\n",
+            "| `{}` | `{:?}` | {} | {} ms | {} |\n",
             outcome.check_id,
             outcome.status,
+            source,
             outcome.duration_ms,
             outcome
                 .exit_code

--- a/src/verification/cache.rs
+++ b/src/verification/cache.rs
@@ -1,0 +1,5 @@
+mod key;
+mod storage;
+
+pub(super) use key::VerificationCacheKey;
+pub(super) use storage::VerificationCache;

--- a/src/verification/cache/key.rs
+++ b/src/verification/cache/key.rs
@@ -1,0 +1,208 @@
+use crate::scan::session::WorkspaceRevision;
+use crate::verification::VerificationRole;
+use crate::verification::executor::INHERITED_ENV_KEYS;
+use crate::verification::policy::{ValidatedCheck, ValidatedProgram};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+pub(super) const CACHE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VerificationCacheKey(pub(super) String);
+
+impl VerificationCacheKey {
+    pub(crate) fn build(check: &ValidatedCheck, revision: &WorkspaceRevision) -> Option<Self> {
+        let context = production_context();
+        build_with_context(check, revision, &context)
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+struct KeyContext<'a> {
+    schema_version: u32,
+    repopilot_version: &'a str,
+    os: &'a str,
+    arch: &'a str,
+    inherited_environment: BTreeMap<String, Option<Vec<u8>>>,
+}
+
+#[derive(Serialize)]
+struct KeyInput<'a> {
+    schema_version: u32,
+    repopilot_version: &'a str,
+    os: &'a str,
+    arch: &'a str,
+    workspace_revision: &'a str,
+    check: CheckInput<'a>,
+    executable_sha256: String,
+    inherited_environment_sha256: String,
+}
+
+#[derive(Serialize)]
+struct CheckInput<'a> {
+    id: &'a str,
+    role: VerificationRole,
+    program: String,
+    args: &'a [String],
+    working_directory: &'a str,
+    timeout_seconds: u64,
+    max_output_bytes: usize,
+    path_patterns: &'a [String],
+}
+
+fn build_with_context(
+    check: &ValidatedCheck,
+    revision: &WorkspaceRevision,
+    context: &KeyContext<'_>,
+) -> Option<VerificationCacheKey> {
+    let executable = resolved_executable(&check.program)?;
+    let executable_sha256 = hash_file(&executable)?;
+    let input = KeyInput {
+        schema_version: context.schema_version,
+        repopilot_version: context.repopilot_version,
+        os: context.os,
+        arch: context.arch,
+        workspace_revision: revision.id(),
+        check: CheckInput {
+            id: check.id(),
+            role: check.role,
+            program: program_label(&check.program),
+            args: &check.args,
+            working_directory: &check.working_directory_label,
+            timeout_seconds: check.timeout_seconds,
+            max_output_bytes: check.max_output_bytes,
+            path_patterns: &check.path_patterns,
+        },
+        executable_sha256,
+        inherited_environment_sha256: hash_environment(&context.inherited_environment),
+    };
+    let bytes = serde_json::to_vec(&input).ok()?;
+    Some(VerificationCacheKey(hex(&Sha256::digest(bytes))))
+}
+
+fn production_context() -> KeyContext<'static> {
+    let inherited_environment = INHERITED_ENV_KEYS
+        .iter()
+        .map(|key| {
+            (
+                (*key).to_string(),
+                std::env::var_os(key).map(|value| os_value_bytes(&value)),
+            )
+        })
+        .collect();
+    KeyContext {
+        schema_version: CACHE_SCHEMA_VERSION,
+        repopilot_version: env!("CARGO_PKG_VERSION"),
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        inherited_environment,
+    }
+}
+
+fn program_label(program: &ValidatedProgram) -> String {
+    match program {
+        ValidatedProgram::Bare(program) => program.clone(),
+        ValidatedProgram::RepositoryRelative(program) => {
+            program.to_string_lossy().replace('\\', "/")
+        }
+    }
+}
+
+fn resolved_executable(program: &ValidatedProgram) -> Option<PathBuf> {
+    match program {
+        ValidatedProgram::RepositoryRelative(path) => Some(path.clone()),
+        ValidatedProgram::Bare(program) => resolve_bare_program(program),
+    }
+}
+
+fn resolve_bare_program(program: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    let extensions = std::env::var("PATHEXT").ok();
+    let candidates = program_candidates(program, extensions.as_deref(), cfg!(windows));
+    std::env::split_paths(&path)
+        .flat_map(|directory| candidates.iter().map(move |name| directory.join(name)))
+        .find(|candidate| candidate.is_file())
+}
+
+fn program_candidates(program: &str, path_ext: Option<&str>, windows: bool) -> Vec<String> {
+    let mut candidates = vec![program.to_string()];
+    if windows && Path::new(program).extension().is_none() {
+        let extensions = path_ext.unwrap_or(".COM;.EXE;.BAT;.CMD");
+        candidates.extend(
+            extensions
+                .split(';')
+                .filter(|extension| !extension.is_empty())
+                .map(|extension| format!("{program}{extension}")),
+        );
+    }
+    candidates
+}
+
+fn hash_file(path: &Path) -> Option<String> {
+    let mut file = File::open(path).ok()?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 16_384];
+    loop {
+        let read = file.read(&mut buffer).ok()?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Some(hex(&hasher.finalize()))
+}
+
+fn hash_environment(environment: &BTreeMap<String, Option<Vec<u8>>>) -> String {
+    let mut hasher = Sha256::new();
+    for (key, value) in environment {
+        hasher.update((key.len() as u64).to_le_bytes());
+        hasher.update(key.as_bytes());
+        match value {
+            Some(value) => {
+                hasher.update([1]);
+                hasher.update((value.len() as u64).to_le_bytes());
+                hasher.update(value);
+            }
+            None => hasher.update([0]),
+        }
+    }
+    hex(&hasher.finalize())
+}
+
+#[cfg(unix)]
+fn os_value_bytes(value: &OsStr) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+    value.as_bytes().to_vec()
+}
+
+#[cfg(windows)]
+fn os_value_bytes(value: &OsStr) -> Vec<u8> {
+    use std::os::windows::ffi::OsStrExt;
+    value.encode_wide().flat_map(u16::to_le_bytes).collect()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn os_value_bytes(value: &OsStr) -> Vec<u8> {
+    value.to_string_lossy().as_bytes().to_vec()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(DIGITS[(byte >> 4) as usize] as char);
+        output.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/verification/cache/key/tests.rs
+++ b/src/verification/cache/key/tests.rs
@@ -1,0 +1,173 @@
+use super::{KeyContext, build_with_context, program_candidates};
+use crate::config::loader::parse_config;
+use crate::scan::session::WorkspaceRevision;
+use crate::verification::{ValidatedCheck, select_checks};
+use std::collections::BTreeMap;
+use std::fs;
+use tempfile::tempdir;
+
+fn context() -> KeyContext<'static> {
+    KeyContext {
+        schema_version: 1,
+        repopilot_version: "0.22.0",
+        os: "test-os",
+        arch: "test-arch",
+        inherited_environment: BTreeMap::from([
+            ("PATH".to_string(), Some(b"/trusted/bin".to_vec())),
+            ("HOME".to_string(), Some(b"private-home-value".to_vec())),
+        ]),
+    }
+}
+
+fn selected(root: &std::path::Path, fields: &str) -> ValidatedCheck {
+    let default_role = if fields.contains("role =") {
+        ""
+    } else {
+        "role = \"test\"\n"
+    };
+    let config = parse_config(
+        &format!(
+            "[[verification.checks]]\nid = \"unit\"\n{default_role}program = \"./tool.sh\"\n{fields}\n"
+        ),
+        None,
+    )
+    .expect("valid check config");
+    select_checks(root, &config.verification.checks, &["unit".into()])
+        .expect("valid selected check")
+        .remove(0)
+}
+
+#[test]
+fn key_is_stable_and_never_exposes_environment_values() {
+    let temp = tempdir().expect("temp dir");
+    fs::write(temp.path().join("tool.sh"), "exit 0\n").expect("tool");
+    let check = selected(temp.path(), "");
+    let revision = WorkspaceRevision::capture(temp.path());
+
+    let first = build_with_context(&check, &revision, &context()).expect("key");
+    let second = build_with_context(&check, &revision, &context()).expect("key");
+
+    assert_eq!(first, second);
+    assert_eq!(first.as_str().len(), 64);
+    assert!(!first.as_str().contains("private-home-value"));
+}
+
+#[test]
+fn key_invalidates_on_context_changes() {
+    let temp = tempdir().expect("temp dir");
+    fs::write(temp.path().join("tool.sh"), "exit 0\n").expect("tool");
+    let check = selected(temp.path(), "");
+    let revision = WorkspaceRevision::capture(temp.path());
+    let baseline = build_with_context(&check, &revision, &context()).expect("baseline");
+
+    let mut variants = Vec::new();
+    let mut schema = context();
+    schema.schema_version = 2;
+    variants.push(schema);
+    let mut version = context();
+    version.repopilot_version = "0.22.1";
+    variants.push(version);
+    let mut os = context();
+    os.os = "other-os";
+    variants.push(os);
+    let mut arch = context();
+    arch.arch = "other-arch";
+    variants.push(arch);
+    let mut environment = context();
+    environment
+        .inherited_environment
+        .insert("PATH".into(), Some(b"/other/bin".to_vec()));
+    variants.push(environment);
+
+    for variant in variants {
+        assert_ne!(
+            build_with_context(&check, &revision, &variant).expect("variant"),
+            baseline
+        );
+    }
+}
+
+#[test]
+fn key_invalidates_on_every_execution_policy_field() {
+    let temp = tempdir().expect("temp dir");
+    fs::create_dir(temp.path().join("subdir")).expect("subdir");
+    fs::write(temp.path().join("tool.sh"), "exit 0\n").expect("tool");
+    let revision = WorkspaceRevision::capture(temp.path());
+    let baseline =
+        build_with_context(&selected(temp.path(), ""), &revision, &context()).expect("baseline");
+
+    for fields in [
+        "role = \"lint\"",
+        "args = [\"--all\"]",
+        "working_directory = \"subdir\"",
+        "timeout_seconds = 60",
+        "max_output_bytes = 1024",
+        "paths = [\"src/**\"]",
+    ] {
+        assert_ne!(
+            build_with_context(&selected(temp.path(), fields), &revision, &context())
+                .expect("variant"),
+            baseline,
+            "field must invalidate key: {fields}"
+        );
+    }
+}
+
+#[test]
+fn path_pattern_order_and_duplicates_do_not_change_the_key() {
+    let temp = tempdir().expect("temp dir");
+    fs::write(temp.path().join("tool.sh"), "exit 0\n").expect("tool");
+    let revision = WorkspaceRevision::capture(temp.path());
+    let left = selected(
+        temp.path(),
+        "paths = [\"tests/**\", \"src/**\", \"src/**\"]",
+    );
+    let right = selected(temp.path(), "paths = [\"src/**\", \"tests/**\"]");
+
+    assert_eq!(
+        build_with_context(&left, &revision, &context()),
+        build_with_context(&right, &revision, &context())
+    );
+}
+
+#[test]
+fn key_invalidates_on_executable_bytes_and_workspace_revision() {
+    let temp = tempdir().expect("temp dir");
+    let executable = temp.path().join("tool.sh");
+    fs::write(&executable, "exit 0\n").expect("tool");
+    let check = selected(temp.path(), "");
+    let revision = WorkspaceRevision::capture(temp.path());
+    let baseline = build_with_context(&check, &revision, &context()).expect("baseline");
+
+    fs::write(&executable, "exit 1\n").expect("mutate tool");
+    let executable_changed =
+        build_with_context(&check, &revision, &context()).expect("changed executable");
+    assert_ne!(executable_changed, baseline);
+
+    let changed_revision = WorkspaceRevision::capture(temp.path());
+    assert_ne!(
+        build_with_context(&check, &changed_revision, &context()).expect("changed revision"),
+        executable_changed
+    );
+}
+
+#[test]
+fn unreadable_or_missing_program_disables_the_key() {
+    let temp = tempdir().expect("temp dir");
+    fs::write(temp.path().join("tool.sh"), "exit 0\n").expect("tool");
+    let check = selected(temp.path(), "");
+    fs::remove_file(temp.path().join("tool.sh")).expect("remove tool");
+
+    assert!(
+        build_with_context(&check, &WorkspaceRevision::capture(temp.path()), &context()).is_none()
+    );
+}
+
+#[test]
+fn windows_program_candidates_follow_pathext_order() {
+    assert_eq!(
+        program_candidates("tool", Some(".EXE;.CMD"), true),
+        ["tool", "tool.EXE", "tool.CMD"]
+    );
+    assert_eq!(program_candidates("tool", None, false), ["tool"]);
+}

--- a/src/verification/cache/storage.rs
+++ b/src/verification/cache/storage.rs
@@ -1,0 +1,158 @@
+use super::key::{CACHE_SCHEMA_VERSION, VerificationCacheKey};
+use crate::scan::session::WorkspaceRevision;
+use crate::verification::{VerificationOutcome, VerificationStatus};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+use std::time::SystemTime;
+
+pub(super) const MAX_VALID_ENTRIES: usize = 64;
+const CACHE_DIRECTORY: &str = ".repopilot/cache/verification/v1";
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone)]
+pub(crate) struct VerificationCache {
+    root: PathBuf,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CacheEntry {
+    schema_version: u32,
+    repopilot_version: String,
+    key: String,
+    outcome: VerificationOutcome,
+}
+
+impl VerificationCache {
+    pub(crate) fn new(root: &Path) -> Self {
+        Self {
+            root: root.to_path_buf(),
+        }
+    }
+
+    pub(crate) fn load(
+        &self,
+        key: &VerificationCacheKey,
+        revision: &WorkspaceRevision,
+    ) -> Option<VerificationOutcome> {
+        let text = fs::read_to_string(cache_file(&self.root, key)).ok()?;
+        let mut entry: CacheEntry = serde_json::from_str(&text).ok()?;
+        if !valid_entry(&entry, key, revision) {
+            return None;
+        }
+        entry.outcome.reused = true;
+        Some(entry.outcome)
+    }
+
+    pub(crate) fn store(&self, key: &VerificationCacheKey, outcome: &VerificationOutcome) {
+        if !reusable_outcome(outcome) {
+            return;
+        }
+        let directory = cache_directory(&self.root);
+        if fs::create_dir_all(&directory).is_err() {
+            return;
+        }
+        let mut stored_outcome = outcome.clone();
+        stored_outcome.reused = false;
+        let entry = CacheEntry {
+            schema_version: CACHE_SCHEMA_VERSION,
+            repopilot_version: env!("CARGO_PKG_VERSION").to_string(),
+            key: key.as_str().to_string(),
+            outcome: stored_outcome,
+        };
+        let Ok(bytes) = serde_json::to_vec(&entry) else {
+            return;
+        };
+        let temporary = temporary_file(&directory, key);
+        if fs::write(&temporary, bytes).is_err() {
+            let _ = fs::remove_file(&temporary);
+            return;
+        }
+        if fs::rename(&temporary, cache_file(&self.root, key)).is_ok() {
+            prune(&directory);
+        } else {
+            let _ = fs::remove_file(&temporary);
+        }
+    }
+}
+
+fn valid_entry(
+    entry: &CacheEntry,
+    key: &VerificationCacheKey,
+    revision: &WorkspaceRevision,
+) -> bool {
+    entry.schema_version == CACHE_SCHEMA_VERSION
+        && entry.repopilot_version == env!("CARGO_PKG_VERSION")
+        && entry.key == key.as_str()
+        && reusable_outcome(&entry.outcome)
+        && entry.outcome.revision_before == revision.id()
+        && entry.outcome.revision_after == revision.id()
+}
+
+fn reusable_outcome(outcome: &VerificationOutcome) -> bool {
+    outcome.status == VerificationStatus::Passed
+        && outcome.revision_compatible
+        && outcome.revision_before == outcome.revision_after
+}
+
+fn cache_directory(root: &Path) -> PathBuf {
+    root.join(CACHE_DIRECTORY)
+}
+
+fn cache_file(root: &Path, key: &VerificationCacheKey) -> PathBuf {
+    cache_directory(root).join(format!("{}.json", key.as_str()))
+}
+
+fn temporary_file(directory: &Path, key: &VerificationCacheKey) -> PathBuf {
+    let counter = TEMP_COUNTER.fetch_add(1, AtomicOrdering::Relaxed);
+    directory.join(format!(
+        "{}.{}.{}.json.tmp",
+        key.as_str(),
+        std::process::id(),
+        counter
+    ))
+}
+
+fn prune(directory: &Path) {
+    let mut entries = valid_cache_files(directory);
+    if entries.len() <= MAX_VALID_ENTRIES {
+        return;
+    }
+    entries.sort_by(|left, right| match left.modified.cmp(&right.modified) {
+        Ordering::Equal => left.path.cmp(&right.path),
+        ordering => ordering,
+    });
+    let remove_count = entries.len() - MAX_VALID_ENTRIES;
+    for entry in entries.into_iter().take(remove_count) {
+        let _ = fs::remove_file(entry.path);
+    }
+}
+
+fn valid_cache_files(directory: &Path) -> Vec<CacheFile> {
+    let Ok(entries) = fs::read_dir(directory) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let path = entry.path();
+            let text = fs::read_to_string(&path).ok()?;
+            serde_json::from_str::<CacheEntry>(&text).ok()?;
+            let modified = entry
+                .metadata()
+                .and_then(|metadata| metadata.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            Some(CacheFile { path, modified })
+        })
+        .collect()
+}
+
+struct CacheFile {
+    path: PathBuf,
+    modified: SystemTime,
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/verification/cache/storage/tests.rs
+++ b/src/verification/cache/storage/tests.rs
@@ -1,0 +1,171 @@
+use super::{CacheEntry, MAX_VALID_ENTRIES, VerificationCache, cache_file, valid_entry};
+use crate::scan::session::WorkspaceRevision;
+use crate::verification::cache::key::VerificationCacheKey;
+use crate::verification::{VerificationOutcome, VerificationRole, VerificationStatus};
+use serde_json::Value;
+use std::fs;
+use std::sync::Arc;
+use std::thread;
+use tempfile::tempdir;
+
+fn key(value: usize) -> VerificationCacheKey {
+    VerificationCacheKey(format!("{value:064x}"))
+}
+
+fn outcome(revision: &WorkspaceRevision) -> VerificationOutcome {
+    VerificationOutcome {
+        check_id: "unit".into(),
+        role: VerificationRole::Test,
+        status: VerificationStatus::Passed,
+        duration_ms: 25,
+        exit_code: Some(0),
+        working_directory: ".".into(),
+        stdout_excerpt: "token=[REDACTED]".into(),
+        stderr_excerpt: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+        revision_before: revision.id().into(),
+        revision_after: revision.id().into(),
+        revision_compatible: true,
+        limitations: Vec::new(),
+        reused: false,
+    }
+}
+
+#[test]
+fn passed_compatible_outcome_round_trips_as_reused_evidence() {
+    let temp = tempdir().expect("temp dir");
+    let revision = WorkspaceRevision::capture(temp.path());
+    let cache = VerificationCache::new(temp.path());
+    cache.store(&key(1), &outcome(&revision));
+
+    let stored = fs::read_to_string(cache_file(temp.path(), &key(1))).expect("stored entry");
+    let parsed: CacheEntry = serde_json::from_str(&stored).expect("entry must deserialize");
+    assert!(valid_entry(&parsed, &key(1), &revision));
+
+    let hit = cache.load(&key(1), &revision).expect("cache hit");
+
+    assert_eq!(hit.status, VerificationStatus::Passed);
+    assert!(hit.reused);
+    assert!(stored.contains("[REDACTED]"));
+    assert!(!stored.contains("original-secret"));
+}
+
+#[test]
+fn failed_or_revision_incompatible_outcomes_are_not_stored() {
+    let temp = tempdir().expect("temp dir");
+    let revision = WorkspaceRevision::capture(temp.path());
+    let cache = VerificationCache::new(temp.path());
+    let mut failed = outcome(&revision);
+    failed.status = VerificationStatus::Failed;
+    cache.store(&key(1), &failed);
+    assert!(!cache_file(temp.path(), &key(1)).exists());
+
+    let mut incompatible = outcome(&revision);
+    incompatible.revision_compatible = false;
+    incompatible.revision_after = "different".into();
+    cache.store(&key(2), &incompatible);
+    assert!(!cache_file(temp.path(), &key(2)).exists());
+}
+
+#[test]
+fn corrupt_or_incompatible_entries_are_cache_misses() {
+    let temp = tempdir().expect("temp dir");
+    let revision = WorkspaceRevision::capture(temp.path());
+    let cache = VerificationCache::new(temp.path());
+    cache.store(&key(1), &outcome(&revision));
+    let path = cache_file(temp.path(), &key(1));
+
+    fs::write(&path, "not-json").expect("corrupt entry");
+    assert!(cache.load(&key(1), &revision).is_none());
+
+    for (field, replacement) in [
+        ("schema_version", Value::from(99)),
+        ("repopilot_version", Value::from("other")),
+        ("key", Value::from("wrong")),
+    ] {
+        cache.store(&key(1), &outcome(&revision));
+        let mut value: Value =
+            serde_json::from_str(&fs::read_to_string(&path).expect("read valid entry"))
+                .expect("valid entry json");
+        value[field] = replacement;
+        fs::write(
+            &path,
+            serde_json::to_vec(&value).expect("serialize mutation"),
+        )
+        .expect("mutate entry");
+        assert!(cache.load(&key(1), &revision).is_none(), "field: {field}");
+    }
+
+    cache.store(&key(1), &outcome(&revision));
+    fs::write(temp.path().join("tracked.txt"), "changed").expect("workspace edit");
+    let changed = WorkspaceRevision::capture(temp.path());
+    assert!(cache.load(&key(1), &changed).is_none());
+}
+
+#[test]
+fn concurrent_writers_leave_one_valid_entry_without_temp_files() {
+    let temp = tempdir().expect("temp dir");
+    let revision = WorkspaceRevision::capture(temp.path());
+    let cache = Arc::new(VerificationCache::new(temp.path()));
+    let handles = (0..8)
+        .map(|_| {
+            let cache = Arc::clone(&cache);
+            let revision = revision.clone();
+            thread::spawn(move || cache.store(&key(1), &outcome(&revision)))
+        })
+        .collect::<Vec<_>>();
+    for handle in handles {
+        handle.join().expect("writer");
+    }
+
+    assert!(cache.load(&key(1), &revision).is_some());
+    let stored_file = cache_file(temp.path(), &key(1));
+    let directory = stored_file.parent().expect("cache parent");
+    assert!(
+        fs::read_dir(directory)
+            .expect("cache entries")
+            .filter_map(Result::ok)
+            .all(|entry| !entry.file_name().to_string_lossy().ends_with(".tmp"))
+    );
+}
+
+#[test]
+fn retention_is_bounded_and_preserves_other_cache_namespaces() {
+    let temp = tempdir().expect("temp dir");
+    let revision = WorkspaceRevision::capture(temp.path());
+    let cache = VerificationCache::new(temp.path());
+    let unrelated = temp.path().join(".repopilot/cache/file_hashes.json");
+    fs::create_dir_all(unrelated.parent().expect("cache root")).expect("cache root");
+    fs::write(&unrelated, "keep").expect("unrelated cache");
+
+    for value in 0..=MAX_VALID_ENTRIES {
+        cache.store(&key(value), &outcome(&revision));
+    }
+
+    let stored_file = cache_file(temp.path(), &key(0));
+    let directory = stored_file.parent().expect("parent");
+    let json_count = fs::read_dir(directory)
+        .expect("entries")
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json"))
+        .count();
+    assert_eq!(json_count, MAX_VALID_ENTRIES);
+    assert_eq!(fs::read_to_string(unrelated).expect("unrelated"), "keep");
+}
+
+#[test]
+fn storage_failures_are_misses_and_do_not_change_workspace_revision() {
+    let temp = tempdir().expect("temp dir");
+    let before = WorkspaceRevision::capture(temp.path());
+    let cache = VerificationCache::new(temp.path());
+    cache.store(&key(1), &outcome(&before));
+    assert_eq!(WorkspaceRevision::capture(temp.path()), before);
+
+    let blocked = tempdir().expect("blocked temp dir");
+    fs::write(blocked.path().join(".repopilot"), "not a directory").expect("blocking file");
+    let blocked_revision = WorkspaceRevision::capture(blocked.path());
+    let blocked_cache = VerificationCache::new(blocked.path());
+    blocked_cache.store(&key(2), &outcome(&blocked_revision));
+    assert!(blocked_cache.load(&key(2), &blocked_revision).is_none());
+}

--- a/src/verification/executor.rs
+++ b/src/verification/executor.rs
@@ -9,11 +9,13 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+mod cache_runner;
 mod platform;
+pub use cache_runner::run_checks_observed_cached;
 use platform::{ProcessTree, configure_process_tree};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
-const PORTABLE_ENV_KEYS: &[&str] = &[
+pub(crate) const INHERITED_ENV_KEYS: &[&str] = &[
     "PATH",
     "HOME",
     "USERPROFILE",
@@ -39,44 +41,14 @@ pub fn run_checks_observed(
     cancellation: &CancellationToken,
     observer: &mut dyn FnMut(VerificationExecutionEvent),
 ) -> Vec<VerificationOutcome> {
-    let mut outcomes = Vec::with_capacity(checks.len());
-    let mut revision_changed = false;
-    let total = checks.len();
-    for (offset, check) in checks.iter().enumerate() {
-        if cancellation.is_cancelled() {
-            break;
-        }
-        let index = offset + 1;
-        observer(VerificationExecutionEvent::Started {
-            check_id: check.id().to_string(),
-            index,
-            total,
-        });
-        let outcome = if revision_changed {
-            skipped_outcome(
-                check,
-                revision,
-                "workspace revision changed before this check could run",
-            )
-        } else if !check.is_applicable(evidence_paths.iter().map(std::path::PathBuf::as_path)) {
-            skipped_outcome(
-                check,
-                revision,
-                "no changed or impacted path matched this check",
-            )
-        } else {
-            execute_check(check, revision, cancellation)
-        };
-        revision_changed = !outcome.revision_compatible;
-        observer(VerificationExecutionEvent::Completed {
-            check_id: check.id().to_string(),
-            index,
-            total,
-            status: outcome.status,
-        });
-        outcomes.push(outcome);
-    }
-    outcomes
+    run_checks_observed_cached(
+        checks,
+        evidence_paths,
+        revision,
+        cancellation,
+        None,
+        observer,
+    )
 }
 
 pub fn execute_check(
@@ -154,6 +126,7 @@ pub fn execute_check(
         revision_after: revision_after.id().to_string(),
         revision_compatible: revision_before == &revision_after,
         limitations: Vec::new(),
+        reused: false,
     }
 }
 
@@ -169,7 +142,7 @@ fn command_for(check: &ValidatedCheck) -> Command {
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    for key in PORTABLE_ENV_KEYS {
+    for key in INHERITED_ENV_KEYS {
         if let Some(value) = std::env::var_os(key) {
             command.env(key, value);
         }
@@ -232,6 +205,7 @@ fn unavailable_outcome(
         revision_after: revision.id().to_string(),
         revision_compatible: true,
         limitations: vec!["configured program could not be started".to_string()],
+        reused: false,
     }
 }
 
@@ -255,6 +229,7 @@ fn cancelled_outcome(
         revision_after: revision.id().to_string(),
         revision_compatible: true,
         limitations: vec!["verification was cancelled before the check started".to_string()],
+        reused: false,
     }
 }
 
@@ -278,6 +253,7 @@ fn skipped_outcome(
         revision_after: revision.id().to_string(),
         revision_compatible: true,
         limitations: vec![limitation.to_string()],
+        reused: false,
     }
 }
 

--- a/src/verification/executor/cache_runner.rs
+++ b/src/verification/executor/cache_runner.rs
@@ -1,0 +1,109 @@
+use super::{cancelled_outcome, execute_check, skipped_outcome};
+use crate::scan::session::WorkspaceRevision;
+use crate::verification::cache::{VerificationCache, VerificationCacheKey};
+use crate::verification::model::{
+    CancellationToken, VerificationExecutionEvent, VerificationOutcome,
+};
+use crate::verification::policy::ValidatedCheck;
+use std::path::Path;
+use std::time::Instant;
+
+pub fn run_checks_observed_cached(
+    checks: &[ValidatedCheck],
+    evidence_paths: &[std::path::PathBuf],
+    revision: &WorkspaceRevision,
+    cancellation: &CancellationToken,
+    cache_root: Option<&Path>,
+    observer: &mut dyn FnMut(VerificationExecutionEvent),
+) -> Vec<VerificationOutcome> {
+    let mut outcomes = Vec::with_capacity(checks.len());
+    let mut revision_changed = false;
+    let total = checks.len();
+    let cache = cache_root.map(VerificationCache::new);
+    for (offset, check) in checks.iter().enumerate() {
+        if cancellation.is_cancelled() {
+            break;
+        }
+        let index = offset + 1;
+        observer(VerificationExecutionEvent::Started {
+            check_id: check.id().to_string(),
+            index,
+            total,
+        });
+        let outcome = outcome_for_check(
+            check,
+            evidence_paths,
+            revision,
+            cancellation,
+            cache.as_ref(),
+            revision_changed,
+        );
+        revision_changed = !outcome.revision_compatible;
+        observer(VerificationExecutionEvent::Completed {
+            check_id: check.id().to_string(),
+            index,
+            total,
+            status: outcome.status,
+        });
+        outcomes.push(outcome);
+    }
+    outcomes
+}
+
+fn outcome_for_check(
+    check: &ValidatedCheck,
+    evidence_paths: &[std::path::PathBuf],
+    revision: &WorkspaceRevision,
+    cancellation: &CancellationToken,
+    cache: Option<&VerificationCache>,
+    revision_changed: bool,
+) -> VerificationOutcome {
+    if revision_changed {
+        return skipped_outcome(
+            check,
+            revision,
+            "workspace revision changed before this check could run",
+        );
+    }
+    if !check.is_applicable(evidence_paths.iter().map(std::path::PathBuf::as_path)) {
+        return skipped_outcome(
+            check,
+            revision,
+            "no changed or impacted path matched this check",
+        );
+    }
+    execute_or_reuse(check, revision, cancellation, cache)
+}
+
+fn execute_or_reuse(
+    check: &ValidatedCheck,
+    revision: &WorkspaceRevision,
+    cancellation: &CancellationToken,
+    cache: Option<&VerificationCache>,
+) -> VerificationOutcome {
+    if cancellation.is_cancelled() {
+        return cancelled_outcome(check, revision, Instant::now());
+    }
+    let key = cache
+        .filter(|_| check.cache_enabled())
+        .and_then(|_| VerificationCacheKey::build(check, revision));
+    if cancellation.is_cancelled() {
+        return cancelled_outcome(check, revision, Instant::now());
+    }
+    if let Some(hit) =
+        cache.and_then(|cache| key.as_ref().and_then(|key| cache.load(key, revision)))
+    {
+        return if cancellation.is_cancelled() {
+            cancelled_outcome(check, revision, Instant::now())
+        } else {
+            hit
+        };
+    }
+    let outcome = execute_check(check, revision, cancellation);
+    if !cancellation.is_cancelled()
+        && let (Some(cache), Some(key)) = (cache, key.as_ref())
+    {
+        cache.store(key, &outcome);
+    }
+    outcome
+}

--- a/src/verification/executor/tests.rs
+++ b/src/verification/executor/tests.rs
@@ -1,8 +1,31 @@
-use super::{VerificationExecutionEvent, execute_check, run_checks, run_checks_observed};
+use super::{
+    VerificationExecutionEvent, execute_check, run_checks, run_checks_observed,
+    run_checks_observed_cached,
+};
 use crate::config::loader::parse_config;
 use crate::scan::session::WorkspaceRevision;
 use crate::verification::{CancellationToken, VerificationStatus, select_checks};
 use tempfile::tempdir;
+
+#[cfg(unix)]
+fn executable(root: &std::path::Path, body: &str) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let path = root.join("tool.sh");
+    std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).expect("write executable");
+    let mut permissions = std::fs::metadata(&path).expect("metadata").permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&path, permissions).expect("executable permissions");
+    path
+}
+
+#[cfg(unix)]
+fn marker_runs(path: &std::path::Path) -> usize {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .chars()
+        .filter(|character| *character == 'x')
+        .count()
+}
 
 fn check(root: &std::path::Path, toml: &str, id: &str) -> crate::verification::ValidatedCheck {
     let config = parse_config(toml, None).expect("valid config");
@@ -203,6 +226,213 @@ fn cancellation_is_structured_and_bounded() {
         &cancellation,
     );
     assert_eq!(outcome.status, VerificationStatus::Cancelled);
+}
+
+#[test]
+fn reuse_provenance_is_additive_and_omitted_for_executed_outcomes() {
+    let temp = tempdir().expect("temp dir");
+    let check = check(
+        temp.path(),
+        "[[verification.checks]]\nid = \"missing\"\nrole = \"test\"\nprogram = \"repopilot-missing-program\"\n",
+        "missing",
+    );
+    let mut outcome = execute_check(
+        &check,
+        &WorkspaceRevision::capture(temp.path()),
+        &CancellationToken::new(),
+    );
+
+    let fresh = serde_json::to_value(&outcome).expect("serialize fresh outcome");
+    assert!(fresh.get("reused").is_none());
+    let decoded: crate::verification::VerificationOutcome =
+        serde_json::from_value(fresh).expect("fresh outcome must round trip");
+    assert_eq!(decoded, outcome);
+
+    outcome.reused = true;
+    let reused = serde_json::to_value(&outcome).expect("serialize reused outcome");
+    assert_eq!(reused["reused"], true);
+}
+
+#[cfg(unix)]
+#[test]
+fn cache_enabled_pass_executes_once_then_reuses_with_stable_lifecycle() {
+    let root = tempdir().expect("root");
+    let evidence = tempdir().expect("external evidence");
+    let marker = evidence.path().join("runs.txt");
+    executable(root.path(), "printf x >> \"$1\"");
+    let check = check(
+        root.path(),
+        &format!(
+            "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"./tool.sh\"\nargs = [{}]\n[verification.checks.cache]\nenabled = true\n",
+            toml_string(marker.to_string_lossy().as_ref())
+        ),
+        "unit",
+    );
+    let revision = WorkspaceRevision::capture(root.path());
+    let cancellation = CancellationToken::new();
+
+    let first = run_checks_observed_cached(
+        std::slice::from_ref(&check),
+        &[],
+        &revision,
+        &cancellation,
+        Some(root.path()),
+        &mut |_| {},
+    );
+    let mut events = Vec::new();
+    let second = run_checks_observed_cached(
+        &[check],
+        &[],
+        &revision,
+        &cancellation,
+        Some(root.path()),
+        &mut |event| events.push(event),
+    );
+
+    assert_eq!(marker_runs(&marker), 1);
+    assert!(!first[0].reused);
+    assert!(second[0].reused);
+    assert_eq!(
+        events,
+        [
+            VerificationExecutionEvent::Started {
+                check_id: "unit".into(),
+                index: 1,
+                total: 1,
+            },
+            VerificationExecutionEvent::Completed {
+                check_id: "unit".into(),
+                index: 1,
+                total: 1,
+                status: VerificationStatus::Passed,
+            },
+        ]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn disabled_failed_skipped_and_incompatible_checks_never_reuse() {
+    let root = tempdir().expect("root");
+    let evidence = tempdir().expect("external evidence");
+    let marker = evidence.path().join("runs.txt");
+    executable(root.path(), "printf x >> \"$1\"; exit \"$2\"");
+    let revision = WorkspaceRevision::capture(root.path());
+
+    for (name, cache, exit) in [("disabled", false, "0"), ("failed", true, "1")] {
+        let check = check(
+            root.path(),
+            &format!(
+                "[[verification.checks]]\nid = \"{name}\"\nrole = \"test\"\nprogram = \"./tool.sh\"\nargs = [{}, \"{exit}\"]\ncache = {{ enabled = {cache} }}\n",
+                toml_string(marker.to_string_lossy().as_ref())
+            ),
+            name,
+        );
+        for _ in 0..2 {
+            let outcome = run_checks_observed_cached(
+                std::slice::from_ref(&check),
+                &[],
+                &revision,
+                &CancellationToken::new(),
+                Some(root.path()),
+                &mut |_| {},
+            );
+            assert!(!outcome[0].reused);
+        }
+    }
+    assert_eq!(marker_runs(&marker), 4);
+
+    let skipped = check(
+        root.path(),
+        "[[verification.checks]]\nid = \"skipped\"\nrole = \"test\"\nprogram = \"./tool.sh\"\npaths = [\"src/**\"]\ncache = { enabled = true }\n",
+        "skipped",
+    );
+    let outcome = run_checks_observed_cached(
+        &[skipped],
+        &["docs/readme.md".into()],
+        &revision,
+        &CancellationToken::new(),
+        Some(root.path()),
+        &mut |_| {},
+    );
+    assert_eq!(outcome[0].status, VerificationStatus::Skipped);
+
+    let tracked = root.path().join("tracked.txt");
+    std::fs::write(&tracked, "before").expect("tracked input");
+    executable(
+        root.path(),
+        "printf after > tracked.txt; printf x >> \"$1\"",
+    );
+    let mutating_revision = WorkspaceRevision::capture(root.path());
+    let mutating = check(
+        root.path(),
+        &format!(
+            "[[verification.checks]]\nid = \"mutating\"\nrole = \"test\"\nprogram = \"./tool.sh\"\nargs = [{}]\ncache = {{ enabled = true }}\n",
+            toml_string(marker.to_string_lossy().as_ref())
+        ),
+        "mutating",
+    );
+    for _ in 0..2 {
+        let outcome = run_checks_observed_cached(
+            std::slice::from_ref(&mutating),
+            &[],
+            &mutating_revision,
+            &CancellationToken::new(),
+            Some(root.path()),
+            &mut |_| {},
+        );
+        assert!(!outcome[0].revision_compatible);
+        assert!(!outcome[0].reused);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn cancellation_after_started_never_attaches_a_readable_hit() {
+    let root = tempdir().expect("root");
+    let evidence = tempdir().expect("external evidence");
+    let marker = evidence.path().join("runs.txt");
+    executable(root.path(), "printf x >> \"$1\"");
+    let check = check(
+        root.path(),
+        &format!(
+            "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"./tool.sh\"\nargs = [{}]\ncache = {{ enabled = true }}\n",
+            toml_string(marker.to_string_lossy().as_ref())
+        ),
+        "unit",
+    );
+    let revision = WorkspaceRevision::capture(root.path());
+    run_checks_observed_cached(
+        std::slice::from_ref(&check),
+        &[],
+        &revision,
+        &CancellationToken::new(),
+        Some(root.path()),
+        &mut |_| {},
+    );
+    let cancellation = CancellationToken::new();
+    let observer_token = cancellation.clone();
+    let outcome = run_checks_observed_cached(
+        &[check],
+        &[],
+        &revision,
+        &cancellation,
+        Some(root.path()),
+        &mut |event| {
+            if matches!(event, VerificationExecutionEvent::Started { .. }) {
+                observer_token.cancel();
+            }
+        },
+    );
+
+    assert_eq!(outcome[0].status, VerificationStatus::Cancelled);
+    assert!(!outcome[0].reused);
+    assert_eq!(marker_runs(&marker), 1);
+}
+
+#[cfg(unix)]
+fn toml_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
 #[cfg(unix)]

--- a/src/verification/mod.rs
+++ b/src/verification/mod.rs
@@ -1,9 +1,10 @@
+mod cache;
 mod executor;
 mod model;
 mod policy;
 mod redaction;
 
-pub use executor::{execute_check, run_checks, run_checks_observed};
+pub use executor::{execute_check, run_checks, run_checks_observed, run_checks_observed_cached};
 pub use model::{
     CancellationToken, VerificationExecutionEvent, VerificationOutcome, VerificationRole,
     VerificationStatus,

--- a/src/verification/model.rs
+++ b/src/verification/model.rs
@@ -11,7 +11,7 @@ pub enum VerificationRole {
     Lint,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum VerificationStatus {
     Passed,
@@ -37,7 +37,7 @@ pub enum VerificationExecutionEvent {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct VerificationOutcome {
     pub check_id: String,
     pub role: VerificationRole,
@@ -53,8 +53,14 @@ pub struct VerificationOutcome {
     pub revision_before: String,
     pub revision_after: String,
     pub revision_compatible: bool,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub limitations: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub reused: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/verification/policy.rs
+++ b/src/verification/policy.rs
@@ -21,6 +21,8 @@ pub struct ValidatedCheck {
     pub(crate) timeout_seconds: u64,
     pub(crate) max_output_bytes: usize,
     pub(crate) paths: Option<GlobSet>,
+    pub(crate) path_patterns: Vec<String>,
+    cache_enabled: bool,
 }
 
 impl ValidatedCheck {
@@ -36,6 +38,10 @@ impl ValidatedCheck {
             let normalized = path.to_string_lossy().replace('\\', "/");
             patterns.is_match(normalized)
         })
+    }
+
+    pub fn cache_enabled(&self) -> bool {
+        self.cache_enabled
     }
 }
 
@@ -182,6 +188,14 @@ fn validate_check(
         )));
     }
 
+    let mut path_patterns = config
+        .paths
+        .iter()
+        .map(|path| path.replace('\\', "/"))
+        .collect::<Vec<_>>();
+    path_patterns.sort();
+    path_patterns.dedup();
+
     Ok(ValidatedCheck {
         id: config.id.clone(),
         role: config.role,
@@ -192,6 +206,8 @@ fn validate_check(
         timeout_seconds: config.timeout_seconds,
         max_output_bytes: config.max_output_bytes,
         paths: compile_paths(&config.id, &config.paths)?,
+        path_patterns,
+        cache_enabled: config.cache.enabled,
     })
 }
 

--- a/tests/config_loader.rs
+++ b/tests/config_loader.rs
@@ -33,6 +33,34 @@ fn verification_checks_parse_with_bounded_defaults() {
 }
 
 #[test]
+fn verification_cache_is_disabled_by_default_and_requires_explicit_opt_in() {
+    let default = parse_config(
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"cargo\"\n",
+        None,
+    )
+    .expect("default check");
+    assert!(!default.verification.checks[0].cache.enabled);
+
+    let enabled = parse_config(
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"cargo\"\n[verification.checks.cache]\nenabled = true\n",
+        None,
+    )
+    .expect("cached check");
+    assert!(enabled.verification.checks[0].cache.enabled);
+}
+
+#[test]
+fn verification_cache_rejects_unknown_fields() {
+    let error = parse_config(
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"cargo\"\n[verification.checks.cache]\nunknown = true\n",
+        None,
+    )
+    .expect_err("unknown cache policy fields must fail closed");
+
+    assert!(error.to_string().contains("unknown field `unknown`"));
+}
+
+#[test]
 fn verification_check_rejects_unknown_fields() {
     let error = parse_config(
         r#"

--- a/tests/mcp_verification.rs
+++ b/tests/mcp_verification.rs
@@ -121,6 +121,51 @@ args = ["-c", "printf failure >&2; exit 7"]
     assert!(result["analysisHandle"].is_string());
 }
 
+#[test]
+fn opted_in_cache_is_shared_by_mcp_calls_and_remains_publishable() {
+    let temp = verification_repo(
+        r#"[[verification.checks]]
+id = "unit"
+role = "test"
+program = "sh"
+args = ["-c", "mkdir -p .repopilot/cache; printf x >> .repopilot/cache/mcp-verification-runs"]
+cache = { enabled = true }
+"#,
+    );
+    let responses = run_mcp(
+        temp.path(),
+        vec![
+            tool_call(
+                7,
+                json!({ "path": ".", "detail": "full", "verify": ["unit"] }),
+            ),
+            tool_call(
+                8,
+                json!({ "path": ".", "detail": "full", "verify": ["unit"] }),
+            ),
+        ],
+    );
+
+    let first = result_for(&responses, 7);
+    let second = result_for(&responses, 8);
+    assert!(
+        first["structuredContent"]["merge_readiness"]["verification"][0]
+            .get("reused")
+            .is_none()
+    );
+    assert_eq!(
+        second["structuredContent"]["merge_readiness"]["verification"][0]["reused"],
+        true
+    );
+    assert!(first["analysisHandle"].is_string());
+    assert!(second["analysisHandle"].is_string());
+    assert_eq!(
+        fs::read_to_string(temp.path().join(".repopilot/cache/mcp-verification-runs"))
+            .expect("marker"),
+        "x"
+    );
+}
+
 fn verification_repo(config: &str) -> tempfile::TempDir {
     let temp = tempfile::tempdir().expect("temp dir");
     git(temp.path(), &["init", "-q"]);

--- a/tests/review_readiness.rs
+++ b/tests/review_readiness.rs
@@ -99,6 +99,29 @@ fn human_reports_project_readiness_and_owners() {
 }
 
 #[test]
+fn human_reports_show_when_verification_was_reused() {
+    let mut report = report_with_ownership(OwnershipSummary::default());
+    report.verification = vec![verification_outcome(VerificationStatus::Passed, true)];
+
+    let executed_console = repopilot::review::render::render_console(&report, None);
+    let executed_markdown = repopilot::review::render::render_markdown(&report, None);
+    assert!(executed_console.contains("unit: PASSED (10 ms)"));
+    assert!(!executed_console.contains("cached"));
+    assert!(executed_markdown.contains("| `unit` | `Passed` | executed | 10 ms | 1 |"));
+
+    let mut outcome = report.verification.remove(0);
+    outcome.reused = true;
+    report.verification = vec![outcome];
+
+    let console = repopilot::review::render::render_console(&report, None);
+    let markdown = repopilot::review::render::render_markdown(&report, None);
+
+    assert!(console.contains("unit: PASSED (10 ms, cached)"));
+    assert!(markdown.contains("| Check | Status | Source | Duration | Exit |"));
+    assert!(markdown.contains("| `unit` | `Passed` | cached | 10 ms | 1 |"));
+}
+
+#[test]
 fn failed_verification_blocks_canonical_readiness() {
     let mut report = report_with_ownership(OwnershipSummary::default());
     report.verification = vec![verification_outcome(VerificationStatus::Failed, true)];
@@ -147,6 +170,7 @@ fn verification_outcome(
         revision_after: "after".to_string(),
         revision_compatible,
         limitations: Vec::new(),
+        reused: false,
     }
 }
 

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -736,6 +736,9 @@ fn cache_clear_removes_cache_and_is_idempotent() {
 
     let cache_dir = temp.path().join(".repopilot/cache");
     assert!(cache_dir.is_dir());
+    let verification_entry = cache_dir.join("verification/v1/entry.json");
+    write(verification_entry.clone(), "{}");
+    assert!(verification_entry.is_file());
 
     clear_cache(temp.path());
     assert!(!cache_dir.exists());

--- a/tests/verification_cli.rs
+++ b/tests/verification_cli.rs
@@ -228,6 +228,60 @@ fn failed_check_writes_report_before_exit_one() {
     assert_eq!(json["merge_readiness"]["verification"][0]["exit_code"], 7);
 }
 
+#[cfg(unix)]
+#[test]
+fn opted_in_cache_reuses_across_cli_processes_and_invalidates_on_edit() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    fs::write(temp.path().join("README.md"), "before\n").expect("source");
+    fs::write(
+        temp.path().join("repopilot.toml"),
+        "[[verification.checks]]\nid = \"unit\"\nrole = \"test\"\nprogram = \"sh\"\nargs = [\"-c\", \"mkdir -p .repopilot/cache; printf x >> .repopilot/cache/verification-runs\"]\ncache = { enabled = true }\n",
+    )
+    .expect("config");
+    commit_all(temp.path(), "initial");
+    fs::write(temp.path().join("README.md"), "after\n").expect("change");
+
+    let first = review_json(temp.path(), "unit");
+    let second = review_json(temp.path(), "unit");
+    assert!(
+        first["merge_readiness"]["verification"][0]
+            .get("reused")
+            .is_none()
+    );
+    assert_eq!(second["merge_readiness"]["verification"][0]["reused"], true);
+    assert_eq!(
+        fs::read_to_string(temp.path().join(".repopilot/cache/verification-runs")).expect("marker"),
+        "x"
+    );
+
+    fs::write(temp.path().join("README.md"), "changed again\n").expect("second edit");
+    let invalidated = review_json(temp.path(), "unit");
+    assert!(
+        invalidated["merge_readiness"]["verification"][0]
+            .get("reused")
+            .is_none()
+    );
+    assert_eq!(
+        fs::read_to_string(temp.path().join(".repopilot/cache/verification-runs")).expect("marker"),
+        "xx"
+    );
+}
+
+fn review_json(root: &Path, check_id: &str) -> Value {
+    let output = repopilot()
+        .args(["review", ".", "--format", "json", "--verify", check_id])
+        .current_dir(root)
+        .output()
+        .expect("review");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("JSON report")
+}
+
 fn init_repo(root: &Path) {
     git(root, &["init"]);
     git(root, &["config", "user.email", "repopilot@example.invalid"]);


### PR DESCRIPTION
## Summary

Add an opt-in, persistent verification result cache shared by CLI and MCP review flows. Only passing, revision-compatible evidence can be reused.

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- Add conservative keys covering workspace revision, full check policy, executable bytes, inherited portability environment, platform, RepoPilot version, and cache schema.
- Add atomic, bounded, best-effort storage under `.repopilot/cache/verification/v1`, with safe fallback to fresh execution.
- Expose reuse provenance as `reused: true` in JSON/MCP and `cached` in console/Markdown, with CLI/MCP parity and cancellation/invalidation coverage.

## Why

Repeated allowlisted checks can dominate local review latency. This gives maintainers an explicit safe optimization without weakening deterministic analysis, cancellation, readiness, or publication semantics.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [ ] New or changed findings/signals include deterministic evidence and tests
- [ ] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [ ] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

## Changelog

- [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
npm run test:release-contract
cargo run -- scan . --fail-on-priority p1
cargo build --release
npm run review:performance
```