### PR TITLE
fix: make report schema docs match v0.22 emitters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the reports guide and v0.22 release notes to match the emitted
+  scan, baseline-scan, and review schema `0.26`. Added CLI-backed checks for
+  documented JSON envelopes, clarified the current scan-reader schema range,
+  and separated it from unverified old-reader compatibility. No runtime format
+  or package version changed.
+
 ## [0.22.0] - 2026-08-28
 
 RepoPilot 0.22 unifies the graph core behind every projection, adds

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -20,12 +20,12 @@ Release: [v0.23 roadmap](../roadmap/v0.23.md).
 Priorities below are release-triage estimates, not RepoPilot-emitted finding
 priorities. Owners are subsystems; no person is implicitly assigned.
 
-## Open Items
+## Tracked Items
 
 | ID | Priority / kind | Status | Owner / slice | Observation and closure requirement |
 |---|---|---|---|---|
 | RP23-001 | P1 defect | open | Distribution / 0C | Original Release run failed in npm publication; separate manual Publish npm succeeded, while the original public-channel verifier stayed skipped. Close with tested recovery, exact-version identity checks, and a complete per-channel verification result. |
-| RP23-002 | P2 defect | open | Report docs / 0B–0D | `docs/releases/v0.22.0.md` says scan `0.24` and review `0.25`; emitters share `SCAN_REPORT_SCHEMA_VERSION = "0.26"`. Close with emitted-artifact parity, corrected documentation, and a regression guard. |
+| RP23-002 | P2 defect | verified | Report docs / 0B1 | Original release notes said scan `0.24` and review `0.25`; emitters share `0.26`. Corrected the notes and reports guide; CLI-backed envelope regression tests pass. See the 0B1 evidence below. |
 | RP23-003 | P1 evidence-gap | open | Compatibility / 0B | v0.22 scorecard leaves prior baselines/readers unverified. Existing current-reader tests alone cannot close all compatibility directions. Close with a supported-direction matrix and version-provenanced fixtures or pinned binaries. |
 | RP23-004 | P2 evidence-gap | open | Performance / 0E | v0.22 scorecard lacks fresh peak RSS. Close with reproducible cold/warm measurements, units, source identity, and an approved ceiling; do not infer memory from latency. |
 | RP23-005 | P2 defect | open | Documentation / 0D | Historical scorecard still describes an uncut tag, while the release is published. Platform state prose also retains already-completed migration work as missing. Close by distinguishing original audit state from subsequent evidence and checking current claims against code. |
@@ -39,6 +39,33 @@ priorities. Owners are subsystems; no person is implicitly assigned.
 
 No item is marked verified solely by being listed here. Phase A/B/E items remain
 visible release work but are not silently folded into Phase 0 implementation.
+
+## 0B1 — Schema Truth Evidence (2026-08-31)
+
+- Source: `feat/v0.23-schema-truth`, based on
+  `51f44f2d2f098f7af7a2fef87d634481c66dfbd4`; no runtime source or version changes.
+- Historical source check: `git show v0.22.0:src/report/schema.rs` confirms the
+  shared `0.26` constant and scan/baseline-scan/review envelopes. This is tagged
+  source inspection, not execution of a downloaded v0.22 binary.
+- Red: all three `report_schema_docs_cli` tests failed before the documentation
+  repair. Scan and baseline examples said `0.24` while the CLI emitted `0.26`;
+  the review envelope excerpt was missing.
+- Green: `cargo test --test report_schema_docs_cli --test report_schema_contract
+  --test scan_baseline_cli --test receipt_cli` passed all 23 tests. Three new
+  tests create temporary Git repositories and execute the actual CLI,
+  including baseline creation and a nonempty changed-file review. They compare
+  the guide's parsed JSON metadata with top-level and nested emitted envelopes.
+- A fourth new test guards the release note's report schemas and scan-reader
+  range against frozen declarations from the tagged source (including receipt
+  schema `6` from `src/receipt/model.rs`). It failed with missing declarations;
+  changing the corrected scan declaration back to `0.24` also failed. Its
+  expectations deliberately do not follow the current emitter after a future
+  schema bump. This is historical declaration coverage, not a binary replay.
+- Corrected release notes and reader-range documentation. The guide's JSON
+  blocks are explicitly partial output excerpts, not historical input fixtures.
+- Scope limit: RP23-002 is closed; RP23-003 stays open. Current-reader fixture
+  tests, schema parity, and tagged source inspection do not establish old-reader
+  forward compatibility, baseline migration safety, or a completed Phase 0.
 
 ## Release Observation Sources
 
