### PR TITLE
feat: collect differential utility observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added a gated real-history metrics artifact with case-level confusion counts,
   recall, specificity, precision, Wilson intervals, input hashes, and an
   explicit corpus-only limitation.
+- Added a differential observation runner for the preregistered utility
+  protocol. It repeats allowlisted baseline checks and exact-SHA RepoPilot
+  reviews, records timing/output/determinism/resource observations, and validates
+  the artifact while keeping labels pending and utility claims gated.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -286,6 +286,12 @@ bump is needed to start.
 - `scripts/differential.py check` validates that the differential case set and
   baseline IDs exactly match the independent holdout manifest. It produces no
   measurements and cannot create a utility claim by itself.
-- Boundary: the runner still needs frozen environments, completed labels,
-  timing/resource capture, and an independent scoring artifact before RP23-014
-  can close or RepoPilot can claim value beyond existing checks.
+- `scripts/differential.py collect` now runs the allowlisted baseline commands
+  and repeated exact-SHA RepoPilot reviews, recording output hashes, wall time,
+  determinism, scanner provenance, and best-effort child-resource samples.
+  `validate-result` rejects manifest drift, command drift, missing repetitions,
+  and labeled artifacts before a result can be used downstream.
+- Boundary: these are still unlabeled observations. Frozen environments,
+  completed independent labels, and a preregistered scoring artifact remain
+  required before RP23-014 can close or RepoPilot can claim value beyond
+  existing checks.

--- a/scripts/differential.py
+++ b/scripts/differential.py
@@ -8,25 +8,84 @@ import json
 import sys
 from pathlib import Path
 
+from differential_artifact import validate_artifact, validate_data
 from differential_contract import DifferentialManifestError, validate_differential
+from differential_runner import collect_differential
+from real_history_contract import HoldoutManifestError
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("command", nargs="?", choices=("check",), default="check")
+    parser.add_argument("command", nargs="?", choices=("check", "collect", "validate-result"), default="check")
     parser.add_argument("--manifest", type=Path, default=Path("tests/benchmarks/differential.toml"))
     parser.add_argument("--holdout-manifest", type=Path, default=Path("tests/benchmarks/manifest.toml"))
     parser.add_argument("--rules-reference", type=Path, default=Path("docs/rules-reference.md"))
     parser.add_argument("--zoo-manifest", type=Path, default=Path("tests/zoo/manifest.toml"))
     parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--scanner", help="use an existing repopilot binary instead of building the workspace")
+    parser.add_argument("--allow-version-mismatch", action="store_true")
+    parser.add_argument("--timeout", type=int, default=300)
+    parser.add_argument("--output", type=Path, help="write a differential artifact")
+    parser.add_argument("--artifact", type=Path, help="differential artifact to validate")
     args = parser.parse_args(argv)
     try:
-        result = validate_differential(
-            args.manifest, args.holdout_manifest, args.rules_reference, args.zoo_manifest
-        )
+        result = validate_differential(args.manifest, args.holdout_manifest, args.rules_reference, args.zoo_manifest)
     except (DifferentialManifestError, OSError) as error:
         print(f"differential manifest invalid: {error}", file=sys.stderr)
         return 1
