### PR TITLE
docs: add the v0.22 release scorecard

### DIFF
--- a/docs/engineering/v0.22-release-scorecard.md
+++ b/docs/engineering/v0.22-release-scorecard.md
@@ -1,0 +1,180 @@
+# v0.22 Release Scorecard
+
+Use this checklist during every 0.22 PR and at release time. Each gate is either
+machine-checkable (run the listed command) or clearly auditable (inspect the
+listed artifact). Status below reflects the last full verification pass
+(2026-08-28, commit `81deca06` on `fix/import-order-determinism`, targeting
+`main`) — re-run before cutting the actual release tag, since later PRs can
+regress a previously green gate.
+
+## Trust
+
+- [x] Zero finding contract violations
+  - `cargo test --all` — 890+ lib tests plus the full integration suite green
+- [x] Zero unlabeled default zoo findings
+  - `python3 scripts/zoo.py report` — 25 default-visible findings across 11
+    repos, 0 unlabeled (9 actionable, 16 valid-but-accepted, 0 false-positive)
+- [x] Zero stale or ambiguous zoo expectations
+  - `python3 scripts/zoo.py scan --bless` reconciles clean; the one stale
+    entry found this cycle (`architecture.excessive-fan-out` in wagtail,
+    caused by the import-order determinism bug below) is fixed and
+    re-sampled
+- [x] Zero known default-visible P0/P1 false positives
+  - `python3 scripts/zoo.py report` shows 0 false-positive entries; the 3
+    known false positives on record are all strict-only (dead-module
+    resolver gaps), never default-visible
+- [x] All selected strict recall anchors preserved
+  - zoo scan validates strict expectations; anchors unchanged this cycle
+- [x] Complete evidence and recommendation coverage
+  - self-scan (`cargo run --release -- scan . --fail-on-priority p1`): 0
+    visible findings at P1, decision PASS; 384 strict-only findings, all
+    expected preview/experimental-tier code-quality/architecture noise, no
+    new unexplained findings
+- [ ] Documentation coverage for high-priority stable rules
+  - `cargo test --test rules_reference_doc` — run at release time; no
+    known drift as of this pass
+
+**Correctness fix this cycle:** import-order non-determinism. Two functions in
+`graph::imports` collected a `HashSet<String>` straight into a `Vec` without
+sorting, so `architecture.excessive-fan-out` and
+`architecture.high-instability-hub` evidence text (and therefore their
+finding-ID hash) varied between separate `repopilot scan` runs on identical
+source — breaking the finding-ID stability contract below for any file
+tripping either rule. Found via zoo re-verification, fixed by sorting both
+extractors' output (`fix/import-order-determinism`). No other instance of
+this pattern found in the codebase; one sibling extractor
+(`extract_guarded_optional_imports_from`) already sorted correctly.
+
+## Performance
+
+- [x] Benchmark matrix recorded
+  - `npm run review:performance`: median 355.38ms changed / 951.63ms full
+    review; ratio 0.373, under the 0.6 budget
+  - `npm run scan:performance`: warm full scan 366.94ms (480-file synthetic)
+    / 905.21ms (1000-file synthetic); both under budget
+  - see `docs/engineering/performance-budgets.md` for the full matrix and
+    baselines this cycle's numbers are checked against
+- [x] No unexplained regression above threshold
+  - both performance gates above passed their release-only smoke budgets
+- [x] Deterministic outputs across thread counts
+  - `cargo test --test perf_matrix` —
+    `full_scan_is_deterministic_across_thread_counts_on_{small,medium}_synthetic_repo`
+    green
+- [x] Cache invalidation and corruption recovery tested
+  - `cargo test --test perf_matrix` —
+    `parsed_cache_records_hit_miss_and_invalidation_across_changed_added_and_removed_files`
+    covers unchanged/changed/added/removed
+- [ ] Memory result recorded
+  - no fresh peak-RSS measurement taken this cycle; last recorded baseline
+    is from 0.20 (`docs/engineering/v0.20-release-scorecard.md`) — record a
+    0.22 number before cutting the release if the graph-v2 core (Phase A)
+    materially changed memory shape
+
+## Product
+
+- [x] Install -> init -> useful review workflow
+  - `./scripts/smoke-product.sh` — version, init, review, scan, baseline, AI
+    context all green
+- [x] Verdict-first default output
+  - unchanged this cycle; review/scan console output still leads with the
+    summary verdict
+- [x] Honest scope limitations
+  - `docs/agent-guardrail.md` and README's evidence-tiers paragraph both
+    name what broken-code detection does and doesn't cover (path aliases,
+    package imports, re-exports, etc. are explicitly out of scope)
+- [x] Useful changed-review output
+  - `repopilot review . --base origin/main` — verified via the new
+    broken-code demo (`scripts/demo-broken-code-review.sh`,
+    `docs/demos/05-broken-code.gif`) and the pre-existing agent-review demos
+- [x] Bounded MCP responses
+  - unchanged contract this cycle; explicit verification (`--verify`) adds
+    bounded/redacted process output, not unbounded MCP responses
+- [x] GitHub Action artifacts verified
+  - `scripts/repopilot-action-review.sh` now runs through the canonical
+    baseline engine (`baseline create` + `scan --baseline`) instead of the
+    retired `scripts/review_delta.py`; `delta-json-file` is the head scan's
+    own baseline-aware JSON report
+
+## Compatibility
+
+- [x] CLI commands unchanged
+  - no new top-level commands this cycle; `--verify` and `--record-history`
+    extend existing `review`/`scan`, per project convention
+- [ ] Baseline identity preserved
+  - not yet checked: 0.21 baselines against 0.22 findings. Baseline schema
+    itself didn't change shape (only gained `resolved`), so this is
+    expected to hold, but wasn't explicitly re-verified this pass
+- [x] Finding IDs stable
+  - **was broken this cycle** for any file tripping
+    `architecture.excessive-fan-out` / `architecture.high-instability-hub`
+    (see Trust above); fixed and directly verified (same pinned repo,
+    scanned twice, byte-identical finding ID) before this line was checked
+- [x] SARIF output compatible
+  - review SARIF taint severity now derives from the canonical
+    `signal.tier` instead of re-matching `signal.kind` strings (#391);
+    structure itself unchanged, additive only
+- [ ] Supported report readers
+  - schema advanced twice this cycle (review `0.24`→`0.25`, scan
+    `0.23`→`0.24`, audit receipt `5`→`6`); readers accepting the prior
+    schema range weren't re-verified against 0.22 output this pass
+- [x] MCP tool names stable
+  - still six tools; `repopilot_review_change` gained an optional `verify`
+    parameter, no new tool added
+- [x] Visibility profiles consistent
+  - `default`/`strict` behavior unchanged; new rules
+    (`architecture.unresolved-local-import`,
+    `behavioral.removed-export-still-imported`) ship at their documented
+    lifecycle tier
+
+## Distribution
+
+- [ ] Cargo
+  - `cargo install repopilot --version 0.22.0` — not yet publishable;
+    version is still `0.21.0` in `Cargo.toml`
+- [ ] npm
+  - `npm install -g repopilot@0.22.0` — same blocker, version not yet
+    bumped
+- [ ] GitHub Releases
+  - no 0.22.0 tag cut yet
+- [ ] Homebrew
+  - depends on the GitHub Release above
+- [ ] GitHub Action and reusable workflow
+  - `action.yml` / reusable workflow still reference 0.21.0; needs the same
+    version-pin sweep the 0.18.0 cut used (Cargo.toml + Cargo.lock,
+    package.json + pins, action.yml, reusable workflow default + action
+    ref, doc `@v` pins)
+- [ ] Platform smoke tests
+  - darwin-arm64 verified locally via this pass's gate run; darwin-x64,
+    linux-x64-gnu, linux-arm64-gnu, win32-x64-msvc need the CI matrix run
+    against the final tagged head, not just this local pass
+- [ ] Checksums and available provenance artifacts
+  - produced by the release workflow at tag time; not yet run
+
+## What's blocking the actual release cut
+
+Everything under Trust/Performance/Product passed a full gate run against
+`main` this pass (fmt, clippy, full test suite, both performance budgets,
+`smoke-product.sh`, `verify-release.sh`, zoo report) — the only failure was
+the import-order determinism bug above, now fixed
+(`fix/import-order-determinism`, open as a PR). Once that merges:
+
+1. **Version bump** — `0.21.0` → `0.22.0` across `Cargo.toml`, `Cargo.lock`,
+   `package.json` and its pins, `action.yml`, the reusable workflow's default
+   and action ref, and doc `@v` pins. Not started.
+2. **CHANGELOG consolidation** — `[Unreleased]` → `[0.22.0] - <date>`. The
+   Unreleased section already holds the full 0.22 feature set (resolved-
+   finding baseline tracking, the Action's baseline-engine delta, explicit
+   local verification + MCP parity + trusted caching, honest decision scores
+   and progressive review disclosure, changed-scan removed-export parity,
+   review-first removed-export evidence, the first broken-code detector, and
+   the zoo/scorecard evidence work) — not yet touched.
+3. **Distribution version sweep** — all five unchecked Distribution items
+   above are blocked on step 1.
+4. **Full CI platform matrix** on the version-bumped head, not just this
+   local darwin-arm64 pass.
+5. **A fresh peak-RSS measurement** — optional but recommended given Phase
+   A's graph-v2 core rewrite; the last recorded number is from 0.20.
+
+Nothing found this pass points at unshippable product behavior — the
+blockers are release mechanics (version/CHANGELOG/CI matrix), not open
+correctness or evidence gaps.


### PR DESCRIPTION
## What

The last outstanding Phase E deliverable from `docs/roadmap/v0.22.md`: "release scorecard covering correctness, signal quality, latency, memory, determinism, cache behavior, and distribution channels."
