### PR TITLE
docs: document v0.22 broken-code checks, verification, and repository health

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ adoption or CI policy.
 
 - [Installation](install.md)
 - [Guard your agent runs](agent-guardrail.md)
+- [Track repository health over time](repository-health.md)
 - [Common workflows](commands.md)
 - [CLI reference](cli.md)
 - [Configuration and local feedback](configuration.md)

--- a/docs/agent-guardrail.md
+++ b/docs/agent-guardrail.md
@@ -126,12 +126,56 @@ debt, `repopilot baseline create .` pins the current state so only new
 findings count. See
 [GitHub pull request integration](integrations/github-code-scanning.md).
 
+## Catch broken imports and exports, not just risky patterns
+
+Two review-first checks look for provably broken code rather than risky
+patterns, so an agent's own edits get caught before a human does:
+
+- **`architecture.unresolved-local-import`** — an explicit local TypeScript/
+  JavaScript or Python relative import whose complete candidate set is absent.
+  Ambiguous forms (aliases, extensionless imports, workspace packages) stay
+  bounded diagnostics, never a false broken-code claim.
+- **`behavioral.removed-export-still-imported`** — a named export an agent
+  deleted or renamed while a local caller still imports the old name. Fires
+  only when the resolver proves the caller targets the changed module; a
+  coordinated rename across both sides produces no signal.
+
+Neither runs a compiler; both are AST-plus-resolver proofs, so they hold even
+when nothing else in the diff looks risky — exactly the failure mode an agent
+introduces by editing one side of an import and forgetting the other.
+
+## Let RepoPilot run your own checks
+
+`--verify <ID>` executes one repository-declared check (test, build,
+type-check, or lint) and folds a timeout, non-zero exit, or spawn error into
+the review record as evidence — never as a silent pass. Off by default;
+RepoPilot never runs anything you have not explicitly allowlisted:
+
+```toml
+# repopilot.toml
+[[verification.checks]]
+id = "typecheck"
+role = "type-check"
+program = "npm"
+args = ["run", "typecheck"]
+timeout_seconds = 120
+```
+
+```bash
+repopilot review --since-snapshot --verify typecheck
+```
+
+Static findings are never suppressed by a passing check — verification adds
+evidence, it does not gate what static analysis already proved. Full contract,
+including opt-in result caching: [Configuration](configuration.md#explicit-local-verification).
+
 ## What the review actually checks
 
 Security boundaries (access control, request trust, deploy surface, supply
 chain, secrets), behavioral changes (network, subprocess, filesystem, SQL,
 removed error handling or auth checks), algorithmic shifts, taint-lite flows
 (changed request/process input reaching SQL, exec, filesystem-write, or
-network sinks), and blast radius through the import graph. Signals are
-structural evidence with file:line provenance — flags to verify, not
-verdicts. Details: [Reports and schemas](reports.md).
+network sinks), broken local imports/exports (above), and blast radius
+through the import graph. Signals are structural evidence with file:line
+provenance — flags to verify, not verdicts. Details:
+[Reports and schemas](reports.md).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,7 +84,10 @@ repopilot review . --record-history
 Receipts live under `.repopilot/history/` and are never uploaded. RepoPilot
 compares only runs with the same target, scope, revisions, profile, filters,
 configuration, overlay, and report schema; it never treats an incompatible
-changed-only run as proof that full-scan findings were resolved.
+changed-only run as proof that full-scan findings were resolved. For the full
+workflow — reading the delta, pairing it with baseline resolved-tracking, and
+wiring a periodic health scan — see
+[Track repository health over time](repository-health.md).
 
 ## Review An Agent Run
 

