### PR TITLE
test: add held-out recall corpus contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.
+- Added a held-out recall corpus contract with seeded-defect and safe-guard
+  cases, stable IDs, declared profiles and languages, path confinement, and a
+  deterministic manifest summary. The contract is evidence scaffolding; it
+  makes no recall claim until a frozen scanner runner executes it.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -210,3 +210,19 @@ bump is needed to start.
   not implied to be verified.
 - Boundary: this slice changes documentation and contract checks only. It does
   not close remaining scorecard, performance, ownership, or ChangeProof gaps.
+
+## 0E — Held-out Recall Corpus Contract
+
+- The first recall-evidence artifact is now committed in
+  `tests/recall/manifest.toml` with six cases across three rules: three
+  seeded defects that must fire and three safe guards that must remain silent.
+  Cases declare stable IDs, rule, profile, language, rationale, and a fixture
+  directory outside the precision fixture tree and zoo labels.
+- `scripts/recall.py` validates schema, rule-reference membership, unique case
+  identity, profile/outcome consistency, fixture-root confinement, and the
+  required positive/safe-guard split. Its text and JSON summaries are
+  deterministic and have focused unit coverage in `scripts/tests/test_recall.py`.
+- Boundary: this is corpus and manifest scaffolding, not a recall result. A
+  later frozen scanner runner must execute the cases and publish true-positive,
+  false-negative, specificity, revision, and tool metadata before RP23-013 can
+  close or any recall claim is made.

