### PR TITLE
feat: expose ChangeProof in review outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- Projected the canonical `ChangeProof` into review JSON, MCP review results,
+  and the console Proof Card while preserving legacy readiness, gates, and exit
+  behavior. The additive projection reports verdict, analyzed scope, and proof
+  obligation counts from the same review evidence.
+
 ### Fixed
 
 - Hardened `security.secret-candidate` evidence redaction: connection strings

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -201,7 +201,7 @@ bump is needed to start.
   report version/schema claims with source-owned registries, so future drift
   fails the existing CI contract without a new workflow.
 - The roadmap and phase specification now distinguish Phase 0 progress from
-  the not-yet-started ChangeProof runtime, and mark the completed 0B slices
+  the in-progress ChangeProof projection work, and mark the completed 0B slices
   separately from the in-progress 0C/0D work.
 - Reports documentation explicitly limits `PASS`, health scores, and
   `assessment_status` to analyzed scope; unsupported and excluded files are

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -1,6 +1,7 @@
 # RepoPilot 0.23 — Change Proof
 
-Status: Phase 0 implementation in progress; ChangeProof runtime implementation has not started.
+Status: Phase 0 implementation in progress; ChangeProof foundation exists and
+the first additive review projection is now implemented.
 
 RepoPilot 0.23 turns change review from a collection of findings and signals
 into one bounded proof of what changed, which contracts and consumers are

--- a/src/report/schema/review.rs
+++ b/src/report/schema/review.rs
@@ -3,6 +3,7 @@ use crate::review::ImpactPaths;
 use crate::review::MergeReadinessRecord;
 use crate::review::ReviewSignalGateResult;
 use crate::review::derive_readiness;
+use crate::review::proof::{ChangeProof, derive_change_proof_from_review};
 use crate::review::signals::BoundarySignal;
 use crate::review::signals::tiered::TieredSignals;
 
@@ -20,6 +21,7 @@ pub struct ReviewJsonReport<'a> {
     pub blast_radius: Vec<String>,
     pub impact_paths: &'a ImpactPaths,
     pub merge_readiness: MergeReadinessRecord,
+    pub change_proof: ChangeProof,
     pub boundary_signals: &'a [BoundarySignal],
     /// Boundary, behavioral, algorithmic, and taint signals grouped by tier.
     /// `boundary_signals` remains as a compatibility view and feeds the
