### PR TITLE
chore: trim redundant private rustdoc

### DIFF
--- a/src/analysis/symbols/javascript.rs
+++ b/src/analysis/symbols/javascript.rs
@@ -70,11 +70,8 @@ fn extract_export(node: Node<'_>, content: &str, facts: &mut JavaScriptSymbolFac
     }
 }
 
-/// Records what a sourced `export ... from "..."` statement can still supply.
-///
-/// The forwarded symbols live in another module, so their kind is unknown here.
-/// A bare `export * from "..."` can supply any name, which makes every removal
-/// claim about this module unprovable.
+// Forwarded symbols are owned by another module. A wildcard re-export therefore
+// makes removal claims about this module unprovable.
 fn extract_re_export(node: Node<'_>, content: &str, facts: &mut JavaScriptSymbolFacts) {
     let mut cursor = node.walk();
     let mut forwards_named_symbols = false;
@@ -96,7 +93,7 @@ fn extract_re_export(node: Node<'_>, content: &str, facts: &mut JavaScriptSymbol
     }
 }
 
-/// `export * as api from "..."` supplies only the alias it binds.
+// A namespace re-export supplies only its declared alias.
 fn record_namespace_export(node: Node<'_>, content: &str, facts: &mut JavaScriptSymbolFacts) {
     match node.named_child(0).and_then(|alias| {
         alias

--- a/src/audits/architecture/deep_directory_nesting.rs
+++ b/src/audits/architecture/deep_directory_nesting.rs
@@ -43,19 +43,8 @@ impl ProjectAudit for DeepDirectoryNestingAudit {
     }
 }
 
-/// Whether this file's depth reflects a decision someone made about layout.
-///
-/// The rule's claim is that a tree is hard to navigate, which only holds where
-/// the tree could have been shallower. Two large classes of file fail that:
-///
-/// * **Non-source files.** A compiled gettext catalog under
-///   `locale/<lang>/LC_MESSAGES/`, a vendored minified stylesheet, a Django
-///   template — their location is fixed by the tool that reads them, and nobody
-///   navigates them by directory anyway.
-/// * **JVM sources.** Java, Kotlin, and Scala require the directory path to
-///   mirror the declared package, so `com/google/samples/apps/nowinandroid/core/`
-///   is a package name rendered as folders, not nesting anyone chose. Reporting
-///   it flags every file in the repository.
+// Only count source files whose directory depth is a layout choice. Generated
+// assets and JVM package paths are fixed by their tooling.
 fn depth_is_a_layout_choice(path: &Path) -> bool {
     const SOURCE_EXTENSIONS: &[&str] = &[
         "rs", "ts", "tsx", "js", "jsx", "mjs", "cjs", "py", "go", "rb", "php", "cs", "swift", "c",

--- a/src/audits/architecture/graph_queries/entrypoints.rs
+++ b/src/audits/architecture/graph_queries/entrypoints.rs
@@ -165,11 +165,8 @@ fn is_framework_autoload(path: &Path, name: &str) -> bool {
     )
 }
 
-/// File-system routing: the framework derives the route from the path, so the
-/// module is never imported by name.
-///
-/// Next.js App Router, Next.js Pages Router, and Expo Router all reserve a
-/// small set of file names inside a routing directory.
+// Framework routing derives the route from a reserved path, so these modules
+// need not be imported by name.
 fn is_file_system_route(path: &Path, name: &str) -> bool {
     let Some(stem) = script_stem(name) else {
         return false;

--- a/src/audits/architecture/graph_queries/layers.rs
+++ b/src/audits/architecture/graph_queries/layers.rs
@@ -32,8 +32,6 @@ impl LayerIndex {
         Self { layers }
     }
 
-    /// Position of the file in the declared layer order (0 = highest-level), or
-    /// `None` when the file matches no declared layer.
     fn layer_of(&self, info: &NodeInfo) -> Option<usize> {
         self.layers
             .iter()

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -134,16 +134,8 @@ impl GraphQueriesAudit {
     }
 }
 
-/// A production file that nothing imports and that is not an entrypoint or a
-/// package's public API surface is likely dead code.
-///
-/// "Nothing imports this file" is an absence claim, so it is only as good as
-/// the import graph: an unresolved internal import whose final segment matches
-/// this file's name could well be the missing importer (skip entirely), and
-/// any other unresolved internal import still means the graph is incomplete
-/// (report at `Medium` instead of the registry's `High`). Internal imports
-/// include relative paths, recognized aliases, and bare imports that target a
-/// repository directory — the monorepo/workspace shapes the resolver misses.
+// Emit dead-module evidence only when the import graph is ready for an absence
+// claim; unresolved internal imports lower confidence or suppress the claim.
 fn dead_module_finding(
     info: &NodeInfo,
     fan_in: Option<usize>,

--- a/src/audits/architecture/import_coupling/cycles.rs
+++ b/src/audits/architecture/import_coupling/cycles.rs
@@ -113,11 +113,7 @@ fn is_type_erasing_language(path: &Path) -> bool {
     )
 }
 
-/// `component` is the full strongly-connected component (all mutually dependent
-/// files); `shortest` is the minimal cycle within it, as a closed path
-/// (`a -> b -> a`). The finding leads with the actionable minimal cycle and
-/// carries the component size as context, instead of repeating the whole
-/// component into every evidence snippet.
+// Lead with the shortest cycle and retain the full component size as context.
 fn circular_dependency_finding(
     component: &[PathBuf],
     shortest: &[PathBuf],

--- a/src/audits/architecture/unresolved_local_imports/speculation.rs
+++ b/src/audits/architecture/unresolved_local_imports/speculation.rs
@@ -30,11 +30,8 @@ pub(super) fn is_python_package_member(
     source_facts.is_some_and(|facts| facts.imports.iter().any(|import| import == parent))
 }
 
-/// The module a derived candidate would have been derived from: everything
-/// before the last dotted segment, keeping the leading relative dots.
-///
-/// `.a` → `.`, `..a` → `..`, `.a.b` → `.a`, `pkg.a` → `pkg`. A bare `.` or `..`
-/// has no parent to check.
+// Return the parent module while preserving leading relative dots. Bare `.` and
+// `..` have no parent candidate.
 fn parent_module(raw_import: &str) -> Option<&str> {
     let leading_dots = raw_import.len() - raw_import.trim_start_matches('.').len();
     let (dots, rest) = raw_import.split_at(leading_dots);

--- a/src/audits/code_quality/sanitize.rs
+++ b/src/audits/code_quality/sanitize.rs
@@ -7,8 +7,7 @@
 /// state and pass a mutable reference for each line in the file.
 ///
 /// Handles mid-line block comments correctly (e.g. `foo(); /* comment */ bar()`).
-/// Does not handle Rust raw strings or nested block comments — a future
-/// parser-level pass is the right place for those.
+/// Rust raw strings and nested block comments are not handled.
 pub fn sanitize_c_style(line: &str, in_block_comment: &mut bool) -> String {
     let mut output = String::with_capacity(line.len());
     let mut chars = line.chars().peekable();

--- a/src/audits/context/classify/helpers.rs
+++ b/src/audits/context/classify/helpers.rs
@@ -180,12 +180,8 @@ fn is_minified(path: &Path) -> bool {
         })
 }
 
-/// Vendored or generated JS/TS bundles — Emscripten/WASM glue, codegen output —
-/// are not hand-maintained source, so their runtime constructs (e.g. an
-/// Emscripten `process.exit` shim) are noise rather than the hazard a rule
-/// targets. They announce themselves with an Emscripten runtime marker or a
-/// bare, whole-file lint opt-out as the very first line (no rule list — a
-/// signature hand-written code does not use).
+// Ignore generated JS/TS bundles identified by Emscripten markers or a bare
+// whole-file lint opt-out; their runtime shims are not authored application code.
 fn looks_like_vendored_bundle(content: &str) -> bool {
     if content.contains("Emscripten Module") || content.contains("EMSCRIPTEN_") {
         return true;

--- a/src/audits/context/classify/helpers.rs
+++ b/src/audits/context/classify/helpers.rs
@@ -81,7 +81,6 @@ pub fn is_test_file(path: &Path) -> bool {
         || (file_name.starts_with("test_") && conventions.test_prefix_marks_test)
 }
 
-/// Whether any of `names` appears as a whole directory component of the path.
 fn has_test_directory(path_text: &str, names: &[&str]) -> bool {
     let mut components = path_text.split(['/', '\\']).collect::<Vec<_>>();
     components.pop(); // the file name itself is not a directory

--- a/src/audits/context/classify/roles.rs
+++ b/src/audits/context/classify/roles.rs
@@ -11,9 +11,8 @@ use crate::audits::context::model::{
 };
 use std::path::Path;
 
-// This is the single orchestration boundary for role classification. Keeping
-// all classifier inputs explicit makes path/content/framework decisions visible
-// and avoids hiding them inside mutable global state.
+// Keep classifier inputs explicit so path/content/framework decisions stay
+// visible and do not depend on mutable global state.
 #[allow(clippy::too_many_arguments)]
 pub fn classify_roles(
     roles: &mut Vec<FileRole>,

--- a/src/audits/framework/react_native/async_storage.rs
+++ b/src/audits/framework/react_native/async_storage.rs
@@ -61,8 +61,7 @@ impl ProjectAudit for AsyncStorageFromCoreAudit {
     }
 }
 
-/// Returns the 1-based line number of the import start if AsyncStorage is imported from
-/// react-native. Handles both single-line and multi-line imports.
+// Return the import's 1-based start line; imports may span multiple lines.
 fn find_async_storage_from_core(content: &str) -> Option<usize> {
     let lines: Vec<&str> = content.lines().collect();
     let mut i = 0;

--- a/src/audits/framework/react_native/hermes.rs
+++ b/src/audits/framework/react_native/hermes.rs
@@ -78,8 +78,7 @@ impl ProjectAudit for ReactNativeCodegenMissingAudit {
     }
 }
 
-/// Returns true when gradle.properties explicitly disables Hermes.
-/// Tolerates spaces around `=` and ignores inline comments.
+// Tolerate spaces around `=` and ignore inline comments.
 fn gradle_properties_hermes_disabled(content: &str) -> bool {
     for line in content.lines() {
         let line = line.trim();

--- a/src/audits/framework/react_native/navigation.rs
+++ b/src/audits/framework/react_native/navigation.rs
@@ -128,7 +128,7 @@ impl ProjectAudit for DirectStateMutationAudit {
     }
 }
 
-/// Returns true if the line looks like `this.state.someKey = value` (not `==` or `===`).
+// Match assignment to `this.state.someKey`, excluding equality operators.
 fn is_direct_state_mutation(trimmed: &str) -> bool {
     let Some(pos) = trimmed.find("this.state.") else {
         return false;

--- a/src/audits/framework/rn_dep_health.rs
+++ b/src/audits/framework/rn_dep_health.rs
@@ -241,8 +241,7 @@ fn read_all_deps(root: &std::path::Path) -> Option<serde_json::Map<String, serde
     }
 }
 
-/// Parse a semver-like version string into (major, minor, patch).
-/// Strips leading `^`, `~`, `>=`, `>`, `=`.
+// Accept the common semver prefixes used in dependency manifests.
 fn parse_version(s: &str) -> Option<(u64, u64, u64)> {
     let s = s
         .trim()

--- a/src/audits/security/secret_candidate/parsing.rs
+++ b/src/audits/security/secret_candidate/parsing.rs
@@ -87,17 +87,8 @@ fn is_algolia_public_key(matched_key: &str) -> bool {
     matches!(matched_key, "apikey" | "api_key")
 }
 
-/// The 1-based line numbers that fall inside a `#[cfg(test)]`/`#[test]`-gated
-/// item in a Rust source file.
-///
-/// Secret candidates in an inline `#[cfg(test)] mod tests` block are almost
-/// always fixtures (`password: "short"`, a fake-but-high-entropy token), yet
-/// the file-path test skip only catches whole *test files* — an inline test
-/// module living in a production `.rs` file slips through. Returns an empty set
-/// for non-Rust files. Brace depth is tracked over comment-sanitized lines; the
-/// common `#[cfg(test)]\nmod tests { … }` idiom is matched precisely, and a
-/// gated *declaration* without a body (`#[cfg(test)] mod helpers;`) does not
-/// open a region.
+// Collect lines inside inline Rust test modules so fixture credentials are
+// skipped without excluding production code in the same source file.
 fn rust_cfg_test_lines(file: &FileFacts) -> HashSet<usize> {
     let mut gated = HashSet::new();
     if file.path.extension().and_then(|ext| ext.to_str()) != Some("rs") {

--- a/src/audits/security/secret_candidate/parsing.rs
+++ b/src/audits/security/secret_candidate/parsing.rs
@@ -4,12 +4,8 @@
 // `include!`d into `secret_candidate.rs`, so it uses plain comments, not a `//!`
 // module doc.
 
-/// Returns the content of the first `"..."`/`'...'` segment in `value`, falling
-/// back to trimming surrounding quotes. This survives a trailing token after the
-/// closing quote — `"$PGPASSWORD" \` (a shell line continuation) becomes
-/// `$PGPASSWORD`, and `"short".to_string()` becomes `short` — so placeholder and
-/// shell-expansion detection see the real value instead of a fragment that
-/// looks high-entropy.
+// Extract the first quoted segment so trailing syntax cannot fool placeholder
+// and shell-expansion checks.
 fn unwrap_first_quoted(value: &str) -> &str {
     for quote in ['"', '\''] {
         if let Some(rest) = value.strip_prefix(quote)
@@ -21,16 +17,14 @@ fn unwrap_first_quoted(value: &str) -> &str {
     value.trim_matches('"').trim_matches('\'')
 }
 
-/// True when the value is a shell command substitution (`$(...)`, backticks) or
-/// begins one. A captured command output or expansion is not a literal secret.
+// A captured command output or expansion is not a literal secret.
 fn is_shell_expansion(value: &str) -> bool {
     let value = value.trim();
     value.starts_with("$(") || value.starts_with('`') || value.contains("$(")
 }
 
-/// Lines carrying the public search-only `apiKey` inside an Algolia DocSearch
-/// config block. The signature trio keeps the downgrade scoped to that widget,
-/// so unrelated `apiKey` credentials elsewhere in the file stay High.
+// Find public search-only `apiKey` lines in an Algolia DocSearch block. The
+// signature trio keeps unrelated credentials in the same file at High.
 fn algolia_public_api_key_lines(content: &str) -> HashSet<usize> {
     let lines: Vec<_> = content.lines().collect();
     let mut public_key_lines = HashSet::new();
@@ -88,9 +82,7 @@ fn algolia_config_block_end(lines: &[&str], start: usize) -> usize {
     start
 }
 
-/// True when `matched_key` is the public-facing Algolia search key field. Only
-/// the `apiKey` family is the published search-only key; other secret keys in the
-/// same file are unaffected.
+// Only the `apiKey` family is public; other secret keys in the file are not.
 fn is_algolia_public_key(matched_key: &str) -> bool {
     matches!(matched_key, "apikey" | "api_key")
 }

--- a/src/audits/testing/source_without_test/classification.rs
+++ b/src/audits/testing/source_without_test/classification.rs
@@ -13,17 +13,8 @@ pub(super) fn is_source_file(path: &Path) -> bool {
         && !is_documentation_path(path)
 }
 
-/// Documentation / example source that does not warrant a unit test.
-///
-/// A `docs_src/` tree is an unambiguous documentation name and is skipped wherever
-/// it appears. A bare `docs/` directory is trickier: at a package root (repo root
-/// or a monorepo package such as `packages/<pkg>/docs/`) it holds rendered
-/// examples, but *inside* a source tree (`src/docs/`, `src/features/docs/`,
-/// `lib/domain/docs/`, …) it is an ordinary `docs` domain module — common in a
-/// document-management app — and must stay visible. We therefore treat `docs/` as
-/// documentation only when no source root (`src`/`lib`/`app`) appears anywhere
-/// above it, not merely as its immediate parent. This is position-independent, so
-/// it holds regardless of any scan-root prefix on the path.
+// Skip documentation trees at the package root, but keep `docs/` modules that
+// live below a source root (`src`, `lib`, or `app`).
 fn is_documentation_path(path: &Path) -> bool {
     const SOURCE_ROOTS: &[&str] = &["src", "lib", "app"];
     let components: Vec<String> = path

--- a/src/audits/testing/source_without_test/matching.rs
+++ b/src/audits/testing/source_without_test/matching.rs
@@ -42,19 +42,8 @@ pub(super) fn has_nearby_test(
         || has_rust_integration_test(source, ext, tests_suffixes)
 }
 
-/// A test file named after this module, wherever the suite keeps it.
-///
-/// Path-shaped matching only finds a test that sits beside the module or in a
-/// `tests/` directory named exactly like it. Two dominant conventions do
-/// neither: pytest and Django name the *test* (`tests/test_workflows.py` for
-/// `workflows.py`, in any app's test package), and JUnit names the *class*
-/// (`VetTests.java` under `src/test/java/<package>/`, never beside the source).
-/// Claiming "no test found" for those is simply false.
-///
-/// Matching on the name alone rather than the location is deliberate: the
-/// rule's claim is that no test exists, and a file named for this module is a
-/// test that exists. Locality would be a refinement of a claim this rule does
-/// not make.
+// Match the naming conventions used by pytest/Django (`test_<module>`) and
+// JUnit (`<Class>Test[s]`); test locality is intentionally not inferred.
 fn has_named_test(stem: &str, ext: &str, test_stems: &HashSet<String>) -> bool {
     if stem.is_empty() {
         return false;

--- a/src/commands/mcp/scan_cache.rs
+++ b/src/commands/mcp/scan_cache.rs
@@ -76,9 +76,7 @@ pub(super) fn store(path: &Path, key: &str, output: &str) {
     storage::store(path, key, output);
 }
 
-/// Config content folded into the key so a config change invalidates the cache:
-/// the explicit `config` argument, or the same path-discovered default config the
-/// MCP scan call uses when `config` is omitted.
+// Include the explicit or path-discovered config so edits invalidate the cache.
 fn config_blob(path: &Path, arguments: &Value) -> String {
     let config_path = arguments
         .get("config")

--- a/src/graph/resolver/jvm.rs
+++ b/src/graph/resolver/jvm.rs
@@ -97,11 +97,8 @@ fn file_name_declares(path: &Path, type_name: &str, extensions: &[&str]) -> bool
         .is_some_and(|extension| extensions.contains(&extension))
 }
 
-/// Whether `path` is the file declaring `type_path`: its tail is exactly the
-/// package path plus a source extension, starting at a directory boundary.
-///
-/// `known_files` only ever holds scanned repository files, so matching the tail
-/// cannot reach outside the repository.
+// Match the package/type tail at a directory boundary; callers provide scanned
+// paths, so this cannot resolve outside the repository.
 fn declares_type(path: &Path, type_path: &str, extensions: &[&str]) -> bool {
     let text = path.to_string_lossy().replace('\\', "/");
     let Some(without_extension) = extensions

--- a/src/graph/v2/capabilities.rs
+++ b/src/graph/v2/capabilities.rs
@@ -2,10 +2,9 @@
 //!
 //! [`graph_capabilities`] reports, for one `GraphSnapshot`, which dependency
 //! facts the graph actually carries — counts of file vs external nodes and of
-//! dependency edges by confidence tier. The roadmap calls for rules to declare
-//! whether the graph evidence they need is available for a repository or scope;
-//! this is the bounded, deterministic foundation for that check. It is internal
-//! and has no command or report consumer yet — it does not add a public surface.
+//! dependency edges by confidence tier. Architecture audits and context
+//! analysis use these capabilities to decide whether graph-backed claims are
+//! ready to emit. The calculation is bounded and deterministic.
 
 use super::{GraphEdgeConfidence, GraphNodeKind, GraphSnapshot};
 use std::collections::BTreeMap;

--- a/src/graph/v2/coupling_snapshot.rs
+++ b/src/graph/v2/coupling_snapshot.rs
@@ -13,10 +13,8 @@ use std::path::{Path, PathBuf};
 /// node even if the graph's `nodes` set omits it, so no edge is silently dropped
 /// by snapshot validation (a well-formed `CouplingGraph` already lists them).
 ///
-/// This is the shared bridge between the v1 coupling graph and graph v2. It is
-/// deliberately free of audit concepts (no severities, rule ids, findings, or
-/// evidence), so any future graph v2 consumer can reuse it without depending on
-/// a particular rule.
+/// This bridge is free of audit concepts (no severities, rule ids, findings, or
+/// evidence), so graph consumers can reuse it without depending on a rule.
 pub fn build_coupling_graph_snapshot(
     graph: &CouplingGraph,
 ) -> (GraphSnapshot, BTreeMap<GraphNodeId, PathBuf>) {

--- a/src/graph/v2/readiness.rs
+++ b/src/graph/v2/readiness.rs
@@ -57,16 +57,8 @@ impl GraphReadiness {
     }
 }
 
-/// Whether the graph maps this language well enough to reason from an absence.
-///
-/// An absence claim says "no edge points here". That is only information when
-/// the graph found most of the edges that exist. Comparing a language's
-/// resolved edges against its unresolved internal imports gives that directly:
-/// when more of its imports failed than succeeded, the map has more holes than
-/// roads, and a missing edge says nothing about the code.
-///
-/// No unresolved imports means nothing failed, so a language with few edges is
-/// still fully mapped — sparse is not the same as unmapped.
+// Absence claims are meaningful only when resolved edges cover at least the
+// unresolved internal imports. No unresolved imports means the graph is mapped.
 fn language_is_mapped(
     capabilities: &GraphCapabilities,
     resolution: &ImportResolutionStats,

--- a/src/knowledge/loader.rs
+++ b/src/knowledge/loader.rs
@@ -20,11 +20,7 @@ impl<'a> KnowledgePackSource<'a> {
     }
 }
 
-/// Returns the runtime Knowledge Engine source for this release line.
-///
-/// RepoPilot 0.12 keeps the bundled pack as the only runtime source. The
-/// indirection keeps rule decisions independent from how future local overlays
-/// are loaded and validated.
+/// Returns the bundled Knowledge Engine source used by this process.
 pub fn active_knowledge() -> &'static KnowledgeBase {
     bundled_knowledge()
 }

--- a/src/knowledge/overlay/rules.rs
+++ b/src/knowledge/overlay/rules.rs
@@ -112,14 +112,9 @@ fn discover_overlay(start: &Path) -> Option<std::path::PathBuf> {
 /// process, so a single `OnceLock` (mirroring `active_knowledge()`) is safe.
 ///
 /// This ordering is not enforced at runtime: if [`active_overlay`] is ever
-/// called first, `OnceLock::get_or_init` permanently pins the process to an
-/// empty ruleset, and every subsequent `init_active_overlay(root)` call
-/// silently becomes a no-op — no error, no diagnostic. Today that hazard is
-/// controlled entirely by there being exactly one, early production call
-/// site (`src/commands/product_scan.rs`, wired in PR-2's Task 2.3), which
-/// calls this before any scan mode runs and therefore before `decide()` is
-/// reachable. If a second call site is ever added, whoever adds it is
-/// responsible for preserving that "init before any decide()" ordering.
+/// called first, `OnceLock` permanently pins the process to an empty ruleset.
+/// Keep initialization before the first `decide()` call; the scan startup path
+/// does this once for both CLI and MCP invocations.
 pub fn init_active_overlay(root: &Path) -> &'static OverlayRules {
     OVERLAY.get_or_init(|| {
         OverlayRules::load(root).unwrap_or_else(|_| OverlayRules {

--- a/src/languages/csharp/imports.rs
+++ b/src/languages/csharp/imports.rs
@@ -9,11 +9,8 @@ pub(super) fn spans(parsed: &ParsedFile) -> BTreeMap<String, (usize, usize)> {
     extract_spans(parsed.content())
 }
 
-/// Line-based `using` directive extraction, mirroring the Java/Kotlin
-/// extractors. Handles `using N;`, `global using N;`, `using static T;`,
-/// and the alias form `using A = N.T;` (the aliased path is the edge).
-/// `using (resource)` statements and `using var x = …` declarations are
-/// resource management, not imports, and are skipped.
+// Extract C# `using` directives, including aliases; resource-management
+// statements (`using (...)`, `using var`) are not imports.
 fn extract_spans(content: &str) -> BTreeMap<String, (usize, usize)> {
     let mut result = BTreeMap::new();
     for (i, line) in content.lines().enumerate() {

--- a/src/languages/javascript/imports.rs
+++ b/src/languages/javascript/imports.rs
@@ -36,14 +36,8 @@ fn extract(tree: &Tree, content: &str) -> HashSet<String> {
     extract_spans(tree, content).into_keys().collect()
 }
 
-/// Module paths imported *type-only* — `import type { … }`, `export type { … }`,
-/// or named imports/exports whose every specifier is inline type-only
-/// (`import { type A, type B }`) — and never imported as a value. The TypeScript
-/// compiler erases these, so they create no runtime edge and must be subtracted
-/// from cycle detection (they stay real edges for coupling/fan-out, like Python
-/// deferred imports). A module that is *also* imported as a value anywhere —
-/// including a mixed `import { type A, B }`, a default/namespace import, or a
-/// dynamic `import("…")` — is a runtime edge and is excluded here.
+// Type-only imports are erased at runtime and excluded from cycle detection,
+// unless the same module is imported as a value anywhere in the file.
 fn extract_type_only(tree: &Tree, content: &str) -> HashSet<String> {
     let mut type_only: HashSet<String> = HashSet::new();
     let mut value: HashSet<String> = HashSet::new();

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -1,23 +1,11 @@
-//! Language frontend registry — the single place that answers "what does
-//! RepoPilot know about language X".
+//! Language frontend registry: the compile-time map of language support.
 //!
-//! Today language knowledge is spread across detection profiles
-//! (`knowledge/packs/core.toml`), grammar wiring (`analysis/parse.rs`),
-//! import extractors (`graph/imports/*`), review signal tables, runtime-risk
-//! patterns, and path conventions. Each frontend in this registry will own
-//! its language's slice of those concerns; consumers look the frontend up by
-//! [`LanguageKind`] or knowledge-pack id instead of matching on label
-//! strings.
+//! Each frontend groups the language-specific grammar, imports, review signals,
+//! runtime-risk tables, conventions, and framework probes. Detection profiles
+//! remain in `knowledge/packs/core.toml`; consumers resolve a frontend by
+//! [`LanguageKind`] or knowledge-pack id instead of matching label strings.
 //!
-//! This module is the 0.21 skeleton (PR-1): descriptors and guard tests
-//! only, wired to nothing. Follow-up PRs migrate dispatch here one concern
-//! at a time (detection/parse, imports, review tables, risk, conventions),
-//! each behavior-frozen against the zoo snapshots. Per-language files grow
-//! into directories when they gain their first extractor.
-//!
-//! Frontends are static data assembled at compile time — this is not a
-//! plugin system, and per the Knowledge Engine runtime boundaries it must
-//! not become one.
+//! Frontends are static data assembled at compile time, not a plugin system.
 
 pub mod capability;
 pub(crate) mod conventions;
@@ -42,10 +30,8 @@ use crate::analysis::parse::{ParseLanguage, ParsedFile};
 use crate::audits::context::LanguageKind;
 use std::collections::{BTreeMap, HashSet};
 
-/// Binds one detection label (as stored on `FileFacts.language`) to the
-/// tree-sitter grammar that parses it. Mirrors `ParseLanguage::from_label`
-/// until parse dispatch is rewired through the registry; the guard tests
-/// keep the two in lockstep in the meantime.
+/// Binds one detection label (as stored on `FileFacts.language`) to its
+/// tree-sitter grammar.
 pub struct GrammarBinding {
     pub label: &'static str,
     pub(crate) grammar: ParseLanguage,
@@ -235,9 +221,7 @@ pub(crate) fn review_for_label(
     frontend_for_label(label).and_then(|frontend| frontend.review)
 }
 
-/// The removed-behavior recognizers claiming a file extension, if any. This
-/// dispatch predates label-based detection; the extension lists live on the
-/// tables verbatim and the guard tests keep them from drifting or colliding.
+/// The removed-behavior recognizers claiming a file extension, if any.
 pub(crate) fn removed_for_extension(
     ext: &str,
 ) -> Option<&'static crate::review::signals::tables::RemovedTables> {

--- a/src/languages/python/imports.rs
+++ b/src/languages/python/imports.rs
@@ -39,15 +39,9 @@ fn extract(tree: &Tree, content: &str) -> HashSet<String> {
     extract_spans(tree, content).into_keys().collect()
 }
 
-/// Imports that appear *only* inside a `def`/method body. A function body runs
-/// only when called, so such an import is a *deferred* import — the idiomatic
-/// way Python breaks an import cycle, and not part of the module-load dependency
-/// graph. The coupling graph still records these as edges (they are a real, if
-/// lazy, dependency, which `dead-module`/`excessive-fan-out` must see), but
-/// cycle detection subtracts them so a deferral does not resurrect the very
-/// cycle it broke. A module imported *both* eagerly and lazily keeps its eager
-/// edge, so it is excluded here. Module-scope imports inside `if`/`try` blocks
-/// run at import time and are never deferred.
+// Imports found only inside function bodies are deferred: they remain coupling
+// edges but are excluded from module-load cycle detection. Module-scope imports
+// and modules imported eagerly as well are not deferred.
 fn extract_deferred(tree: &Tree, content: &str) -> HashSet<String> {
     let mut scan = ImportScan::default();
     visit(tree.root_node(), content, false, &mut scan);

--- a/src/report/schema/review.rs
+++ b/src/report/schema/review.rs
@@ -21,9 +21,9 @@ pub struct ReviewJsonReport<'a> {
     pub impact_paths: &'a ImpactPaths,
     pub merge_readiness: MergeReadinessRecord,
     pub boundary_signals: &'a [BoundarySignal],
-    /// Boundary + behavioral + algorithmic + taint signals by confidence tier.
-    /// Additive to `boundary_signals` (which feeds the `definitely` tier); the
-    /// two are expected to collapse into this field in a future schema.
+    /// Boundary, behavioral, algorithmic, and taint signals grouped by tier.
+    /// `boundary_signals` remains as a compatibility view and feeds the
+    /// `definitely` tier.
     pub tiered_signals: &'a TieredSignals,
     pub review_timings: crate::review::model::ReviewTimings,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/review/impact.rs
+++ b/src/review/impact.rs
@@ -106,11 +106,8 @@ pub fn compute_impact_paths(
     }
 }
 
-/// BFS over the importer relation from `seed`, returning every dependent
-/// found within `depth` hops mapped to its minimum hop distance. Excludes
-/// `seed` itself and every other changed file (mirroring `compute_blast_radius`'s
-/// exclusion of changed-from-changed importers). Sorted iteration throughout
-/// (`BTreeMap`/`BTreeSet`) keeps the result deterministic.
+// BFS over importers up to `depth`, excluding the seed and changed files. The
+// ordered maps keep the result deterministic.
 fn bounded_hops(
     seed: &Path,
     importers_by_target: &BTreeMap<PathBuf, BTreeSet<PathBuf>>,

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -253,10 +253,6 @@ fn render_impact_paths(output: &mut String, report: &ReviewReport) {
     }
 }
 
-/// Render the unified, confidence-tiered "Review signals" block. Boundary,
-/// behavioral, algorithmic, and taint signals are grouped into three tiers so
-/// the eye goes to the riskiest part of the diff first. The old standalone
-/// boundary block is folded into the `definitely` tier.
 fn render_tiered_signals(output: &mut String, report: &ReviewReport) {
     let tiered = &report.tiered_signals;
     if tiered.is_empty() {

--- a/src/review/signals/classify.rs
+++ b/src/review/signals/classify.rs
@@ -299,11 +299,8 @@ const ACCESS_STRONG: &[&str] = &[
 /// Request-trust terms (CORS / security headers), matched as whole tokens.
 const REQUEST_TRUST_TOKENS: &[&str] = &["cors", "csp", "helmet"];
 
-/// Whether `text` (already lowercased) names a boundary concept: any
-/// high-specificity `strong` substring, or any vague `tokens` term as a whole
-/// token. The token path is what keeps `author`/`sessionStorage`/`security_logger`
-/// from being misread as boundaries — the same fix applied to the coarse
-/// behavioral fallback.
+// Match specific boundary substrings or vague terms as whole tokens, avoiding
+// lookalikes such as `author` and `security_logger`.
 fn text_names_boundary(text: &str, strong: &[&str], tokens: &[&str]) -> bool {
     if strong.iter().any(|needle| text.contains(needle)) {
         return true;

--- a/src/review/signals/tables.rs
+++ b/src/review/signals/tables.rs
@@ -34,9 +34,8 @@ pub struct AlgorithmicKinds {
 /// Recognizers for the "removed behavioral signal" detectors (deleted tests,
 /// removed error handling, removed auth checks).
 pub struct RemovedTables {
-    /// Extensions this table answers for. This dispatch predates label-based
-    /// detection and is kept verbatim — including `cts`, which detection
-    /// never labels today, preserved as-is rather than silently dropped.
+    /// Extensions this table answers for, including `cts`, which detection does
+    /// not currently label.
     pub(crate) extensions: &'static [&'static str],
     /// Whether a node declares one test case (`it(...)`, `def test_…`, …).
     pub(crate) is_test_case: for<'a> fn(tree_sitter::Node<'a>, &'a str) -> bool,

--- a/src/review/signals/taint/sanitizers.rs
+++ b/src/review/signals/taint/sanitizers.rs
@@ -12,7 +12,7 @@
 //! Context-specific sanitizers (shell quoting like `shlex.quote`, URL encoding
 //! like `encodeURIComponent`, HTML escaping like `escape`) only neutralize for
 //! *their* sink and would cause false negatives if applied to SQL/exec/fs
-//! universally — recognizing them per-sink is a documented follow-up.
+//! universally. Per-sink sanitizer semantics are not modeled here.
 
 use super::tables::TaintTables;
 use tree_sitter::Node;

--- a/src/rules/eval/fixtures.rs
+++ b/src/rules/eval/fixtures.rs
@@ -76,11 +76,8 @@ fn discover_rule_fixture_dirs(
     Ok(fixture_dirs)
 }
 
-/// A fixture directory's name *is* its rule id. A directory that matches no
-/// registered rule (a typo, a renamed rule, a stray folder) would otherwise be
-/// evaluated with no quality gate — `apply_rule_quality_gate` returns early when
-/// `lookup_rule_metadata` is `None` — and silently contribute nothing. Reject it
-/// loudly instead so coverage can never rot unnoticed.
+// Reject fixture directories that do not name a registered rule; otherwise they
+// would bypass the quality gate and silently disappear from coverage.
 fn ensure_fixture_dirs_are_known_rules(
     fixture_dirs: &BTreeMap<String, PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/rules/registry/architecture.rs
+++ b/src/rules/registry/architecture.rs
@@ -226,8 +226,8 @@ pub(super) static RULES: &[RuleMetadata] = &[
         rule_id: "architecture.test-leak",
         title: "Test code leaked into production",
         category: FindingCategory::Architecture,
-        // Medium while Experimental and undocumented; a High default would
-        // require a `docs_url` per the finding contract (rules reference: PR-J).
+        // Keep Medium while Experimental and undocumented; a High default would
+        // require a `docs_url` per the finding contract.
         default_severity: Severity::Medium,
         default_confidence: Confidence::High,
         lifecycle: RuleLifecycle::Experimental,

--- a/src/scan/cache.rs
+++ b/src/scan/cache.rs
@@ -346,10 +346,8 @@ impl CachePath for FindingsEntry {
     }
 }
 
-/// File-hash and file-role caches store only file metadata (path, hash, LOC,
-/// language). They do not depend on which rules are active, so they only need
-/// to be invalidated when the binary schema changes — not on every version
-/// bump. This lets incremental rescans stay warm across patch releases.
+// File metadata caches are independent of active rules; invalidate them only
+// when their schema changes so patch releases retain warm rescans.
 fn valid_file_hashes_cache(cache: &FileHashesCache) -> bool {
     cache.schema_version == CACHE_SCHEMA_VERSION
 }
@@ -359,12 +357,8 @@ fn valid_file_roles_cache(cache: &FileRolesCache) -> bool {
     cache.schema_version == CACHE_SCHEMA_VERSION
 }
 
-/// The findings cache header is also validated by schema version only.
-/// Per-entry invalidation is handled by `FindingsEntry::config_fingerprint`,
-/// which is a hash of every active rule + config setting computed by
-/// `config_fingerprint()` in `cache/fingerprint.rs`. When rules change,
-/// the fingerprint changes and that entry is skipped; unaffected entries
-/// remain valid across version bumps.
+// Per-entry findings invalidation uses `FindingsEntry::config_fingerprint`;
+// unchanged entries survive rule/config changes and version bumps.
 fn valid_findings_cache(cache: &FindingsCache) -> bool {
     cache.schema_version == CACHE_SCHEMA_VERSION
 }


### PR DESCRIPTION
## What
- remove Rustdoc from private helpers where it only repeats the signature
- keep short implementation comments for non-obvious parsing and matching rules
- leave public API docs, contracts, security invariants, and regression rationale unchanged

## Why
The repository had many function descriptions that read like generated documentation even though the functions are private. This keeps the code navigable without deleting the comments that explain why behavior exists.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all --quiet` (891 lib + integration tests passed)