### PR TITLE
fix: recognize pytest and JUnit test naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,15 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- `testing.source-without-test` stops claiming no test exists when one does. It
+  matched a test only beside the module or inside a `tests/` directory named
+  exactly like it, which misses the two dominant conventions: pytest and Django
+  name the test (`tests/test_workflows.py` covers `workflows.py`), and JUnit
+  names the class (`VetTests.java`, never beside the source). Both are now
+  recognized, and the camel form stays out of non-JVM languages. Across the zoo
+  this removes 229 of 1507 strict findings with no other rule affected and no
+  default-profile change.
+
 - Move the existing conservative TypeScript/JavaScript export and named-import
   facts into the shared analysis core and persist the complete typed payload,
   including exact import spans, in parsed-facts cache schema v4. Older derived

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -165,6 +165,14 @@ Current progress:
   turn third-party imports into repository holes. Re-measurement exposed the
   deeper same-package-reference limitation above; a future JVM symbol/reference
   graph can restore dead-module coverage without relying on missing imports.
+- `testing.source-without-test` was measured next, as the largest remaining
+  rule at 1507 zoo findings. Recognizing the pytest/Django `test_<module>` and
+  JUnit `<Class>Test(s)` conventions removes 229 false claims. The residual is a
+  structural limit rather than a calibration gap: a suite organized by feature
+  names its tests after behaviors, not modules
+  (`admin/tests/pages/test_edit_page.py` covers `edit.py`), and no naming rule
+  can derive that. Whether the rule stays default-hidden, gains a coverage-tool
+  input, or is retired is a lifecycle decision rather than another heuristic.
 
 Deliverables:
 

