### PR TITLE
fix: redact matched secret segments safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- Hardened `security.secret-candidate` evidence redaction: connection strings
+  now mask the matched credential segment instead of the first assignment, and
+  Unicode secrets no longer risk a byte-boundary panic. Real demo/Docker
+  credentials remain visible as findings while their values stay masked.
+
 - Added source-driven documentation parity checks: MCP tool names now come
   from the Rust registry, and the reports guide is checked against the current
   package and report-schema versions. The existing release-contract job runs

--- a/src/audits/security/secret_candidate.rs
+++ b/src/audits/security/secret_candidate.rs
@@ -160,7 +160,7 @@ fn detect_secret_line(
             line_number,
             path,
             matched_key,
-            mask_secret_value(line.trim()),
+            mask_secret_value(line.trim(), matched_key),
             confidence,
         ));
     }

--- a/src/audits/security/secret_candidate/finding.rs
+++ b/src/audits/security/secret_candidate/finding.rs
@@ -61,14 +61,64 @@ fn mask_token_in_line(line: &str, token: &str) -> String {
     line.replace(token, &format!("{visible_prefix}...***"))
 }
 
-fn mask_secret_value(line: &str) -> String {
-    // Find the first = or : assignment and mask everything after the first 3 chars of value
-    if let Some(pos) = line.find('=').or_else(|| line.find(':')) {
-        let (key_part, value_part) = line.split_at(pos + 1);
-        let value = value_part.trim().trim_matches('"').trim_matches('\'');
-        if value.len() > 3 {
-            return format!("{key_part} \"{}...***\"", &value[..3]);
+fn mask_secret_value(line: &str, matched_key: &str) -> String {
+    let lower_line = line.to_ascii_lowercase();
+    let lower_key = matched_key.to_ascii_lowercase();
+    let Some(key_start) = lower_line.find(&lower_key) else {
+        return format!("{line} [value masked]");
+    };
+
+    let key_end = key_start + matched_key.len();
+    let after_key = &line[key_end..];
+    let whitespace = after_key.len() - after_key.trim_start().len();
+    let mut value_start = key_end + whitespace;
+    let assignment = &line[value_start..];
+    if assignment.starts_with('=') {
+        value_start += 1;
+    } else if assignment.starts_with(':') {
+        value_start += 1;
+        let after_colon = &line[value_start..];
+        value_start += after_colon.len() - after_colon.trim_start().len();
+        if line[value_start..].starts_with('=') {
+            value_start += 1;
         }
+    } else {
+        return format!("{line} [value masked]");
     }
-    format!("{line} [value masked]")
+
+    let value = line[value_start..].trim_start();
+    value_start += line[value_start..].len() - value.len();
+    let (value_end, quote) = match value.chars().next() {
+        Some(quote @ ('"' | '\'')) => {
+            let end = value[quote.len_utf8()..]
+                .find(quote)
+                .map(|offset| quote.len_utf8() + offset + quote.len_utf8())
+                .unwrap_or(value.len());
+            (value_start + end, Some(quote))
+        }
+        Some(_) => {
+            let end = value
+                .find(|character: char| {
+                    character.is_whitespace() || matches!(character, ';' | ',' | '}')
+                })
+                .unwrap_or(value.len());
+            (value_start + end, None)
+        }
+        None => return format!("{line} [value masked]"),
+    };
+
+    let raw_value = &line[value_start..value_end];
+    let unquoted = quote
+        .map(|quote| raw_value.trim_start_matches(quote).trim_end_matches(quote))
+        .unwrap_or(raw_value);
+    if unquoted.chars().count() <= 3 {
+        return format!("{line} [value masked]");
+    }
+
+    let prefix = unquoted.chars().take(3).collect::<String>();
+    let replacement = match quote {
+        Some(quote) => format!("{quote}{prefix}...***{quote}"),
+        None => format!("{prefix}...***"),
+    };
+    format!("{}{}{}", &line[..value_start], replacement, &line[value_end..])
 }

--- a/tests/security_rules.rs
+++ b/tests/security_rules.rs
@@ -23,6 +23,62 @@ fn secret_candidate_masks_secret_values_and_skips_placeholders() {
 }
 
 #[test]
+fn secret_candidate_redaction_handles_unicode_without_panicking() {
+    let file = file("src/config.rs", "PASSWORD = \"pa😊ssword-with-unicode\"\n");
+
+    let findings = SecretCandidateAudit.audit(&file, &ScanConfig::default());
+
+    assert_eq!(findings.len(), 1);
+    let snippet = &findings[0].evidence[0].snippet;
+    assert!(
+        snippet.contains("pa😊...***"),
+        "unexpected redaction: {snippet}"
+    );
+    assert!(!snippet.contains("pa😊ssword-with-unicode"));
+}
+
+#[test]
+fn secret_candidate_keeps_demo_docker_credentials_visible_and_masked() {
+    let compose = file(
+        "docker-compose.yml",
+        "environment:\n  SA_PASSWORD=@someThingComplicated1234\n",
+    );
+    let appsettings = file(
+        "src/PublicApi/appsettings.Docker.json",
+        "    \"CatalogConnection\": \"Server=sqlserver,1433;User Id=sa;Password=@someThingComplicated1234;Trusted_Connection=false;TrustServerCertificate=true;\",\n",
+    );
+
+    let compose_findings = SecretCandidateAudit.audit(&compose, &ScanConfig::default());
+    assert_eq!(
+        compose_findings.len(),
+        1,
+        "demo credential must remain a finding"
+    );
+    assert_eq!(compose_findings[0].confidence, Confidence::High);
+    let compose_snippet = &compose_findings[0].evidence[0].snippet;
+    assert!(
+        compose_snippet.contains("@so...***"),
+        "unexpected redaction: {compose_snippet}"
+    );
+    assert!(!compose_snippet.contains("@someThingComplicated1234"));
+
+    let appsettings_findings = SecretCandidateAudit.audit(&appsettings, &ScanConfig::default());
+    assert_eq!(
+        appsettings_findings.len(),
+        1,
+        "demo credential must remain a finding"
+    );
+    assert_eq!(appsettings_findings[0].confidence, Confidence::High);
+    let appsettings_snippet = &appsettings_findings[0].evidence[0].snippet;
+    assert!(
+        appsettings_snippet.contains("Server=sqlserver")
+            && appsettings_snippet.contains("Password=@so...***"),
+        "the matched password segment should be masked in place: {appsettings_snippet}"
+    );
+    assert!(!appsettings_snippet.contains("@someThingComplicated1234"));
+}
+
+#[test]
 fn secret_candidate_skips_test_and_fixture_paths() {
     let file = file("tests/fixture.rs", "API_KEY = \"abc123xyz987\"\n");
 


### PR DESCRIPTION
## What
- mask the matched secret assignment instead of the first `=` in a line
- make secret redaction Unicode-safe
- keep real demo/Docker credentials visible while masking their values

## Why
The zoo found real credentials in connection strings. The detector was correct, but evidence redaction masked `Server=...` rather than `Password=...`, and byte slicing could panic on Unicode.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test security_rules` (35 passed)