### PR TITLE
docs: streamline public documentation navigation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,59 +1,40 @@
 # RepoPilot Documentation
 
-RepoPilot is a review-first local CLI. Start with change review, then use the
-full scan, baseline, and reporting surfaces when a repository needs broader
+RepoPilot is a review-first local CLI. Start with a change review, then use a
+full scan, baseline, or reporting surface when a repository needs broader
 adoption or CI policy.
 
-## User Guides
+## Start here
 
 - [Installation](install.md)
-- [Guard your agent runs](agent-guardrail.md)
-- [Track repository health over time](repository-health.md)
 - [Common workflows](commands.md)
 - [CLI reference](cli.md)
 - [Configuration and local feedback](configuration.md)
+
+## Understand results
+
 - [Reports and schemas](reports.md)
+- [Repository health](repository-health.md)
+- [Rulesets](rulesets.md)
+- [Rules reference](rules-reference.md)
+- [Trust mode](trust-mode.md)
+- [Risk engine](risk-engine.md)
+
+## Advanced analysis
+
+- [Knowledge engine and local calibration](knowledge-engine.md)
+- [Architecture anti-patterns](architecture-antipatterns.md)
+- [React Native analysis](react-native.md)
+
+## Integrations and safety
+
+- [Guard your agent runs](agent-guardrail.md)
 - [GitHub pull request integration](integrations/github-code-scanning.md)
 - [MCP server](mcp.md)
 - [Language and framework support](language-support.md)
 - [Security model](security.md)
 
-## Product Behavior
+## Project
 
-- [Rulesets](rulesets.md)
-- [Rules reference](rules-reference.md)
-- [Trust mode](trust-mode.md)
-- [Risk engine](risk-engine.md)
-- [Knowledge engine](knowledge-engine.md)
-- [Architecture anti-patterns](architecture-antipatterns.md)
-- [React Native analysis](react-native.md)
-
-## Maintainer Guides
-
-- [v0.23 roadmap and release contract](roadmap/v0.23.md)
-- [v0.23 Phase 0 truth foundation specification](engineering/v0.23-phase-0-spec.md)
-- [v0.23 Phase 0A evidence-baseline plan](engineering/v0.23-phase-0a-plan.md)
-- [v0.23 report compatibility matrix](engineering/v0.23-compatibility-matrix.md)
-- [v0.23 Phase 0B2 compatibility implementation plan](engineering/v0.23-phase-0b-compatibility-plan.md)
-- [v0.23 Phase 0C recoverable publication plan](engineering/v0.23-0c-publication-recovery-plan.md)
-- [v0.23 release evidence ledger](engineering/v0.23-evidence-ledger.md)
-- [v0.22 repository intelligence design](engineering/v0.22-repository-intelligence-design.md)
-- [v0.22 Phase A1 context graph specification](engineering/v0.22-phase-a1-context-graph-v2.md)
-- [v0.22 Phase A3 graph state convergence specification](engineering/v0.22-phase-a3-graph-state-convergence.md)
-- [Analysis platform state](engineering/analysis-platform-state.md)
-- [Dependency Graph v2 design](engineering/dependency-graph-v2.md)
-- [Signal contract](engineering/signal-contract.md)
-- [Language surface inventory](engineering/language-surface-inventory.md)
-- [Add a language](engineering/add-a-language.md)
-- [Engine pipeline](engineering/engine-pipeline.md)
-- [Graph scan hardening](engineering/graph-scan-hardening.md)
-- [Performance budgets](engineering/performance-budgets.md)
-- [Release process](release.md)
-- [Distribution](distribution.md)
 - [Roadmap](roadmap.md)
