### PR TITLE
docs: add scientific evidence track to v0.23

### DIFF
--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -39,6 +39,8 @@ check does not close an item without the required fresh evidence.
 | RP23-010 | P2 evidence-gap | open | Rule quality / E | Committed scorecard reports three strict-only dead-module false positives and many rules without zoo evidence. Close each measured issue with safe/unsafe regression and fresh labeled evidence; never label unmeasured rules clean. |
 | RP23-011 | P2 defect | in-progress | Release contract / 0D | `check_roadmap_docs()` checks v0.20 headings/links only. PR 4 adds focused v0.23 lifecycle/link and scope-boundary contract tests while retaining older supported docs. Close after the current claims and tests are merged. |
 | RP23-012 | P2 design-risk | open | Proof semantics / A | A failed lint/check is not necessarily contract breakage, and no selected checks is not sufficient proof. Roadmap wording now makes this explicit; close only when Phase A truth tables and runtime projection tests enforce it. |
+| RP23-013 | P1 evidence-gap | open | Rule quality / E | The current committed scorecard has default-profile zoo evidence for 6 of 54 rules. Zero false-positive labels do not establish recall. Close with a frozen evidence protocol, labeled real-repository precision, held-out recall cases, and explicit low-power claims for unmeasured rules. |
+| RP23-014 | P2 product-validation | open | Independent benchmark / E | RepoPilot's benefit beyond existing checks is not yet measured. Close with a pre-registered differential benchmark covering decision latency, novel actionable evidence, duplicate work, determinism, and resource cost on fixed revisions. |
 
 No item is marked verified solely by being listed here. Phase A/B/E items remain
 visible release work but are not silently folded into Phase 0 implementation.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,6 +18,9 @@ the change:
   verification, intent drift, limitations, gate behavior, and the next action;
 - **truth and release confidence** close known compatibility, quality,
   documentation, performance, and publication gaps before release claims ship.
+- **scientific product evidence** measures detector precision, held-out recall,
+  and decision value against existing checks instead of treating unmeasured
+  rules or extra findings as proof of quality;
 
 The release deepens the existing commands and MCP tools. It does not add a new
 top-level command, hosted service, source upload, telemetry, implicit LLM,

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -114,6 +114,10 @@ any runtime verdict changes.
 - Keep public schema changes additive and retain supported 0.x readers.
 - Improve signal quality before expanding the raw rule count.
 - Require real-repository evidence for user-facing quality claims.
+- Treat every quality claim as a measured estimate with an explicit denominator,
+  evidence scope, and recall limitation.
+- Prove user value against an independent baseline of existing checks instead of
+  treating detector output volume as product value.
 
 ## Phase 0 — Truth Foundation and Bug Burn-down
 
@@ -293,6 +297,10 @@ Deliverables:
 
 - a generated v0.23 release scorecard covering truth, contract quality,
   coverage, latency, peak RSS, determinism, compatibility, and distribution;
+- a scientific evidence protocol that separates fixture correctness, labeled
+  real-repository precision, held-out recall, and operator utility;
+- a differential benchmark against existing repository checks with frozen
+  revisions, reproducible environments, and pre-registered scoring;
 - previous-release fixtures for scan/review reports, baselines, receipts,
   histories, Action outputs, and MCP additive readers;
 - property and fuzz coverage for path normalization, stable identities,
@@ -315,6 +323,61 @@ Definition of done:
   already-published channel;
 - every release claim points to a fixture, benchmark, zoo label, compatibility
   test, or public artifact.
