### PR TITLE
feat: adapt reviews to ChangeProof

### DIFF
--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -9,6 +9,9 @@ pub mod model;
 mod ownership;
 pub(crate) mod paths;
 pub mod proof;
+#[cfg(test)]
+#[path = "proof_adapter_tests.rs"]
+mod proof_adapter_tests;
 mod readiness;
 pub mod render;
 mod report;

--- a/src/review/proof.rs
+++ b/src/review/proof.rs
@@ -1,5 +1,10 @@
 use serde::Serialize;
 
+use crate::review::model::ReviewReport;
+use crate::review::readiness::{MergeReadinessRecord, ReadinessReasonCode};
+use crate::scan::types::ScanMode;
+use crate::verification::VerificationStatus;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ChangeProofVerdict {
@@ -17,8 +22,19 @@ pub enum ChangeProofReasonCode {
     RequiredVerificationFailed,
     RequiredVerificationUnavailable,
     RequiredVerificationUnselected,
+    RequiredVerificationStale,
     RequiredVerificationCoverageIncomplete,
     InsufficientPolicy,
+    AnalysisError,
+    FindingGateFailed,
+    ReviewSignalGateFailed,
+    PriorityP0,
+    PriorityP1,
+    DefinitelySensitive,
+    MaybeSensitive,
+    BoundaryMissingTest,
+    VisibleFinding,
+    UnownedSurface,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -67,6 +83,7 @@ pub struct ProofObligations {
     pub failed: usize,
     pub unavailable: usize,
     pub unselected: usize,
+    pub stale: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -145,6 +162,95 @@ pub fn derive_change_proof(input: ChangeProofInput) -> ChangeProof {
     }
 }
 
+/// Build the canonical proof from the current review and readiness records.
+/// This adapter is intentionally additive: callers can compare the result with
+/// legacy readiness before any output or exit-code projection changes.
+pub fn derive_change_proof_from_review(
+    report: &ReviewReport,
+    readiness: &MergeReadinessRecord,
+) -> ChangeProof {
+    let requested_files = match report.summary.mode {
+        ScanMode::Changed => report.changed_files.len(),
+        ScanMode::Full => report.summary.metrics.files_discovered,
+    };
+    let analyzed_files = report.summary.metrics.files_analyzed;
+    let (satisfied, failed, unavailable, unselected, stale) = verification_counts(report);
+    let reasons = readiness
+        .reasons
+        .iter()
+        .filter_map(map_readiness_reason)
+        .collect();
+
+    derive_change_proof(ChangeProofInput {
+        coverage: ProofCoverage {
+            scope: match report.summary.mode {
+                ScanMode::Changed => ProofScope::Changed,
+                ScanMode::Full => ProofScope::Full,
+            },
+            requested_files,
+            analyzed_files,
+            excluded_files: requested_files.saturating_sub(analyzed_files),
+            unsupported_files: 0,
+        },
+        obligations: ProofObligations {
+            applicable: report.verification.len(),
+            satisfied,
+            failed,
+            unavailable,
+            unselected,
+            stale,
+        },
+        sufficient_policy: !report.verification.is_empty(),
+        broken_contracts: 0,
+        reasons,
+    })
+}
+
+fn verification_counts(report: &ReviewReport) -> (usize, usize, usize, usize, usize) {
+    let mut counts = (0, 0, 0, 0, 0);
+    for outcome in &report.verification {
+        match outcome.status {
+            VerificationStatus::Passed if outcome.revision_compatible => counts.0 += 1,
+            VerificationStatus::Passed => counts.4 += 1,
+            VerificationStatus::Failed => counts.1 += 1,
+            VerificationStatus::TimedOut
+            | VerificationStatus::Unavailable
+            | VerificationStatus::Cancelled => counts.2 += 1,
+            VerificationStatus::Skipped => counts.3 += 1,
+        }
+    }
+    counts
+}
+
+fn map_readiness_reason(
+    reason: &crate::review::readiness::ReadinessReason,
+) -> Option<ChangeProofReason> {
+    let code = match reason.code {
+        ReadinessReasonCode::AnalysisError => ChangeProofReasonCode::AnalysisError,
+        ReadinessReasonCode::FindingGateFailed => ChangeProofReasonCode::FindingGateFailed,
+        ReadinessReasonCode::ReviewSignalGateFailed => {
+            ChangeProofReasonCode::ReviewSignalGateFailed
+        }
+        ReadinessReasonCode::PriorityP0 => ChangeProofReasonCode::PriorityP0,
+        ReadinessReasonCode::PriorityP1 => ChangeProofReasonCode::PriorityP1,
+        ReadinessReasonCode::DefinitelySensitive => ChangeProofReasonCode::DefinitelySensitive,
+        ReadinessReasonCode::MaybeSensitive => ChangeProofReasonCode::MaybeSensitive,
+        ReadinessReasonCode::BoundaryMissingTest => ChangeProofReasonCode::BoundaryMissingTest,
+        ReadinessReasonCode::VisibleFinding => ChangeProofReasonCode::VisibleFinding,
+        ReadinessReasonCode::UnownedSurface => ChangeProofReasonCode::UnownedSurface,
+        ReadinessReasonCode::VerificationFailed
+        | ReadinessReasonCode::VerificationTimedOut
+        | ReadinessReasonCode::VerificationUnavailable
+        | ReadinessReasonCode::VerificationCancelled
+        | ReadinessReasonCode::VerificationRevisionChanged => return None,
+    };
+    Some(ChangeProofReason::new(
+        code,
+        reason.count,
+        reason.message.clone(),
+    ))
+}
+
 fn add_obligation_reasons(reasons: &mut Vec<ChangeProofReason>, obligations: ProofObligations) {
     if obligations.failed > 0 {
         add_reason(
@@ -176,11 +282,22 @@ fn add_obligation_reasons(reasons: &mut Vec<ChangeProofReason>, obligations: Pro
             ),
         );
     }
+    if obligations.stale > 0 {
+        add_reason(
+            reasons,
+            ChangeProofReason::new(
+                ChangeProofReasonCode::RequiredVerificationStale,
+                obligations.stale,
+                "A required verification check passed on a different workspace revision.",
+            ),
+        );
+    }
 }
 
 impl ProofObligations {
     fn accounted_for(self) -> bool {
-        self.satisfied + self.failed + self.unavailable + self.unselected == self.applicable
+        self.satisfied + self.failed + self.unavailable + self.unselected + self.stale
+            == self.applicable
     }
 }
 

--- a/src/review/proof_adapter_tests.rs
+++ b/src/review/proof_adapter_tests.rs
@@ -1,0 +1,194 @@
+use super::proof::{
+    ChangeProofReasonCode, ChangeProofVerdict, ProofScope, derive_change_proof_from_review,
+};
+use super::{MergeReadinessRecord, ReadinessReason, ReadinessReasonCode, ReadinessVerdict};
+use crate::review::diff::{ChangeStatus, ChangedFile};
+use crate::review::model::ReviewReport;
+use crate::scan::types::{ScanMetadata, ScanMetrics, ScanMode, ScanSummary};
+use crate::verification::{VerificationOutcome, VerificationRole, VerificationStatus};
+use std::path::PathBuf;
+
+fn report(mode: ScanMode, discovered: usize, analyzed: usize) -> ReviewReport {
+    let changed_files = (0..discovered.min(1))
+        .map(|_| ChangedFile {
+            path: PathBuf::from("src/lib.rs"),
+            status: ChangeStatus::Modified,
+            ranges: Vec::new(),
+            hunks: Vec::new(),
+        })
+        .collect();
+    let mut summary = ScanSummary {
+        metadata: ScanMetadata {
+            mode,
+            ..ScanMetadata::default()
+        },
+        metrics: ScanMetrics {
+            files_discovered: discovered,
+            files_analyzed: analyzed,
+            changed_files_count: discovered.min(1),
+            ..ScanMetrics::default()
+        },
+        ..ScanSummary::default()
+    };
+    summary.metadata.root_path = PathBuf::from("/repo");
+    ReviewReport {
+        summary,
+        repo_root: PathBuf::from("/repo"),
+        baseline_path: None,
+        changed_files,
+        blast_radius: Vec::new(),
+        impact_paths: Default::default(),
+        ownership: Default::default(),
+        ownership_diagnostics: Vec::new(),
+        boundary_signals: Vec::new(),
+        boundary_missing_test: false,
+        tiered_signals: Default::default(),
+        timings: Default::default(),
+        verification: Vec::new(),
+        findings: Vec::new(),
+    }
+}
+
+fn readiness(verdict: ReadinessVerdict, reasons: Vec<ReadinessReason>) -> MergeReadinessRecord {
+    MergeReadinessRecord {
+        verdict,
+        reasons,
+        impact: Default::default(),
+        ownership: Default::default(),
+        verification_steps: Vec::new(),
+        verification: Vec::new(),
+        limitations: Vec::new(),
+        risk_delta: None,
+    }
+}
+
+fn outcome(status: VerificationStatus, revision_compatible: bool) -> VerificationOutcome {
+    VerificationOutcome {
+        check_id: "unit".to_string(),
+        role: VerificationRole::Test,
+        status,
+        duration_ms: 1,
+        exit_code: Some(0),
+        working_directory: ".".to_string(),
+        stdout_excerpt: String::new(),
+        stderr_excerpt: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+        revision_before: "before".to_string(),
+        revision_after: "after".to_string(),
+        revision_compatible,
+        limitations: Vec::new(),
+        reused: false,
+    }
+}
+
+#[test]
+fn assessed_ready_review_with_passed_check_maps_to_verified() {
+    let mut report = report(ScanMode::Changed, 1, 1);
+    report.verification = vec![outcome(VerificationStatus::Passed, true)];
+    let proof =
+        derive_change_proof_from_review(&report, &readiness(ReadinessVerdict::Ready, vec![]));
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::Verified);
+    assert_eq!(proof.coverage.scope, ProofScope::Changed);
+}
+
+#[test]
+fn static_only_ready_review_stays_at_review() {
+    let report = report(ScanMode::Changed, 1, 1);
+    let proof =
+        derive_change_proof_from_review(&report, &readiness(ReadinessVerdict::Ready, vec![]));
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::Review);
+    assert!(
+        proof
+            .reasons
+            .iter()
+            .any(|reason| reason.code == ChangeProofReasonCode::InsufficientPolicy)
+    );
+}
+
+#[test]
+fn blocked_verification_maps_to_review_not_broken() {
+    let mut report = report(ScanMode::Changed, 1, 1);
+    report.verification = vec![outcome(VerificationStatus::Failed, true)];
+    let readiness = readiness(
+        ReadinessVerdict::Blocked,
+        vec![ReadinessReason {
+            code: ReadinessReasonCode::VerificationFailed,
+            count: 1,
+            message: "Selected verification check(s) failed.".to_string(),
+        }],
+    );
+
+    let proof = derive_change_proof_from_review(&report, &readiness);
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::Review);
+    assert!(
+        !proof
+            .reasons
+            .iter()
+            .any(|reason| reason.code == ChangeProofReasonCode::BrokenContract)
+    );
+    assert!(
+        proof
+            .reasons
+            .iter()
+            .any(|reason| reason.code == ChangeProofReasonCode::RequiredVerificationFailed)
+    );
+}
+
+#[test]
+fn empty_review_scope_is_not_assessed() {
+    let report = report(ScanMode::Changed, 0, 0);
+    let proof =
+        derive_change_proof_from_review(&report, &readiness(ReadinessVerdict::Ready, vec![]));
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::NotAssessed);
+    assert!(
+        proof
+            .reasons
+            .iter()
+            .any(|reason| reason.code == ChangeProofReasonCode::ScopeNotAssessed)
+    );
+}
+
+#[test]
+fn full_review_uses_discovered_files_for_coverage() {
+    let report = report(ScanMode::Full, 4, 3);
+    let proof =
+        derive_change_proof_from_review(&report, &readiness(ReadinessVerdict::Ready, vec![]));
+
+    assert_eq!(proof.coverage.scope, ProofScope::Full);
+    assert_eq!(proof.coverage.requested_files, 4);
+    assert_eq!(proof.coverage.analyzed_files, 3);
+}
+
+#[test]
+fn incompatible_pass_is_reported_as_stale_proof() {
+    let mut report = report(ScanMode::Changed, 1, 1);
+    report.verification = vec![outcome(VerificationStatus::Passed, false)];
+    let readiness = readiness(
+        ReadinessVerdict::Blocked,
+        vec![ReadinessReason {
+            code: ReadinessReasonCode::VerificationRevisionChanged,
+            count: 1,
+            message: "Workspace revision changed during verification.".to_string(),
+        }],
+    );
+
+    let proof = derive_change_proof_from_review(&report, &readiness);
+
+    assert!(
+        proof
+            .reasons
+            .iter()
+            .any(|reason| reason.code == ChangeProofReasonCode::RequiredVerificationStale)
+    );
+    assert!(
+        !proof
+            .reasons
+            .iter()
+            .any(|reason| reason.code == ChangeProofReasonCode::RequiredVerificationUnavailable)
+    );
+}

