### PR TITLE
fix: make release publication recoverable

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
@@ -47,7 +49,9 @@ jobs:
           if [[ -z "$TAG" ]]; then
             TAG="v$(node -p 'require("./package.json").version')"
           fi
+          VERSION_NUMBER="${TAG#v}"
           echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
+          echo "VERSION_NUMBER=$VERSION_NUMBER" >> "$GITHUB_ENV"
 
       - name: Verify package version matches release tag
         run: |
@@ -97,10 +101,96 @@ jobs:
       - name: Publish platform packages to npm
         run: |
           set -euo pipefail
+          ROOT_DIR="$GITHUB_WORKSPACE"
+          publish_if_needed() {
+            local package_dir="$1"
+            local package_name local_integrity metadata error_file state_json state
+            package_name="$(node -p 'require(process.argv[1]).name' "$package_dir/package.json")"
+            local_integrity="$(cd "$package_dir" && npm pack --dry-run --json | node -e 'let data=""; process.stdin.on("data", chunk => data += chunk).on("end", () => process.stdout.write(JSON.parse(data)[0].integrity || ""))')"
+            error_file="$(mktemp)"
+            if metadata="$(npm view "${package_name}@${VERSION_NUMBER}" version dist.integrity --json 2>"$error_file")"; then
+              state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER" --observed-version "$(jq -r 'if type == "string" then . else .version end' <<<"$metadata")" --expected-digest "$local_integrity" --observed-digest "$(jq -r 'if type == "string" then "" else .["dist.integrity"] // "" end' <<<"$metadata")")"
+            elif grep -Eq 'E401|E403|401 Unauthorized|403 Forbidden' "$error_file"; then
+              state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER" --error-kind auth)"
+            elif grep -Eq 'E404|404 Not Found|code E404' "$error_file"; then
+              state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER")"
+            elif grep -Eiq 'E429|429 Too Many Requests|rate limit' "$error_file"; then
+              state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER" --error-kind rate-limit)"
+            elif grep -Eq 'E5[0-9]{2}|5[0-9]{2} (Internal|Bad|Service|Gateway)' "$error_file"; then
+              state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER" --error-kind service)"
+            else
+              state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER" --error-kind network)"
+            fi
+            rm -f "$error_file"
+            state="$(jq -r '.state' <<<"$state_json")"
+            echo "$state_json"
+            case "$state" in
+              published-matching)
+                echo "Skipping $package_name@$VERSION_NUMBER: immutable identity matches."
+                ;;
+              absent)
+                echo "Publishing $package_name@$VERSION_NUMBER: package is absent."
+                npm publish "$package_dir" --access public
+                ;;
+              published-mismatch)
+                echo "::error::published-mismatch for $package_name@$VERSION_NUMBER; refusing to overwrite an immutable package"
+                return 1
+                ;;
+              auth-failure|network-failure|rate-limit-failure|service-failure)
+                echo "::error::$state while checking $package_name@$VERSION_NUMBER; rerun recovery after the service recovers"
+                return 1
+                ;;
+              *)
+                echo "::error::unknown publication state $state for $package_name"
+                return 1
+                ;;
+            esac
+          }
           node -e 'const fs=require("node:fs"); const packages=JSON.parse(fs.readFileSync("dist/npm-platform-packages.json","utf8")); for (const pkg of packages) console.log(pkg.directory);' |
           while IFS= read -r package_dir; do
-            npm publish "$package_dir" --access public
+            publish_if_needed "$package_dir"
           done
 
       - name: Publish root package to npm
-        run: npm publish
+        run: |
+          set -euo pipefail
+          ROOT_DIR="$GITHUB_WORKSPACE"
+          package_name="$(node -p 'require("./package.json").name')"
+          local_integrity="$(npm pack --dry-run --json | node -e 'let data=""; process.stdin.on("data", chunk => data += chunk).on("end", () => process.stdout.write(JSON.parse(data)[0].integrity || ""))')"
+          error_file="$(mktemp)"
+          if metadata="$(npm view "${package_name}@${VERSION_NUMBER}" version dist.integrity --json 2>"$error_file")"; then
+            state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER" --observed-version "$(jq -r 'if type == "string" then . else .version end' <<<"$metadata")" --expected-digest "$local_integrity" --observed-digest "$(jq -r 'if type == "string" then "" else .["dist.integrity"] // "" end' <<<"$metadata")")"
+          elif grep -Eq 'E401|E403|401 Unauthorized|403 Forbidden' "$error_file"; then
+            state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER" --error-kind auth)"
+          elif grep -Eq 'E404|404 Not Found|code E404' "$error_file"; then
+            state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER")"
+          elif grep -Eiq 'E429|429 Too Many Requests|rate limit' "$error_file"; then
+            state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER" --error-kind rate-limit)"
+          elif grep -Eq 'E5[0-9]{2}|5[0-9]{2} (Internal|Bad|Service|Gateway)' "$error_file"; then
+            state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER" --error-kind service)"
+          else
+            state_json="$(python3 "$ROOT_DIR/scripts/publication_state.py" classify --channel "$package_name" --expected-version "$VERSION_NUMBER" --error-kind network)"
+          fi
+          rm -f "$error_file"
+          state="$(jq -r '.state' <<<"$state_json")"
+          echo "$state_json"
+          case "$state" in
+            published-matching)
+              echo "Skipping $package_name@$VERSION_NUMBER: immutable identity matches."
+              ;;
+            absent)
+              npm publish --access public
+              ;;
+            published-mismatch)
+              echo "::error::published-mismatch for $package_name@$VERSION_NUMBER; refusing to overwrite an immutable package"
+              exit 1
+              ;;
+            auth-failure|network-failure|rate-limit-failure|service-failure)
+              echo "::error::$state while checking $package_name@$VERSION_NUMBER; rerun recovery after the service recovers"
+              exit 1
+              ;;
+            *)
+              echo "::error::unknown publication state $state for $package_name"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,8 +216,45 @@ jobs:
         with:
           toolchain: ${{ env.RUST_STABLE }}
 
