### PR TITLE
fix(mcp): harden JSON-RPC admission and queue bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,17 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- Harden the local stdio MCP transport against invalid and excessive client
+  input. RepoPilot now rejects non-2.0 or structurally invalid JSON-RPC
+  envelopes with `-32600`, preserves `-32700` for malformed JSON, and bounds
+  the serial worker to eight waiting tool calls. Further calls receive the
+  retryable `-32000` overload response without being retained in the request
+  registry. Unknown or late cancellation IDs are ignored rather than buffered;
+  admission and cancellation remain responsive during active analysis; and a
+  duplicate active ID cannot replace the original cancellation token. Request
+  validation also preserves null IDs while rejecting non-scalar IDs and
+  non-structured explicit `params`. Accepted calls keep their existing
+  cancellation and progress flow.
 - Stop `architecture.unresolved-local-import` from treating handled optional
   Python dependencies as broken code. Imports in a `try` body guarded by an
   absorbing `ImportError` or `ModuleNotFoundError` handler are excluded, while

--- a/docs/engineering/v0.22-e1-mcp-hardening-plan.md
+++ b/docs/engineering/v0.22-e1-mcp-hardening-plan.md
@@ -1,0 +1,88 @@
+# v0.22 E1 MCP Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject invalid JSON-RPC envelopes and bound queued MCP tool work without changing accepted-call behavior.
+
+**Architecture:** `jsonrpc.rs` owns syntax-versus-envelope parsing. `mod.rs` owns admission into an eight-slot `sync_channel`; a small helper performs registry registration, non-blocking enqueue, overload response, and cleanup as one testable unit.
+
+**Tech Stack:** Rust 2024, `std::sync::mpsc`, Serde JSON, existing MCP stdio transport.
+
+**Spec:** `docs/engineering/v0.22-e1-mcp-hardening-spec.md`
+
+## Global Constraints
+
+- No new runtime dependencies or network behavior.
+- One tool worker; at most eight waiting jobs.
+- Preserve cancellation, progress, response-size, and initialization contracts.
+- Keep source files below the repository size limits.
+- Do not commit, push, or open a PR until explicitly requested.
+
+---
+
+### Task 1: JSON-RPC envelope validation
+
+**Files:**
+- Modify: `src/commands/mcp/jsonrpc.rs`
+- Modify: `src/commands/mcp/mod.rs`
+- Test: `src/commands/mcp/tests.rs`
+- Test: `tests/mcp_cli.rs`
+
+**Interfaces:**
+- Produces: `parse_request(&str) -> Result<Request, RequestParseError>`.
+- Produces: `PARSE_ERROR = -32700` and `INVALID_REQUEST = -32600`.
+
+- [x] Add failing tests for JSON-RPC 1.0, missing `jsonrpc`, invalid request shape,
+  and malformed JSON followed by a valid request.
+- [x] Run `cargo test commands::mcp::tests --lib` and the focused real-binary
+  test; confirm failures come from the currently accepted invalid envelopes.
+- [x] Parse into `serde_json::Value` first, deserialize `Request` second, and
+  reject any version other than exactly `"2.0"`, non-scalar IDs, and
+  non-structured explicit `params`; preserve an explicit null ID.
+- [x] Route syntax errors to `-32700` and envelope errors to `-32600`, both with
+  `id: null`.
+- [x] Re-run focused tests and keep valid notifications silent.
+
+### Task 2: Bounded tool admission
+
+**Files:**
+- Modify: `src/commands/mcp/mod.rs`
+- Test: `src/commands/mcp/tests.rs`
+- Verify: `src/commands/mcp/worker/tests.rs`
+
+**Interfaces:**
+- Produces: `TOOL_QUEUE_CAPACITY: usize = 8`.
+- Produces: a private enqueue helper consuming `mpsc::SyncSender<ToolJob>` and
+  returning `io::Result<()>` after admission or response.
+
+- [x] Add a failing deterministic unit test using a capacity-one channel with
+  no consumer; prove the second job returns `-32000` and leaves no active
+  registry entry.
+- [x] Run the test and confirm the unbounded sender API cannot satisfy it.
+- [x] Replace `mpsc::channel` with `mpsc::sync_channel(TOOL_QUEUE_CAPACITY)` and
+  use `try_send` so the reader never blocks on overload. Read initialization
+  state without acquiring the analysis mutex held by the worker.
+- [x] On `TrySendError::Full`, remove the registry entry and write
+  `MCP tool queue is full; retry later`; on `Disconnected`, clean up and retain
+  the existing broken-pipe failure.
+- [x] Ignore cancellation for unknown or completed IDs instead of retaining
+  unbounded future-request state; keep active cancellation idempotent.
+- [x] Reject duplicate active request IDs without replacing the original
+  cancellation token, and make worker cleanup unable to remove newer state.
+- [x] Re-run MCP unit, cancellation, progress, and integration coverage.
+
+### Task 3: Documentation and verification
+
+**Files:**
+- Modify: `docs/mcp.md`
+- Modify: `CHANGELOG.md`
+- Modify: `docs/engineering/v0.22-e1-mcp-hardening-spec.md`
+- Modify: `docs/engineering/v0.22-e1-mcp-hardening-plan.md`
+
+- [x] Document serial execution, the eight-job waiting bound, and the retryable
+  overload error without promising automatic retries.
+- [x] Add an `[Unreleased]` changelog entry.
+- [x] Run focused MCP tests, `cargo fmt --all -- --check`, Clippy, and the
+  repository handoff gate.
+- [x] Mark the spec `done` and every completed plan checkbox only after fresh
+  evidence exists; leave publication to a separate user command.

