### PR TITLE
feat: add corpus-only real-history metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   reviewers and an adjudication template. Worksheets pin collection evidence
   while leaving labels and rationales human-entered; no quality metric is
   inferred before explicit adjudication.
+- Added a gated real-history metrics artifact with case-level confusion counts,
+  recall, specificity, precision, Wilson intervals, input hashes, and an
+  explicit corpus-only limitation.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -265,7 +265,12 @@ bump is needed to start.
   hashes, case revisions, baseline statuses, and observed in-diff rule IDs;
   labels and rationales remain human-entered. A separate adjudication template
   preserves both independent labels and leaves the final decision blank.
+- A metrics artifact is now gated on validated A/B worksheets plus explicit
+  adjudication. It reports case-level TP/FN/TN/FP, recall, specificity, and
+  precision with Wilson 95% intervals, and records the three input hashes and
+  corpus-only scope in the output.
 - Boundary: baseline/test failures are retained for diagnosis and are not
   interpreted as RepoPilot defects. The generated worksheets are still empty;
-  recall, precision, and differential utility metrics remain unavailable until
-  two labels and an explicit adjudication are completed.
+  no metric is available until two labels and an explicit adjudication are
+  completed. Even then the result is descriptive evidence for this holdout,
+  not a production or language-wide estimate.

--- a/scripts/real_history.py
+++ b/scripts/real_history.py
@@ -20,6 +20,7 @@ from real_history_annotations import (
     render_worksheet,
 )
 from real_history_adjudication import render_adjudication_template, validate_adjudication
+from real_history_metrics import write_metrics
 from real_history_runner import collect_holdout
 
 
@@ -36,6 +37,7 @@ def main(argv: list[str] | None = None) -> int:
             "validate-annotation",
             "adjudication-template",
             "validate-adjudication",
+            "metrics",
         ),
         default="check",
     )
@@ -156,6 +158,31 @@ def main(argv: list[str] | None = None) -> int:
             print(f"adjudication invalid: {error}", file=sys.stderr)
             return 1
         print(f"Adjudication: valid ({count} cases)")
