### PR TITLE
feat: project removed exports into ChangeProof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   and the console Proof Card while preserving legacy readiness, gates, and exit
   behavior. The additive projection reports verdict, analyzed scope, and proof
   obligation counts from the same review evidence.
+- Added the first typed contract delta to `ChangeProof`: a proven removed public
+  export with a resolved local consumer is emitted as `public-symbol /
+  removed-export` evidence and drives the `BROKEN` verdict. Coordinated renames
+  remain free of this delta.
 
 ### Fixed
 

--- a/src/review/proof.rs
+++ b/src/review/proof.rs
@@ -5,6 +5,9 @@ use crate::review::readiness::{MergeReadinessRecord, ReadinessReasonCode};
 use crate::scan::types::ScanMode;
 use crate::verification::VerificationStatus;
 
+mod contracts;
+pub use contracts::{ChangeProofContractDelta, ContractChangeKind, ContractFamily};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ChangeProofVerdict {
@@ -112,6 +115,7 @@ pub struct ChangeProof {
     pub reasons: Vec<ChangeProofReason>,
     pub coverage: ProofCoverage,
     pub obligations: ProofObligations,
+    pub contract_deltas: Vec<ChangeProofContractDelta>,
 }
 
 pub fn derive_change_proof(input: ChangeProofInput) -> ChangeProof {
@@ -170,6 +174,7 @@ pub fn derive_change_proof(input: ChangeProofInput) -> ChangeProof {
         reasons,
         coverage: input.coverage,
         obligations: input.obligations,
+        contract_deltas: Vec::new(),
     }
 }
 
@@ -192,7 +197,8 @@ pub fn derive_change_proof_from_review(
         .filter_map(map_readiness_reason)
         .collect();
 
-    derive_change_proof(ChangeProofInput {
+    let contract_deltas = contracts::from_review(report);
+    let mut proof = derive_change_proof(ChangeProofInput {
         coverage: ProofCoverage {
             scope: match report.summary.mode {
                 ScanMode::Changed => ProofScope::Changed,
@@ -212,9 +218,11 @@ pub fn derive_change_proof_from_review(
             stale,
         },
         sufficient_policy: !report.verification.is_empty(),
-        broken_contracts: 0,
+        broken_contracts: contract_deltas.len(),
         reasons,
-    })
+    });
+    proof.contract_deltas = contract_deltas;
+    proof
 }
 
 fn verification_counts(report: &ReviewReport) -> (usize, usize, usize, usize, usize) {

--- a/src/review/proof/contracts.rs
+++ b/src/review/proof/contracts.rs
@@ -1,0 +1,63 @@
+use serde::Serialize;
+
+use crate::review::model::ReviewReport;
+
+const REMOVED_EXPORT_SIGNAL: &str = "behavioral.removed-export-still-imported";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContractFamily {
+    PublicSymbol,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContractChangeKind {
+    RemovedExport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChangeProofContractDelta {
+    pub family: ContractFamily,
+    #[serde(rename = "change")]
+    pub change: ContractChangeKind,
+    pub exporter_path: String,
+    pub consumer_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_start: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_end: Option<usize>,
+    pub evidence: String,
+}
+
+pub(crate) fn from_review(report: &ReviewReport) -> Vec<ChangeProofContractDelta> {
+    let mut deltas = report
+        .tiered_signals
+        .definitely
+        .iter()
+        .filter(|signal| signal.kind == REMOVED_EXPORT_SIGNAL && !signal.suppressed)
+        .filter_map(|signal| {
+            Some(ChangeProofContractDelta {
+                family: ContractFamily::PublicSymbol,
+                change: ContractChangeKind::RemovedExport,
+                exporter_path: signal.target_path.clone()?,
+                consumer_path: signal.path.clone(),
+                line_start: signal.line_start,
+                line_end: signal.line_end,
+                evidence: signal
+                    .detail
+                    .clone()
+                    .unwrap_or_else(|| signal.headline.clone()),
+            })
+        })
+        .collect::<Vec<_>>();
+    deltas.sort_by(|left, right| {
+        left.exporter_path
+            .cmp(&right.exporter_path)
+            .then(left.consumer_path.cmp(&right.consumer_path))
+            .then(left.line_start.cmp(&right.line_start))
+            .then(left.line_end.cmp(&right.line_end))
+            .then(left.evidence.cmp(&right.evidence))
+    });
+    deltas
+}

--- a/tests/removed_export_review/parity.rs
+++ b/tests/removed_export_review/parity.rs
@@ -23,6 +23,23 @@ fn working_tree_ref_range_and_definitely_gate_share_the_canonical_occurrence() {
     let working = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
     let working_signal = only_b21(&working);
     assert_canonical_occurrence(working_signal);
+    assert_eq!(working["change_proof"]["verdict"], "BROKEN");
+    assert_eq!(
+        working["change_proof"]["contract_deltas"][0]["family"],
+        "public-symbol"
+    );
+    assert_eq!(
+        working["change_proof"]["contract_deltas"][0]["change"],
+        "removed-export"
+    );
+    assert_eq!(
+        working["change_proof"]["contract_deltas"][0]["exporter_path"],
+        "src/api.ts"
+    );
+    assert_eq!(
+        working["change_proof"]["contract_deltas"][0]["consumer_path"],
+        "src/caller.ts"
+    );
     let snapshot_style = run_review_json(
         temp.path(),
         &["review", ".", "--since-snapshot", "--format", "json"],
@@ -72,6 +89,12 @@ fn coordinated_rename_is_not_a_removed_export_failure() {
 
     let report = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
     assert!(b21_records(&report).is_empty());
+    assert_ne!(report["change_proof"]["verdict"], "BROKEN");
+    assert!(
+        report["change_proof"]["contract_deltas"]
+            .as_array()
+            .is_some_and(Vec::is_empty)
+    );
     let gated = run_review(
         temp.path(),
         &["review", ".", "--fail-on-review", "definitely"],


### PR DESCRIPTION
## Problem

The review pipeline already proves a supported removed public export with a surviving local consumer, but the canonical `ChangeProof` projection did not carry that contract evidence. The same unsafe change could therefore remain `REVIEW` instead of producing a typed `BROKEN` proof.

## What changed

- Add an additive `change_proof.contract_deltas` projection for supported public-symbol contract breaks.
- Emit deterministic `public-symbol` / `removed-export` deltas with exporter, consumer, line, and evidence fields.
- Drive the canonical `BROKEN` verdict from visible, unsuppressed removed-export deltas.
- Preserve the coordinated export-and-consumer rename guard: it produces no contract delta.
- Add parity regression coverage and document the behavior in the changelog.

## Scope and limits

This slice promotes only the existing TypeScript/JavaScript removed named-export detector. Other contract families, dynamic/generated forms, and broader before/after symbol changes remain future work and are not claimed by this PR.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `python3 scripts/release-contract.py check`
- `npm run review:performance`
- `cargo run -- scan . --fail-on-priority p1`
