### PR TITLE
refactor: split graph query audit stages

### DIFF
--- a/src/audits/architecture/graph_queries/audit_helpers.rs
+++ b/src/audits/architecture/graph_queries/audit_helpers.rs
@@ -1,0 +1,122 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use crate::analysis::{ArchitectureClassifier, ArchitectureContext};
+use crate::findings::types::Finding;
+use crate::graph::ImportResolutionStats;
+use crate::graph::v2::{GraphEdge, GraphNodeId, GraphSnapshot};
+use crate::scan::facts::{FileFacts, ScanFacts};
+
+use super::layers::LayerIndex;
+use super::packages::PackageIndex;
+use super::{NodeInfo, dead_module_finding, relative_path, test_leak_finding};
+
+pub(super) fn build_file_indexes<'a>(
+    facts: &'a ScanFacts,
+    root: &Path,
+    classifier: &ArchitectureClassifier,
+) -> (
+    HashMap<PathBuf, ArchitectureContext>,
+    HashMap<PathBuf, &'a FileFacts>,
+    HashSet<PathBuf>,
+) {
+    let mut file_context = HashMap::new();
+    let mut facts_by_path = HashMap::new();
+    let mut known_files = HashSet::new();
+    for file in &facts.files {
+        let context = classifier.classify(file);
+        let abs_path = root.join(&file.path);
+        file_context.insert(abs_path.clone(), context.clone());
+        file_context.insert(file.path.clone(), context);
+        facts_by_path.insert(abs_path, file);
+        facts_by_path.insert(file.path.clone(), file);
+        known_files.insert(crate::graph::resolver::normalize_path(&file.path));
+    }
+    (file_context, facts_by_path, known_files)
+}
+
+pub(super) fn build_node_info<'a>(
+    snapshot: &GraphSnapshot,
+    path_by_id: &std::collections::BTreeMap<GraphNodeId, PathBuf>,
+    root: &Path,
+    file_context: &HashMap<PathBuf, ArchitectureContext>,
+    facts_by_path: &HashMap<PathBuf, &'a FileFacts>,
+) -> HashMap<GraphNodeId, NodeInfo<'a>> {
+    snapshot
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            let path = path_by_id.get(&node.id)?;
+            let context = file_context.get(path)?;
+            let file_facts = facts_by_path.get(path)?;
+            Some((
+                node.id.clone(),
+                NodeInfo {
+                    relative: relative_path(path, root),
+                    context: context.clone(),
+                    facts: Some(*file_facts),
+                },
+            ))
+        })
+        .collect()
+}
+
+pub(super) fn fan_in_by_target(edges: &[GraphEdge]) -> HashMap<GraphNodeId, usize> {
+    let mut fan_in = HashMap::new();
+    for edge in edges {
+        *fan_in.entry(edge.to.clone()).or_insert(0) += 1;
+    }
+    fan_in
+}
+
+pub(super) fn dead_module_findings(
+    snapshot: &GraphSnapshot,
+    node_info: &HashMap<GraphNodeId, NodeInfo<'_>>,
+    fan_in: &HashMap<GraphNodeId, usize>,
+    capabilities: &crate::graph::v2::GraphCapabilities,
+    resolution: &ImportResolutionStats,
+) -> Vec<Finding> {
+    snapshot
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            let info = node_info.get(&node.id)?;
+            dead_module_finding(
+                info,
+                fan_in.get(&node.id).copied(),
+                super::target_absence_readiness(info, capabilities, resolution),
+            )
+        })
+        .collect()
+}
+
+pub(super) fn edge_findings(
+    snapshot: &GraphSnapshot,
+    node_info: &HashMap<GraphNodeId, NodeInfo<'_>>,
+    root: &Path,
+    known_files: &HashSet<PathBuf>,
+    layer_index: &LayerIndex,
+    package_index: &PackageIndex,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let mut reported_edges = HashSet::new();
+    for edge in &snapshot.edges {
+        if !reported_edges.insert((edge.from.clone(), edge.to.clone())) {
+            continue;
+        }
+        let (Some(source), Some(target)) = (node_info.get(&edge.from), node_info.get(&edge.to))
+        else {
+            continue;
+        };
+        if let Some(finding) = test_leak_finding(source, target, root, known_files) {
+            findings.push(finding);
+        }
+        if let Some(finding) = layer_index.violation_finding(source, target, root, known_files) {
+            findings.push(finding);
+        }
+        if let Some(finding) = package_index.violation_finding(source, target, root, known_files) {
+            findings.push(finding);
+        }
+    }
+    findings
+}