-- [v0.22 release contract](roadmap/v0.22.md)
-- [v0.21 roadmap and release contract](roadmap/v0.21.md)
-- [v0.20 roadmap and release contract](roadmap/v0.20.md)
-- [v0.20 release scorecard](engineering/v0.20-release-scorecard.md)
-- [Rule scorecard](engineering/rule-scorecard.md)
-- [GitHub ruleset](github-ruleset.md)
+- [Maintainer and engineering documentation](engineering/README.md)

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -1,0 +1,73 @@
+# Engineering Documentation
+
+This is the working area for RepoPilot maintainers. It contains implementation
+contracts, release evidence, generated measurements, and historical records.
+It is not required for normal RepoPilot use; start with the [public
+documentation](../README.md) instead.
+
+## Current maintainer and release material
+
+- [Release process](../release.md)
+- [Distribution](../distribution.md)
+- [GitHub ruleset](../github-ruleset.md)
+- [Roadmap](../roadmap.md)
+- [v0.23 roadmap and release contract](../roadmap/v0.23.md)
+- [Add a language](add-a-language.md)
+- [Analysis platform state](analysis-platform-state.md)
+- [Dependency Graph v2 design](dependency-graph-v2.md)
+- [Engine pipeline contract](engine-pipeline.md)
+- [Graph and scan hardening notes](graph-scan-hardening.md)
+- [Performance budgets](performance-budgets.md)
+- [Signal contract](signal-contract.md)
+
+## Generated evidence and quality measurements
+
+- [Rule scorecard](rule-scorecard.md)
+- [Language surface inventory](language-surface-inventory.md)
+- [v0.23 report compatibility matrix](v0.23-compatibility-matrix.md)
+- [v0.23 release evidence ledger](v0.23-evidence-ledger.md)
+
+## v0.23 current implementation records
+
+- [Phase 0 truth foundation specification](v0.23-phase-0-spec.md)
+- [Phase 0A evidence baseline plan](v0.23-phase-0a-plan.md)
+- [Phase 0B2 compatibility evidence plan](v0.23-phase-0b-compatibility-plan.md)
+- [Recoverable publication plan](v0.23-0c-publication-recovery-plan.md)
+
+<details>
+<summary>Historical release records (v0.20–v0.22)</summary>
+
+Historical plans and completed release packets are retained for provenance and
+debugging. They are not part of the current implementation path.
+
+- [v0.20 roadmap and release contract](../roadmap/v0.20.md)
+- [v0.20 release scorecard](v0.20-release-scorecard.md)
+- [v0.21 roadmap and release contract](../roadmap/v0.21.md)
+- [v0.22 roadmap and release contract](../roadmap/v0.22.md)
+- [v0.22 release scorecard](v0.22-release-scorecard.md)
+
+- [Repository intelligence design](v0.22-repository-intelligence-design.md)
+- [Phase A1 context graph v2](v0.22-phase-a1-context-graph-v2.md)
+- [Phase A3 graph state convergence plan](v0.22-phase-a3-graph-state-convergence-plan.md)
+- [Phase A3 graph state convergence](v0.22-phase-a3-graph-state-convergence.md)
+- [B2.1 removed export review](v0.22-removed-export-review-spec.md)
+- [B2.2a symbol facts plan](v0.22-b2.2-symbol-fact-cache-plan.md)
+- [B2.2a symbol facts specification](v0.22-b2.2-symbol-fact-cache-spec.md)
+- [B2.2b changed-scan API plan](v0.22-b2.2b-changed-scan-api-contract-plan.md)
+- [B2.2b changed-scan API specification](v0.22-b2.2b-changed-scan-api-contract-spec.md)
+- [Broken import evidence](v0.22-broken-import-evidence-spec.md)
+- [Optional Python imports](v0.22-optional-python-imports-plan.md)
+- [Decision UX plan](v0.22-decision-ux-plan.md)
+- [Decision UX contract](v0.22-decision-ux-spec.md)
+- [D1 review verification plan](v0.22-d1-review-verification-plan.md)
+- [D1 review verification specification](v0.22-d1-review-verification-spec.md)
+- [D2 MCP verification plan](v0.22-d2-mcp-verification-plan.md)
+- [D2 MCP verification specification](v0.22-d2-mcp-verification-spec.md)
+- [D3 verification cache plan](v0.22-d3-verification-cache-plan.md)
+- [D3 verification cache specification](v0.22-d3-verification-cache-spec.md)
+- [E1 MCP hardening plan](v0.22-e1-mcp-hardening-plan.md)
+- [E1 MCP hardening specification](v0.22-e1-mcp-hardening-spec.md)
+- [E2 CLI truth and UX plan](v0.22-e2-cli-truth-ux-plan.md)
+- [E2 CLI truth and UX specification](v0.22-e2-cli-truth-ux-spec.md)
+
+</details>

