### PR TITLE
feat: collect and validate real-history evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   base/head/merge SHAs, exclusion of precision-zoo repositories, declared
   compiler/test baselines, and a two-reviewer plus adjudication label state.
   The initial cases remain pending until they are independently labeled.
+- Added collection for the pinned holdout: temporary exact-SHA worktrees,
+  allowlisted baseline execution, base-to-head RepoPilot review, and bounded
+  status/output hashes. Collection records failures as observations and still
+  makes no real-history quality claim while labels are pending.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   allowlisted baseline execution, base-to-head RepoPilot review, and bounded
   status/output hashes. Collection records failures as observations and still
   makes no real-history quality claim while labels are pending.
+- Added collection-artifact validation against manifest hashes, immutable PR
+  revisions, scanner provenance, baseline command identity, and per-case review
+  coverage. A collected artifact cannot silently drift from its protocol.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -247,3 +247,12 @@ bump is needed to start.
 - Boundary: this is the protocol and corpus reservation only. The next slice
   must clone the pinned revisions, execute declared baselines and RepoPilot,
   collect labels, and publish an auditable result with denominators.
+- The collector now performs the first three steps in a temporary workspace:
+  exact-SHA clone/worktrees, allowlisted baseline commands, and base-to-head
+  RepoPilot review. A local run collected both cases; `python.compile` passed,
+  `python.tests` returned nonzero for both repos, and the review reports were
+  recorded with raw and stable evidence hashes. These are run observations,
+  not labels or quality estimates.
+- Boundary: baseline/test failures are retained for diagnosis and are not
+  interpreted as RepoPilot defects. Dual independent labels and adjudication
+  are still required before recall, precision, or differential utility metrics.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -256,3 +256,7 @@ bump is needed to start.
 - Boundary: baseline/test failures are retained for diagnosis and are not
   interpreted as RepoPilot defects. Dual independent labels and adjudication
   are still required before recall, precision, or differential utility metrics.
+- `validate-result` now rejects artifact drift in manifest hash, pinned SHAs,
+  baseline command identity, scanner provenance, or case coverage. The local
+  collection artifact passes this validator; it remains an unlabeled
+  observation packet rather than a benchmark score.

--- a/scripts/real_history.py
+++ b/scripts/real_history.py
@@ -1,206 +1,66 @@
 #!/usr/bin/env python3
-"""Validate the independent real-history holdout protocol."""
+"""Validate and collect the independent real-history holdout protocol."""
 
 from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
-import tomllib
-from dataclasses import dataclass
 from pathlib import Path
 
