### PR TITLE
fix: blind real-history annotation worksheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   reviewers and an adjudication template. Worksheets pin collection evidence
   while leaving labels and rationales human-entered; no quality metric is
   inferred before explicit adjudication.
+- Made real-history worksheets explicitly blinded: machine findings stay in the
+  collection artifact and are withheld from labelers to reduce confirmation
+  bias before adjudication.
 - Added a gated real-history metrics artifact with case-level confusion counts,
   recall, specificity, precision, Wilson intervals, input hashes, and an
   explicit corpus-only limitation.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -262,9 +262,11 @@ bump is needed to start.
   observation packet rather than a benchmark score.
 - The annotation workflow now generates two deterministic reviewer worksheets
   from the validated collection artifact. It pins the manifest and collection
-  hashes, case revisions, baseline statuses, and observed in-diff rule IDs;
-  labels and rationales remain human-entered. A separate adjudication template
-  preserves both independent labels and leaves the final decision blank.
+  hashes, case revisions, and baseline statuses. Worksheets declare
+  `blinded = true`: RepoPilot findings remain in the collection artifact and
+  are not shown to labelers, reducing confirmation bias. Labels and rationales
+  remain human-entered. A separate adjudication template preserves both
+  independent labels and leaves the final decision blank.
 - A metrics artifact is now gated on validated A/B worksheets plus explicit
   adjudication. It reports case-level TP/FN/TN/FP, recall, specificity, and
   precision with Wilson 95% intervals, and records the three input hashes and

--- a/scripts/real_history_adjudication.py
+++ b/scripts/real_history_adjudication.py
@@ -48,6 +48,7 @@ def render_adjudication_template(
         f"protocol = {_toml_string(data_a['protocol'])}",
         f"manifest_sha256 = {_toml_string(data_a['manifest_sha256'])}",
         f"collection_sha256 = {_toml_string(data_a['collection_sha256'])}",
+        "blinded = true",
         "",
     ]
     for case_id in sorted(cases_a):