--- a/scripts/release-contract.py
+++ b/scripts/release-contract.py
@@ -276,6 +276,59 @@ def check_markdown_links() -> None:
         raise ContractError("Broken Markdown links:\n  " + "\n  ".join(failures))
 
 
+def _local_markdown_targets(document: Path) -> set[Path]:
+    targets: set[Path] = set()
+    for raw_target in MARKDOWN_LINK.findall(read_text(document)):
+        target = raw_target.strip().split(maxsplit=1)[0].strip("<>")
+        if not target or target.startswith(("#", "http://", "https://", "mailto:")):
+            continue
+        path_text = unquote(target.split("#", 1)[0].split("?", 1)[0])
+        if path_text:
+            targets.add((document.parent / path_text).resolve())
+    return targets
+
+
+def check_docs_navigation() -> None:
+    """Keep public docs concise while making engineering docs discoverable."""
+    public_index = ROOT / "docs" / "README.md"
+    engineering_index = ROOT / "docs" / "engineering" / "README.md"
+    if not engineering_index.exists():
+        raise ContractError("Missing docs/engineering/README.md engineering index")
+
+    public_targets = _local_markdown_targets(public_index)
+    expected_index = engineering_index.resolve()
+    if expected_index not in public_targets:
+        raise ContractError("docs/README.md must link to engineering/README.md")
+
+    public_text = read_text(public_index)
+    leaked = [
+        target
+        for target in MARKDOWN_LINK.findall(public_text)
+        if target.strip().split(maxsplit=1)[0].strip("<>").startswith("engineering/")
+        and target.strip().split(maxsplit=1)[0].strip("<>") != "engineering/README.md"
+    ]
+    historical = [
+        target
+        for target in MARKDOWN_LINK.findall(public_text)
+        if re.match(r"roadmap/v0\.(?:20|21|22|23)\.md(?:#|$)", target.strip())
+    ]
+    if leaked or historical:
+        details = ", ".join(leaked + historical)
+        raise ContractError(f"public docs index links internal/history docs: {details}")
+
+    indexed = _local_markdown_targets(engineering_index)
+    missing = [
+        path.relative_to(ROOT)
+        for path in sorted((ROOT / "docs" / "engineering").glob("*.md"))
+        if path.name != "README.md" and path.resolve() not in indexed
+    ]
+    if missing:
+        raise ContractError(
+            "engineering index is missing links:\n  "
+            + "\n  ".join(map(str, missing))
+        )
+
+
 def check_npm_claims() -> None:
     stale_patterns = [
         re.compile(r"REPOPILOT_SKIP_DOWNLOAD"),
@@ -446,11 +499,11 @@ def check_roadmap_docs() -> None:
             + "\n  ".join(missing_headings)
         )
 
-    docs_index = read_text(ROOT / "docs" / "README.md")
-    if "roadmap/v0.20.md" not in docs_index:
-        raise ContractError("docs/README.md does not link to v0.20 roadmap")
-    if "v0.20-release-scorecard.md" not in docs_index:
-        raise ContractError("docs/README.md does not link to v0.20 release scorecard")
+    engineering_index = read_text(ROOT / "docs" / "engineering" / "README.md")
+    if "../roadmap/v0.20.md" not in engineering_index:
+        raise ContractError("engineering index does not link to v0.20 roadmap")
+    if "v0.20-release-scorecard.md" not in engineering_index:
+        raise ContractError("engineering index does not link to v0.20 release scorecard")
 
 
 def _v023_doc_files() -> dict[str, Path]:
@@ -462,17 +515,15 @@ def _v023_doc_files() -> dict[str, Path]:
     }
 
 
-def _check_v023_doc_links(docs_index: str) -> None:
+def _check_v023_doc_links(engineering_index: str) -> None:
     required_links = (
-        "roadmap/v0.23.md",
-        "engineering/v0.23-phase-0-spec.md",
-        "engineering/v0.23-evidence-ledger.md",
+        "../roadmap/v0.23.md",
+        "v0.23-phase-0-spec.md",
+        "v0.23-evidence-ledger.md",
     )
-    missing_links = [link for link in required_links if link not in docs_index]
+    missing_links = [link for link in required_links if link not in engineering_index]
     if missing_links:
