### PR TITLE
feat: expose scorecard evidence coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   export with a resolved local consumer is emitted as `public-symbol /
   removed-export` evidence and drives the `BROKEN` verdict. Coordinated renames
   remain free of this delta.
+- Made the generated rule scorecard report evidence denominators directly:
+  default-profile coverage, labeled findings, repository coverage, strict
+  samples, and the explicit boundary that these labels do not establish recall.
 
 ### Fixed
 

--- a/docs/engineering/rule-scorecard.md
+++ b/docs/engineering/rule-scorecard.md
@@ -66,6 +66,14 @@ Every default-visible zoo finding is labeled, so these rows are exhaustive for t
 | `testing.missing-test-folder` | experimental | no zoo evidence | n/a | 0 |
 | `testing.source-without-test` | experimental | no zoo evidence | n/a | 0 |
 
+## Evidence coverage
+
+- Default-profile evidence: 6 of 54 rules (11.1%), 25 labeled findings across 7 repo(s).
+- Default-profile rules without evidence: 48 (unmeasured, not clean).
+- Strict-profile sampled evidence: 6 rules, 14 sampled findings across 5 repo(s).
+- These coverage counts describe committed labels and do not establish recall.
+
+
 ## Strict-profile sampled evidence
 
 Rules that fire only in the strict profile are too numerous to label exhaustively. These rows come from deterministic per-rule samples (`python3 scripts/zoo.py sample --rule <id>`), so the precision estimate describes the sampled findings, not the rule's full strict-profile population. A rule missing from this table has no sampled evidence at all.

--- a/scripts/tests/test_zoo_scorecard.py
+++ b/scripts/tests/test_zoo_scorecard.py
@@ -140,6 +140,38 @@ class RenderScorecardMarkdownTests(unittest.TestCase):
         )
         self.assertIn("| `architecture.dead-module` | experimental | no zoo evidence | n/a | 0 |", rendered)
 
+    def test_evidence_summary_reports_denominator_and_unmeasured_rules(self) -> None:
+        lifecycles = {
+            "architecture.circular-dependency": "stable",
+            "architecture.dead-module": "experimental",
+            "security.secret-candidate": "preview",
+        }
+        scores = {
+            "architecture.circular-dependency": zs.RuleScore(
+                rule_id="architecture.circular-dependency",
+                labeled=4,
+                actionable=4,
+                repos={"repo-a", "repo-b"},
+            )
+        }
+        strict_scores = {
+            "architecture.dead-module": zs.RuleScore(
+                rule_id="architecture.dead-module",
+                labeled=2,
+                actionable=1,
+                repos={"repo-a"},
+            )
+        }
+        rendered = zs.render_scorecard_markdown(scores, lifecycles, strict_scores)
+
+        self.assertIn(
+            "- Default-profile evidence: 1 of 3 rules (33.3%), 4 labeled findings across 2 repo(s).",
+            rendered,
+        )
+        self.assertIn("- Default-profile rules without evidence: 2 (unmeasured, not clean).", rendered)
+        self.assertIn("- Strict-profile sampled evidence: 1 rules, 2 sampled findings across 1 repo(s).", rendered)
+        self.assertIn("These coverage counts describe committed labels and do not establish recall.", rendered)
+
     def test_rule_with_no_labeled_findings_reports_zero_debt(self) -> None:
         score = zs.RuleScore(rule_id="x.rule", labeled=0)
         rendered = zs.render_scorecard_markdown(

--- a/scripts/zoo_scorecard.py
+++ b/scripts/zoo_scorecard.py
@@ -143,6 +143,36 @@ def render_strict_sample_section(scores: dict[str, RuleScore], lifecycles: dict[
     return lines
 
 
+def render_evidence_summary(
+    scores: dict[str, RuleScore],
+    lifecycles: dict[str, str],
+    strict_scores: dict[str, RuleScore],
+) -> list[str]:
+    """Render scorecard denominators and the evidence coverage boundary."""
+    rule_ids = set(lifecycles) | set(scores)
+    measured = [score for score in scores.values() if score.labeled > 0]
+    sampled = [score for score in strict_scores.values() if score.labeled > 0]
+    labeled = sum(score.labeled for score in measured)
+    repos = {repo for score in measured for repo in score.repos}
+    strict_labeled = sum(score.labeled for score in sampled)
+    strict_repos = {repo for score in sampled for repo in score.repos}
+    total_rules = len(rule_ids)
+    coverage = (len(measured) / total_rules * 100) if total_rules else 0.0
+    return [
+        "",
+        "## Evidence coverage",
+        "",
+        f"- Default-profile evidence: {len(measured)} of {total_rules} rules "
+        f"({coverage:.1f}%), {labeled} labeled findings across {len(repos)} repo(s).",
+        f"- Default-profile rules without evidence: {total_rules - len(measured)} "
+        "(unmeasured, not clean).",
+        f"- Strict-profile sampled evidence: {len(sampled)} rules, {strict_labeled} "
+        f"sampled findings across {len(strict_repos)} repo(s).",
+        "- These coverage counts describe committed labels and do not establish recall.",
+        "",
+    ]
+
+
 def render_scorecard_markdown(
     scores: dict[str, RuleScore],
     lifecycles: dict[str, str],
@@ -190,7 +220,9 @@ def render_scorecard_markdown(
             precision = f"{score.precision_estimate:.2f}"
             debt = str(score.false_positive)
         lines.append(f"| `{rule_id}` | {lifecycle} | {evidence} | {precision} | {debt} |")
-    lines += render_strict_sample_section(strict_scores or {}, lifecycles)
+    strict_scores = strict_scores or {}
+    lines += render_evidence_summary(scores, lifecycles, strict_scores)
+    lines += render_strict_sample_section(strict_scores, lifecycles)
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Problem

The rule scorecard listed each rule's evidence row, but the release evidence denominator still had to be counted manually. That made the key scientific limitation easy to miss: the current committed baseline has evidence for only 6 of 54 rules, and labeled false-positive absence does not establish recall.

## What changed

- Add a generated `Evidence coverage` section to the rule scorecard.
- Report default-profile measured rules, total rule denominator, labeled findings, repository coverage, and unmeasured rules.
- Report strict-profile sampled rule and finding coverage separately.
- State directly that committed label counts do not establish recall.
- Add deterministic unit coverage and an Unreleased changelog entry.

## Scope

This is a small evidence-surface slice for the scientific v0.23 track. It changes scorecard generation and documentation only; detector behavior, findings, schemas, and runtime verdicts are unchanged.

## Validation

- `python3 -m unittest scripts/tests/test_zoo_scorecard.py scripts/tests/test_release_contract.py scripts/tests/test_zoo_sample.py` (65 passed)
- `python3 scripts/zoo.py scorecard` (freshness check passed)
- `python3 scripts/release-contract.py check` (passed)
- `git diff --check`
