### PR TITLE
feat: add independent real-history annotation workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added collection-artifact validation against manifest hashes, immutable PR
   revisions, scanner provenance, baseline command identity, and per-case review
   coverage. A collected artifact cannot silently drift from its protocol.
+- Added deterministic real-history annotation worksheets for two independent
+  reviewers and an adjudication template. Worksheets pin collection evidence
+  while leaving labels and rationales human-entered; no quality metric is
+  inferred before explicit adjudication.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -260,3 +260,12 @@ bump is needed to start.
   baseline command identity, scanner provenance, or case coverage. The local
   collection artifact passes this validator; it remains an unlabeled
   observation packet rather than a benchmark score.
+- The annotation workflow now generates two deterministic reviewer worksheets
+  from the validated collection artifact. It pins the manifest and collection
+  hashes, case revisions, baseline statuses, and observed in-diff rule IDs;
+  labels and rationales remain human-entered. A separate adjudication template
+  preserves both independent labels and leaves the final decision blank.
+- Boundary: baseline/test failures are retained for diagnosis and are not
+  interpreted as RepoPilot defects. The generated worksheets are still empty;
+  recall, precision, and differential utility metrics remain unavailable until
+  two labels and an explicit adjudication are completed.

--- a/scripts/real_history.py
+++ b/scripts/real_history.py
@@ -14,13 +14,30 @@ from real_history_contract import (
     validate_manifest,
 )
 from real_history_artifact import validate_collection_artifact, validate_collection_data
+from real_history_annotations import (
+    HoldoutManifestError as AnnotationManifestError,
+    load_annotation,
+    render_worksheet,
+)
+from real_history_adjudication import render_adjudication_template, validate_adjudication
 from real_history_runner import collect_holdout
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "command", nargs="?", choices=("check", "collect", "validate-result"), default="check"
+        "command",
+        nargs="?",
+        choices=(
+            "check",
+            "collect",
+            "validate-result",
+            "template",
+            "validate-annotation",
+            "adjudication-template",
+            "validate-adjudication",
+        ),
+        default="check",
     )
     parser.add_argument("--manifest", type=Path, default=Path("tests/benchmarks/manifest.toml"))
     parser.add_argument("--rules-reference", type=Path, default=Path("docs/rules-reference.md"))
@@ -32,6 +49,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--timeout", type=int, default=300)
     parser.add_argument("--output", type=Path, help="write a collection artifact instead of stdout")
     parser.add_argument("--artifact", type=Path, help="collection artifact to validate")
+    parser.add_argument("--annotation", type=Path, help="completed reviewer worksheet to validate")
+    parser.add_argument("--annotation-a", type=Path, help="reviewer A worksheet")
+    parser.add_argument("--annotation-b", type=Path, help="reviewer B worksheet")
+    parser.add_argument("--reviewer", choices=("a", "b"), help="independent worksheet owner")
     args = parser.parse_args(argv)
     try:
         corpus, protocol, cases = validate_manifest(args.manifest, args.rules_reference, args.zoo_manifest)
@@ -53,6 +74,88 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(result, indent=2, sort_keys=True))
         else:
             print(f"Collection artifact: {result['status']} ({result['cases']} cases)")
