### PR TITLE
docs: enforce v0.23 documentation truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- Added source-driven documentation parity checks: MCP tool names now come
+  from the Rust registry, and the reports guide is checked against the current
+  package and report-schema versions. The existing release-contract job runs
+  this automatically in CI.
+
 - Reconciled v0.23 planning and reports documentation with the current Phase 0
   lifecycle. The release contract now checks the v0.23 docs index, evidence
   links, status markers, and assessed-scope boundaries; `PASS` and health

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- Reconciled v0.23 planning and reports documentation with the current Phase 0
+  lifecycle. The release contract now checks the v0.23 docs index, evidence
+  links, status markers, and assessed-scope boundaries; `PASS` and health
+  scores are explicitly limited to analyzed scope.
+
 - Started recoverable release publication: exact version and package identity
   checks now skip only matching immutable npm/crates artifacts, fail closed on
   mismatches, distinguish authentication/network/rate-limit/service failures,

--- a/docs/engineering/v0.23-0c-publication-recovery-plan.md
+++ b/docs/engineering/v0.23-0c-publication-recovery-plan.md
@@ -1,5 +1,8 @@
 # v0.23 Recoverable Publication Implementation Plan
 
+Status: implementation merged in PR 3; hosted publication and installation
+evidence remain pending.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (recommended) to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make release publication rerunnable and digest-aware so partial channel success is explicit and safe to recover.
@@ -61,5 +64,5 @@
 ### Task 6: Verify and hand off
 
 - [x] Run focused Python/unit/release-contract checks, actionlint, and RepoPilot self-review.
-- [ ] Run the full gate before opening a draft PR; report any hosted-CI or registry evidence separately from code results.
-- [ ] Commit, push, and open one focused draft PR against `main`.
+- [ ] Run the full gate before declaring release-ready; report any hosted-CI or registry evidence separately from code results.
+- [x] Commit, push, and open one focused draft PR against `main`.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -20,21 +20,24 @@ Release: [v0.23 roadmap](../roadmap/v0.23.md).
 Priorities below are release-triage estimates, not RepoPilot-emitted finding
 priorities. Owners are subsystems; no person is implicitly assigned.
 
+Every tracked item retains an explicit closure criterion; a green documentation
+check does not close an item without the required fresh evidence.
+
 ## Tracked Items
 
 | ID | Priority / kind | Status | Owner / slice | Observation and closure requirement |
 |---|---|---|---|---|
-| RP23-001 | P1 defect | in-progress | Distribution / 0C | Original Release run failed in npm publication; separate manual Publish npm succeeded, while the original public-channel verifier stayed skipped. PR 3 adds exact-version/digest-aware npm and crates recovery plus explicit channel states. Close with offline fault coverage and a complete per-channel verification result. |
+| RP23-001 | P1 defect | in-progress | Distribution / 0C | Original Release run failed in npm publication; separate manual Publish npm succeeded, while the original public-channel verifier stayed skipped. PR 3 adds exact-version/digest-aware npm and crates recovery plus explicit channel states; offline fixture coverage is now landed. Close with hosted per-channel verification and supported-platform install smoke. |
 | RP23-002 | P2 defect | verified | Report docs / 0B1 | Original release notes said scan `0.24` and review `0.25`; emitters share `0.26`. Corrected the notes and reports guide; CLI-backed envelope regression tests pass. See the 0B1 evidence below. |
 | RP23-003 | P1 evidence-gap | verified | Compatibility / 0B2 | Directional matrix now covers released producers, exact released Rust readers, baseline movement, incompatible history, synthetic transitions, and non-reader projections. Evidence is pinned by tag, asset/crate/report SHA-256, fixture, and offline regression. |
 | RP23-004 | P2 evidence-gap | open | Performance / 0E | v0.22 scorecard lacks fresh peak RSS. Close with reproducible cold/warm measurements, units, source identity, and an approved ceiling; do not infer memory from latency. |