@@ -88,6 +89,8 @@ def validate_adjudication(
     data = _load_toml(adjudication_path, "adjudication")
     if data.get("schema_version") != ANNOTATION_SCHEMA_VERSION:
         raise HoldoutManifestError("adjudication schema_version is unsupported")
+    if data.get("blinded") is not True:
+        raise HoldoutManifestError("adjudication must declare blinded = true")
     for field in ("corpus", "protocol", "manifest_sha256", "collection_sha256"):
         if data.get(field) != collection.get(field):
             raise HoldoutManifestError(f"adjudication {field} does not match collection")

--- a/scripts/real_history_annotations.py
+++ b/scripts/real_history_annotations.py
@@ -18,7 +18,7 @@ from real_history_contract import (
 )
 
 
-ANNOTATION_SCHEMA_VERSION = 1
+ANNOTATION_SCHEMA_VERSION = 2
 ANNOTATION_PROTOCOL = "dual-independent-adjudication-v1"
 ANNOTATION_FIELDS = {
     "id",
@@ -27,7 +27,6 @@ ANNOTATION_FIELDS = {
     "base_sha",
     "head_sha",
     "merge_sha",
-    "observed_in_diff_rule_ids",
     "baseline_statuses",
     "label",
     "expected_rule_ids",
@@ -79,15 +78,12 @@ def _worksheet_header(data: dict[str, Any], reviewer: str) -> list[str]:
         f"reviewer = {_toml_string(reviewer)}",
         f"manifest_sha256 = {_toml_string(data['manifest_sha256'])}",
         f"collection_sha256 = {_toml_string(data['collection_sha256'])}",
+        "blinded = true",
         "",
     ]
 
 
 def _worksheet_case(case: HoldoutCase, observation: dict[str, Any]) -> list[str]:
-    review = observation["review"]
-    rule_ids = review.get("in_diff_rule_ids", []) if isinstance(review, dict) else []
-    if not isinstance(rule_ids, list) or not all(isinstance(item, str) for item in rule_ids):
-        raise HoldoutManifestError(f"collection case {case.case_id}: invalid rule evidence")
     baselines = observation["baselines"]
     statuses = [f"{baseline_id}={baselines[baseline_id]['status']}" for baseline_id in case.baseline_ids]
     return [
@@ -98,7 +94,6 @@ def _worksheet_case(case: HoldoutCase, observation: dict[str, Any]) -> list[str]
         f"base_sha = {_toml_string(case.base_sha)}",
         f"head_sha = {_toml_string(case.head_sha)}",
         f"merge_sha = {_toml_string(case.merge_sha)}",
-        f"observed_in_diff_rule_ids = {_toml_array(sorted(set(rule_ids)))}",
         f"baseline_statuses = {_toml_array(statuses)}",
         'label = ""',
         "expected_rule_ids = []",
@@ -150,6 +145,8 @@ def _validate_context(
 ) -> dict[str, dict[str, Any]]:
     if data.get("schema_version") != ANNOTATION_SCHEMA_VERSION:
         raise HoldoutManifestError("annotation schema_version is unsupported")
+    if data.get("blinded") is not True:
+        raise HoldoutManifestError("annotation must declare blinded = true")
     for field in ("corpus", "protocol", "manifest_sha256", "collection_sha256"):
         if data.get(field) != collection.get(field, collection.get("manifest_sha256")):
             expected = collection.get(field)
@@ -178,10 +175,6 @@ def _validate_context(
                 raise HoldoutManifestError(f"annotation case {case_id}: {field} does not match manifest")
         if raw.get("pull_request") != case.pull_request:
             raise HoldoutManifestError(f"annotation case {case_id}: pull_request does not match manifest")
-        if not isinstance(raw.get("observed_in_diff_rule_ids"), list) or not all(
-            isinstance(item, str) for item in raw["observed_in_diff_rule_ids"]
-        ):
-            raise HoldoutManifestError(f"annotation case {case_id}: invalid observed rule IDs")
         if not isinstance(raw.get("baseline_statuses"), list) or not all(
             isinstance(item, str) for item in raw["baseline_statuses"]
         ):
@@ -189,10 +182,6 @@ def _validate_context(
         observation = collected.get(case_id)
         if observation is None:
             raise HoldoutManifestError(f"collection is missing case {case_id}")
-        review = observation.get("review")
-        expected_rules = sorted(set(review.get("in_diff_rule_ids", []))) if isinstance(review, dict) else []
-        if raw["observed_in_diff_rule_ids"] != expected_rules:
-            raise HoldoutManifestError(f"annotation case {case_id}: observed rule evidence drifted")
         expected_statuses = [
             f"{baseline_id}={observation['baselines'][baseline_id]['status']}"
             for baseline_id in case.baseline_ids
@@ -230,4 +219,3 @@ def load_annotation(
     data = _load_toml(path, "annotation")
     known_rules = set(re.findall(r"^### `([^`]+)`", rules_reference.read_text(encoding="utf-8"), re.MULTILINE))
     return data, _validate_context(data, collection, cases, known_rules, reviewer)
-

--- a/scripts/tests/test_real_history_annotations.py
+++ b/scripts/tests/test_real_history_annotations.py
@@ -137,6 +137,8 @@ label_state = "pending"
         left = render_worksheet(self.collection, self.manifest, self.rules, self.zoo, "a")
         right = render_worksheet(self.collection, self.manifest, self.rules, self.zoo, "b")
         self.assertEqual(left.replace('reviewer = "a"', 'reviewer = "b"'), right)
+        self.assertNotIn("observed_in_diff_rule_ids", left)
+        self.assertIn("blinded = true", left)
         self.assertEqual(tomllib.loads(left)["case"][0]["label"], "")
 
     def test_blank_template_is_not_admissible_as_annotation(self) -> None:

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -47,9 +47,10 @@ the manifest hash, immutable PR revisions, scanner provenance, baseline command
 allowlist, and one review observation per case.
 
 `template` creates one deterministic worksheet per independent reviewer. It
-copies only pinned case identity, baseline statuses, and observed in-diff rule
-IDs from the collection artifact; labels and rationales stay empty. Complete
-both worksheets from the diff and repository evidence, then run
+copies only pinned case identity and baseline statuses from the collection
+artifact. The worksheet is explicitly blinded: RepoPilot findings stay in the
+collection artifact and are not shown to the labeler. Labels and rationales
+stay empty. Complete both worksheets from the diff and repository evidence, then run
 `validate-annotation` before creating the `adjudication-template`. The latter
 copies both independent labels and leaves the adjudicated label and rationale
 empty for an explicit third decision. These commands create evidence packets;


### PR DESCRIPTION
## Summary
- make real-history reviewer worksheets explicitly blinded
- remove RepoPilot in-diff rule IDs from the reviewer-visible packet while keeping them in the hashed collection artifact
- pin `blinded = true` through annotation and adjudication validation
- document the confirmation-bias control and preserve the corpus-only metrics boundary

## Why
The previous worksheet exposed the analyzer's findings to the labeler. That could bias independent labels toward confirming RepoPilot. Reviewers now label from the pinned PR context and baseline status; the machine evidence remains available for post-label comparison.

## Validation
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (108 passed)
- `python3 scripts/release-contract.py check`
- `npm run test:release-contract`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- scan . --fail-on-priority p1` (PASS; pre-existing strict-only contract warnings remain)
- generated worksheet from the local collection artifact contains no `observed_in_diff_rule_ids`
