### PR TITLE
fix: only report directory depth someone chose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,17 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- `architecture.deep-directory-nesting` only judges depth someone chose. It
+  reported every file whose path exceeded the threshold, including compiled
+  gettext catalogs under `locale/<lang>/LC_MESSAGES/`, vendored minified
+  stylesheets, Django templates, and every JVM source — Java, Kotlin, and Scala
+  require the directory path to mirror the declared package, so
+  `com/google/samples/apps/nowinandroid/core/` is a package name rendered as
+  folders rather than nesting anyone picked. The rule now applies to source
+  files whose layout is a decision, taking the zoo from 1336 to 32 strict
+  findings with no other rule affected and no default-profile change. A nested
+  component tree such as `client/src/components/CommentApp/components/Comment/`
+  is still reported.
 - `testing.source-without-test` stops claiming no test exists when one does. It
   matched a test only beside the module or inside a `tests/` directory named
   exactly like it, which misses the two dominant conventions: pytest and Django

--- a/docs/roadmap/v0.22.md
+++ b/docs/roadmap/v0.22.md
@@ -165,6 +165,12 @@ Current progress:
   turn third-party imports into repository holes. Re-measurement exposed the
   deeper same-package-reference limitation above; a future JVM symbol/reference
   graph can restore dead-module coverage without relying on missing imports.
+- `architecture.deep-directory-nesting` followed, at 1336 zoo findings. Almost
+  all of them were depth nobody chose: tool-placed files (gettext catalogs,
+  vendored stylesheets, templates) and JVM sources, whose directory path is the
+  declared package. Restricting the rule to source files whose layout is a
+  decision leaves 32 — nested component trees and ASP.NET Areas scaffolding,
+  which is what the rule is for.
 - `testing.source-without-test` was measured next, as the largest remaining
   rule at 1507 zoo findings. Recognizing the pytest/Django `test_<module>` and
   JUnit `<Class>Test(s)` conventions removes 229 false claims. The residual is a

--- a/src/audits/architecture/deep_directory_nesting.rs
+++ b/src/audits/architecture/deep_directory_nesting.rs
@@ -15,7 +15,8 @@ impl ProjectAudit for DeepDirectoryNestingAudit {
             .iter()
             .filter_map(|file| {
                 let context = classifier.classify(file);
-                if context.file_role == FileRole::Production {
+                if context.file_role == FileRole::Production && depth_is_a_layout_choice(&file.path)
+                {
                     // Measure nesting relative to the scan root so the depth is
                     // about the repository's own layout, not how deep the repo
                     // happens to sit on disk (an absolute scan path would
@@ -40,6 +41,29 @@ impl ProjectAudit for DeepDirectoryNestingAudit {
             })
             .collect()
     }
+}
+
+/// Whether this file's depth reflects a decision someone made about layout.
+///
+/// The rule's claim is that a tree is hard to navigate, which only holds where
+/// the tree could have been shallower. Two large classes of file fail that:
+///
+/// * **Non-source files.** A compiled gettext catalog under
+///   `locale/<lang>/LC_MESSAGES/`, a vendored minified stylesheet, a Django
+///   template — their location is fixed by the tool that reads them, and nobody
+///   navigates them by directory anyway.
+/// * **JVM sources.** Java, Kotlin, and Scala require the directory path to
+///   mirror the declared package, so `com/google/samples/apps/nowinandroid/core/`
+///   is a package name rendered as folders, not nesting anyone chose. Reporting
+///   it flags every file in the repository.
+fn depth_is_a_layout_choice(path: &Path) -> bool {
+    const SOURCE_EXTENSIONS: &[&str] = &[
+        "rs", "ts", "tsx", "js", "jsx", "mjs", "cjs", "py", "go", "rb", "php", "cs", "swift", "c",
+        "cpp", "h", "hpp",
+    ];
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| SOURCE_EXTENSIONS.contains(&extension))
 }
 
 fn compute_directory_nesting(path: &Path) -> usize {
@@ -200,6 +224,54 @@ mod tests {
             has_inline_tests: false,
             in_executable_package: false,
             deferred_imports: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod layout_choice_tests {
+    use super::depth_is_a_layout_choice;
+    use std::path::Path;
+
+    #[test]
+    fn files_a_tool_places_are_not_a_layout_choice() {
+        // A gettext catalog's path is fixed by gettext, a vendored stylesheet's
+        // by its bundle, a Django template's by the loader. Nobody navigates
+        // these by directory, and nobody chose their depth.
+        for path in [
+            "wagtail/contrib/forms/locale/zh_Hans/LC_MESSAGES/django.mo",
+            "wagtail/contrib/simple_translation/locale/be/LC_MESSAGES/django.po",
+            "src/BlazorAdmin/wwwroot/css/open-iconic/font/css/open-iconic-bootstrap.min.css",
+            "wagtail/admin/templates/wagtailadmin/pages/action_menu/page_locked.html",
+        ] {
+            assert!(!depth_is_a_layout_choice(Path::new(path)), "{path}");
+        }
+    }
+
+    #[test]
+    fn jvm_package_directories_are_a_package_name_not_nesting() {
+        // Java, Kotlin, and Scala require the path to mirror the declared
+        // package, so every file in the repository would be reported.
+        for path in [
+            "core/testing/src/main/kotlin/com/google/samples/apps/nowinandroid/core/testing/data/Fixtures.kt",
+            "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+        ] {
+            assert!(!depth_is_a_layout_choice(Path::new(path)), "{path}");
+        }
+    }
+
+    #[test]
+    fn ordinary_sources_remain_judged() {
+        // The false-negative guard: a genuinely nested component tree is what
+        // this rule is for.
+        for path in [
+            "client/src/components/CommentApp/components/Comment/index.tsx",
+            "src/Web/Areas/Identity/Pages/Account/Login.cshtml.cs",
+            "wagtail/admin/views/pages/edit.py",
+            "internal/server/handler.go",
+            "src/graph/resolver/jvm.rs",
+        ] {
+            assert!(depth_is_a_layout_choice(Path::new(path)), "{path}");
         }
     }
 }

--- a/tests/zoo/snapshots/eshoponweb.json
+++ b/tests/zoo/snapshots/eshoponweb.json
@@ -25,7 +25,7 @@
   "strict": {
     "by_rule": {
       "architecture.dead-module": 2,
-      "architecture.deep-directory-nesting": 30,
+      "architecture.deep-directory-nesting": 5,
       "architecture.large-file": 1,
       "code-marker.todo": 9,
       "code-quality.complex-file": 3,
@@ -33,6 +33,6 @@
       "security.secret-candidate": 7,
       "testing.source-without-test": 2
     },
-    "visible_total": 62
+    "visible_total": 37
   }
 }

--- a/tests/zoo/snapshots/nowinandroid.json
+++ b/tests/zoo/snapshots/nowinandroid.json
@@ -17,7 +17,6 @@
   "sha": "7d45eae4f8720a0c77f507712ba2437ff974b6ed",
   "strict": {
     "by_rule": {
-      "architecture.deep-directory-nesting": 244,
       "architecture.large-file": 9,
       "code-marker.todo": 30,
       "code-quality.complex-function": 2,
@@ -25,6 +24,6 @@
       "language.managed.fatal-exception-risk": 6,
       "testing.source-without-test": 197
     },
-    "visible_total": 520
+    "visible_total": 276
   }
 }

--- a/tests/zoo/snapshots/spring-petclinic.json
+++ b/tests/zoo/snapshots/spring-petclinic.json
@@ -11,10 +11,9 @@
   "sha": "a2c2ef994340d3970eb6db51247456a51bb161f8",
   "strict": {
     "by_rule": {
-      "architecture.deep-directory-nesting": 44,
       "language.managed.fatal-exception-risk": 1,
       "testing.source-without-test": 22
     },
-    "visible_total": 67
+    "visible_total": 23
   }
 }

