### PR TITLE
test: refresh secret-candidate zoo evidence

### DIFF
--- a/tests/zoo/expectations/eshoponweb.toml
+++ b/tests/zoo/expectations/eshoponweb.toml
@@ -10,7 +10,7 @@ strict_coverage = "selective"
 
 [[finding]]
 profile = "default"
-finding_id = "security.secret-candidate:docker-compose.yml:51c0493bf3025959"
+finding_id = "security.secret-candidate:docker-compose.yml:1831fc89486577ba"
 rule_id = "security.secret-candidate"
 path = "docker-compose.yml"
 disposition = "valid-but-accepted"
@@ -18,7 +18,7 @@ reason = "Hardcoded SA_PASSWORD in docker-compose; intentional demo credential f
 
 [[finding]]
 profile = "default"
-finding_id = "security.secret-candidate:src/ApplicationCore/Constants/AuthorizationConstants.cs:a9ec5b53067db7ff"
+finding_id = "security.secret-candidate:src/ApplicationCore/Constants/AuthorizationConstants.cs:f6c3d2fad604e951"
 rule_id = "security.secret-candidate"
 path = "src/ApplicationCore/Constants/AuthorizationConstants.cs"
 disposition = "valid-but-accepted"
@@ -26,7 +26,7 @@ reason = "Hardcoded JWT_SECRET_KEY constant; demo signing key shipped by the ref
 
 [[finding]]
 profile = "default"
-finding_id = "security.secret-candidate:src/ApplicationCore/Constants/AuthorizationConstants.cs:5a72f55e73b3db87"
+finding_id = "security.secret-candidate:src/ApplicationCore/Constants/AuthorizationConstants.cs:251c0c616980f575"
 rule_id = "security.secret-candidate"
 path = "src/ApplicationCore/Constants/AuthorizationConstants.cs"
 disposition = "valid-but-accepted"
@@ -36,7 +36,7 @@ reason = "Hardcoded DEFAULT_PASSWORD constant used to seed sample accounts; inte
 # connection strings) -> both occurrences are disambiguated by line.
 [[finding]]
 profile = "default"
-finding_id = "security.secret-candidate:src/PublicApi/appsettings.Docker.json:01d78fc0be373598"
+finding_id = "security.secret-candidate:src/PublicApi/appsettings.Docker.json:456a29ec69193872"
 rule_id = "security.secret-candidate"
 path = "src/PublicApi/appsettings.Docker.json"
 line = 3
@@ -45,7 +45,7 @@ reason = "CatalogConnection string with an embedded demo password for the Docker
 
 [[finding]]
 profile = "default"
-finding_id = "security.secret-candidate:src/PublicApi/appsettings.Docker.json:01d78fc0be373598"
+finding_id = "security.secret-candidate:src/PublicApi/appsettings.Docker.json:d4e88c63d02b9c65"
 rule_id = "security.secret-candidate"
 path = "src/PublicApi/appsettings.Docker.json"
 line = 4
@@ -54,7 +54,7 @@ reason = "IdentityConnection string with an embedded demo password for the Docke
 
 [[finding]]
 profile = "default"
-finding_id = "security.secret-candidate:src/Web/appsettings.Docker.json:01d78fc0be373598"
+finding_id = "security.secret-candidate:src/Web/appsettings.Docker.json:456a29ec69193872"
 rule_id = "security.secret-candidate"
 path = "src/Web/appsettings.Docker.json"
 line = 3
@@ -63,7 +63,7 @@ reason = "CatalogConnection string with an embedded demo password for the Docker
 
 [[finding]]
 profile = "default"
-finding_id = "security.secret-candidate:src/Web/appsettings.Docker.json:01d78fc0be373598"
+finding_id = "security.secret-candidate:src/Web/appsettings.Docker.json:d4e88c63d02b9c65"
 rule_id = "security.secret-candidate"
 path = "src/Web/appsettings.Docker.json"
 line = 4