-      - name: Publish
-        run: cargo publish
+      - name: Publish or verify crates.io package
+        run: |
+          set -euo pipefail
+          VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          CRATE_PATH="target/package/repopilot-${VERSION}.crate"
+          cargo package --allow-dirty --no-verify
+          LOCAL_CHECKSUM="$(sha256sum "$CRATE_PATH" | awk '{print $1}')"
+          metadata_file="$(mktemp)"
+          if ! status="$(curl -sS -o "$metadata_file" -w '%{http_code}' "https://crates.io/api/v1/crates/repopilot/${VERSION}")"; then
+            echo "::error::network-failure while checking crates.io repopilot@${VERSION}"
+            exit 1
+          fi
+          case "$status" in
+            200)
+              REMOTE_CHECKSUM="$(jq -r '.version.checksum // empty' "$metadata_file")"
+              if [[ -z "$REMOTE_CHECKSUM" || "$REMOTE_CHECKSUM" != "$LOCAL_CHECKSUM" ]]; then
+                echo "::error::published-mismatch for crates.io repopilot@${VERSION}; refusing to overwrite an immutable package"
+                exit 1
+              fi
+              echo "Skipping crates.io repopilot@${VERSION}: version.checksum matches."
+              ;;
+            404)
+              echo "Publishing crates.io repopilot@${VERSION}: package is absent."
+              cargo publish
+              ;;
+            401|403)
+              echo "::error::auth-failure while checking crates.io repopilot@${VERSION}"
+              exit 1
+              ;;
+            429)
+              echo "::error::rate-limit-failure while checking crates.io repopilot@${VERSION}"
+              exit 1
+              ;;
+            *)
+              echo "::error::service-failure while checking crates.io repopilot@${VERSION} (HTTP ${status})"
+              exit 1
+              ;;
+          esac
+          rm -f "$metadata_file"
 
   publish-npm:
     name: Publish npm packages
@@ -295,9 +332,20 @@ jobs:
       - publish-crates
       - publish-npm
       - update-homebrew-tap
+    if: ${{ always() }}
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 24
+
       - name: Verify GitHub, crates.io, npm, and Homebrew
         env:
           GH_TOKEN: ${{ github.token }}
@@ -305,37 +353,131 @@ jobs:
         run: |
           set -euo pipefail
           VERSION_NUMBER="${VERSION#v}"
+          echo "Upstream results: crates=${{ needs.publish-crates.result }}, npm=${{ needs.publish-npm.result }}, homebrew=${{ needs.update-homebrew-tap.result }}"
+          verify_tmp="$(mktemp -d)"
+          trap 'rm -rf "$verify_tmp"' EXIT
 
-          assets="$(gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
+          gh release download "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir "$verify_tmp" \
+            --pattern "repopilot-${VERSION}-*" \
+            --clobber
           for target in \
             x86_64-unknown-linux-gnu \
             aarch64-unknown-linux-gnu \
             x86_64-apple-darwin \
             aarch64-apple-darwin \
             x86_64-pc-windows-msvc; do
-            grep -q "repopilot-${VERSION}-${target}" <<<"$assets"
+            if [[ "$target" == x86_64-pc-windows-msvc ]]; then
+              archive="repopilot-${VERSION}-${target}.zip"
+            else
+              archive="repopilot-${VERSION}-${target}.tar.gz"
+            fi
+            test -f "$verify_tmp/$archive"
+            test -f "$verify_tmp/$archive.sha256"
+            (cd "$verify_tmp" && sha256sum -c "$archive.sha256")
           done