-| RP23-005 | P2 defect | open | Documentation / 0D | Historical scorecard still describes an uncut tag, while the release is published. Platform state prose also retains already-completed migration work as missing. Close by distinguishing original audit state from subsequent evidence and checking current claims against code. |
+| RP23-005 | P2 defect | in-progress | Documentation / 0D | Historical scorecard still describes an uncut tag, while the release is published. Platform state prose also retains already-completed migration work as missing. PR 4 adds current lifecycle and scope-boundary checks; close by reconciling the remaining scorecard claims against code and fresh evidence. |
 | RP23-006 | P2 design-risk | open | Review/readiness / A | Absent CODEOWNERS produces unowned paths and review reasons. Close with explicit absent/configured-unmatched/resolved states and regression coverage; do not claim a config policy is violated when it does not exist. |
 | RP23-007 | P2 defect | open | Decision UX / 0D–A | Decision and readiness are printed separately; finding-only plan counts omit signal verification guidance. Close with accurate current copy, then one canonical Phase A obligations model and projection parity. |
 | RP23-008 | P2 limitation | open | Semantic review / B | Manifest/workflow boundary classification is path-based. Close only for supported semantic families with metadata-only safe guards; preserve unknown forms and strict recall. |
 | RP23-009 | P2 design-risk | open | Coverage UX / 0D–A | PASS and visible health scores can be read as broader proof than analyzed scope. Close with assessed-scope copy and a capability ledger; excluded files or hidden suggestions are not automatically missed defects. |
 | RP23-010 | P2 evidence-gap | open | Rule quality / E | Committed scorecard reports three strict-only dead-module false positives and many rules without zoo evidence. Close each measured issue with safe/unsafe regression and fresh labeled evidence; never label unmeasured rules clean. |
-| RP23-011 | P2 defect | open | Release contract / 0D | `check_roadmap_docs()` checks v0.20 headings/links only. Its green result does not validate v0.23 planning semantics. Close with focused lifecycle/link contract tests that retain older supported docs. |
+| RP23-011 | P2 defect | in-progress | Release contract / 0D | `check_roadmap_docs()` checks v0.20 headings/links only. PR 4 adds focused v0.23 lifecycle/link and scope-boundary contract tests while retaining older supported docs. Close after the current claims and tests are merged. |
 | RP23-012 | P2 design-risk | open | Proof semantics / A | A failed lint/check is not necessarily contract breakage, and no selected checks is not sufficient proof. Roadmap wording now makes this explicit; close only when Phase A truth tables and runtime projection tests enforce it. |
 
 No item is marked verified solely by being listed here. Phase A/B/E items remain
@@ -188,3 +191,18 @@ bump is needed to start.
   incomplete channels, and terminal mismatches. Boundary: no real registry
   publication or release rerun was performed. Hosted release verification and
   installation smoke remain required before RP23-001 can close.
+
+## 0D — Documentation and Current UX Truth (PR 4, in progress)
+
+- The release contract now checks that the v0.23 roadmap, phase specification,
+  evidence ledger, and reports guide are present, linked from the docs index,
+  and carry current lifecycle/scope-boundary markers. Historical v0.20
+  documentation checks remain unchanged.
+- The roadmap and phase specification now distinguish Phase 0 progress from
+  the not-yet-started ChangeProof runtime, and mark the completed 0B slices
+  separately from the in-progress 0C/0D work.
+- Reports documentation explicitly limits `PASS`, health scores, and
+  `assessment_status` to analyzed scope; unsupported and excluded files are
+  not implied to be verified.
+- Boundary: this slice changes documentation and contract checks only. It does
+  not close remaining scorecard, performance, ownership, or ChangeProof gaps.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -197,7 +197,9 @@ bump is needed to start.
 - The release contract now checks that the v0.23 roadmap, phase specification,
   evidence ledger, and reports guide are present, linked from the docs index,
   and carry current lifecycle/scope-boundary markers. Historical v0.20
-  documentation checks remain unchanged.
+  documentation checks remain unchanged. It also compares MCP tool names and
+  report version/schema claims with source-owned registries, so future drift
+  fails the existing CI contract without a new workflow.
 - The roadmap and phase specification now distinguish Phase 0 progress from
   the not-yet-started ChangeProof runtime, and mark the completed 0B slices
   separately from the in-progress 0C/0D work.

