### PR TITLE
refactor: reduce code quality audit complexity

### DIFF
--- a/src/audits/code_quality/complexity.rs
+++ b/src/audits/code_quality/complexity.rs
@@ -78,48 +78,76 @@ impl FileAudit for ComplexityAudit {
 /// Counts branching constructs and logical operators as a heuristic complexity metric.
 /// Skips comment-only lines. Word-boundary check prevents matching inside identifiers.
 pub fn count_branches(content: &str) -> usize {
-    const KEYWORDS: &[&str] = &[
-        "if ", "else ", "elif ", "for ", "while ", "match ", "switch ", "case ", "catch ",
-    ];
-    const OPERATORS: &[&str] = &["&&", "||"];
+    content.lines().map(count_line_branches).sum()
+}
 
-    let mut count = 0usize;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("//")
-            || trimmed.starts_with('#')
-            || trimmed.starts_with('*')
-            || trimmed.starts_with("/*")
-        {
-            continue;
-        }
-
-        for op in OPERATORS {
-            let mut rest = trimmed;
-            while let Some(pos) = rest.find(op) {
-                count += 1;
-                rest = &rest[pos + op.len()..];
-            }
-        }
-
-        for kw in KEYWORDS {
-            let mut rest = trimmed;
-            let mut offset = 0usize;
-            while let Some(pos) = rest.find(kw) {
-                let abs = offset + pos;
-                let prev_char = trimmed.as_bytes().get(abs.wrapping_sub(1));
-                let good_boundary =
-                    abs == 0 || prev_char.is_none_or(|b| !b.is_ascii_alphanumeric() && *b != b'_');
-                if good_boundary {
-                    count += 1;
-                }
-                let step = pos + 1;
-                rest = &rest[step..];
-                offset += step;
-            }
-        }
+fn count_line_branches(line: &str) -> usize {
+    let trimmed = line.trim();
+    if is_comment_line(trimmed) {
+        return 0;
     }
 
+    count_operator_matches(trimmed) + count_keyword_matches(trimmed)
+}
+
+fn is_comment_line(line: &str) -> bool {
+    line.starts_with("//")
+        || line.starts_with('#')
+        || line.starts_with('*')
+        || line.starts_with("/*")
+}
+
+fn count_operator_matches(line: &str) -> usize {
+    ["&&", "||"]
+        .iter()
+        .map(|operator| count_substrings(line, operator))
+        .sum()
+}
+
+fn count_keyword_matches(line: &str) -> usize {
+    [
+        "if ", "else ", "elif ", "for ", "while ", "match ", "switch ", "case ", "catch ",
+    ]
+    .iter()
+    .map(|keyword| count_bounded_keyword(line, keyword))
+    .sum()
+}
+
+fn count_substrings(line: &str, needle: &str) -> usize {
+    let mut count = 0;
+    let mut rest = line;
+    while let Some(pos) = rest.find(needle) {
+        count += 1;
+        rest = &rest[pos + needle.len()..];
+    }
     count
+}
+
+fn count_bounded_keyword(line: &str, keyword: &str) -> usize {
+    let mut count = 0;
+    let mut rest = line;
+    let mut offset = 0usize;
+    while let Some(pos) = rest.find(keyword) {
+        let absolute = offset + pos;
+        let previous = line.as_bytes().get(absolute.wrapping_sub(1));
+        if absolute == 0
+            || previous.is_none_or(|byte| !byte.is_ascii_alphanumeric() && *byte != b'_')
+        {
+            count += 1;
+        }
+        let step = pos + 1;
+        rest = &rest[step..];
+        offset += step;
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::count_line_branches;
+
+    #[test]
+    fn line_branch_counter_counts_keyword_and_logical_operator() {
+        assert_eq!(count_line_branches("if ready && valid {"), 2);
+    }
 }

--- a/src/audits/code_quality/rust_panic_risk.rs
+++ b/src/audits/code_quality/rust_panic_risk.rs
@@ -63,88 +63,7 @@ impl RustPanicRiskAudit {
         };
 
         match parsed.tree() {
-            Some(tree) => {
-                let candidates = ast::collect_candidates(tree.root_node(), content);
-
-                let mut findings = Vec::new();
-                let mut sorted_lines: Vec<usize> = candidates.keys().copied().collect();
-                sorted_lines.sort_unstable();
-
-                for line_number in sorted_lines {
-                    let (node, pattern) = candidates.get(&line_number).unwrap();
-                    let trimmed_line = content.lines().nth(line_number - 1).unwrap_or("").trim();
-
-                    // Apply infallible write unwrap structural check
-                    if is_report_renderer_path(&file.path)
-                        && is_structural_infallible_render_write_unwrap(*node, content)
-                    {
-                        continue;
-                    }
-
-                    // A literal `Regex::new("…")`/`Selector::parse("…")` only fails
-                    // on a malformed compile-time pattern — a deterministic bug, not
-                    // a runtime panic risk — so skip it structurally (handles the
-                    // multi-line form the text heuristic below cannot).
-                    if is_infallible_literal_construction_unwrap(*node, content) {
-                        continue;
-                    }
-
-                    // Apply contextual ignore patterns
-                    if should_ignore_contextual_panic_pattern(*pattern, trimmed_line) {
-                        continue;
-                    }
-
-                    let decision = decide_for_audit_context(
-                        RULE_ID,
-                        &context,
-                        pattern.base_severity(),
-                        Some(pattern.signal()),
-                    );
-
-                    if decision.is_suppressed() {
-                        continue;
-                    }
-
-                    // Sanitize line for external failure checks
-                    let mut in_block_comment = false;
-                    let sanitized = sanitize_c_style(trimmed_line, &mut in_block_comment);
-                    let sanitized = sanitized.trim();
-
-                    // A `"literal".parse().unwrap()` parses authored input: it can
-                    // still panic (`"999".parse::<u8>()`), but as a deterministic bug
-                    // caught on the first run, not external-input risk. Downgrade it
-                    // to Low (hidden in default, kept in strict) rather than escalate.
-                    // The text fallback handles the macro form (`vec![…parse()…]`)
-                    // whose body is an unparsed token tree the AST check cannot see.
-                    let severity = if is_literal_parse_unwrap(*node, content)
-                        || is_literal_parse_unwrap_line(trimmed_line)
-                    {
-                        Severity::Low
-                    } else if is_external_failure_path(*pattern, sanitized) && !context.is_test {
-                        decision.severity.max(Severity::High)
-                    } else {
-                        decision.severity
-                    };
-
-                    let mut finding = build_finding(
-                        file,
-                        line_number,
-                        trimmed_line,
-                        *pattern,
-                        &context,
-                        severity,
-                    );
-                    record_decision_provenance(
-                        &mut finding,
-                        pattern.base_severity(),
-                        Some(pattern.signal()),
-                        &decision,
-                    );
-                    findings.push(finding);
-                }
-
-                findings
-            }
+            Some(tree) => self.analyze_ast_candidates(file, content, &context, tree.root_node()),
             None => {
                 let mut findings = self.line_scan(file, content, &context);
                 mark_text_heuristic(&mut findings);
@@ -153,84 +72,193 @@ impl RustPanicRiskAudit {
         }
     }
 
+    fn analyze_ast_candidates(
+        &self,
+        file: &FileFacts,
+        content: &str,
+        context: &crate::audits::context::AuditContext,
+        root: tree_sitter::Node<'_>,
+    ) -> Vec<Finding> {
+        let candidates = ast::collect_candidates(root, content);
+        let mut sorted_lines: Vec<usize> = candidates.keys().copied().collect();
+        sorted_lines.sort_unstable();
+        sorted_lines
+            .into_iter()
+            .filter_map(|line_number| {
+                let (node, pattern) = candidates.get(&line_number)?;
+                self.analyze_candidate(file, content, context, line_number, *node, *pattern)
+            })
+            .collect()
+    }
+
+    fn analyze_candidate(
+        &self,
+        file: &FileFacts,
+        content: &str,
+        context: &crate::audits::context::AuditContext,
+        line_number: usize,
+        node: tree_sitter::Node<'_>,
+        pattern: pattern::RustPanicPattern,
+    ) -> Option<Finding> {
+        let trimmed_line = content.lines().nth(line_number - 1).unwrap_or("").trim();
+        if should_skip_ast_candidate(file, content, node, pattern, trimmed_line) {
+            return None;
+        }
+
+        let decision = decide_for_audit_context(
+            RULE_ID,
+            context,
+            pattern.base_severity(),
+            Some(pattern.signal()),
+        );
+        if decision.is_suppressed() {
+            return None;
+        }
+
+        let mut in_block_comment = false;
+        let sanitized = sanitize_c_style(trimmed_line, &mut in_block_comment);
+        let severity = candidate_severity(
+            node,
+            content,
+            trimmed_line,
+            pattern,
+            sanitized.trim(),
+            context,
+            decision.severity,
+        );
+        let mut finding =
+            build_finding(file, line_number, trimmed_line, pattern, context, severity);
+        record_decision_provenance(
+            &mut finding,
+            pattern.base_severity(),
+            Some(pattern.signal()),
+            &decision,
+        );
+        Some(finding)
+    }
+
     fn line_scan(
         &self,
         file: &FileFacts,
         content: &str,
         context: &crate::audits::context::AuditContext,
     ) -> Vec<Finding> {
-        let mut findings = Vec::new();
-        let mut in_block_comment = false;
-        let mut pending_render_write = false;
+        let mut state = LineScanState::default();
+        content
+            .lines()
+            .enumerate()
+            .filter_map(|(index, line)| scan_line(file, line, index + 1, context, &mut state))
+            .collect()
+    }
+}
 
-        for (index, line) in content.lines().enumerate() {
-            let line_number = index + 1;
-            let trimmed = line.trim();
+#[derive(Default)]
+struct LineScanState {
+    in_block_comment: bool,
+    pending_render_write: bool,
+}
 
-            if trimmed.is_empty() {
-                continue;
-            }
+fn should_skip_ast_candidate(
+    file: &FileFacts,
+    content: &str,
+    node: tree_sitter::Node<'_>,
+    pattern: pattern::RustPanicPattern,
+    trimmed_line: &str,
+) -> bool {
+    (is_report_renderer_path(&file.path)
+        && is_structural_infallible_render_write_unwrap(node, content))
+        || is_infallible_literal_construction_unwrap(node, content)
+        || should_ignore_contextual_panic_pattern(pattern, trimmed_line)
+}
 
-            let sanitized = sanitize_c_style(line, &mut in_block_comment);
-            let sanitized = sanitized.trim();
-            if is_infallible_render_write_start(&file.path, sanitized) {
-                pending_render_write = true;
-            }
+fn candidate_severity(
+    node: tree_sitter::Node<'_>,
+    content: &str,
+    trimmed_line: &str,
+    pattern: pattern::RustPanicPattern,
+    sanitized: &str,
+    context: &crate::audits::context::AuditContext,
+    decision_severity: Severity,
+) -> Severity {
+    if is_literal_parse_unwrap(node, content) || is_literal_parse_unwrap_line(trimmed_line) {
+        Severity::Low
+    } else if is_external_failure_path(pattern, sanitized) && !context.is_test {
+        decision_severity.max(Severity::High)
+    } else {
+        decision_severity
+    }
+}
 
-            let Some(pattern) = detect_pattern(sanitized) else {
-                if sanitized.ends_with(';') {
-                    pending_render_write = false;
-                }
-                continue;
-            };
+fn scan_line(
+    file: &FileFacts,
+    line: &str,
+    line_number: usize,
+    context: &crate::audits::context::AuditContext,
+    state: &mut LineScanState,
+) -> Option<Finding> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
 
-            if pending_render_write && is_infallible_render_write_result_unwrap(pattern, sanitized)
-            {
-                if sanitized.ends_with(';') {
-                    pending_render_write = false;
-                }
-                continue;
-            }
+    let sanitized = sanitize_c_style(line, &mut state.in_block_comment);
+    let sanitized = sanitized.trim();
+    if is_infallible_render_write_start(&file.path, sanitized) {
+        state.pending_render_write = true;
+    }
 
-            if should_ignore_contextual_panic_pattern(pattern, trimmed) {
-                if sanitized.ends_with(';') {
-                    pending_render_write = false;
-                }
-                continue;
-            }
+    let Some(pattern) = detect_pattern(sanitized) else {
+        clear_pending_render_write(sanitized, state);
+        return None;
+    };
+    if skip_line_pattern(pattern, sanitized, trimmed, state) {
+        return None;
+    }
 
-            let decision = decide_for_audit_context(
-                RULE_ID,
-                context,
-                pattern.base_severity(),
-                Some(pattern.signal()),
-            );
+    let decision = decide_for_audit_context(
+        RULE_ID,
+        context,
+        pattern.base_severity(),
+        Some(pattern.signal()),
+    );
+    if decision.is_suppressed() {
+        return None;
+    }
 
-            if decision.is_suppressed() {
-                continue;
-            }
+    let severity = if is_external_failure_path(pattern, sanitized) && !context.is_test {
+        decision.severity.max(Severity::High)
+    } else {
+        decision.severity
+    };
+    let mut finding = build_finding(file, line_number, trimmed, pattern, context, severity);
+    record_decision_provenance(
+        &mut finding,
+        pattern.base_severity(),
+        Some(pattern.signal()),
+        &decision,
+    );
+    clear_pending_render_write(sanitized, state);
+    Some(finding)
+}
 
-            let severity = if is_external_failure_path(pattern, sanitized) && !context.is_test {
-                decision.severity.max(Severity::High)
-            } else {
-                decision.severity
-            };
+fn skip_line_pattern(
+    pattern: pattern::RustPanicPattern,
+    sanitized: &str,
+    trimmed: &str,
+    state: &mut LineScanState,
+) -> bool {
+    let skip = (state.pending_render_write
+        && is_infallible_render_write_result_unwrap(pattern, sanitized))
+        || should_ignore_contextual_panic_pattern(pattern, trimmed);
+    if skip {
+        clear_pending_render_write(sanitized, state);
+    }
+    skip
+}
 
-            let mut finding = build_finding(file, line_number, trimmed, pattern, context, severity);
-            record_decision_provenance(
-                &mut finding,
-                pattern.base_severity(),
-                Some(pattern.signal()),
-                &decision,
-            );
-            findings.push(finding);
-
-            if sanitized.ends_with(';') {
-                pending_render_write = false;
-            }
-        }
-
-        findings
+fn clear_pending_render_write(sanitized: &str, state: &mut LineScanState) {
+    if sanitized.ends_with(';') {
+        state.pending_render_write = false;
     }
 }
 

--- a/src/audits/code_quality/sanitize.rs
+++ b/src/audits/code_quality/sanitize.rs
@@ -9,77 +9,106 @@
 /// Handles mid-line block comments correctly (e.g. `foo(); /* comment */ bar()`).
 /// Rust raw strings and nested block comments are not handled.
 pub fn sanitize_c_style(line: &str, in_block_comment: &mut bool) -> String {
-    let mut output = String::with_capacity(line.len());
-    let mut chars = line.chars().peekable();
-    let mut in_string = false;
-    let mut in_char = false;
-    let mut escaped = false;
+    CStyleSanitizer::new(line, in_block_comment).run()
+}
 
-    while let Some(ch) = chars.next() {
-        if *in_block_comment {
-            if ch == '*' && chars.peek() == Some(&'/') {
-                chars.next();
-                *in_block_comment = false;
-                output.push(' ');
-                output.push(' ');
-            } else {
-                output.push(' ');
-            }
-            continue;
+struct CStyleSanitizer<'a> {
+    chars: std::iter::Peekable<std::str::Chars<'a>>,
+    output: String,
+    in_block_comment: &'a mut bool,
+    in_string: bool,
+    in_char: bool,
+    escaped: bool,
+}
+
+impl<'a> CStyleSanitizer<'a> {
+    fn new(line: &'a str, in_block_comment: &'a mut bool) -> Self {
+        Self {
+            chars: line.chars().peekable(),
+            output: String::with_capacity(line.len()),
+            in_block_comment,
+            in_string: false,
+            in_char: false,
+            escaped: false,
         }
-
-        if in_string {
-            if escaped {
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else if ch == '"' {
-                in_string = false;
-            }
-            output.push(' ');
-            continue;
-        }
-
-        if in_char {
-            if escaped {
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else if ch == '\'' {
-                in_char = false;
-            }
-            output.push(' ');
-            continue;
-        }
-
-        if ch == '/' && chars.peek() == Some(&'/') {
-            break;
-        }
-
-        if ch == '/' && chars.peek() == Some(&'*') {
-            chars.next();
-            *in_block_comment = true;
-            output.push(' ');
-            output.push(' ');
-            continue;
-        }
-
-        if ch == '"' {
-            in_string = true;
-            output.push(' ');
-            continue;
-        }
-
-        if ch == '\'' {
-            in_char = true;
-            output.push(' ');
-            continue;
-        }
-
-        output.push(ch);
     }
 
-    output
+    fn run(mut self) -> String {
+        while let Some(ch) = self.chars.next() {
+            if self.consume_block_comment(ch) || self.consume_literal(ch) {
+                continue;
+            }
+            if self.is_line_comment_start(ch) {
+                break;
+            }
+            if self.consume_literal_start(ch) {
+                continue;
+            }
+            self.output.push(ch);
+        }
+        self.output
+    }
+
+    fn consume_block_comment(&mut self, ch: char) -> bool {
+        if !*self.in_block_comment {
+            return false;
+        }
+        if ch == '*' && self.chars.peek() == Some(&'/') {
+            self.chars.next();
+            *self.in_block_comment = false;
+            self.output.push_str("  ");
+        } else {
+            self.output.push(' ');
+        }
+        true
+    }
+
+    fn consume_literal(&mut self, ch: char) -> bool {
+        let delimiter = if self.in_string {
+            Some('"')
+        } else if self.in_char {
+            Some('\'')
+        } else {
+            None
+        };
+        let Some(delimiter) = delimiter else {
+            return false;
+        };
+        if self.escaped {
+            self.escaped = false;
+        } else if ch == '\\' {
+            self.escaped = true;
+        } else if ch == delimiter {
+            self.in_string = false;
+            self.in_char = false;
+        }
+        self.output.push(' ');
+        true
+    }
+
+    fn is_line_comment_start(&mut self, ch: char) -> bool {
+        ch == '/' && self.chars.peek() == Some(&'/')
+    }
+
+    fn consume_literal_start(&mut self, ch: char) -> bool {
+        if ch == '/' && self.chars.peek() == Some(&'*') {
+            self.chars.next();
+            *self.in_block_comment = true;
+            self.output.push_str("  ");
+            return true;
+        }
+        if ch == '"' {
+            self.in_string = true;
+            self.output.push(' ');
+            return true;
+        }
+        if ch == '\'' {
+            self.in_char = true;
+            self.output.push(' ');
+            return true;
+        }
+        false
+    }
 }
 
 /// Returns `Some(sanitized)` for Python code lines, or `None` if the line
@@ -99,42 +128,48 @@ pub fn sanitize_python_line(line: &str) -> Option<String> {
 }
 
 fn strip_python_string_literals(line: &str) -> String {
-    let mut result = String::with_capacity(line.len());
-    let mut string_delimiter: Option<char> = None;
-    let mut escaped = false;
-
+    let mut state = PythonStringState::default();
     for ch in line.chars() {
-        if let Some(delim) = string_delimiter {
-            if escaped {
-                escaped = false;
-                result.push(' ');
-                continue;
-            }
-            if ch == '\\' {
-                escaped = true;
-                result.push(' ');
-                continue;
-            }
-            if ch == delim {
-                string_delimiter = None;
-                result.push(ch);
-            } else {
-                result.push(' ');
-            }
+        if state.consume_string(ch) {
             continue;
         }
-
         if ch == '#' {
             break;
         }
+        state.start_or_copy(ch);
+    }
+    state.result
+}
 
-        if matches!(ch, '"' | '\'') {
-            string_delimiter = Some(ch);
-            result.push(ch);
-        } else {
-            result.push(ch);
+#[derive(Default)]
+struct PythonStringState {
+    result: String,
+    delimiter: Option<char>,
+    escaped: bool,
+}
+
+impl PythonStringState {
+    fn consume_string(&mut self, ch: char) -> bool {
+        let Some(delimiter) = self.delimiter else {
+            return false;
+        };
+        if self.escaped {
+            self.escaped = false;
+        } else if ch == '\\' {
+            self.escaped = true;
+        } else if ch == delimiter {
+            self.delimiter = None;
+            self.result.push(ch);
+            return true;
         }
+        self.result.push(' ');
+        true
     }
 
-    result
+    fn start_or_copy(&mut self, ch: char) {
+        if matches!(ch, '"' | '\'') {
+            self.delimiter = Some(ch);
+        }
+        self.result.push(ch);
+    }
 }


### PR DESCRIPTION
## What
- reduce complexity in the file complexity metric
- split Rust panic-risk AST and fallback line analysis into focused helpers
- make C-style and Python sanitization state explicit and testable
- preserve the existing finding contract and add a unit contract for per-line complexity counting

## Why
After the graph-query debt cleanup, the remaining P1 complexity findings were concentrated in `complexity.rs`, `rust_panic_risk.rs`, and `sanitize.rs`. This PR addresses all five of those findings together, keeping the technical-debt work coherent instead of splitting it across multiple PRs.

## Behavior
No rule IDs, thresholds, severities, finding ordering, or output schemas were intentionally changed.

## Verification
- `cargo test --all` passed (893 library tests, 80 binary tests, all integration tests; 1 intentional ignored compatibility test)
- `cargo clippy --all-targets --all-features -- -D warnings` passed
- `cargo fmt --all -- --check` passed
- `python3 scripts/release-contract.py check` passed for 0.22.0
- default self-scan: PASS, 0 visible findings
- strict self-scan: 374 findings / 9 P1 (before: 382 / 14 P1)