+
+          cargo package --allow-dirty --no-verify >/dev/null
+          crate_checksum="$(sha256sum "target/package/repopilot-${VERSION_NUMBER}.crate" | awk '{print $1}')"
+          node scripts/build-npm-platform-packages.js \
+            --dist "$verify_tmp" \
+            --out "$verify_tmp/npm-platform-packages" \
+            --version "$VERSION_NUMBER" \
+            > "$verify_tmp/npm-platform-packages.json"
+          root_integrity="$(npm pack --dry-run --json | jq -r '.[0].integrity')"
+
+          retry_needed=false
+          record_state() {
+            local result state
+            result="$(python3 scripts/publication_state.py classify "$@")"
+            echo "$result"
+            state="$(jq -r '.state' <<<"$result")"
+            case "$state" in
+              published-matching) ;;
+              published-mismatch)
+                echo "::error::published-mismatch; refusing to report a release as converged"
+                exit 1
+                ;;
+              *) retry_needed=true ;;
+            esac
+          }
+
+          check_npm() {
+            local package="$1" expected_digest="$2" metadata error_file
+            error_file="$(mktemp)"
+            if metadata="$(npm view "${package}@${VERSION_NUMBER}" version dist.integrity --json 2>"$error_file")"; then
+              record_state \
+                --channel "$package" \
+                --expected-version "$VERSION_NUMBER" \
+                --expected-digest "$expected_digest" \
+                --observed-version "$(jq -r 'if type == "string" then . else .version end' <<<"$metadata")" \
+                --observed-digest "$(jq -r 'if type == "string" then "" else .["dist.integrity"] // "" end' <<<"$metadata")"
+            elif grep -Eq 'E401|E403|401 Unauthorized|403 Forbidden' "$error_file"; then
+              record_state --channel "$package" --expected-version "$VERSION_NUMBER" --error-kind auth
+            elif grep -Eq 'E404|404 Not Found|code E404' "$error_file"; then
+              record_state --channel "$package" --expected-version "$VERSION_NUMBER"
+            elif grep -Eiq 'E429|429 Too Many Requests|rate limit' "$error_file"; then
+              record_state --channel "$package" --expected-version "$VERSION_NUMBER" --error-kind rate-limit
+            elif grep -Eq 'E5[0-9]{2}|5[0-9]{2} (Internal|Bad|Service|Gateway)' "$error_file"; then
+              record_state --channel "$package" --expected-version "$VERSION_NUMBER" --error-kind service
+            else
+              record_state --channel "$package" --expected-version "$VERSION_NUMBER" --error-kind network
+            fi
+            rm -f "$error_file"
+          }
 
           for attempt in {1..20}; do
             echo "Publication verification attempt ${attempt}/20"