--- a/docs/engineering/v0.23-phase-0-spec.md
+++ b/docs/engineering/v0.23-phase-0-spec.md
@@ -1,6 +1,6 @@
 # v0.23 Phase 0 — Truth Foundation Specification
 
-Status: draft for review. Release direction is approved; this document does not
+Status: in-progress; release direction is approved. This document does not
 claim that Phase 0 defects are fixed.
 
 Parent: [v0.23 roadmap](../roadmap/v0.23.md).
@@ -103,7 +103,7 @@ documented behavior, not implied compatibility.
 
 #### 0B1 — Schema Truth (PR 1)
 
-Status: in-progress; bounded implementation approved on 2026-08-31.
+Status: verified; closure evidence is recorded in the release evidence ledger.
 
 Owns RP23-002 only: the current reports guide and v0.22 release notes disagree
 with the shared scan, baseline-scan, and review JSON emitters. The package
@@ -134,7 +134,7 @@ Execution / acceptance:
 
 #### 0B2 — Released Compatibility Evidence (PR 2)
 
-Status: in-progress; execution approved on 2026-09-02.
+Status: verified; closure evidence is recorded in the release evidence ledger.
 
 Owns RP23-003. Evidence is split by direction and consumer instead of using
 "backward compatible" as one undifferentiated claim.
@@ -168,6 +168,9 @@ Execution: [0B2 implementation plan](v0.23-phase-0b-compatibility-plan.md).
 
 ### 0C — Recoverable Publication
 
+Status: in-progress; PR 3 is merged and hosted publication/install evidence is
+still required for closure.
+
 Owns release workflows, publication helpers, and distribution checks.
 
 - Extend the existing `verify-publication` job rather than create a parallel
@@ -192,6 +195,8 @@ partial publication, auth/network failures, exact-tag checkout, and repeat runs;
 live publishing remains a separate explicit release operation.
 
 ### 0D — Documentation and Current UX Truth
+
+Status: in-progress; PR 4 owns documentation parity and bounded scope copy.
 
 Owns current copy, documentation parity, and bounded guidance.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -54,6 +54,8 @@ It verifies:
 - the curated GitHub Release note exists, has the required structure, and can
   produce the release title and body;
 - local Markdown links resolve;
+- current MCP tool names and report version/schema claims match source-owned
+  registries;
 - stale npm installer claims are absent;
 - third-party GitHub Actions are pinned to commit SHAs;
 - the tag workflow directly calls reusable npm publishing;

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -111,6 +111,15 @@ Binary `0.22.0` emits schema `0.26` for scan, baseline-scan, and review.
 Schema numbers are monotonic contract revisions, not predictions of the next
 RepoPilot package version.
 
+### Assessment boundaries
+
+`assessment_status` applies to scan and baseline-scan scope: `assessed` means
+that at least one file was analyzed, while `not_assessed` means that the
+requested scope produced no analyzed files. This is not a safety verdict.
+`PASS` and health scores describe the analyzed scope only; unsupported scope
+and excluded files remain outside that claim and must not be read as silently
+verified.
+
 ### Compatibility
 
 RepoPilot renders JSON through explicit report DTOs instead of serializing the

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -1,6 +1,6 @@
 # RepoPilot 0.23 — Change Proof
 
-Status: approved product direction; implementation has not started.
+Status: Phase 0 implementation in progress; ChangeProof runtime implementation has not started.
 
 RepoPilot 0.23 turns change review from a collection of findings and signals
 into one bounded proof of what changed, which contracts and consumers are

--- a/scripts/release-contract.py
+++ b/scripts/release-contract.py
@@ -453,6 +453,87 @@ def check_roadmap_docs() -> None:
         raise ContractError("docs/README.md does not link to v0.20 release scorecard")
 
 