--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Validate RepoPilot's held-out recall corpus contract.
+
+The corpus is intentionally separate from rule fixtures and zoo labels.  This
+module validates the evidence manifest; executing the scanner is a later step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+MANIFEST_SCHEMA_VERSION = 1
+ALLOWED_PROFILES = {"default", "strict"}
+ALLOWED_OUTCOMES = {"must-fire", "must-not-fire"}
+ALLOWED_KINDS = {"seeded-defect", "safe-guard"}
+CASE_ID = re.compile(r"^[a-z0-9][a-z0-9._-]+$")
+TOP_LEVEL_FIELDS = {"schema_version", "corpus", "case"}
+CASE_FIELDS = {"id", "rule_id", "path", "profile", "outcome", "kind", "language", "rationale"}
+
+
+class RecallManifestError(ValueError):
+    """Raised when a recall corpus violates its evidence contract."""
+
+
+@dataclass(frozen=True)
+class RecallCase:
+    case_id: str
+    rule_id: str
+    path: str
+    profile: str
+    outcome: str
+    kind: str
+    language: str
+    rationale: str
+
+
+def _required_string(raw: dict[str, object], field: str, index: int) -> str:
+    value = raw.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise RecallManifestError(f"case {index}: {field} must be a non-empty string")
+    return value.strip()
+
+
+def load_manifest(path: Path) -> tuple[str, list[RecallCase]]:
+    try:
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise RecallManifestError(f"cannot read manifest {path}: {error}") from error
+
+    unknown_fields = set(document) - TOP_LEVEL_FIELDS
+    if unknown_fields:
+        raise RecallManifestError(f"unknown top-level fields: {', '.join(sorted(unknown_fields))}")
+    if document.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        raise RecallManifestError(
+            f"schema_version must be {MANIFEST_SCHEMA_VERSION}"
+        )
+    corpus = document.get("corpus")
+    if not isinstance(corpus, str) or not corpus.strip():
+        raise RecallManifestError("corpus must be a non-empty string")
+    raw_cases = document.get("case")
+    if not isinstance(raw_cases, list) or not raw_cases:
+        raise RecallManifestError("manifest must contain at least one [[case]]")
+
+    cases: list[RecallCase] = []
+    for index, raw in enumerate(raw_cases, start=1):
+        if not isinstance(raw, dict):
+            raise RecallManifestError(f"case {index}: entry must be a table")
+        unknown_fields = set(raw) - CASE_FIELDS
+        if unknown_fields:
+            raise RecallManifestError(
+                f"case {index}: unknown fields: {', '.join(sorted(unknown_fields))}"
+            )
+        cases.append(
+            RecallCase(
+                case_id=_required_string(raw, "id", index),
+                rule_id=_required_string(raw, "rule_id", index),
+                path=_required_string(raw, "path", index),
+                profile=_required_string(raw, "profile", index),
+                outcome=_required_string(raw, "outcome", index),
+                kind=_required_string(raw, "kind", index),
+                language=_required_string(raw, "language", index),
+                rationale=_required_string(raw, "rationale", index),
+            )
+        )
+    return corpus.strip(), cases
+
+
+def validate_manifest(
+    manifest_path: Path,
+    rules_reference_path: Path,
+    fixture_root: Path,
+) -> tuple[str, list[RecallCase]]:
+    corpus, cases = load_manifest(manifest_path)
+    try:
+        rule_text = rules_reference_path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise RecallManifestError(
+            f"cannot read rule reference {rules_reference_path}: {error}"
+        ) from error
+    known_rules = set(re.findall(r"^### `([^`]+)`", rule_text, re.MULTILINE))
+    if not known_rules:
+        raise RecallManifestError("rule reference contains no rule IDs")
+
+    manifest_root = manifest_path.parent.resolve()
+    fixture_root = fixture_root.resolve()
+    ids: set[str] = set()
+    locations: set[tuple[str, str]] = set()
+    seeded_rules: set[str] = set()
+    for index, case in enumerate(cases, start=1):
+        if not CASE_ID.fullmatch(case.case_id):
+            raise RecallManifestError(f"case {index}: invalid id {case.case_id!r}")
+        if case.case_id in ids:
+            raise RecallManifestError(f"duplicate case id: {case.case_id}")
+        ids.add(case.case_id)
+        if case.rule_id not in known_rules:
+            raise RecallManifestError(f"case {case.case_id}: unknown rule_id {case.rule_id}")
+        if case.profile not in ALLOWED_PROFILES:
+            raise RecallManifestError(f"case {case.case_id}: invalid profile {case.profile}")
+        if case.outcome not in ALLOWED_OUTCOMES:
+            raise RecallManifestError(f"case {case.case_id}: invalid outcome {case.outcome}")
+        if case.kind not in ALLOWED_KINDS:
+            raise RecallManifestError(f"case {case.case_id}: invalid kind {case.kind}")
+        expected_outcome = "must-fire" if case.kind == "seeded-defect" else "must-not-fire"
+        if case.outcome != expected_outcome:
+            raise RecallManifestError(
+                f"case {case.case_id}: {case.kind} requires outcome {expected_outcome}"
+            )
+        if Path(case.path).is_absolute():
+            raise RecallManifestError(f"case {case.case_id}: path must be relative")
+        resolved = (manifest_root / case.path).resolve()
+        try:
+            resolved.relative_to(fixture_root)
+        except ValueError as error:
+            raise RecallManifestError(
+                f"case {case.case_id}: path escapes recall fixture root"
+            ) from error
+        if not resolved.is_dir():
+            raise RecallManifestError(f"case {case.case_id}: fixture directory missing: {case.path}")
+        if not any(candidate.is_file() for candidate in resolved.rglob("*")):
+            raise RecallManifestError(f"case {case.case_id}: fixture directory is empty: {case.path}")
+        location = (str(resolved), case.profile)
+        if location in locations:
+            raise RecallManifestError(f"duplicate case location: {case.path} ({case.profile})")
+        locations.add(location)
+        if case.kind == "seeded-defect":
+            seeded_rules.add(case.rule_id)
+
+    if not seeded_rules:
+        raise RecallManifestError("manifest must contain at least one seeded-defect case")
+    if not any(case.kind == "safe-guard" for case in cases):
+        raise RecallManifestError("manifest must contain at least one safe-guard case")
+    return corpus, cases
+
+
+def summary(corpus: str, cases: list[RecallCase]) -> dict[str, object]:
+    return {
+        "corpus": corpus,
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "cases": len(cases),
+        "seeded_defects": sum(case.kind == "seeded-defect" for case in cases),
+        "safe_guards": sum(case.kind == "safe-guard" for case in cases),
+        "rules": sorted({case.rule_id for case in cases}),
+        "languages": sorted({case.language for case in cases}),
+        "profiles": sorted({case.profile for case in cases}),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=Path("tests/recall/manifest.toml"))
+    parser.add_argument("--rules-reference", type=Path, default=Path("docs/rules-reference.md"))
+    parser.add_argument("--fixture-root", type=Path, default=Path("tests/fixtures/recall"))
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+    try:
+        corpus, cases = validate_manifest(args.manifest, args.rules_reference, args.fixture_root)
+    except RecallManifestError as error:
+        print(f"recall manifest invalid: {error}", file=sys.stderr)
+        return 1
+    data = summary(corpus, cases)
+    if args.format == "json":
+        print(json.dumps(data, indent=2, sort_keys=True))
+    else:
+        print(f"Recall corpus: {data['corpus']}")
+        print(f"Cases: {data['cases']} ({data['seeded_defects']} seeded defects, {data['safe_guards']} safe guards)")
+        print(f"Rules: {', '.join(data['rules'])}")
+        print(f"Languages: {', '.join(data['languages'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_recall.py
+++ b/scripts/tests/test_recall.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import recall  # noqa: E402
+
+
+RULE_REFERENCE = "### `demo.rule` — Demo\n\n- **Lifecycle:** stable\n"
+
+
+def write_manifest(root: Path, cases: list[str]) -> Path:
+    manifest = root / "manifest.toml"
+    manifest.write_text(
+        "schema_version = 1\ncorpus = \"test\"\n\n" + "\n".join(cases),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def case(case_id: str, path: str, outcome: str = "must-fire", kind: str = "seeded-defect") -> str:
+    return f'''[[case]]
+id = "{case_id}"
+rule_id = "demo.rule"
+path = "{path}"
+profile = "default"
+outcome = "{outcome}"
+kind = "{kind}"
+language = "rust"
+rationale = "A documented test case with explicit expected behavior."
+'''
+
+
+class RecallManifestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.fixture_root = self.root / "recall"
+        (self.fixture_root / "positive").mkdir(parents=True)
+        (self.fixture_root / "positive" / "case.rs").write_text("fn main() {}", encoding="utf-8")
+        (self.fixture_root / "negative").mkdir()
+        (self.fixture_root / "negative" / "case.rs").write_text("fn main() {}", encoding="utf-8")
+        self.rules = self.root / "rules-reference.md"
+        self.rules.write_text(RULE_REFERENCE, encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_valid_manifest_reports_seeded_and_safe_cases(self) -> None:
+        manifest = write_manifest(
+            self.root,
+            [
+                case("positive-case", "recall/positive"),
+                case("negative-case", "recall/negative", "must-not-fire", "safe-guard"),
+            ],
+        )
+        corpus, cases = recall.validate_manifest(manifest, self.rules, self.fixture_root)
+        self.assertEqual(corpus, "test")
+        self.assertEqual(recall.summary(corpus, cases)["safe_guards"], 1)
+
+    def test_rejects_duplicate_case_ids(self) -> None:
+        manifest = write_manifest(
+            self.root,
+            [case("same-case", "recall/positive"), case("same-case", "recall/negative", "must-not-fire", "safe-guard")],
+        )
+        with self.assertRaisesRegex(recall.RecallManifestError, "duplicate case id"):
+            recall.validate_manifest(manifest, self.rules, self.fixture_root)
+
+    def test_rejects_unknown_rule(self) -> None:
+        manifest = write_manifest(self.root, [case("unknown-case", "recall/positive")])
+        manifest.write_text(manifest.read_text().replace("demo.rule", "missing.rule"), encoding="utf-8")
+        with self.assertRaisesRegex(recall.RecallManifestError, "unknown rule_id"):
+            recall.validate_manifest(manifest, self.rules, self.fixture_root)
+
+    def test_rejects_path_outside_recall_root(self) -> None:
+        outside = self.root / "outside"
+        outside.mkdir()
+        manifest = write_manifest(self.root, [case("escape-case", "outside")])
+        with self.assertRaisesRegex(recall.RecallManifestError, "escapes recall fixture root"):
+            recall.validate_manifest(manifest, self.rules, self.fixture_root)
+
+    def test_rejects_empty_fixture_directory(self) -> None:
+        (self.fixture_root / "empty").mkdir()
+        manifest = write_manifest(
+            self.root,
+            [
+                case("empty-case", "recall/empty", "must-not-fire", "safe-guard"),
+                case("positive-case", "recall/positive"),
+            ],
+        )
+        with self.assertRaisesRegex(recall.RecallManifestError, "fixture directory is empty"):
+            recall.validate_manifest(manifest, self.rules, self.fixture_root)
+
+    def test_kind_and_outcome_must_agree(self) -> None:
+        manifest = write_manifest(self.root, [case("mismatch-case", "recall/positive", "must-not-fire")])
+        with self.assertRaisesRegex(recall.RecallManifestError, "requires outcome must-fire"):
+            recall.validate_manifest(manifest, self.rules, self.fixture_root)
+
+    def test_rejects_unknown_case_fields(self) -> None:
+        manifest = write_manifest(self.root, [case("unknown-field-case", "recall/positive")])
+        manifest.write_text(manifest.read_text().replace('rationale = "', 'unexpected = "x"\nrationale = "'), encoding="utf-8")
+        with self.assertRaisesRegex(recall.RecallManifestError, "unknown fields: unexpected"):
+            recall.validate_manifest(manifest, self.rules, self.fixture_root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fixtures/recall/README.md
+++ b/tests/fixtures/recall/README.md
@@ -1,0 +1,20 @@
+# Held-out recall corpus
+
+`tests/fixtures/recall` contains synthetic cases reserved for recall and
+regression measurement. They are deliberately separate from rule fixtures and
+zoo expectation labels, so a rule cannot pass by replaying its precision test
+set.
+
+The manifest at `tests/recall/manifest.toml` describes each case. A
+`seeded-defect` must emit its declared rule; a `safe-guard` must stay silent.
+Each case has a stable ID, declared profile, language, rationale, and fixture
+path. Run the deterministic contract check from the repository root:
+
+```bash
+python3 scripts/recall.py
+python3 scripts/recall.py --format json
+```
+
+This contract validates corpus structure only. It does not claim recall until a
+frozen scanner runner executes the cases and records true-positive, false-
+negative, and specificity counts with tool and revision metadata.

--- a/tests/fixtures/recall/architecture.circular-dependency/safe_guard/src/alpha.ts
+++ b/tests/fixtures/recall/architecture.circular-dependency/safe_guard/src/alpha.ts
@@ -1,0 +1,3 @@
+import { beta } from "./beta";
+
+export const alpha = beta + 2;

--- a/tests/fixtures/recall/architecture.circular-dependency/safe_guard/src/beta.ts
+++ b/tests/fixtures/recall/architecture.circular-dependency/safe_guard/src/beta.ts
@@ -1,0 +1,1 @@
+export const beta = 2;

--- a/tests/fixtures/recall/architecture.circular-dependency/seeded_defect/src/alpha.ts
+++ b/tests/fixtures/recall/architecture.circular-dependency/seeded_defect/src/alpha.ts
@@ -1,0 +1,3 @@
+import { beta } from "./beta";
+
+export const alpha = beta + 2;

--- a/tests/fixtures/recall/architecture.circular-dependency/seeded_defect/src/beta.ts
+++ b/tests/fixtures/recall/architecture.circular-dependency/seeded_defect/src/beta.ts
@@ -1,0 +1,3 @@
+import { alpha } from "./alpha";
+
+export const beta = alpha + 2;

--- a/tests/fixtures/recall/language.rust.panic-risk/safe_guard/src/lib.rs
+++ b/tests/fixtures/recall/language.rust.panic-risk/safe_guard/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn parse_port(value: Option<&str>) -> Option<&str> {
+    value
+}

--- a/tests/fixtures/recall/language.rust.panic-risk/seeded_defect/src/lib.rs
+++ b/tests/fixtures/recall/language.rust.panic-risk/seeded_defect/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn parse_port(value: Option<&str>) -> &str {
+    value.expect("port must be configured")
+}

--- a/tests/fixtures/recall/security.secret-candidate/safe_guard/src/config.rs
+++ b/tests/fixtures/recall/security.secret-candidate/safe_guard/src/config.rs
@@ -1,0 +1,1 @@
+pub const SERVICE_TOKEN_ENV: &str = "${SERVICE_TOKEN}";

--- a/tests/fixtures/recall/security.secret-candidate/seeded_defect/src/config.rs
+++ b/tests/fixtures/recall/security.secret-candidate/seeded_defect/src/config.rs
@@ -1,0 +1,1 @@
+pub const SERVICE_TOKEN: &str = "fixtureSecret-Z8n4vQ2rM6xP9kL3sT7wY1cH5";

--- a/tests/recall/manifest.toml
+++ b/tests/recall/manifest.toml
@@ -1,0 +1,64 @@
+schema_version = 1
+corpus = "v0.23-held-out-recall"
+
+# These cases are held out from tests/fixtures/rules and from zoo labels.
+# A runner will later execute the frozen scanner against each directory.
+[[case]]
+id = "circular-import-seeded-defect"
+rule_id = "architecture.circular-dependency"
+path = "../fixtures/recall/architecture.circular-dependency/seeded_defect"
+profile = "default"
+outcome = "must-fire"
+kind = "seeded-defect"
+language = "typescript"
+rationale = "Two runtime imports form a circular dependency through alpha and beta."
+
+[[case]]
+id = "circular-import-safe-guard"
+rule_id = "architecture.circular-dependency"
+path = "../fixtures/recall/architecture.circular-dependency/safe_guard"
+profile = "default"
+outcome = "must-not-fire"
+kind = "safe-guard"
+language = "typescript"
+rationale = "The dependency is one-way; beta has no import back to alpha."
+
+[[case]]
+id = "rust-expect-seeded-defect"
+rule_id = "language.rust.panic-risk"
+path = "../fixtures/recall/language.rust.panic-risk/seeded_defect"
+profile = "default"
+outcome = "must-fire"
+kind = "seeded-defect"
+language = "rust"
+rationale = "expect on an optional configuration value can panic at runtime."
+
+[[case]]
+id = "rust-option-safe-guard"
+rule_id = "language.rust.panic-risk"
+path = "../fixtures/recall/language.rust.panic-risk/safe_guard"
+profile = "default"
+outcome = "must-not-fire"
+kind = "safe-guard"
+language = "rust"
+rationale = "The optional value is returned without an unwrap or expect."
+
+[[case]]
+id = "secret-assignment-seeded-defect"
+rule_id = "security.secret-candidate"
+path = "../fixtures/recall/security.secret-candidate/seeded_defect"
+profile = "default"
+outcome = "must-fire"
+kind = "seeded-defect"
+language = "rust"
+rationale = "A high-entropy service token is committed as a source literal."
+
+[[case]]
+id = "secret-env-reference-safe-guard"
+rule_id = "security.secret-candidate"
+path = "../fixtures/recall/security.secret-candidate/safe_guard"
+profile = "default"
+outcome = "must-not-fire"
+kind = "safe-guard"
+language = "rust"
+rationale = "The value is an environment placeholder rather than a credential literal."


### PR DESCRIPTION
## Problem

RepoPilot's v0.23 scorecard now reports labeled zoo evidence coverage, but it still has no independent recall corpus. Without a held-out denominator, an unmeasured rule cannot be described as clean and a precision snapshot cannot establish missed-defect behavior.

## Change

- add `tests/recall/manifest.toml` as a versioned held-out corpus contract;
- add six synthetic cases across three rules: three seeded defects that must fire and three safe guards that must remain silent;
- validate stable IDs, known rule IDs, profile/outcome consistency, fixture-root confinement, non-empty fixtures, duplicate locations, and explicit positive/safe-guard coverage in `scripts/recall.py`;
- provide deterministic text/JSON summaries and focused Python tests;
- document the evidence boundary in the v0.23 ledger, fixture README, and changelog.

## Validation

- `python3 -m unittest discover -s scripts/tests` — 86 passed
- `python3 scripts/recall.py --format json` — 6 cases, 3 seeded defects, 3 safe guards
- `python3 scripts/release-contract.py check` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo test --all` — 906 library tests and 80 binary tests passed
- `npm run test:release-contract` — 87 passed; zoo gate skipped because `.zoo/` is absent
- `cargo run -- scan . --fail-on-priority p1` — passed with 0 P0/P1 findings