-        raise ContractError(
-            "docs/README.md is missing v0.23 links:\n  " + "\n  ".join(missing_links)
-        )
+        raise ContractError("engineering index is missing v0.23 links:\n  " + "\n  ".join(missing_links))
 
 
 def _v023_required_markers(files: dict[str, Path]) -> dict[Path, tuple[str, ...]]:
@@ -530,7 +581,7 @@ def check_v023_docs() -> None:
     if missing:
         raise ContractError("Missing v0.23 documentation:\n  " + "\n  ".join(missing))
 
-    _check_v023_doc_links(read_text(ROOT / "docs/README.md"))
+    _check_v023_doc_links(read_text(ROOT / "docs/engineering" / "README.md"))
     _check_v023_markers(files)
 
 
@@ -598,9 +649,9 @@ def check_rule_scorecard() -> None:
             "regenerate with `python3 scripts/zoo.py scorecard --write`"
         )
 
-    docs_index = read_text(ROOT / "docs" / "README.md")
-    if "rule-scorecard.md" not in docs_index:
-        raise ContractError("docs/README.md does not link to the rule scorecard")
+    engineering_index = read_text(ROOT / "docs" / "engineering" / "README.md")
+    if "rule-scorecard.md" not in engineering_index:
+        raise ContractError("engineering index does not link to the rule scorecard")
 
 
 def check_zoo_gate() -> None:
@@ -644,6 +695,7 @@ def check_contract(tag: str | None) -> None:
     release_notes(version)
     check_markdown_links()
     check_npm_claims()
+    check_docs_navigation()
     check_cargo_package()
     check_action_pins()
     check_release_orchestration()

--- a/scripts/tests/test_release_contract.py
+++ b/scripts/tests/test_release_contract.py
@@ -306,7 +306,8 @@ class ReleaseContractTests(unittest.TestCase):
             "## Release Gates\n## Definition of Done\n",
         )
         self.write("docs/engineering/v0.20-release-scorecard.md", "# Scorecard\n")
-        self.write("docs/README.md", "- no links here\n")
+        self.write("docs/engineering/README.md", "- [r](../roadmap/v0.20.md)\n")
+        self.write("docs/README.md", "- [Engineering](engineering/README.md)\n")
 
         with self.assertRaisesRegex(
             release_contract.ContractError, "does not link"
@@ -321,7 +322,11 @@ class ReleaseContractTests(unittest.TestCase):
             "## Release Gates\n## Definition of Done\n",
         )
         self.write("docs/engineering/v0.20-release-scorecard.md", "# Scorecard\n")
-        self.write("docs/README.md", "- [r](roadmap/v0.20.md)\n- [s](engineering/v0.20-release-scorecard.md)\n")
+        self.write(
+            "docs/engineering/README.md",
+            "- [r](../roadmap/v0.20.md)\n- [s](v0.20-release-scorecard.md)\n",
+        )
+        self.write("docs/README.md", "- [Engineering](engineering/README.md)\n")
 
         release_contract.check_roadmap_docs()
 
@@ -338,11 +343,15 @@ class ReleaseContractTests(unittest.TestCase):
             "docs/README.md",
             "\n".join(
                 [
-                    "roadmap/v0.23.md",
-                    "engineering/v0.23-phase-0-spec.md",
-                    "engineering/v0.23-evidence-ledger.md",
+                    "engineering/README.md",
                 ]
             ),
+        )
+        self.write(
+            "docs/engineering/README.md",
+            "../roadmap/v0.23.md\n"
+            "v0.23-phase-0-spec.md\n"
+            "v0.23-evidence-ledger.md\n",
         )
         self.write(
             "docs/roadmap/v0.23.md",
@@ -382,6 +391,49 @@ class ReleaseContractTests(unittest.TestCase):
             release_contract.ContractError, "documentation contract"
         ):
             release_contract.check_v023_docs()