+def _v023_doc_files() -> dict[str, Path]:
+    return {
+        "roadmap": ROOT / "docs/roadmap/v0.23.md",
+        "phase specification": ROOT / "docs/engineering/v0.23-phase-0-spec.md",
+        "evidence ledger": ROOT / "docs/engineering/v0.23-evidence-ledger.md",
+        "reports guide": ROOT / "docs/reports.md",
+    }
+
+
+def _check_v023_doc_links(docs_index: str) -> None:
+    required_links = (
+        "roadmap/v0.23.md",
+        "engineering/v0.23-phase-0-spec.md",
+        "engineering/v0.23-evidence-ledger.md",
+    )
+    missing_links = [link for link in required_links if link not in docs_index]
+    if missing_links:
+        raise ContractError(
+            "docs/README.md is missing v0.23 links:\n  " + "\n  ".join(missing_links)
+        )
+
+
+def _v023_required_markers(files: dict[str, Path]) -> dict[Path, tuple[str, ...]]:
+    return {
+        files["roadmap"]: (
+            "Status: Phase 0 implementation in progress",
+            "## Phase 0 — Truth Foundation and Bug Burn-down",
+            "## Phase A — Canonical ChangeProof",
+        ),
+        files["phase specification"]: (
+            "Status: in-progress",
+            "Progress source:",
+            "Statuses: `open`, `in-progress`, `verified`, and `accepted`.",
+            "#### 0B1 — Schema Truth (PR 1)",
+            "#### 0B1 — Schema Truth (PR 1)\n\nStatus: verified;",
+            "#### 0B2 — Released Compatibility Evidence (PR 2)",
+            "#### 0B2 — Released Compatibility Evidence (PR 2)\n\nStatus: verified;",
+            "### 0C — Recoverable Publication",
+            "### 0C — Recoverable Publication\n\nStatus: in-progress;",
+            "### 0D — Documentation and Current UX Truth",
+            "### 0D — Documentation and Current UX Truth\n\nStatus: in-progress;",
+        ),
+        files["evidence ledger"]: (
+            "Status: open;",
+            "## Tracked Items",
+            "closure criterion",
+        ),
+        files["reports guide"]: (
+            "`assessment_status`",
+            "not a safety verdict",
+            "Unsupported scope",
+            "excluded files",
+        ),
+    }
+
+
+def _check_v023_markers(files: dict[str, Path]) -> None:
+    missing_markers = [
+        f"{path.relative_to(ROOT)}: {marker}"
+        for path, markers in _v023_required_markers(files).items()
+        for marker in markers
+        if marker.casefold() not in read_text(path).casefold()
+    ]
+    if missing_markers:
+        raise ContractError(
+            "v0.23 documentation contract is incomplete:\n  "
+            + "\n  ".join(missing_markers)
+        )
+
+
+def check_v023_docs() -> None:
+    """Keep current v0.23 planning and scope claims discoverable and bounded."""
+    files = _v023_doc_files()
+    missing = [name for name, path in files.items() if not path.exists()]
+    if missing:
+        raise ContractError("Missing v0.23 documentation:\n  " + "\n  ".join(missing))
+
+    _check_v023_doc_links(read_text(ROOT / "docs/README.md"))
+    _check_v023_markers(files)
+
+
 def check_rule_scorecard() -> None:
     """The committed per-rule scorecard must be fresh and linked from the docs index.
 
@@ -532,6 +613,7 @@ def check_contract(tag: str | None) -> None:
     check_publication_recovery_contract()
     check_removed_vscode_surface()
     check_roadmap_docs()
+    check_v023_docs()
     check_rule_scorecard()
     check_zoo_gate()
     print(f"Release contract passed for {version}")

--- a/scripts/release-contract.py
+++ b/scripts/release-contract.py
@@ -534,6 +534,43 @@ def check_v023_docs() -> None:
     _check_v023_markers(files)
 
 
+def mcp_tool_names() -> tuple[str, ...]:
+    names = {
+        name
+        for path in (ROOT / "src/commands/mcp").glob("*.rs")
+        for name in re.findall(r'pub const TOOL_NAME: &str = "([^"]+)"', read_text(path))
+    }
+    if not names:
+        raise ContractError("docs parity could not find MCP tool registry entries")
+    return tuple(sorted(names))
+
+
+def check_docs_parity() -> None:
+    """Compare stable docs claims with source-owned registry and schema values."""
+    mcp_docs = read_text(ROOT / "docs/mcp.md")
+    cli_docs = read_text(ROOT / "docs/cli.md")
+    missing_tools = [
+        f"{tool} missing from {path}"
+        for path, content in (("docs/mcp.md", mcp_docs), ("docs/cli.md", cli_docs))
+        for tool in mcp_tool_names()
+        if tool not in content
+    ]
+    if missing_tools:
+        raise ContractError("docs parity is incomplete:\n  " + "\n  ".join(missing_tools))
+
+    schema_text = read_text(ROOT / "src/report/schema.rs")
+    schema_match = re.search(
+        r'pub const SCAN_REPORT_SCHEMA_VERSION: &str = "([^"]+)"', schema_text
+    )
+    if not schema_match:
+        raise ContractError("docs parity could not find report schema registry value")
+    version = cargo_version()
+    schema = schema_match.group(1)
+    expected = f"Binary `{version}` emits schema `{schema}`"
+    if expected not in read_text(ROOT / "docs/reports.md"):
+        raise ContractError(f"docs parity is incomplete: missing `{expected}`")
+
+
 def check_rule_scorecard() -> None:
     """The committed per-rule scorecard must be fresh and linked from the docs index.
 
