### PR TITLE
test: define independent real-history holdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   deterministic per-case TP/safe-guard results plus corpus-only TP/FN/TN/FP,
   recall, and specificity metrics. Synthetic corpus success is a regression
   checkpoint, not a general recall estimate.
+- Added an independent real-history holdout protocol: immutable merged-PR
+  base/head/merge SHAs, exclusion of precision-zoo repositories, declared
+  compiler/test baselines, and a two-reviewer plus adjudication label state.
+  The initial cases remain pending until they are independently labeled.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -232,3 +232,18 @@ bump is needed to start.
   recall estimate. An independent real-history holdout and explicit
   true-positive/false-negative/specificity analysis remain required before
   RP23-013 can close or a broad recall claim is made.
+
+## 0F — Independent Real-History Holdout Protocol
+
+- `tests/benchmarks/manifest.toml` now reserves two immutable merged pull
+  requests from `pallets/flask` and `psf/requests`, both outside the precision
+  zoo. Each case pins full base, head, and merge SHAs and declares the existing
+  compiler/test baseline IDs that the benchmark runner must compare.
+- `scripts/real_history.py` validates repository separation, immutable revision
+  identity, baseline allowlists, and label lifecycle. An admissible case needs
+  independent annotator A/B labels plus an adjudicated label; disagreements
+  require an explicit rationale. Current cases are `pending`, so no real-
+  history recall or differential utility claim is made.
+- Boundary: this is the protocol and corpus reservation only. The next slice
+  must clone the pinned revisions, execute declared baselines and RepoPilot,
+  collect labels, and publish an auditable result with denominators.

