### PR TITLE
docs: plan v0.23 Change Proof and Phase 0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,10 @@ adoption or CI policy.
 
 ## Maintainer Guides
 
+- [v0.23 roadmap and release contract](roadmap/v0.23.md)
+- [v0.23 Phase 0 truth foundation specification](engineering/v0.23-phase-0-spec.md)
+- [v0.23 Phase 0A evidence-baseline plan](engineering/v0.23-phase-0a-plan.md)
+- [v0.23 release evidence ledger](engineering/v0.23-evidence-ledger.md)
 - [v0.22 repository intelligence design](engineering/v0.22-repository-intelligence-design.md)
 - [v0.22 Phase A1 context graph specification](engineering/v0.22-phase-a1-context-graph-v2.md)
 - [v0.22 Phase A3 graph state convergence specification](engineering/v0.22-phase-a3-graph-state-convergence.md)
@@ -44,7 +48,7 @@ adoption or CI policy.
 - [Release process](release.md)
 - [Distribution](distribution.md)
 - [Roadmap](roadmap.md)
-- [v0.22 roadmap and release contract](roadmap/v0.22.md)
+- [v0.22 release contract](roadmap/v0.22.md)
 - [v0.21 roadmap and release contract](roadmap/v0.21.md)
 - [v0.20 roadmap and release contract](roadmap/v0.20.md)
 - [v0.20 release scorecard](engineering/v0.20-release-scorecard.md)

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -1,0 +1,110 @@
+# v0.23 Release Evidence Ledger
+
+Status: open; initial evidence baseline, not a completed Phase 0 scorecard.
+
+Parent: [Phase 0 specification](v0.23-phase-0-spec.md).
+Replay: [0A plan](v0.23-phase-0a-plan.md).
+Release: [v0.23 roadmap](../roadmap/v0.23.md).
+
+## Observation Identity
+
+- Observed: 2026-08-30.
+- Runtime source: `a000dc7cf189798b814672673076cf9179b1a267` (`v0.22.0`).
+- Planning files differ from that tag; current self-scan inventory is therefore
+  workspace-specific rather than a pinned-tag measurement.
+- `origin/main` matched the tag at inspection; open GitHub issues and PRs were
+  both empty before this planning PR. This is not evidence of zero defects.
+- Existing release docs and labels describe historical runs; they are not
+  automatically fresh validation for 0.23.
+
+Priorities below are release-triage estimates, not RepoPilot-emitted finding
+priorities. Owners are subsystems; no person is implicitly assigned.
+
+## Open Items
+
+| ID | Priority / kind | Status | Owner / slice | Observation and closure requirement |
+|---|---|---|---|---|
+| RP23-001 | P1 defect | open | Distribution / 0C | Original Release run failed in npm publication; separate manual Publish npm succeeded, while the original public-channel verifier stayed skipped. Close with tested recovery, exact-version identity checks, and a complete per-channel verification result. |
+| RP23-002 | P2 defect | open | Report docs / 0B–0D | `docs/releases/v0.22.0.md` says scan `0.24` and review `0.25`; emitters share `SCAN_REPORT_SCHEMA_VERSION = "0.26"`. Close with emitted-artifact parity, corrected documentation, and a regression guard. |
+| RP23-003 | P1 evidence-gap | open | Compatibility / 0B | v0.22 scorecard leaves prior baselines/readers unverified. Existing current-reader tests alone cannot close all compatibility directions. Close with a supported-direction matrix and version-provenanced fixtures or pinned binaries. |
+| RP23-004 | P2 evidence-gap | open | Performance / 0E | v0.22 scorecard lacks fresh peak RSS. Close with reproducible cold/warm measurements, units, source identity, and an approved ceiling; do not infer memory from latency. |
+| RP23-005 | P2 defect | open | Documentation / 0D | Historical scorecard still describes an uncut tag, while the release is published. Platform state prose also retains already-completed migration work as missing. Close by distinguishing original audit state from subsequent evidence and checking current claims against code. |
+| RP23-006 | P2 design-risk | open | Review/readiness / A | Absent CODEOWNERS produces unowned paths and review reasons. Close with explicit absent/configured-unmatched/resolved states and regression coverage; do not claim a config policy is violated when it does not exist. |
+| RP23-007 | P2 defect | open | Decision UX / 0D–A | Decision and readiness are printed separately; finding-only plan counts omit signal verification guidance. Close with accurate current copy, then one canonical Phase A obligations model and projection parity. |
+| RP23-008 | P2 limitation | open | Semantic review / B | Manifest/workflow boundary classification is path-based. Close only for supported semantic families with metadata-only safe guards; preserve unknown forms and strict recall. |
+| RP23-009 | P2 design-risk | open | Coverage UX / 0D–A | PASS and visible health scores can be read as broader proof than analyzed scope. Close with assessed-scope copy and a capability ledger; excluded files or hidden suggestions are not automatically missed defects. |
+| RP23-010 | P2 evidence-gap | open | Rule quality / E | Committed scorecard reports three strict-only dead-module false positives and many rules without zoo evidence. Close each measured issue with safe/unsafe regression and fresh labeled evidence; never label unmeasured rules clean. |
+| RP23-011 | P2 defect | open | Release contract / 0D | `check_roadmap_docs()` checks v0.20 headings/links only. Its green result does not validate v0.23 planning semantics. Close with focused lifecycle/link contract tests that retain older supported docs. |
+| RP23-012 | P2 design-risk | open | Proof semantics / A | A failed lint/check is not necessarily contract breakage, and no selected checks is not sufficient proof. Roadmap wording now makes this explicit; close only when Phase A truth tables and runtime projection tests enforce it. |
+
+No item is marked verified solely by being listed here. Phase A/B/E items remain
+visible release work but are not silently folded into Phase 0 implementation.
+
+## Release Observation Sources
+
+- [Original v0.22 Release run](https://github.com/MykytaStel/repopilot/actions/runs/33183540919):
+  overall failure; five platform builds, GitHub Release, crates publication, and
+  Homebrew update reported success; nested npm publish failed; public-channel
+  verification skipped. These are job outcomes, not fresh install tests.
+- [Separate Publish npm run](https://github.com/MykytaStel/repopilot/actions/runs/33184346391):
+  `workflow_dispatch`, success, same source SHA. This does not retroactively
+  make the original Release run green.
+- [Published v0.22.0 release](https://github.com/MykytaStel/repopilot/releases/tag/v0.22.0):
+  not draft; published 2026-08-28; API lists five platform archives and five
+  checksum files with digests. Downloaded payload verification and provenance
+  validation are separate unperformed checks in this initial baseline.
+- Exact-version `npm view` returned `0.22.0` and integrity metadata for the root
+  package and all five platform packages on 2026-08-30. This is metadata, not a
+  wrapper/platform installation test.
+- The Homebrew formula API returned version `0.22.0` and four archive SHA-256
+  values matching the GitHub asset metadata on 2026-08-30; no brew install was
+  performed.
+- The exact-version crates.io API request returned HTTP 403 on 2026-08-30.
+  Fresh crates metadata remains unverified; the successful historical publish
+  job does not substitute for that request or an installation smoke test.
+- `python3 scripts/zoo.py report` on 2026-08-30 found 25/25 default-visible
+  snapshot findings labeled across 11 repositories, zero default false-positive
+  labels, and 18 strict recall anchors. `zoo.py scorecard` reported the committed
+  scorecard current. These are reports over stored snapshots/labels, not fresh
+  scans or a claim of universal precision.
+
+The original npm error was E404 at package publication. Root cause is not
+established here: do not infer package absence, token failure, or OIDC mismatch
+solely from that status. 0C must inspect workflow/auth context without exposing
+secrets and pin the actual recovery behavior with offline fault tests.
+
+## Source-Level Evidence
+
+- `src/report/schema.rs`, `src/report/schema/review.rs`, and
+  `src/report/schema/baseline.rs` share schema `0.26`.
+- `src/review/ownership/model.rs` records unmatched paths even with an empty
+  ownership index; `src/review/readiness/derive.rs` includes them as reasons.
+- `src/output/decision_summary.rs` counts finding verification plans;
+  `src/review/render/console.rs` separately renders signal guidance.
+- `src/review/signals/classify.rs` classifies deployment and manifest boundaries
+  by path/filename without inspecting semantic field changes.
+- `.github/workflows/release.yml` already contains `verify-publication`; it
+  depends on publication jobs and checks mutable npm latest versions. Recovery
+  must extend this path, not duplicate it.
+- `.github/workflows/publish-npm.yml` invokes unconditional `npm publish` for
+  platform packages and then the root package. Dispatch checkout defaults to
+  its selected workflow ref rather than explicitly resolving the tag input.
+
+These are source observations, not fresh failing regression tests. The repair
+spec for each subsystem must reproduce its claim before changing behavior.
+
+## Validation Boundaries
+
+The planning PR's fresh handoff output belongs in its verification section.
+It validates the unchanged current code and this docs-only packet; it does not
+close the items above. Before Phase 0 closes, retain separate evidence for:
+
+- old-reader and old-producer compatibility directions;
+- fresh labeled zoo rescans, not just reports over committed labels;
+- cold/warm latency and process RSS;
+- exact-version downloads, digests, provenance, and installation smoke tests;
+- release recovery under mismatched artifacts and auth/service failures;
+- runtime regression tests for each corrected user-visible claim.
+
+Next implementation scope: detailed 0B compatibility/schema-truth repair spec,
+followed by 0C publication recovery. No 0.23 version bump is needed to start.

--- a/docs/engineering/v0.23-phase-0-spec.md
+++ b/docs/engineering/v0.23-phase-0-spec.md
@@ -1,0 +1,191 @@
+# v0.23 Phase 0 — Truth Foundation Specification
+
+Status: draft for review. Release direction is approved; this document does not
+claim that Phase 0 defects are fixed.
+
+Parent: [v0.23 roadmap](../roadmap/v0.23.md).
+First executable slice: [0A evidence-baseline plan](v0.23-phase-0a-plan.md).
+Progress source: [release evidence ledger](v0.23-evidence-ledger.md).
+
+## Problem
+
+The tagged 0.22 code, historical release documentation, and public publication
+state are different sources of evidence. A green local contract check does not
+prove registry availability, an old reader's compatibility, or the correctness
+of future ChangeProof verdicts. Missing evidence must not become a checked box.
+
+Phase 0 closes these gaps before new contract families affect default results.
+It establishes an evidence baseline and splits repairs into independently
+reviewable scopes instead of combining release engineering, schemas, UX, and
+performance into one implementation PR.
+
+## Outcome
+
+A maintainer can inspect one ledger and find each known release-relevant issue,
+its reproduction, current status, responsible subsystem, closure evidence, and
+next delivery slice. A completed Phase 0 has no open P0/P1 defects, no unresolved
+required Phase 0-owned evidence gaps, and no publication or documentation claim
+contradicted by the recorded evidence. Phase A/B/E work stays open in the ledger
+until its own phase is completed.
+
+## Global Constraints
+
+- Runtime analysis remains local-only and deterministic.
+- Verification runs only configured checks explicitly selected by the caller.
+- No top-level CLI command or MCP tool is added or removed.
+- No package version bump, tag change, registry publication, or release rerun is part of the planning PR.
+- Public schema and gate changes require a separate reviewed implementation spec.
+- Finding identity, strict-mode recall, and unrelated user changes are preserved.
+- A failed check is evidence of that outcome, not proof that the diff caused it.
+- A missing measurement remains unverified, never passed by assumption.
+
+Read-only network inspection of release services is allowed in maintainer
+verification, not in RepoPilot's analysis engine. Do not record credentials,
+environment dumps, private source, or unredacted process output in evidence.
+
+## Evidence Ledger Contract
+
+Every entry records a stable ID, priority, kind, status, subsystem owner,
+observation revision/date, reproduction or source, next action, and closure
+criterion. A subsystem owner is not a fabricated assignment to a person.
+
+Kinds: `defect`, `evidence-gap`, `limitation`, and `design-risk`.
+Statuses: `open`, `in-progress`, `verified`, and `accepted`.
+
+- `verified` requires fresh evidence for the exact closure criterion.
+- `accepted` requires an explicit maintainer decision, rationale, and follow-up;
+  P0/P1 defects cannot be accepted for the release.
+- Issue counts, source inspection, registry metadata, downloaded checksum
+  validation, and installation smoke tests are separate evidence levels.
+- A historical result retains its original revision and date. New runs append
+  evidence instead of rewriting history into a false current pass.
+- A missing external permission can block a particular measurement, but not
+  justify marking its outcome successful.
+
+## Delivery Slices
+
+### 0A — Evidence Baseline and Triage
+
+Owns the ledger and the distinction between known failures, unmeasured quality,
+configuration gaps, and future feature work.
+
+1. Record the tagged source revision, runtime schemas, Python/toolchain
+   prerequisites, open issues/PRs, and current hosted job outcomes.
+2. Replay representative review/scan behavior using explicit inputs and record
+   coverage, ownership, verification guidance, and gate observations.
+3. Inspect exact-version release metadata and distinguish original Release
+   workflow status from separate recovery publication jobs.
+4. Run existing schema/baseline/receipt/MCP/CLI tests and document exactly what
+   they prove; do not relabel current-reader tests as old-binary tests.
+5. Populate every known gap with an owner and an independently verifiable next
+   slice. Keep the historical v0.22 scorecard intact until fresh reconciliation
+   evidence is sufficient to update it.
+
+Acceptance: all observations have revision/source provenance; no open issue is
+called fixed by creating this ledger; follow-on slices have distinct ownership.
+
+### 0B — Compatibility Evidence
+
+Owns fixture provenance and supported reader/baseline compatibility.
+
+- Pin actual prior-release producers/readers and distinguish current-reader
+  ingestion of old output from old-reader ingestion of new output.
+- Cover scan/review, baseline identity and resolved findings, receipt/history
+  compatibility, SARIF, Action outputs, and MCP additive fields.
+- Prove that moved lines do not generate false new/resolved pairs and that
+  distinct occurrences are not deduplicated solely by baseline ID.
+- Keep incompatible history explicit, never reinterpret it as resolved risk.
+- Reconcile release schema documentation against the emitters and tests.
+
+Acceptance: a reviewed matrix identifies each supported direction and contains
+fixture or pinned-binary evidence; unsupported directions are limitations with
+documented behavior, not implied compatibility.
+
+### 0C — Recoverable Publication
+
+Owns release workflows, publication helpers, and distribution checks.
+
+- Extend the existing `verify-publication` job rather than create a parallel
+  publication truth system.
+- Resolve the release tag's source and exact package versions, not mutable
+  `latest` pointers, when verifying an old or resumed release.
+- Distinguish absent artifacts from authentication, rate-limit, and service
+  failures. An arbitrary npm 404 is not sufficient proof of absence.
+- On rerun, verify already-published immutable payload identity before skipping
+  a package. A version match alone is insufficient; a mismatch fails closed.
+- Define identity per distribution format: reproducible archive digest where
+  available, otherwise versioned file inventory and native payload digests.
+  Repacking timestamps must not turn matching payloads into false mismatches.
+- Publish the root npm wrapper only after all pinned platform packages are
+  verified; retain a useful per-channel result when one channel fails.
+- Verify public availability and supported-platform installation after publish.
+  Publication cannot be atomic across independent registries: use convergent,
+  recoverable steps, never deletion or replacement of immutable releases.
+
+Acceptance: offline fault fixtures cover absent/matching/mismatched artifacts,
+partial publication, auth/network failures, exact-tag checkout, and repeat runs;
+live publishing remains a separate explicit release operation.
+
+### 0D — Documentation and Current UX Truth
+
+Owns current copy, documentation parity, and bounded guidance.
+
+- Fix demonstrably stale schema, command, tool, and release-state claims.
+- Extend existing release-contract checks to validate current planning links and
+  lifecycle state without hardcoding every later milestone to v0.20.
+- Distinguish skipped/excluded files from unsupported analysis and hidden
+  suggestions in copy; neither count is itself proof of a missed vulnerability.
+- State that tests were not requested on this run, not that RepoPilot cannot
+  execute tests.
+- Preserve current gate/exit behavior while clarifying disabled policy.
+
+Acceptance: emitted copy and docs match tested behavior and registry values.
+The new proof model, ownership-state behavior, and unified obligations belong
+to Phase A; semantic manifest/workflow calibration belongs to Phase B.
+
+### 0E — Performance Baseline and Phase Closure
+
+Owns timing/RSS evidence and final Phase 0 reconciliation.
+
+- Use the existing pinned synthetic review/scan scenarios and record source
+  SHA, build profile, platform, toolchain, cache state, repetitions, latency,
+  and peak RSS. Distinguish process RSS from allocator or OS footprint metrics.
+- Pin units and measurement method before setting a hard memory ceiling.
+- Retain the existing 10% unexplained-regression rule; do not lower workload or
+  broaden exclusions to make the budget pass.
+- Reconcile the ledger, fresh zoo labels, required documentation checks, and
+  publication evidence before closing the phase.
+
+Acceptance: fresh reproducible measurements and no open required Phase 0 gaps.
+
+## First-Slice Architecture
+
+0A introduces no runtime abstraction. Existing tools produce evidence; the
+ledger stores bounded observations and closure criteria. Links connect the
+roadmap, this spec, the execution plan, and the ledger. Later implementation
+specs own code changes; the planning PR changes documentation only.
+
+0B and 0C may proceed independently after 0A is reviewed. 0D uses their findings
+to reconcile claims. 0E closes the phase after required repairs and evidence.
+Cross-cutting gate failures discovered during any slice are added to the ledger
+and repaired in their owning slice, not hidden by a green unrelated command.
+
+## Verification
+
+For this planning packet: Markdown links, whitespace, internal requirement
+coverage, independent review, and the existing handoff gate. The existing
+release-contract checker validates current 0.22 contracts; its pass does not
+validate future 0.23 functionality.
+
+For implementation: targeted regression first, unsafe/safe guards where
+applicable, then the full handoff gate on the final head. Full release rehearsal,
+fresh zoo rescans, RSS benchmarks, old-binary compatibility, and public install
+tests remain distinct required evidence, not inferred from `cargo test --all`.
+
+## Non-Goals and Completion
+
+This phase does not implement ChangeProof, new semantic detectors, Intent Drift,
+HTML Change Map, or new onboarding. Those remain Phases A–D.
+
+Phase 0 is complete only after all required slice criteria pass. Merging this
+spec or planning PR starts tracked work; it does not mark Phase 0 or 0.23 done.

--- a/docs/engineering/v0.23-phase-0a-plan.md
+++ b/docs/engineering/v0.23-phase-0a-plan.md
@@ -1,0 +1,232 @@
+# v0.23 Phase 0A Evidence Baseline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans
+> to execute this read-only audit and documentation slice task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking. No parallel agent work is required.
+
+**Status:** draft for review; the initial ledger is seeded, not closed.
+
+**Goal:** establish a reproducible v0.22 truth baseline and a triaged v0.23
+release ledger before runtime changes.
+
+**Architecture:** reuse existing CLI, tests, release APIs, and documentation.
+Write bounded evidence into the ledger; do not create a new runtime subsystem.
+Each later repair receives its own implementation spec and PR.
+
+**Tech Stack:** Rust edition 2024, pinned Rust toolchain, Python 3.11+ for
+existing zoo/release tools, Node/npm, Git, and GitHub CLI.
+
+**Spec:** [Phase 0 specification](v0.23-phase-0-spec.md), specifically 0A and
+the shared evidence rules; this plan does not implement 0B–0E.
+
+## Global Constraints
+
+- Runtime analysis remains local-only and deterministic.
+- Verification runs only configured checks explicitly selected by the caller.
+- No top-level CLI command or MCP tool is added or removed.
+- No package version bump, tag change, registry publication, or release rerun is part of the planning PR.
+- Public schema and gate changes require a separate reviewed implementation spec.
+- Finding identity, strict-mode recall, and unrelated user changes are preserved.
+- A failed check is evidence of that outcome, not proof that the diff caused it.
+- A missing measurement remains unverified, never passed by assumption.
+
+Use `apply_patch` for documentation edits. Do not change source, fixtures,
+snapshots, expectation labels, workflow settings, registry data, or release tags
+as part of this audit. Commands may create normal build/cache artifacts.
+
+## Task 1 — Pin Source and Runtime Claims
+
+**Files:**
+- Read: `src/report/schema.rs`, `src/report/schema/review.rs`,
+  `src/report/schema/baseline.rs`, `docs/releases/v0.22.0.md`.
+- Update: `docs/engineering/v0.23-evidence-ledger.md`.
+
+**Interfaces:** consumes repository/tag metadata and CLI output; produces
+revision-stamped schema, scope, ownership, guidance, and gate observations.
+
+- [ ] **1. Record the input identity and toolchain.**
+
+```bash
+git status --short --branch
+git rev-parse HEAD
+git rev-parse 'v0.22.0^{commit}'
+rustc --version
+python3 --version
+node --version
+```
+
+Expected baseline tag: `a000dc7cf189798b814672673076cf9179b1a267`.
+If HEAD differs, record both revisions; do not silently treat HEAD as 0.22.
+
+- [ ] **2. Reproduce claims using emitted artifacts and source values.**
+
+```bash
+cargo run --quiet -- review --help
+cargo run --quiet -- scan --help
+cargo run --quiet -- review . --base 'v0.22.0^' --head v0.22.0
+cargo run --quiet -- review . --base 'v0.22.0^' --head v0.22.0 --format json
+rg -n 'SCHEMA_VERSION|ACCEPTED_SCAN_REPORT_SCHEMA_VERSIONS' src/report/schema.rs
+```
+
+Do not request `--verify`. Record the runtime `schema_version` and compare it
+with release notes. Record the exit code separately from the printed verdict.
+For self-scan, use `cargo run --quiet -- scan .`; label it current workspace
+evidence, not immutable tag evidence, because planning files alter the inventory.
+
+- [ ] **3. Update ledger observations.**
+
+Record schema mismatch, duplicate summary terms, verification-plan counting,
+absent-versus-unmatched ownership, and assessed-scope copy with source pointers.
+Use observed counts only for the exact run; do not hardcode them as acceptance
+criteria. No detector or renderer changes occur in this task.
+
+## Task 2 — Inspect Publication Without Republishing
+
+**Files:**
+- Read: `.github/workflows/release.yml`,
+  `.github/workflows/publish-npm.yml`.
+- Update: `docs/engineering/v0.23-evidence-ledger.md`.
+
+**Interfaces:** consumes exact-version API metadata and hosted job results;
+produces separate publication, orchestration, and installation evidence states.
+
+- [ ] **1. Inspect issues, jobs, and exact release assets.**
+
+```bash
+gh issue list --state open --limit 100 --json number,title,url
+gh pr list --state open --limit 100 --json number,title,url
+gh run view 33183540919 --json conclusion,jobs
+gh run view 33184346391 --json conclusion,headSha,event,url
+gh release view v0.22.0 --json tagName,publishedAt,isDraft,assets,url
+```
+
+If either issue/PR query fills its limit, paginate before reporting totals.
+The original failed job and a successful separate recovery job remain separate
+facts. A skipped `verify-publication` is not a pass.
+
+- [ ] **2. Inspect exact registry versions and the formula.**
+
+```bash
+npm view repopilot@0.22.0 version dist.integrity --json
+npm view @repopilot/darwin-arm64@0.22.0 version dist.integrity --json
+npm view @repopilot/darwin-x64@0.22.0 version dist.integrity --json
+npm view @repopilot/linux-arm64-gnu@0.22.0 version dist.integrity --json
+npm view @repopilot/linux-x64-gnu@0.22.0 version dist.integrity --json
+npm view @repopilot/win32-x64-msvc@0.22.0 version dist.integrity --json
+curl -fsSL https://crates.io/api/v1/crates/repopilot/0.22.0
+gh api repos/MykytaStel/homebrew-repopilot/contents/Formula/repopilot.rb \
+  -H 'Accept: application/vnd.github.raw+json'
+```
+
+Metadata proves availability at inspection time, not an install test. Any API
+failure stays unverified with its bounded error; never substitute `latest`.
+
+- [ ] **3. Record the recovery requirements.**
+
+Inspect tag checkout, publish retries, immutable payload comparison, and the
+existing verifier's dependency chain. Assign concrete repair work to 0C. Do not
+rerun workflows, change npm trust settings, or republish any version.
+
+## Task 3 — Establish Existing Test Evidence
+
+**Files:**
+- Read: `tests/report_schema_contract.rs`, `tests/baseline_reader.rs`,
+  `tests/baseline_key.rs`, `tests/receipt_cli.rs`, `tests/history_cli.rs`.
+- Update: `docs/engineering/v0.23-evidence-ledger.md`.
+
+**Interfaces:** consumes current test suite results; produces scoped assertions
+and explicit missing old-producer/old-reader matrix rows for 0B.
+
+- [ ] **1. Run the existing contract suites.**
+
+```bash
+cargo test --test report_schema_contract --test baseline_reader \
+  --test baseline_key --test scan_baseline_cli --test receipt_cli \
+  --test history_cli --test cli_stabilization --test mcp_cli \
+  --test rules_reference_doc
+python3 scripts/release-contract.py check
+npm run test:release-contract
+```
+
+Expected: each command exits 0. A failure is a new ledger item, not permission
+to alter tests or bless fixtures in this audit slice.
+
+- [ ] **2. Inspect what the tests actually assert.**
+
+Current code parsing old fixture shapes proves current-reader backward input
+support. It does not prove a released 0.21/0.22 binary accepts future output.
+Keep the old-binary compatibility gap open until 0B provides that evidence.
+
+- [ ] **3. Check rule evidence without blessing.**
+
+```bash
+python3 scripts/zoo.py report
+python3 scripts/zoo.py scorecard
+```
+
+These summarize committed labels; do not call them fresh zoo measurements.
+Record absent local clones or unlabeled/strict false-positive debt explicitly.
+Do not use `--bless` or `--write` as a way to make a gate green.
+
+## Task 4 — Reconcile the Documentation Packet
+
+**Files:**
+- Update: `docs/engineering/v0.23-evidence-ledger.md`,
+  `docs/engineering/v0.23-phase-0-spec.md`,
+  `docs/engineering/v0.23-phase-0a-plan.md`, `docs/roadmap/v0.23.md`,
+  `docs/roadmap.md`, `docs/README.md`.
+
+**Interfaces:** consumes observations from Tasks 1–3; produces navigable,
+reviewable scope and an honest next repair sequence.
+
+- [ ] **1. Reconcile each ledger item with its closure criterion.**
+
+Do not close defects merely because their reproduction is now documented.
+Record missing RSS, public installs, fresh zoo rescans, prior-binary tests,
+and auth root-cause evidence as gaps. Keep global Phase 0 status open.
+
+- [ ] **2. Validate whitespace, links, and planning status.**
+
+```bash
+git diff --check
+python3 scripts/release-contract.py check
+```
+
+Check every relative Markdown link in the six changed documents resolves.
+Review the packet for contradictory verdict semantics, accidental version
+bumps, executable policy, implicit verification, and claims of implemented
+0.23 behavior. Verify that all 0B–0E repairs remain separate reviewed scopes.
+
+## Task 5 — Handoff Gate and Planning PR
+
+**Files:** inspect only the six documentation files above.
+
+**Interfaces:** consumes the reviewed packet; produces one docs-only PR to
+`main`, not a release and not a claim that all Phase 0 repairs are complete.
+
+- [ ] **1. Run the full handoff gate on the intended tree.**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+python3 scripts/release-contract.py check
+npm run test:release-contract
+cargo run -- scan . --fail-on-priority p1
+```
+
+Record failures honestly. A full gate is not a fresh benchmark, old-binary
+compatibility run, or public installation matrix.
+
+- [ ] **2. Review the docs-only diff and publish when authorized.**
+
+The current request authorizes committing/pushing this planning packet and a
+PR to `main`; it does not authorize tagging or publishing 0.23. Use explicit
+file paths for staging, the repository PR template, and no automatic merge.
+Check hosted PR state after dispatch and report pending checks as pending.
+
+- [ ] **3. Hand off the first repair scope.**
+
+Start with 0B schema/baseline compatibility or 0C release recovery after the
+corresponding detailed repair spec is reviewed. Keep Phase A ownership/verdict
+changes and Phase B semantic detectors outside those PRs.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,24 +4,32 @@ RepoPilot is a review-first, local CLI for maintainers and coding agents. The
 product should help answer: what changed, which boundaries moved, and how far
 the change reaches before merge.
 
-## Now: 0.22 — repository intelligence and local verification
+## Now: 0.23 — Change Proof
 
-RepoPilot 0.22 turns the existing `review` and `scan` workflows into two
-projections of one evidence-driven repository intelligence core:
+RepoPilot 0.23 turns the evidence-driven review core into one bounded proof of
+the change:
 
-- **fast change review** for developers and coding agents, using the Git diff
-  plus only the repository context needed to explain risk and blast radius;
-- **incremental repository health** for maintainers, covering architecture
-  drift, broken-code evidence, antipatterns, hotspots, and risk trends;
-- **explicit local verification** through repository-configured, allowlisted
-  checks whose results participate in the same canonical readiness decision;
-- **measured signal quality and performance**, with zoo-backed rule evidence,
-  deterministic cache behavior, and separate review/scan budgets.
+- **typed contract changes** explain what changed across public symbols,
+  dependencies, delivery workflows, runtime configuration, security boundaries,
+  and tests;
+- **consumer proof chains** connect each contract delta to resolved direct and
+  bounded transitive impact;
+- **one canonical ChangeProof** combines evidence, coverage, ownership,
+  verification, intent drift, limitations, gate behavior, and the next action;
+- **truth and release confidence** close known compatibility, quality,
+  documentation, performance, and publication gaps before release claims ship.
 
-The release deepens the existing commands and MCP tools. It does not restore
-removed diagnostic commands, add a hosted service, upload source, introduce
-telemetry, or put an implicit LLM inside RepoPilot. Details:
-[v0.22 roadmap and release contract](roadmap/v0.22.md).
+The release deepens the existing commands and MCP tools. It does not add a new
+top-level command, hosted service, source upload, telemetry, implicit LLM,
+autofix, or automatic repository command execution. Details:
+[v0.23 roadmap and release contract](roadmap/v0.23.md).
+
+## Shipped: 0.22
+
+Unified graph-backed repository intelligence, conservative broken import/export
+evidence, explicit allowlisted local verification, resolved baseline findings,
+truthful assessment output, and measured real-repository rule quality. Details:
+[v0.22 release contract](roadmap/v0.22.md).
 
 ## Shipped: 0.21
 

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -1,0 +1,425 @@
+# RepoPilot 0.23 — Change Proof
+
+Status: approved product direction; implementation has not started.
+
+RepoPilot 0.23 turns change review from a collection of findings and signals
+into one bounded proof of what changed, which contracts and consumers are
+affected, what verification established, and what remains unknown.
+
+Detailed implementation work requires a reviewed phase specification before
+code changes begin. This roadmap is the release-level product contract.
+
+Start with the [Phase 0 specification](../engineering/v0.23-phase-0-spec.md),
+the [0A evidence-baseline plan](../engineering/v0.23-phase-0a-plan.md), and the
+[release evidence ledger](../engineering/v0.23-evidence-ledger.md).
+
+## Problem Statement
+
+RepoPilot 0.22 established a strong local intelligence core: graph-backed
+impact, conservative broken import/export evidence, explicit repository-defined
+verification, compatible history, measured rule quality, and shared CLI/MCP/
+Action projections.
+
+The remaining problem is product truth. Users still have to combine findings,
+review signals, merge readiness, ownership, impact paths, verification plans,
+gates, profiles, and limitations themselves. Several individually correct
+records can produce a confusing overall experience:
+
+- a review can say `REVIEW`, show zero findings and zero verification plans,
+  then list several signals with manual verification steps;
+- missing ownership configuration can look like many actionable ownership gaps;
+- filename-only manifest and workflow signals identify a sensitive surface but
+  do not explain the semantic change;
+- a scan can show `PASS` and `100/100` while unsupported or excluded files and
+  hidden suggestions require separate interpretation;
+- a release can publish some channels successfully while the orchestration run
+  still fails, leaving the final public state to be reconstructed manually.
+
+RepoPilot must not imply more certainty than its evidence supports. It also
+must make the useful evidence understandable without requiring users to learn
+the internal analysis model.
+
+## Product Promise
+
+After `repopilot review`, a developer, maintainer, or coding agent can answer:
+
+1. Which externally meaningful contracts changed?
+2. Which local consumers and critical paths can be affected?
+3. What is proven broken, what needs review, and what was not assessed?
+4. Which explicit checks can satisfy the remaining proof obligations?
+5. Did the actual impact stay within the declared intent?
+6. What exact action should happen before merge?
+
+The primary output is one canonical `ChangeProof`. Existing findings, review
+signals, readiness records, ownership, verification, and history remain useful
+inputs and compatible public data, but no longer require a user to derive the
+top-level conclusion independently.
+
+## Visible Difference From 0.22
+
+| 0.22 | 0.23 |
+|---|---|
+| Reports risky files and changed-code signals | Reports typed contract changes and their meaning |
+| Shows blast radius and impact paths | Shows contract-to-consumer breakage chains |
+| Separates decision, readiness, gate, and verification details | Leads with one proof verdict and explicit gate/exit behavior |
+| Lists selected verification outcomes | Tracks proof obligations as satisfied, failed, unselected, or unavailable |
+| Treats sensitive manifest/workflow files primarily by path | Explains dependency, permission, trigger, source, or metadata deltas |
+| Reports configured or missing ownership as path results | Distinguishes configured gaps from ownership not assessed |
+| Provides console, Markdown, JSON, SARIF, MCP, and Action output | Adds a compact Proof Card and local HTML Change Map across the same core |
+| Reviews the observed diff | Compares observed impact with optional declared intent and critical paths |
+
+## Proof Verdict Contract
+
+The canonical proof verdict is one of:
+
+- `BROKEN` — deterministic supported evidence proves a broken contract;
+- `REVIEW` — evidence is sensitive or impactful, a configured policy is not
+  satisfied, a selected check failed, or required proof remains incomplete;
+- `VERIFIED` — a non-empty supported scope was assessed, no review-required
+  evidence remains, and every applicable required proof obligation succeeded
+  within the reported coverage, including explicitly requested local checks;
+- `NOT ASSESSED` — the requested scope could not be meaningfully assessed.
+
+`VERIFIED` never means universally safe. Every verdict carries analysis scope,
+capability coverage, limitations, workspace revision, and verification
+provenance. Passing checks never suppress static evidence.
+
+A check failure proves only that check's outcome on the recorded revision; it
+does not by itself prove a broken contract or that the diff caused the failure.
+An empty selection cannot satisfy required checks by omission. Without a
+declared sufficient proof policy, static-only review must not award `VERIFIED`.
+An unavailable optional capability is disclosed; an unavailable required
+capability prevents `VERIFIED`.
+
+Existing `ready` / `review` / `blocked` readiness values remain available
+during the 0.x compatibility window and are derived from the canonical proof
+rather than computed through a second decision path. Legacy readiness and
+existing gate/exit behavior remain policy-aware projections of the same
+evidence; there is no unconditional one-to-one mapping of proof labels to exit
+codes. The Phase A spec must pin the compatibility mapping with fixtures before
+any runtime verdict changes.
+
+## Release Principles
+
+- Remain local-only, deterministic, offline-capable, and free of source upload.
+- Keep `review`, `scan`, `snapshot`, `baseline`, `ai context`, and the six MCP
+  tools; add no top-level command.
+- Execute repository checks only when they are configured and explicitly
+  selected. Suggested verification is not implicit execution.
+- Prefer typed semantic evidence over filename or keyword inference.
+- Preserve uncertainty as coverage or limitations, never as invented facts.
+- Use one canonical proof record across CLI, JSON, Markdown, HTML, SARIF, MCP,
+  GitHub Action, and AI context.
+- Keep public schema changes additive and retain supported 0.x readers.
+- Improve signal quality before expanding the raw rule count.
+- Require real-repository evidence for user-facing quality claims.
+
+## Phase 0 — Truth Foundation and Bug Burn-down
+
+Close the known contradictions before new contract families affect verdicts.
+
+Deliverables:
+
+- reconcile the v0.22 release scorecard with the actual tagged and published
+  state, including npm, crates.io, GitHub Release, Homebrew, platform artifacts,
+  checksums, and provenance;
+- make release publication rerunnable and digest-aware so a partially
+  successful run can verify already-published artifacts and safely continue;
+- verify v0.21-to-v0.22 baseline identity and every supported report reader;
+- record fresh peak RSS for cold/warm review and scan scenarios;
+- reconcile architecture, MCP, command, and roadmap documentation with live
+  registries and implementation state;
+- inventory every open issue, failing or flaky test, known false positive,
+  recall gap, compatibility gap, stale scorecard item, and user-visible
+  contradiction in one tracked release ledger;
+- fix decision copy that overstates assessed scope or obscures gate/exit-code
+  behavior.
+
+Definition of done:
+
+- no known P0/P1 defect remains open;
+- every required Phase 0-owned lower-priority defect is fixed or explicitly
+  accepted with owner, rationale, and release impact; later-phase work stays
+  visible in the release ledger and is not a Phase 0 completion claim;
+- no release scorecard checkbox contradicts current public state;
+- all supported distribution channels install and report the same version;
+- documentation parity gates cover CLI commands, MCP tools, schemas, and
+  roadmap status in both directions.
+
+## Phase A — Canonical ChangeProof
+
+Build the shared proof record before adding new product projections.
+
+Deliverables:
+
+- one internal `ChangeProof` composed from contract deltas, findings, review
+  signals, impact, ownership, proof obligations, verification outcomes,
+  capability coverage, limitations, and compatible history;
+- one verdict derivation path with stable reason codes;
+- explicit gate status and expected process exit behavior separate from the
+  proof verdict;
+- a coverage ledger that records analyzed, excluded, unsupported, ambiguous,
+  and unavailable capabilities by relevant scope;
+- proof obligations shared by findings and review signals rather than separate
+  verification-plan models;
+- a three-state ownership interpretation: resolved, configured-but-unmatched,
+  and not configured/not assessed;
+- additive JSON and MCP projection with legacy readiness derived from the same
+  record.
+
+Definition of done:
+
+- console output has one top-level conclusion, not competing decision and
+  readiness conclusions;
+- every reason links to bounded evidence or an explicit limitation;
+- `VERIFIED` is impossible when an applicable required obligation is failed,
+  unavailable, unselected, stale, or outside supported coverage;
+- CLI, JSON, Markdown, SARIF, MCP, Action, and AI context agree on verdict,
+  reasons, coverage, and verification state;
+- existing consumers can ignore additive fields and retain their 0.22 behavior.
+
+## Phase B — Semantic Contract Map
+
+Replace broad surface flags with typed contract changes where local evidence
+can support them.
+
+Initial delivery slices:
+
+1. **Public symbol contracts** — extend the existing TypeScript/JavaScript
+   symbol facts from removed named exports to changed or removed public
+   definitions and resolved local consumers, preserving explicit unsupported
+   forms.
+2. **Dependency contracts** — classify manifest and lockfile changes as added,
+   removed, upgraded, downgraded, source-changed, feature-changed, or metadata-
+   only for initially supported Cargo and npm-family formats.
+3. **Delivery contracts** — identify meaningful workflow/action changes such as
+   trigger, permission, secret use, action-ref pinning, artifact, or deployment
+   behavior instead of treating every file edit identically.
+4. **Runtime configuration contracts** — track supported environment/config key
+   introduction, removal, and rename together with proven local consumers.
+5. **Security and test contracts** — connect changed authorization or request-
+   trust boundaries to impacted entrypoints and corresponding changed tests
+   without claiming coverage that static naming cannot prove.
+
+Each contract delta records:
+
+- stable contract identity and family;
+- before/after change kind;
+- source evidence and confidence;
+- resolved direct and bounded transitive consumers;
+- critical-path intersections;
+- required capabilities and limitations;
+- deterministic proof obligations and recommended allowlisted check roles.
+
+Definition of done:
+
+- default-visible contract claims have an unsafe fixture and a near-identical
+  safe guard;
+- full, changed, cold-cache, and warm-cache paths agree on identical evidence;
+- unsupported aliases, dynamic forms, generated code, or incomplete resolvers
+  become limitations, not broken-contract claims;
+- semantic manifest/workflow detectors distinguish metadata-only edits from
+  behaviorally meaningful changes;
+- promoted contract families have labeled zoo evidence and no known default-
+  visible false-positive debt.
+
+## Phase C — Intent Drift and Critical Paths
+
+Let users describe the expected boundary of a change without turning RepoPilot
+into a task tracker or accepting arbitrary executable policy.
+
+Deliverables:
+
+- an optional, bounded intent contract that declares expected path scopes,
+  contract families, critical areas, and allowlisted verification check IDs;
+- repository-configured critical paths for domains such as authentication,
+  billing, migrations, public API, deployment, or secrets;
+- deterministic intent drift when actual changed contracts, consumers, or
+  critical-path intersections exceed the declared scope;
+- proof reasons for expected impact, unexpected impact, and intent not supplied;
+- additive CLI/JSON/MCP inputs with root confinement and size limits.
+
+Intent is optional. Its absence is `not supplied`, not a finding and not a
+penalty. Free-form prose is preserved only as bounded display metadata and
+never interpreted by an LLM or executed.
+
+Definition of done:
+
+- identical intent plus identical workspace revision produces identical drift;
+- path traversal, absolute out-of-root paths, excessive input, and unknown
+  check IDs fail before analysis or process spawn;
+- a change inside declared paths can still surface contract breakage;
+- intent never suppresses findings, signals, or failed verification.
+
+## Phase D — Proof Experience
+
+Make the new model visible within the first screen and consistent everywhere.
+
+Deliverables:
+
+- a compact CLI Proof Card showing verdict, changed contracts, proven broken
+  consumers, impacted consumers, coverage, verification, intent drift, gate,
+  exit behavior, and one next action;
+- full detail that expands contract-to-consumer chains and proof obligations
+  without duplicating the summary conclusion;
+- a local, self-contained HTML Change Map with contract/consumer navigation,
+  before/after evidence, verification outcomes, and limitations;
+- a sticky GitHub Action Proof Card with bounded collapsible details and the
+  complete machine-readable artifact;
+- the same additive `change_proof` record in `repopilot_review_change`, stored
+  analyses, explain tools, and `repopilot_context`;
+- deterministic `init` detection that can propose stack-appropriate checks and
+  critical paths without running commands or overwriting existing config;
+- direct CLI guidance for explaining one retained contract or review signal
+  through existing `review`/`ai context` surfaces rather than a new command.
+
+Definition of done:
+
+- a first-time user can identify the verdict, strongest reason, coverage limit,
+  and next action from the first screen;
+- human and machine projections use identical reason codes and counts;
+- HTML remains local and self-contained with no remote scripts, fonts, or data;
+- compact output stays bounded for large diffs and links every omitted count to
+  an exact expansion command or artifact;
+- accessibility, no-color terminals, narrow terminals, and Windows paths have
+  dedicated fixtures.
+
+## Phase E — Quality, Compatibility, and Release Confidence
+
+Prove that Change Proof is trustworthy across repositories and versions.
+
+Deliverables:
+
+- a generated v0.23 release scorecard covering truth, contract quality,
+  coverage, latency, peak RSS, determinism, compatibility, and distribution;
+- previous-release fixtures for scan/review reports, baselines, receipts,
+  histories, Action outputs, and MCP additive readers;
+- property and fuzz coverage for path normalization, stable identities,
+  resolver inputs, report/config parsing, and corrupted caches;
+- parity matrices for full/changed, cold/warm, sequential/parallel, and every
+  public projection;
+- zoo expectations and recall anchors for each promoted contract family;
+- an idempotent release state check that verifies artifact version, checksum,
+  and public availability before reporting success.
+
+Definition of done:
+
+- zero known default-visible P0/P1 false positives;
+- zero unlabeled default-visible zoo findings and zero stale expectations;
+- no unexplained performance regression above 10% against an approved scenario;
+- peak RSS is recorded and stays within the approved v0.23 budget;
+- supported v0.21/v0.22 readers and baselines pass the compatibility matrix;
+- the final tag passes every platform build and install smoke test;
+- a failed release step can be rerun without corrupting or contradicting an
+  already-published channel;
+- every release claim points to a fixture, benchmark, zoo label, compatibility
+  test, or public artifact.
+
+## Bug Closure Contract
+
+“All bugs closed” means all *known* release-relevant defects are accounted for,
+not that unknown defects cannot exist.
+
+Before 0.23.0 is tagged:
+
+- every open GitHub issue is triaged for the milestone or explicitly deferred;
+- no known P0/P1 defect is open or accepted;
+- every known false positive and false negative has a regression fixture or a
+  documented capability limitation;
+- flaky tests are fixed, quarantined with a tracked owner and deadline, or block
+  the release; silent retries do not count as a fix;
+- every unchecked release-scorecard item has evidence or blocks the release;
+- self-review and self-scan have no unexplained blocking evidence.
+
+After the tag triggers publication, public-channel verification must pass before
+declaring release completion. This post-publication result is not a pre-tag
+prerequisite and cannot be substituted with a dry run.
+
+## Performance and Security Contract
+
+- `review` remains the latency-sensitive path and computes only required
+  contract facts and repository context.
+- Contract facts are content-addressed and reused across eligible consumers.
+- Graph and consumer chains are built once per compatible analysis session.
+- Stage timings separate diff, parse, facts, contracts, graph, proof, and
+  rendering.
+- Peak RSS is measured for cold and warm review/scan matrices before setting the
+  final hard ceiling.
+- Results remain deterministic across supported thread counts.
+- Intent, config, cache, baseline, and MCP paths remain root-confined.
+- Verification remains explicit, allowlisted, bounded, cancellable, redacted,
+  revision-aware, and incapable of accepting shell text from CLI/MCP inputs.
+- HTML and report rendering escape repository-controlled content.
+
+## Compatibility Contract
+
+- No top-level CLI command is added or removed.
+- Existing flags retain their meaning; new inputs are additive.
+- Existing finding IDs and occurrence identity remain stable unless a reviewed
+  correctness migration provides explicit compatibility handling.
+- Legacy readiness remains derived and serialized during the 0.x window.
+- Scan/review JSON, SARIF, baseline, receipt, history, Action outputs, and MCP
+  schemas evolve additively with previous-version fixtures.
+- Cache schema changes fail closed to recomputation and never reinterpret old
+  bytes as richer proof.
+
+## Non-Goals
+
+RepoPilot 0.23 does not add:
+
+- hosted storage, telemetry, source upload, or a remote dashboard;
+- an embedded or implicit LLM reviewer;
+- automatic source modification or autofix;
+- implicit repository command execution;
+- arbitrary shell commands or executable intent policy;
+- a new top-level command or plugin runtime;
+- compiler-equivalence claims, unrestricted interprocedural taint, or generic
+  whole-program type checking;
+- broad new language frontends without pinned fixture and zoo evidence;
+- contract families whose correctness depends on guessing unsupported runtime
+  behavior.
+
+## Release Gates
+
+Every implementation slice uses focused tests plus its phase-specific parity
+fixtures. The final release gate includes the existing full handoff and release
+checks:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+npm run release:contract
+npm run test:release-contract
+npm run review:performance
+npm run scan:performance
+cargo run -- scan . --fail-on-priority p1
+./scripts/smoke-product.sh
+./scripts/verify-release.sh
+```
+
+The v0.23 gate additionally requires the compatibility matrix, ChangeProof
+projection parity, contract-fixture matrix, fresh zoo report and scorecard,
+peak-RSS budget, intent security fixtures, local HTML safety/accessibility
+checks, and post-publication channel verification.
+
+## Implementation Order
+
+Work proceeds through independently reviewable phase specifications:
+
+1. Phase 0 closes current truth, compatibility, documentation, and release
+   reliability gaps.
+2. Phase A establishes the canonical proof and coverage model without new
+   contract claims.
+3. Phase B ships one contract family at a time, starting with the strongest
+   existing symbol and resolver foundations.
+4. Phase C adds optional intent and critical-path policy after contract identity
+   is stable.
+5. Phase D exposes the canonical model through existing product surfaces and
+   the local HTML Change Map.
+6. Phase E establishes quality evidence, compatibility, performance, and tested
+   publication recovery before the version cut. It closes release delivery only
+   after post-tag publication and public-channel verification succeed.
+
+No phase may create a second verdict engine, a projection-specific semantic
+model, or a public claim that exceeds its measured evidence.


### PR DESCRIPTION
## Summary

Establish the approved v0.23 Change Proof product direction and the reviewed planning packet for starting Phase 0. Documentation only: this does not ship ChangeProof, complete Phase 0, or publish version 0.23.

## Type of change

- [x] Documentation

## What changed

- Add the v0.23 release roadmap: Truth Foundation, canonical ChangeProof, semantic contract/consumer evidence, optional Intent Drift, Proof Card/HTML experience, compatibility, quality, and release gates.
- Add a Phase 0 spec, a concrete 0A evidence-baseline execution plan, and a revision-stamped ledger with 12 still-open defects, evidence gaps,  limitations, and design risks.
- Move v0.22 to Shipped in the roadmap index and link the planning packet from the documentation index.
- Clarify truth constraints: check failures do not automatically prove contract breakage; empty verification selection cannot earn VERIFIED; pre-tag readiness is separate from post-publication release completion.

## Why

0.23 should make a visible, evidence-backed difference to users, not just add rules. The first step is a precise record of current behavior, unresolved compatibility questions, and recoverable publication requirements before new runtime claims are introduced.

The ledger distinguishes a failed original v0.22 Release workflow from a successful separate npm recovery run. npm/Homebrew metadata is not labeled as an install test; a crates.io API 403 stays unverified. No listed issue is closed merely by documenting it.

## Contract and ownership

- [x] The change stays within a clear subsystem or ownership boundary: release planning documentation
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility were considered
- [x] No unrelated refactor or generated-file churn is included
- No Rust/JavaScript/Python runtime, workflow, version, registry, or tag changes.
- No new findings/signals or claimed noise reduction; detector-specific checks are not applicable to this documentation PR.
- Roadmap direction is approved. Phase 0 spec and 0A plan are drafts for review, with later repairs explicitly scoped to their own implementation specs/PRs.

## Verification

```bash
git diff --check
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
npm run test:release-contract
cargo run -- scan . --fail-on-priority p1
```