@@ -614,6 +651,7 @@ def check_contract(tag: str | None) -> None:
     check_removed_vscode_surface()
     check_roadmap_docs()
     check_v023_docs()
+    check_docs_parity()
     check_rule_scorecard()
     check_zoo_gate()
     print(f"Release contract passed for {version}")

--- a/scripts/tests/test_release_contract.py
+++ b/scripts/tests/test_release_contract.py
@@ -383,6 +383,37 @@ class ReleaseContractTests(unittest.TestCase):
         ):
             release_contract.check_v023_docs()
 
+    def test_docs_parity_requires_registry_tools_in_both_guides(self) -> None:
+        self.write(
+            "src/commands/mcp/review.rs",
+            'pub const TOOL_NAME: &str = "repopilot_review_change";\n',
+        )
+        self.write(
+            "src/commands/mcp/scan.rs",
+            'pub const TOOL_NAME: &str = "repopilot_scan";\n',
+        )
+        self.write("docs/mcp.md", "`repopilot_review_change`\n")
+        self.write("docs/cli.md", "`repopilot_review_change`\n")
+
+        with self.assertRaisesRegex(release_contract.ContractError, "docs parity"):
+            release_contract.check_docs_parity()
+
+    def test_docs_parity_requires_current_schema_and_binary_version(self) -> None:
+        self.write(
+            "Cargo.toml",
+            '[package]\nname = "repopilot"\nversion = "9.9.9"\n',
+        )
+        self.write(
+            "src/report/schema.rs",
+            'pub const SCAN_REPORT_SCHEMA_VERSION: &str = "9.99";\n',
+        )
+        self.write("docs/mcp.md", "")
+        self.write("docs/cli.md", "")
+        self.write("docs/reports.md", "Binary `0.22.0` emits schema `0.26`.\n")
+
+        with self.assertRaisesRegex(release_contract.ContractError, "docs parity"):
+            release_contract.check_docs_parity()
+
     def _write_zoo_scorecard_fixture(self) -> None:
         self.write("tests/zoo/manifest.toml", '[[repo]]\nname = "repo-a"\n')
         self.write("docs/rules-reference.md", "### `a.rule` — Title\n\n- **Lifecycle:** stable\n")

--- a/scripts/tests/test_release_contract.py
+++ b/scripts/tests/test_release_contract.py
@@ -325,6 +325,64 @@ class ReleaseContractTests(unittest.TestCase):
 
         release_contract.check_roadmap_docs()
 
