### PR TITLE
fix: derive review SARIF taint severity from the canonical tier

### DIFF
--- a/src/review/render/sarif.rs
+++ b/src/review/render/sarif.rs
@@ -2,7 +2,7 @@ use crate::findings::provenance::FindingProvenance;
 use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use crate::output::sarif::findings_to_sarif;
 use crate::review::model::ReviewReport;
-use crate::review::signals::tiered::SignalFamily;
+use crate::review::signals::tiered::{ConfidenceTier, SignalFamily};
 use std::path::PathBuf;
 
 pub fn render_review_sarif(report: &ReviewReport) -> Result<String, serde_json::Error> {
@@ -34,11 +34,13 @@ pub fn render_review_sarif(report: &ReviewReport) -> Result<String, serde_json::
                 "Validate the input boundary and use a safe, parameterized or allowlisted sink API."
                     .to_string(),
             category: FindingCategory::Security,
-            severity: if signal.kind == "taint.sql" || signal.kind == "taint.exec" {
-                Severity::High
-            } else {
-                Severity::Medium
-            },
+            // Read off `signal.tier`, the canonical field `taint_tier(SinkKind)`
+            // already set when the signal was built — not re-derived from
+            // `signal.kind`. A second string match here (`"taint.sql" | "taint.exec"
+            // => High`) let this silently default a new SinkKind variant to Medium
+            // even if `taint_tier` tiered it DefinitelySensitive, since nothing
+            // forced the two matches to agree.
+            severity: severity_for_tier(signal.tier),
             confidence: signal.confidence,
             evidence: vec![Evidence {
                 path: PathBuf::from(&signal.path),
@@ -64,3 +66,18 @@ pub fn render_review_sarif(report: &ReviewReport) -> Result<String, serde_json::
 
     serde_json::to_string_pretty(&findings_to_sarif(&findings, &report.repo_root))
 }
+
+/// Exhaustive so a new `ConfidenceTier` variant fails to compile here instead
+/// of silently landing on a default.
+fn severity_for_tier(tier: ConfidenceTier) -> Severity {
+    match tier {
+        ConfidenceTier::DefinitelySensitive => Severity::High,
+        ConfidenceTier::MaybeSensitive => Severity::Medium,
+        // Taint signals are only ever bucketed into definitely/maybe; this arm
+        // exists so the match stays exhaustive if that ever changes.
+        ConfidenceTier::LargeDiffOrNoise => Severity::Low,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/review/render/sarif/tests.rs
+++ b/src/review/render/sarif/tests.rs
@@ -1,0 +1,96 @@
+use super::{render_review_sarif, severity_for_tier};
+use crate::findings::provenance::AnalysisScope;
+use crate::findings::types::{Confidence, Severity};
+use crate::review::model::ReviewReport;
+use crate::review::signals::tiered::{
+    ConfidenceTier, ReviewSignal, ReviewSignalProvenance, SignalFamily, TieredSignals,
+};
+use crate::rules::{RuleLifecycle, SignalSource};
+use crate::scan::types::ScanSummary;
+use std::path::Path;
+
+fn taint_signal(kind: &str, tier: ConfidenceTier) -> ReviewSignal {
+    ReviewSignal {
+        signal_id: format!("{kind}:src/app.py:1"),
+        kind: kind.to_string(),
+        family: SignalFamily::Taint,
+        tier,
+        confidence: Confidence::High,
+        path: "src/app.py".to_string(),
+        target_path: None,
+        line: Some(1),
+        line_start: Some(1),
+        line_end: Some(1),
+        evidence_lines: Vec::new(),
+        headline: "untrusted input reaches a sink".to_string(),
+        detail: None,
+        blast_radius: 0,
+        provenance: ReviewSignalProvenance {
+            detector: "taint".to_string(),
+            lifecycle: RuleLifecycle::Stable,
+            signal_source: SignalSource::Ast,
+            analysis_scope: AnalysisScope::GitDiff,
+        },
+        suppressed: false,
+        suppression_reason: None,
+        gate_eligible: true,
+        verification_plan: None,
+    }
+}
+
+fn report_with_signal(signal: ReviewSignal) -> ReviewReport {
+    let mut tiered_signals = TieredSignals::default();
+    match signal.tier {
+        ConfidenceTier::DefinitelySensitive => tiered_signals.definitely.push(signal),
+        ConfidenceTier::MaybeSensitive => tiered_signals.maybe.push(signal),
+        ConfidenceTier::LargeDiffOrNoise => tiered_signals.noise.push(signal),
+    }
+    ReviewReport {
+        summary: ScanSummary::default(),
+        repo_root: Path::new("/repo").to_path_buf(),
+        baseline_path: None,
+        changed_files: Vec::new(),
+        blast_radius: Vec::new(),
+        impact_paths: Default::default(),
+        ownership: Default::default(),
+        ownership_diagnostics: Vec::new(),
+        boundary_signals: Vec::new(),
+        boundary_missing_test: false,
+        tiered_signals,
+        timings: Default::default(),
+        verification: Vec::new(),
+        findings: Vec::new(),
+    }
+}
+
+#[test]
+fn severity_is_read_from_the_tier_not_the_kind_string() {
+    // The regression this pins: an unrecognized `kind` string used to fall
+    // through to Medium regardless of its actual tier. A signal whose kind is
+    // neither "taint.sql" nor "taint.exec" but is still tiered
+    // DefinitelySensitive must render as High, proving severity now tracks
+    // `SinkKind`'s canonical tier rather than a second, separately maintained
+    // string match.
+    assert_eq!(
+        severity_for_tier(ConfidenceTier::DefinitelySensitive),
+        Severity::High
+    );
+    assert_eq!(
+        severity_for_tier(ConfidenceTier::MaybeSensitive),
+        Severity::Medium
+    );
+
+    let report = report_with_signal(taint_signal(
+        "taint.deserialize",
+        ConfidenceTier::DefinitelySensitive,
+    ));
+    let rendered = render_review_sarif(&report).expect("sarif renders");
+    let value: serde_json::Value = serde_json::from_str(&rendered).expect("valid json");
+    let level = value["runs"][0]["results"][0]["level"]
+        .as_str()
+        .expect("result level");
+    assert_eq!(
+        level, "error",
+        "DefinitelySensitive must map to SARIF error (High)"
+    );
+}


### PR DESCRIPTION
## Summary

Found while auditing v0.22 Phase E's "all public projections read shared canonical evidence" requirement across CLI console/JSON/Markdown/HTML/SARIF, MCP, and the Action. Five of six surfaces checked out clean (evidence below). This is the one that didn't: review's SARIF renderer computed taint severity with its own string match instead of reading the signal's already-assigned tier.

## Type of change

- [ ] Feature
- [ ] Refactor
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI / repository maintenance

## What changed

- `render_review_sarif` now reads `signal.tier` (set once, canonically, by `taint_tier(SinkKind)` in `tiered.rs` when the signal is built) instead of re-deriving severity from `signal.kind == "taint.sql" || "taint.exec"`.
- New `severity_for_tier(ConfidenceTier) -> Severity`, an exhaustive match — a new `ConfidenceTier` variant fails to compile here rather than silently defaulting.
- Regression test: a signal tiered `DefinitelySensitive` under a kind string that is neither `"taint.sql"` nor `"taint.exec"` still renders as SARIF `"error"`.

## Why

`taint_tier(SinkKind)` in `tiered.rs` is a compiler-exhaustive match — adding a `SinkKind` variant forces you to tier it. `render_review_sarif` had a second, physically separate match keyed on the *string* `signal.kind` rather than the enum, with no such enforcement. Nothing kept the two in sync: a new sink kind (e.g. an eventual deserialization sink) tiered `DefinitelySensitive` by `taint_tier` would silently fall into the SARIF renderer's `else => Medium` arm, since its kind string wouldn't be one of the two hardcoded literals.

`ReviewSignal` already carries the `tier` field `taint_tier` produced — the fix is to read it instead of reconstructing it.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] New or changed findings/signals include deterministic evidence and tests
- [x] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [x] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
cargo run -- scan . --fail-on-priority p1
```