--- a/docs/engineering/v0.22-e1-mcp-hardening-spec.md
+++ b/docs/engineering/v0.22-e1-mcp-hardening-spec.md
@@ -1,0 +1,73 @@
+# v0.22 E1 MCP Hardening Specification
+
+Status: done
+
+## Problem
+
+The stdio MCP server accepts structurally invalid JSON-RPC messages and feeds
+tool calls into an unbounded channel. A client can therefore receive a success
+response for JSON-RPC 1.0 and can enqueue work faster than the single worker can
+consume it, growing both the queue and cancellation registry without a bound.
+
+## Outcome
+
+RepoPilot validates the JSON-RPC 2.0 envelope before dispatch and applies a
+fixed, deterministic bound to queued tool work. Syntax errors, invalid request
+objects, unsupported JSON-RPC versions, overload, cancellation, and worker
+failure remain distinguishable to MCP clients.
+
+## Contract
+
+- Only requests whose `jsonrpc` field is exactly `"2.0"` are dispatched.
+- Request IDs are absent, null, strings, or numbers; null remains a request ID
+  and receives a response. `params`, when present, is an object or array.
+- Invalid JSON syntax returns JSON-RPC error `-32700` with `id: null`.
+- Valid JSON that cannot form a supported request returns `-32600` with
+  `id: null`.
+- The server runs one tool worker and retains at most eight waiting tool jobs.
+- A ninth waiting job is not blocked or retained. It returns `-32000` with the
+  message `MCP tool queue is full; retry later` and its registry entry is
+  removed.
+- Admission remains responsive while a tool owns the analysis state lock, so
+  overload responses and cancellation notifications are not serialized behind
+  the active analysis.
+- A duplicate active request ID is rejected with `-32600`; it cannot replace
+  the original request's cancellation token.
+- A disconnected worker remains a transport failure, not an overload response.
+- Cancellation state exists only for accepted active or queued work. Unknown or
+  already completed request IDs are ignored rather than buffered for a future
+  request.
+- Notifications still produce no response when their envelope is valid.
+- Cancellation and progress behavior for accepted jobs remains unchanged.
+- The transport remains standard-library based, deterministic, local-only, and
+  free of new runtime dependencies.
+
+## Scope
+
+### In scope
+
+- JSON-RPC parsing and validation in `src/commands/mcp/jsonrpc.rs`.
+- Bounded queue admission and cleanup in `src/commands/mcp/mod.rs`.
+- Unit and real-binary MCP regression tests.
+- MCP documentation and the `[Unreleased]` changelog.
+
+### Out of scope
+
+- Parallel tool execution.
+- User-configurable queue capacity.
+- Retries inside the MCP server.
+- CPU thread limits, CLI output changes, and audit-rule calibration; those are
+  subsequent v0.22 stabilization PRs.
+
+## Acceptance
+
+1. JSON-RPC 1.0, missing `jsonrpc`, and structurally invalid request objects
+   return `-32600`; malformed JSON returns `-32700`.
+2. A full queue returns `-32000` without blocking and without leaving an active
+   request in the registry.
+3. Unknown or late cancellation IDs do not allocate registry state.
+4. Active analysis does not delay overload admission or cancellation handling.
+5. Duplicate active IDs cannot replace or remove the original cancellation
+   entry.
+6. Accepted tool calls still support cancellation and progress.
+7. Focused MCP tests, formatting, Clippy, and the RepoPilot handoff gate pass.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -123,8 +123,13 @@ suggestions still exist. Changed-scope tools are optimized for edited files and
 cache reuse; run a full scan when repository-wide architecture/framework findings
 or aggregate counts must be authoritative.
 