+    if args.command == "validate-result":
+        if args.artifact is None:
+            print("--artifact is required for validate-result", file=sys.stderr)
+            return 2
+        try:
+            artifact_result = validate_artifact(
+                args.artifact,
+                args.holdout_manifest,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (DifferentialManifestError, HoldoutManifestError, OSError) as error:
+            print(f"differential artifact invalid: {error}", file=sys.stderr)
+            return 1
+        if args.format == "json":
+            print(json.dumps(artifact_result, indent=2, sort_keys=True))
+        else:
+            print(f"Differential artifact: {artifact_result['status']} ({artifact_result['cases']} cases)")
+        return 0
+    if args.command == "collect":
+        if args.output is None:
+            print("--output is required for collect", file=sys.stderr)
+            return 2
+        if args.timeout <= 0:
+            print("--timeout must be positive", file=sys.stderr)
+            return 2
+        try:
+            artifact = collect_differential(
+                args.repo_root.resolve(),
+                args.holdout_manifest,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+                args.scanner,
+                args.allow_version_mismatch,
+                args.timeout,
+            )
+            validate_data(
+                artifact,
+                args.holdout_manifest,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        except (DifferentialManifestError, HoldoutManifestError, OSError) as error:
+            print(f"differential collection failed: {error}", file=sys.stderr)
+            return 2
+        print(f"Differential collection: {args.output} ({len(artifact['cases'])} cases)")
+        return 0
     if args.format == "json":
         print(json.dumps(result, indent=2, sort_keys=True))
     else:

--- a/scripts/differential_artifact.py
+++ b/scripts/differential_artifact.py
@@ -1,0 +1,135 @@
+"""Validate repeated differential utility observations without scoring them."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from differential_contract import validate_differential
+from differential_manifest import DifferentialManifestError
+from real_history_contract import HoldoutManifestError, validate_manifest
+from real_history_runner import BASELINE_COMMANDS
+
+
+REVIEW_STATUSES = {"collected", "timeout"}
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def validate_data(
+    data: dict[str, Any],
+    manifest_path: Path,
+    differential_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    protocol = validate_differential(differential_path, manifest_path, rules_reference, zoo_manifest)
+    if data.get("schema_version") != 1:
+        raise DifferentialManifestError("differential artifact schema_version is unsupported")
+    if data.get("corpus") != protocol["corpus"] or data.get("protocol") != protocol["protocol"]:
+        raise DifferentialManifestError("differential artifact corpus/protocol does not match manifest")
+    if data.get("manifest_sha256") != sha256_file(manifest_path):
+        raise DifferentialManifestError("differential artifact manifest_sha256 does not match manifest")
+    if data.get("differential_manifest_sha256") != sha256_file(differential_path):
+        raise DifferentialManifestError("differential artifact differential_manifest_sha256 does not match manifest")
+    if data.get("repetitions") != protocol["repetitions"]:
+        raise DifferentialManifestError("differential artifact repetitions do not match manifest")
+    if data.get("label_state") != "pending":
+        raise DifferentialManifestError("differential artifact must remain unlabeled")
+    scanner = data.get("scanner")
+    if not isinstance(scanner, dict):
+        raise DifferentialManifestError("differential artifact is missing scanner provenance")
+    for field in ("mode", "version", "report_schema_version", "workspace_version"):
+        if not isinstance(scanner.get(field), str) or not scanner[field]:
+            raise DifferentialManifestError(f"scanner provenance missing {field}")
+    observations = data.get("cases")
+    if not isinstance(observations, list):
+        raise DifferentialManifestError("differential artifact cases must be an array")
+    _, _, holdout_cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    expected = {case.case_id: case for case in holdout_cases}
+    differential_cases = {case.case_id: case for case in _load_cases(differential_path)}
+    observed: set[str] = set()
+    for observation in observations:
+        if not isinstance(observation, dict):
+            raise DifferentialManifestError("differential case must be an object")
+        case_id = observation.get("id")
+        if not isinstance(case_id, str) or case_id in observed or case_id not in expected:
+            raise DifferentialManifestError(f"differential artifact has unknown or duplicate case {case_id!r}")
+        observed.add(case_id)
+        validate_case(observation, expected[case_id], differential_cases[case_id].baseline_ids, data["repetitions"])
+    if observed != set(expected):
+        raise DifferentialManifestError(f"differential artifact is missing cases: {', '.join(sorted(set(expected) - observed))}")
+    return {
+        "status": "valid",
+        "corpus": protocol["corpus"],
+        "protocol": protocol["protocol"],
+        "cases": len(observations),
+        "baseline_observations": sum(
+            sum(len(runs) for runs in observation["baselines"].values())
+            for observation in observations
+        ),
+        "review_observations": sum(len(observation["reviews"]) for observation in observations),
+    }
+
+
+def _load_cases(path: Path) -> list[Any]:
+    from differential_manifest import load_differential
+
+    return load_differential(path)[4]
+
+
+def validate_case(
+    observation: dict[str, Any],
+    case: Any,
+    baseline_ids: tuple[str, ...],
+    repetitions: int,
+) -> None:
+    for field in ("repo", "base_sha", "head_sha", "merge_sha"):
+        if observation.get(field) != getattr(case, field):
+            raise DifferentialManifestError(f"case {case.case_id}: {field} does not match holdout manifest")
+    baselines = observation.get("baselines")
+    if not isinstance(baselines, dict) or set(baselines) != set(baseline_ids):
+        raise DifferentialManifestError(f"case {case.case_id}: baseline set does not match differential manifest")
+    for baseline_id, runs in baselines.items():
+        if not isinstance(runs, list) or len(runs) != repetitions:
+            raise DifferentialManifestError(f"case {case.case_id}: baseline {baseline_id} repetition count drift")
+        for run in runs:
+            if not isinstance(run, dict) or run.get("command") != list(BASELINE_COMMANDS[baseline_id]):
+                raise DifferentialManifestError(f"case {case.case_id}: baseline command drift for {baseline_id}")
+            if run.get("status") not in {"passed", "failed", "unavailable", "timeout"}:
+                raise DifferentialManifestError(f"case {case.case_id}: invalid baseline status")
+            if not isinstance(run.get("wall_ms"), (int, float)) or run["wall_ms"] < 0:
+                raise DifferentialManifestError(f"case {case.case_id}: invalid baseline timing")
+    reviews = observation.get("reviews")
+    if not isinstance(reviews, list) or len(reviews) != repetitions:
+        raise DifferentialManifestError(f"case {case.case_id}: review repetition count drift")
+    for review in reviews:
+        if not isinstance(review, dict) or review.get("status") not in REVIEW_STATUSES:
+            raise DifferentialManifestError(f"case {case.case_id}: invalid review status")
+        if not isinstance(review.get("wall_ms"), (int, float)) or review["wall_ms"] < 0:
+            raise DifferentialManifestError(f"case {case.case_id}: invalid review timing")
+        if review["status"] == "collected" and not isinstance(review.get("stable_evidence_sha256"), str):
+            raise DifferentialManifestError(f"case {case.case_id}: collected review lacks stable evidence hash")
+    determinism = observation.get("determinism")
+    if not isinstance(determinism, dict) or not isinstance(determinism.get("stable_evidence_deterministic"), bool):
+        raise DifferentialManifestError(f"case {case.case_id}: determinism summary is missing")
+
+
+def validate_artifact(
+    artifact_path: Path,
+    manifest_path: Path,
+    differential_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    try:
+        data = json.loads(artifact_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read differential artifact {artifact_path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError("differential artifact must be a JSON object")
+    return validate_data(data, manifest_path, differential_path, rules_reference, zoo_manifest)

--- a/scripts/differential_runner.py
+++ b/scripts/differential_runner.py
@@ -1,0 +1,207 @@
+"""Collect repeated baseline and RepoPilot observations for utility benchmarking."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from differential_contract import validate_differential
+from differential_manifest import load_differential
+from real_history_contract import HoldoutCase, HoldoutManifestError, validate_manifest
+from real_history_runner import BASELINE_COMMANDS, clone_case, summarize_review
+from zoo_scanner import ScannerPreparationError, ScannerProvenanceError, prepare_scanner
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - Windows has no resource module.
+    resource = None
+
+
+DIFFERENTIAL_ARTIFACT_SCHEMA_VERSION = 1
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _resource_snapshot() -> tuple[str, int | None]:
+    if resource is None:
+        return "unavailable", None
+    try:
+        usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    except (AttributeError, OSError):
+        return "unavailable", None
+    max_rss = int(usage.ru_maxrss)
+    if sys.platform == "darwin":
+        max_rss //= 1024
+    return "available", max_rss
+
+
+def run_timed_command(command: tuple[str, ...], cwd: Path, timeout_seconds: int) -> dict[str, Any]:
+    resource_status, resource_before = _resource_snapshot()
+    started = time.perf_counter()
+    try:
+        process = subprocess.run(
+            list(command), cwd=cwd, capture_output=True, check=False, timeout=timeout_seconds
+        )
+    except FileNotFoundError:
+        status, returncode, stdout, stderr = "unavailable", None, b"", b""
+    except subprocess.TimeoutExpired as error:
+        status, returncode = "timeout", None
+        stdout = error.stdout or b""
+        stderr = error.stderr or b""
+    else:
+        status = "passed" if process.returncode == 0 else "failed"
+        returncode, stdout, stderr = process.returncode, process.stdout, process.stderr
+    _, resource_after = _resource_snapshot()
+    result: dict[str, Any] = {
+        "status": status,
+        "returncode": returncode,
+        "command": list(command),
+        "wall_ms": round((time.perf_counter() - started) * 1000, 3),
+        "stdout_sha256": sha256_bytes(stdout if isinstance(stdout, bytes) else stdout.encode()),
+        "stderr_sha256": sha256_bytes(stderr if isinstance(stderr, bytes) else stderr.encode()),
+        "resource_status": resource_status,
+    }
+    if resource_before is not None and resource_after is not None:
+        result["child_max_rss_kb"] = max(0, resource_after - resource_before)
+    return result
+
+
+def _review_once(scanner: Any, case: HoldoutCase, head: Path, timeout_seconds: int) -> dict[str, Any]:
+    command = (
+        *scanner.command,
+        "review",
+        str(head),
+        "--base",
+        case.base_sha,
+        "--head",
+        case.head_sha,
+        "--format",
+        "json",
+        "--profile",
+        "default",
+        "--no-progress",
+    )
+    resource_status, resource_before = _resource_snapshot()
+    started = time.perf_counter()
+    try:
+        process = subprocess.run(list(command), cwd=head, capture_output=True, check=False, timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        return {"status": "timeout", "returncode": None, "wall_ms": round((time.perf_counter() - started) * 1000, 3)}
+    if process.returncode not in (0, 1):
+        raise HoldoutManifestError(
+            f"differential review failed for {case.case_id}: {process.stderr.decode(errors='replace').strip()}"
+        )
+    try:
+        report = json.loads(process.stdout)
+    except json.JSONDecodeError as error:
+        raise HoldoutManifestError(f"differential review returned invalid JSON for {case.case_id}: {error}") from error
+    result = {
+        **summarize_review(report, process.stdout),
+        "status": "collected",
+        "returncode": process.returncode,
+        "wall_ms": round((time.perf_counter() - started) * 1000, 3),
+        "resource_status": resource_status,
+    }
+    _, resource_after = _resource_snapshot()
+    if resource_before is not None and resource_after is not None:
+        result["child_max_rss_kb"] = max(0, resource_after - resource_before)
+    return result
+
+
+def collect_case(
+    scanner: Any,
+    case: HoldoutCase,
+    baseline_ids: tuple[str, ...],
+    repetitions: int,
+    root: Path,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    _, head, merge = clone_case(case, root)
+    baselines = {baseline_id: [] for baseline_id in baseline_ids}
+    reviews = []
+    for repeat in range(1, repetitions + 1):
+        for baseline_id in baseline_ids:
+            result = run_timed_command(BASELINE_COMMANDS[baseline_id], merge, timeout_seconds)
+            result["repeat"] = repeat
+            baselines[baseline_id].append(result)
+        review = _review_once(scanner, case, head, timeout_seconds)
+        review["repeat"] = repeat
+        reviews.append(review)
+    stable_hashes = [run["stable_evidence_sha256"] for run in reviews if run["status"] == "collected"]
+    return {
+        "id": case.case_id,
+        "repo": case.repo,
+        "pull_request": case.pull_request,
+        "base_sha": case.base_sha,
+        "head_sha": case.head_sha,
+        "merge_sha": case.merge_sha,
+        "baselines": baselines,
+        "reviews": reviews,
+        "determinism": {
+            "comparable_runs": len(stable_hashes),
+            "stable_evidence_unique": sorted(set(stable_hashes)),
+            "stable_evidence_deterministic": len(stable_hashes) > 1 and len(set(stable_hashes)) == 1,
+        },
+    }
+
+
+def collect_differential(
+    repo_root: Path,
+    manifest_path: Path,
+    differential_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+    scanner_path: str | None,
+    allow_version_mismatch: bool,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    summary = validate_differential(differential_path, manifest_path, rules_reference, zoo_manifest)
+    corpus, _, holdout_cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    _, _, _, _, differential_cases = load_differential(differential_path)
+    case_config = {case.case_id: case for case in differential_cases}
+    try:
+        scanner = prepare_scanner(repo_root, scanner_path, allow_version_mismatch)
+    except (ScannerPreparationError, ScannerProvenanceError) as error:
+        raise HoldoutManifestError(f"scanner preparation failed: {error}") from error
+    observations = []
+    with tempfile.TemporaryDirectory(prefix="repopilot-differential-") as temporary:
+        for index, case in enumerate(holdout_cases):
+            config = case_config[case.case_id]
+            observations.append(
+                collect_case(
+                    scanner,
+                    case,
+                    config.baseline_ids,
+                    summary["repetitions"],
+                    Path(temporary) / str(index),
+                    timeout_seconds,
+                )
+            )
+    return {
+        "schema_version": DIFFERENTIAL_ARTIFACT_SCHEMA_VERSION,
+        "corpus": corpus,
+        "protocol": summary["protocol"],
+        "manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+        "differential_manifest_sha256": hashlib.sha256(differential_path.read_bytes()).hexdigest(),
+        "scanner": {
+            "mode": scanner.mode,
+            "version": scanner.version,
+            "report_schema_version": scanner.report_schema_version,
+            "workspace_version": scanner.workspace_version,
+            "workspace_commit": scanner.workspace_commit,
+            "workspace_dirty": scanner.workspace_dirty,
+            "version_mismatch_allowed": scanner.version_mismatch_allowed,
+        },
+        "repetitions": summary["repetitions"],
+        "cases": observations,
+        "label_state": "pending",
+        "limitation": "observations only; no labels, scoring, or utility claim",
+    }

--- a/scripts/tests/test_differential_runner.py
+++ b/scripts/tests/test_differential_runner.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from differential_artifact import validate_data  # noqa: E402
+from differential_runner import run_timed_command  # noqa: E402
+from real_history_runner import BASELINE_COMMANDS  # noqa: E402
+
+
+class DifferentialRunnerTests(unittest.TestCase):
+    def test_timed_command_records_pass_and_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_timed_command((sys.executable, "-c", "print('ok')"), Path(tmp), 5)
+        self.assertEqual(result["status"], "passed")
+        self.assertEqual(result["returncode"], 0)
+        self.assertGreaterEqual(result["wall_ms"], 0)
+        self.assertEqual(len(result["stdout_sha256"]), 64)
+
+    def test_timed_command_records_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_timed_command((sys.executable, "-c", "raise SystemExit(3)"), Path(tmp), 5)
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["returncode"], 3)
+
+    def test_artifact_validator_accepts_complete_pending_observations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            holdout, differential, rules, zoo = self._write_manifests(root)
+            cases = []
+            for case_id, baseline_ids, base_sha, head_sha, merge_sha in (
+                ("case-one", ("python.compile",), "a" * 40, "b" * 40, "c" * 40),
+                ("case-two", ("python.tests",), "d" * 40, "e" * 40, "f" * 40),
+            ):
+                cases.append(
+                    {
+                        "id": case_id,
+                        "repo": "owner/one" if case_id == "case-one" else "owner/two",
+                        "base_sha": base_sha,
+                        "head_sha": head_sha,
+                        "merge_sha": merge_sha,
+                        "baselines": {
+                            baseline_id: [
+                                {
+                                    "command": list(BASELINE_COMMANDS[baseline_id]),
+                                    "status": "passed",
+                                    "wall_ms": 1.0,
+                                }
+                                for _ in range(3)
+                            ]
+                            for baseline_id in baseline_ids
+                        },
+                        "reviews": [
+                            {"status": "collected", "wall_ms": 1.0, "stable_evidence_sha256": "1" * 64}
+                            for _ in range(3)
+                        ],
+                        "determinism": {"stable_evidence_deterministic": True},
+                    }
+                )
+            artifact = {
+                "schema_version": 1,
+                "corpus": "test",
+                "protocol": "differential-utility-v1",
+                "manifest_sha256": hashlib.sha256(holdout.read_bytes()).hexdigest(),
+                "differential_manifest_sha256": hashlib.sha256(differential.read_bytes()).hexdigest(),
+                "scanner": {"mode": "workspace", "version": "0.23", "report_schema_version": "1", "workspace_version": "0.23"},
+                "repetitions": 3,
+                "cases": cases,
+                "label_state": "pending",
+            }
+            result = validate_data(artifact, holdout, differential, rules, zoo)
+        self.assertEqual(result["status"], "valid")
+        self.assertEqual(result["baseline_observations"], 6)
+        self.assertEqual(result["review_observations"], 6)
+
+    @staticmethod
+    def _write_manifests(root: Path) -> tuple[Path, Path, Path, Path]:
+        rules = root / "rules.md"
+        zoo = root / "zoo.toml"
+        holdout = root / "holdout.toml"
+        differential = root / "differential.toml"
+        rules.write_text("### `demo.rule` — Demo\n", encoding="utf-8")
+        zoo.write_text("", encoding="utf-8")
+        holdout.write_text(
+            """schema_version = 1
+corpus = "test"
+protocol = "dual-independent-adjudication-v1"
+
+[[case]]
+id = "case-one"
+repo = "owner/one"
+url = "https://github.com/owner/one.git"
+pull_request = 1
+base_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+head_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+merge_sha = "cccccccccccccccccccccccccccccccccccccccc"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile"]
+label_state = "pending"
+
+[[case]]
+id = "case-two"
+repo = "owner/two"
+url = "https://github.com/owner/two.git"
+pull_request = 2
+base_sha = "dddddddddddddddddddddddddddddddddddddddd"
+head_sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+merge_sha = "ffffffffffffffffffffffffffffffffffffffff"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.tests"]
+label_state = "pending"
+""",
+            encoding="utf-8",
+        )
+        differential.write_text(
+            """schema_version = 1
+corpus = "test"
+protocol = "differential-utility-v1"
+repetitions = 3
+measurements = ["novel-actionable-evidence", "duplicate-work", "time-to-first-useful-evidence", "decision-latency", "determinism", "resource-cost"]
+
+[[case]]
+id = "case-one"
+baseline_ids = ["python.compile"]
+
+[[case]]
+id = "case-two"
+baseline_ids = ["python.tests"]
+""",
+            encoding="utf-8",
+        )
+        return holdout, differential, rules, zoo
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -14,12 +14,19 @@ The differential utility protocol is preregistered separately:
 ```bash
 python3 scripts/differential.py check
 python3 scripts/differential.py check --format json
+python3 scripts/differential.py collect --repo-root . \
+  --scanner target/release/repopilot --timeout 300 \
+  --output differential-run.json
+python3 scripts/differential.py validate-result \
+  --artifact differential-run.json
 ```
 
 It freezes the six utility measurements, the baseline set, the holdout case
-set, and three repetitions before a benchmark run. It is only a contract;
-until a runner records labels, timings, determinism, and resource samples it
-does not claim that RepoPilot adds value over existing checks.
+set, and three repetitions before a benchmark run. `collect` executes the
+allowlisted checks and repeated RepoPilot reviews on exact-SHA worktrees and
+records timings, output hashes, determinism, scanner provenance, and best
+effort child-resource samples. The artifact remains unlabeled and makes no
+utility claim until the independent labeling and scoring step exists.
 
 Validate the protocol contract without cloning repositories:
 


### PR DESCRIPTION
## Problem
The preregistered differential utility protocol defined the measurements but had no repeatable collector or artifact gate. That left the project unable to produce comparable observations without risking protocol drift.

## Change
- add `differential.py collect` for exact-SHA holdout worktrees
- repeat allowlisted baseline commands and RepoPilot reviews
- record timings, output hashes, scanner provenance, determinism, and best-effort child-resource samples
- add artifact validation for manifest hashes, command identity, case coverage, repetitions, and pending labels
- document the observation-only boundary and add runner/artifact tests

## Evidence
- 114 Python tests passed
- `python3 scripts/release-contract.py check` passed
- `npm run review:performance` passed (`changed_to_full_ratio`: 0.437)
- `cargo fmt --all -- --check` passed
- `cargo clippy --all-targets --all-features -- -D warnings` passed
- `cargo run --quiet -- scan . --fail-on-priority p1` passed with 0 visible P1 findings

## Boundary
This PR does not claim differential utility, recall, precision, or production performance. It produces unlabeled observations only. Independent annotations, adjudication, and a preregistered scoring artifact remain required.