-            crate_version="$(curl -fsSL "https://crates.io/api/v1/crates/repopilot/${VERSION_NUMBER}" | jq -r '.version.num' || true)"
-            npm_version="$(npm view repopilot version 2>/dev/null || true)"
-            formula="$(curl -fsSL "https://raw.githubusercontent.com/MykytaStel/homebrew-repopilot/main/Formula/repopilot.rb" || true)"
-            npm_platforms_ready=true
-            for package in \
-              @repopilot/darwin-arm64 \
-              @repopilot/darwin-x64 \
-              @repopilot/linux-arm64-gnu \
-              @repopilot/linux-x64-gnu \
-              @repopilot/win32-x64-msvc; do
-              if [[ "$(npm view "$package" version 2>/dev/null || true)" != "$VERSION_NUMBER" ]]; then
-                npm_platforms_ready=false
+            retry_needed=false
+            if crate_metadata="$(curl -fsSL "https://crates.io/api/v1/crates/repopilot/${VERSION_NUMBER}" 2>"$verify_tmp/crates.err")"; then
+              record_state \
+                --channel crates \
+                --expected-version "$VERSION_NUMBER" \
+                --observed-version "$(jq -r '.version.num' <<<"$crate_metadata")" \
+                --expected-digest "$crate_checksum" \
+                --observed-digest "$(jq -r '.version.checksum // empty' <<<"$crate_metadata")"
+            elif grep -Eq '401|403|unauthorized|forbidden' "$verify_tmp/crates.err"; then
+              record_state --channel crates --expected-version "$VERSION_NUMBER" --error-kind auth
+            elif grep -Eq '429|too many requests|rate limit' "$verify_tmp/crates.err"; then
+              record_state --channel crates --expected-version "$VERSION_NUMBER" --error-kind rate-limit
+            elif grep -Eq '5[0-9]{2}|service unavailable|bad gateway' "$verify_tmp/crates.err"; then
+              record_state --channel crates --expected-version "$VERSION_NUMBER" --error-kind service
+            elif grep -Eq '404|not found' "$verify_tmp/crates.err"; then
+              record_state --channel crates --expected-version "$VERSION_NUMBER"
+            else
+              record_state --channel crates --expected-version "$VERSION_NUMBER" --error-kind network
+            fi
+
+            check_npm "repopilot" "$root_integrity"
+            # shellcheck disable=SC2016
+            while IFS=$'\t' read -r package package_dir; do
+              package_integrity="$(cd "$package_dir" && npm pack --dry-run --json | jq -r '.[0].integrity')"
+              check_npm "$package" "$package_integrity"
+            done < <(node -e 'const fs=require("node:fs"); for (const pkg of JSON.parse(fs.readFileSync(process.argv[1], "utf8"))) console.log(`${pkg.packageName}\t${pkg.directory}`)' "$verify_tmp/npm-platform-packages.json")
+
+            if formula="$(curl -fsSL "https://raw.githubusercontent.com/MykytaStel/homebrew-repopilot/main/Formula/repopilot.rb" 2>"$verify_tmp/formula.err")"; then
+              formula_version="$(sed -nE 's/^version "([^"]+)".*/\1/p' <<<"$formula" | head -n 1)"
+              if [[ "$formula_version" == "$VERSION_NUMBER" ]]; then
+                record_state --channel homebrew --expected-version "$VERSION_NUMBER" --observed-version "$formula_version"
+              elif [[ -z "$formula_version" ]]; then
+                record_state --channel homebrew --expected-version "$VERSION_NUMBER"
+              else
+                record_state --channel homebrew --expected-version "$VERSION_NUMBER" --observed-version "$formula_version"
               fi
-            done
-            if [[ "$crate_version" == "$VERSION_NUMBER" \
-              && "$npm_version" == "$VERSION_NUMBER" \
-              && "$formula" == *"repopilot-${VERSION}-"* \
-              && "$npm_platforms_ready" == true ]]; then
+            elif grep -Eq '401|403|unauthorized|forbidden' "$verify_tmp/formula.err"; then
+              record_state --channel homebrew --expected-version "$VERSION_NUMBER" --error-kind auth
+            elif grep -Eq '404|not found' "$verify_tmp/formula.err"; then
+              record_state --channel homebrew --expected-version "$VERSION_NUMBER"
+            elif grep -Eq '429|too many requests|rate limit' "$verify_tmp/formula.err"; then
+              record_state --channel homebrew --expected-version "$VERSION_NUMBER" --error-kind rate-limit
+            elif grep -Eq '5[0-9]{2}|service unavailable|bad gateway' "$verify_tmp/formula.err"; then
+              record_state --channel homebrew --expected-version "$VERSION_NUMBER" --error-kind service
+            else
+              record_state --channel homebrew --expected-version "$VERSION_NUMBER" --error-kind network
+            fi
+
+            if [[ "$retry_needed" == false ]]; then
               exit 0
             fi
             sleep 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- Started recoverable release publication: exact version and package identity
+  checks now skip only matching immutable npm/crates artifacts, fail closed on
+  mismatches, distinguish authentication/network/rate-limit/service failures,
+  and keep post-release npm integrity and crates checksum verification exact.
+
 - Added released producer/reader compatibility evidence for schemas 0.18–0.26,
   including exact asset/crate provenance and a line-movement baseline guard.
   Incompatible history now emits `history.comparison-unavailable` instead of

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ adoption or CI policy.
 - [v0.23 Phase 0A evidence-baseline plan](engineering/v0.23-phase-0a-plan.md)
 - [v0.23 report compatibility matrix](engineering/v0.23-compatibility-matrix.md)
 - [v0.23 Phase 0B2 compatibility implementation plan](engineering/v0.23-phase-0b-compatibility-plan.md)
+- [v0.23 Phase 0C recoverable publication plan](engineering/v0.23-0c-publication-recovery-plan.md)
 - [v0.23 release evidence ledger](engineering/v0.23-evidence-ledger.md)
 - [v0.22 repository intelligence design](engineering/v0.22-repository-intelligence-design.md)
 - [v0.22 Phase A1 context graph specification](engineering/v0.22-phase-a1-context-graph-v2.md)

--- a/docs/engineering/v0.23-0c-publication-recovery-plan.md
+++ b/docs/engineering/v0.23-0c-publication-recovery-plan.md
@@ -1,0 +1,65 @@
+# v0.23 Recoverable Publication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (recommended) to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make release publication rerunnable and digest-aware so partial channel success is explicit and safe to recover.
+
+**Architecture:** Reuse the existing release and reusable npm workflows. Add a small, deterministic publication-state evaluator for exact version and artifact identity checks; keep network calls at the workflow boundary and preserve per-channel outcomes. Do not add a new CLI command or publish any existing release while implementing this slice.
+
+**Tech Stack:** GitHub Actions YAML, Bash, Python 3.11 tests, Node/npm packaging, SHA-256 digests.
+
+**Spec:** `docs/engineering/v0.23-phase-0-spec.md` section 0C and `docs/engineering/v0.23-evidence-ledger.md` item RP23-001.
+
+## Global Constraints
+
+- Runtime analysis remains local-only and deterministic.
+- Exact release tags and package versions are required; mutable `latest` is not release evidence.
+- A matching immutable artifact may be reused; a mismatched artifact fails closed.
+- Platform npm packages publish before the root wrapper package.
+- Recovery distinguishes absent, matching, mismatched, partial, authentication/network/rate-limit/service failures, and skipped actions.
+- Offline fixtures test recovery logic; no real registry publication or release rerun occurs in this PR.
+
+### Task 1: Capture the current publication contract
+
+**Files:** `scripts/release-contract.py`, `.github/workflows/release.yml`, `.github/workflows/publish-npm.yml`, tests under `scripts/tests/`.
+
+- [x] Write failing contract tests for mutable-version verification and ambiguous failure handling.
+- [x] Run the focused Python tests and confirm the failures identify the missing exact-identity behavior.
+- [x] Record the current workflow dependency chain and channel names in the test fixtures.
+
+### Task 2: Add deterministic publication states
+
+**Files:** `scripts/publication_state.py`, `scripts/tests/test_publication_state.py`.
+
+- [x] Write failing tests for absent, matching, mismatched, partial, auth/network, and skipped observations.
+- [x] Implement a typed state evaluator that accepts exact expected version plus observed version/digest and returns a stable state/reason.
+- [x] Reject mismatched immutable payloads and never convert an unavailable observation into success.
+
+### Task 3: Make workflow verification exact and recoverable
+
+**Files:** `.github/workflows/release.yml`, `.github/workflows/publish-npm.yml`, `scripts/release-contract.py`.
+
+- [x] Write workflow-contract tests requiring exact tag/version arguments, digest or payload identity checks, and per-channel diagnostics.
+- [x] Update `verify-publication` to verify the requested version, classify service/auth failures separately, and stop on mismatches.
+- [x] Update npm recovery to verify/download the exact tag, publish platform packages before root, and allow safe manual reruns.
+
+### Task 4: Exercise partial publication and retry behavior
+
+**Files:** `scripts/tests/test_publication_recovery.py`, offline fixtures under `tests/fixtures/release/`.
+
+- [x] Add fixtures for absent, matching, mismatched, partial, and transient-failure channel snapshots.
+- [x] Assert a second run skips only matching immutable channels and retries only incomplete channels.
+- [x] Assert a mismatch fails closed without deletion, replacement, or root-package publication.
+
+### Task 5: Document evidence and limitations
+
+**Files:** `CHANGELOG.md`, `docs/reports.md`, `docs/engineering/v0.23-evidence-ledger.md`.
+
+- [x] Document the exact state vocabulary, recovery boundary, and no-publish implementation scope.
+- [x] Keep RP23-001 open until the workflow tests and a later explicit release verification provide fresh evidence.
+
+### Task 6: Verify and hand off
+
+- [x] Run focused Python/unit/release-contract checks, actionlint, and RepoPilot self-review.
+- [ ] Run the full gate before opening a draft PR; report any hosted-CI or registry evidence separately from code results.
+- [ ] Commit, push, and open one focused draft PR against `main`.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -24,7 +24,7 @@ priorities. Owners are subsystems; no person is implicitly assigned.
 
 | ID | Priority / kind | Status | Owner / slice | Observation and closure requirement |
 |---|---|---|---|---|
-| RP23-001 | P1 defect | open | Distribution / 0C | Original Release run failed in npm publication; separate manual Publish npm succeeded, while the original public-channel verifier stayed skipped. Close with tested recovery, exact-version identity checks, and a complete per-channel verification result. |
+| RP23-001 | P1 defect | in-progress | Distribution / 0C | Original Release run failed in npm publication; separate manual Publish npm succeeded, while the original public-channel verifier stayed skipped. PR 3 adds exact-version/digest-aware npm and crates recovery plus explicit channel states. Close with offline fault coverage and a complete per-channel verification result. |
 | RP23-002 | P2 defect | verified | Report docs / 0B1 | Original release notes said scan `0.24` and review `0.25`; emitters share `0.26`. Corrected the notes and reports guide; CLI-backed envelope regression tests pass. See the 0B1 evidence below. |
 | RP23-003 | P1 evidence-gap | verified | Compatibility / 0B2 | Directional matrix now covers released producers, exact released Rust readers, baseline movement, incompatible history, synthetic transitions, and non-reader projections. Evidence is pinned by tag, asset/crate/report SHA-256, fixture, and offline regression. |
 | RP23-004 | P2 evidence-gap | open | Performance / 0E | v0.22 scorecard lacks fresh peak RSS. Close with reproducible cold/warm measurements, units, source identity, and an approved ceiling; do not infer memory from latency. |
@@ -165,5 +165,26 @@ close the items above. Before Phase 0 closes, retain separate evidence for:
 - release recovery under mismatched artifacts and auth/service failures;
 - runtime regression tests for each corrected user-visible claim.
 
-Next implementation scope: 0C publication recovery. No 0.23 version bump is
-needed to start.
+Next implementation scope: complete 0C publication recovery. No 0.23 version
+bump is needed to start.
+
+## 0C — Recoverable Publication (PR 3, in progress)
+
+- The publication state evaluator now distinguishes absent, matching immutable,
+  mismatched, authentication, network, rate-limit, and service observations. Matching
+  artifacts are safe to skip; mismatches fail closed; unavailable channels are
+  retryable rather than reported as success.
+- The npm reusable workflow checks exact `package@version` metadata and the
+  generated package `dist.integrity` before publishing. Platform packages still
+  run before the root package, and manual `workflow_dispatch` keeps its exact
+  tag input.
+- The crates workflow packages the exact version, compares the local crate
+  SHA-256 with the crates.io `version.checksum`, and publishes only when the
+  version is absent.
+- The public verifier downloads the exact release tag assets, validates each
+  checksum file, checks exact registry versions plus npm integrity and crates
+  checksum identity, and retries transient channel convergence.
+- Offline fixture coverage now exercises partial publication, retry-only
+  incomplete channels, and terminal mismatches. Boundary: no real registry
+  publication or release rerun was performed. Hosted release verification and
+  installation smoke remain required before RP23-001 can close.

--- a/scripts/publication_state.py
+++ b/scripts/publication_state.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Classify immutable release-channel observations for safe recovery."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from enum import Enum
+
+
+class State(str, Enum):
+    ABSENT = "absent"
+    MATCHING = "published-matching"
+    MISMATCHED = "published-mismatch"
+    AUTH_FAILURE = "auth-failure"
+    NETWORK_FAILURE = "network-failure"
+    RATE_LIMIT_FAILURE = "rate-limit-failure"
+    SERVICE_FAILURE = "service-failure"
+
+
+class AggregateState(str, Enum):
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    MISMATCHED = "mismatched"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class Observation:
+    channel: str
+    expected_version: str
+    observed_version: str | None = None
+    expected_digest: str | None = None
+    observed_digest: str | None = None
+    error_kind: str | None = None
+
+
+def classify(observation: Observation) -> State:
+    if observation.error_kind:
+        failures = {
+            "auth": State.AUTH_FAILURE,
+            "network": State.NETWORK_FAILURE,
+            "rate-limit": State.RATE_LIMIT_FAILURE,
+            "service": State.SERVICE_FAILURE,
+        }
+        try:
+            return failures[observation.error_kind]
+        except KeyError as error:
+            raise ValueError(f"unknown publication error: {observation.error_kind}") from error
+
+    if observation.observed_version is None:
+        return State.ABSENT
+    if observation.observed_version != observation.expected_version:
+        return State.MISMATCHED
+    if (
+        observation.expected_digest is not None
+        and observation.observed_digest != observation.expected_digest
+    ):
+        return State.MISMATCHED
+    return State.MATCHING
+
+
+def action(observation: Observation) -> str:
+    state = classify(observation)
+    if state is State.MATCHING:
+        return "skip"
+    if state is State.ABSENT:
+        return "publish"
+    if state is State.MISMATCHED:
+        return "fail"
+    return "retry"
+
+
+def aggregate(observations: list[Observation]) -> AggregateState:
+    if not observations:
+        return AggregateState.PARTIAL
+    states = {classify(observation) for observation in observations}
+    if State.MISMATCHED in states:
+        return AggregateState.MISMATCHED
+    if states & {
+        State.AUTH_FAILURE,
+        State.NETWORK_FAILURE,
+        State.RATE_LIMIT_FAILURE,
+        State.SERVICE_FAILURE,
+    }:
+        return AggregateState.BLOCKED
+    if State.ABSENT in states:
+        return AggregateState.PARTIAL
+    return AggregateState.COMPLETE
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    classify_parser = subcommands.add_parser("classify")
+    classify_parser.add_argument("--channel", required=True)
+    classify_parser.add_argument("--expected-version", required=True)
+    classify_parser.add_argument("--observed-version")
+    classify_parser.add_argument("--expected-digest")
+    classify_parser.add_argument("--observed-digest")
+    classify_parser.add_argument("--error-kind")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    observation = Observation(
+        channel=args.channel,
+        expected_version=args.expected_version,
+        observed_version=args.observed_version,
+        expected_digest=args.expected_digest,
+        observed_digest=args.observed_digest,
+        error_kind=args.error_kind,
+    )
+    print(
+        json.dumps(
+            {
+                "channel": observation.channel,
+                "state": classify(observation).value,
+                "action": action(observation),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release-contract.py
+++ b/scripts/release-contract.py
@@ -357,6 +357,46 @@ def check_release_orchestration() -> None:
         raise ContractError("Release workflow still contains a VS Code/VSIX surface")
 
 
+def check_publication_recovery_contract() -> None:
+    release = read_text(ROOT / ".github/workflows/release.yml")
+    npm = read_text(ROOT / ".github/workflows/publish-npm.yml")
+    mutable_query = re.compile(r'npm view\s+"?(?:repopilot|\$package)"?\s+version')
+    if mutable_query.search(release) or mutable_query.search(npm):
+        raise ContractError("publication recovery contains a mutable npm query")
+    if re.search(r'\.dist\.integrity\b', release) or re.search(r'\.dist\.integrity\b', npm):
+        raise ContractError("publication recovery must read the literal dist.integrity key")
+
+    required_release = (
+        'VERSION_NUMBER="${VERSION#v}"',
+        "scripts/publication_state.py classify",
+        'npm view "${package}@${VERSION_NUMBER}" version dist.integrity --json',
+        "cargo package --allow-dirty --no-verify",
+        "version.checksum",
+        "404",
+        "rate-limit-failure",
+        "published-mismatch",
+    )
+    required_npm = (
+        'ref: ${{ inputs.tag || github.ref }}',
+        'npm view "${package_name}@${VERSION_NUMBER}" version dist.integrity --json',
+        "published-mismatch",
+        'npm publish "$package_dir"',
+        "npm publish",
+        "rate-limit-failure",
+    )
+    missing = [marker for marker in required_release if marker not in release]
+    missing.extend(marker for marker in required_npm if marker not in npm)
+    if missing:
+        raise ContractError(
+            "publication recovery contract is incomplete: " + ", ".join(missing)
+        )
+
+    platform_publish = npm.find('npm publish "$package_dir"')
+    root_publish = npm.find("npm publish", platform_publish + 1)
+    if platform_publish == -1 or root_publish == -1 or platform_publish > root_publish:
+        raise ContractError("npm platform packages must publish before the root package")
+
+
 def check_removed_vscode_surface() -> None:
     stale_paths = [
         ROOT / "editors/vscode/package.json",
@@ -489,6 +529,7 @@ def check_contract(tag: str | None) -> None:
     check_cargo_package()
     check_action_pins()
     check_release_orchestration()
+    check_publication_recovery_contract()
     check_removed_vscode_surface()
     check_roadmap_docs()
     check_rule_scorecard()

--- a/scripts/tests/test_publication_recovery.py
+++ b/scripts/tests/test_publication_recovery.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "tests/fixtures/release/publication-recovery.json"
+SCRIPT = ROOT / "scripts/publication_state.py"
+SPEC = importlib.util.spec_from_file_location("publication_state", SCRIPT)
+assert SPEC and SPEC.loader
+publication_state = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = publication_state
+SPEC.loader.exec_module(publication_state)
+
+
+class PublicationRecoveryFixtureTests(unittest.TestCase):
+    def test_partial_second_run_only_reuses_matching_channels(self) -> None:
+        fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        observations = []
+
+        for channel in fixture["channels"]:
+            observation = publication_state.Observation(
+                channel=channel["channel"],
+                expected_version=fixture["expected_version"],
+                observed_version=channel.get("observed_version"),
+                expected_digest=channel.get("expected_digest"),
+                observed_digest=channel.get("observed_digest"),
+                error_kind=channel.get("error_kind"),
+            )
+            observations.append(observation)
+            self.assertEqual(publication_state.classify(observation).value, channel["state"])
+            self.assertEqual(publication_state.action(observation), channel["action"])
+
+        self.assertEqual(
+            publication_state.aggregate(observations),
+            publication_state.AggregateState.MISMATCHED,
+        )
+
+        matching = [
+            observation
+            for observation in observations
+            if publication_state.action(observation) == "skip"
+        ]
+        incomplete = [
+            observation
+            for observation in observations
+            if publication_state.action(observation) in {"publish", "retry"}
+        ]
+        self.assertEqual([item.channel for item in matching], ["github"])
+        self.assertEqual(
+            [item.channel for item in incomplete], ["npm-root", "crates"]
+        )
+
+    def test_mismatch_is_a_terminal_recovery_guard(self) -> None:
+        fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        mismatch = next(
+            item for item in fixture["channels"] if item["state"] == "published-mismatch"
+        )
+        observation = publication_state.Observation(
+            channel=mismatch["channel"],
+            expected_version=fixture["expected_version"],
+            observed_version=mismatch["observed_version"],
+            expected_digest=mismatch["expected_digest"],
+            observed_digest=mismatch["observed_digest"],
+        )
+
+        self.assertEqual(publication_state.action(observation), "fail")
+        self.assertNotIn(publication_state.action(observation), {"publish", "retry"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_publication_state.py
+++ b/scripts/tests/test_publication_state.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "publication_state.py"
+SPEC = importlib.util.spec_from_file_location("publication_state", SCRIPT)
+assert SPEC and SPEC.loader
+publication_state = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = publication_state
+SPEC.loader.exec_module(publication_state)
+
+
+class PublicationStateTests(unittest.TestCase):
+    def test_matching_identity_is_safe_to_skip(self) -> None:
+        observation = publication_state.Observation(
+            channel="npm-root",
+            expected_version="0.23.0",
+            observed_version="0.23.0",
+            expected_digest="sha512-local",
+            observed_digest="sha512-local",
+        )
+
+        self.assertEqual(
+            publication_state.classify(observation),
+            publication_state.State.MATCHING,
+        )
+        self.assertEqual(publication_state.action(observation), "skip")
+
+    def test_absent_identity_is_publishable(self) -> None:
+        observation = publication_state.Observation(
+            channel="npm-root",
+            expected_version="0.23.0",
+        )
+
+        self.assertEqual(
+            publication_state.classify(observation),
+            publication_state.State.ABSENT,
+        )
+        self.assertEqual(publication_state.action(observation), "publish")
+
+    def test_version_or_digest_mismatch_fails_closed(self) -> None:
+        for observed_version, observed_digest in [
+            ("0.22.0", "sha512-local"),
+            ("0.23.0", "sha512-other"),
+        ]:
+            with self.subTest(observed_version=observed_version, observed_digest=observed_digest):
+                observation = publication_state.Observation(
+                    channel="npm-root",
+                    expected_version="0.23.0",
+                    observed_version=observed_version,
+                    expected_digest="sha512-local",
+                    observed_digest=observed_digest,
+                )
+                self.assertEqual(
+                    publication_state.classify(observation),
+                    publication_state.State.MISMATCHED,
+                )
+                self.assertEqual(publication_state.action(observation), "fail")
+
+    def test_auth_network_and_service_failures_stay_distinct(self) -> None:
+        for error_kind, expected in [
+            ("auth", publication_state.State.AUTH_FAILURE),
+            ("network", publication_state.State.NETWORK_FAILURE),
+            ("rate-limit", publication_state.State.RATE_LIMIT_FAILURE),
+            ("service", publication_state.State.SERVICE_FAILURE),
+        ]:
+            with self.subTest(error_kind):
+                observation = publication_state.Observation(
+                    channel="crates",
+                    expected_version="0.23.0",
+                    error_kind=error_kind,
+                )
+                self.assertEqual(publication_state.classify(observation), expected)
+                self.assertEqual(publication_state.action(observation), "retry")
+
+    def test_aggregate_marks_partial_and_mismatch_recovery(self) -> None:
+        matching = publication_state.Observation(
+            channel="github",
+            expected_version="0.23.0",
+            observed_version="0.23.0",
+        )
+        absent = publication_state.Observation(
+            channel="npm-root",
+            expected_version="0.23.0",
+        )
+        self.assertEqual(
+            publication_state.aggregate([matching, absent]),
+            publication_state.AggregateState.PARTIAL,
+        )
+
+        mismatch = publication_state.Observation(
+            channel="crates",
+            expected_version="0.23.0",
+            observed_version="0.22.0",
+        )
+        self.assertEqual(
+            publication_state.aggregate([matching, mismatch]),
+            publication_state.AggregateState.MISMATCHED,
+        )
+
+    def test_empty_observations_are_not_complete(self) -> None:
+        self.assertEqual(
+            publication_state.aggregate([]),
+            publication_state.AggregateState.PARTIAL,
+        )
+
+    def test_rate_limit_blocks_aggregate_convergence(self) -> None:
+        observation = publication_state.Observation(
+            channel="npm-root",
+            expected_version="0.23.0",
+            error_kind="rate-limit",
+        )
+        self.assertEqual(
+            publication_state.aggregate([observation]),
+            publication_state.AggregateState.BLOCKED,
+        )
+
+    def test_cli_emits_machine_readable_state_and_action(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "classify",
+                "--channel",
+                "npm-root",
+                "--expected-version",
+                "0.23.0",
+                "--observed-version",
+                "0.23.0",
+                "--expected-digest",
+                "sha512-local",
+                "--observed-digest",
+                "sha512-local",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(
+            json.loads(result.stdout),
+            {
+                "channel": "npm-root",
+                "state": "published-matching",
+                "action": "skip",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_contract.py
+++ b/scripts/tests/test_release_contract.py
@@ -178,6 +178,50 @@ class ReleaseContractTests(unittest.TestCase):
         with self.assertRaisesRegex(release_contract.ContractError, "does not call"):
             release_contract.check_release_orchestration()
 
+    def test_publication_recovery_requires_exact_identity_checks(self) -> None:
+        self.write(".github/workflows/release.yml", "jobs: {}\n")
+        self.write(".github/workflows/publish-npm.yml", "jobs: {}\n")
+
+        with self.assertRaisesRegex(
+            release_contract.ContractError, "publication recovery"
+        ):
+            release_contract.check_publication_recovery_contract()
+
+    def test_publication_recovery_rejects_mutable_latest_queries(self) -> None:
+        self.write(
+            ".github/workflows/release.yml",
+            """
+            VERSION_NUMBER="${VERSION#v}"
+            python3 scripts/publication_state.py classify
+            npm view "${package}@${VERSION_NUMBER}" version dist.integrity --json
+            npm view repopilot version
+            """,
+        )
+        self.write(
+            ".github/workflows/publish-npm.yml",
+            """
+            npm view "${package_name}@${VERSION_NUMBER}" version dist.integrity --json
+            published-mismatch
+            """,
+        )
+
+        with self.assertRaisesRegex(
+            release_contract.ContractError, "mutable npm query"
+        ):
+            release_contract.check_publication_recovery_contract()
+
+    def test_publication_recovery_rejects_nested_integrity_lookup(self) -> None:
+        self.write(
+            ".github/workflows/release.yml",
+            'jq -r \'if type == "string" then "" else (.dist.integrity // "") end\'\n',
+        )
+        self.write(".github/workflows/publish-npm.yml", "")
+
+        with self.assertRaisesRegex(
+            release_contract.ContractError, "literal dist.integrity"
+        ):
+            release_contract.check_publication_recovery_contract()
+
     def test_cargo_package_rejects_files_outside_allowlist(self) -> None:
         result = subprocess.CompletedProcess(
             args=["cargo", "package"],

--- a/tests/fixtures/release/publication-recovery.json
+++ b/tests/fixtures/release/publication-recovery.json
@@ -1,0 +1,30 @@
+{
+  "expected_version": "0.23.0",
+  "channels": [
+    {
+      "channel": "github",
+      "observed_version": "0.23.0",
+      "state": "published-matching",
+      "action": "skip"
+    },
+    {
+      "channel": "npm-root",
+      "state": "absent",
+      "action": "publish"
+    },
+    {
+      "channel": "npm-linux-x64",
+      "observed_version": "0.23.0",
+      "expected_digest": "sha512-local",
+      "observed_digest": "sha512-other",
+      "state": "published-mismatch",
+      "action": "fail"
+    },
+    {
+      "channel": "crates",
+      "error_kind": "network",
+      "state": "network-failure",
+      "action": "retry"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Make v0.23 release publication safe to rerun after partial channel success.

- Verify exact tag/version and immutable npm integrity / crates checksum identity.
- Skip only matching artifacts; publish absent packages; fail closed on mismatches.
- Classify auth, network, rate-limit, and service failures for npm, crates.io, and Homebrew.
- Keep platform npm packages before the root package and run public verification even when an upstream channel fails.
- Add deterministic publication-state logic, offline partial-publication fixtures, contract tests, and implementation/evidence docs.

## Verification

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (71 passed)
- `python3 scripts/release-contract.py check`
- `actionlint .github/workflows/release.yml .github/workflows/publish-npm.yml`
- `python3 -m py_compile scripts/publication_state.py scripts/release-contract.py scripts/tests/test_publication_recovery.py`
- `git diff --check`
- RepoPilot self-review: 0 findings; deploy-surface signals remain expected for workflow changes.