-
-SCHEMA_VERSION = 1
-ALLOWED_LABEL_STATES = {"pending", "adjudicated", "excluded"}
-ALLOWED_LABELS = {"defect-present", "no-defect", "uncertain"}
-ALLOWED_SOURCE_KINDS = {"merged-pull-request"}
-BASELINES = {"python.compile", "python.tests", "python.lint", "python.typecheck"}
-CASE_ID = re.compile(r"^[a-z0-9][a-z0-9._-]+$")
-REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
-SHA = re.compile(r"^[0-9a-f]{40}$")
-TOP_LEVEL_FIELDS = {"schema_version", "corpus", "protocol", "case"}
-CASE_FIELDS = {
-    "id", "repo", "url", "pull_request", "base_sha", "head_sha", "merge_sha",
-    "language", "source_kind", "baseline_ids", "label_state", "annotator_a",
-    "annotator_b", "adjudicated", "adjudication_rationale", "expected_rule_ids",
-    "exclusion_reason",
-}
-
-
-class HoldoutManifestError(ValueError):
-    """Raised when the real-history evidence contract is incomplete or unsafe."""
-
-
-@dataclass(frozen=True)
-class HoldoutCase:
-    case_id: str
-    repo: str
-    url: str
-    pull_request: int
-    base_sha: str
-    head_sha: str
-    merge_sha: str
-    language: str
-    source_kind: str
-    baseline_ids: tuple[str, ...]
-    label_state: str
-    annotator_a: str | None
-    annotator_b: str | None
-    adjudicated: str | None
-    adjudication_rationale: str | None
-    expected_rule_ids: tuple[str, ...]
-    exclusion_reason: str | None
-
-
-def required_string(raw: dict[str, object], field: str, index: int) -> str:
-    value = raw.get(field)
-    if not isinstance(value, str) or not value.strip():
-        raise HoldoutManifestError(f"case {index}: {field} must be a non-empty string")
-    return value.strip()
-
-
-def optional_string(raw: dict[str, object], field: str) -> str | None:
-    value = raw.get(field)
-    if value is None:
-        return None
-    if not isinstance(value, str) or not value.strip():
-        raise HoldoutManifestError(f"{field} must be a non-empty string when supplied")
-    return value.strip()
-
-
-def load_manifest(path: Path) -> tuple[str, str, list[HoldoutCase]]:
-    try:
-        document = tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError) as error:
-        raise HoldoutManifestError(f"cannot read manifest {path}: {error}") from error
-    if set(document) - TOP_LEVEL_FIELDS:
-        unknown = sorted(set(document) - TOP_LEVEL_FIELDS)
-        raise HoldoutManifestError(f"unknown top-level fields: {', '.join(unknown)}")
-    if document.get("schema_version") != SCHEMA_VERSION:
-        raise HoldoutManifestError(f"schema_version must be {SCHEMA_VERSION}")
-    corpus = document.get("corpus")
-    protocol = document.get("protocol")
-    if not isinstance(corpus, str) or not corpus.strip():
-        raise HoldoutManifestError("corpus must be a non-empty string")
-    if not isinstance(protocol, str) or not protocol.strip():
-        raise HoldoutManifestError("protocol must be a non-empty string")
-    raw_cases = document.get("case")
-    if not isinstance(raw_cases, list) or len(raw_cases) < 2:
-        raise HoldoutManifestError("manifest must contain at least two [[case]] entries")
-    cases: list[HoldoutCase] = []
-    for index, raw in enumerate(raw_cases, start=1):
-        if not isinstance(raw, dict):
-            raise HoldoutManifestError(f"case {index}: entry must be a table")
-        unknown = set(raw) - CASE_FIELDS
-        if unknown:
-            raise HoldoutManifestError(f"case {index}: unknown fields: {', '.join(sorted(unknown))}")
-        baseline_ids = raw.get("baseline_ids")
-        if not isinstance(baseline_ids, list) or not baseline_ids or not all(isinstance(item, str) for item in baseline_ids):
-            raise HoldoutManifestError(f"case {index}: baseline_ids must be a non-empty string array")
-        expected = raw.get("expected_rule_ids", [])
-        if not isinstance(expected, list) or not all(isinstance(item, str) for item in expected):
-            raise HoldoutManifestError(f"case {index}: expected_rule_ids must be a string array")
-        pull_request = raw.get("pull_request")
-        if not isinstance(pull_request, int) or pull_request <= 0:
-            raise HoldoutManifestError(f"case {index}: pull_request must be a positive integer")
-        cases.append(HoldoutCase(
-            case_id=required_string(raw, "id", index),
-            repo=required_string(raw, "repo", index),
-            url=required_string(raw, "url", index),
-            pull_request=pull_request,
-            base_sha=required_string(raw, "base_sha", index),
-            head_sha=required_string(raw, "head_sha", index),
-            merge_sha=required_string(raw, "merge_sha", index),
-            language=required_string(raw, "language", index),
-            source_kind=required_string(raw, "source_kind", index),
-            baseline_ids=tuple(baseline_ids),
-            label_state=required_string(raw, "label_state", index),
-            annotator_a=optional_string(raw, "annotator_a"),
-            annotator_b=optional_string(raw, "annotator_b"),
-            adjudicated=optional_string(raw, "adjudicated"),
-            adjudication_rationale=optional_string(raw, "adjudication_rationale"),
-            expected_rule_ids=tuple(expected),
-            exclusion_reason=optional_string(raw, "exclusion_reason"),
-        ))
-    return corpus.strip(), protocol.strip(), cases
-
-
-def validate_manifest(path: Path, rules_reference: Path, zoo_manifest: Path) -> tuple[str, str, list[HoldoutCase]]:
-    corpus, protocol, cases = load_manifest(path)
-    known_rules = set(re.findall(r"^### `([^`]+)`", rules_reference.read_text(encoding="utf-8"), re.MULTILINE))
-    zoo_repos = {entry["name"] for entry in tomllib.loads(zoo_manifest.read_text(encoding="utf-8")).get("repo", [])}
-    if not known_rules:
-        raise HoldoutManifestError("rules reference contains no rule IDs")
-    ids: set[str] = set()
-    repos: set[str] = set()
-    for index, case in enumerate(cases, start=1):
-        if not CASE_ID.fullmatch(case.case_id) or case.case_id in ids:
-            raise HoldoutManifestError(f"case {index}: invalid or duplicate id {case.case_id!r}")
-        ids.add(case.case_id)
-        if not REPO.fullmatch(case.repo) or case.repo in repos:
-            raise HoldoutManifestError(f"case {case.case_id}: invalid or duplicate repo {case.repo}")
-        repos.add(case.repo)
-        if case.repo in zoo_repos:
-            raise HoldoutManifestError(f"case {case.case_id}: repo overlaps precision zoo: {case.repo}")
-        if case.url != f"https://github.com/{case.repo}.git":
-            raise HoldoutManifestError(f"case {case.case_id}: URL must pin the declared GitHub repo")
-        if any(not SHA.fullmatch(value) for value in (case.base_sha, case.head_sha, case.merge_sha)):
-            raise HoldoutManifestError(f"case {case.case_id}: revisions must be full lowercase SHA-1 values")
-        if case.base_sha == case.head_sha:
-            raise HoldoutManifestError(f"case {case.case_id}: base and head revisions must differ")
-        if case.source_kind not in ALLOWED_SOURCE_KINDS:
-            raise HoldoutManifestError(f"case {case.case_id}: unsupported source_kind {case.source_kind}")
-        unknown_baselines = set(case.baseline_ids) - BASELINES
-        if unknown_baselines:
-            raise HoldoutManifestError(f"case {case.case_id}: unknown baselines: {', '.join(sorted(unknown_baselines))}")
-        if case.label_state not in ALLOWED_LABEL_STATES:
-            raise HoldoutManifestError(f"case {case.case_id}: invalid label_state {case.label_state}")
-        if any(rule_id not in known_rules for rule_id in case.expected_rule_ids):
-            raise HoldoutManifestError(f"case {case.case_id}: expected_rule_ids contains an unknown rule")
-        labels = (case.annotator_a, case.annotator_b, case.adjudicated)
-        if case.label_state == "pending" and any(label is not None for label in labels):
-            raise HoldoutManifestError(f"case {case.case_id}: pending case cannot contain labels")
-        if case.label_state == "adjudicated":
-            if any(label not in ALLOWED_LABELS for label in labels):
-                raise HoldoutManifestError(f"case {case.case_id}: adjudicated case needs three valid labels")
-            if case.adjudicated == "defect-present" and not case.expected_rule_ids:
-                raise HoldoutManifestError(f"case {case.case_id}: defect-present case needs expected_rule_ids")
-            if case.annotator_a != case.annotator_b and not case.adjudication_rationale:
-                raise HoldoutManifestError(f"case {case.case_id}: disagreement needs adjudication_rationale")
-        if case.label_state == "excluded" and not case.exclusion_reason:
-            raise HoldoutManifestError(f"case {case.case_id}: excluded case needs exclusion_reason")
-    if len(repos) < 2:
-        raise HoldoutManifestError("holdout must cover at least two independent repositories")
-    return corpus, protocol, cases
-
-
-def summary(corpus: str, protocol: str, cases: list[HoldoutCase]) -> dict[str, object]:
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "corpus": corpus,
-        "protocol": protocol,
-        "cases": len(cases),
-        "repositories": sorted(case.repo for case in cases),
-        "label_states": {state: sum(case.label_state == state for case in cases) for state in sorted(ALLOWED_LABEL_STATES)},
-        "baseline_ids": sorted({baseline for case in cases for baseline in case.baseline_ids}),
-    }
+from real_history_contract import (
+    HoldoutManifestError,
+    summary,
+    validate_manifest,
+)
+from real_history_runner import collect_holdout
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("command", nargs="?", choices=("check",), default="check")
+    parser.add_argument("command", nargs="?", choices=("check", "collect"), default="check")
     parser.add_argument("--manifest", type=Path, default=Path("tests/benchmarks/manifest.toml"))
     parser.add_argument("--rules-reference", type=Path, default=Path("docs/rules-reference.md"))
     parser.add_argument("--zoo-manifest", type=Path, default=Path("tests/zoo/manifest.toml"))
     parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--scanner", help="use an existing repopilot binary instead of building the workspace")
