### PR TITLE
feat: add ChangeProof foundation

### DIFF
--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -8,6 +8,7 @@ mod impact;
 pub mod model;
 mod ownership;
 pub(crate) mod paths;
+pub mod proof;
 mod readiness;
 pub mod render;
 mod report;

--- a/src/review/proof.rs
+++ b/src/review/proof.rs
@@ -1,0 +1,197 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ChangeProofVerdict {
+    Broken,
+    Review,
+    Verified,
+    NotAssessed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChangeProofReasonCode {
+    BrokenContract,
+    ScopeNotAssessed,
+    RequiredVerificationFailed,
+    RequiredVerificationUnavailable,
+    RequiredVerificationUnselected,
+    RequiredVerificationCoverageIncomplete,
+    InsufficientPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChangeProofReason {
+    pub code: ChangeProofReasonCode,
+    pub count: usize,
+    pub message: String,
+}
+
+impl ChangeProofReason {
+    pub fn new(code: ChangeProofReasonCode, count: usize, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            count,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProofScope {
+    Changed,
+    Full,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProofCoverage {
+    pub scope: ProofScope,
+    pub requested_files: usize,
+    pub analyzed_files: usize,
+    pub excluded_files: usize,
+    pub unsupported_files: usize,
+}
+
+impl ProofCoverage {
+    fn is_meaningful(&self) -> bool {
+        self.requested_files > 0 && self.analyzed_files > 0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct ProofObligations {
+    pub applicable: usize,
+    pub satisfied: usize,
+    pub failed: usize,
+    pub unavailable: usize,
+    pub unselected: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeProofInput {
+    pub coverage: ProofCoverage,
+    pub obligations: ProofObligations,
+    pub sufficient_policy: bool,
+    pub broken_contracts: usize,
+    pub reasons: Vec<ChangeProofReason>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChangeProof {
+    pub verdict: ChangeProofVerdict,
+    pub reasons: Vec<ChangeProofReason>,
+    pub coverage: ProofCoverage,
+    pub obligations: ProofObligations,
+}
+
+pub fn derive_change_proof(input: ChangeProofInput) -> ChangeProof {
+    let mut reasons = input.reasons;
+    let verdict = if !input.coverage.is_meaningful() {
+        add_reason(
+            &mut reasons,
+            ChangeProofReason::new(
+                ChangeProofReasonCode::ScopeNotAssessed,
+                input.coverage.requested_files,
+                "The requested scope did not contain analyzable files.",
+            ),
+        );
+        ChangeProofVerdict::NotAssessed
+    } else if input.broken_contracts > 0 {
+        add_reason(
+            &mut reasons,
+            ChangeProofReason::new(
+                ChangeProofReasonCode::BrokenContract,
+                input.broken_contracts,
+                "Supported evidence proves a changed contract is broken.",
+            ),
+        );
+        ChangeProofVerdict::Broken
+    } else {
+        add_obligation_reasons(&mut reasons, input.obligations);
+        if !input.obligations.accounted_for() {
+            add_reason(
+                &mut reasons,
+                ChangeProofReason::new(
+                    ChangeProofReasonCode::RequiredVerificationCoverageIncomplete,
+                    1,
+                    "The proof obligation counts do not cover every applicable check.",
+                ),
+            );
+        }
+        if !input.sufficient_policy {
+            add_reason(
+                &mut reasons,
+                ChangeProofReason::new(
+                    ChangeProofReasonCode::InsufficientPolicy,
+                    1,
+                    "No sufficient proof policy was selected for this assessment.",
+                ),
+            );
+        }
+        if reasons.is_empty() {
+            ChangeProofVerdict::Verified
+        } else {
+            ChangeProofVerdict::Review
+        }
+    };
+    reasons.sort_by_key(|reason| reason.code);
+    ChangeProof {
+        verdict,
+        reasons,
+        coverage: input.coverage,
+        obligations: input.obligations,
+    }
+}
+
+fn add_obligation_reasons(reasons: &mut Vec<ChangeProofReason>, obligations: ProofObligations) {
+    if obligations.failed > 0 {
+        add_reason(
+            reasons,
+            ChangeProofReason::new(
+                ChangeProofReasonCode::RequiredVerificationFailed,
+                obligations.failed,
+                "A required verification check failed.",
+            ),
+        );
+    }
+    if obligations.unavailable > 0 {
+        add_reason(
+            reasons,
+            ChangeProofReason::new(
+                ChangeProofReasonCode::RequiredVerificationUnavailable,
+                obligations.unavailable,
+                "A required verification check was unavailable.",
+            ),
+        );
+    }
+    if obligations.unselected > 0 {
+        add_reason(
+            reasons,
+            ChangeProofReason::new(
+                ChangeProofReasonCode::RequiredVerificationUnselected,
+                obligations.unselected,
+                "A required verification check was not selected.",
+            ),
+        );
+    }
+}
+
+impl ProofObligations {
+    fn accounted_for(self) -> bool {
+        self.satisfied + self.failed + self.unavailable + self.unselected == self.applicable
+    }
+}
+
+fn add_reason(reasons: &mut Vec<ChangeProofReason>, reason: ChangeProofReason) {
+    if let Some(existing) = reasons.iter_mut().find(|item| item.code == reason.code) {
+        existing.count += reason.count;
+    } else {
+        reasons.push(reason);
+    }
+}
+
+#[cfg(test)]
+#[path = "proof_tests.rs"]
+mod tests;

--- a/src/review/proof_tests.rs
+++ b/src/review/proof_tests.rs
@@ -1,0 +1,134 @@
+use super::*;
+
+fn coverage(analyzed_files: usize) -> ProofCoverage {
+    ProofCoverage {
+        scope: ProofScope::Changed,
+        requested_files: 1,
+        analyzed_files,
+        excluded_files: 0,
+        unsupported_files: 0,
+    }
+}
+
+fn obligations() -> ProofObligations {
+    ProofObligations {
+        applicable: 1,
+        satisfied: 1,
+        failed: 0,
+        unavailable: 0,
+        unselected: 0,
+    }
+}
+
+#[test]
+fn empty_scope_is_not_assessed() {
+    let proof = derive_change_proof(ChangeProofInput {
+        coverage: coverage(0),
+        obligations: obligations(),
+        sufficient_policy: true,
+        broken_contracts: 0,
+        reasons: Vec::new(),
+    });
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::NotAssessed);
+    assert_eq!(
+        proof.reasons[0].code,
+        ChangeProofReasonCode::ScopeNotAssessed
+    );
+}
+
+#[test]
+fn explicit_broken_contract_wins_over_review_reasons() {
+    let proof = derive_change_proof(ChangeProofInput {
+        coverage: coverage(1),
+        obligations: obligations(),
+        sufficient_policy: true,
+        broken_contracts: 1,
+        reasons: vec![ChangeProofReason::new(
+            ChangeProofReasonCode::RequiredVerificationFailed,
+            1,
+            "a required check failed",
+        )],
+    });
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::Broken);
+    assert!(
+        proof
+            .reasons
+            .iter()
+            .any(|reason| reason.code == ChangeProofReasonCode::BrokenContract)
+    );
+}
+
+#[test]
+fn incomplete_obligation_keeps_proof_at_review() {
+    let proof = derive_change_proof(ChangeProofInput {
+        coverage: coverage(1),
+        obligations: ProofObligations {
+            failed: 1,
+            satisfied: 0,
+            ..obligations()
+        },
+        sufficient_policy: true,
+        broken_contracts: 0,
+        reasons: Vec::new(),
+    });
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::Review);
+    assert!(
+        proof
+            .reasons
+            .iter()
+            .any(|reason| reason.code == ChangeProofReasonCode::RequiredVerificationFailed)
+    );
+}
+
+#[test]
+fn complete_sufficient_policy_is_verified() {
+    let proof = derive_change_proof(ChangeProofInput {
+        coverage: coverage(1),
+        obligations: obligations(),
+        sufficient_policy: true,
+        broken_contracts: 0,
+        reasons: Vec::new(),
+    });
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::Verified);
+    assert!(proof.reasons.is_empty());
+}
+
+#[test]
+fn static_only_policy_cannot_claim_verified() {
+    let proof = derive_change_proof(ChangeProofInput {
+        coverage: coverage(1),
+        obligations: obligations(),
+        sufficient_policy: false,
+        broken_contracts: 0,
+        reasons: Vec::new(),
+    });
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::Review);
+    assert_eq!(
+        proof.reasons[0].code,
+        ChangeProofReasonCode::InsufficientPolicy
+    );
+}
+
+#[test]
+fn incomplete_obligation_accounting_cannot_verify() {
+    let proof = derive_change_proof(ChangeProofInput {
+        coverage: coverage(1),
+        obligations: ProofObligations {
+            applicable: 2,
+            ..obligations()
+        },
+        sufficient_policy: true,
+        broken_contracts: 0,
+        reasons: Vec::new(),
+    });
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::Review);
+    assert!(proof.reasons.iter().any(|reason| {
+        reason.code == ChangeProofReasonCode::RequiredVerificationCoverageIncomplete
+    }));
+}


### PR DESCRIPTION
## What

Add the first additive Phase A foundation for the v0.23 ChangeProof model:

- explicit verdicts: `BROKEN`, `REVIEW`, `VERIFIED`, `NOT_ASSESSED`
- stable reason codes for contract, scope, verification, coverage, and policy gaps
- deterministic coverage and obligation accounting
- precedence rules where broken contract evidence wins over review-only reasons
- focused truth-table unit tests for all initial verdict paths

## Why

This gives v0.23 one canonical, typed decision core before wiring it into CLI, JSON, MCP, or the Proof Card. It makes claims about verification explicit without rewriting the existing readiness path.

## Safety boundary

This PR is intentionally additive. It does not change existing `review`/`scan` callers, report schemas, CLI output, exit codes, or legacy readiness behavior. The next slice can add a parity adapter and compare the new model with current behavior before any user-visible projection changes.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo run --quiet -- scan . --fail-on-priority p1`
- strict self-scan: 365 findings, all P2/P3, 0 P1
- `python3 scripts/release-contract.py check`