--- a/src/review/proof_tests.rs
+++ b/src/review/proof_tests.rs
@@ -17,6 +17,7 @@ fn obligations() -> ProofObligations {
         failed: 0,
         unavailable: 0,
         unselected: 0,
+        stale: 0,
     }
 }
 
@@ -131,4 +132,27 @@ fn incomplete_obligation_accounting_cannot_verify() {
     assert!(proof.reasons.iter().any(|reason| {
         reason.code == ChangeProofReasonCode::RequiredVerificationCoverageIncomplete
     }));
+}
+
+#[test]
+fn stale_obligation_cannot_claim_verified() {
+    let proof = derive_change_proof(ChangeProofInput {
+        coverage: coverage(1),
+        obligations: ProofObligations {
+            stale: 1,
+            satisfied: 0,
+            ..obligations()
+        },
+        sufficient_policy: true,
+        broken_contracts: 0,
+        reasons: Vec::new(),
+    });
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::Review);
+    assert!(
+        proof
+            .reasons
+            .iter()
+            .any(|reason| reason.code == ChangeProofReasonCode::RequiredVerificationStale)
+    );
 }


### PR DESCRIPTION
## What

Add the first adapter from the existing review/readiness records into the canonical ChangeProof core:

- derive changed/full coverage from the real scan scope;
- count passed, failed, unavailable, skipped, and stale verification outcomes;
- preserve revision-incompatible checks as explicit stale proof;
- carry existing readiness reasons into stable ChangeProof reason codes;
- keep blocked verification as `REVIEW`, not `BROKEN`.

## Why

This is the compatibility bridge for v0.23 Phase A. It lets us compare the new proof model with the current readiness behavior before projecting anything to CLI, JSON, MCP, or exit codes.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` — 906 library tests, 80 binary tests, and all integration suites passed
- targeted proof/parity tests — 13 passed
