### PR TITLE
refactor: clear remaining complexity debt

### DIFF
--- a/src/audits/code_quality/deep_control_flow.rs
+++ b/src/audits/code_quality/deep_control_flow.rs
@@ -138,25 +138,36 @@ fn is_control_flow_node(kind: &str, language: &str) -> bool {
 }
 
 fn is_else_if(node: Node<'_>, language: &str) -> bool {
-    let kind = node.kind();
-    let is_if = match language {
-        "Rust" | "Kotlin" => kind == "if_expression",
-        _ => kind == "if_statement",
+    if !is_if_node(node, language) {
+        return false;
+    }
+    let Some(parent) = node.parent() else {
+        return false;
     };
-    if is_if && let Some(parent) = node.parent() {
-        if parent.kind() == "else_clause" || parent.kind() == "else" {
-            return true;
-        }
-        if language == "Kotlin" && parent.kind() == "if_expression" {
-            let mut cursor = parent.walk();
-            let mut saw_else = false;
-            for child in parent.children(&mut cursor) {
-                if child.kind() == "else" {
-                    saw_else = true;
-                } else if child.id() == node.id() {
-                    return saw_else;
-                }
-            }
+    if matches!(parent.kind(), "else_clause" | "else") {
+        return true;
+    }
+    language == "Kotlin" && kotlin_else_if_child(parent, node)
+}
+
+fn is_if_node(node: Node<'_>, language: &str) -> bool {
+    match language {
+        "Rust" | "Kotlin" => node.kind() == "if_expression",
+        _ => node.kind() == "if_statement",
+    }
+}
+
+fn kotlin_else_if_child(parent: Node<'_>, node: Node<'_>) -> bool {
+    if parent.kind() != "if_expression" {
+        return false;
+    }
+    let mut cursor = parent.walk();
+    let mut saw_else = false;
+    for child in parent.children(&mut cursor) {
+        if child.kind() == "else" {
+            saw_else = true;
+        } else if child.id() == node.id() {
+            return saw_else;
         }
     }
     false

--- a/src/audits/framework/js_common.rs
+++ b/src/audits/framework/js_common.rs
@@ -3,6 +3,7 @@ use crate::findings::types::{Evidence, Finding, FindingCategory, Severity};
 use crate::knowledge::decision::apply_file_decision;
 use crate::scan::config::ScanConfig;
 use crate::scan::facts::{FileContentProvider, ScanFacts};
+use std::path::Path;
 
 pub const JS_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx"];
 const TEST_PATH_SEGMENTS: &[&str] = &[
@@ -21,61 +22,12 @@ pub struct VarDeclarationAudit;
 
 impl ProjectAudit for VarDeclarationAudit {
     fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
-        let mut findings = Vec::new();
-
-        for file in &facts.files {
-            if !is_js_file(&file.path) || is_test_path(&file.path) {
-                continue;
-            }
-
-            let Some(content) = FileContentProvider.content(file) else {
-                continue;
-            };
-
-            for (idx, line) in content.lines().enumerate() {
-                let trimmed = line.trim();
-
-                if is_comment_line(trimmed) {
-                    continue;
-                }
-
-                if has_var_declaration(trimmed) {
-                    let finding = Finding {
-                        id: String::new(),
-                        rule_id: "framework.js.var-declaration".to_string(),
-        recommendation: Finding::recommendation_for_rule_id("framework.js.var-declaration"),
-                        title: "var declaration found".to_string(),
-                        description: concat!(
-                            "`var` has function-level scope and is hoisted to the top of its function, ",
-                            "which can cause subtle bugs when variables are accessed before assignment or escape block scope unexpectedly. ",
-                            "Replace `var` with `const` (for values that do not change) or `let` (for values that do). ",
-                            "Both are block-scoped and behave predictably."
-                        ).to_string(),
-                        category: FindingCategory::Framework,
-                        severity: Severity::Low,
-                        confidence: Default::default(),
-                        evidence: vec![Evidence {
-                            path: file.path.clone(),
-                            line_start: idx + 1,
-                            line_end: None,
-                            snippet: trimmed.to_string(),
-                        }],
-                        workspace_package: None,
-                        docs_url: None,
-            provenance: Default::default(),
-            risk: Default::default(),
-                    };
-                    if let Some(finding) =
-                        apply_file_decision("framework.js.var-declaration", file, finding, None)
-                    {
-                        findings.push(finding);
-                    }
-                    break;
-                }
-            }
-        }
-
-        findings
+        audit_javascript_files(
+            facts,
+            has_var_declaration,
+            build_var_finding,
+            "framework.js.var-declaration",
+        )
     }
 }
 
@@ -85,61 +37,102 @@ pub struct ConsoleLogAudit;
 
 impl ProjectAudit for ConsoleLogAudit {
     fn audit(&self, facts: &ScanFacts, _config: &ScanConfig) -> Vec<Finding> {
-        let mut findings = Vec::new();
+        audit_javascript_files(
+            facts,
+            |line| line.contains("console.log("),
+            build_console_log_finding,
+            "framework.js.console-log",
+        )
+    }
+}
 
-        for file in &facts.files {
-            if !is_js_file(&file.path) || is_test_path(&file.path) {
-                continue;
-            }
-
-            let Some(content) = FileContentProvider.content(file) else {
-                continue;
-            };
-
-            for (idx, line) in content.lines().enumerate() {
-                let trimmed = line.trim();
-
-                if is_comment_line(trimmed) {
-                    continue;
-                }
-
-                if trimmed.contains("console.log(") {
-                    let finding = Finding {
-                        id: String::new(),
-                        rule_id: "framework.js.console-log".to_string(),
-        recommendation: Finding::recommendation_for_rule_id("framework.js.console-log"),
-                        title: "console.log found in production source".to_string(),
-                        description: concat!(
-                            "`console.log` statements left in production code expose internal state and data to the device console, ",
-                            "add unnecessary serialisation overhead, and are a minor security concern. ",
-                            "Use a logging library that can be silenced in production builds ",
-                            "(e.g. `react-native-logs` or `loglevel`), or wrap calls in `if (__DEV__)`."
-                        ).to_string(),
-                        category: FindingCategory::Framework,
-                        severity: Severity::Low,
-                        confidence: Default::default(),
-                        evidence: vec![Evidence {
-                            path: file.path.clone(),
-                            line_start: idx + 1,
-                            line_end: None,
-                            snippet: trimmed.to_string(),
-                        }],
-                        workspace_package: None,
-                        docs_url: None,
-            provenance: Default::default(),
-            risk: Default::default(),
-                    };
-                    if let Some(finding) =
-                        apply_file_decision("framework.js.console-log", file, finding, None)
-                    {
-                        findings.push(finding);
-                    }
-                    break;
-                }
-            }
+fn audit_javascript_files(
+    facts: &ScanFacts,
+    matches_line: fn(&str) -> bool,
+    build_finding: fn(&Path, usize, &str) -> Finding,
+    rule_id: &str,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    for file in &facts.files {
+        if !is_js_file(&file.path) || is_test_path(&file.path) {
+            continue;
         }
+        let Some(content) = FileContentProvider.content(file) else {
+            continue;
+        };
+        let Some((line_number, snippet)) = content.lines().enumerate().find_map(|(idx, line)| {
+            let trimmed = line.trim();
+            (!is_comment_line(trimmed) && matches_line(trimmed)).then(|| (idx + 1, trimmed))
+        }) else {
+            continue;
+        };
+        let finding = build_finding(&file.path, line_number, snippet);
+        if let Some(finding) = apply_file_decision(rule_id, file, finding, None) {
+            findings.push(finding);
+        }
+    }
+    findings
+}
 
-        findings
+fn build_var_finding(path: &Path, line_start: usize, snippet: &str) -> Finding {
+    build_finding(
+        "framework.js.var-declaration",
+        "var declaration found",
+        concat!(
+            "`var` has function-level scope and is hoisted to the top of its function, ",
+            "which can cause subtle bugs when variables are accessed before assignment or escape block scope unexpectedly. ",
+            "Replace `var` with `const` (for values that do not change) or `let` (for values that do). ",
+            "Both are block-scoped and behave predictably."
+        ),
+        path,
+        line_start,
+        snippet,
+    )
+}
+
+fn build_console_log_finding(path: &Path, line_start: usize, snippet: &str) -> Finding {
+    build_finding(
+        "framework.js.console-log",
+        "console.log found in production source",
+        concat!(
+            "`console.log` statements left in production code expose internal state and data to the device console, ",
+            "add unnecessary serialisation overhead, and are a minor security concern. ",
+            "Use a logging library that can be silenced in production builds ",
+            "(e.g. `react-native-logs` or `loglevel`), or wrap calls in `if (__DEV__)`."
+        ),
+        path,
+        line_start,
+        snippet,
+    )
+}
+
+fn build_finding(
+    rule_id: &str,
+    title: &str,
+    description: &str,
+    path: &Path,
+    line_start: usize,
+    snippet: &str,
+) -> Finding {
+    Finding {
+        id: String::new(),
+        rule_id: rule_id.to_string(),
+        recommendation: Finding::recommendation_for_rule_id(rule_id),
+        title: title.to_string(),
+        description: description.to_string(),
+        category: FindingCategory::Framework,
+        severity: Severity::Low,
+        confidence: Default::default(),
+        evidence: vec![Evidence {
+            path: path.to_path_buf(),
+            line_start,
+            line_end: None,
+            snippet: snippet.to_string(),
+        }],
+        workspace_package: None,
+        docs_url: None,
+        provenance: Default::default(),
+        risk: Default::default(),
     }
 }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -62,64 +62,17 @@ pub fn build_coupling_graph_with_resolution(
     let mut resolution = ImportResolutionStats::default();
 
     for file in &facts.files {
-        let source = file.path.clone();
-        let normalized_source = resolver::normalize_path(&source);
-        let deferred_raws = file
-            .deferred_imports
-            .iter()
-            .map(|raw| raw.trim())
-            .collect::<HashSet<_>>();
-        let mut eager_targets = BTreeSet::new();
-        // Insert into edges (one clone); nodes is derived from edges keys afterwards.
-        let outgoing = edges.entry(source.clone()).or_default();
-
-        for raw in &file.imports {
-            match resolve_import(raw, &normalized_source, root, &known_files) {
-                Some(target) if target != normalized_source => {
-                    let resolved = known_file_by_normalized
-                        .get(&target)
-                        .cloned()
-                        .unwrap_or(target);
-                    if !deferred_raws.contains(raw.trim()) {
-                        eager_targets.insert(resolved.clone());
-                    }
-                    outgoing.insert(resolved);
-                }
-                // A file importing itself carries no dependency information.
-                Some(_) => {}
-                None => {
-                    let raw = raw.trim();
-                    if resolution_stats::is_unresolved_internal_import(
-                        raw,
-                        &source,
-                        &repo_jvm_packages,
-                        &repo_dirs,
-                    ) {
-                        resolution.record_classified(&source, raw, root);
-                    }
-                }
-            }
-        }
-
-        // Record the non-runtime subset against the same source so cycle detection
-        // can subtract these edges. `deferred_imports ⊆ imports`, so every resolved
-        // target is already present in `edges` above.
-        for raw in &file.deferred_imports {
-            if let Some(target) = resolve_import(raw, &normalized_source, root, &known_files)
-                && target != normalized_source
-            {
-                let resolved = known_file_by_normalized
-                    .get(&target)
-                    .cloned()
-                    .unwrap_or(target);
-                if !eager_targets.contains(&resolved) {
-                    deferred_edges
-                        .entry(source.clone())
-                        .or_default()
-                        .insert(resolved);
-                }
-            }
-        }
+        process_graph_file(
+            file,
+            root,
+            &known_file_by_normalized,
+            &known_files,
+            &repo_dirs,
+            &repo_jvm_packages,
+            &mut edges,
+            &mut deferred_edges,
+            &mut resolution,
+        );
     }
 
     // Build nodes from all sources (edge origins + edge targets).
@@ -136,6 +89,103 @@ pub fn build_coupling_graph_with_resolution(
         },
         resolution,
     )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_graph_file(
+    file: &crate::scan::facts::FileFacts,
+    root: &Path,
+    known_file_by_normalized: &HashMap<PathBuf, PathBuf>,
+    known_files: &HashSet<PathBuf>,
+    repo_dirs: &HashSet<String>,
+    repo_jvm_packages: &HashSet<PathBuf>,
+    edges: &mut BTreeMap<PathBuf, BTreeSet<PathBuf>>,
+    deferred_edges: &mut BTreeMap<PathBuf, BTreeSet<PathBuf>>,
+    resolution: &mut ImportResolutionStats,
+) {
+    let source = file.path.clone();
+    let normalized_source = resolver::normalize_path(&source);
+    let deferred_raws = file
+        .deferred_imports
+        .iter()
+        .map(|raw| raw.trim())
+        .collect::<HashSet<_>>();
+    let mut eager_targets = BTreeSet::new();
+    let outgoing = edges.entry(source.clone()).or_default();
+
+    for raw in &file.imports {
+        process_import(
+            raw,
+            &source,
+            &normalized_source,
+            &deferred_raws,
+            root,
+            known_file_by_normalized,
+            known_files,
+            repo_dirs,
+            repo_jvm_packages,
+            outgoing,
+            &mut eager_targets,
+            resolution,
+        );
+    }
+
+    for raw in &file.deferred_imports {
+        if let Some(target) = resolve_import(raw, &normalized_source, root, known_files)
+            && target != normalized_source
+        {
+            let resolved = known_file_by_normalized
+                .get(&target)
+                .cloned()
+                .unwrap_or(target);
+            if !eager_targets.contains(&resolved) {
+                deferred_edges
+                    .entry(source.clone())
+                    .or_default()
+                    .insert(resolved);
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_import(
+    raw: &str,
+    source: &Path,
+    normalized_source: &Path,
+    deferred_raws: &HashSet<&str>,
+    root: &Path,
+    known_file_by_normalized: &HashMap<PathBuf, PathBuf>,
+    known_files: &HashSet<PathBuf>,
+    repo_dirs: &HashSet<String>,
+    repo_jvm_packages: &HashSet<PathBuf>,
+    outgoing: &mut BTreeSet<PathBuf>,
+    eager_targets: &mut BTreeSet<PathBuf>,
+    resolution: &mut ImportResolutionStats,
+) {
+    match resolve_import(raw, normalized_source, root, known_files) {
+        Some(target) if target != normalized_source => {
+            let resolved = known_file_by_normalized
+                .get(&target)
+                .cloned()
+                .unwrap_or(target);
+            if !deferred_raws.contains(raw.trim()) {
+                eager_targets.insert(resolved.clone());
+            }
+            outgoing.insert(resolved);
+        }
+        Some(_) => {}
+        None if resolution_stats::is_unresolved_internal_import(
+            raw.trim(),
+            source,
+            repo_jvm_packages,
+            repo_dirs,
+        ) =>
+        {
+            resolution.record_classified(source, raw.trim(), root)
+        }
+        None => {}
+    }
 }
 
 // ── Metrics ───────────────────────────────────────────────────────────────────

--- a/src/knowledge/decision.rs
+++ b/src/knowledge/decision.rs
@@ -5,7 +5,8 @@ use crate::frameworks::DetectedFramework;
 use crate::knowledge::active_knowledge;
 use crate::knowledge::language::{language_id_for_name, profile_by_id};
 use crate::knowledge::model::{
-    RuleDecision, RuleDecisionAction, RuleMatchContext, RuleOverride, SupportLevel,
+    RuleApplicability, RuleDecision, RuleDecisionAction, RuleMatchContext, RuleOverride,
+    SupportLevel,
 };
 use crate::scan::facts::{FileFacts, ScanFacts};
 use crate::scan::path_classification::is_low_signal_audit_path;
@@ -182,152 +183,8 @@ fn decide_internal(context: &RuleMatchContext<'_>, trace: &mut TraceRecorder<'_>
         override_index: None,
     });
 
-    if !rule.languages.is_empty() {
-        let passed = context
-            .languages
-            .iter()
-            .any(|language| rule.languages.contains(*language));
-        if let Some(decision) = record_applicability(
-            trace,
-            "language",
-            || {
-                vec![
-                    format!("allowed={}", sorted_values(&rule.languages)),
-                    format!("actual={}", joined_ids(context.languages)),
-                ]
-            },
-            passed,
-            SuppressReason::LanguageNotMatched,
-            context.base_severity,
-        ) {
-            return decision;
-        }
-    }
-
-    if let Some(minimum_support) = rule.minimum_support {
-        let passed = language_support_satisfies(rule, context.languages, minimum_support);
-        if let Some(decision) = record_applicability(
-            trace,
-            "language-support",
-            || {
-                vec![
-                    format!("minimum={}", support_level_id(minimum_support)),
-                    format!("languages={}", joined_ids(context.languages)),
-                ]
-            },
-            passed,
-            SuppressReason::LanguageSupportTooLow,
-            context.base_severity,
-        ) {
-            return decision;
-        }
-    }
-
-    if !rule.frameworks.is_empty() {
-        let passed = context
-            .frameworks
-            .iter()
-            .any(|framework| rule.frameworks.contains(*framework));
-        if let Some(decision) = record_applicability(
-            trace,
-            "framework",
-            || {
-                vec![
-                    format!("allowed={}", sorted_values(&rule.frameworks)),
-                    format!("actual={}", joined_ids(context.frameworks)),
-                ]
-            },
-            passed,
-            SuppressReason::FrameworkNotMatched,
-            context.base_severity,
-        ) {
-            return decision;
-        }
-    }
-
-    if !rule.runtimes.is_empty() {
-        let passed = context
-            .runtimes
-            .iter()
-            .any(|runtime| rule.runtimes.contains(*runtime));
-        if let Some(decision) = record_applicability(
-            trace,
-            "runtime",
-            || {
-                vec![
-                    format!("allowed={}", sorted_values(&rule.runtimes)),
-                    format!("actual={}", joined_ids(context.runtimes)),
-                ]
-            },
-            passed,
-            SuppressReason::RuntimeNotMatched,
-            context.base_severity,
-        ) {
-            return decision;
-        }
-    }
-
-    if !rule.paradigms.is_empty() {
-        let passed = context
-            .paradigms
-            .iter()
-            .any(|paradigm| rule.paradigms.contains(*paradigm));
-        if let Some(decision) = record_applicability(
-            trace,
-            "paradigm",
-            || {
-                vec![
-                    format!("allowed={}", sorted_values(&rule.paradigms)),
-                    format!("actual={}", joined_ids(context.paradigms)),
-                ]
-            },
-            passed,
-            SuppressReason::ParadigmNotMatched,
-            context.base_severity,
-        ) {
-            return decision;
-        }
-    }
-
-    if rule.suppress_low_signal
-        && let Some(decision) = record_applicability(
-            trace,
-            "low-signal-path",
-            || vec![format!("is_low_signal={}", context.is_low_signal)],
-            !context.is_low_signal,
-            SuppressReason::LowSignalPath,
-            context.base_severity,
-        )
-    {
+    if let Some(decision) = check_applicability(rule, context, trace) {
         return decision;
-    }
-
-    if rule.suppress_config {
-        let is_config = context.roles.contains(&"config");
-        if let Some(decision) = record_applicability(
-            trace,
-            "config-role",
-            || vec![format!("roles={}", joined_ids(context.roles))],
-            !is_config,
-            SuppressReason::ConfigFile,
-            context.base_severity,
-        ) {
-            return decision;
-        }
-    }
-
-    if rule.suppress_generated {
-        let is_generated = context.roles.contains(&"generated");
-        if let Some(decision) = record_applicability(
-            trace,
-            "generated-role",
-            || vec![format!("roles={}", joined_ids(context.roles))],
-            !is_generated,
-            SuppressReason::GeneratedFile,
-            context.base_severity,
-        ) {
-            return decision;
-        }
     }
 
     let mut decision =
@@ -410,6 +267,171 @@ fn decide_internal(context: &RuleMatchContext<'_>, trace: &mut TraceRecorder<'_>
     decision = apply_overlay(context, decision, trace);
 
     decision
+}
+
+fn check_applicability(
+    rule: &RuleApplicability,
+    context: &RuleMatchContext<'_>,
+    trace: &mut TraceRecorder<'_>,
+) -> Option<RuleDecision> {
+    if let Some(decision) = check_dimension(
+        trace,
+        "language",
+        !rule.languages.is_empty(),
+        context
+            .languages
+            .iter()
+            .any(|language| rule.languages.contains(*language)),
+        || {
+            vec![
+                format!("allowed={}", sorted_values(&rule.languages)),
+                format!("actual={}", joined_ids(context.languages)),
+            ]
+        },
+        SuppressReason::LanguageNotMatched,
+        context.base_severity,
+    ) {
+        return Some(decision);
+    }
+    if let Some(decision) = check_dimension(
+        trace,
+        "language-support",
+        rule.minimum_support.is_some(),
+        rule.minimum_support
+            .is_some_and(|minimum| language_support_satisfies(rule, context.languages, minimum)),
+        || {
+            vec![
+                format!(
+                    "minimum={}",
+                    rule.minimum_support.map(support_level_id).unwrap_or("none")
+                ),
+                format!("languages={}", joined_ids(context.languages)),
+            ]
+        },
+        SuppressReason::LanguageSupportTooLow,
+        context.base_severity,
+    ) {
+        return Some(decision);
+    }
+    if let Some(decision) = check_dimension(
+        trace,
+        "framework",
+        !rule.frameworks.is_empty(),
+        context
+            .frameworks
+            .iter()
+            .any(|framework| rule.frameworks.contains(*framework)),
+        || {
+            vec![
+                format!("allowed={}", sorted_values(&rule.frameworks)),
+                format!("actual={}", joined_ids(context.frameworks)),
+            ]
+        },
+        SuppressReason::FrameworkNotMatched,
+        context.base_severity,
+    ) {
+        return Some(decision);
+    }
+    if let Some(decision) = check_dimension(
+        trace,
+        "runtime",
+        !rule.runtimes.is_empty(),
+        context
+            .runtimes
+            .iter()
+            .any(|runtime| rule.runtimes.contains(*runtime)),
+        || {
+            vec![
+                format!("allowed={}", sorted_values(&rule.runtimes)),
+                format!("actual={}", joined_ids(context.runtimes)),
+            ]
+        },
+        SuppressReason::RuntimeNotMatched,
+        context.base_severity,
+    ) {
+        return Some(decision);
+    }
+    if let Some(decision) = check_dimension(
+        trace,
+        "paradigm",
+        !rule.paradigms.is_empty(),
+        context
+            .paradigms
+            .iter()
+            .any(|paradigm| rule.paradigms.contains(*paradigm)),
+        || {
+            vec![
+                format!("allowed={}", sorted_values(&rule.paradigms)),
+                format!("actual={}", joined_ids(context.paradigms)),
+            ]
+        },
+        SuppressReason::ParadigmNotMatched,
+        context.base_severity,
+    ) {
+        return Some(decision);
+    }
+    check_role_applicability(rule, context, trace)
+}
+
+fn check_dimension<F>(
+    trace: &mut TraceRecorder<'_>,
+    label: &'static str,
+    enabled: bool,
+    passed: bool,
+    criteria: F,
+    reason: SuppressReason,
+    base_severity: Severity,
+) -> Option<RuleDecision>
+where
+    F: FnOnce() -> Vec<String>,
+{
+    enabled.then(|| record_applicability(trace, label, criteria, passed, reason, base_severity))?
+}
+
+fn check_role_applicability(
+    rule: &RuleApplicability,
+    context: &RuleMatchContext<'_>,
+    trace: &mut TraceRecorder<'_>,
+) -> Option<RuleDecision> {
+    if rule.suppress_low_signal
+        && let Some(decision) = record_applicability(
+            trace,
+            "low-signal-path",
+            || vec![format!("is_low_signal={}", context.is_low_signal)],
+            !context.is_low_signal,
+            SuppressReason::LowSignalPath,
+            context.base_severity,
+        )
+    {
+        return Some(decision);
+    }
+    if rule.suppress_config {
+        let is_config = context.roles.contains(&"config");
+        if let Some(decision) = record_applicability(
+            trace,
+            "config-role",
+            || vec![format!("roles={}", joined_ids(context.roles))],
+            !is_config,
+            SuppressReason::ConfigFile,
+            context.base_severity,
+        ) {
+            return Some(decision);
+        }
+    }
+    if rule.suppress_generated {
+        let is_generated = context.roles.contains(&"generated");
+        if let Some(decision) = record_applicability(
+            trace,
+            "generated-role",
+            || vec![format!("roles={}", joined_ids(context.roles))],
+            !is_generated,
+            SuppressReason::GeneratedFile,
+            context.base_severity,
+        ) {
+            return Some(decision);
+        }
+    }
+    None
 }
 
 fn apply_overlay(

--- a/src/review/diff.rs
+++ b/src/review/diff.rs
@@ -316,78 +316,7 @@ pub fn parse_diff(diff: &str) -> Vec<ChangedFile> {
     let mut hunk: Option<DiffHunk> = None;
 
     for line in diff.lines() {
-        if let Some((_, new_path)) = parse_diff_git_line(line) {
-            if let Some(file) = current.take() {
-                files.push(finalize_file(file, hunk.take()));
-            }
-
-            current = Some(ChangedFile {
-                path: PathBuf::from(new_path),
-                status: ChangeStatus::Modified,
-                ranges: Vec::new(),
-                hunks: Vec::new(),
-            });
-
-            continue;
-        }
-
-        let Some(file) = current.as_mut() else {
-            continue;
-        };
-
-        if line.starts_with("new file mode ") {
-            file.status = ChangeStatus::Added;
-            continue;
-        }
-
-        if line.starts_with("deleted file mode ") {
-            file.status = ChangeStatus::Deleted;
-            continue;
-        }
-
-        if line.starts_with("rename from ") {
-            file.status = ChangeStatus::Renamed;
-            continue;
-        }
-
-        if let Some(path) = line.strip_prefix("+++ ") {
-            if let Some(path) = normalize_diff_path(path)
-                && file.status != ChangeStatus::Deleted
-            {
-                file.path = PathBuf::from(path);
-            }
-            continue;
-        }
-
-        if let Some(path) = line.strip_prefix("--- ") {
-            if let Some(path) = normalize_diff_path(path)
-                && file.status == ChangeStatus::Deleted
-            {
-                file.path = PathBuf::from(path);
-            }
-            continue;
-        }
-
-        if line.starts_with("@@") {
-            if let Some(done) = hunk.take() {
-                file.hunks.push(done);
-            }
-            hunk = Some(DiffHunk {
-                new_range: parse_hunk_added_range(line),
-                old_range: parse_hunk_removed_range(line),
-                added_lines: Vec::new(),
-                removed_lines: Vec::new(),
-            });
-            continue;
-        }
-
-        if let Some(active) = hunk.as_mut() {
-            if let Some(added) = line.strip_prefix('+') {
-                active.added_lines.push(added.to_string());
-            } else if let Some(removed) = line.strip_prefix('-') {
-                active.removed_lines.push(removed.to_string());
-            }
-        }
+        consume_diff_line(line, &mut files, &mut current, &mut hunk);
     }
 
     if let Some(file) = current {
@@ -395,6 +324,110 @@ pub fn parse_diff(diff: &str) -> Vec<ChangedFile> {
     }
 
     files
+}
+
+fn consume_diff_line(
+    line: &str,
+    files: &mut Vec<ChangedFile>,
+    current: &mut Option<ChangedFile>,
+    hunk: &mut Option<DiffHunk>,
+) {
+    if let Some((_, new_path)) = parse_diff_git_line(line) {
+        finish_current_file(files, current, hunk.take());
+        *current = Some(ChangedFile {
+            path: PathBuf::from(new_path),
+            status: ChangeStatus::Modified,
+            ranges: Vec::new(),
+            hunks: Vec::new(),
+        });
+        return;
+    }
+
+    let Some(file) = current.as_mut() else {
+        return;
+    };
+    if update_file_status(line, file) {
+        return;
+    }
+    if update_file_path(line, file) {
+        return;
+    }
+    if line.starts_with("@@") {
+        finish_hunk(file, hunk);
+        *hunk = Some(DiffHunk {
+            new_range: parse_hunk_added_range(line),
+            old_range: parse_hunk_removed_range(line),
+            added_lines: Vec::new(),
+            removed_lines: Vec::new(),
+        });
+        return;
+    }
+    append_hunk_line(line, hunk);
+}
+
+fn finish_current_file(
+    files: &mut Vec<ChangedFile>,
+    current: &mut Option<ChangedFile>,
+    trailing: Option<DiffHunk>,
+) {
+    if let Some(file) = current.take() {
+        files.push(finalize_file(file, trailing));
+    }
+}
+
+fn update_file_status(line: &str, file: &mut ChangedFile) -> bool {
+    let status = if line.starts_with("new file mode ") {
+        Some(ChangeStatus::Added)
+    } else if line.starts_with("deleted file mode ") {
+        Some(ChangeStatus::Deleted)
+    } else if line.starts_with("rename from ") {
+        Some(ChangeStatus::Renamed)
+    } else {
+        None
+    };
+    if let Some(status) = status {
+        file.status = status;
+        true
+    } else {
+        false
+    }
+}
+
+fn update_file_path(line: &str, file: &mut ChangedFile) -> bool {
+    if let Some(path) = line.strip_prefix("+++ ") {
+        if let Some(path) = normalize_diff_path(path)
+            && file.status != ChangeStatus::Deleted
+        {
+            file.path = PathBuf::from(path);
+        }
+        return true;
+    }
+    if let Some(path) = line.strip_prefix("--- ") {
+        if let Some(path) = normalize_diff_path(path)
+            && file.status == ChangeStatus::Deleted
+        {
+            file.path = PathBuf::from(path);
+        }
+        return true;
+    }
+    false
+}
+
+fn finish_hunk(file: &mut ChangedFile, hunk: &mut Option<DiffHunk>) {
+    if let Some(done) = hunk.take() {
+        file.hunks.push(done);
+    }
+}
+
+fn append_hunk_line(line: &str, hunk: &mut Option<DiffHunk>) {
+    let Some(active) = hunk.as_mut() else {
+        return;
+    };
+    if let Some(added) = line.strip_prefix('+') {
+        active.added_lines.push(added.to_string());
+    } else if let Some(removed) = line.strip_prefix('-') {
+        active.removed_lines.push(removed.to_string());
+    }
 }
 
 /// Push the trailing hunk (if any) and derive the public `ranges` view from the

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -26,10 +26,25 @@ pub fn render_console_with_options(
     options: ReviewRenderOptions,
 ) -> String {
     let mut output = String::new();
+    render_console_header(&mut output, report, ci_gate, review_gate);
 
+    if options.detail == DetailLevel::Summary {
+        return output;
+    }
+
+    render_console_details(&mut output, report, options);
+    output
+}
+
+fn render_console_header(
+    output: &mut String,
+    report: &ReviewReport,
+    ci_gate: Option<&CiGateResult>,
+    review_gate: Option<&ReviewSignalGateResult>,
+) {
     output.push_str("RepoPilot Review\n\n");
     render_decision_summary(
-        &mut output,
+        output,
         &review_decision_summary(report, ci_gate, review_gate),
     );
     let readiness = derive_readiness(
@@ -75,7 +90,7 @@ pub fn render_console_with_options(
             feedback.suppressed_review_signals_count,
         ));
     }
-    diagnostics::render_console(&mut output, &report.summary);
+    diagnostics::render_console(output, &report.summary);
     output.push('\n');
 
     output.push_str(&format!("Changed files: {}\n", report.changed_files.len()));
@@ -113,20 +128,22 @@ pub fn render_console_with_options(
             output.push_str("Review gate: disabled\n");
         }
     }
+}
 
-    if options.detail == DetailLevel::Summary {
-        return output;
-    }
-
-    inventory::render_changed_files(&mut output, report, options.detail);
+fn render_console_details(
+    output: &mut String,
+    report: &ReviewReport,
+    options: ReviewRenderOptions,
+) {
+    inventory::render_changed_files(output, report, options.detail);
 
     if options.detail == DetailLevel::Full {
-        render_blast_radius(&mut output, report);
-        render_impact_paths(&mut output, report);
+        render_blast_radius(output, report);
+        render_impact_paths(output, report);
     }
-    render_tiered_signals(&mut output, report);
+    render_tiered_signals(output, report);
     render_findings_group(
-        &mut output,
+        output,
         "In-diff findings",
         &report.in_diff_findings(),
         options.detail,
@@ -134,7 +151,7 @@ pub fn render_console_with_options(
     );
     if options.detail == DetailLevel::Full {
         render_findings_group(
-            &mut output,
+            output,
             "Out-of-diff findings",
             &report.out_of_diff_findings(),
             options.detail,
@@ -142,11 +159,9 @@ pub fn render_console_with_options(
         );
     }
 
-    render_verification(&mut output, report);
+    render_verification(output, report);
 
-    inventory::render_next_action(&mut output, report, options.detail);
-
-    output
+    inventory::render_next_action(output, report, options.detail);
 }
 
 fn render_verification(output: &mut String, report: &ReviewReport) {

--- a/src/review/signals/taint/flow_state.rs
+++ b/src/review/signals/taint/flow_state.rs
@@ -98,52 +98,51 @@ pub(super) fn normalize_access_path(text: &str) -> Option<String> {
         return None;
     }
 
-    let bytes = normalized.as_bytes();
     let mut index = 0;
-    let mut segments = Vec::new();
-
-    let first_start = index;
-    while index < bytes.len() && is_identifier_char(bytes[index] as char) {
-        index += 1;
-    }
-    if first_start == index || !is_identifier(&normalized[first_start..index]) {
-        return None;
-    }
-    segments.push(normalized[first_start..index].to_string());
-
-    while index < bytes.len() {
-        match bytes[index] as char {
-            '.' => {
-                index += 1;
-                let start = index;
-                while index < bytes.len() && is_identifier_char(bytes[index] as char) {
-                    index += 1;
-                }
-                if start == index || !is_identifier(&normalized[start..index]) {
-                    return None;
-                }
-                segments.push(normalized[start..index].to_string());
-            }
-            '[' => {
-                index += 1;
-                let start = index;
-                while index < bytes.len() && (bytes[index] as char).is_ascii_digit() {
-                    index += 1;
-                }
-                if start == index || index >= bytes.len() || bytes[index] as char != ']' {
-                    return None;
-                }
-                segments.push(normalized[start..index].to_string());
-                index += 1;
-            }
-            _ => return None,
-        }
-    }
+    let mut segments = vec![parse_identifier_segment(&normalized, &mut index)?];
+    parse_access_suffixes(&normalized, &mut index, &mut segments)?;
 
     if segments.len() < 2 {
         return None;
     }
     Some(segments.join("."))
+}
+
+fn parse_access_suffixes(text: &str, index: &mut usize, segments: &mut Vec<String>) -> Option<()> {
+    while *index < text.len() {
+        match text.as_bytes()[*index] as char {
+            '.' => {
+                *index += 1;
+                segments.push(parse_identifier_segment(text, index)?);
+            }
+            '[' => segments.push(parse_index_segment(text, index)?),
+            _ => return None,
+        }
+    }
+    Some(())
+}
+
+fn parse_identifier_segment(text: &str, index: &mut usize) -> Option<String> {
+    let start = *index;
+    while *index < text.len() && is_identifier_char(text.as_bytes()[*index] as char) {
+        *index += 1;
+    }
+    (start != *index && is_identifier(&text[start..*index]))
+        .then(|| text[start..*index].to_string())
+}
+
+fn parse_index_segment(text: &str, index: &mut usize) -> Option<String> {
+    *index += 1;
+    let start = *index;
+    while *index < text.len() && (text.as_bytes()[*index] as char).is_ascii_digit() {
+        *index += 1;
+    }
+    if start == *index || *index >= text.len() || text.as_bytes()[*index] as char != ']' {
+        return None;
+    }
+    let segment = text[start..*index].to_string();
+    *index += 1;
+    Some(segment)
 }
 
 fn path_is_same_or_descendant(path: &str, parent: &str) -> bool {

--- a/src/scan/scanner/changed/file_analysis.rs
+++ b/src/scan/scanner/changed/file_analysis.rs
@@ -111,28 +111,16 @@ impl<'a> ChangedScanEngine<'a> {
             .entry(change_reason.clone())
             .or_insert(0) += 1;
 
-        if changed_file.status == ChangeStatus::Deleted {
-            remove_changed_cache_entries(cache, parsed_cache, &changed_file.path);
-            record_skipped_cache_file(
-                cache_telemetry,
-                &changed_file.path,
-                &change_reason,
-                "deleted",
-            );
+        let Some(absolute_path) = prepare_changed_file(
+            changed_file,
+            repo_root,
+            &change_reason,
+            cache,
+            parsed_cache,
+            cache_telemetry,
+        ) else {
             return Ok(());
-        }
-
-        let absolute_path = repo_root.join(&changed_file.path);
-        if !absolute_path.is_file() {
-            let reason = if absolute_path.exists() {
-                "not-regular-file"
-            } else {
-                "missing-file"
-            };
-            remove_changed_cache_entries(cache, parsed_cache, &changed_file.path);
-            record_skipped_cache_file(cache_telemetry, &changed_file.path, &change_reason, reason);
-            return Ok(());
-        }
+        };
 
         if let Some(parent) = changed_file.path.parent()
             && !parent.as_os_str().is_empty()
@@ -392,6 +380,38 @@ impl<'a> ChangedScanEngine<'a> {
                 cache_reason: "unchanged-content-and-config".to_string(),
             });
     }
+}
+
+fn prepare_changed_file(
+    changed_file: &ChangedFile,
+    repo_root: &Path,
+    change_reason: &str,
+    cache: &mut ScanCache,
+    parsed_cache: &mut ParsedFactsCache,
+    cache_telemetry: &mut ScanCacheTelemetry,
+) -> Option<PathBuf> {
+    if changed_file.status == ChangeStatus::Deleted {
+        remove_changed_cache_entries(cache, parsed_cache, &changed_file.path);
+        record_skipped_cache_file(
+            cache_telemetry,
+            &changed_file.path,
+            change_reason,
+            "deleted",
+        );
+        return None;
+    }
+    let path = repo_root.join(&changed_file.path);
+    if path.is_file() {
+        return Some(path);
+    }
+    let reason = if path.exists() {
+        "not-regular-file"
+    } else {
+        "missing-file"
+    };
+    remove_changed_cache_entries(cache, parsed_cache, &changed_file.path);
+    record_skipped_cache_file(cache_telemetry, &changed_file.path, change_reason, reason);
+    None
 }
 
 fn remove_changed_cache_entries(


### PR DESCRIPTION
## What

Refactor the remaining complexity hotspots without changing RepoPilot's scan, review, graph, knowledge, taint, output, or changed-cache contracts.

## Why

The strict self-scan had 9 P1 `code-quality.complex-function` findings across core analysis and pipeline code. This PR keeps the same rules and thresholds, but splits the control flow into focused helpers so future changes can be made safely.

## Scope

- share the JavaScript audit traversal and finding construction
- split deep-control-flow else-if detection
- split taint access-path parsing
- split diff parsing into explicit line/state helpers
- separate console rendering header and detail stages
- isolate graph file/import processing
- isolate knowledge applicability checks while preserving ordering and lazy trace behavior
- isolate changed-file availability handling

## Evidence

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (893 library, 80 binary, all integration/doc tests passed; one explicit compatibility test ignored)
- `python3 scripts/release-contract.py check` passed for 0.22.0
- strict self-scan: 362 findings, 0 P1
- default self-scan with `--fail-on-priority p1`: PASS, 0 visible findings