+    parser.add_argument("--allow-version-mismatch", action="store_true")
+    parser.add_argument("--timeout", type=int, default=300)
+    parser.add_argument("--output", type=Path, help="write a collection artifact instead of stdout")
     args = parser.parse_args(argv)
     try:
         corpus, protocol, cases = validate_manifest(args.manifest, args.rules_reference, args.zoo_manifest)
     except (HoldoutManifestError, OSError) as error:
         print(f"holdout manifest invalid: {error}", file=sys.stderr)
         return 1
+    if args.command == "collect":
+        if args.timeout <= 0:
+            print("--timeout must be positive", file=sys.stderr)
+            return 2
+        try:
+            data = collect_holdout(
+                args.repo_root.resolve(),
+                args.manifest,
+                corpus,
+                protocol,
+                cases,
+                args.scanner,
+                args.allow_version_mismatch,
+                args.timeout,
+            )
+        except (HoldoutManifestError, OSError) as error:
+            print(f"holdout collection failed: {error}", file=sys.stderr)
+            return 2
+        rendered = json.dumps(data, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            args.output.write_text(rendered, encoding="utf-8")
+        elif args.format == "json":
+            print(rendered, end="")
+        else:
+            print(f"Holdout collection: {data['corpus']}")
+            print(f"Cases collected: {len(data['cases'])}; labels: {data['label_state']}")
+        return 0
     data = summary(corpus, protocol, cases)
     if args.format == "json":
         print(json.dumps(data, indent=2, sort_keys=True))

--- a/scripts/real_history.py
+++ b/scripts/real_history.py
@@ -13,12 +13,15 @@ from real_history_contract import (
     summary,
     validate_manifest,
 )
+from real_history_artifact import validate_collection_artifact, validate_collection_data
 from real_history_runner import collect_holdout
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("command", nargs="?", choices=("check", "collect"), default="check")
+    parser.add_argument(
+        "command", nargs="?", choices=("check", "collect", "validate-result"), default="check"
+    )
     parser.add_argument("--manifest", type=Path, default=Path("tests/benchmarks/manifest.toml"))
     parser.add_argument("--rules-reference", type=Path, default=Path("docs/rules-reference.md"))
     parser.add_argument("--zoo-manifest", type=Path, default=Path("tests/zoo/manifest.toml"))
@@ -28,12 +31,29 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--allow-version-mismatch", action="store_true")
     parser.add_argument("--timeout", type=int, default=300)
     parser.add_argument("--output", type=Path, help="write a collection artifact instead of stdout")
+    parser.add_argument("--artifact", type=Path, help="collection artifact to validate")
     args = parser.parse_args(argv)
     try:
         corpus, protocol, cases = validate_manifest(args.manifest, args.rules_reference, args.zoo_manifest)
     except (HoldoutManifestError, OSError) as error:
         print(f"holdout manifest invalid: {error}", file=sys.stderr)
         return 1
+    if args.command == "validate-result":
+        if args.artifact is None:
+            print("--artifact is required for validate-result", file=sys.stderr)
+            return 2
+        try:
+            result = validate_collection_artifact(
+                args.artifact, args.manifest, args.rules_reference, args.zoo_manifest
+            )
+        except (HoldoutManifestError, OSError) as error:
+            print(f"collection artifact invalid: {error}", file=sys.stderr)
+            return 1
+        if args.format == "json":
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print(f"Collection artifact: {result['status']} ({result['cases']} cases)")
+        return 0
     if args.command == "collect":
         if args.timeout <= 0:
             print("--timeout must be positive", file=sys.stderr)
@@ -51,6 +71,11 @@ def main(argv: list[str] | None = None) -> int:
             )
         except (HoldoutManifestError, OSError) as error:
             print(f"holdout collection failed: {error}", file=sys.stderr)
+            return 2
+        try:
+            validate_collection_data(data, args.manifest, args.rules_reference, args.zoo_manifest)
+        except HoldoutManifestError as error:
+            print(f"holdout collection produced invalid artifact: {error}", file=sys.stderr)
             return 2
         rendered = json.dumps(data, indent=2, sort_keys=True) + "\n"
         if args.output:

--- a/scripts/real_history_artifact.py
+++ b/scripts/real_history_artifact.py
@@ -1,0 +1,103 @@
+"""Validate collected real-history benchmark artifacts against their manifest."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from real_history_contract import HoldoutCase, HoldoutManifestError, validate_manifest
+from real_history_runner import BASELINE_COMMANDS
+
+
+COLLECTION_SCHEMA_VERSION = 1
+BASELINE_STATUSES = {"passed", "failed", "unavailable", "timeout"}
+REVIEW_STATUSES = {"collected", "timeout"}
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def validate_collection_data(
+    data: dict[str, Any],
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    corpus, protocol, cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    if data.get("schema_version") != COLLECTION_SCHEMA_VERSION:
+        raise HoldoutManifestError("collection schema_version is unsupported")
+    if data.get("corpus") != corpus or data.get("protocol") != protocol:
+        raise HoldoutManifestError("collection corpus/protocol does not match manifest")
+    if data.get("manifest_sha256") != sha256_file(manifest_path):
+        raise HoldoutManifestError("collection manifest_sha256 does not match manifest")
+    scanner = data.get("scanner")
+    if not isinstance(scanner, dict):
+        raise HoldoutManifestError("collection is missing scanner provenance")
+    for field in ("mode", "version", "report_schema_version", "workspace_version"):
+        if not isinstance(scanner.get(field), str) or not scanner[field]:
+            raise HoldoutManifestError(f"scanner provenance missing {field}")
+    observations = data.get("cases")
+    if not isinstance(observations, list):
+        raise HoldoutManifestError("collection cases must be an array")
+    expected = {case.case_id: case for case in cases}
+    observed: set[str] = set()
+    for observation in observations:
+        if not isinstance(observation, dict):
+            raise HoldoutManifestError("collection case must be an object")
+        case_id = observation.get("id")
+        if not isinstance(case_id, str) or case_id in observed or case_id not in expected:
+            raise HoldoutManifestError(f"collection has unknown or duplicate case {case_id!r}")
+        observed.add(case_id)
+        validate_observation(observation, expected[case_id])
+    if observed != set(expected):
+        missing = sorted(set(expected) - observed)
+        raise HoldoutManifestError(f"collection is missing cases: {', '.join(missing)}")
+    if data.get("label_state") != "pending" and any(case.label_state == "pending" for case in cases):
+        raise HoldoutManifestError("collection cannot advance label_state while manifest labels are pending")
+    return {
+        "corpus": corpus,
+        "protocol": protocol,
+        "cases": len(observations),
+        "baseline_observations": sum(len(observation["baselines"]) for observation in observations),
+        "review_observations": len(observations),
+        "status": "valid",
+    }
+
+
+def validate_observation(observation: dict[str, Any], case: HoldoutCase) -> None:
+    for field in ("repo", "base_sha", "head_sha", "merge_sha"):
+        if observation.get(field) != getattr(case, field):
+            raise HoldoutManifestError(f"collection case {case.case_id}: {field} does not match manifest")
+    if observation.get("pull_request") != case.pull_request:
+        raise HoldoutManifestError(f"collection case {case.case_id}: pull_request does not match manifest")
+    if observation.get("label_state") != case.label_state:
+        raise HoldoutManifestError(f"collection case {case.case_id}: label_state does not match manifest")
+    baselines = observation.get("baselines")
+    if not isinstance(baselines, dict) or set(baselines) != set(case.baseline_ids):
+        raise HoldoutManifestError(f"collection case {case.case_id}: baseline set does not match manifest")
+    for baseline_id, result in baselines.items():
+        if not isinstance(result, dict) or result.get("status") not in BASELINE_STATUSES:
+            raise HoldoutManifestError(f"collection case {case.case_id}: invalid baseline result {baseline_id}")
+        if result.get("command") != list(BASELINE_COMMANDS[baseline_id]):
+            raise HoldoutManifestError(f"collection case {case.case_id}: baseline command drift for {baseline_id}")
+    review = observation.get("review")
+    if not isinstance(review, dict) or review.get("status") not in REVIEW_STATUSES:
+        raise HoldoutManifestError(f"collection case {case.case_id}: invalid review result")
+
+
+def validate_collection_artifact(
+    artifact_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    try:
+        data = json.loads(artifact_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read collection artifact {artifact_path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError("collection artifact must be a JSON object")
+    return validate_collection_data(data, manifest_path, rules_reference, zoo_manifest)

--- a/scripts/real_history_contract.py
+++ b/scripts/real_history_contract.py
@@ -1,0 +1,184 @@
+"""Manifest model and validation for the real-history evidence protocol."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+ALLOWED_LABEL_STATES = {"pending", "adjudicated", "excluded"}
+ALLOWED_LABELS = {"defect-present", "no-defect", "uncertain"}
+ALLOWED_SOURCE_KINDS = {"merged-pull-request"}
+BASELINES = {"python.compile", "python.tests", "python.lint", "python.typecheck"}
+CASE_ID = re.compile(r"^[a-z0-9][a-z0-9._-]+$")
+REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+SHA = re.compile(r"^[0-9a-f]{40}$")
+TOP_LEVEL_FIELDS = {"schema_version", "corpus", "protocol", "case"}
+CASE_FIELDS = {
+    "id", "repo", "url", "pull_request", "base_sha", "head_sha", "merge_sha",
+    "language", "source_kind", "baseline_ids", "label_state", "annotator_a",
+    "annotator_b", "adjudicated", "adjudication_rationale", "expected_rule_ids",
+    "exclusion_reason",
+}
+
+
+class HoldoutManifestError(ValueError):
+    """Raised when the real-history evidence contract is incomplete or unsafe."""
+
+
+@dataclass(frozen=True)
+class HoldoutCase:
+    case_id: str
+    repo: str
+    url: str
+    pull_request: int
+    base_sha: str
+    head_sha: str
+    merge_sha: str
+    language: str
+    source_kind: str
+    baseline_ids: tuple[str, ...]
+    label_state: str
+    annotator_a: str | None
+    annotator_b: str | None
+    adjudicated: str | None
+    adjudication_rationale: str | None
+    expected_rule_ids: tuple[str, ...]
+    exclusion_reason: str | None
+
+
+def required_string(raw: dict[str, object], field: str, index: int) -> str:
+    value = raw.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise HoldoutManifestError(f"case {index}: {field} must be a non-empty string")
+    return value.strip()
+
+
+def optional_string(raw: dict[str, object], field: str) -> str | None:
+    value = raw.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise HoldoutManifestError(f"{field} must be a non-empty string when supplied")
+    return value.strip()
+
+
+def load_manifest(path: Path) -> tuple[str, str, list[HoldoutCase]]:
+    try:
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read manifest {path}: {error}") from error
+    if set(document) - TOP_LEVEL_FIELDS:
+        unknown = sorted(set(document) - TOP_LEVEL_FIELDS)
+        raise HoldoutManifestError(f"unknown top-level fields: {', '.join(unknown)}")
+    if document.get("schema_version") != SCHEMA_VERSION:
+        raise HoldoutManifestError(f"schema_version must be {SCHEMA_VERSION}")
+    corpus = document.get("corpus")
+    protocol = document.get("protocol")
+    if not isinstance(corpus, str) or not corpus.strip():
+        raise HoldoutManifestError("corpus must be a non-empty string")
+    if not isinstance(protocol, str) or not protocol.strip():
+        raise HoldoutManifestError("protocol must be a non-empty string")
+    raw_cases = document.get("case")
+    if not isinstance(raw_cases, list) or len(raw_cases) < 2:
+        raise HoldoutManifestError("manifest must contain at least two [[case]] entries")
+    cases: list[HoldoutCase] = []
+    for index, raw in enumerate(raw_cases, start=1):
+        if not isinstance(raw, dict):
+            raise HoldoutManifestError(f"case {index}: entry must be a table")
+        unknown = set(raw) - CASE_FIELDS
+        if unknown:
+            raise HoldoutManifestError(f"case {index}: unknown fields: {', '.join(sorted(unknown))}")
+        baseline_ids = raw.get("baseline_ids")
+        if not isinstance(baseline_ids, list) or not baseline_ids or not all(isinstance(item, str) for item in baseline_ids):
+            raise HoldoutManifestError(f"case {index}: baseline_ids must be a non-empty string array")
+        expected = raw.get("expected_rule_ids", [])
+        if not isinstance(expected, list) or not all(isinstance(item, str) for item in expected):
+            raise HoldoutManifestError(f"case {index}: expected_rule_ids must be a string array")
+        pull_request = raw.get("pull_request")
+        if not isinstance(pull_request, int) or pull_request <= 0:
+            raise HoldoutManifestError(f"case {index}: pull_request must be a positive integer")
+        cases.append(HoldoutCase(
+            case_id=required_string(raw, "id", index),
+            repo=required_string(raw, "repo", index),
+            url=required_string(raw, "url", index),
+            pull_request=pull_request,
+            base_sha=required_string(raw, "base_sha", index),
+            head_sha=required_string(raw, "head_sha", index),
+            merge_sha=required_string(raw, "merge_sha", index),
+            language=required_string(raw, "language", index),
+            source_kind=required_string(raw, "source_kind", index),
+            baseline_ids=tuple(baseline_ids),
+            label_state=required_string(raw, "label_state", index),
+            annotator_a=optional_string(raw, "annotator_a"),
+            annotator_b=optional_string(raw, "annotator_b"),
+            adjudicated=optional_string(raw, "adjudicated"),
+            adjudication_rationale=optional_string(raw, "adjudication_rationale"),
+            expected_rule_ids=tuple(expected),
+            exclusion_reason=optional_string(raw, "exclusion_reason"),
+        ))
+    return corpus.strip(), protocol.strip(), cases
+
+
+def validate_manifest(path: Path, rules_reference: Path, zoo_manifest: Path) -> tuple[str, str, list[HoldoutCase]]:
+    corpus, protocol, cases = load_manifest(path)
+    known_rules = set(re.findall(r"^### `([^`]+)`", rules_reference.read_text(encoding="utf-8"), re.MULTILINE))
+    zoo_repos = {entry["name"] for entry in tomllib.loads(zoo_manifest.read_text(encoding="utf-8")).get("repo", [])}
+    if not known_rules:
+        raise HoldoutManifestError("rules reference contains no rule IDs")
+    ids: set[str] = set()
+    repos: set[str] = set()
+    for index, case in enumerate(cases, start=1):
+        if not CASE_ID.fullmatch(case.case_id) or case.case_id in ids:
+            raise HoldoutManifestError(f"case {index}: invalid or duplicate id {case.case_id!r}")
+        ids.add(case.case_id)
+        if not REPO.fullmatch(case.repo) or case.repo in repos:
+            raise HoldoutManifestError(f"case {case.case_id}: invalid or duplicate repo {case.repo}")
+        repos.add(case.repo)
+        if case.repo in zoo_repos:
+            raise HoldoutManifestError(f"case {case.case_id}: repo overlaps precision zoo: {case.repo}")
+        if case.url != f"https://github.com/{case.repo}.git":
+            raise HoldoutManifestError(f"case {case.case_id}: URL must pin the declared GitHub repo")
+        if any(not SHA.fullmatch(value) for value in (case.base_sha, case.head_sha, case.merge_sha)):
+            raise HoldoutManifestError(f"case {case.case_id}: revisions must be full lowercase SHA-1 values")
+        if case.base_sha == case.head_sha:
+            raise HoldoutManifestError(f"case {case.case_id}: base and head revisions must differ")
+        if case.source_kind not in ALLOWED_SOURCE_KINDS:
+            raise HoldoutManifestError(f"case {case.case_id}: unsupported source_kind {case.source_kind}")
+        unknown_baselines = set(case.baseline_ids) - BASELINES
+        if unknown_baselines:
+            raise HoldoutManifestError(f"case {case.case_id}: unknown baselines: {', '.join(sorted(unknown_baselines))}")
+        if case.label_state not in ALLOWED_LABEL_STATES:
+            raise HoldoutManifestError(f"case {case.case_id}: invalid label_state {case.label_state}")
+        if any(rule_id not in known_rules for rule_id in case.expected_rule_ids):
+            raise HoldoutManifestError(f"case {case.case_id}: expected_rule_ids contains an unknown rule")
+        labels = (case.annotator_a, case.annotator_b, case.adjudicated)
+        if case.label_state == "pending" and any(label is not None for label in labels):
+            raise HoldoutManifestError(f"case {case.case_id}: pending case cannot contain labels")
+        if case.label_state == "adjudicated":
+            if any(label not in ALLOWED_LABELS for label in labels):
+                raise HoldoutManifestError(f"case {case.case_id}: adjudicated case needs three valid labels")
+            if case.adjudicated == "defect-present" and not case.expected_rule_ids:
+                raise HoldoutManifestError(f"case {case.case_id}: defect-present case needs expected_rule_ids")
+            if case.annotator_a != case.annotator_b and not case.adjudication_rationale:
+                raise HoldoutManifestError(f"case {case.case_id}: disagreement needs adjudication_rationale")
+        if case.label_state == "excluded" and not case.exclusion_reason:
+            raise HoldoutManifestError(f"case {case.case_id}: excluded case needs exclusion_reason")
+    if len(repos) < 2:
+        raise HoldoutManifestError("holdout must cover at least two independent repositories")
+    return corpus, protocol, cases
+
+
+def summary(corpus: str, protocol: str, cases: list[HoldoutCase]) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "corpus": corpus,
+        "protocol": protocol,
+        "cases": len(cases),
+        "repositories": sorted(case.repo for case in cases),
+        "label_states": {state: sum(case.label_state == state for case in cases) for state in sorted(ALLOWED_LABEL_STATES)},
+        "baseline_ids": sorted({baseline for case in cases for baseline in case.baseline_ids}),
+    }