-Tool failures use MCP `isError: true`. Malformed input produces JSON-RPC error
-`-32700` instead of being skipped.
+Tool failures use MCP `isError: true`. Malformed JSON produces JSON-RPC error
+`-32700`; a valid JSON value that is not a JSON-RPC 2.0 request produces
+`-32600`. RepoPilot does not dispatch envelopes whose `jsonrpc` field is
+missing or differs from `"2.0"`, whose ID is neither null, a string, nor a
+number, or whose explicit `params` is not an object or array. A null ID is
+still a request and receives a response. A duplicate active request ID is
+rejected with `-32600` without replacing the original request.
 
 ## `repopilot_scan` Persistent Cache
 
@@ -216,7 +221,13 @@ Clients must call `initialize`, send `notifications/initialized`, then use
 worker built with standard-library channels, so the stdio loop can receive
 `notifications/cancelled` while analysis is running. Calls that include
 `_meta.progressToken` receive start/completion `notifications/progress`.
-No async runtime is used.
+Cancellation for an unknown or already completed request ID is ignored and is
+not retained as state for a future request.
+The worker executes one tool call at a time and retains at most eight waiting
+calls. When that queue is full, an additional call receives JSON-RPC error
+`-32000` with `MCP tool queue is full; retry later`; the server does not retry
+the call automatically. Queue admission and cancellation remain responsive
+while the active tool owns analysis state. No async runtime is used.
 
 HTTP transport, hosted MCP, sampling, and source upload are outside the current
 local stdio MCP scope.

--- a/src/commands/mcp/jsonrpc.rs
+++ b/src/commands/mcp/jsonrpc.rs
@@ -10,17 +10,45 @@ use serde_json::Value;
 /// JSON-RPC error code for an unknown method or tool.
 pub const METHOD_NOT_FOUND: i32 = -32601;
 
+/// JSON-RPC error codes for invalid transport input.
+pub const PARSE_ERROR: i32 = -32700;
+pub const INVALID_REQUEST: i32 = -32600;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestParseError {
+    Parse,
+    InvalidRequest,
+}
+
 /// An incoming JSON-RPC request or notification. Notifications omit `id` and
 /// receive no response.
 #[derive(Debug, Deserialize)]
 pub struct Request {
-    #[allow(dead_code)]
     pub jsonrpc: String,
     #[serde(default)]
     pub id: Option<Value>,
     pub method: String,
     #[serde(default)]
     pub params: Value,
+}
+
+pub fn parse_request(line: &str) -> Result<Request, RequestParseError> {
+    let value = serde_json::from_str::<Value>(line).map_err(|_| RequestParseError::Parse)?;
+    let explicit_id = value.get("id").cloned();
+    let valid_params = value
+        .get("params")
+        .is_none_or(|params| params.is_array() || params.is_object());
+    let mut request =
+        serde_json::from_value::<Request>(value).map_err(|_| RequestParseError::InvalidRequest)?;
+    request.id = explicit_id;
+    let valid_id = request
+        .id
+        .as_ref()
+        .is_none_or(|id| id.is_null() || id.is_string() || id.is_number());
+    if request.jsonrpc != "2.0" || !valid_id || !valid_params {
+        return Err(RequestParseError::InvalidRequest);
+    }
+    Ok(request)
 }
 
 /// An outgoing JSON-RPC response. Exactly one of `result`/`error` is set.

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -34,7 +34,10 @@ use catalog::{
     handle_prompt_get, handle_resource_read, prompts_list_result, resources_list_result,
     tools_list_result,
 };
-use jsonrpc::{METHOD_NOT_FOUND, Request, Response};
+use jsonrpc::{
+    INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR, Request, RequestParseError, Response,
+    parse_request,
+};
 #[cfg(test)]
 use publication::tool_result;
 use request_registry::RequestRegistry;
