### PR TITLE
feat: preregister differential utility benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Made real-history worksheets explicitly blinded: machine findings stay in the
   collection artifact and are withheld from labelers to reduce confirmation
   bias before adjudication.
+- Added a preregistered differential utility contract that freezes baseline
+  checks, six usefulness measurements, holdout membership, and repetitions
+  before any benchmark result is collected.
 - Added a gated real-history metrics artifact with case-level confusion counts,
   recall, specificity, precision, Wilson intervals, input hashes, and an
   explicit corpus-only limitation.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -276,3 +276,16 @@ bump is needed to start.
   no metric is available until two labels and an explicit adjudication are
   completed. Even then the result is descriptive evidence for this holdout,
   not a production or language-wide estimate.
+
+## 0G — Differential Utility Protocol
+
+- `tests/benchmarks/differential.toml` preregisters the utility comparison for
+  the same immutable holdout: the compiler/test baseline set, six measurements
+  (novel actionable evidence, duplicate work, time to first useful evidence,
+  decision latency, determinism, and resource cost), and three repetitions.
+- `scripts/differential.py check` validates that the differential case set and
+  baseline IDs exactly match the independent holdout manifest. It produces no
+  measurements and cannot create a utility claim by itself.
+- Boundary: the runner still needs frozen environments, completed labels,
+  timing/resource capture, and an independent scoring artifact before RP23-014
+  can close or RepoPilot can claim value beyond existing checks.