--- a/tests/zoo/expectations/excalidraw.toml
+++ b/tests/zoo/expectations/excalidraw.toml
@@ -51,17 +51,16 @@ path = "packages/excalidraw/data/blob.ts"
 disposition = "actionable"
 reason = "Mutual dependency between data/blob.ts and data/filesystem.ts; two sibling modules that import each other directly."
 
-# Strict recall anchor: the public Algolia DocSearch key was downgraded to a
-# strict-only Low in #246. Keep it pinned so the downgrade can't silently become
-# a full suppression.
+# Strict recall anchor: the public Algolia DocSearch key is intentionally
+# strict-only Low. Keep it pinned so the downgrade cannot become a suppression.
 [[finding]]
 profile = "strict"
-finding_id = "security.secret-candidate:dev-docs/docusaurus.config.js:9fe21045a4599527"
+finding_id = "security.secret-candidate:dev-docs/docusaurus.config.js:dad96017f07ffb4c"
 rule_id = "security.secret-candidate"
 path = "dev-docs/docusaurus.config.js"
 line = 139
 disposition = "valid-but-accepted"
-reason = "Public, search-only Algolia DocSearch apiKey in the docs site config; safe to publish and intentionally retained as a strict recall anchor (#246)."
+reason = "Public, search-only Algolia DocSearch apiKey in the docs site config; safe to publish and intentionally retained as a strict recall anchor."
 
 [[finding]]
 profile = "strict"

--- a/tests/zoo/snapshots/eshoponweb.json
+++ b/tests/zoo/snapshots/eshoponweb.json
@@ -8,13 +8,13 @@
       "security.secret-candidate": 7
     },
     "fingerprints": [
-      "security.secret-candidate:docker-compose.yml:51c0493bf3025959",
-      "security.secret-candidate:src/ApplicationCore/Constants/AuthorizationConstants.cs:5a72f55e73b3db87",
-      "security.secret-candidate:src/ApplicationCore/Constants/AuthorizationConstants.cs:a9ec5b53067db7ff",
-      "security.secret-candidate:src/PublicApi/appsettings.Docker.json:01d78fc0be373598",
-      "security.secret-candidate:src/PublicApi/appsettings.Docker.json:01d78fc0be373598",
-      "security.secret-candidate:src/Web/appsettings.Docker.json:01d78fc0be373598",
-      "security.secret-candidate:src/Web/appsettings.Docker.json:01d78fc0be373598"
+      "security.secret-candidate:docker-compose.yml:1831fc89486577ba",
+      "security.secret-candidate:src/ApplicationCore/Constants/AuthorizationConstants.cs:251c0c616980f575",
+      "security.secret-candidate:src/ApplicationCore/Constants/AuthorizationConstants.cs:f6c3d2fad604e951",
+      "security.secret-candidate:src/PublicApi/appsettings.Docker.json:456a29ec69193872",
+      "security.secret-candidate:src/PublicApi/appsettings.Docker.json:d4e88c63d02b9c65",
+      "security.secret-candidate:src/Web/appsettings.Docker.json:456a29ec69193872",
+      "security.secret-candidate:src/Web/appsettings.Docker.json:d4e88c63d02b9c65"
     ],
     "visible_total": 7
   },


### PR DESCRIPTION
## What
- refresh eShopOnWeb secret-candidate fingerprints after the redaction contract change
- refresh the Excalidraw strict Algolia anchor
- remove historical PR-number references from the expectation note

## Why
The detector still emits the same accepted demo/public credentials; only evidence hashes changed after the merged secret-segment redaction fix. Keeping snapshots and expectations aligned makes the pinned zoo a truthful quality gate.

## Verification
- `python3 scripts/zoo.py scan`
- `python3 scripts/zoo.py scorecard`
- `python3 scripts/release-contract.py check`
- `git diff --check`