+        return 0
+    if args.command == "metrics":
+        required = (args.artifact, args.annotation_a, args.annotation_b, args.annotation, args.output)
+        if any(value is None for value in required):
+            print(
+                "metrics requires --artifact, --annotation-a, --annotation-b, --annotation, and --output",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            result = write_metrics(
+                args.output,
+                args.annotation,
+                args.annotation_a,
+                args.annotation_b,
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (AnnotationManifestError, OSError) as error:
+            print(f"metrics failed: {error}", file=sys.stderr)
+            return 1
+        counts = result["counts"]
+        print(f"Metrics: {args.output} (TP {counts['tp']}, FN {counts['fn']}, TN {counts['tn']}, FP {counts['fp']})")
         return 0
     if args.command == "collect":
         if args.timeout <= 0:

--- a/scripts/real_history_metrics.py
+++ b/scripts/real_history_metrics.py
@@ -1,0 +1,151 @@
+"""Compute bounded, corpus-only metrics from an adjudicated holdout."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from real_history_adjudication import validate_adjudication
+from real_history_annotations import load_collection
+from real_history_contract import HoldoutManifestError
+
+
+METRICS_SCHEMA_VERSION = 1
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def wilson_interval(successes: int, trials: int, z: float = 1.96) -> tuple[float, float] | None:
+    if trials < 0 or successes < 0 or successes > trials:
+        raise HoldoutManifestError("invalid binomial counts")
+    if trials == 0:
+        return None
+    proportion = successes / trials
+    denominator = 1 + z * z / trials
+    center = (proportion + z * z / (2 * trials)) / denominator
+    margin = z * math.sqrt(proportion * (1 - proportion) / trials + z * z / (4 * trials * trials)) / denominator
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+def _metric(successes: int, trials: int) -> dict[str, object]:
+    interval = wilson_interval(successes, trials)
+    return {
+        "successes": successes,
+        "trials": trials,
+        "value": successes / trials if trials else None,
+        "wilson_95": list(interval) if interval else None,
+    }
+
+
+def _load_adjudication(path: Path) -> dict[str, Any]:
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read adjudication {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError("adjudication must be a TOML table")
+    return data
+
+
+def _case_outcome(gold_label: str, expected_rules: list[str], observed_rules: list[str]) -> str:
+    predicted_positive = bool(observed_rules)
+    if gold_label == "defect-present":
+        return "tp" if any(rule_id in observed_rules for rule_id in expected_rules) else "fn"
+    if gold_label == "no-defect":
+        return "fp" if predicted_positive else "tn"
+    return "excluded"
+
+
+def build_metrics(
+    adjudication_path: Path,
+    annotation_a_path: Path,
+    annotation_b_path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    validate_adjudication(
+        adjudication_path,
+        annotation_a_path,
+        annotation_b_path,
+        collection_path,
+        manifest_path,
+        rules_reference,
+        zoo_manifest,
+    )
+    adjudication = _load_adjudication(adjudication_path)
+    collection = load_collection(collection_path, manifest_path, rules_reference, zoo_manifest)
+    observations = {
+        case["id"]: case for case in collection["cases"] if isinstance(case, dict)
+    }
+    cases: list[dict[str, object]] = []
+    counts = {key: 0 for key in ("tp", "fn", "tn", "fp", "excluded")}
+    for labeled in adjudication["case"]:
+        case_id = labeled["id"]
+        observation = observations.get(case_id)
+        if observation is None:
+            raise HoldoutManifestError(f"collection is missing case {case_id}")
+        observed_rules = sorted(set(observation["review"].get("in_diff_rule_ids", [])))
+        expected_rules = sorted(set(labeled["expected_rule_ids"]))
+        outcome = _case_outcome(labeled["adjudicated"], expected_rules, observed_rules)
+        counts[outcome] += 1
+        cases.append(
+            {
+                "id": case_id,
+                "gold_label": labeled["adjudicated"],
+                "expected_rule_ids": expected_rules,
+                "observed_in_diff_rule_ids": observed_rules,
+                "outcome": outcome,
+            }
+        )
+    positive_predictions = counts["tp"] + counts["fp"]
+    actual_positives = counts["tp"] + counts["fn"]
+    actual_negatives = counts["tn"] + counts["fp"]
+    return {
+        "schema_version": METRICS_SCHEMA_VERSION,
+        "corpus": adjudication["corpus"],
+        "protocol": adjudication["protocol"],
+        "manifest_sha256": adjudication["manifest_sha256"],
+        "collection_sha256": adjudication["collection_sha256"],
+        "adjudication_sha256": sha256_file(adjudication_path),
+        "scope": "adjudicated real-history holdout cases only",
+        "limitation": "descriptive corpus evidence; not a production or language-wide estimate",
+        "cases": cases,
+        "counts": counts,
+        "metrics": {
+            "recall": _metric(counts["tp"], actual_positives),
+            "specificity": _metric(counts["tn"], actual_negatives),
+            "precision": _metric(counts["tp"], positive_predictions),
+            "case_coverage": _metric(actual_positives + actual_negatives, len(cases)),
+        },
+    }
+
+
+def write_metrics(
+    output_path: Path,
+    adjudication_path: Path,
+    annotation_a_path: Path,
+    annotation_b_path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    result = build_metrics(
+        adjudication_path,
+        annotation_a_path,
+        annotation_b_path,
+        collection_path,
+        manifest_path,
+        rules_reference,
+        zoo_manifest,
+    )
+    output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return result

--- a/scripts/tests/test_real_history_annotations.py
+++ b/scripts/tests/test_real_history_annotations.py
@@ -19,6 +19,7 @@ from real_history_adjudication import (  # noqa: E402
     render_adjudication_template,
     validate_adjudication,
 )
+from real_history_metrics import _case_outcome, build_metrics, wilson_interval  # noqa: E402
 from real_history_contract import validate_manifest  # noqa: E402
 from real_history_runner import BASELINE_COMMANDS  # noqa: E402
 
@@ -192,6 +193,47 @@ label_state = "pending"
             validate_adjudication(path, left, right, self.collection, self.manifest, self.rules, self.zoo),
             2,
         )
+
+    def test_metrics_are_corpus_scoped_and_include_intervals(self) -> None:
+        left, right = self.worksheet("a"), self.worksheet("b")
+        self.complete(left, "defect-present")
+        self.complete(right, "defect-present")
+        for path in (left, right):
+            text = path.read_text(encoding="utf-8")
+            marker = '[[case]]\nid = "case-two"'
+            head, tail = text.split(marker, 1)
+            tail = tail.replace('label = "defect-present"', 'label = "no-defect"', 1)
+            tail = tail.replace('expected_rule_ids = ["demo.rule"]', "expected_rule_ids = []", 1)
+            path.write_text(head + marker + tail, encoding="utf-8")
+        adjudication = self.root / "adjudication.toml"
+        adjudication.write_text(
+            render_adjudication_template(
+                left, right, self.collection, self.manifest, self.rules, self.zoo
+            ),
+            encoding="utf-8",
+        )
+        text = adjudication.read_text(encoding="utf-8")
+        text = text.replace('adjudicated = ""', 'adjudicated = "defect-present"', 1)
+        text = text.replace('expected_rule_ids = []', 'expected_rule_ids = ["demo.rule"]', 1)
+        text = text.replace('rationale = ""', 'rationale = "confirmed"', 1)
+        text = text.replace('adjudicated = ""', 'adjudicated = "no-defect"', 1)
+        text = text.replace('rationale = ""', 'rationale = "confirmed"', 1)
+        adjudication.write_text(text, encoding="utf-8")
+        result = build_metrics(
+            adjudication, left, right, self.collection, self.manifest, self.rules, self.zoo
+        )
+        self.assertEqual(result["counts"], {"tp": 1, "fn": 0, "tn": 1, "fp": 0, "excluded": 0})
+        self.assertEqual(result["metrics"]["recall"]["trials"], 1)
+        self.assertEqual(result["scope"], "adjudicated real-history holdout cases only")
+        self.assertIsNotNone(result["metrics"]["recall"]["wilson_95"])
+        self.assertIsNone(wilson_interval(0, 0))
+
+    def test_case_outcomes_cover_confusion_matrix_and_uncertainty(self) -> None:
+        self.assertEqual(_case_outcome("defect-present", ["demo.rule"], ["demo.rule"]), "tp")
+        self.assertEqual(_case_outcome("defect-present", ["demo.rule"], []), "fn")
+        self.assertEqual(_case_outcome("no-defect", [], []), "tn")
+        self.assertEqual(_case_outcome("no-defect", [], ["demo.rule"]), "fp")
+        self.assertEqual(_case_outcome("uncertain", [], ["demo.rule"]), "excluded")
 
 
 if __name__ == "__main__":

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -30,6 +30,9 @@ python3 scripts/real_history.py adjudication-template \
 python3 scripts/real_history.py validate-adjudication \
   --artifact real-history-run.json --annotation-a annotation-a.toml \
   --annotation-b annotation-b.toml --annotation adjudication.toml
+python3 scripts/real_history.py metrics --artifact real-history-run.json \
+  --annotation-a annotation-a.toml --annotation-b annotation-b.toml \
+  --annotation adjudication.toml --output real-history-metrics.json
 ```
 
 Both entries are intentionally `pending`. This PR does not invent defect labels
@@ -52,5 +55,7 @@ copies both independent labels and leaves the adjudicated label and rationale
 empty for an explicit third decision. These commands create evidence packets;
 `validate-adjudication` requires that decision and its rationale to be filled
 and verifies that the copied independent labels still match both worksheets.
-These commands create evidence packets; they do not infer labels or calculate
-recall.
+`metrics` is then allowed to calculate corpus-only case-level TP/FN/TN/FP,
+recall, specificity, and precision with Wilson 95% intervals. Its output pins
+all three input hashes and states that the result is descriptive evidence for
+this holdout, not a production or language-wide estimate.


### PR DESCRIPTION
## Summary
- add a deterministic metrics artifact gated on validated A/B worksheets and explicit adjudication
- compute case-level TP/FN/TN/FP, recall, specificity, precision, and Wilson 95% intervals
- pin manifest, collection, and adjudication hashes and state the corpus-only evidence boundary
- document the next measurement step without adding labels or claiming production quality

## Evidence boundary
This PR adds the measurement mechanism; it does not label the pending holdout. Metrics remain unavailable until two independent reviewers and an explicit adjudicator complete the artifacts. Even then the output is descriptive evidence for this corpus, not a production or language-wide estimate.

## Validation
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (108 passed)
- `python3 scripts/release-contract.py check`
- `npm run test:release-contract`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (906 lib + 80 bin + integration tests passed; 1 explicit compatibility test ignored)
- `cargo run -- scan . --fail-on-priority p1` (PASS; pre-existing strict-only contract warnings remain)