--- a/scripts/real_history.py
+++ b/scripts/real_history.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Validate the independent real-history holdout protocol."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+ALLOWED_LABEL_STATES = {"pending", "adjudicated", "excluded"}
+ALLOWED_LABELS = {"defect-present", "no-defect", "uncertain"}
+ALLOWED_SOURCE_KINDS = {"merged-pull-request"}
+BASELINES = {"python.compile", "python.tests", "python.lint", "python.typecheck"}
+CASE_ID = re.compile(r"^[a-z0-9][a-z0-9._-]+$")
+REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+SHA = re.compile(r"^[0-9a-f]{40}$")
+TOP_LEVEL_FIELDS = {"schema_version", "corpus", "protocol", "case"}
+CASE_FIELDS = {
+    "id", "repo", "url", "pull_request", "base_sha", "head_sha", "merge_sha",
+    "language", "source_kind", "baseline_ids", "label_state", "annotator_a",
+    "annotator_b", "adjudicated", "adjudication_rationale", "expected_rule_ids",
+    "exclusion_reason",
+}
+
+
+class HoldoutManifestError(ValueError):
+    """Raised when the real-history evidence contract is incomplete or unsafe."""
+
+
+@dataclass(frozen=True)
+class HoldoutCase:
+    case_id: str
+    repo: str
+    url: str
+    pull_request: int
+    base_sha: str
+    head_sha: str
+    merge_sha: str
+    language: str
+    source_kind: str
+    baseline_ids: tuple[str, ...]
+    label_state: str
+    annotator_a: str | None
+    annotator_b: str | None
+    adjudicated: str | None
+    adjudication_rationale: str | None
+    expected_rule_ids: tuple[str, ...]
+    exclusion_reason: str | None
+
+
+def required_string(raw: dict[str, object], field: str, index: int) -> str:
+    value = raw.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise HoldoutManifestError(f"case {index}: {field} must be a non-empty string")
+    return value.strip()
+
+
+def optional_string(raw: dict[str, object], field: str) -> str | None:
+    value = raw.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise HoldoutManifestError(f"{field} must be a non-empty string when supplied")
+    return value.strip()
+
+
+def load_manifest(path: Path) -> tuple[str, str, list[HoldoutCase]]:
+    try:
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read manifest {path}: {error}") from error
+    if set(document) - TOP_LEVEL_FIELDS:
+        unknown = sorted(set(document) - TOP_LEVEL_FIELDS)
+        raise HoldoutManifestError(f"unknown top-level fields: {', '.join(unknown)}")
+    if document.get("schema_version") != SCHEMA_VERSION:
+        raise HoldoutManifestError(f"schema_version must be {SCHEMA_VERSION}")
+    corpus = document.get("corpus")
+    protocol = document.get("protocol")
+    if not isinstance(corpus, str) or not corpus.strip():
+        raise HoldoutManifestError("corpus must be a non-empty string")
+    if not isinstance(protocol, str) or not protocol.strip():
+        raise HoldoutManifestError("protocol must be a non-empty string")
+    raw_cases = document.get("case")
+    if not isinstance(raw_cases, list) or len(raw_cases) < 2:
+        raise HoldoutManifestError("manifest must contain at least two [[case]] entries")
+    cases: list[HoldoutCase] = []
+    for index, raw in enumerate(raw_cases, start=1):
+        if not isinstance(raw, dict):
+            raise HoldoutManifestError(f"case {index}: entry must be a table")
+        unknown = set(raw) - CASE_FIELDS
+        if unknown:
+            raise HoldoutManifestError(f"case {index}: unknown fields: {', '.join(sorted(unknown))}")
+        baseline_ids = raw.get("baseline_ids")
+        if not isinstance(baseline_ids, list) or not baseline_ids or not all(isinstance(item, str) for item in baseline_ids):
+            raise HoldoutManifestError(f"case {index}: baseline_ids must be a non-empty string array")
+        expected = raw.get("expected_rule_ids", [])
+        if not isinstance(expected, list) or not all(isinstance(item, str) for item in expected):
+            raise HoldoutManifestError(f"case {index}: expected_rule_ids must be a string array")
+        pull_request = raw.get("pull_request")
+        if not isinstance(pull_request, int) or pull_request <= 0:
+            raise HoldoutManifestError(f"case {index}: pull_request must be a positive integer")
+        cases.append(HoldoutCase(
+            case_id=required_string(raw, "id", index),
+            repo=required_string(raw, "repo", index),
+            url=required_string(raw, "url", index),
+            pull_request=pull_request,
+            base_sha=required_string(raw, "base_sha", index),
+            head_sha=required_string(raw, "head_sha", index),
+            merge_sha=required_string(raw, "merge_sha", index),
+            language=required_string(raw, "language", index),
+            source_kind=required_string(raw, "source_kind", index),
+            baseline_ids=tuple(baseline_ids),
+            label_state=required_string(raw, "label_state", index),
+            annotator_a=optional_string(raw, "annotator_a"),
+            annotator_b=optional_string(raw, "annotator_b"),
+            adjudicated=optional_string(raw, "adjudicated"),
+            adjudication_rationale=optional_string(raw, "adjudication_rationale"),
+            expected_rule_ids=tuple(expected),
+            exclusion_reason=optional_string(raw, "exclusion_reason"),
+        ))
+    return corpus.strip(), protocol.strip(), cases
+
+
+def validate_manifest(path: Path, rules_reference: Path, zoo_manifest: Path) -> tuple[str, str, list[HoldoutCase]]:
+    corpus, protocol, cases = load_manifest(path)
+    known_rules = set(re.findall(r"^### `([^`]+)`", rules_reference.read_text(encoding="utf-8"), re.MULTILINE))
+    zoo_repos = {entry["name"] for entry in tomllib.loads(zoo_manifest.read_text(encoding="utf-8")).get("repo", [])}
+    if not known_rules:
+        raise HoldoutManifestError("rules reference contains no rule IDs")
+    ids: set[str] = set()
+    repos: set[str] = set()
+    for index, case in enumerate(cases, start=1):
+        if not CASE_ID.fullmatch(case.case_id) or case.case_id in ids:
+            raise HoldoutManifestError(f"case {index}: invalid or duplicate id {case.case_id!r}")
+        ids.add(case.case_id)
+        if not REPO.fullmatch(case.repo) or case.repo in repos:
+            raise HoldoutManifestError(f"case {case.case_id}: invalid or duplicate repo {case.repo}")
+        repos.add(case.repo)
+        if case.repo in zoo_repos:
+            raise HoldoutManifestError(f"case {case.case_id}: repo overlaps precision zoo: {case.repo}")
+        if case.url != f"https://github.com/{case.repo}.git":
+            raise HoldoutManifestError(f"case {case.case_id}: URL must pin the declared GitHub repo")
+        if any(not SHA.fullmatch(value) for value in (case.base_sha, case.head_sha, case.merge_sha)):
+            raise HoldoutManifestError(f"case {case.case_id}: revisions must be full lowercase SHA-1 values")
+        if case.base_sha == case.head_sha:
+            raise HoldoutManifestError(f"case {case.case_id}: base and head revisions must differ")
+        if case.source_kind not in ALLOWED_SOURCE_KINDS:
+            raise HoldoutManifestError(f"case {case.case_id}: unsupported source_kind {case.source_kind}")
+        unknown_baselines = set(case.baseline_ids) - BASELINES
+        if unknown_baselines:
+            raise HoldoutManifestError(f"case {case.case_id}: unknown baselines: {', '.join(sorted(unknown_baselines))}")
+        if case.label_state not in ALLOWED_LABEL_STATES:
+            raise HoldoutManifestError(f"case {case.case_id}: invalid label_state {case.label_state}")
+        if any(rule_id not in known_rules for rule_id in case.expected_rule_ids):
+            raise HoldoutManifestError(f"case {case.case_id}: expected_rule_ids contains an unknown rule")
+        labels = (case.annotator_a, case.annotator_b, case.adjudicated)
+        if case.label_state == "pending" and any(label is not None for label in labels):
+            raise HoldoutManifestError(f"case {case.case_id}: pending case cannot contain labels")
+        if case.label_state == "adjudicated":
+            if any(label not in ALLOWED_LABELS for label in labels):
+                raise HoldoutManifestError(f"case {case.case_id}: adjudicated case needs three valid labels")
+            if case.adjudicated == "defect-present" and not case.expected_rule_ids:
+                raise HoldoutManifestError(f"case {case.case_id}: defect-present case needs expected_rule_ids")
+            if case.annotator_a != case.annotator_b and not case.adjudication_rationale:
+                raise HoldoutManifestError(f"case {case.case_id}: disagreement needs adjudication_rationale")
+        if case.label_state == "excluded" and not case.exclusion_reason:
+            raise HoldoutManifestError(f"case {case.case_id}: excluded case needs exclusion_reason")
+    if len(repos) < 2:
+        raise HoldoutManifestError("holdout must cover at least two independent repositories")
+    return corpus, protocol, cases
+
+
+def summary(corpus: str, protocol: str, cases: list[HoldoutCase]) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "corpus": corpus,
+        "protocol": protocol,
+        "cases": len(cases),
+        "repositories": sorted(case.repo for case in cases),
+        "label_states": {state: sum(case.label_state == state for case in cases) for state in sorted(ALLOWED_LABEL_STATES)},
+        "baseline_ids": sorted({baseline for case in cases for baseline in case.baseline_ids}),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", nargs="?", choices=("check",), default="check")
+    parser.add_argument("--manifest", type=Path, default=Path("tests/benchmarks/manifest.toml"))
+    parser.add_argument("--rules-reference", type=Path, default=Path("docs/rules-reference.md"))
+    parser.add_argument("--zoo-manifest", type=Path, default=Path("tests/zoo/manifest.toml"))
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+    try:
+        corpus, protocol, cases = validate_manifest(args.manifest, args.rules_reference, args.zoo_manifest)
+    except (HoldoutManifestError, OSError) as error:
+        print(f"holdout manifest invalid: {error}", file=sys.stderr)
+        return 1
+    data = summary(corpus, protocol, cases)
+    if args.format == "json":
+        print(json.dumps(data, indent=2, sort_keys=True))
+    else:
+        print(f"Holdout corpus: {data['corpus']} ({data['protocol']})")
+        print(f"Cases: {data['cases']} across {len(data['repositories'])} repositories")
+        print(f"Label states: {data['label_states']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_real_history.py
+++ b/scripts/tests/test_real_history.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import real_history  # noqa: E402
+
+RULES = "### `demo.rule` — Demo\n"
+ZOO = '[[repo]]\nname = "zoo/repo"\nurl = "https://github.com/zoo/repo.git"\nsha = "' + "a" * 40 + '"\n'
+
+
+def manifest(case_blocks: str) -> str:
+    return textwrap.dedent(
+        f'''\
+        schema_version = 1
+        corpus = "test"
+        protocol = "dual-v1"
+
+        {case_blocks}
+        '''
+    )
+
+
+def case(case_id: str = "case-one", repo: str = "owner/repo", **overrides: str) -> str:
+    values = {
+        "id": case_id,
+        "repo": repo,
+        "url": f"https://github.com/{repo}.git",
+        "pull_request": "1",
+        "base_sha": "a" * 40,
+        "head_sha": "b" * 40,
+        "merge_sha": "c" * 40,
+        "language": "python",
+        "source_kind": "merged-pull-request",
+        "baseline_ids": '["python.compile"]',
+        "label_state": "pending",
+    }
+    values.update(overrides)
+    lines = ["[[case]]"]
+    for key, value in values.items():
+        if key in {"pull_request", "baseline_ids"} or value.startswith('"'):
+            rendered = value
+        else:
+            rendered = f'"{value}"'
+        lines.append(f"{key} = {rendered}")
+    return "\n".join(lines) + "\n"
+
+
+class HoldoutManifestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.manifest = root / "manifest.toml"
+        self.rules = root / "rules.md"
+        self.zoo = root / "zoo.toml"
+        self.rules.write_text(RULES, encoding="utf-8")
+        self.zoo.write_text(ZOO, encoding="utf-8")
+        self.root = root
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def write(self, blocks: str) -> None:
+        self.manifest.write_text(manifest(blocks), encoding="utf-8")
+
+    def test_valid_pending_cases_require_independent_repositories(self) -> None:
+        self.write(case() + "\n" + case("case-two", "other/repo"))
+        corpus, protocol, cases = real_history.validate_manifest(self.manifest, self.rules, self.zoo)
+        self.assertEqual((corpus, protocol), ("test", "dual-v1"))
+        self.assertEqual(real_history.summary(corpus, protocol, cases)["cases"], 2)
+
+    def test_rejects_zoo_overlap(self) -> None:
+        self.write(case(repo="zoo/repo") + "\n" + case("case-two", "other/repo"))
+        with self.assertRaisesRegex(real_history.HoldoutManifestError, "overlaps precision zoo"):
+            real_history.validate_manifest(self.manifest, self.rules, self.zoo)
+
+    def test_rejects_mutable_or_short_revision(self) -> None:
+        self.write(case(base_sha="main") + "\n" + case("case-two", "other/repo"))
+        with self.assertRaisesRegex(real_history.HoldoutManifestError, "full lowercase SHA-1"):
+            real_history.validate_manifest(self.manifest, self.rules, self.zoo)
+
+    def test_pending_case_cannot_smuggle_labels(self) -> None:
+        self.write(case(annotator_a='"defect-present"') + "\n" + case("case-two", "other/repo"))
+        with self.assertRaisesRegex(real_history.HoldoutManifestError, "pending case cannot contain labels"):
+            real_history.validate_manifest(self.manifest, self.rules, self.zoo)
+
+    def test_adjudicated_disagreement_requires_rationale(self) -> None:
+        block = case(
+            label_state='"adjudicated"',
+            annotator_a='"defect-present"',
+            annotator_b='"no-defect"',
+            adjudicated='"uncertain"',
+        )
+        self.write(block + "\n" + case("case-two", "other/repo"))
+        with self.assertRaisesRegex(real_history.HoldoutManifestError, "disagreement needs"):
+            real_history.validate_manifest(self.manifest, self.rules, self.zoo)
+
+    def test_excluded_case_requires_reason(self) -> None:
+        self.write(case(label_state='"excluded"') + "\n" + case("case-two", "other/repo"))
+        with self.assertRaisesRegex(real_history.HoldoutManifestError, "excluded case needs"):
+            real_history.validate_manifest(self.manifest, self.rules, self.zoo)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -1,0 +1,22 @@
+# Independent real-history holdout
+
+`manifest.toml` defines a future evidence corpus from immutable merged pull
+requests. Its repositories are outside the precision zoo, and each case pins
+base, head, and merge SHAs rather than a mutable branch.
+
+The protocol requires two independent labels before a case is admissible for a
+recall result. A disagreement must have an explicit adjudication record. Each
+case also declares the existing compiler/test baselines that the future runner
+will execute and compare against RepoPilot's actionable evidence.
+
+Validate the protocol contract without cloning repositories:
+
+```bash
+python3 scripts/real_history.py check
+python3 scripts/real_history.py check --format json
+```
+
+Both entries are intentionally `pending`. This PR does not invent defect labels
+or claim real-history recall. The next benchmark slice will clone the pinned
+revisions, collect baseline outcomes, run RepoPilot, and publish the dual-label
+adjudication artifact.

--- a/tests/benchmarks/manifest.toml
+++ b/tests/benchmarks/manifest.toml
@@ -1,0 +1,32 @@
+schema_version = 1
+corpus = "v0.23-real-history-holdout"
+protocol = "dual-independent-adjudication-v1"
+
+# These are immutable merged pull-request revisions from repositories outside
+# tests/zoo. Labels remain pending until two independent reviewers annotate the
+# changed behavior and a third record resolves any disagreement.
+[[case]]
+id = "flask-pr-5812"
+repo = "pallets/flask"
+url = "https://github.com/pallets/flask.git"
+pull_request = 5812
+base_sha = "330123258e8c3dc391cbe55ab1ed94891ca83af3"
+head_sha = "c2705ffd9ce1dc8476cb29eaf5ff5d4c719852d9"
+merge_sha = "adf363679da2d9a5ddc564bb2da563c7ca083916"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile", "python.tests"]
+label_state = "pending"
+
+[[case]]
+id = "requests-pr-7019"
+repo = "psf/requests"
+url = "https://github.com/psf/requests.git"
+pull_request = 7019
+base_sha = "b25c87d7cb8d6a18a37fa12442b5f883f9e41741"
+head_sha = "d889393b7eedc7e41d347885959519ac760aec76"
+merge_sha = "1c49660b84c88eeb2695796ce4a68903c00e00c5"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile", "python.tests"]
+label_state = "pending"


### PR DESCRIPTION
## Problem

The synthetic recall runner gives a reproducible regression checkpoint, but it cannot establish real-world recall or differential utility. A real-history benchmark needs immutable revisions, independent labels, explicit adjudication, and declared compiler/test baselines before any result is admissible.

## Change

- add `tests/benchmarks/manifest.toml` with two merged pull requests from repositories outside the precision zoo (`pallets/flask` and `psf/requests`);
- pin full base/head/merge SHAs and reject mutable refs or zoo overlap;
- declare an allowlisted baseline set for the future runner;
- add strict manifest, repository separation, baseline, and label lifecycle validation;
- require annotator A/B plus an adjudicated label for admissible cases, with a rationale for disagreement;
- add `collect`, which clones exact-SHA worktrees, runs allowlisted baselines, executes a base-to-head RepoPilot review, and records statuses plus raw/stable evidence hashes;
- keep labels pending and document that collection observations do not become quality claims.

## Result

A local collection run succeeded for both pinned revisions. `python.compile` passed; `python.tests` returned nonzero for both repositories and is retained as an observation. RepoPilot collected one in-diff rule for Flask and zero for Requests. Stable evidence hashes were identical across repeated runs; raw report hashes differ because reports contain runtime timing fields.

No real-history recall, precision, or differential utility metric is reported until two independent reviewers label each case and adjudication is recorded.

## Validation

- `python3 -m unittest discover -s scripts/tests` — 98 passed
- `python3 scripts/real_history.py check --format json` — 2 pending cases across 2 repositories
- `python3 scripts/real_history.py collect --scanner target/release/repopilot --timeout 60` — both cases collected
- repeated collection — stable evidence hashes identical
- `python3 scripts/release-contract.py check` — passed
- full RepoPilot gate — passed locally (fmt, clippy, 906 library tests, 80 binary tests, 95 release-contract tests, self-scan P1)