--- a/src/audits/testing/source_without_test.rs
+++ b/src/audits/testing/source_without_test.rs
@@ -17,9 +17,15 @@ impl ProjectAudit for SourceWithoutTestAudit {
         // Single pass: collect all paths + extract tests/ suffix set simultaneously
         let mut all_paths: HashSet<PathBuf> = HashSet::with_capacity(facts.files.len());
         let mut tests_suffixes: HashSet<String> = HashSet::new();
+        let mut test_stems: HashSet<String> = HashSet::new();
         for f in &facts.files {
             if let Some(suffix) = tests_dir_suffix(&f.path) {
                 tests_suffixes.insert(suffix);
+            }
+            if is_test_file(&f.path)
+                && let Some(stem) = f.path.file_stem().and_then(|stem| stem.to_str())
+            {
+                test_stems.insert(stem.to_string());
             }
             all_paths.insert(f.path.clone());
         }
@@ -31,7 +37,7 @@ impl ProjectAudit for SourceWithoutTestAudit {
             .filter(|file| !is_test_file(&file.path))
             .filter(|file| !is_low_signal_wrapper(&file.path))
             .filter(|file| !file.has_inline_tests)
-            .filter(|file| !has_nearby_test(&file.path, &all_paths, &tests_suffixes))
+            .filter(|file| !has_nearby_test(&file.path, &all_paths, &tests_suffixes, &test_stems))
             .map(|file| build_finding(&file.path))
             .collect()
     }

--- a/src/audits/testing/source_without_test/classification.rs
+++ b/src/audits/testing/source_without_test/classification.rs
@@ -53,6 +53,17 @@ pub(super) fn is_test_file(path: &Path) -> bool {
         || stem.ends_with("_test")
         || stem.ends_with(".test")
         || stem.ends_with(".spec")
+        // pytest and Django name the test, not the module: `test_workflows.py`.
+        || stem.starts_with("test_")
+        // JUnit names the class: `VetTests.java`, `VetControllerTests.java`.
+        || (is_jvm(path) && (stem.ends_with("Test") || stem.ends_with("Tests")))
+}
+
+fn is_jvm(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|value| value.to_str()),
+        Some("java" | "kt")
+    )
 }
 
 pub(super) fn is_low_signal_wrapper(path: &Path) -> bool {

--- a/src/audits/testing/source_without_test/matching.rs
+++ b/src/audits/testing/source_without_test/matching.rs
@@ -18,6 +18,7 @@ pub(super) fn has_nearby_test(
     source: &Path,
     all_paths: &HashSet<PathBuf>,
     tests_suffixes: &HashSet<String>,
+    test_stems: &HashSet<String>,
 ) -> bool {
     let stem = source
         .file_stem()
@@ -37,7 +38,35 @@ pub(super) fn has_nearby_test(
 
     has_sibling_test(parent, stem, ext, all_paths)
         || has_tests_directory_match(stem, ext, tests_suffixes)
+        || has_named_test(stem, ext, test_stems)
         || has_rust_integration_test(source, ext, tests_suffixes)
+}
+
+/// A test file named after this module, wherever the suite keeps it.
+///
+/// Path-shaped matching only finds a test that sits beside the module or in a
+/// `tests/` directory named exactly like it. Two dominant conventions do
+/// neither: pytest and Django name the *test* (`tests/test_workflows.py` for
+/// `workflows.py`, in any app's test package), and JUnit names the *class*
+/// (`VetTests.java` under `src/test/java/<package>/`, never beside the source).
+/// Claiming "no test found" for those is simply false.
+///
+/// Matching on the name alone rather than the location is deliberate: the
+/// rule's claim is that no test exists, and a file named for this module is a
+/// test that exists. Locality would be a refinement of a claim this rule does
+/// not make.
+fn has_named_test(stem: &str, ext: &str, test_stems: &HashSet<String>) -> bool {
+    if stem.is_empty() {
+        return false;
+    }
+    let mut candidates = vec![format!("test_{stem}")];
+    if matches!(ext, "java" | "kt") {
+        candidates.push(format!("{stem}Test"));
+        candidates.push(format!("{stem}Tests"));
+    }
+    candidates
+        .iter()
+        .any(|candidate| test_stems.contains(candidate))
 }
 
 fn has_sibling_test(parent: &Path, stem: &str, ext: &str, all_paths: &HashSet<PathBuf>) -> bool {
@@ -138,4 +167,59 @@ fn rust_module_parts(source: &Path) -> Vec<String> {
             (!matches!(value, "mod" | "lib" | "main")).then(|| value.to_string())
         })
         .collect()
+}
+
+#[cfg(test)]
+mod named_test_tests {
+    use super::has_named_test;
+    use std::collections::HashSet;
+
+    fn stems(values: &[&str]) -> HashSet<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn pytest_and_django_name_the_test_not_the_module() {
+        // `wagtail/admin/tests/test_workflows.py` covers `wagtail/workflows.py`;
+        // claiming no test exists for it is simply false.
+        assert!(has_named_test(
+            "workflows",
+            "py",
+            &stems(&["test_workflows"])
+        ));
+        assert!(!has_named_test("workflows", "py", &stems(&["test_pages"])));
+    }
+
+    #[test]
+    fn junit_names_the_class_and_never_sits_beside_the_source() {
+        // Spring PetClinic keeps `VetTests.java` under `src/test/java/...`.
+        assert!(has_named_test("Vet", "java", &stems(&["VetTests"])));
+        assert!(has_named_test(
+            "VetController",
+            "java",
+            &stems(&["VetControllerTest"])
+        ));
+        assert!(!has_named_test("Vets", "java", &stems(&["VetTests"])));
+    }
+
+    #[test]
+    fn the_camel_form_stays_out_of_non_jvm_languages() {
+        // `WorkflowsTest.py` is not a Python convention, so matching it would
+        // invent coverage.
+        assert!(!has_named_test(
+            "Workflows",
+            "py",
+            &stems(&["WorkflowsTest"])
+        ));
+        assert!(!has_named_test(
+            "workflows",
+            "ts",
+            &stems(&["workflowsTests"])
+        ));
+    }
+
+    #[test]
+    fn an_empty_stem_matches_nothing() {
+        assert!(!has_named_test("", "py", &stems(&["test_"])));
+    }
 }

--- a/tests/zoo/snapshots/fastapi.json
+++ b/tests/zoo/snapshots/fastapi.json
@@ -29,8 +29,8 @@
       "code-quality.long-function": 90,
       "language.python.exception-risk": 103,
       "security.secret-candidate": 2,
-      "testing.source-without-test": 36
+      "testing.source-without-test": 33
     },
