### PR TITLE
docs: label zoo evidence for excessive-fan-out and env-file-committed

### DIFF
--- a/docs/engineering/rule-scorecard.md
+++ b/docs/engineering/rule-scorecard.md
@@ -73,6 +73,8 @@ Rules that fire only in the strict profile are too numerous to label exhaustivel
 | Rule | Lifecycle | Sampled | Precision Estimate | False-Positive Debt |
 |---|---|---|---:|---:|
 | `architecture.dead-module` | experimental | 3 sampled across 2 repo(s) | 0.00 | 3 |
+| `architecture.excessive-fan-out` | stable | 1 sampled across 1 repo(s) | 1.00 | 0 |
 | `architecture.large-file` | experimental | 3 sampled across 3 repo(s) | 1.00 | 0 |
 | `code-quality.complex-function` | preview | 3 sampled across 3 repo(s) | 1.00 | 0 |
 | `code-quality.long-function` | preview | 3 sampled across 3 repo(s) | 1.00 | 0 |
+| `security.env-file-committed` | stable | 1 sampled across 1 repo(s) | 1.00 | 0 |

--- a/tests/zoo/expectations/excalidraw.toml
+++ b/tests/zoo/expectations/excalidraw.toml
@@ -72,3 +72,13 @@ line = 196
 evidence = "sample"
 disposition = "actionable"
 reason = "Complexity 21 against a threshold of 15 in hit-testing logic, where branch density is exactly where erasing bugs hide."
+
+[[finding]]
+profile = "strict"
+finding_id = "security.env-file-committed:.env.production:2c69a58fcc634ff5"
+rule_id = "security.env-file-committed"
+path = ".env.production"
+line = 1
+evidence = "sample"
+disposition = "valid-but-accepted"
+reason = "Committed Vite build-time config (VITE_* vars, a Firebase apiKey, and an RSA *public* export key). All VITE_* vars ship into the client bundle regardless of .gitignore, so there is nothing secret to protect; excalidraw commits .env.production/.env.development/.env.test deliberately."

--- a/tests/zoo/expectations/wagtail.toml
+++ b/tests/zoo/expectations/wagtail.toml
@@ -67,3 +67,13 @@ line = 275
 evidence = "sample"
 disposition = "actionable"
 reason = "Complexity 25 in an __init__, well over the threshold of 15. Constructor-time branching this dense is worth extracting."
+
+[[finding]]
+profile = "strict"
+finding_id = "architecture.excessive-fan-out:wagtail/users/views/users.py:e4cd4dadcbd33b60"
+rule_id = "architecture.excessive-fan-out"
+path = "wagtail/users/views/users.py"
+line = 1
+evidence = "sample"
+disposition = "valid-but-accepted"
+reason = "fan_out=17 against threshold=15 in a Django admin ModelViewSet module: it legitimately wires together many admin widgets, forms, and filters. A coordinator file doing its job, not tangled logic worth refactoring."


### PR DESCRIPTION
## What

Two stable-lifecycle rules had **zero zoo evidence** per the rule
scorecard — shipped as trusted/default-visible with no real-repo
measurement, which contradicts Phase E's definition of done ("no release
claim exceeds fixture or zoo evidence"). Sampled and labeled both:

- `architecture.excessive-fan-out` — `wagtail/users/views/users.py`,
  fan_out=17 vs threshold=15 → `valid-but-accepted`. A Django admin
  `ModelViewSet` module that legitimately wires together many admin
  widgets/forms/filters.
- `security.env-file-committed` — excalidraw's `.env.production` →
  `valid-but-accepted`. Committed Vite build-time config; every `VITE_*`
  var ships into the client bundle regardless of `.gitignore`, and
  excalidraw commits these deliberately.

## Investigated but not actionable right now

- `architecture.high-instability-hub`, `security.private-key-candidate` —
  genuinely fire **zero times** across all 11 pinned repos in both
  profiles. Both already have fixture TP/FP coverage, so this is an honest
  "measured, no real-world instances yet" state, not neglect.
- `architecture.unresolved-local-import`, `behavioral.removed-export-still-
  imported` (this cycle's headline broken-code rules) — the zoo harness
  only runs full-repo `scan` at one pinned commit.
  `removed-export-still-imported` lives entirely in the review/diff path
  (`src/scan/scanner/changed/api_contract.rs`) and needs two revisions, so
  it's **structurally unmeasurable** by the current zoo, not just
  unsampled. `unresolved-local-import` is a scan audit and correctly fires
  zero times (real repos at a pinned commit don't have broken imports) —
  real evidence, just not a precision sample. Closing this for real needs a
  "review zoo" that samples historical commit pairs — flagging as a
  follow-up rather than improvising it into this PR.

## Verification

- `python3 scripts/zoo.py scorecard --write` — scorecard regenerated, diff
  reviewed.
- `python3 scripts/zoo.py report` — 0 unlabeled default findings.
- `cargo test --release --test zoo_regression` — green, snapshots match
  committed state (no drift from the new labels).

No CHANGELOG entry — test-fixture/evidence addition only, no behavior
change.