+
+## Scientific Evidence and Independent Validation
+
+The current committed scorecard has default-profile zoo evidence for 6 of 54
+registered rules. That is a useful baseline for deciding what to measure next,
+not evidence that the remaining rules are clean. A zero false-positive label
+count describes only the labeled findings; it does not establish recall or
+detect defects the corpus never exercises.
+
+Every promoted rule and contract family therefore reports an evidence ladder:
+
+1. **Fixture correctness** — an unsafe case, a near-identical safe guard, and
+   regression coverage for the supported boundary.
+2. **Real-repository precision** — independently reviewed default-profile
+   findings with the actionable, valid-but-accepted, and false-positive
+   dispositions and the exact labeled denominator.
+3. **Recall evidence** — held-out seeded defects, mutation cases, or recall
+   anchors that are excluded from the precision estimate and reported
+   separately.
+4. **Differential utility** — the same revisions evaluated against existing
+   checks and an independent benchmark harness, measuring novel actionable
+   evidence, duplicate work, time to first useful evidence, decision latency,
+   determinism, and resource cost.
+5. **Operator value** — a bounded review study that records whether maintainers
+   can reach the right merge decision faster or with fewer unexplained steps.
+
+The evidence protocol must:
+
+- freeze the repository revisions, tool versions, configuration, corpus
+  selection, expected labels, and scoring rules before a benchmark run;
+- keep detector implementation and evaluation harness separate enough that a
+  detector cannot grade its own output without an independent check;
+- publish counts, denominators, exclusions, confidence bounds where the sample
+  supports them, and the exact capability boundary;
+- run full/changed and cold/warm paths where the claim depends on parity;
+- treat an unmeasured rule as unmeasured, a missed-defect result as recall
+  evidence, and a performance result as workload-specific rather than global;
+- compare against existing checks to show additional decision value, not merely
+  more findings.
+
+Initial release discipline:
+
+- a rule cannot be described as broadly precise without labeled default evidence
+  from at least three independent repositories and ten findings, or an explicit
+  low-power label that limits the claim;
+- every default-visible promoted contract family has an unsafe fixture and a
+  safe guard before it can affect a release verdict;
+- a benchmark result is release evidence only when its corpus, revision, and
+  scoring artifact are committed or linked from the evidence ledger;
+- no RepoPilot-versus-competitor superiority claim is made from one repository,
+  one workflow, or an unlabeled anecdote.
+
+This track measures the product's independent value: local, reproducible change
+proof with bounded evidence and no source upload. It does not require adding an
+implicit LLM or reproducing a competitor's full security coverage.
 
 ## Bug Closure Contract
 
@@ -376,6 +439,8 @@ RepoPilot 0.23 does not add:
 - a new top-level command or plugin runtime;
 - compiler-equivalence claims, unrestricted interprocedural taint, or generic
   whole-program type checking;
+- universal precision, recall, or competitor-superiority claims from a small or
+  self-selected corpus;
 - broad new language frontends without pinned fixture and zoo evidence;
 - contract families whose correctness depends on guessing unsupported runtime
   behavior.
@@ -418,9 +483,10 @@ Work proceeds through independently reviewable phase specifications:
    is stable.
 5. Phase D exposes the canonical model through existing product surfaces and
    the local HTML Change Map.
-6. Phase E establishes quality evidence, compatibility, performance, and tested
-   publication recovery before the version cut. It closes release delivery only
-   after post-tag publication and public-channel verification succeed.
+6. Phase E establishes scientific evidence, independent utility benchmarks,
+   compatibility, performance, and tested publication recovery before the
+   version cut. It closes release delivery only after post-tag publication and
+   public-channel verification succeed.
 
 No phase may create a second verdict engine, a projection-specific semantic
 model, or a public claim that exceeds its measured evidence.


### PR DESCRIPTION
## Problem

The v0.23 roadmap requires real-repository evidence, but the current scorecard shows default-profile zoo evidence for only 6 of 54 rules. A zero false-positive label count is useful for the labeled sample, yet it does not establish recall or broader product value.

## What changed

- Add a scientific evidence track to the v0.23 roadmap.
- Separate fixture correctness, labeled real-repository precision, held-out recall, differential utility, and operator value.
- Require frozen revisions, reproducible environments, explicit denominators, exclusions, capability boundaries, and independent evaluation harnesses.
- Add initial release discipline for low-power evidence and promoted contract families.
- Add RP23-013 for rule-quality evidence and RP23-014 for an independent benchmark against existing checks.
- Make measured decision value part of the top-level roadmap and preserve the local-only product boundary.

## Scope

Documentation and release-planning only. No runtime behavior, schema, detector, or release version changes.

## Validation

- `python3 -m unittest scripts/tests/test_release_contract.py scripts/tests/test_zoo_scorecard.py scripts/tests/test_zoo_sample.py` (64 passed)
- `python3 scripts/release-contract.py check` (passed)
- `git diff --check`