+
+    def test_docs_navigation_rejects_direct_internal_public_link(self) -> None:
+        self.write("docs/engineering/foo.md", "# Foo\n")
+        self.write("docs/engineering/README.md", "- [Foo](foo.md)\n")
+        self.write(
+            "docs/README.md",
+            "- [Engineering](engineering/README.md)\n"
+            "- [Foo](engineering/foo.md)\n",
+        )
+
+        with self.assertRaisesRegex(release_contract.ContractError, "public docs index"):
+            release_contract.check_docs_navigation()
+
+    def test_docs_navigation_rejects_versioned_roadmap_public_link(self) -> None:
+        self.write("docs/engineering/foo.md", "# Foo\n")
+        self.write("docs/engineering/README.md", "- [Foo](foo.md)\n")
+        self.write(
+            "docs/README.md",
+            "- [Engineering](engineering/README.md)\n"
+            "- [v0.22](roadmap/v0.22.md)\n",
+        )
+
+        with self.assertRaisesRegex(release_contract.ContractError, "internal/history"):
+            release_contract.check_docs_navigation()
+
+    def test_docs_navigation_rejects_orphan_engineering_file(self) -> None:
+        self.write("docs/engineering/foo.md", "# Foo\n")
+        self.write("docs/engineering/bar.md", "# Bar\n")
+        self.write("docs/engineering/README.md", "- [Foo](foo.md)\n")
+        self.write("docs/README.md", "- [Engineering](engineering/README.md)\n")
+
+        with self.assertRaisesRegex(release_contract.ContractError, "engineering index"):
+            release_contract.check_docs_navigation()
+
+    def test_docs_navigation_passes_with_single_public_engineering_link(self) -> None:
+        self.write("docs/engineering/foo.md", "# Foo\n")
+        self.write("docs/engineering/README.md", "- [Foo](foo.md)\n")
+        self.write(
+            "docs/README.md",
+            "- [Engineering](engineering/README.md)\n- [Roadmap](roadmap.md)\n",
+        )
+
+        release_contract.check_docs_navigation()
 
     def test_docs_parity_requires_registry_tools_in_both_guides(self) -> None:
         self.write(
@@ -444,7 +496,7 @@ class ReleaseContractTests(unittest.TestCase):
     def test_rule_scorecard_fails_when_stale(self) -> None:
         self._write_zoo_scorecard_fixture()
         self.write("docs/engineering/rule-scorecard.md", "stale content\n")
-        self.write("docs/README.md", "- [x](engineering/rule-scorecard.md)\n")
+        self.write("docs/engineering/README.md", "- [x](rule-scorecard.md)\n")
 
         with self.assertRaisesRegex(release_contract.ContractError, "stale"):
             release_contract.check_rule_scorecard()
@@ -452,7 +504,7 @@ class ReleaseContractTests(unittest.TestCase):
     def test_rule_scorecard_requires_docs_index_link(self) -> None:
         self._write_zoo_scorecard_fixture()
         self.write("docs/engineering/rule-scorecard.md", self._fresh_rule_scorecard())
-        self.write("docs/README.md", "- no links here\n")
+        self.write("docs/engineering/README.md", "- no scorecard link\n")
 
         with self.assertRaisesRegex(release_contract.ContractError, "does not link"):
             release_contract.check_rule_scorecard()
@@ -460,7 +512,7 @@ class ReleaseContractTests(unittest.TestCase):
     def test_rule_scorecard_passes_when_fresh(self) -> None:
         self._write_zoo_scorecard_fixture()
         self.write("docs/engineering/rule-scorecard.md", self._fresh_rule_scorecard())
-        self.write("docs/README.md", "- [x](engineering/rule-scorecard.md)\n")
+        self.write("docs/engineering/README.md", "- [x](rule-scorecard.md)\n")
 
         release_contract.check_rule_scorecard()
 


### PR DESCRIPTION
## What

- Keep the public documentation index focused on the normal RepoPilot user journey.
- Add a maintainer engineering index for current contracts, generated evidence, and history.
- Collapse v0.20–v0.22 historical records without deleting or renaming their URLs.
- Enforce the navigation boundary in the release contract.

## Why

The repository should feel like a usable product, not a chronological implementation notebook. Historical provenance remains available, but it no longer dominates the first documentation path.

## Verification

- `python3 -m unittest scripts.tests.test_release_contract` — 39 passed
- `python3 scripts/release-contract.py check` — passed
- `git diff --check` — passed
- Zoo report unchanged: 25 default-visible findings, 9 actionable, 16 accepted, 0 false-positive
