### PR TITLE
fix: make differential novelty baseline-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   protocol. It repeats allowlisted baseline checks and exact-SHA RepoPilot
   reviews, records timing/output/determinism/resource observations, and validates
   the artifact while keeping labels pending and utility claims gated.
+- Made differential novelty baseline-aware: each case now records exact base
+  scan evidence identities, so an existing architecture finding cannot be
+  counted as novel merely because it touches a changed file.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -288,9 +288,12 @@ bump is needed to start.
   measurements and cannot create a utility claim by itself.
 - `scripts/differential.py collect` now runs the allowlisted baseline commands
   and repeated exact-SHA RepoPilot reviews, recording output hashes, wall time,
-  determinism, scanner provenance, and best-effort child-resource samples.
+  determinism, scanner provenance, and best-effort child-resource samples. It
+  also scans the base revision and marks review evidence novel only when its
+  exact rule/path/line/snippet identity is absent from that base scan.
   `validate-result` rejects manifest drift, command drift, missing repetitions,
-  and labeled artifacts before a result can be used downstream.
+  missing base evidence, and labeled artifacts before a result can be used
+  downstream.
 - Boundary: these are still unlabeled observations. Frozen environments,
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond

--- a/scripts/differential_artifact.py
+++ b/scripts/differential_artifact.py
@@ -14,6 +14,7 @@ from real_history_runner import BASELINE_COMMANDS
 
 
 REVIEW_STATUSES = {"collected", "timeout"}
+BASE_SCAN_STATUSES = REVIEW_STATUSES
 
 
 def sha256_file(path: Path) -> str:
@@ -104,6 +105,13 @@ def validate_case(
                 raise DifferentialManifestError(f"case {case.case_id}: invalid baseline status")
             if not isinstance(run.get("wall_ms"), (int, float)) or run["wall_ms"] < 0:
                 raise DifferentialManifestError(f"case {case.case_id}: invalid baseline timing")
+    base_scan = observation.get("base_scan")
+    if not isinstance(base_scan, dict) or base_scan.get("status") not in BASE_SCAN_STATUSES:
+        raise DifferentialManifestError(f"case {case.case_id}: base scan observation is missing")
+    if not isinstance(base_scan.get("wall_ms"), (int, float)) or base_scan["wall_ms"] < 0:
+        raise DifferentialManifestError(f"case {case.case_id}: invalid base scan timing")
+    if base_scan["status"] == "collected" and not isinstance(base_scan.get("evidence_keys"), list):
+        raise DifferentialManifestError(f"case {case.case_id}: base scan evidence keys are missing")
     reviews = observation.get("reviews")
     if not isinstance(reviews, list) or len(reviews) != repetitions:
         raise DifferentialManifestError(f"case {case.case_id}: review repetition count drift")
@@ -114,6 +122,10 @@ def validate_case(
             raise DifferentialManifestError(f"case {case.case_id}: invalid review timing")
         if review["status"] == "collected" and not isinstance(review.get("stable_evidence_sha256"), str):
             raise DifferentialManifestError(f"case {case.case_id}: collected review lacks stable evidence hash")
+        if review["status"] == "collected":
+            for field in ("in_diff_evidence_keys", "novel_in_diff_evidence_keys"):
+                if not isinstance(review.get(field), list) or not all(isinstance(item, str) for item in review[field]):
+                    raise DifferentialManifestError(f"case {case.case_id}: collected review lacks {field}")
     determinism = observation.get("determinism")
     if not isinstance(determinism, dict) or not isinstance(determinism.get("stable_evidence_deterministic"), bool):
         raise DifferentialManifestError(f"case {case.case_id}: determinism summary is missing")

--- a/scripts/differential_novelty.py
+++ b/scripts/differential_novelty.py
@@ -1,0 +1,48 @@
+"""Compare review evidence with a base scan for differential novelty."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+
+def _finding_key(finding: dict[str, Any]) -> str:
+    rule_id = finding.get("rule_id")
+    if not isinstance(rule_id, str) or not rule_id:
+        return ""
+    evidence = finding.get("evidence")
+    if not isinstance(evidence, list) or not evidence:
+        return rule_id
+    locations = []
+    for item in evidence:
+        if not isinstance(item, dict):
+            continue
+        locations.append(
+            (
+                item.get("path", ""),
+                item.get("line_start"),
+                item.get("line_end"),
+                item.get("snippet", ""),
+            )
+        )
+    if not locations:
+        return rule_id
+    return json.dumps([rule_id, sorted(locations)], ensure_ascii=False, separators=(",", ":"))
+
+
+def evidence_keys(findings: Iterable[dict[str, Any]]) -> set[str]:
+    """Return deterministic exact-evidence identities for findings."""
+
+    return {
+        key
+        for finding in findings
+        if isinstance(finding, dict)
+        for key in (_finding_key(finding),)
+        if key
+    }
+
+
+def novel_evidence_keys(findings: Iterable[dict[str, Any]], base_keys: set[str]) -> list[str]:
+    """Return review evidence identities absent from the base scan."""
+
+    return sorted(evidence_keys(findings) - base_keys)

--- a/scripts/differential_runner.py
+++ b/scripts/differential_runner.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from differential_contract import validate_differential
 from differential_manifest import load_differential
+from differential_novelty import evidence_keys, novel_evidence_keys
 from real_history_contract import HoldoutCase, HoldoutManifestError, validate_manifest
 from real_history_runner import BASELINE_COMMANDS, clone_case, summarize_review
 from zoo_scanner import ScannerPreparationError, ScannerProvenanceError, prepare_scanner
@@ -74,7 +75,40 @@ def run_timed_command(command: tuple[str, ...], cwd: Path, timeout_seconds: int)
     return result
 
 
-def _review_once(scanner: Any, case: HoldoutCase, head: Path, timeout_seconds: int) -> dict[str, Any]:
+def _scan_base(scanner: Any, case: HoldoutCase, base: Path, timeout_seconds: int) -> dict[str, Any]:
+    command = (*scanner.command, "scan", str(base), "--format", "json", "--profile", "default", "--no-progress")
+    started = time.perf_counter()
+    try:
+        process = subprocess.run(list(command), cwd=base, capture_output=True, check=False, timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        return {"status": "timeout", "returncode": None, "wall_ms": round((time.perf_counter() - started) * 1000, 3)}
+    if process.returncode not in (0, 1):
+        raise HoldoutManifestError(
+            f"differential base scan failed for {case.case_id}: {process.stderr.decode(errors='replace').strip()}"
+        )
+    try:
+        report = json.loads(process.stdout)
+    except json.JSONDecodeError as error:
+        raise HoldoutManifestError(f"differential base scan returned invalid JSON for {case.case_id}: {error}") from error
+    findings = report.get("findings")
+    if not isinstance(findings, list):
+        raise HoldoutManifestError(f"differential base scan has no findings array for {case.case_id}")
+    return {
+        "status": "collected",
+        "returncode": process.returncode,
+        "wall_ms": round((time.perf_counter() - started) * 1000, 3),
+        "command": list(command),
+        "evidence_keys": sorted(evidence_keys(findings)),
+    }
+
+
+def _review_once(
+    scanner: Any,
+    case: HoldoutCase,
+    head: Path,
+    base_evidence: set[str],
+    timeout_seconds: int,
+) -> dict[str, Any]:
     command = (
         *scanner.command,
         "review",
@@ -94,7 +128,13 @@ def _review_once(scanner: Any, case: HoldoutCase, head: Path, timeout_seconds: i
     try:
         process = subprocess.run(list(command), cwd=head, capture_output=True, check=False, timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return {"status": "timeout", "returncode": None, "wall_ms": round((time.perf_counter() - started) * 1000, 3)}
+        return {
+            "status": "timeout",
+            "returncode": None,
+            "wall_ms": round((time.perf_counter() - started) * 1000, 3),
+            "in_diff_evidence_keys": [],
+            "novel_in_diff_evidence_keys": [],
+        }
     if process.returncode not in (0, 1):
         raise HoldoutManifestError(
             f"differential review failed for {case.case_id}: {process.stderr.decode(errors='replace').strip()}"
@@ -103,12 +143,16 @@ def _review_once(scanner: Any, case: HoldoutCase, head: Path, timeout_seconds: i
         report = json.loads(process.stdout)
     except json.JSONDecodeError as error:
         raise HoldoutManifestError(f"differential review returned invalid JSON for {case.case_id}: {error}") from error
+    in_diff_findings = [finding for finding in report["findings"] if isinstance(finding, dict) and finding.get("in_diff") is True]
+    in_diff_keys = sorted(evidence_keys(in_diff_findings))
     result = {
         **summarize_review(report, process.stdout),
         "status": "collected",
         "returncode": process.returncode,
         "wall_ms": round((time.perf_counter() - started) * 1000, 3),
         "resource_status": resource_status,
+        "in_diff_evidence_keys": in_diff_keys,
+        "novel_in_diff_evidence_keys": novel_evidence_keys(in_diff_findings, base_evidence),
     }
     _, resource_after = _resource_snapshot()
     if resource_before is not None and resource_after is not None:
@@ -124,7 +168,9 @@ def collect_case(
     root: Path,
     timeout_seconds: int,
 ) -> dict[str, Any]:
-    _, head, merge = clone_case(case, root)
+    base, head, merge = clone_case(case, root)
+    base_scan = _scan_base(scanner, case, base, timeout_seconds)
+    base_evidence = set(base_scan.get("evidence_keys", []))
     baselines = {baseline_id: [] for baseline_id in baseline_ids}
     reviews = []
     for repeat in range(1, repetitions + 1):
@@ -132,7 +178,7 @@ def collect_case(
             result = run_timed_command(BASELINE_COMMANDS[baseline_id], merge, timeout_seconds)
             result["repeat"] = repeat
             baselines[baseline_id].append(result)
-        review = _review_once(scanner, case, head, timeout_seconds)
+        review = _review_once(scanner, case, head, base_evidence, timeout_seconds)
         review["repeat"] = repeat
         reviews.append(review)
     stable_hashes = [run["stable_evidence_sha256"] for run in reviews if run["status"] == "collected"]
@@ -143,6 +189,7 @@ def collect_case(
         "base_sha": case.base_sha,
         "head_sha": case.head_sha,
         "merge_sha": case.merge_sha,
+        "base_scan": base_scan,
         "baselines": baselines,
         "reviews": reviews,
         "determinism": {

--- a/scripts/tests/test_differential_novelty.py
+++ b/scripts/tests/test_differential_novelty.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from differential_novelty import evidence_keys, novel_evidence_keys  # noqa: E402
+
+
+class DifferentialNoveltyTests(unittest.TestCase):
+    def test_existing_base_evidence_is_not_novel(self) -> None:
+        base = [
+            {
+                "rule_id": "architecture.circular-dependency",
+                "evidence": [
+                    {
+                        "path": "src/flask/__init__.py",
+                        "line_start": 1,
+                        "snippet": "Cycle: src/flask/__init__.py -> src/flask/app.py",
+                    }
+                ],
+            }
+        ]
+        review = [*base, {"rule_id": "security.secret-candidate", "evidence": []}]
+
+        base_keys = evidence_keys(base)
+        novel = novel_evidence_keys(review, base_keys)
+
+        self.assertEqual(len(base_keys), 1)
+        self.assertEqual(novel, ["security.secret-candidate"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_differential_runner.py
+++ b/scripts/tests/test_differential_runner.py
@@ -46,6 +46,7 @@ class DifferentialRunnerTests(unittest.TestCase):
                         "base_sha": base_sha,
                         "head_sha": head_sha,
                         "merge_sha": merge_sha,
+                        "base_scan": {"status": "collected", "wall_ms": 1.0, "evidence_keys": []},
                         "baselines": {
                             baseline_id: [
                                 {
@@ -58,7 +59,13 @@ class DifferentialRunnerTests(unittest.TestCase):
                             for baseline_id in baseline_ids
                         },
                         "reviews": [
-                            {"status": "collected", "wall_ms": 1.0, "stable_evidence_sha256": "1" * 64}
+                            {
+                                "status": "collected",
+                                "wall_ms": 1.0,
+                                "stable_evidence_sha256": "1" * 64,
+                                "in_diff_evidence_keys": [],
+                                "novel_in_diff_evidence_keys": [],
+                            }
                             for _ in range(3)
                         ],
                         "determinism": {"stable_evidence_deterministic": True},
@@ -79,6 +86,71 @@ class DifferentialRunnerTests(unittest.TestCase):
         self.assertEqual(result["status"], "valid")
         self.assertEqual(result["baseline_observations"], 6)
         self.assertEqual(result["review_observations"], 6)
+
+    def test_artifact_validator_requires_base_scan_for_novelty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            holdout, differential, rules, zoo = self._write_manifests(root)
+            artifact = self._valid_artifact(holdout, differential)
+            artifact["cases"][0].pop("base_scan")
+            with self.assertRaisesRegex(ValueError, "base scan"):
+                validate_data(artifact, holdout, differential, rules, zoo)
+
+    @staticmethod
+    def _valid_artifact(holdout: Path, differential: Path) -> dict[str, object]:
+        cases = []
+        for case_id, baseline_ids, repo, base_sha, head_sha, merge_sha in (
+            ("case-one", ("python.compile",), "owner/one", "a" * 40, "b" * 40, "c" * 40),
+            ("case-two", ("python.tests",), "owner/two", "d" * 40, "e" * 40, "f" * 40),
+        ):
+            cases.append(
+                {
+                    "id": case_id,
+                    "repo": repo,
+                    "base_sha": base_sha,
+                    "head_sha": head_sha,
+                    "merge_sha": merge_sha,
+                    "base_scan": {"status": "collected", "wall_ms": 1.0, "evidence_keys": []},
+                    "baselines": {
+                        baseline_id: [
+                            {
+                                "command": list(BASELINE_COMMANDS[baseline_id]),
+                                "status": "passed",
+                                "wall_ms": 1.0,
+                            }
+                            for _ in range(3)
+                        ]
+                        for baseline_id in baseline_ids
+                    },
+                    "reviews": [
+                        {
+                            "status": "collected",
+                            "wall_ms": 1.0,
+                            "stable_evidence_sha256": "1" * 64,
+                            "in_diff_evidence_keys": [],
+                            "novel_in_diff_evidence_keys": [],
+                        }
+                        for _ in range(3)
+                    ],
+                    "determinism": {"stable_evidence_deterministic": True},
+                }
+            )
+        return {
+            "schema_version": 1,
+            "corpus": "test",
+            "protocol": "differential-utility-v1",
+            "manifest_sha256": hashlib.sha256(holdout.read_bytes()).hexdigest(),
+            "differential_manifest_sha256": hashlib.sha256(differential.read_bytes()).hexdigest(),
+            "scanner": {
+                "mode": "workspace",
+                "version": "0.23",
+                "report_schema_version": "1",
+                "workspace_version": "0.23",
+            },
+            "repetitions": 3,
+            "cases": cases,
+            "label_state": "pending",
+        }
 
     @staticmethod
     def _write_manifests(root: Path) -> tuple[Path, Path, Path, Path]:

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -24,9 +24,11 @@ python3 scripts/differential.py validate-result \
 It freezes the six utility measurements, the baseline set, the holdout case
 set, and three repetitions before a benchmark run. `collect` executes the
 allowlisted checks and repeated RepoPilot reviews on exact-SHA worktrees and
-records timings, output hashes, determinism, scanner provenance, and best
-effort child-resource samples. The artifact remains unlabeled and makes no
-utility claim until the independent labeling and scoring step exists.
+records timings, output hashes, determinism, scanner provenance, best-effort
+child-resource samples, and the base scan's exact evidence identities. Review
+evidence is marked novel only when its rule/path/line/snippet identity is absent
+from that base scan. The artifact remains unlabeled and makes no utility claim
+until the independent labeling and scoring step exists.
 
 Validate the protocol contract without cloning repositories:
 


### PR DESCRIPTION
## Problem
The differential runner counted every in-diff review finding as potentially novel. A repository-level finding can already exist in the base revision and still touch a changed file, which would overstate RepoPilot's new evidence.

## Change
- run a base-revision scan for each differential case
- derive exact evidence identities from rule, path, line, and snippet
- record `in_diff_evidence_keys` and `novel_in_diff_evidence_keys`
- reject artifacts missing base evidence or novelty fields
- add regression coverage and document the measurement boundary

## Evidence
- Re-ran the pinned Flask and Requests holdout: Flask's circular-dependency signal is present in base and yields zero novel evidence; Requests yields zero novel evidence.
- 116 Python tests passed
- `python3 scripts/release-contract.py check` passed
- `cargo fmt --all -- --check` passed
- `cargo clippy --all-targets --all-features -- -D warnings` passed
- self-scan passed with 0 visible P1 findings
- `npm run review:performance` passed (`changed_to_full_ratio`: 0.437)