-    "visible_total": 317
+    "visible_total": 314
   }
 }

--- a/tests/zoo/snapshots/nowinandroid.json
+++ b/tests/zoo/snapshots/nowinandroid.json
@@ -23,8 +23,8 @@
       "code-quality.complex-function": 2,
       "code-quality.long-function": 32,
       "language.managed.fatal-exception-risk": 6,
-      "testing.source-without-test": 232
+      "testing.source-without-test": 197
     },
-    "visible_total": 555
+    "visible_total": 520
   }
 }

--- a/tests/zoo/snapshots/spring-petclinic.json
+++ b/tests/zoo/snapshots/spring-petclinic.json
@@ -13,8 +13,8 @@
     "by_rule": {
       "architecture.deep-directory-nesting": 44,
       "language.managed.fatal-exception-risk": 1,
-      "testing.source-without-test": 30
+      "testing.source-without-test": 22
     },
-    "visible_total": 75
+    "visible_total": 67
   }
 }

--- a/tests/zoo/snapshots/wagtail.json
+++ b/tests/zoo/snapshots/wagtail.json
@@ -41,8 +41,8 @@
       "framework.react.class-component": 4,
       "framework.react.prop-types": 12,
       "language.python.exception-risk": 45,
-      "testing.source-without-test": 668
+      "testing.source-without-test": 485
     },
-    "visible_total": 2431
+    "visible_total": 2248
   }
 }


### PR DESCRIPTION
## Summary

`testing.source-without-test` is the largest rule in the zoo at 1507 findings reported "No test found" for files whose tests exist. It matched only tests beside the module or in an identically-named `tests/` file, missing the pytest
and JUnit conventions. Recognizing them removes 229 false claims.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- `has_named_test`: a test named after the module counts wherever the suite keeps it  `test_<module>` for pytest/Django, `<Class>Test` and `<Class>Tests` for JUnit.
- The audit's own `is_test_file` gained the same two forms; it missed them symmetrically, so those test files were themselves reported as untested sources.
- The camel form is scoped to `.java`/`.kt` — `WorkflowsTest.py` is not a Python convention and matching it would invent coverage.
- 4 unit tests, including the guard that the camel form stays out of non-JVM languages.

## Why

Sampling the rule showed the evidence line was literally wrong:

```
wagtail/workflows.py   "No test found; expected e.g. workflows_test.py"
```

while `wagtail/admin/tests/test_workflows.py` sits in the repository. Same for Spring PetClinic, where `VetTests.java` lives under `src/test/java/.../vet/` and can never sit beside `Vet.java`.

The sample was a genuine mix, which is worth saying: `excalidraw/Avatar.tsx` has no test anywhere, and `petclinic/Vets.java` has `VetTests.java` but no `VetsTests.java` — both correct findings, left alone.

## Measurement

```
repo                before  after
wagtail                668    485
nowinandroid           232    197
spring-petclinic        30     22
fastapi                 36     33
(others)          unchanged
                    ------  -----
TOTAL                 1507   1278
```

No other rule moved in any repository; no default profile changed.

## A gate I built and threw away

The obvious next step was a per-repository gate: only run the rule where the per-module naming convention is actually in use. I implemented it, measured it, and dropped it - it silenced ignite and express while leaving wagtail, the case that motivated it. Two attempts at the discriminator failed for different reasons:

- comparing covered against uncovered modules is circular, since low coverage is the thing the rule reports;
- comparing how many test files link back to a module name gated the wrong repositories.

So the residual 1278 is a structural limit rather than a calibration gap. A suite organized by feature names its tests after behaviors, not modules (`admin/tests/pages/test_edit_page.py` covers `edit.py`), and no naming rule can
derive that. Whether this rule stays default-hidden, gains a coverage-tool input or is retired is a lifecycle decision recorded in the roadmap rather than papered over with a third heuristic.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
cargo run -- scan . --fail-on-priority p1
```