@@ -43,14 +46,14 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, mpsc};
 use tool_call::handle_tools_call;
-use worker::{ToolJob, run_tool_worker, write_message};
+use worker::{ToolJob, enqueue_tool_job, run_tool_worker, write_message};
 
 const SERVER_NAME: &str = "repopilot";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const LATEST_PROTOCOL_VERSION: &str = "2025-11-25";
 const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[LATEST_PROTOCOL_VERSION, "2024-11-05"];
-const PARSE_ERROR: i32 = -32700;
 const DEFAULT_MAX_RESPONSE_BYTES: usize = 1_048_576;
+const TOOL_QUEUE_CAPACITY: usize = 8;
 
 struct ServerState {
     root: PathBuf,
@@ -114,9 +117,10 @@ fn serve_with_options<R: BufRead, W: Write + Send>(
     }));
     let registry = Arc::new(Mutex::new(RequestRegistry::default()));
     let writer = Arc::new(Mutex::new(&mut writer));
-    let (jobs_tx, jobs_rx) = mpsc::channel::<ToolJob>();
+    let (jobs_tx, jobs_rx) = mpsc::sync_channel::<ToolJob>(TOOL_QUEUE_CAPACITY);
 
     std::thread::scope(|scope| -> std::io::Result<()> {
+        let mut initialized = false;
         let worker_state = Arc::clone(&state);
         let worker_registry = Arc::clone(&registry);
         let worker_writer = Arc::clone(&writer);
@@ -130,12 +134,22 @@ fn serve_with_options<R: BufRead, W: Write + Send>(
                 continue;
             }
 
-            let Ok(request) = serde_json::from_str::<Request>(&line) else {
-                write_message(
-                    &writer,
-                    &Response::error(Value::Null, PARSE_ERROR, "parse error"),
-                )?;
-                continue;
+            let request = match parse_request(&line) {
+                Ok(request) => request,
+                Err(RequestParseError::Parse) => {
+                    write_message(
+                        &writer,
+                        &Response::error(Value::Null, PARSE_ERROR, "parse error"),
+                    )?;
+                    continue;
+                }
+                Err(RequestParseError::InvalidRequest) => {
+                    write_message(
+                        &writer,
+                        &Response::error(Value::Null, INVALID_REQUEST, "invalid request"),
+                    )?;
+                    continue;
+                }
             };
 
             if request.method == "notifications/cancelled" {
@@ -151,7 +165,6 @@ fn serve_with_options<R: BufRead, W: Write + Send>(
             if request.method == "tools/call"
                 && let Some(id) = request.id.clone()
             {
-                let initialized = state.lock().map_err(lock_error)?.initialized;
                 if !initialized {
                     write_message(
                         &writer,
@@ -164,33 +177,26 @@ fn serve_with_options<R: BufRead, W: Write + Send>(
                     .get("_meta")
                     .and_then(|meta| meta.get("progressToken"))
                     .cloned();
-                let key = request_key(&id);
                 let cancellation = repopilot::verification::CancellationToken::new();
-                registry
-                    .lock()
-                    .map_err(lock_error)?
-                    .register(key.clone(), cancellation.clone());
-                if jobs_tx
-                    .send(ToolJob {
+                enqueue_tool_job(
+                    &jobs_tx,
+                    ToolJob {
                         id,
                         params: request.params,
                         progress_token,
                         cancellation,
-                    })
-                    .is_err()
-                {
-                    registry.lock().map_err(lock_error)?.finish(&key);
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "MCP tool worker stopped",
-                    ));
-                }
+                    },
+                    &registry,
+                    &writer,
+                )?;
                 continue;
             }
 
             let response = {
                 let mut state = state.lock().map_err(lock_error)?;
-                handle(&request, &mut state)
+                let response = handle(&request, &mut state);
+                initialized = state.initialized;
+                response
             };
             if let Some(response) = response {
                 write_message(&writer, &response)?;

--- a/src/commands/mcp/request_registry.rs
+++ b/src/commands/mcp/request_registry.rs
@@ -1,32 +1,30 @@
 use repopilot::verification::CancellationToken;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 #[derive(Default)]
 pub(super) struct RequestRegistry {
-    pending: HashSet<String>,
     active: HashMap<String, CancellationToken>,
 }
 
 impl RequestRegistry {
-    pub(super) fn register(&mut self, key: String, token: CancellationToken) {
-        if self.pending.remove(&key) {
-            token.cancel();
+    pub(super) fn register(&mut self, key: String, token: CancellationToken) -> bool {
+        if self.active.contains_key(&key) {
+            return false;
         }
-        if let Some(replaced) = self.active.insert(key, token) {
-            replaced.cancel();
-        }
+        self.active.insert(key, token);
+        true
     }
 
-    pub(super) fn cancel(&mut self, key: &str) {
+    pub(super) fn cancel(&mut self, key: &str) -> bool {
         if let Some(token) = self.active.get(key) {
             token.cancel();
+            true
         } else {
-            self.pending.insert(key.to_string());
+            false
         }
     }
 
     pub(super) fn finish(&mut self, key: &str) {
-        self.pending.remove(key);
         self.active.remove(key);
     }
 }

--- a/src/commands/mcp/request_registry/tests.rs
+++ b/src/commands/mcp/request_registry/tests.rs
@@ -2,18 +2,14 @@ use super::RequestRegistry;
 use repopilot::verification::CancellationToken;
 
 #[test]
-fn pending_cancellation_applies_when_request_registers() {
+fn unknown_cancellation_is_ignored_instead_of_buffered() {
     let mut registry = RequestRegistry::default();
-    registry.cancel("7");
+    assert!(!registry.cancel("7"));
     let token = CancellationToken::new();
 
     registry.register("7".to_string(), token.clone());
 
-    assert!(token.is_cancelled());
-    registry.finish("7");
-    let reused = CancellationToken::new();
-    registry.register("7".to_string(), reused.clone());
-    assert!(!reused.is_cancelled());
+    assert!(!token.is_cancelled());
 }
 
 #[test]
@@ -22,8 +18,8 @@ fn active_and_repeated_cancellation_are_idempotent() {
     let token = CancellationToken::new();
     registry.register("active".to_string(), token.clone());
 
-    registry.cancel("active");
-    registry.cancel("active");
+    assert!(registry.cancel("active"));
+    assert!(registry.cancel("active"));
 
     assert!(token.is_cancelled());
     registry.finish("active");
@@ -33,19 +29,13 @@ fn active_and_repeated_cancellation_are_idempotent() {
 }
 
 #[test]
-fn finish_clears_pending_and_active_state() {
+fn finish_clears_active_state() {
     let mut registry = RequestRegistry::default();
-    registry.cancel("pending");
-    registry.finish("pending");
-    let pending_reuse = CancellationToken::new();
-    registry.register("pending".to_string(), pending_reuse.clone());
-    assert!(!pending_reuse.is_cancelled());
-
     let active = CancellationToken::new();
     registry.register("active".to_string(), active);
     registry.finish("active");
-    registry.cancel("active");
+    assert!(!registry.cancel("active"));
     let active_reuse = CancellationToken::new();
     registry.register("active".to_string(), active_reuse.clone());
-    assert!(active_reuse.is_cancelled());
+    assert!(!active_reuse.is_cancelled());
 }

--- a/src/commands/mcp/tests.rs
+++ b/src/commands/mcp/tests.rs
@@ -1,6 +1,8 @@
-use super::{ServerState, handle_tools_call, scan, serve};
+use super::{ServerState, ToolJob, enqueue_tool_job, handle_tools_call, scan, serve};
+use repopilot::verification::CancellationToken;
 use serde_json::{Value, json};
 use std::io::Cursor;
+use std::sync::{Arc, Mutex, mpsc};
 
 /// Runs the server over newline-delimited request lines and returns the decoded
 /// JSON responses in order.
@@ -195,6 +197,127 @@ fn malformed_line_returns_parse_error_and_server_continues() {
     assert_eq!(responses[0]["error"]["code"], -32700);
     assert_eq!(responses[1]["id"], 9);
     assert!(responses[1]["result"].is_object());
+}
+
+#[test]
+fn unsupported_jsonrpc_version_returns_invalid_request() {
+    let responses = exchange(&[json!({
+        "jsonrpc": "1.0",
+        "id": 10,
+        "method": "ping"
+    })]);
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0]["id"], Value::Null);
+    assert_eq!(responses[0]["error"]["code"], -32600);
+}
+
+#[test]
+fn null_request_id_is_not_treated_as_a_notification() {
+    let responses = exchange(&[json!({
+        "jsonrpc": "2.0",
+        "id": null,
+        "method": "ping"
+    })]);
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0]["id"], Value::Null);
+    assert!(responses[0]["result"].is_object());
+}
+
+#[test]
+fn structurally_invalid_request_returns_invalid_request_and_server_continues() {
+    let input = concat!(
+        "{\"id\":11,\"method\":\"ping\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":12,\"method\":7}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":{},\"method\":\"ping\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":13,\"method\":\"ping\",\"params\":\"bad\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":14,\"method\":\"ping\",\"params\":null}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":15,\"method\":\"ping\"}"
+    );
+    let mut output = Vec::new();
+    serve(Cursor::new(input), &mut output).expect("serve");
+
+    let responses = decode(output);
+    assert_eq!(responses.len(), 6);
+    assert_eq!(responses[0]["id"], Value::Null);
+    assert_eq!(responses[0]["error"]["code"], -32600);
+    assert_eq!(responses[1]["id"], Value::Null);
+    assert_eq!(responses[1]["error"]["code"], -32600);
+    assert_eq!(responses[2]["id"], Value::Null);
+    assert_eq!(responses[2]["error"]["code"], -32600);
+    assert_eq!(responses[3]["id"], Value::Null);
+    assert_eq!(responses[3]["error"]["code"], -32600);
+    assert_eq!(responses[4]["id"], Value::Null);
+    assert_eq!(responses[4]["error"]["code"], -32600);
+    assert_eq!(responses[5]["id"], 15);
+    assert!(responses[5]["result"].is_object());
+}
+
+#[test]
+fn full_tool_queue_returns_busy_without_retaining_the_request() {
+    let (sender, _receiver) = mpsc::sync_channel(1);
+    sender
+        .try_send(tool_job(20))
+        .expect("first job fills the queue");
+    let registry = Arc::new(Mutex::new(super::RequestRegistry::default()));
+    let mut output = Vec::new();
+    {
+        let writer = Arc::new(Mutex::new(&mut output));
+        enqueue_tool_job(&sender, tool_job(21), &registry, &writer)
+            .expect("overload is a protocol response");
+    }
+
+    let responses = decode(output);
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0]["id"], 21);
+    assert_eq!(responses[0]["error"]["code"], -32000);
+    assert_eq!(
+        responses[0]["error"]["message"],
+        "MCP tool queue is full; retry later"
+    );
+
+    let mut registry = registry.lock().expect("registry");
+    assert!(
+        !registry.cancel("21"),
+        "overloaded request remained active in the registry"
+    );
+}
+
+#[test]
+fn duplicate_tool_id_is_rejected_without_replacing_the_active_request() {
+    let (sender, receiver) = mpsc::sync_channel(2);
+    let registry = Arc::new(Mutex::new(super::RequestRegistry::default()));
+    let first = tool_job(30);
+    let first_cancellation = first.cancellation.clone();
+    let second = tool_job(30);
+    let second_cancellation = second.cancellation.clone();
+    let mut output = Vec::new();
+    {
+        let writer = Arc::new(Mutex::new(&mut output));
+        enqueue_tool_job(&sender, first, &registry, &writer).expect("first job accepted");
+        enqueue_tool_job(&sender, second, &registry, &writer)
+            .expect("duplicate rejection is a protocol response");
+    }
+
+    let responses = decode(output);
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0]["id"], 30);
+    assert_eq!(responses[0]["error"]["code"], -32600);
+    assert_eq!(receiver.try_recv().expect("original job").id, json!(30));
+    assert!(receiver.try_recv().is_err(), "duplicate job was queued");
+    assert!(registry.lock().expect("registry").cancel("30"));
+    assert!(first_cancellation.is_cancelled());
+    assert!(!second_cancellation.is_cancelled());
+}
+
+fn tool_job(id: i64) -> ToolJob {
+    ToolJob {
+        id: json!(id),
+        params: json!({}),
+        progress_token: None,
+        cancellation: CancellationToken::new(),
+    }
 }
 
 #[test]

--- a/src/commands/mcp/worker.rs
+++ b/src/commands/mcp/worker.rs
@@ -1,4 +1,4 @@
-use super::jsonrpc::Response;
+use super::jsonrpc::{INVALID_REQUEST, Response};
 use super::progress::{ProgressReporter, mode_for_tool_call};
 use super::request_registry::RequestRegistry;
 use super::{ServerState, lock_error, request_key};
@@ -8,6 +8,8 @@ use serde::Serialize;
 use serde_json::Value;
 use std::io::Write;
 use std::sync::{Arc, Mutex, mpsc};
+
+const SERVER_BUSY: i32 = -32000;
 
 pub(super) struct ToolJob {
     pub id: Value,
@@ -25,6 +27,43 @@ pub(super) fn write_message<W: Write, T: Serialize>(
     writer.write_all(encoded.as_bytes())?;
     writer.write_all(b"\n")?;
     writer.flush()
+}
+
+pub(super) fn enqueue_tool_job<W: Write>(
+    jobs_tx: &mpsc::SyncSender<ToolJob>,
+    job: ToolJob,
+    registry: &Arc<Mutex<RequestRegistry>>,
+    writer: &Arc<Mutex<&mut W>>,
+) -> std::io::Result<()> {
+    let key = request_key(&job.id);
+    let registered = registry
+        .lock()
+        .map_err(lock_error)?
+        .register(key.clone(), job.cancellation.clone());
+    if !registered {
+        return write_message(
+            writer,
+            &Response::error(job.id, INVALID_REQUEST, "request id is already active"),
+        );
+    }
+
+    match jobs_tx.try_send(job) {
+        Ok(()) => Ok(()),
+        Err(mpsc::TrySendError::Full(job)) => {
+            registry.lock().map_err(lock_error)?.finish(&key);
+            write_message(
+                writer,
+                &Response::error(job.id, SERVER_BUSY, "MCP tool queue is full; retry later"),
+            )
+        }
+        Err(mpsc::TrySendError::Disconnected(_)) => {
+            registry.lock().map_err(lock_error)?.finish(&key);
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "MCP tool worker stopped",
+            ))
+        }
+    }
 }
 
 pub(super) fn run_tool_worker<W: Write>(

--- a/src/commands/mcp/worker/tests.rs
+++ b/src/commands/mcp/worker/tests.rs
@@ -45,12 +45,15 @@ fn writer_failure_still_cleans_request_registry() {
         run_tool_worker(receiver, &state, &registry, &writer).expect_err("closed writer must fail");
 
     assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
-    let reused = CancellationToken::new();
     let mut registry = registry.lock().expect("registry");
-    registry.cancel("41");
+    assert!(
+        !registry.cancel("41"),
+        "completed request remained active after writer failure"
+    );
+    let reused = CancellationToken::new();
     registry.register("41".to_string(), reused.clone());
     assert!(
-        reused.is_cancelled(),
-        "completed request remained active after writer failure"
+        !reused.is_cancelled(),
+        "completed request ID should be reusable"
     );
 }

--- a/tests/mcp_cli.rs
+++ b/tests/mcp_cli.rs
@@ -83,6 +83,19 @@ fn initialize_mcp(stdin: &mut ChildStdin, stdout: &mut BufReader<ChildStdout>) {
     );
 }
 
+#[test]
+fn mcp_server_rejects_non_2_jsonrpc_envelopes() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let responses = run_mcp(
+        &[r#"{"jsonrpc":"1.0","id":1,"method":"ping"}"#],
+        temp.path(),
+    );
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0]["id"], Value::Null);
+    assert_eq!(responses[0]["error"]["code"], -32600);
+}
+
 fn setup_removed_export_change(root: &Path) {
     git(root, &["init", "-q"]);
     git(root, &["config", "user.email", "test@example.com"]);
@@ -502,19 +515,13 @@ fn mcp_server_cancels_background_tool_calls() {
 }
 
 #[cfg(unix)]
-#[test]
-fn mcp_cancellation_stops_active_verification() {
-    let temp = tempfile::tempdir().expect("temp dir");
-    git(temp.path(), &["init", "-q"]);
-    git(temp.path(), &["config", "user.email", "test@example.com"]);
-    git(temp.path(), &["config", "user.name", "Test"]);
+fn setup_slow_verification_repo(root: &Path) {
+    git(root, &["init", "-q"]);
+    git(root, &["config", "user.email", "test@example.com"]);
+    git(root, &["config", "user.name", "Test"]);
+    fs::write(root.join("lib.rs"), "pub fn value() -> usize { 1 }\n").expect("source");
     fs::write(
-        temp.path().join("lib.rs"),
-        "pub fn value() -> usize { 1 }\n",
-    )
-    .expect("source");
-    fs::write(
-        temp.path().join("repopilot.toml"),
+        root.join("repopilot.toml"),
         r#"[[verification.checks]]
 id = "slow"
 role = "test"
@@ -524,13 +531,25 @@ timeout_seconds = 2
 "#,
     )
     .expect("config");
-    git(temp.path(), &["add", "."]);
-    git(temp.path(), &["commit", "-qm", "initial"]);
-    fs::write(
-        temp.path().join("lib.rs"),
-        "pub fn value() -> usize { 2 }\n",
-    )
-    .expect("change");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-qm", "initial"]);
+    fs::write(root.join("lib.rs"), "pub fn value() -> usize { 2 }\n").expect("change");
+}
+
+#[cfg(unix)]
+fn slow_verification_guard() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .expect("slow verification test lock")
+}
+
+#[cfg(unix)]
+#[test]
+fn mcp_cancellation_stops_active_verification() {
+    let _guard = slow_verification_guard();
+    let temp = tempfile::tempdir().expect("temp dir");
+    setup_slow_verification_repo(temp.path());
 
     let (mut child, mut stdin, mut stdout) = start_mcp(temp.path());
     initialize_mcp(&mut stdin, &mut stdout);
@@ -574,6 +593,74 @@ timeout_seconds = 2
         cancellation_latency < std::time::Duration::from_secs(1),
         "active cancellation took {cancellation_latency:?}"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn mcp_queue_overload_stays_responsive_during_an_active_tool() {
+    let _guard = slow_verification_guard();
+    let temp = tempfile::tempdir().expect("temp dir");
+    setup_slow_verification_repo(temp.path());
+    let (mut child, mut stdin, mut stdout) = start_mcp(temp.path());
+    initialize_mcp(&mut stdin, &mut stdout);
+    send_mcp(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 40,
+            "method": "tools/call",
+            "params": {
+                "name": "repopilot_review_change",
+                "arguments": { "path": ".", "verify": ["slow"] }
+            }
+        }),
+    );
+    let marker = temp.path().join("verification-started");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !marker.exists() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(marker.exists(), "verification process did not start");
+
+    let overloaded_at = std::time::Instant::now();
+    for id in 100..=108 {
+        send_mcp(
+            &mut stdin,
+            &json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "tools/call",
+                "params": { "name": "repopilot_nope", "arguments": {} }
+            }),
+        );
+    }
+    let overloaded = receive_mcp(&mut stdout);
+    assert_eq!(overloaded["id"], 108);
+    assert_eq!(overloaded["error"]["code"], -32000);
+    assert!(
+        overloaded_at.elapsed() < std::time::Duration::from_secs(1),
+        "overload response was blocked behind active analysis"
+    );
+
+    let cancelled_at = std::time::Instant::now();
+    send_mcp(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/cancelled",
+            "params": { "requestId": 40, "reason": "test overload cancellation" }
+        }),
+    );
+    let cancelled = receive_mcp(&mut stdout);
+    assert_eq!(cancelled["id"], 40);
+    assert_eq!(cancelled["error"]["code"], -32800);
+    assert!(
+        cancelled_at.elapsed() < std::time::Duration::from_secs(1),
+        "cancellation was blocked behind queued work"
+    );
+
+    drop(stdin);
+    assert!(child.wait().expect("MCP server exits").success());
 }
 
 fn git(root: &Path, args: &[&str]) {


### PR DESCRIPTION
## Summary

Hardens the local MCP server against invalid JSON-RPC envelopes, unbounded queued work, duplicate active IDs, and cancellation-state growth.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- Validate JSON-RPC 2.0 envelopes before dispatch and distinguish parse errors from invalid requests.
- Bound the single-worker queue to eight waiting jobs with non-blocking overload responses.
- Preserve null IDs, reject duplicate active IDs, and ignore unknown or completed cancellations without retaining state.
- Add deterministic unit and real-stdio regression coverage plus MCP contract documentation.

## Why

The server previously accepted structurally invalid requests and used an unbounded work queue and cancellation registry. A client could grow retained state or make the stdio reader unresponsive while long analysis was running.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests — N/A, no finding contract changed
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests — N/A
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement — N/A
- [x] No unrelated refactor or generated-file churn is included

## Changelog

- [x] `CHANGELOG.md` updated

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan . --fail-on-priority p1
```

All applicable gates pass. Release-contract checks were not applicable because this PR does not change the release contract or top-level CLI surface.