### PR TITLE
chore: remove stale dead_code allow on review::signals::api_contract

### DIFF
--- a/src/review/signals/mod.rs
+++ b/src/review/signals/mod.rs
@@ -19,7 +19,6 @@
 pub mod algorithmic;
 #[cfg(test)]
 mod algorithmic_tests;
-#[allow(dead_code)] // Facts are consumed by the following removed-export detector slice.
 pub(crate) mod api_contract;
 pub mod behavioral;
 #[cfg(test)]


### PR DESCRIPTION
## What

Found while surveying for release-blocking tech debt (nothing to do with
Phase E directly, just a genuine loose end).

`src/review/signals/mod.rs` had a module-level `#[allow(dead_code)]` on
`api_contract` dating from when it was built incrementally — the comment
("Facts are consumed by the following removed-export detector slice") was
forward-looking to a slice that has since landed. `api_contract` is now
actively consumed by production code (`signal_pass.rs`, `content_signals.rs`,
`tiered.rs`), not only tests, so the allow was pure leftover.

## Verification

- Removed the allow; `cargo clippy --all-targets --all-features -- -D
  warnings` stays clean, confirming nothing inside the module is actually
  unused.
- `cargo test --lib review::signals` — 143 passed.
- `cargo fmt --all -- --check` clean.

No behavior change, no CHANGELOG entry.