@@ -106,5 +133,6 @@ close the items above. Before Phase 0 closes, retain separate evidence for:
 - release recovery under mismatched artifacts and auth/service failures;
 - runtime regression tests for each corrected user-visible claim.
 
-Next implementation scope: detailed 0B compatibility/schema-truth repair spec,
-followed by 0C publication recovery. No 0.23 version bump is needed to start.
+Next implementation scope: remaining 0B compatibility matrix and historical
+reader/baseline evidence, followed by 0C publication recovery. No 0.23 version
+bump is needed to start.

--- a/docs/engineering/v0.23-phase-0-spec.md
+++ b/docs/engineering/v0.23-phase-0-spec.md
@@ -101,6 +101,36 @@ Acceptance: a reviewed matrix identifies each supported direction and contains
 fixture or pinned-binary evidence; unsupported directions are limitations with
 documented behavior, not implied compatibility.
 
+#### 0B1 — Schema Truth (PR 1)
+
+Status: in-progress; bounded implementation approved on 2026-08-31.
+
+Owns RP23-002 only: the current reports guide and v0.22 release notes disagree
+with the shared scan, baseline-scan, and review JSON emitters. The package
+version and report schema version are independent contracts.
+
+- Correct the guide's JSON excerpts, schema history, and current scan-reader
+  range; correct the historical v0.22 release notes against the tagged source.
+- Guard the release note's schema declarations separately with the frozen
+  v0.22.0 source contract, so future schema changes do not rewrite history.
+- Exercise the real CLI on a temporary Git repository for scan, baseline-scan,
+  and a nonempty review. Compare top-level and nested envelope metadata with
+  the documented JSON excerpts; do not test only the schema constant.
+- Keep examples explicitly partial, distinguish baseline snapshot schema from
+  baseline-scan report schema, and avoid old-reader compatibility claims.
+- Preserve runtime behavior, package/schema versions, gate policy, and all
+  historical fixtures. No publication, old-binary matrix, or Phase A work.
+
+Execution / acceptance:
+
+- [x] Run the existing `report_schema_contract` tests as a clean baseline.
+- [x] Add `tests/report_schema_docs_cli.rs`; observe stale examples fail against
+  emitted artifacts before correcting the docs.
+- [x] Correct documentation and add a review-envelope excerpt; rerun the new
+  tests and existing schema/baseline/receipt coverage.
+- [ ] Update the changelog and ledger with precise closure evidence, run the
+  handoff gate, and open one focused PR. RP23-003 remains open.
+
 ### 0C — Recoverable Publication
 
 Owns release workflows, publication helpers, and distribution checks.

--- a/docs/releases/v0.22.0.md
+++ b/docs/releases/v0.22.0.md
@@ -13,7 +13,26 @@ description: RepoPilot 0.22 catches broken imports and exports no compiler is ru
 
 ## Compatibility
 
-RepoPilot 0.22 adds no top-level command. Review report schema advances to `0.25` (`0.24` still accepted); scan report schema advances to `0.24` (`0.23` still accepted); the audit receipt schema advances to `6`. The public `ReviewSignal` struct gains an additive `target_path` field — JSON stays backward compatible, but Rust consumers constructing it with a struct literal need to add the field (normally `None`).
+RepoPilot 0.22 adds no top-level command. The following schema declarations
+describe the tagged `v0.22.0` source, not future releases. The scan-reader input
+range is inclusive.
+
+| JSON surface | Schema version(s) |
+|---|---|
+| `scan` | `0.26` |
+| `baseline-scan` | `0.26` |
+| `review` | `0.26` |
+| `receipt` | `6` |
+| `scan-reader input` | `0.16–0.26` |
+
+Accepting older scan schemas does not prove that older released readers accept
+new output. Baseline snapshot files have a separate schema from baseline-scan
+reports. See [reports and schemas](../reports.md) for the current contract.
+
+The public `ReviewSignal` struct gains an additive `target_path` field. JSON
+consumers must tolerate unknown fields and accept the report's schema version;
+Rust consumers constructing it with a struct literal need to add the field
+(normally `None`).
 
 Explicit local verification is off by default: RepoPilot never runs a repository-declared check unless it is both configured and explicitly selected by `--verify`/the MCP `verify` parameter, and it never accepts arbitrary shell text. Static analysis remains fully usable when verification is disabled or unavailable.
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -11,19 +11,22 @@ repopilot scan . --format json --output repopilot-report.json
 
 ## JSON report schema
 