--- a/scripts/differential.py
+++ b/scripts/differential.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Validate the preregistered differential utility benchmark contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from differential_contract import DifferentialManifestError, validate_differential
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", nargs="?", choices=("check",), default="check")
+    parser.add_argument("--manifest", type=Path, default=Path("tests/benchmarks/differential.toml"))
+    parser.add_argument("--holdout-manifest", type=Path, default=Path("tests/benchmarks/manifest.toml"))
+    parser.add_argument("--rules-reference", type=Path, default=Path("docs/rules-reference.md"))
+    parser.add_argument("--zoo-manifest", type=Path, default=Path("tests/zoo/manifest.toml"))
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+    try:
+        result = validate_differential(
+            args.manifest, args.holdout_manifest, args.rules_reference, args.zoo_manifest
+        )
+    except (DifferentialManifestError, OSError) as error:
+        print(f"differential manifest invalid: {error}", file=sys.stderr)
+        return 1
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(f"Differential protocol: {result['status']} ({result['cases']} cases)")
+        print(f"Measurements: {', '.join(result['measurements'])}")
+        print(f"Repetitions: {result['repetitions']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/differential_case_validation.py
+++ b/scripts/differential_case_validation.py
@@ -1,0 +1,17 @@
+"""Validate case identity and baselines shared by both benchmark manifests."""
+
+from __future__ import annotations
+
+from differential_manifest import DifferentialCase, DifferentialManifestError
+
+
+def validate_case_alignment(expected_cases: list[object], observed_cases: list[DifferentialCase]) -> None:
+    expected = {case.case_id: case for case in expected_cases}
+    observed = {case.case_id: case for case in observed_cases}
+    if set(observed) != set(expected):
+        missing = sorted(set(expected) - set(observed))
+        extra = sorted(set(observed) - set(expected))
+        raise DifferentialManifestError(f"case set mismatch (missing={missing}, extra={extra})")
+    for case_id, case in observed.items():
+        if tuple(sorted(case.baseline_ids)) != tuple(sorted(expected[case_id].baseline_ids)):
+            raise DifferentialManifestError(f"case {case_id}: baseline set does not match holdout manifest")

--- a/scripts/differential_contract.py
+++ b/scripts/differential_contract.py
@@ -1,0 +1,8 @@
+"""Contract and summary helpers for the preregistered utility benchmark."""
+
+from __future__ import annotations
+
+from differential_manifest import DifferentialManifestError
+from differential_validation import validate_differential
+
+__all__ = ["DifferentialManifestError", "validate_differential"]

--- a/scripts/differential_manifest.py
+++ b/scripts/differential_manifest.py
@@ -1,0 +1,75 @@
+"""Parsing primitives for the preregistered differential utility manifest."""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+from real_history_contract import BASELINES, HoldoutManifestError
+
+
+SCHEMA_VERSION = 1
+PROTOCOL = "differential-utility-v1"
+MEASUREMENTS = {
+    "novel-actionable-evidence",
+    "duplicate-work",
+    "time-to-first-useful-evidence",
+    "decision-latency",
+    "determinism",
+    "resource-cost",
+}
+
+
+@dataclass(frozen=True)
+class DifferentialCase:
+    case_id: str
+    baseline_ids: tuple[str, ...]
+
+
+class DifferentialManifestError(HoldoutManifestError):
+    """Raised when the preregistered utility benchmark is unsafe or incomplete."""
+
+
+def _parse_case(raw: object, index: int) -> DifferentialCase:
+    if not isinstance(raw, dict):
+        raise DifferentialManifestError(f"case {index}: entry must be a table")
+    case_id, baseline_ids = raw.get("id"), raw.get("baseline_ids")
+    if not isinstance(case_id, str) or not case_id.strip():
+        raise DifferentialManifestError(f"case {index}: id must be a non-empty string")
+    if not isinstance(baseline_ids, list) or not baseline_ids or not all(
+        isinstance(item, str) for item in baseline_ids
+    ):
+        raise DifferentialManifestError(f"case {case_id}: baseline_ids must be a non-empty string array")
+    unknown = set(baseline_ids) - BASELINES
+    if unknown:
+        raise DifferentialManifestError(f"case {case_id}: unknown baselines: {', '.join(sorted(unknown))}")
+    return DifferentialCase(case_id.strip(), tuple(baseline_ids))
+
+
+def load_differential(path: Path) -> tuple[str, str, int, tuple[str, ...], list[DifferentialCase]]:
+    try:
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise DifferentialManifestError(f"cannot read differential manifest {path}: {error}") from error
+    if document.get("schema_version") != SCHEMA_VERSION:
+        raise DifferentialManifestError(f"schema_version must be {SCHEMA_VERSION}")
+    corpus, protocol = document.get("corpus"), document.get("protocol")
+    if not isinstance(corpus, str) or not corpus.strip():
+        raise DifferentialManifestError("corpus must be a non-empty string")
+    if protocol != PROTOCOL:
+        raise DifferentialManifestError(f"protocol must be {PROTOCOL}")
+    repetitions = document.get("repetitions")
+    if not isinstance(repetitions, int) or repetitions < 2:
+        raise DifferentialManifestError("repetitions must be an integer of at least 2")
+    measurements = document.get("measurements")
+    if not isinstance(measurements, list) or set(measurements) != MEASUREMENTS:
+        raise DifferentialManifestError("measurements must enumerate the fixed utility metric set")
+    raw_cases = document.get("case")
+    if not isinstance(raw_cases, list) or not raw_cases:
+        raise DifferentialManifestError("differential manifest must contain cases")
+    cases = [_parse_case(raw, index) for index, raw in enumerate(raw_cases, start=1)]
+    ids = [case.case_id for case in cases]
+    if len(set(ids)) != len(ids):
+        raise DifferentialManifestError("case IDs must be unique")
+    return corpus.strip(), protocol, repetitions, tuple(sorted(measurements)), cases

--- a/scripts/differential_validation.py
+++ b/scripts/differential_validation.py
@@ -1,0 +1,41 @@
+"""Cross-manifest validation for the differential utility protocol."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from differential_case_validation import validate_case_alignment
+from differential_manifest import DifferentialManifestError, load_differential
+from real_history_contract import validate_manifest
+
+
+SCHEMA_VERSION = 1
+
+
+def validate_differential(
+    path: Path,
+    holdout_manifest: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    """Return a deterministic protocol summary when both manifests agree."""
+    corpus, protocol, repetitions, measurements, cases = load_differential(path)
+    holdout_corpus, holdout_protocol, holdout_cases = validate_manifest(
+        holdout_manifest, rules_reference, zoo_manifest
+    )
+    if corpus != holdout_corpus:
+        raise DifferentialManifestError("differential corpus does not match holdout corpus")
+    if any(case.source_kind != "merged-pull-request" for case in holdout_cases):
+        raise DifferentialManifestError("differential cases require merged pull-request holdout sources")
+    validate_case_alignment(holdout_cases, cases)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "corpus": corpus,
+        "protocol": protocol,
+        "holdout_protocol": holdout_protocol,
+        "repetitions": repetitions,
+        "measurements": list(measurements),
+        "cases": len(cases),
+        "baseline_ids": sorted({baseline for case in cases for baseline in case.baseline_ids}),
+        "status": "valid",
+    }

--- a/scripts/tests/test_differential.py
+++ b/scripts/tests/test_differential.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from differential_contract import DifferentialManifestError, validate_differential  # noqa: E402
+
+
+class DifferentialContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.holdout = self.root / "holdout.toml"
+        self.rules = self.root / "rules.md"
+        self.zoo = self.root / "zoo.toml"
+        self.diff = self.root / "differential.toml"
+        self.rules.write_text("### `demo.rule` — Demo\n", encoding="utf-8")
+        self.zoo.write_text("", encoding="utf-8")
+        self.holdout.write_text(
+            """schema_version = 1
+corpus = "test"
+protocol = "dual-independent-adjudication-v1"
+
+[[case]]
+id = "case-one"
+repo = "owner/one"
+url = "https://github.com/owner/one.git"
+pull_request = 1
+base_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+head_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+merge_sha = "cccccccccccccccccccccccccccccccccccccccc"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile"]
+label_state = "pending"
+
+[[case]]
+id = "case-two"
+repo = "owner/two"
+url = "https://github.com/owner/two.git"
+pull_request = 2
+base_sha = "dddddddddddddddddddddddddddddddddddddddd"
+head_sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+merge_sha = "ffffffffffffffffffffffffffffffffffffffff"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.tests"]
+label_state = "pending"
+""",
+            encoding="utf-8",
+        )
+        self.diff.write_text(
+            """schema_version = 1
+corpus = "test"
+protocol = "differential-utility-v1"
+repetitions = 3
+measurements = ["novel-actionable-evidence", "duplicate-work", "time-to-first-useful-evidence", "decision-latency", "determinism", "resource-cost"]
+
+[[case]]
+id = "case-one"
+baseline_ids = ["python.compile"]
+
+[[case]]
+id = "case-two"
+baseline_ids = ["python.tests"]
+""",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_accepts_frozen_metric_contract(self) -> None:
+        result = validate_differential(self.diff, self.holdout, self.rules, self.zoo)
+        self.assertEqual(result["status"], "valid")
+        self.assertEqual(result["repetitions"], 3)
+        self.assertEqual(result["measurements"][0], "decision-latency")
+
+    def test_rejects_case_or_baseline_drift(self) -> None:
+        text = self.diff.read_text(encoding="utf-8").replace('id = "case-two"', 'id = "case-other"')
+        self.diff.write_text(text, encoding="utf-8")
+        with self.assertRaisesRegex(DifferentialManifestError, "case set mismatch"):
+            validate_differential(self.diff, self.holdout, self.rules, self.zoo)
+
+    def test_rejects_single_repeat(self) -> None:
+        text = self.diff.read_text(encoding="utf-8").replace("repetitions = 3", "repetitions = 1")
+        self.diff.write_text(text, encoding="utf-8")
+        with self.assertRaisesRegex(DifferentialManifestError, "at least 2"):
+            validate_differential(self.diff, self.holdout, self.rules, self.zoo)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -9,6 +9,18 @@ recall result. A disagreement must have an explicit adjudication record. Each
 case also declares the existing compiler/test baselines that the future runner
 will execute and compare against RepoPilot's actionable evidence.
 
+The differential utility protocol is preregistered separately:
+
+```bash
+python3 scripts/differential.py check
+python3 scripts/differential.py check --format json
+```
+
+It freezes the six utility measurements, the baseline set, the holdout case
+set, and three repetitions before a benchmark run. It is only a contract;
+until a runner records labels, timings, determinism, and resource samples it
+does not claim that RepoPilot adds value over existing checks.
+
 Validate the protocol contract without cloning repositories:
 
 ```bash

--- a/tests/benchmarks/differential.toml
+++ b/tests/benchmarks/differential.toml
@@ -1,0 +1,23 @@
+schema_version = 1
+corpus = "v0.23-real-history-holdout"
+protocol = "differential-utility-v1"
+repetitions = 3
+
+# The benchmark compares the same pinned PR revisions against the declared
+# repository checks and RepoPilot. It does not assign defect labels.
+measurements = [
+  "novel-actionable-evidence",
+  "duplicate-work",
+  "time-to-first-useful-evidence",
+  "decision-latency",
+  "determinism",
+  "resource-cost",
+]
+
+[[case]]
+id = "flask-pr-5812"
+baseline_ids = ["python.compile", "python.tests"]
+
+[[case]]
+id = "requests-pr-7019"
+baseline_ids = ["python.compile", "python.tests"]


### PR DESCRIPTION
## Summary
- add a frozen differential utility manifest for the real-history holdout
- validate exact case membership and baseline identity against the independent holdout
- preregister novel evidence, duplicate work, time-to-first-useful-evidence, decision latency, determinism, and resource cost with three repetitions
- document that this is a protocol only and produces no utility claim until a runner collects labeled observations

## Evidence boundary
This PR freezes how RepoPilot will be compared with existing compiler/test/lint checks. It does not run the benchmark, assign labels, or claim superiority. A future runner must use the pinned revisions, completed adjudication, repeated measurements, and an independent scoring artifact.

## Validation
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (111 passed)
- `python3 scripts/differential.py check --format json`
- `python3 scripts/release-contract.py check`
- `npm run test:release-contract`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- scan . --fail-on-priority p1` (PASS; only pre-existing strict-only warnings remain)