+    def test_v023_docs_require_index_links_and_evidence_files(self) -> None:
+        self.write("docs/README.md", "- [roadmap](roadmap/v0.23.md)\n")
+
+        with self.assertRaisesRegex(
+            release_contract.ContractError, "v0.23 documentation"
+        ):
+            release_contract.check_v023_docs()
+
+    def test_v023_docs_require_current_lifecycle_and_scope_boundaries(self) -> None:
+        self.write(
+            "docs/README.md",
+            "\n".join(
+                [
+                    "roadmap/v0.23.md",
+                    "engineering/v0.23-phase-0-spec.md",
+                    "engineering/v0.23-evidence-ledger.md",
+                ]
+            ),
+        )
+        self.write(
+            "docs/roadmap/v0.23.md",
+            "Status: Phase 0 implementation in progress; ChangeProof runtime implementation has not started.\n"
+            "## Phase 0 — Truth Foundation and Bug Burn-down\n"
+            "## Phase A — Canonical ChangeProof\n",
+        )
+        self.write(
+            "docs/engineering/v0.23-phase-0-spec.md",
+            "Status: in-progress; release direction approved.\n"
+            "Progress source: release evidence ledger\n"
+            "Statuses: `open`, `in-progress`, `verified`, and `accepted`.\n"
+            "#### 0B1 — Schema Truth (PR 1)\n\nStatus: verified;\n"
+            "#### 0B2 — Released Compatibility Evidence (PR 2)\n\nStatus: verified;\n"
+            "### 0C — Recoverable Publication\n\nStatus: in-progress;\n"
+            "### 0D — Documentation and Current UX Truth\n\nStatus: in-progress;\n",
+        )
+        self.write(
+            "docs/engineering/v0.23-evidence-ledger.md",
+            "Status: open; initial evidence baseline, not a completed Phase 0 scorecard.\n"
+            "## Tracked Items\n"
+            "Each closure criterion remains explicit.\n",
+        )
+        self.write(
+            "docs/reports.md",
+            "`assessment_status` is not a safety verdict. Unsupported scope and excluded files remain disclosed.\n",
+        )
+
+        release_contract.check_v023_docs()
+        self.write(
+            "docs/roadmap/v0.23.md",
+            "Status: approved product direction; implementation has not started.\n"
+            "## Phase 0 — Truth Foundation and Bug Burn-down\n"
+            "## Phase A — Canonical ChangeProof\n",
+        )
+        with self.assertRaisesRegex(
+            release_contract.ContractError, "documentation contract"
+        ):
+            release_contract.check_v023_docs()
+
     def _write_zoo_scorecard_fixture(self) -> None:
         self.write("tests/zoo/manifest.toml", '[[repo]]\nname = "repo-a"\n')
         self.write("docs/rules-reference.md", "### `a.rule` — Title\n\n- **Lifecycle:** stable\n")


### PR DESCRIPTION
## What

Make v0.23 Phase 0 documentation reflect the current repository state and keep future drift visible.

## Why

The roadmap still said implementation had not started, and the existing release contract only validated the historical v0.20 planning packet. Users could read `PASS`/health output without an explicit scope boundary for analyzed, unsupported, or excluded files.

## Changes explained

- `scripts/release-contract.py`: adds `check_v023_docs()` for required docs links, lifecycle statuses, and bounded scope wording. It does not replace the existing v0.20 checks.
- `scripts/tests/test_release_contract.py`: proves the new contract fails for missing links and stale lifecycle text, then passes for the current docs.
- `docs/roadmap/v0.23.md` and `docs/engineering/v0.23-phase-0-spec.md`: distinguish Phase 0 progress from the not-yet-started ChangeProof runtime; mark 0B verified and 0C/0D in progress.
- `docs/reports.md`: states that `assessment_status`, `PASS`, and health scores describe analyzed scope only; unsupported and excluded files are not implied to be verified.
- `docs/engineering/v0.23-evidence-ledger.md` and the 0C plan: record PR3 as merged while keeping hosted release/install evidence open, and add the PR4 evidence entry.
- `CHANGELOG.md`: records the user-visible documentation truth improvement.

## Verification

- `python3 scripts/release-contract.py check --tag v0.22.0`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (73 passed)
- `python3 -m py_compile scripts/release-contract.py scripts/tests/test_release_contract.py`
- `git diff --check`
- RepoPilot self-review: 0 findings and 0 review signals.