--- a/tests/zoo/snapshots/wagtail.json
+++ b/tests/zoo/snapshots/wagtail.json
@@ -23,7 +23,7 @@
     "by_rule": {
       "architecture.circular-dependency": 11,
       "architecture.dead-module": 48,
-      "architecture.deep-directory-nesting": 1018,
+      "architecture.deep-directory-nesting": 27,
       "architecture.deep-relative-imports": 33,
       "architecture.excessive-fan-out": 17,
       "architecture.large-file": 85,
@@ -43,6 +43,6 @@
       "language.python.exception-risk": 45,
       "testing.source-without-test": 485
     },
-    "visible_total": 2248
+    "visible_total": 1257
   }
 }


### PR DESCRIPTION
## Summary

`architecture.deep-directory-nesting` — the largest rule in the zoo at 1336
findings — reported depth that nobody chose: gettext catalogs, vendored
stylesheets, Django templates, and every JVM source, whose directory path *is*
the declared package. Restricting it to files whose layout is a decision leaves
**32**.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- `depth_is_a_layout_choice` gates the rule to source files.
- 3 unit tests: the tool-placed class, the JVM class, and a false-negative guard
  keeping ordinary sources judged.

## Why

The first sampled draw made the problem obvious — four of eight findings were
`.mo`/`.po` translation catalogs, one was a vendored `.min.css`, one a Django
template, and one a Kotlin file at depth 13:

```
wagtail/contrib/forms/locale/zh_Hans/LC_MESSAGES/django.mo          depth 6
src/BlazorAdmin/wwwroot/css/open-iconic/font/css/…bootstrap.min.css depth 7
core/testing/src/main/kotlin/com/google/samples/apps/…/Fixtures.kt  depth 13
```

Two different reasons, one conclusion:

- **A tool placed the file.** gettext requires `locale/<lang>/LC_MESSAGES/`, the
  bundle decided the stylesheet's path, the template loader the template's. The
  depth is not a design decision, and nobody navigates these by directory.
- **The language requires the path.** Java, Kotlin, and Scala compile only when
  the directory mirrors the declared package, so
  `com/google/samples/apps/nowinandroid/core/` is a package name rendered as
  folders. Reporting it flags every file in the repository — which is exactly
  what happened to Now in Android and Spring PetClinic.

The rule's claim is that a tree is hard to navigate. That only holds where the
tree could have been shallower.

## Measurement

```
repo                before  after
wagtail               1018     27
nowinandroid           244      0
spring-petclinic        44      0
eshoponweb              30      5
                    ------  -----
TOTAL                 1336     32
```

No other rule's count moved and no default profile changed.

## What survives, and why that is right

```
client/src/components/CommentApp/components/Comment/index.tsx
src/Web/Areas/Identity/Pages/Account/Login.cshtml.cs
```

A nested component tree and ASP.NET Areas scaffolding — both layouts someone
picked and could flatten. That is the rule working.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

Subsystem: `src/audits/architecture/deep_directory_nesting.rs`. No rule id,
severity, or schema change; the rule is strict-only and experimental.

## Changelog

- [x] `CHANGELOG.md` updated (skip for CI-only or doc changes with no user-visible effect)

Also updated: `docs/roadmap/v0.22.md` Phase C progress.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
cargo run -- scan . --fail-on-priority p1
```

All green: 104 test binaries, 0 failures; release contract passes with the zoo
cloned locally.