--- a/src/audits/architecture/graph_queries/mod.rs
+++ b/src/audits/architecture/graph_queries/mod.rs
@@ -5,17 +5,16 @@
 //! workspace and can also be driven explicitly by `[architecture] package_roots`;
 //! with neither a workspace nor config the rule is silent.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::analysis::{ArchitectureClassifier, ArchitectureContext, FileRole};
 use crate::findings::types::{Confidence, Evidence, Finding, FindingCategory, Severity};
 use crate::graph::ImportResolutionStats;
-use crate::graph::v2::{
-    GraphClaim, GraphNodeId, GraphReadiness, graph_capabilities, graph_readiness,
-};
+use crate::graph::v2::{GraphClaim, GraphReadiness, graph_capabilities, graph_readiness};
 use crate::scan::facts::FileFacts;
 
+mod audit_helpers;
 mod edge_evidence;
 mod entrypoints;
 mod layers;
@@ -25,6 +24,9 @@ mod packages;
 mod tests;
 
 use super::graph_context::GraphAuditContext;
+use audit_helpers::{
+    build_file_indexes, build_node_info, dead_module_findings, edge_findings, fan_in_by_target,
+};
 use edge_evidence::edge_evidence;
 use layers::LayerIndex;
 use packages::PackageIndex;
@@ -39,97 +41,37 @@ pub(crate) struct NodeInfo<'a> {
 
 impl GraphQueriesAudit {
     pub(crate) fn audit(&self, analysis: &GraphAuditContext<'_>) -> Vec<Finding> {
-        let facts = analysis.facts;
-        let config = analysis.config;
-        let snapshot = analysis.snapshot;
-        let path_by_id = analysis.path_by_id;
-        let resolution = analysis.resolution;
-        let root = analysis.root;
-        let classifier = ArchitectureClassifier::new(&config.module_mappings);
+        let classifier = ArchitectureClassifier::new(&analysis.config.module_mappings);
+        let (file_context, facts_by_path, known_files) =
+            build_file_indexes(analysis.facts, analysis.root, &classifier);
+        let node_info = build_node_info(
+            analysis.snapshot,
+            analysis.path_by_id,
+            analysis.root,
+            &file_context,
+            &facts_by_path,
+        );
+        let fan_in = fan_in_by_target(&analysis.snapshot.edges);
+        let capabilities = graph_capabilities(analysis.snapshot);
+        let mut findings = dead_module_findings(
+            analysis.snapshot,
+            &node_info,
+            &fan_in,
+            &capabilities,
+            analysis.resolution,
+        );
 
-        let mut file_context = HashMap::new();
-        let mut facts_by_path = HashMap::new();
-        for file in &facts.files {
-            let context = classifier.classify(file);
-            let abs_path = root.join(&file.path);
-            file_context.insert(abs_path.clone(), context.clone());
-            file_context.insert(file.path.clone(), context);
-            facts_by_path.insert(abs_path, file);
-            facts_by_path.insert(file.path.clone(), file);
-        }
-
-        let known_files: HashSet<PathBuf> = facts
-            .files
-            .iter()
-            .map(|f| crate::graph::resolver::normalize_path(&f.path))
-            .collect();
-
-        let capabilities = graph_capabilities(snapshot);
-
-        let mut node_info: HashMap<GraphNodeId, NodeInfo> = HashMap::new();
-        for node in &snapshot.nodes {
-            if let Some(path) = path_by_id.get(&node.id)
-                && let Some(context) = file_context.get(path)
-                && let Some(file_facts) = facts_by_path.get(path)
-            {
-                node_info.insert(
-                    node.id.clone(),
-                    NodeInfo {
-                        relative: relative_path(path, root),
-                        context: context.clone(),
-                        facts: Some(file_facts),
-                    },
-                );
-            }
-        }
-
-        let mut fan_in: HashMap<GraphNodeId, usize> = HashMap::new();
-        for edge in &snapshot.edges {
-            *fan_in.entry(edge.to.clone()).or_insert(0) += 1;
-        }
-
-        let mut findings = Vec::new();
-
-        for node in &snapshot.nodes {
-            if let Some(info) = node_info.get(&node.id)
-                && let Some(finding) = dead_module_finding(
-                    info,
-                    fan_in.get(&node.id).copied(),
-                    target_absence_readiness(info, &capabilities, resolution),
-                )
-            {
-                findings.push(finding);
-            }
-        }
-
-        let layer_index = LayerIndex::from_config(config);
-        let detected_packages = crate::scan::workspace::detect_workspace_packages(root);
-        let package_index = PackageIndex::new(config, &detected_packages, root);
-
-        let mut reported_edges = HashSet::new();
-        for edge in &snapshot.edges {
-            if !reported_edges.insert((edge.from.clone(), edge.to.clone())) {
-                continue;
-            }
-            let (Some(source), Some(target)) = (node_info.get(&edge.from), node_info.get(&edge.to))
-            else {
-                continue;
-            };
-
-            if let Some(finding) = test_leak_finding(source, target, root, &known_files) {
-                findings.push(finding);
-            }
-            if let Some(finding) = layer_index.violation_finding(source, target, root, &known_files)
-            {
-                findings.push(finding);
-            }
-            if let Some(finding) =
-                package_index.violation_finding(source, target, root, &known_files)
-            {
-                findings.push(finding);
-            }
-        }
-
+        let layer_index = LayerIndex::from_config(analysis.config);
+        let detected_packages = crate::scan::workspace::detect_workspace_packages(analysis.root);
+        let package_index = PackageIndex::new(analysis.config, &detected_packages, analysis.root);
+        findings.extend(edge_findings(
+            analysis.snapshot,
+            &node_info,
+            analysis.root,
+            &known_files,
+            &layer_index,
+            &package_index,
+        ));
         findings
     }
 }