--- a/docs/repository-health.md
+++ b/docs/repository-health.md
@@ -1,0 +1,126 @@
+# Track Repository Health Over Time
+
+Change review answers "is this diff safe to merge." This page is for the other
+question: is the repository, as a whole, getting better or worse across
+releases — and which findings from last quarter are still open. Everything
+here is local; nothing is uploaded.
+
+## Turn on local history
+
+History is opt-in and disabled by default:
+
+```toml
+# repopilot.toml
+[history]
+enabled = true
+max_runs = 50
+max_bytes = 5242880
+```
+
+Or record one run without changing config:
+
+```bash
+repopilot scan . --record-history
+```
+
+Each run appends a bounded receipt to `.repopilot/history/runs.jsonl` — never
+uploaded, ignored by Git and by analysis fingerprints. The same opt-in works
+for `review . --record-history`.
+
+## Read the compatible delta
+
+From the second recorded run on, `--format json` carries a `risk_delta`
+comparing this run against the most recent *compatible* one — same target,
+scope, revisions, profile, filters, config, overlay, and report schema.
+RepoPilot never treats an incompatible run (a changed-only scan compared
+against a full scan, say) as proof that anything was resolved:
+
+```bash
+repopilot scan . --record-history --format json | jq '.risk_delta'
+```
+
+```json
+{
+  "comparison": { "prior_revision": "…", "current_revision": "…" },
+  "new_findings": [],
+  "persisting_findings": [
+    { "rule_id": "security.secret-candidate", "path": "src/app.py", "severity": "HIGH" }
+  ],
+  "resolved_findings": [],
+  "severity_shifts": []
+}
+```
+
+`new_findings` is what landed since the last compatible run; `resolved_findings`
+is what disappeared; `severity_shifts` is a finding whose severity changed
+without disappearing. `persisting_findings` is everything unchanged — the
+number to watch trend downward. Console and Markdown output do not render this
+yet; read it from JSON or the `repopilot_scan`/`repopilot_review_change` MCP
+tools.
+
+## Track accepted debt separately from new risk
+
+History answers "what changed since last time." A baseline answers "what did
+we already know about and accept":
+
+```bash
+repopilot baseline create . --profile strict --min-severity high
+```
+
+Scope `--profile`/`--min-severity`/`--min-priority` to match how you'll scan
+later — a finding one side's filter hides and the other's does not reads as
+spuriously new or resolved, not as unchanged. Later runs classify every
+finding against that snapshot:
+
+```bash
+repopilot scan . --baseline .repopilot/baseline.json
+```
+
+```
+New findings: 0
+Existing findings: 12
+Resolved findings: 3
+```
+
+`resolved` — the same idea as history's `resolved_findings`, but against a
+snapshot you deliberately accepted rather than the last run — is what proves
+debt actually got paid down, not just displaced. In JSON, resolved findings
+carry only what the baseline snapshot itself stored (`key`, `rule_id`,
+`severity`, `path`, `message`), not a full finding — the source location that
+produced one may no longer exist to re-derive it from. Refresh the baseline
+only when the team explicitly re-accepts the current state, never as a way to
+silence CI: `repopilot baseline create . --force`.
+
+## Wire it into CI as a trend, not a gate
+
+A per-PR gate belongs to [change review](agent-guardrail.md), not here. For a
+periodic health signal, schedule a workflow that scans `main` and commits (or
+uploads as an artifact) the JSON report:
+
+```yaml
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # weekly
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: MykytaStel/repopilot@v0.21.0
+        with:
+          command: scan
+          format: json
+```
+
+Diff successive artifacts, or record history in the same job and read
+`risk_delta`, to see whether the repository trended toward or away from health
+since the last run.
+
+## Know how much to trust a given rule
+
+Not every rule carries the same evidence. The generated
+[rule scorecard](engineering/rule-scorecard.md) reports, per rule, whether it
+has been measured against real repositories at all, and if so, its precision
+estimate and outstanding false-positive debt. A rule with `no zoo evidence` is
+unmeasured, which is not the same as clean — weight its findings accordingly
+until it earns evidence.


### PR DESCRIPTION
## Summary

Two Phase E doc gaps. `agent-guardrail.md` never mentioned any of v0.22's own
review surface — broken-code checks, `--verify`. And Phase E's own deliverable
list asks for "maintainer workflow documentation for repository health and
historical deltas," which nothing existing covered — `commands.md` and
`configuration.md` document the flags, not the workflow.

## Type of change

- [ ] Feature
- [ ] Refactor
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

**`docs/agent-guardrail.md`**: two new sections.
- Broken-code checks (`architecture.unresolved-local-import`,
  `behavioral.removed-export-still-imported`) — described as what they
  actually are: AST-plus-resolver proofs, not compiler runs, that catch
  exactly the failure mode an agent introduces (editing one side of an import,
  forgetting the other).
- `--verify` — the config shape, the CLI flag, and what it does and does not
  do (adds evidence, never suppresses a static finding).

**New `docs/repository-health.md`**, in the same worked-example style as
`agent-guardrail.md`: turning on `--record-history`, reading `risk_delta`
(`new`/`persisting`/`resolved`/`severity_shifts`), how that differs from
baseline resolved-tracking (`#392`) and when to reach for which, a periodic-
scan CI snippet, and a pointer to the rule scorecard for calibrating trust per
rule. Linked from `docs/README.md` and cross-linked from `commands.md`'s
existing history section.

## Why

Both gaps came from actually using the product to survey what Phase E still
needed, not from a doc audit — `agent-guardrail.md`'s "what the review checks"
list was simply out of date the moment B1/B2/D1 shipped, and repository health
had reference docs but no workflow doc, unlike the developer/agent side.

## Verified, not assumed

- `architecture.unresolved-local-import` really does surface as an in-diff
  review finding when the changed line introduces it (built a two-commit repo,
  ran `review . --format json`, confirmed `in_diff: true`).
- The `--verify` example in the doc runs against the real binary and reports
  `PASSED`.
- The `risk_delta` JSON shape, and the exact "New findings: N / Existing
  findings: N / Resolved findings: N" console wording, are both copied from
  real recorded scans, not written from memory.
- The GitHub Action snippet's org/repo, input keys, and version-pin style match
  `action.yml` and the existing `github-code-scanning.md` convention.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [ ] New or changed findings/signals include deterministic evidence and tests
- [ ] False-positive/noise-reduction changes preserve strict-mode recall and include false-negative guard tests
- [ ] Any claimed noise reduction is backed by a fixture, focused regression, or zoo measurement
- [x] No unrelated refactor or generated-file churn is included

## Verification

```bash
cargo fmt --all -- --check
cargo test --all
cargo run -- scan . --fail-on-priority p1
```