@@ -55,6 +57,13 @@ impl<'a> ReviewJsonReport<'a> {
         ci_gate: Option<&CiGateResult>,
         review_gate: Option<&'a ReviewSignalGateResult>,
     ) -> Self {
+        let readiness = derive_readiness(
+            report,
+            ci_gate,
+            review_gate,
+            report.summary.artifacts.risk_delta.as_ref(),
+        );
+        let change_proof = derive_change_proof_from_review(report, &readiness);
         Self {
             schema_version: SCAN_REPORT_SCHEMA_VERSION,
             repopilot_version: REPOPILOT_VERSION,
@@ -71,12 +80,8 @@ impl<'a> ReviewJsonReport<'a> {
                 .map(|path| path.to_string_lossy().to_string())
                 .collect(),
             impact_paths: &report.impact_paths,
-            merge_readiness: derive_readiness(
-                report,
-                ci_gate,
-                review_gate,
-                report.summary.artifacts.risk_delta.as_ref(),
-            ),
+            merge_readiness: readiness,
+            change_proof,
             boundary_signals: &report.boundary_signals,
             tiered_signals: &report.tiered_signals,
             review_timings: report.timings,

--- a/src/review/proof.rs
+++ b/src/review/proof.rs
@@ -14,6 +14,17 @@ pub enum ChangeProofVerdict {
     NotAssessed,
 }
 
+impl ChangeProofVerdict {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Broken => "BROKEN",
+            Self::Review => "REVIEW",
+            Self::Verified => "VERIFIED",
+            Self::NotAssessed => "NOT ASSESSED",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ChangeProofReasonCode {

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -6,6 +6,7 @@ use crate::output::{DetailLevel, FindingRenderLimit};
 use crate::review::ReviewSignalGateResult;
 use crate::review::derive_readiness;
 use crate::review::model::ReviewReport;
+use crate::review::proof::derive_change_proof_from_review;
 use crate::review::render::ReviewRenderOptions;
 use crate::review::render::helpers::verification_duration_evidence;
 use crate::review::signals::tiered::ReviewSignal;
@@ -53,6 +54,15 @@ fn render_console_header(
         review_gate,
         report.summary.artifacts.risk_delta.as_ref(),
     );
+    let proof = derive_change_proof_from_review(report, &readiness);
+    output.push_str(&format!("Change Proof: {}\n", proof.verdict.label()));
+    output.push_str(&format!(
+        "Proof scope: {}/{} file(s) analyzed; obligations: {}/{} satisfied\n",
+        proof.coverage.analyzed_files,
+        proof.coverage.requested_files,
+        proof.obligations.satisfied,
+        proof.obligations.applicable,
+    ));
     output.push_str(&format!(
         "Merge readiness: {}\n",
         readiness.verdict.label().to_uppercase()

--- a/tests/mcp_cli.rs
+++ b/tests/mcp_cli.rs
@@ -262,6 +262,11 @@ fn mcp_review_projects_the_canonical_merge_readiness_record() {
     ));
     assert!(report["merge_readiness"]["impact"].is_object());
     assert!(report["merge_readiness"]["ownership"].is_object());
+    assert!(report["change_proof"].is_object());
+    assert!(matches!(
+        report["change_proof"]["verdict"].as_str(),
+        Some("BROKEN" | "REVIEW" | "VERIFIED" | "NOT_ASSESSED")
+    ));
 }
 
 #[test]

--- a/tests/review_console_detail.rs
+++ b/tests/review_console_detail.rs
@@ -2,7 +2,7 @@ use repopilot::output::{DetailLevel, FindingRenderLimit, OutputFormat};
 use repopilot::review::diff::{ChangeStatus, ChangedFile};
 use repopilot::review::model::ReviewReport;
 use repopilot::review::render::{ReviewRenderOptions, render_with_options};
-use repopilot::scan::types::{ScanMetadata, ScanSummary};
+use repopilot::scan::types::{ScanMetadata, ScanMetrics, ScanMode, ScanSummary};
 use std::path::PathBuf;
 
 #[test]
@@ -12,6 +12,7 @@ fn findings_detail_bounds_changed_files_and_summarizes_areas() {
     let output = render_console(&report, DetailLevel::Findings);
 
     assert!(output.contains("Changed areas:\n"));
+    assert!(output.contains("Change Proof: REVIEW"));
     assert!(output.contains("  docs: 2\n"));
     assert!(output.contains("  root: 1\n"));
     assert!(output.contains("  src: 8\n"));
@@ -77,6 +78,12 @@ fn report_with_changed_files() -> ReviewReport {
         summary: ScanSummary {
             metadata: ScanMetadata {
                 root_path: PathBuf::from("."),
+                mode: ScanMode::Changed,
+                ..Default::default()
+            },
+            metrics: ScanMetrics {
+                files_discovered: 15,
+                files_analyzed: 15,
                 ..Default::default()
             },
             ..Default::default()

--- a/tests/review_readiness.rs
+++ b/tests/review_readiness.rs
@@ -5,7 +5,7 @@ use repopilot::review::model::ReviewReport;
 use repopilot::review::{
     MergeReadinessRecord, OwnershipSummary, ReadinessReasonCode, ReadinessVerdict, derive_readiness,
 };
-use repopilot::scan::types::ScanSummary;
+use repopilot::scan::types::{ScanMetadata, ScanMetrics, ScanMode, ScanSummary};
 use repopilot::verification::{VerificationOutcome, VerificationRole, VerificationStatus};
 use std::path::PathBuf;
 
@@ -70,6 +70,10 @@ fn review_json_projects_the_canonical_readiness_record() {
     let json: serde_json::Value = serde_json::from_str(&rendered).unwrap();
 
     assert_eq!(json["merge_readiness"]["verdict"], "ready");
+    assert_eq!(json["change_proof"]["verdict"], "REVIEW");
+    assert_eq!(json["change_proof"]["coverage"]["scope"], "changed");
+    assert_eq!(json["change_proof"]["coverage"]["analyzed_files"], 1);
+    assert_eq!(json["change_proof"]["obligations"]["applicable"], 0);
     assert_eq!(json["merge_readiness"]["impact"]["depth"], 0);
     assert_eq!(
         json["merge_readiness"]["ownership"]["suggested_owners"][0]["value"],
@@ -93,6 +97,8 @@ fn human_reports_project_readiness_and_owners() {
     let console = repopilot::review::render::render_console(&report, None);
     let markdown = repopilot::review::render::render_markdown(&report, None);
     assert!(console.contains("Merge readiness: READY"));
+    assert!(console.contains("Change Proof: REVIEW"));
+    assert!(console.contains("Proof scope: 1/1 file(s) analyzed"));
     assert!(console.contains("Suggested owners: @team"));
     assert!(markdown.contains("**Merge readiness:** `ready`"));
     assert!(markdown.contains("**Suggested owners:** `@team`"));
@@ -177,7 +183,18 @@ fn verification_outcome(
 
 fn report_with_ownership(ownership: OwnershipSummary) -> ReviewReport {
     ReviewReport {
-        summary: ScanSummary::default(),
+        summary: ScanSummary {
+            metadata: ScanMetadata {
+                mode: ScanMode::Changed,
+                ..Default::default()
+            },
+            metrics: ScanMetrics {
+                files_discovered: 1,
+                files_analyzed: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
         repo_root: PathBuf::from("/repo"),
         baseline_path: None,
         changed_files: vec![ChangedFile {


### PR DESCRIPTION
## Summary

Expose the canonical `ChangeProof` in the real review experience while keeping the existing readiness and gate contracts compatible.

## Type of change

- [x] Feature
- [ ] Refactor
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI / repository maintenance

## What changed

- Add additive `change_proof` data to review JSON.
- Project the same proof through `repopilot_review_change` MCP output.
- Add a console Proof Card with verdict, analyzed scope, and obligation counts.
- Keep legacy `merge_readiness`, gates, exit behavior, and report schema compatibility.
- Add renderer and MCP regression coverage; update the v0.23 roadmap, evidence ledger, and changelog.

## Why

The `ChangeProof` adapter already had conservative verdict semantics and pipeline tests, but users and agents could not see it in the normal review result. This slice connects that foundation to the shared output path without introducing a second decision engine or changing existing gate behavior.

## Contract and ownership

- [x] The change stays within the review/reporting subsystem.
- [x] CLI, JSON, baseline, Action, and MCP compatibility were considered; the new field is additive.
- [x] New output has deterministic evidence and regression tests.
- [x] No unrelated refactor or generated-file churn is included.

## Changelog

- [x] `CHANGELOG.md` updated.

## Verification

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
python3 scripts/release-contract.py check
npm run test:release-contract
cargo run -- scan . --fail-on-priority p1
```