--- a/scripts/real_history_runner.py
+++ b/scripts/real_history_runner.py
@@ -1,0 +1,202 @@
+"""Collect immutable real-history benchmark observations without labels."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from real_history_contract import HoldoutCase, HoldoutManifestError
+from zoo_scanner import ScannerPreparationError, ScannerProvenanceError, prepare_scanner
+
+
+BASELINE_COMMANDS: dict[str, tuple[str, ...]] = {
+    "python.compile": ("python3", "-m", "compileall", "-q", "."),
+    "python.tests": ("python3", "-m", "pytest", "-q"),
+    "python.lint": ("python3", "-m", "ruff", "check", "."),
+    "python.typecheck": ("python3", "-m", "mypy", "."),
+}
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def run_command(command: tuple[str, ...], cwd: Path, timeout_seconds: int) -> dict[str, Any]:
+    try:
+        process = subprocess.run(
+            list(command), cwd=cwd, capture_output=True, check=False, timeout=timeout_seconds
+        )
+    except FileNotFoundError:
+        return {"status": "unavailable", "returncode": None}
+    except subprocess.TimeoutExpired as error:
+        stdout = error.stdout or b""
+        stderr = error.stderr or b""
+        return {
+            "status": "timeout",
+            "returncode": None,
+            "stdout_sha256": sha256_bytes(stdout if isinstance(stdout, bytes) else stdout.encode()),
+            "stderr_sha256": sha256_bytes(stderr if isinstance(stderr, bytes) else stderr.encode()),
+        }
+    return {
+        "status": "passed" if process.returncode == 0 else "failed",
+        "returncode": process.returncode,
+        "stdout_sha256": sha256_bytes(process.stdout),
+        "stderr_sha256": sha256_bytes(process.stderr),
+    }
+
+
+def summarize_review(report: dict[str, Any], raw_output: bytes) -> dict[str, Any]:
+    findings = report.get("findings")
+    if not isinstance(findings, list):
+        raise HoldoutManifestError("review report has no findings array")
+    in_diff = [
+        finding for finding in findings
+        if isinstance(finding, dict) and finding.get("in_diff") is True
+    ]
+    evidence = {
+        "schema_version": report.get("schema_version"),
+        "repopilot_version": report.get("repopilot_version"),
+        "in_diff_findings": len(in_diff),
+        "out_of_diff_findings": len(findings) - len(in_diff),
+        "in_diff_rule_ids": sorted(
+            finding["rule_id"] for finding in in_diff if isinstance(finding.get("rule_id"), str)
+        ),
+    }
+    return {
+        "report_sha256": sha256_bytes(raw_output),
+        "stable_evidence_sha256": sha256_bytes(
+            json.dumps(evidence, sort_keys=True, separators=(",", ":")).encode()
+        ),
+        **evidence,
+    }
+
+
+def clone_case(case: HoldoutCase, root: Path) -> tuple[Path, Path, Path]:
+    root.mkdir(parents=True, exist_ok=True)
+    repository = root / "repository"
+    clone = subprocess.run(
+        ["git", "clone", "--no-tags", "--filter=blob:none", "--no-checkout", case.url, str(repository)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if clone.returncode != 0:
+        raise HoldoutManifestError(f"clone failed for {case.case_id}: {clone.stderr.strip()}")
+    fetch = subprocess.run(
+        ["git", "fetch", "--no-tags", "origin", case.base_sha, case.head_sha, case.merge_sha],
+        cwd=repository,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if fetch.returncode != 0:
+        raise HoldoutManifestError(f"fetch failed for {case.case_id}: {fetch.stderr.strip()}")
+    paths = (root / "base", root / "head", root / "merge")
+    for path, revision in zip(paths, (case.base_sha, case.head_sha, case.merge_sha)):
+        checkout = subprocess.run(
+            ["git", "worktree", "add", "--detach", str(path), revision],
+            cwd=repository,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        if checkout.returncode != 0:
+            raise HoldoutManifestError(
+                f"worktree failed for {case.case_id} ({revision}): {checkout.stderr.strip()}"
+            )
+    return paths
+
+
+def collect_case(scanner: Any, case: HoldoutCase, root: Path, timeout_seconds: int) -> dict[str, Any]:
+    base, head, merge = clone_case(case, root)
+    baselines: dict[str, Any] = {}
+    for baseline_id in case.baseline_ids:
+        command = BASELINE_COMMANDS[baseline_id]
+        result = run_command(command, merge, timeout_seconds)
+        result["command"] = list(command)
+        baselines[baseline_id] = result
+    review_command = (
+        *scanner.command,
+        "review",
+        str(head),
+        "--base",
+        case.base_sha,
+        "--head",
+        case.head_sha,
+        "--format",
+        "json",
+        "--profile",
+        "default",
+        "--no-progress",
+    )
+    try:
+        review = subprocess.run(
+            list(review_command), cwd=head, capture_output=True, check=False, timeout=timeout_seconds
+        )
+    except subprocess.TimeoutExpired:
+        review_result: dict[str, Any] = {"status": "timeout", "returncode": None}
+    else:
+        if review.returncode not in (0, 1):
+            raise HoldoutManifestError(
+                f"review failed for {case.case_id}: {review.stderr.decode(errors='replace').strip()}"
+            )
+        try:
+            report = json.loads(review.stdout)
+        except json.JSONDecodeError as error:
+            raise HoldoutManifestError(f"review returned invalid JSON for {case.case_id}: {error}") from error
+        review_result = summarize_review(report, review.stdout)
+        review_result["status"] = "collected"
+        review_result["returncode"] = review.returncode
+    return {
+        "id": case.case_id,
+        "repo": case.repo,
+        "pull_request": case.pull_request,
+        "base_sha": case.base_sha,
+        "head_sha": case.head_sha,
+        "merge_sha": case.merge_sha,
+        "label_state": case.label_state,
+        "baselines": baselines,
+        "review": review_result,
+    }
+
+
+def collect_holdout(
+    repo_root: Path,
+    manifest_path: Path,
+    corpus: str,
+    protocol: str,
+    cases: list[HoldoutCase],
+    scanner_path: str | None,
+    allow_version_mismatch: bool,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    try:
+        scanner = prepare_scanner(repo_root, scanner_path, allow_version_mismatch)
+    except (ScannerPreparationError, ScannerProvenanceError) as error:
+        raise HoldoutManifestError(f"scanner preparation failed: {error}") from error
+    observations: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="repopilot-real-history-") as temporary:
+        root = Path(temporary)
+        for index, case in enumerate(cases):
+            observations.append(collect_case(scanner, case, root / str(index), timeout_seconds))
+    return {
+        "schema_version": 1,
+        "corpus": corpus,
+        "protocol": protocol,
+        "manifest_sha256": sha256_bytes(manifest_path.read_bytes()),
+        "scanner": {
+            "mode": scanner.mode,
+            "version": scanner.version,
+            "report_schema_version": scanner.report_schema_version,
+            "workspace_version": scanner.workspace_version,
+            "workspace_commit": scanner.workspace_commit,
+            "workspace_dirty": scanner.workspace_dirty,
+            "version_mismatch_allowed": scanner.version_mismatch_allowed,
+        },
+        "cases": observations,
+        "label_state": "pending" if any(case.label_state == "pending" for case in cases) else "ready",
+    }

--- a/scripts/tests/test_real_history_artifact.py
+++ b/scripts/tests/test_real_history_artifact.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from real_history_artifact import validate_collection_data  # noqa: E402
+from real_history_contract import validate_manifest  # noqa: E402
+from real_history_runner import BASELINE_COMMANDS  # noqa: E402
+
+
+class CollectionArtifactTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.manifest = self.root / "manifest.toml"
+        self.rules = self.root / "rules.md"
+        self.zoo = self.root / "zoo.toml"
+        self.rules.write_text("### `demo.rule` — Demo\n", encoding="utf-8")
+        self.zoo.write_text("", encoding="utf-8")
+        self.manifest.write_text(
+            """schema_version = 1
+corpus = "test"
+protocol = "dual-v1"
+
+[[case]]
+id = "case-one"
+repo = "owner/one"
+url = "https://github.com/owner/one.git"
+pull_request = 1
+base_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+head_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+merge_sha = "cccccccccccccccccccccccccccccccccccccccc"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile"]
+label_state = "pending"
+
+[[case]]
+id = "case-two"
+repo = "owner/two"
+url = "https://github.com/owner/two.git"
+pull_request = 2
+base_sha = "dddddddddddddddddddddddddddddddddddddddd"
+head_sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+merge_sha = "ffffffffffffffffffffffffffffffffffffffff"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile"]
+label_state = "pending"
+""",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def artifact(self) -> dict[str, object]:
+        corpus, protocol, cases = validate_manifest(self.manifest, self.rules, self.zoo)
+        observations = []
+        for case in cases:
+            command = list(BASELINE_COMMANDS["python.compile"])
+            observations.append(
+                {
+                    "id": case.case_id,
+                    "repo": case.repo,
+                    "pull_request": case.pull_request,
+                    "base_sha": case.base_sha,
+                    "head_sha": case.head_sha,
+                    "merge_sha": case.merge_sha,
+                    "label_state": case.label_state,
+                    "baselines": {"python.compile": {"status": "passed", "command": command}},
+                    "review": {"status": "collected"},
+                }
+            )
+        return {
+            "schema_version": 1,
+            "corpus": corpus,
+            "protocol": protocol,
+            "manifest_sha256": hashlib.sha256(self.manifest.read_bytes()).hexdigest(),
+            "scanner": {
+                "mode": "explicit",
+                "version": "0.22.0",
+                "report_schema_version": "0.26",
+                "workspace_version": "0.22.0",
+            },
+            "cases": observations,
+            "label_state": "pending",
+        }
+
+    def test_accepts_matching_collection(self) -> None:
+        result = validate_collection_data(self.artifact(), self.manifest, self.rules, self.zoo)
+        self.assertEqual(result["status"], "valid")
+        self.assertEqual(result["cases"], 2)
+
+    def test_rejects_manifest_hash_drift(self) -> None:
+        artifact = self.artifact()
+        artifact["manifest_sha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "manifest_sha256"):
+            validate_collection_data(artifact, self.manifest, self.rules, self.zoo)
+
+    def test_rejects_baseline_command_drift(self) -> None:
+        artifact = self.artifact()
+        artifact["cases"][0]["baselines"]["python.compile"]["command"] = ["sh", "-c", "unsafe"]
+        with self.assertRaisesRegex(ValueError, "baseline command drift"):
+            validate_collection_data(artifact, self.manifest, self.rules, self.zoo)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_real_history_runner.py
+++ b/scripts/tests/test_real_history_runner.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from real_history_runner import BASELINE_COMMANDS, run_command, summarize_review  # noqa: E402
+
+
+class RealHistoryRunnerTests(unittest.TestCase):
+    def test_baseline_catalog_is_allowlisted(self) -> None:
+        self.assertEqual(BASELINE_COMMANDS["python.compile"], ("python3", "-m", "compileall", "-q", "."))
+        self.assertNotIn("shell", BASELINE_COMMANDS)
+
+    def test_run_command_records_pass_and_output_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_command(("python3", "-c", "print('ok')"), Path(tmp), 5)
+        self.assertEqual(result["status"], "passed")
+        self.assertEqual(result["returncode"], 0)
+        self.assertEqual(len(result["stdout_sha256"]), 64)
+
+    def test_summarize_review_separates_in_diff_rules(self) -> None:
+        report = {
+            "schema_version": "0.26",
+            "repopilot_version": "0.22.0",
+            "findings": [
+                {"rule_id": "security.secret-candidate", "in_diff": True},
+                {"rule_id": "architecture.large-file", "in_diff": False},
+            ],
+        }
+        summary = summarize_review(report, b"report")
+        self.assertEqual(summary["in_diff_findings"], 1)
+        self.assertEqual(summary["out_of_diff_findings"], 1)
+        self.assertEqual(summary["in_diff_rule_ids"], ["security.secret-candidate"])
+        self.assertEqual(len(summary["report_sha256"]), 64)
+        self.assertEqual(len(summary["stable_evidence_sha256"]), 64)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -14,9 +14,13 @@ Validate the protocol contract without cloning repositories:
 ```bash
 python3 scripts/real_history.py check
 python3 scripts/real_history.py check --format json
+python3 scripts/real_history.py collect --scanner target/release/repopilot \
+  --timeout 60 --output real-history-run.json
 ```
 
 Both entries are intentionally `pending`. This PR does not invent defect labels
-or claim real-history recall. The next benchmark slice will clone the pinned
-revisions, collect baseline outcomes, run RepoPilot, and publish the dual-label
-adjudication artifact.
+or claim real-history recall. `collect` clones the pinned revisions into a
+temporary workspace, runs only the allowlisted baselines and a base-to-head
+RepoPilot review, and records statuses, output hashes, and stable evidence
+hashes. Baseline failures are retained as observations; they do not become
+RepoPilot findings. The collected artifact still needs dual-label adjudication.

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -16,6 +16,8 @@ python3 scripts/real_history.py check
 python3 scripts/real_history.py check --format json
 python3 scripts/real_history.py collect --scanner target/release/repopilot \
   --timeout 60 --output real-history-run.json
+python3 scripts/real_history.py validate-result \
+  --artifact real-history-run.json
 ```
 
 Both entries are intentionally `pending`. This PR does not invent defect labels
@@ -24,3 +26,7 @@ temporary workspace, runs only the allowlisted baselines and a base-to-head
 RepoPilot review, and records statuses, output hashes, and stable evidence
 hashes. Baseline failures are retained as observations; they do not become
 RepoPilot findings. The collected artifact still needs dual-label adjudication.
+
+`validate-result` checks the artifact against the current manifest, including
+the manifest hash, immutable PR revisions, scanner provenance, baseline command
+allowlist, and one review observation per case.


### PR DESCRIPTION
## Problem

The real-history holdout protocol is merged, but no executable collection path or artifact integrity check existed. Without those, pinned revisions, baseline outcomes, and RepoPilot review evidence could drift or be reported without provenance.

## Change

- collect pinned base/head/merge worktrees in a temporary directory;
- execute only the allowlisted baseline IDs from the manifest;
- run a base-to-head RepoPilot review for every case;
- record baseline status/exit/output hashes and raw plus stable review evidence hashes;
- add `validate-result` to reject manifest SHA drift, changed PR SHAs, scanner provenance gaps, baseline command drift, or missing case observations;
- retain pending labels and explicit boundaries: collection observations are not recall, precision, or differential utility metrics.

## Observed local run

Both pinned cases collected successfully. `python.compile` passed for Flask and Requests; `python.tests` returned nonzero for both and is retained as an observation. RepoPilot reported one in-diff rule for Flask and zero for Requests. Stable evidence hashes were identical across repeated runs, while raw report hashes differed because reports include runtime timing fields.

No labels were invented. The corpus remains `pending` until two independent reviewers and an adjudicator record ground truth.

## Validation

- `python3 -m unittest discover -s scripts/tests` — 101 passed
- `python3 scripts/real_history.py check --format json` — 2 pending cases across 2 repositories
- `python3 scripts/real_history.py collect --scanner target/release/repopilot --timeout 60` — both cases collected
- `python3 scripts/real_history.py validate-result --artifact ...` — valid
- repeated collection — stable evidence hashes identical
- `python3 scripts/release-contract.py check` — passed
- full RepoPilot gate — passed locally: fmt, clippy, 906 library tests, 80 binary tests, 101 release-contract tests, self-scan P1