-JSON scan reports include explicit schema metadata. The current schema is 0.24:
+JSON scan, baseline-scan, and review reports share schema `0.26`. This is
+independent of the RepoPilot package version. The examples below are partial
+output excerpts, not complete input fixtures for a report reader.
 
 ```json
 {
-  "schema_version": "0.24",
+  "schema_version": "0.26",
   "repopilot_version": "0.22.0",
   "report": {
     "kind": "scan",
-    "schema_version": "0.24",
+    "schema_version": "0.26",
     "repopilot_version": "0.22.0"
   },
   "root_path": ".",
   "files_analyzed": 42,
+  "assessment_status": "assessed",
   "directories_count": 12,
   "non_empty_lines": 3200,
   "languages": [],
@@ -79,6 +82,7 @@ JSON scan reports include explicit schema metadata. The current schema is 0.24:
 | `schema_version` | string | RepoPilot JSON report schema version. |
 | `repopilot_version` | string | RepoPilot binary version that produced the report. |
 | `report` | object | Versioned report envelope for consumers that prefer metadata under one stable object. |
+| `assessment_status` | string | Scan and baseline-scan scope: `assessed` when at least one file was analyzed, otherwise `not_assessed`. This is not a safety verdict; review carries its assessment in `merge_readiness`. |
 | `risk_summary` | object | Aggregate priority counts and average risk score derived from finding risk assessments. |
 | `health_score` | number | Visible health after the selected profile and explicit filters; retained for compatibility. |
 | `maintainability_score` | number | Stable score for findings hidden by the default visibility policy, computed before explicit filters. |
@@ -103,7 +107,7 @@ requested report/receipt and then exits with RepoPilot runtime code `3`.
 may fix bugs without changing the report schema, while future minor releases can
 evolve the schema in a documented way.
 
-Binary `0.21.x` emits schema `0.24`.
+Binary `0.22.0` emits schema `0.26` for scan, baseline-scan, and review.
 Schema numbers are monotonic contract revisions, not predictions of the next
 RepoPilot package version.
 
@@ -137,6 +141,10 @@ findings. Schema `0.21` adds occurrence identity and canonical decision records;
 schema `0.22` adds bounded dependency impact paths; schema `0.23` adds
 deterministic verification plans for review signals; schema `0.24` adds the
 stable `maintainability_score` alongside the compatible visible `health_score`.
+Schema `0.25` adds explicit local verification outcomes to review. Schema `0.26`
+adds `assessment_status` to scan and baseline-scan. Review also uses `0.26`
+because all three DTOs share the schema version; it does not gain that top-level
+field.
 
 Migration from pre-`0.13` reports is intentionally consumer-owned:
 
@@ -146,9 +154,14 @@ Migration from pre-`0.13` reports is intentionally consumer-owned:
 | `lines_of_code` | `non_empty_lines` |
 | `skipped_files_count` | `large_files_skipped` |
 
-The current reader accepts `0.16`, `0.17`, `0.18`, `0.19`, `0.20`, `0.21`,
-`0.22`, `0.23`, and current `0.24` scan reports during the transition. Baseline files follow their separate baseline
-schema policy.
+The current scan-report reader accepts `0.16`, `0.17`, `0.18`, `0.19`, `0.20`,
+`0.21`, `0.22`, `0.23`, `0.24`, `0.25`, and current `0.26` scan reports. Older
+versions (including `0.15`) and unknown schema versions are rejected.
+This is current-reader ingestion of older scan output, not evidence that older
+released readers accept new output or that review reports are scan-reader input.
+Consumers that reject unknown schema versions may need an update even for
+additive fields. Baseline snapshot files follow their separate baseline schema
+policy; they are not baseline-scan output reports.
 
 ## Baseline JSON reports
 
@@ -166,15 +179,16 @@ Example shape:
 
 ```json
 {
-  "schema_version": "0.24",
+  "schema_version": "0.26",
   "repopilot_version": "0.22.0",
   "report": {
     "kind": "baseline-scan",
-    "schema_version": "0.24",
+    "schema_version": "0.26",
     "repopilot_version": "0.22.0"
   },
   "root_path": ".",
   "files_analyzed": 42,
+  "assessment_status": "assessed",
   "risk_summary": {
     "total": 12,
     "counts": { "p0": 0, "p1": 2, "p2": 5, "p3": 5 },
@@ -208,6 +222,20 @@ the source location that produced it may no longer exist to re-derive one
 from.
 
 ## Review JSON reports
+
+Envelope excerpt (the remaining review fields are omitted here):
+
+```json
+{
+  "schema_version": "0.26",
+  "repopilot_version": "0.22.0",
+  "report": {
+    "kind": "review",
+    "schema_version": "0.26",
+    "repopilot_version": "0.22.0"
+  }
+}
+```
 
 `repopilot review --format json` uses the same envelope policy with
 `report.kind = "review"`. Review reports include scan scope, changed files,

--- a/tests/report_schema_docs_cli.rs
+++ b/tests/report_schema_docs_cli.rs
@@ -1,0 +1,177 @@
+use repopilot::report::schema::SCAN_REPORT_SCHEMA_VERSION;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+const REPORTS_GUIDE: &str = include_str!("../docs/reports.md");
+
+#[test]
+fn release_022_schema_table_preserves_the_tagged_contract() {
+    // Frozen source contract from v0.22.0 (a000dc7cf189798b814672673076cf9179b1a267),
+    // src/report/schema.rs and src/receipt/model.rs. Do not use the current schema
+    // constant here: future revisions must not rewrite a shipped release's docs.
+    // This guards historical declarations, not old-binary compatibility.
+    let notes = include_str!("../docs/releases/v0.22.0.md");
+    let rows: Vec<_> = notes
+        .lines()
+        .filter(|line| line.starts_with("| `"))
+        .map(|line| {
+            let cells: Vec<_> = line.split('|').map(str::trim).collect();
+            assert_eq!(cells.len(), 4, "expected artifact/schema table row");
+            (cells[1].trim_matches('`'), cells[2].trim_matches('`'))
+        })
+        .collect();
+    assert_eq!(
+        rows.len(),
+        5,
+        "one declaration per v0.22 report/reader surface"
+    );
+    assert_eq!(
+        rows.into_iter().collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([
+            ("scan", "0.26"),
+            ("baseline-scan", "0.26"),
+            ("review", "0.26"),
+            ("receipt", "6"),
+            ("scan-reader input", "0.16–0.26"),
+        ]),
+        "release declarations must preserve the v0.22.0 tagged source contract"
+    );
+}
+
+fn run_ok(program: &str, args: &[&str], root: &Path) -> Output {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run command");
+    assert!(
+        output.status.success(),
+        "{program} {args:?} failed: {}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn cli(args: &[&str], root: &Path) -> Output {
+    run_ok(env!("CARGO_BIN_EXE_repopilot"), args, root)
+}
+
+fn repository() -> tempfile::TempDir {
+    let repo = tempfile::tempdir().expect("temporary repository");
+    fs::write(repo.path().join("main.py"), "print('before')\n").unwrap();
+    run_ok("git", &["init", "-q"], repo.path());
+    run_ok("git", &["add", "main.py"], repo.path());
+    run_ok(
+        "git",
+        &[
+            "-c",
+            "user.name=Schema Test",
+            "-c",
+            "user.email=schema@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "commit",
+            "-qm",
+            "initial source",
+        ],
+        repo.path(),
+    );
+    repo
+}
+
+fn documented_report(kind: &str) -> Value {
+    let examples: Vec<Value> = REPORTS_GUIDE
+        .split("```json\n")
+        .skip(1)
+        .map(|block| {
+            serde_json::from_str(block.split("```").next().unwrap())
+                .expect("reports guide JSON example must parse")
+        })
+        .filter(|value: &Value| value["report"]["kind"] == kind)
+        .collect();
+    assert_eq!(examples.len(), 1, "expected one {kind} envelope example");
+    examples.into_iter().next().unwrap()
+}
+
+fn assert_documented_envelope(output: Output, kind: &str) -> Value {
+    let emitted: Value = serde_json::from_slice(&output.stdout).expect("CLI JSON report");
+    assert_eq!(emitted["report"]["kind"], kind);
+    assert_eq!(emitted["schema_version"], SCAN_REPORT_SCHEMA_VERSION);
+    assert_eq!(
+        emitted["report"]["schema_version"],
+        emitted["schema_version"]
+    );
+    assert_eq!(emitted["repopilot_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(
+        emitted["report"]["repopilot_version"],
+        emitted["repopilot_version"]
+    );
+
+    let documented = documented_report(kind);
+    for key in ["schema_version", "repopilot_version", "report"] {
+        assert_eq!(
+            documented[key], emitted[key],
+            "docs/reports.md {kind}.{key} must match emitted CLI metadata"
+        );
+    }
+    emitted
+}
+
+#[test]
+fn scan_envelope_matches_documented_json() {
+    let repo = repository();
+    let report =
+        assert_documented_envelope(cli(&["scan", ".", "--format", "json"], repo.path()), "scan");
+    assert_eq!(report["files_analyzed"], 1);
+    assert_eq!(report["assessment_status"], "assessed");
+}
+
+#[test]
+fn baseline_scan_envelope_matches_documented_json() {
+    let repo = repository();
+    cli(
+        &[
+            "baseline",
+            "create",
+            ".",
+            "--output",
+            ".repopilot/baseline.json",
+        ],
+        repo.path(),
+    );
+    let report = assert_documented_envelope(
+        cli(
+            &[
+                "scan",
+                ".",
+                "--baseline",
+                ".repopilot/baseline.json",
+                "--format",
+                "json",
+            ],
+            repo.path(),
+        ),
+        "baseline-scan",
+    );
+    assert_eq!(report["files_analyzed"], 1);
+    assert_eq!(report["assessment_status"], "assessed");
+    assert!(report["baseline"].is_object());
+}
+
+#[test]
+fn nonempty_review_envelope_matches_documented_json() {
+    let repo = repository();
+    fs::write(repo.path().join("main.py"), "print('after')\n").unwrap();
+    let report = assert_documented_envelope(
+        cli(&["review", ".", "--format", "json"], repo.path()),
+        "review",
+    );
+    assert_eq!(report["files_analyzed"], 1);
+    assert_eq!(report["changed_files"].as_array().unwrap().len(), 1);
+}


### PR DESCRIPTION
## Summary

Implement v0.23: make the documented report schema match emitted JSON and guard the current guide and historical v0.22 release declarations.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## What changed

- Correct scan, baseline-scan, and review schema declarations to `0.26`; clarify package vs. schema versions and the current scan-reader input range.
- Add three real-CLI tests comparing top-level/nested emitted metadata with parsed JSON guide excerpts, including baseline creation and a nonempty review.
- Add a frozen v0.22.0 schema-table guard, anchored to tagged source rather than future schema constants. Audit receipt schema remains separately `6`.

## Why

The reports guide said `0.24` and the release notes said scan `0.24` / review `0.25`, while v0.22.0 and current emitters share `0.26`. Consumers need accurate metadata, and current-reader tests must not be presented as old-binary evidence.

## Contract and ownership

- [x] Clear report-documentation/test ownership boundary
- [x] CLI, JSON, SARIF, baseline, Action, and MCP compatibility considered:
  no runtime source, output format, gate, package version, or schema change
- [x] No unrelated refactor or generated-file churn
- No detector/noise changes, registry publication, release-note API update, or
  old-binary compatibility matrix are included.


## Verification

```text
cargo fmt --all -- --check                                      PASS
cargo clippy --all-targets --all-features -- -D warnings       PASS
cargo test --all                                                PASS (1,639/1,639)
python3 scripts/release-contract.py check                       PASS
npm run test:release-contract                                   PASS (58/58)
cargo run -- scan . --fail-on-priority p1                       PASS (P0=0, P1=0)
```