--- a/src/audits/architecture/graph_queries/tests.rs
+++ b/src/audits/architecture/graph_queries/tests.rs
@@ -2,12 +2,39 @@ use std::path::{Path, PathBuf};
 
 use crate::analysis::{ArchitectureContext, FileRole, LanguageFamily, ModuleKind};
 use crate::findings::types::Confidence;
-use crate::graph::v2::GraphReadiness;
+use crate::graph::v2::{
+    GraphEdge, GraphEdgeConfidence, GraphEdgeKind, GraphEdgeProvenance, GraphNodeId, GraphReadiness,
+};
 use crate::scan::config::{LayerSpec, ScanConfig};
 
 use super::layers::LayerIndex;
 use super::packages::PackageIndex;
-use super::{NodeInfo, dead_module_finding, test_leak_finding};
+use super::{NodeInfo, dead_module_finding, fan_in_by_target, test_leak_finding};
+
+#[test]
+fn fan_in_index_counts_edges_by_target() {
+    let source_a = GraphNodeId::new("file:src/a.rs");
+    let source_b = GraphNodeId::new("file:src/b.rs");
+    let target = GraphNodeId::new("file:src/target.rs");
+    let edges = vec![
+        GraphEdge {
+            from: source_a,
+            to: target.clone(),
+            kind: GraphEdgeKind::DependsOn,
+            provenance: GraphEdgeProvenance::Import,
+            confidence: GraphEdgeConfidence::High,
+        },
+        GraphEdge {
+            from: source_b,
+            to: target.clone(),
+            kind: GraphEdgeKind::DependsOn,
+            provenance: GraphEdgeProvenance::Import,
+            confidence: GraphEdgeConfidence::High,
+        },
+    ];
+
+    assert_eq!(fan_in_by_target(&edges).get(&target), Some(&2));
+}
 
 fn node(
     relative: &str,


### PR DESCRIPTION
## What
- split `GraphQueriesAudit::audit` into focused index-building, node-info, fan-in, dead-module, and edge-finding stages
- add a regression test for the fan-in index

## Why
The graph-query audit mixed repository indexing, graph preparation, and three edge rule families in one complex method. This made architecture-rule changes harder to review and contributed to a strict-profile P1 complexity finding.

## Verification
- `cargo test --all` passed (892 library tests, 80 binary tests, all integration tests; 1 intentional ignored compatibility test)
- `cargo clippy --all-targets --all-features -- -D warnings` passed
- `cargo fmt --all -- --check` passed
- `python3 scripts/release-contract.py check` passed for 0.22.0
- strict self-scan: 382 findings / 14 P1 (down from 384 / 15)
- graph-query tests: 39 passed
