### PR TITLE
chore(release): prepare RepoPilot v0.22.0

### DIFF
--- a/.github/workflows/repopilot-pr-review.yml
+++ b/.github/workflows/repopilot-pr-review.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: RepoPilot version to run
         type: string
-        default: "0.21.0"
+        default: "0.22.0"
       fail-on-review:
         description: Review signal gate policy
         type: string
@@ -70,7 +70,7 @@ jobs:
 
       - name: Review pull request
         id: repopilot
-        uses: MykytaStel/repopilot@v0.21.0
+        uses: MykytaStel/repopilot@v0.22.0
         with:
           command: review
           version: ${{ inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-08-28
+
+RepoPilot 0.22 unifies the graph core behind every projection, adds
+broken-code evidence for imports and exports that quietly stop resolving,
+and brings explicit local verification (tests/build/type-check/lint) into
+review and MCP with trusted, revision-safe result caching. Baseline scans
+now track resolved findings end to end, including through the GitHub
+Action's PR-comment delta, which runs through the same baseline engine
+instead of a separate Python implementation.
+
 ### Added
 
 - **Resolved-finding tracking in the baseline engine.** `scan --baseline` and
@@ -1906,7 +1916,8 @@ CI and AI-assisted remediation.
 - Added `compare` for diffing two JSON scan reports.
 - Added CI workflow, release workflow, distribution docs, release docs, and ruleset docs.
 
-[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/MykytaStel/repopilot/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/MykytaStel/repopilot/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/MykytaStel/repopilot/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/MykytaStel/repopilot/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/MykytaStel/repopilot/compare/v0.18.0...v0.19.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repopilot"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repopilot"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 description = "Local-first CLI for reviewing Git changes, security boundaries, and blast radius before merge."
 license = "MIT OR Apache-2.0"

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ inputs:
   version:
     description: "GitHub Release version to install and checksum-verify."
     required: false
-    default: "0.21.0"
+    default: "0.22.0"
   upload-sarif:
     description: "Automatically upload SARIF output to GitHub Code Scanning"
     required: false

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -182,7 +182,7 @@ Use the reusable workflow:
 ```yaml
 jobs:
   repopilot:
-    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.21.0
+    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.22.0
     with:
       fail-on-review: none
       upload-sarif: false
@@ -191,7 +191,7 @@ jobs:
 Or use the Action directly:
 
 ```yaml
-- uses: MykytaStel/repopilot@v0.21.0
+- uses: MykytaStel/repopilot@v0.22.0
   with:
     command: review
     scope: changed

--- a/docs/engineering/v0.22-release-scorecard.md
+++ b/docs/engineering/v0.22-release-scorecard.md
@@ -3,9 +3,13 @@
 Use this checklist during every 0.22 PR and at release time. Each gate is either
 machine-checkable (run the listed command) or clearly auditable (inspect the
 listed artifact). Status below reflects the last full verification pass
-(2026-08-28, commit `81deca06` on `fix/import-order-determinism`, targeting
-`main`) — re-run before cutting the actual release tag, since later PRs can
-regress a previously green gate.
+(2026-08-28, `scripts/verify-release.sh` end to end — fmt, clippy, full test
+suite, zoo clone+gate, release-contract + its own unit tests, `cargo audit`,
+`cargo deny`, shellcheck, actionlint, CLI release smoke tests, cargo
+package/publish dry-run, npm wrapper tests + pack dry-run, both performance
+gates, self-review/self-scan signal quality, and the full product smoke
+suite — all green, on the version-bumped head preparing this release) — re-run
+before actually cutting the tag if later commits land first.
 
 ## Trust
 
@@ -128,21 +132,26 @@ this pattern found in the codebase; one sibling extractor
 
 ## Distribution
 
-- [ ] Cargo
-  - `cargo install repopilot --version 0.22.0` — not yet publishable;
-    version is still `0.21.0` in `Cargo.toml`
-- [ ] npm
-  - `npm install -g repopilot@0.22.0` — same blocker, version not yet
-    bumped
+- [x] Cargo
+  - version bumped to `0.22.0` in `Cargo.toml`/`Cargo.lock`;
+    `cargo publish --dry-run --allow-dirty` passes (`verify-release.sh`).
+    Actual `cargo install repopilot --version 0.22.0` only works after the
+    crate is published at tag time
+- [x] npm
+  - `package.json` version + all five platform-package pins bumped to
+    `0.22.0`; `npm pack --dry-run` and the root/platform package dry-runs in
+    `verify-release.sh` pass. Actual `npm install -g repopilot@0.22.0` only
+    works after `publish-npm.yml` runs at tag time
 - [ ] GitHub Releases
-  - no 0.22.0 tag cut yet
+  - no `v0.22.0` tag cut yet — this PR is the last step before tagging
 - [ ] Homebrew
   - depends on the GitHub Release above
-- [ ] GitHub Action and reusable workflow
-  - `action.yml` / reusable workflow still reference 0.21.0; needs the same
-    version-pin sweep the 0.18.0 cut used (Cargo.toml + Cargo.lock,
-    package.json + pins, action.yml, reusable workflow default + action
-    ref, doc `@v` pins)
+- [x] GitHub Action and reusable workflow
+  - `action.yml` default input, the reusable workflow's default input and
+    `@v0.21.0` → `@v0.22.0` action ref, and the doc `@v` pins in
+    `docs/commands.md`/`docs/integrations/github-code-scanning.md`/
+    `docs/repository-health.md` all swept; `release-contract.py check`
+    verifies every version source agrees
 - [ ] Platform smoke tests
   - darwin-arm64 verified locally via this pass's gate run; darwin-x64,
     linux-x64-gnu, linux-arm64-gnu, win32-x64-msvc need the CI matrix run
@@ -153,28 +162,40 @@ this pattern found in the codebase; one sibling extractor
 ## What's blocking the actual release cut
 
 Everything under Trust/Performance/Product passed a full gate run against
-`main` this pass (fmt, clippy, full test suite, both performance budgets,
-`smoke-product.sh`, `verify-release.sh`, zoo report) — the only failure was
-the import-order determinism bug above, now fixed
-(`fix/import-order-determinism`, open as a PR). Once that merges:
+`main` this pass — the import-order determinism bug is fixed and merged
+(#397), the release scorecard itself landed (#398), and this PR does the
+release mechanics:
 
-1. **Version bump** — `0.21.0` → `0.22.0` across `Cargo.toml`, `Cargo.lock`,
-   `package.json` and its pins, `action.yml`, the reusable workflow's default
-   and action ref, and doc `@v` pins. Not started.
-2. **CHANGELOG consolidation** — `[Unreleased]` → `[0.22.0] - <date>`. The
-   Unreleased section already holds the full 0.22 feature set (resolved-
-   finding baseline tracking, the Action's baseline-engine delta, explicit
-   local verification + MCP parity + trusted caching, honest decision scores
-   and progressive review disclosure, changed-scan removed-export parity,
-   review-first removed-export evidence, the first broken-code detector, and
-   the zoo/scorecard evidence work) — not yet touched.
-3. **Distribution version sweep** — all five unchecked Distribution items
-   above are blocked on step 1.
-4. **Full CI platform matrix** on the version-bumped head, not just this
-   local darwin-arm64 pass.
+1. ~~Version bump~~ — done: `0.21.0` → `0.22.0` across `Cargo.toml`,
+   `Cargo.lock`, `package.json` and its pins, `action.yml`, the reusable
+   workflow's default and action ref, and doc `@v` pins.
+2. ~~CHANGELOG consolidation~~ — done: `[Unreleased]` → `[0.22.0] -
+   2026-08-28` with a summary paragraph and compare-link references.
+3. ~~Curated GitHub release notes~~ — done: `docs/releases/v0.22.0.md`
+   (title/description front matter, Highlights/Compatibility/Upgrade
+   sections, pinned upgrade commands) — required by `release_notes()` in
+   `scripts/release-contract.py` and previously missing entirely.
+4. Remaining: **tag `v0.22.0` and push** once this PR merges, which triggers
+   the full CI platform matrix (darwin-x64, linux-x64-gnu, linux-arm64-gnu,
+   win32-x64-msvc — only darwin-arm64 verified locally so far), the GitHub
+   Release, checksums/provenance, and `publish-npm.yml`.
 5. **A fresh peak-RSS measurement** — optional but recommended given Phase
-   A's graph-v2 core rewrite; the last recorded number is from 0.20.
+   A's graph-v2 core rewrite; the last recorded number is from 0.20. Not
+   done this pass; can follow post-release as a docs-only update.
 
-Nothing found this pass points at unshippable product behavior — the
-blockers are release mechanics (version/CHANGELOG/CI matrix), not open
-correctness or evidence gaps.
+Full verification this pass: `scripts/verify-release.sh` end to end on the
+version-bumped head — fmt, clippy, `cargo test --all` (890+ lib tests + full
+integration suite), zoo clone + `zoo.py report` (0 unlabeled), release
+contract + its 58 unit tests, `cargo audit`, `cargo deny check`, shellcheck,
+actionlint, CLI release smoke tests, `cargo package`/`cargo publish
+--dry-run`, npm wrapper tests + `npm pack --dry-run`, both performance gates,
+self-review/self-scan signal quality, and the full product smoke suite — all
+green. One separate `cargo test --release --all` run hit an unrelated local
+environment issue (`python3` resolving to macOS's system 3.9.6, which lacks
+`tomllib`, instead of a 3.11+ interpreter) in `zoo_expectations_contract`;
+confirmed not a regression by rerunning with a corrected `PATH` (passes), and
+confirmed CI is unaffected since no workflow pins a `python3` version — this
+is local-machine PATH ordering only.
+
+Nothing found this pass points at unshippable product behavior — the only
+remaining blocker is the tag/push itself and the CI matrix it triggers.

--- a/docs/integrations/github-code-scanning.md
+++ b/docs/integrations/github-code-scanning.md
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   review:
-    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.21.0
+    uses: MykytaStel/repopilot/.github/workflows/repopilot-pr-review.yml@v0.22.0
     with:
       fail-on-review: definitely
       fail-on-priority: p1
@@ -45,7 +45,7 @@ This default is read-only and works for fork PRs. It does not use
 
 - name: RepoPilot review
   id: repopilot
-  uses: MykytaStel/repopilot@v0.21.0
+  uses: MykytaStel/repopilot@v0.22.0
   with:
     command: review
     scope: changed
@@ -89,7 +89,7 @@ permissions:
   security-events: write
 
 steps:
-  - uses: MykytaStel/repopilot@v0.21.0
+  - uses: MykytaStel/repopilot@v0.22.0
     with:
       command: review
       upload-sarif: "true"
@@ -117,7 +117,7 @@ permissions:
   pull-requests: write
 
 steps:
-  - uses: MykytaStel/repopilot@v0.21.0
+  - uses: MykytaStel/repopilot@v0.22.0
     with:
       command: review
       comment: "true"

--- a/docs/releases/v0.22.0.md
+++ b/docs/releases/v0.22.0.md
@@ -1,0 +1,25 @@
+---
+title: Broken-code evidence, explicit local verification, and a unified graph core
+description: RepoPilot 0.22 catches broken imports and exports no compiler is running to check, adds explicit local verification (tests/build/type-check/lint) to review and MCP with trusted caching, and unifies the import graph behind every projection.
+---
+
+## Highlights
+
+- New broken-code evidence: `architecture.unresolved-local-import` and `behavioral.removed-export-still-imported` catch a deleted or renamed file still imported, or a removed named export still called under its old name — proven by AST plus resolver, no compiler required, in both `review` and `scan --changed`.
+- Explicit local verification. Repositories declare bounded test/build/type-check/lint checks under `[[verification.checks]]`; `review --verify` and `repopilot_review_change`'s `verify` parameter run only the allowlisted IDs, with no shell, a fixed portability environment, bounded and redacted output, and managed-process-tree cancellation. Passing, revision-compatible results can opt into a trusted local cache.
+- Baseline scans now track resolved findings end to end — `scan --baseline` and `review --baseline` report a `resolved` list alongside `new`/`existing`, and the GitHub Action's PR-comment delta runs through that same baseline engine instead of a separate Python implementation.
+- Honest decision scores and progressive review disclosure: scan and review output now separate a strict-only `Maintainability` score from the visible-profile `Visible health` score, and default review output groups changed files by area with a concrete `Next:` action instead of a full dump.
+- The real-repo validation zoo grew a generated rule scorecard (`docs/engineering/rule-scorecard.md`) tracking labeled precision evidence per rule, and a fixed import-order non-determinism bug that could vary `architecture.excessive-fan-out`/`architecture.high-instability-hub` finding IDs between identical scans.
+
+## Compatibility
+
+RepoPilot 0.22 adds no top-level command. Review report schema advances to `0.25` (`0.24` still accepted); scan report schema advances to `0.24` (`0.23` still accepted); the audit receipt schema advances to `6`. The public `ReviewSignal` struct gains an additive `target_path` field — JSON stays backward compatible, but Rust consumers constructing it with a struct literal need to add the field (normally `None`).
+
+Explicit local verification is off by default: RepoPilot never runs a repository-declared check unless it is both configured and explicitly selected by `--verify`/the MCP `verify` parameter, and it never accepts arbitrary shell text. Static analysis remains fully usable when verification is disabled or unavailable.
+
+## Upgrade
+
+```bash
+cargo install repopilot --version 0.22.0 --force
+npm install -g repopilot@0.22.0
+```

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -16,11 +16,11 @@ JSON scan reports include explicit schema metadata. The current schema is 0.24:
 ```json
 {
   "schema_version": "0.24",
-  "repopilot_version": "0.21.0",
+  "repopilot_version": "0.22.0",
   "report": {
     "kind": "scan",
     "schema_version": "0.24",
-    "repopilot_version": "0.21.0"
+    "repopilot_version": "0.22.0"
   },
   "root_path": ".",
   "files_analyzed": 42,
@@ -167,11 +167,11 @@ Example shape:
 ```json
 {
   "schema_version": "0.24",
-  "repopilot_version": "0.21.0",
+  "repopilot_version": "0.22.0",
   "report": {
     "kind": "baseline-scan",
     "schema_version": "0.24",
-    "repopilot_version": "0.21.0"
+    "repopilot_version": "0.22.0"
   },
   "root_path": ".",
   "files_analyzed": 42,
@@ -261,10 +261,10 @@ Receipt JSON is intentionally smaller than a scan report and has its own schema:
   "report": {
     "kind": "receipt",
     "schema_version": "6",
-    "repopilot_version": "0.21.0"
+    "repopilot_version": "0.22.0"
   },
   "tool": "repopilot",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "generated_at": "2026-05-16T00:00:00Z",
   "root_path": ".",
   "git": {

--- a/docs/repository-health.md
+++ b/docs/repository-health.md
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MykytaStel/repopilot@v0.21.0
+      - uses: MykytaStel/repopilot@v0.22.0
         with:
           command: scan
           format: json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repopilot",
-	"version": "0.21.0",
+	"version": "0.22.0",
 	"description": "Local-first CLI for reviewing Git changes, security boundaries, and blast radius before merge.",
 	"license": "MIT OR Apache-2.0",
 	"repository": {
@@ -30,11 +30,11 @@
 		"LICENSE"
 	],
 	"optionalDependencies": {
-		"@repopilot/darwin-arm64": "0.21.0",
-		"@repopilot/darwin-x64": "0.21.0",
-		"@repopilot/linux-arm64-gnu": "0.21.0",
-		"@repopilot/linux-x64-gnu": "0.21.0",
-		"@repopilot/win32-x64-msvc": "0.21.0"
+		"@repopilot/darwin-arm64": "0.22.0",
+		"@repopilot/darwin-x64": "0.22.0",
+		"@repopilot/linux-arm64-gnu": "0.22.0",
+		"@repopilot/linux-x64-gnu": "0.22.0",
+		"@repopilot/win32-x64-msvc": "0.22.0"
 	},
 	"keywords": [
 		"cli",


### PR DESCRIPTION
## What

Release mechanics for 0.22.0 — the last PR before tagging.

- **Version bump** `0.21.0` → `0.22.0`: `Cargo.toml`, `Cargo.lock`, `package.json` (+ its five platform-package pins), `action.yml`, the reusable workflow's default input and `@v` action ref, and the doc `@v` pins in `docs/commands.md` / `docs/integrations/github-code-scanning.md` / `docs/repository-health.md`. Illustrative `repopilot_version` strings in`docs/reports.md` updated to match.
- **CHANGELOG**: `[Unreleased]` → `[0.22.0] - 2026-08-28` with a summary paragraph and the compare-link references.
- **New `docs/releases/v0.22.0.md`** — the curated GitHub release notes `release-contract.py` requires (title/description front matter, Highlights/Compatibility/Upgrade sections, pinned upgrade commands). Didn't exist yet for this version.
- **`docs/engineering/v0.22-release-scorecard.md`** updated with this pass's full verification results and the completed version-bump/CHANGELOG/ release-notes items checked off.