+        return 0
+    if args.command == "template":
+        if args.artifact is None or args.output is None or args.reviewer is None:
+            print("template requires --artifact, --reviewer, and --output", file=sys.stderr)
+            return 2
+        try:
+            rendered = render_worksheet(
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+                args.reviewer,
+            )
+        except (AnnotationManifestError, OSError) as error:
+            print(f"annotation template failed: {error}", file=sys.stderr)
+            return 1
+        args.output.write_text(rendered, encoding="utf-8")
+        print(f"Annotation worksheet: {args.output} (reviewer {args.reviewer})")
+        return 0
+    if args.command == "validate-annotation":
+        if args.artifact is None or args.annotation is None or args.reviewer is None:
+            print("validate-annotation requires --artifact, --annotation, and --reviewer", file=sys.stderr)
+            return 2
+        try:
+            _, cases = load_annotation(
+                args.annotation,
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+                args.reviewer,
+            )
+        except (AnnotationManifestError, OSError) as error:
+            print(f"annotation invalid: {error}", file=sys.stderr)
+            return 1
+        print(f"Annotation: valid ({len(cases)} cases; reviewer {args.reviewer})")
+        return 0
+    if args.command == "adjudication-template":
+        required = (args.artifact, args.annotation_a, args.annotation_b, args.output)
+        if any(value is None for value in required):
+            print(
+                "adjudication-template requires --artifact, --annotation-a, --annotation-b, and --output",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            rendered = render_adjudication_template(
+                args.annotation_a,
+                args.annotation_b,
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (AnnotationManifestError, OSError) as error:
+            print(f"adjudication template failed: {error}", file=sys.stderr)
+            return 1
+        args.output.write_text(rendered, encoding="utf-8")
+        print(f"Adjudication template: {args.output}")
+        return 0
+    if args.command == "validate-adjudication":
+        required = (args.artifact, args.annotation_a, args.annotation_b, args.annotation)
+        if any(value is None for value in required):
+            print(
+                "validate-adjudication requires --artifact, --annotation-a, --annotation-b, and --annotation",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            count = validate_adjudication(
+                args.annotation,
+                args.annotation_a,
+                args.annotation_b,
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (AnnotationManifestError, OSError) as error:
+            print(f"adjudication invalid: {error}", file=sys.stderr)
+            return 1
+        print(f"Adjudication: valid ({count} cases)")
         return 0
     if args.command == "collect":
         if args.timeout <= 0:

--- a/scripts/real_history_adjudication.py
+++ b/scripts/real_history_adjudication.py
@@ -1,0 +1,132 @@
+"""Build and validate the third-party decision artifact for a holdout case."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from real_history_annotations import (
+    ANNOTATION_SCHEMA_VERSION,
+    _toml_array,
+    _toml_string,
+    load_annotation,
+    load_collection,
+    _load_toml,
+)
+from real_history_contract import ALLOWED_LABELS, HoldoutManifestError, validate_manifest
+
+
+ADJUDICATION_FIELDS = {
+    "id",
+    "label_a",
+    "expected_rule_ids_a",
+    "label_b",
+    "expected_rule_ids_b",
+    "adjudicated",
+    "expected_rule_ids",
+    "rationale",
+}
+
+
+def render_adjudication_template(
+    annotation_a_path: Path,
+    annotation_b_path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> str:
+    data_a, cases_a = load_annotation(
+        annotation_a_path, collection_path, manifest_path, rules_reference, zoo_manifest, "a"
+    )
+    data_b, cases_b = load_annotation(
+        annotation_b_path, collection_path, manifest_path, rules_reference, zoo_manifest, "b"
+    )
+    lines = [
+        f"schema_version = {ANNOTATION_SCHEMA_VERSION}",
+        f"corpus = {_toml_string(data_a['corpus'])}",
+        f"protocol = {_toml_string(data_a['protocol'])}",
+        f"manifest_sha256 = {_toml_string(data_a['manifest_sha256'])}",
+        f"collection_sha256 = {_toml_string(data_a['collection_sha256'])}",
+        "",
+    ]
+    for case_id in sorted(cases_a):
+        left, right = cases_a[case_id], cases_b[case_id]
+        lines.extend([
+            "[[case]]",
+            f"id = {_toml_string(case_id)}",
+            f"label_a = {_toml_string(left['label'])}",
+            f"expected_rule_ids_a = {_toml_array(left['expected_rule_ids'])}",
+            f"label_b = {_toml_string(right['label'])}",
+            f"expected_rule_ids_b = {_toml_array(right['expected_rule_ids'])}",
+            'adjudicated = ""',
+            "expected_rule_ids = []",
+            'rationale = ""',
+            "",
+        ])
+    return "\n".join(lines)
+
+
+def validate_adjudication(
+    adjudication_path: Path,
+    annotation_a_path: Path,
+    annotation_b_path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> int:
+    data_a, cases_a = load_annotation(
+        annotation_a_path, collection_path, manifest_path, rules_reference, zoo_manifest, "a"
+    )
+    data_b, cases_b = load_annotation(
+        annotation_b_path, collection_path, manifest_path, rules_reference, zoo_manifest, "b"
+    )
+    collection = load_collection(collection_path, manifest_path, rules_reference, zoo_manifest)
+    _, _, manifest_cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    known_rules = set(re.findall(r"^### `([^`]+)`", rules_reference.read_text(encoding="utf-8"), re.MULTILINE))
+    data = _load_toml(adjudication_path, "adjudication")
+    if data.get("schema_version") != ANNOTATION_SCHEMA_VERSION:
+        raise HoldoutManifestError("adjudication schema_version is unsupported")
+    for field in ("corpus", "protocol", "manifest_sha256", "collection_sha256"):
+        if data.get(field) != collection.get(field):
+            raise HoldoutManifestError(f"adjudication {field} does not match collection")
+    raw_cases = data.get("case")
+    if not isinstance(raw_cases, list):
+        raise HoldoutManifestError("adjudication cases must be an array")
+    expected_ids = {case.case_id for case in manifest_cases}
+    observed: set[str] = set()
+    for raw in raw_cases:
+        if not isinstance(raw, dict):
+            raise HoldoutManifestError("adjudication case must be a table")
+        unknown = set(raw) - ADJUDICATION_FIELDS
+        if unknown:
+            raise HoldoutManifestError(f"adjudication case has unknown fields: {', '.join(sorted(unknown))}")
+        case_id = raw.get("id")
+        if not isinstance(case_id, str) or case_id in observed or case_id not in expected_ids:
+            raise HoldoutManifestError(f"adjudication has unknown or duplicate case {case_id!r}")
+        observed.add(case_id)
+        for side, source in (("a", cases_a), ("b", cases_b)):
+            label_key = f"label_{side}"
+            rules_key = f"expected_rule_ids_{side}"
+            if raw.get(label_key) != source[case_id]["label"]:
+                raise HoldoutManifestError(f"adjudication case {case_id}: {label_key} does not match worksheet")
+            if raw.get(rules_key) != source[case_id]["expected_rule_ids"]:
+                raise HoldoutManifestError(f"adjudication case {case_id}: {rules_key} does not match worksheet")
+        label = raw.get("adjudicated")
+        if label not in ALLOWED_LABELS:
+            raise HoldoutManifestError(f"adjudication case {case_id}: adjudicated label is required")
+        rules = raw.get("expected_rule_ids")
+        if not isinstance(rules, list) or not all(isinstance(item, str) for item in rules):
+            raise HoldoutManifestError(f"adjudication case {case_id}: expected_rule_ids must be a string array")
+        if any(rule_id not in known_rules for rule_id in rules):
+            raise HoldoutManifestError(f"adjudication case {case_id}: expected_rule_ids contains an unknown rule")
+        if label == "defect-present" and not rules:
+            raise HoldoutManifestError(f"adjudication case {case_id}: defect-present needs expected_rule_ids")
+        if not isinstance(raw.get("rationale"), str) or not raw["rationale"].strip():
+            raise HoldoutManifestError(f"adjudication case {case_id}: rationale is required")
+    if observed != expected_ids:
+        raise HoldoutManifestError(f"adjudication is missing cases: {', '.join(sorted(expected_ids - observed))}")
+    if data_a["manifest_sha256"] != data_b["manifest_sha256"]:
+        raise HoldoutManifestError("worksheets do not share the same manifest")
+    return len(raw_cases)

--- a/scripts/real_history_annotations.py
+++ b/scripts/real_history_annotations.py
@@ -1,0 +1,233 @@
+"""Generate and validate independent real-history annotation artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from real_history_artifact import validate_collection_data
+from real_history_contract import (
+    ALLOWED_LABELS,
+    HoldoutCase,
+    HoldoutManifestError,
+    validate_manifest,
+)
+
+
+ANNOTATION_SCHEMA_VERSION = 1
+ANNOTATION_PROTOCOL = "dual-independent-adjudication-v1"
+ANNOTATION_FIELDS = {
+    "id",
+    "repo",
+    "pull_request",
+    "base_sha",
+    "head_sha",
+    "merge_sha",
+    "observed_in_diff_rule_ids",
+    "baseline_statuses",
+    "label",
+    "expected_rule_ids",
+    "rationale",
+}
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_collection(
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, Any]:
+    try:
+        data = json.loads(collection_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read collection artifact {collection_path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError("collection artifact must be a JSON object")
+    validate_collection_data(data, manifest_path, rules_reference, zoo_manifest)
+    data["collection_sha256"] = sha256_file(collection_path)
+    return data
+
+
+def _cases_by_id(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    cases = data.get("cases")
+    if not isinstance(cases, list):
+        raise HoldoutManifestError("collection cases must be an array")
+    return {case["id"]: case for case in cases if isinstance(case, dict) and isinstance(case.get("id"), str)}
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _toml_array(values: list[str]) -> str:
+    return "[" + ", ".join(_toml_string(value) for value in values) + "]"
+
+
+def _worksheet_header(data: dict[str, Any], reviewer: str) -> list[str]:
+    return [
+        f"schema_version = {ANNOTATION_SCHEMA_VERSION}",
+        f"corpus = {_toml_string(data['corpus'])}",
+        f"protocol = {_toml_string(data['protocol'])}",
+        f"reviewer = {_toml_string(reviewer)}",
+        f"manifest_sha256 = {_toml_string(data['manifest_sha256'])}",
+        f"collection_sha256 = {_toml_string(data['collection_sha256'])}",
+        "",
+    ]
+
+
+def _worksheet_case(case: HoldoutCase, observation: dict[str, Any]) -> list[str]:
+    review = observation["review"]
+    rule_ids = review.get("in_diff_rule_ids", []) if isinstance(review, dict) else []
+    if not isinstance(rule_ids, list) or not all(isinstance(item, str) for item in rule_ids):
+        raise HoldoutManifestError(f"collection case {case.case_id}: invalid rule evidence")
+    baselines = observation["baselines"]
+    statuses = [f"{baseline_id}={baselines[baseline_id]['status']}" for baseline_id in case.baseline_ids]
+    return [
+        "[[case]]",
+        f"id = {_toml_string(case.case_id)}",
+        f"repo = {_toml_string(case.repo)}",
+        f"pull_request = {case.pull_request}",
+        f"base_sha = {_toml_string(case.base_sha)}",
+        f"head_sha = {_toml_string(case.head_sha)}",
+        f"merge_sha = {_toml_string(case.merge_sha)}",
+        f"observed_in_diff_rule_ids = {_toml_array(sorted(set(rule_ids)))}",
+        f"baseline_statuses = {_toml_array(statuses)}",
+        'label = ""',
+        "expected_rule_ids = []",
+        'rationale = ""',
+        "",
+    ]
+
+
+def render_worksheet(
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+    reviewer: str,
+) -> str:
+    if reviewer not in {"a", "b"}:
+        raise HoldoutManifestError("reviewer must be 'a' or 'b'")
+    corpus, protocol, cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    if protocol != ANNOTATION_PROTOCOL:
+        raise HoldoutManifestError(f"manifest protocol must be {ANNOTATION_PROTOCOL}")
+    data = load_collection(collection_path, manifest_path, rules_reference, zoo_manifest)
+    observations = _cases_by_id(data)
+    if data["label_state"] != "pending" or any(case.label_state != "pending" for case in cases):
+        raise HoldoutManifestError("annotation worksheets require a pending collection")
+    lines = _worksheet_header(data, reviewer)
+    for case in cases:
+        if case.case_id not in observations:
+            raise HoldoutManifestError(f"collection is missing case {case.case_id}")
+        lines.extend(_worksheet_case(case, observations[case.case_id]))
+    return "\n".join(lines)
+
+
+def _load_toml(path: Path, artifact_name: str) -> dict[str, Any]:
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read {artifact_name} {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError(f"{artifact_name} must be a TOML table")
+    return data
+
+
+def _validate_context(
+    data: dict[str, Any],
+    collection: dict[str, Any],
+    cases: list[HoldoutCase],
+    known_rules: set[str],
+    reviewer: str | None,
+) -> dict[str, dict[str, Any]]:
+    if data.get("schema_version") != ANNOTATION_SCHEMA_VERSION:
+        raise HoldoutManifestError("annotation schema_version is unsupported")
+    for field in ("corpus", "protocol", "manifest_sha256", "collection_sha256"):
+        if data.get(field) != collection.get(field, collection.get("manifest_sha256")):
+            expected = collection.get(field)
+            raise HoldoutManifestError(f"annotation {field} does not match collection ({expected})")
+    actual_reviewer = data.get("reviewer")
+    if actual_reviewer not in {"a", "b"} or (reviewer is not None and actual_reviewer != reviewer):
+        raise HoldoutManifestError("annotation reviewer must match the requested independent reviewer")
+    raw_cases = data.get("case")
+    if not isinstance(raw_cases, list):
+        raise HoldoutManifestError("annotation cases must be an array")
+    expected = {case.case_id: case for case in cases}
+    collected = _cases_by_id(collection)
+    observed: dict[str, dict[str, Any]] = {}
+    for raw in raw_cases:
+        if not isinstance(raw, dict):
+            raise HoldoutManifestError("annotation case must be a table")
+        unknown = set(raw) - ANNOTATION_FIELDS
+        if unknown:
+            raise HoldoutManifestError(f"annotation case has unknown fields: {', '.join(sorted(unknown))}")
+        case_id = raw.get("id")
+        if not isinstance(case_id, str) or case_id in observed or case_id not in expected:
+            raise HoldoutManifestError(f"annotation has unknown or duplicate case {case_id!r}")
+        case = expected[case_id]
+        for field in ("repo", "base_sha", "head_sha", "merge_sha"):
+            if raw.get(field) != getattr(case, field):
+                raise HoldoutManifestError(f"annotation case {case_id}: {field} does not match manifest")
+        if raw.get("pull_request") != case.pull_request:
+            raise HoldoutManifestError(f"annotation case {case_id}: pull_request does not match manifest")
+        if not isinstance(raw.get("observed_in_diff_rule_ids"), list) or not all(
+            isinstance(item, str) for item in raw["observed_in_diff_rule_ids"]
+        ):
+            raise HoldoutManifestError(f"annotation case {case_id}: invalid observed rule IDs")
+        if not isinstance(raw.get("baseline_statuses"), list) or not all(
+            isinstance(item, str) for item in raw["baseline_statuses"]
+        ):
+            raise HoldoutManifestError(f"annotation case {case_id}: invalid baseline statuses")
+        observation = collected.get(case_id)
+        if observation is None:
+            raise HoldoutManifestError(f"collection is missing case {case_id}")
+        review = observation.get("review")
+        expected_rules = sorted(set(review.get("in_diff_rule_ids", []))) if isinstance(review, dict) else []
+        if raw["observed_in_diff_rule_ids"] != expected_rules:
+            raise HoldoutManifestError(f"annotation case {case_id}: observed rule evidence drifted")
+        expected_statuses = [
+            f"{baseline_id}={observation['baselines'][baseline_id]['status']}"
+            for baseline_id in case.baseline_ids
+        ]
+        if raw["baseline_statuses"] != expected_statuses:
+            raise HoldoutManifestError(f"annotation case {case_id}: baseline evidence drifted")
+        if not isinstance(raw.get("label"), str) or raw["label"] not in ALLOWED_LABELS:
+            raise HoldoutManifestError(f"annotation case {case_id}: label must be one of {sorted(ALLOWED_LABELS)}")
+        if not isinstance(raw.get("expected_rule_ids"), list) or not all(
+            isinstance(item, str) for item in raw["expected_rule_ids"]
+        ):
+            raise HoldoutManifestError(f"annotation case {case_id}: expected_rule_ids must be a string array")
+        if any(rule_id not in known_rules for rule_id in raw["expected_rule_ids"]):
+            raise HoldoutManifestError(f"annotation case {case_id}: expected_rule_ids contains an unknown rule")
+        if raw["label"] == "defect-present" and not raw["expected_rule_ids"]:
+            raise HoldoutManifestError(f"annotation case {case_id}: defect-present needs expected_rule_ids")
+        if not isinstance(raw.get("rationale"), str) or not raw["rationale"].strip():
+            raise HoldoutManifestError(f"annotation case {case_id}: rationale is required")
+        observed[case_id] = raw
+    if set(observed) != set(expected):
+        raise HoldoutManifestError(f"annotation is missing cases: {', '.join(sorted(set(expected) - set(observed)))}")
+    return observed
+
+
+def load_annotation(
+    path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+    reviewer: str | None = None,
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    collection = load_collection(collection_path, manifest_path, rules_reference, zoo_manifest)
+    _, _, cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    data = _load_toml(path, "annotation")
+    known_rules = set(re.findall(r"^### `([^`]+)`", rules_reference.read_text(encoding="utf-8"), re.MULTILINE))
+    return data, _validate_context(data, collection, cases, known_rules, reviewer)
+

--- a/scripts/tests/test_real_history_annotations.py
+++ b/scripts/tests/test_real_history_annotations.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from real_history_annotations import (  # noqa: E402
+    load_annotation,
+    render_worksheet,
+)
+from real_history_adjudication import (  # noqa: E402
+    render_adjudication_template,
+    validate_adjudication,
+)
+from real_history_contract import validate_manifest  # noqa: E402
+from real_history_runner import BASELINE_COMMANDS  # noqa: E402
+
+
+class AnnotationWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.manifest = self.root / "manifest.toml"
+        self.rules = self.root / "rules.md"
+        self.zoo = self.root / "zoo.toml"
+        self.collection = self.root / "collection.json"
+        self.rules.write_text("### `demo.rule` — Demo\n", encoding="utf-8")
+        self.zoo.write_text("", encoding="utf-8")
+        self.manifest.write_text(
+            """schema_version = 1
+corpus = "test"
+protocol = "dual-independent-adjudication-v1"
+
+[[case]]
+id = "case-one"
+repo = "owner/one"
+url = "https://github.com/owner/one.git"
+pull_request = 1
+base_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+head_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+merge_sha = "cccccccccccccccccccccccccccccccccccccccc"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile"]
+label_state = "pending"
+
+[[case]]
+id = "case-two"
+repo = "owner/two"
+url = "https://github.com/owner/two.git"
+pull_request = 2
+base_sha = "dddddddddddddddddddddddddddddddddddddddd"
+head_sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+merge_sha = "ffffffffffffffffffffffffffffffffffffffff"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile"]
+label_state = "pending"
+""",
+            encoding="utf-8",
+        )
+        _, _, cases = validate_manifest(self.manifest, self.rules, self.zoo)
+        observations = []
+        for case in cases:
+            observations.append(
+                {
+                    "id": case.case_id,
+                    "repo": case.repo,
+                    "pull_request": case.pull_request,
+                    "base_sha": case.base_sha,
+                    "head_sha": case.head_sha,
+                    "merge_sha": case.merge_sha,
+                    "label_state": "pending",
+                    "baselines": {
+                        "python.compile": {
+                            "status": "passed",
+                            "command": list(BASELINE_COMMANDS["python.compile"]),
+                        }
+                    },
+                    "review": {
+                        "status": "collected",
+                        "in_diff_rule_ids": ["demo.rule"] if case.case_id == "case-one" else [],
+                    },
+                }
+            )
+        data = {
+            "schema_version": 1,
+            "corpus": "test",
+            "protocol": "dual-independent-adjudication-v1",
+            "manifest_sha256": hashlib.sha256(self.manifest.read_bytes()).hexdigest(),
+            "scanner": {
+                "mode": "explicit",
+                "version": "0.23.0",
+                "report_schema_version": "0.26",
+                "workspace_version": "0.23.0",
+            },
+            "cases": observations,
+            "label_state": "pending",
+        }
+        self.collection.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def worksheet(self, reviewer: str) -> Path:
+        path = self.root / f"{reviewer}.toml"
+        path.write_text(
+            render_worksheet(self.collection, self.manifest, self.rules, self.zoo, reviewer),
+            encoding="utf-8",
+        )
+        return path
+
+    def complete(self, path: Path, label: str, rationale: str = "reviewed diff") -> None:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+        for case in data["case"]:
+            case["label"] = label
+            case["rationale"] = rationale
+            if label == "defect-present":
+                case["expected_rule_ids"] = ["demo.rule"]
+        lines = path.read_text(encoding="utf-8")
+        for case in data["case"]:
+            lines = lines.replace('label = ""', f'label = "{case["label"]}"', 1)
+            lines = lines.replace('rationale = ""', f'rationale = "{case["rationale"]}"', 1)
+            if label == "defect-present":
+                lines = lines.replace("expected_rule_ids = []", 'expected_rule_ids = ["demo.rule"]', 1)
+        path.write_text(lines, encoding="utf-8")
+
+    def test_templates_are_deterministic_except_reviewer(self) -> None:
+        left = render_worksheet(self.collection, self.manifest, self.rules, self.zoo, "a")
+        right = render_worksheet(self.collection, self.manifest, self.rules, self.zoo, "b")
+        self.assertEqual(left.replace('reviewer = "a"', 'reviewer = "b"'), right)
+        self.assertEqual(tomllib.loads(left)["case"][0]["label"], "")
+
+    def test_blank_template_is_not_admissible_as_annotation(self) -> None:
+        path = self.worksheet("a")
+        with self.assertRaisesRegex(ValueError, "label must be"):
+            load_annotation(path, self.collection, self.manifest, self.rules, self.zoo, "a")
+
+    def test_annotation_requires_pinned_context(self) -> None:
+        path = self.worksheet("a")
+        self.complete(path, "no-defect")
+        text = path.read_text(encoding="utf-8").replace(
+            'base_sha = "' + "a" * 40 + '"',
+            'base_sha = "' + "b" * 40 + '"',
+        )
+        path.write_text(text, encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "base_sha does not match"):
+            load_annotation(path, self.collection, self.manifest, self.rules, self.zoo, "a")
+
+    def test_adjudication_template_preserves_disagreement(self) -> None:
+        left, right = self.worksheet("a"), self.worksheet("b")
+        self.complete(left, "defect-present")
+        self.complete(right, "no-defect")
+        rendered = render_adjudication_template(
+            left, right, self.collection, self.manifest, self.rules, self.zoo
+        )
+        data = tomllib.loads(rendered)
+        self.assertEqual(data["case"][0]["label_a"], "defect-present")
+        self.assertEqual(data["case"][0]["label_b"], "no-defect")
+        self.assertEqual(data["case"][0]["adjudicated"], "")
+
+    def test_adjudication_requires_explicit_decision(self) -> None:
+        left, right = self.worksheet("a"), self.worksheet("b")
+        self.complete(left, "no-defect")
+        self.complete(right, "no-defect")
+        path = self.root / "adjudication.toml"
+        path.write_text(
+            render_adjudication_template(
+                left, right, self.collection, self.manifest, self.rules, self.zoo
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "adjudicated label is required"):
+            validate_adjudication(
+                path, left, right, self.collection, self.manifest, self.rules, self.zoo
+            )
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace('adjudicated = ""', 'adjudicated = "no-defect"').replace(
+                'rationale = ""', 'rationale = "third reviewer confirmed"'
+            ),
+            encoding="utf-8",
+        )
+        self.assertEqual(
+            validate_adjudication(path, left, right, self.collection, self.manifest, self.rules, self.zoo),
+            2,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -18,6 +18,18 @@ python3 scripts/real_history.py collect --scanner target/release/repopilot \
   --timeout 60 --output real-history-run.json
 python3 scripts/real_history.py validate-result \
   --artifact real-history-run.json
+python3 scripts/real_history.py template --artifact real-history-run.json \
+  --reviewer a --output annotation-a.toml
+python3 scripts/real_history.py template --artifact real-history-run.json \
+  --reviewer b --output annotation-b.toml
+python3 scripts/real_history.py validate-annotation --artifact real-history-run.json \
+  --annotation annotation-a.toml --reviewer a
+python3 scripts/real_history.py adjudication-template \
+  --artifact real-history-run.json --annotation-a annotation-a.toml \
+  --annotation-b annotation-b.toml --output adjudication.toml
+python3 scripts/real_history.py validate-adjudication \
+  --artifact real-history-run.json --annotation-a annotation-a.toml \
+  --annotation-b annotation-b.toml --annotation adjudication.toml
 ```
 
 Both entries are intentionally `pending`. This PR does not invent defect labels
@@ -30,3 +42,15 @@ RepoPilot findings. The collected artifact still needs dual-label adjudication.
 `validate-result` checks the artifact against the current manifest, including
 the manifest hash, immutable PR revisions, scanner provenance, baseline command
 allowlist, and one review observation per case.
+
+`template` creates one deterministic worksheet per independent reviewer. It
+copies only pinned case identity, baseline statuses, and observed in-diff rule
+IDs from the collection artifact; labels and rationales stay empty. Complete
+both worksheets from the diff and repository evidence, then run
+`validate-annotation` before creating the `adjudication-template`. The latter
+copies both independent labels and leaves the adjudicated label and rationale
+empty for an explicit third decision. These commands create evidence packets;
+`validate-adjudication` requires that decision and its rationale to be filled
+and verifies that the copied independent labels still match both worksheets.
+These commands create evidence packets; they do not infer labels or calculate
+recall.


### PR DESCRIPTION
## Summary
- add deterministic reviewer A/B worksheets for the pinned real-history holdout
- pin manifest and collection hashes, immutable case identity, baseline statuses, and observed review evidence
- add strict annotation and adjudication validation so blank or drifted artifacts cannot become quality metrics
- document the evidence workflow and keep labels human-entered

## Evidence boundary
This PR creates an auditable annotation packet workflow. It does not add labels, recall, precision, or differential utility claims. The current holdout remains pending until two independent reviewers and an explicit adjudicator complete the artifacts.

## Validation
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (106 passed)
- `python3 scripts/release-contract.py check`
- `npm run test:release-contract`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (906 lib + 80 bin + integration tests passed; 1 explicit compatibility test ignored)
- `cargo run -- scan . --fail-on-priority p1` (PASS; pre-existing strict-only contract warnings remain)
