### PR TITLE
feat: add single-expert differential pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Made differential novelty baseline-aware: each case now records exact base
   scan evidence identities, so an existing architecture finding cannot be
   counted as novel merely because it touches a changed file.
+- Added a single-expert exploratory pilot workflow with blinded worksheets,
+  hash-pinned validation, case-level scoring, Wilson intervals, and captured
+  determinism/timing/resource summaries. The pilot is explicitly not
+  independent validation and leaves the preregistered dual-review protocol
+  unchanged.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -298,3 +298,9 @@ bump is needed to start.
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond
   existing checks.
+- A separate `single-expert-pilot-v1` workflow now renders a blinded worksheet,
+  validates one reviewer's labels and rationales, and emits exploratory
+  TP/FN/TN/FP outcomes with Wilson intervals plus only the timing/resource
+  measurements the collector actually captured. It is explicitly model-assisted
+  or single-reviewer evidence; it does not alter the dual-review protocol and
+  cannot close RP23-014 by itself.

--- a/docs/superpowers/plans/2026-09-06-single-expert-pilot.md
+++ b/docs/superpowers/plans/2026-09-06-single-expert-pilot.md
@@ -1,0 +1,242 @@
+# Single-Expert Differential Pilot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a validated single-expert exploratory scoring workflow over the existing baseline-aware differential artifact without weakening the preregistered dual-review protocol.
+
+**Architecture:** Add one focused Python module for pilot worksheet rendering/validation and one for scoring. Extend the existing differential CLI with three pilot subcommands. Reuse the existing manifest and differential artifact validators, and keep all outputs explicitly exploratory and hash-pinned.
+
+**Tech Stack:** Python 3.11 standard library (`tomllib`, `json`, `hashlib`, `statistics`, `unittest`), existing RepoPilot benchmark scripts, TOML/JSON artifacts, Markdown documentation.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-single-expert-pilot-design.md`
+
+## Global Constraints
+
+- Preserve `dual-independent-adjudication-v1` unchanged.
+- Do not infer labels from RepoPilot findings, baseline failures, or merge status.
+- Keep outputs deterministic and hash-pinned.
+- Treat `single-expert-exploratory` results as descriptive evidence only.
+- Keep source files below the repository's approximately 300-line limit.
+- Do not commit generated `.repopilot/evidence` artifacts.
+
+---
+
+### Task 1: Define pilot worksheet contract
+
+**Files:**
+- Create: `scripts/differential_pilot.py`
+- Test: `scripts/tests/test_differential_pilot.py`
+
+**Interfaces:**
+- Consumes: `validate_artifact`, `validate_manifest`, and a differential artifact path.
+- Produces: `render_pilot_template(...) -> str`, `validate_pilot(...) -> dict[str, object]`, and `load_pilot(...) -> tuple[dict[str, object], dict[str, dict[str, object]]]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+  Add tests that assert a rendered worksheet declares `protocol = "single-expert-pilot-v1"`, `blinded = true`, and contains no `in_diff_rule_ids`, `in_diff_evidence_keys`, or `novel_in_diff_evidence_keys`; assert that a completed label with a rationale validates; assert that an unknown rule, missing rationale, hash drift, or missing case raises `HoldoutManifestError`.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+  Run:
+
+  ```bash
+  python3 -m unittest scripts.tests.test_differential_pilot
+  ```
+
+  Expected result: import failure because `differential_pilot` does not yet exist.
+
+- [ ] **Step 3: Implement the worksheet contract**
+
+  Define `PILOT_SCHEMA_VERSION = 1`, `PILOT_PROTOCOL = "single-expert-pilot-v1"`, and allowed labels from `real_history_contract`. Load the differential artifact through `validate_artifact`, derive aggregate baseline statuses from the first baseline repetition, and render only pinned case identity plus blank label fields. Validate top-level hashes, `assessment_mode`, `blinded`, exact case identity, allowed labels, known rule IDs, and non-empty rationales.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+  Run the same unittest command and require all pilot contract tests to pass.
+
+- [ ] **Step 5: Commit the contract slice**
+
+  ```bash
+  git add scripts/differential_pilot.py scripts/tests/test_differential_pilot.py
+  git commit -m "feat: add single-expert pilot worksheet contract"
+  ```
+
+### Task 2: Add exploratory scoring
+
+**Files:**
+- Create: `scripts/differential_pilot_metrics.py`
+- Modify: `scripts/tests/test_differential_pilot.py`
+
+**Interfaces:**
+- Consumes: validated pilot worksheet and validated differential artifact.
+- Produces: `build_pilot_metrics(...) -> dict[str, object]` and `write_pilot_metrics(...) -> dict[str, object]`.
+
+- [ ] **Step 1: Write failing scoring tests**
+
+  Add a fixture with one no-defect case containing novel evidence, one no-defect case with none, and one uncertain case. Assert outcomes `fp`, `tn`, and `excluded`; assert recall is `None` when there are no positive cases; assert the output contains scope, limitation, input hashes, Wilson intervals, deterministic case count, and median timing fields.
+
+- [ ] **Step 2: Run scoring tests and verify RED**
+
+  Run:
+
+  ```bash
+  python3 -m unittest scripts.tests.test_differential_pilot.DifferentialPilotTests.test_scores_exploratory_outcomes
+  ```
+
+  Expected result: import failure for `differential_pilot_metrics`.
+
+- [ ] **Step 3: Implement scoring**
+
+  Convert each `novel_in_diff_evidence_keys` entry to its rule ID using the existing novelty identity format. Compute case outcomes using exact rule intersection, exclude `uncertain`, calculate TP/FN/TN/FP and Wilson intervals, and summarize only measurements present in the artifact: deterministic review cases, median baseline wall time, median review wall time, and median child RSS when available. Emit `scope = "single-expert exploratory pilot"` and a limitation that forbids independent or general claims.
+
+- [ ] **Step 4: Run scoring tests and full script tests**
+
+  ```bash
+  python3 -m unittest scripts.tests.test_differential_pilot
+  python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+  ```
+
+- [ ] **Step 5: Commit scoring**
+
+  ```bash
+  git add scripts/differential_pilot_metrics.py scripts/tests/test_differential_pilot.py
+  git commit -m "feat: score single-expert differential pilot"
+  ```
+
+### Task 3: Expose the pilot workflow through the differential CLI
+
+**Files:**
+- Modify: `scripts/differential.py`
+- Modify: `scripts/tests/test_differential.py`
+
+**Interfaces:**
+- Consumes: `render_pilot_template`, `validate_pilot`, `write_pilot_metrics`.
+- Produces: `pilot-template`, `pilot-validate`, and `pilot-score` commands with stable text/JSON summaries and exit codes.
+
+- [ ] **Step 1: Add failing CLI tests**
+
+  Assert missing required arguments return exit code 2, a valid template command writes a worksheet, and pilot-score writes a JSON metrics artifact.
+
+- [ ] **Step 2: Run CLI tests and verify RED**
+
+  ```bash
+  python3 -m unittest scripts.tests.test_differential.DifferentialContractTests.test_pilot_commands
+  ```
+
+  Expected result: argparse rejects `pilot-template` because the command is not yet registered.
+
+- [ ] **Step 3: Implement CLI branches**
+
+  Add the three command choices and arguments `--pilot`, `--reviewer`, and `--output`. Validate the differential artifact before each branch, catch `HoldoutManifestError` and `DifferentialManifestError`, create output parent directories, and print a compact status in text mode or the returned summary in JSON mode.
+
+- [ ] **Step 4: Run CLI and script tests**
+
+  ```bash
+  python3 -m unittest scripts.tests.test_differential scripts.tests.test_differential_pilot
+  python3 scripts/differential.py check --format json
+  ```
+
+- [ ] **Step 5: Commit CLI integration**
+
+  ```bash
+  git add scripts/differential.py scripts/tests/test_differential.py
+  git commit -m "feat: expose single-expert pilot commands"
+  ```
+
+### Task 4: Run the pilot on the collected holdout
+
+**Files:**
+- Generate ignored artifacts under: `.repopilot/evidence/v0.23/`
+
+- [ ] **Step 1: Generate the blinded worksheet**
+
+  ```bash
+  python3 scripts/differential.py pilot-template \
+    --artifact .repopilot/evidence/v0.23/differential-run-v2.json \
+    --reviewer model-assisted \
+    --output .repopilot/evidence/v0.23/model-pilot.toml
+  ```
+
+- [ ] **Step 2: Fill the model-assisted assessment explicitly**
+
+  Record the provisional `no-defect` labels and rationales from the existing assessment file, while retaining `assessment_mode = "single-expert-exploratory"`.
+
+- [ ] **Step 3: Validate and score the pilot**
+
+  ```bash
+  python3 scripts/differential.py pilot-validate \
+    --artifact .repopilot/evidence/v0.23/differential-run-v2.json \
+    --pilot .repopilot/evidence/v0.23/model-pilot.toml
+  python3 scripts/differential.py pilot-score \
+    --artifact .repopilot/evidence/v0.23/differential-run-v2.json \
+    --pilot .repopilot/evidence/v0.23/model-pilot.toml \
+    --output .repopilot/evidence/v0.23/model-pilot-metrics.json
+  ```
+
+- [ ] **Step 4: Inspect the result**
+
+  Confirm that the report says exploratory, has zero positive cases, and does not claim recall or utility beyond the two-case holdout.
+
+### Task 5: Document the larger evidence workflow
+
+**Files:**
+- Modify: `tests/benchmarks/README.md`
+- Modify: `docs/engineering/v0.23-evidence-ledger.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add usage documentation**
+
+  Document the three pilot commands, the blank-field workflow, and the exact limitation that one reviewer does not establish independent validation.
+
+- [ ] **Step 2: Update the evidence ledger**
+
+  Record the pilot as exploratory evidence, keep RP23-014 open, and state that the differential utility claim still requires a larger labeled corpus and independent review.
+
+- [ ] **Step 3: Run documentation and release checks**
+
+  ```bash
+  python3 scripts/release-contract.py check
+  git diff --check
+  ```
+
+- [ ] **Step 4: Commit documentation**
+
+  ```bash
+  git add tests/benchmarks/README.md docs/engineering/v0.23-evidence-ledger.md CHANGELOG.md
+  git commit -m "docs: describe single-expert pilot evidence boundary"
+  ```
+
+### Task 6: Full verification and draft PR
+
+**Files:**
+- No additional source changes expected.
+
+- [ ] **Step 1: Run the complete local gate**
+
+  ```bash
+  python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+  python3 -m compileall -q scripts
+  python3 scripts/release-contract.py check
+  cargo fmt --all -- --check
+  cargo clippy --all-targets --all-features -- -D warnings
+  cargo run --quiet -- scan . --fail-on-priority p1
+  npm run review:performance
+  git diff --check
+  ```
+
+- [ ] **Step 2: Inspect the diff and generated report boundary**
+
+  Confirm generated artifacts remain ignored, no dual-review validator changed, and every metric carries the exploratory limitation.
+
+- [ ] **Step 3: Push the feature branch**
+
+  ```bash
+  git push -u origin feat/single-expert-pilot
+  ```
+
+- [ ] **Step 4: Open one draft PR**
+
+  ```bash
+  gh pr create --draft --base main --head feat/single-expert-pilot \
+    --title "feat: add single-expert differential pilot" \
+    --body-file /tmp/repopilot-single-expert-pilot-pr.md
+  ```

--- a/docs/superpowers/specs/2026-09-06-single-expert-pilot-design.md
+++ b/docs/superpowers/specs/2026-09-06-single-expert-pilot-design.md
@@ -1,0 +1,99 @@
+# Single-Expert Differential Pilot Design
+
+## Problem
+
+RepoPilot now collects repeated, baseline-aware observations for the pinned
+real-history holdout, but the preregistered quality protocol requires two
+independent human annotations. The project currently has one available human
+reviewer. Treating a model assessment or a second pass by the same person as
+independent ground truth would overstate the evidence.
+
+## Goal
+
+Add an explicit `single-expert-pilot-v1` workflow that lets one named reviewer
+label the existing differential artifact, validates the labels and provenance,
+and emits exploratory case-level metrics without changing or weakening the
+existing `dual-independent-adjudication-v1` protocol.
+
+## Non-goals
+
+- Do not alter the preregistered dual-review manifest or its validators.
+- Do not claim production, language-wide, or general recall/precision.
+- Do not infer labels from RepoPilot findings, baseline failures, or upstream
+  merge status.
+- Do not call a model-assisted assessment independent human annotation.
+- Do not add a new top-level Rust CLI command; this workflow remains in the
+  benchmark Python tooling.
+
+## Data flow
+
+```text
+differential-run-v2.json
+        |
+        v
+pilot-template -> pilot-assessment.toml -> pilot-validate -> pilot-score
+                                      |
+                                      v
+                         exploratory-pilot-metrics.json
+```
+
+The template copies case identity and aggregate baseline statuses only. It
+never copies RepoPilot rule IDs or evidence keys, preserving a blinded review
+surface. The completed assessment records the reviewer name, label,
+expected rule IDs, and a rationale for every case.
+
+## Artifact contracts
+
+The pilot worksheet uses schema version 1 and protocol
+`single-expert-pilot-v1`. Its top-level fields are `schema_version`, `corpus`,
+`protocol`, `reviewer`, `manifest_sha256`, `differential_artifact_sha256`,
+`blinded = true`, `assessment_mode = "single-expert-exploratory"`, and one
+`case` table per holdout case. Each case contains pinned identity, baseline
+statuses, `label`, `expected_rule_ids`, and `rationale`.
+
+Allowed labels remain `defect-present`, `no-defect`, and `uncertain`. A
+`defect-present` case must name at least one known rule ID. `uncertain` cases
+are excluded from confusion counts rather than silently treated as negative.
+
+The score artifact records input hashes, per-case observed novel rule IDs,
+outcomes, confusion counts, Wilson 95% intervals, deterministic review count,
+and timing/resource summaries already captured by the differential artifact.
+Its scope is explicitly `single-expert exploratory pilot` and its limitation
+states that the result is not independent validation or a general estimate.
+
+## CLI surface
+
+Extend `scripts/differential.py` with:
+
+```text
+pilot-template --artifact ARTIFACT --reviewer NAME --output WORKSHEET
+pilot-validate --artifact ARTIFACT --pilot WORKSHEET
+pilot-score --artifact ARTIFACT --pilot WORKSHEET --output SCORE
+```
+
+All three commands first validate the differential artifact against its pinned
+manifests. `pilot-score` validates the worksheet again before calculating any
+metric and refuses unknown rules, hash drift, missing cases, missing rationale,
+or invalid labels.
+
+## Measurement semantics
+
+For each labeled case, the predicted positive set is the set of novel in-diff
+evidence identities from the differential artifact. A defect-present case is a
+true positive only when an observed novel rule ID intersects its expected rule
+IDs. A no-defect case with any novel evidence is a false positive. Uncertain
+cases are excluded. The artifact also reports the number of cases with
+deterministic repeated evidence and the median wall time for baselines and
+reviews; it does not invent decision-latency data that the collector did not
+capture.
+
+## Testing and documentation
+
+- Unit-test worksheet rendering, blinding, validation failures, rule matching,
+  uncertain exclusion, and Wilson interval output.
+- Add CLI examples and the single-expert limitation to
+  `tests/benchmarks/README.md`.
+- Add the evidence boundary and RP23-014 status to
+  `docs/engineering/v0.23-evidence-ledger.md` and `CHANGELOG.md`.
+- Keep generated run artifacts under `.repopilot/evidence/`, which is ignored
+  and never committed as release evidence.

--- a/scripts/differential.py
+++ b/scripts/differential.py
@@ -10,13 +10,20 @@ from pathlib import Path
 
 from differential_artifact import validate_artifact, validate_data
 from differential_contract import DifferentialManifestError, validate_differential
+from differential_pilot import render_pilot_template, validate_pilot
+from differential_pilot_metrics import write_pilot_metrics
 from differential_runner import collect_differential
 from real_history_contract import HoldoutManifestError
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("command", nargs="?", choices=("check", "collect", "validate-result"), default="check")
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=("check", "collect", "validate-result", "pilot-template", "pilot-validate", "pilot-score"),
+        default="check",
+    )
     parser.add_argument("--manifest", type=Path, default=Path("tests/benchmarks/differential.toml"))
     parser.add_argument("--holdout-manifest", type=Path, default=Path("tests/benchmarks/manifest.toml"))
     parser.add_argument("--rules-reference", type=Path, default=Path("docs/rules-reference.md"))
@@ -28,6 +35,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--timeout", type=int, default=300)
     parser.add_argument("--output", type=Path, help="write a differential artifact")
     parser.add_argument("--artifact", type=Path, help="differential artifact to validate")
+    parser.add_argument("--pilot", type=Path, help="single-expert pilot worksheet")
+    parser.add_argument("--reviewer", help="single-expert pilot reviewer name")
     args = parser.parse_args(argv)
     try:
         result = validate_differential(args.manifest, args.holdout_manifest, args.rules_reference, args.zoo_manifest)
@@ -85,6 +94,69 @@ def main(argv: list[str] | None = None) -> int:
             print(f"differential collection failed: {error}", file=sys.stderr)
             return 2
         print(f"Differential collection: {args.output} ({len(artifact['cases'])} cases)")
+        return 0
+    if args.command == "pilot-template":
+        if args.artifact is None or args.reviewer is None or args.output is None:
+            print("pilot-template requires --artifact, --reviewer, and --output", file=sys.stderr)
+            return 2
+        try:
+            rendered = render_pilot_template(
+                args.artifact,
+                args.holdout_manifest,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+                args.reviewer,
+            )
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered, encoding="utf-8")
+        except (DifferentialManifestError, HoldoutManifestError, OSError) as error:
+            print(f"pilot template failed: {error}", file=sys.stderr)
+            return 1
+        print(f"Pilot worksheet: {args.output}")
+        return 0
+    if args.command == "pilot-validate":
+        if args.artifact is None or args.pilot is None:
+            print("pilot-validate requires --artifact and --pilot", file=sys.stderr)
+            return 2
+        try:
+            pilot_result = validate_pilot(
+                args.pilot,
+                args.artifact,
+                args.holdout_manifest,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (DifferentialManifestError, HoldoutManifestError, OSError) as error:
+            print(f"pilot worksheet invalid: {error}", file=sys.stderr)
+            return 1
+        if args.format == "json":
+            print(json.dumps(pilot_result, indent=2, sort_keys=True))
+        else:
+            print(f"Pilot worksheet: {pilot_result['status']} ({pilot_result['cases']} cases)")
+        return 0
+    if args.command == "pilot-score":
+        if args.artifact is None or args.pilot is None or args.output is None:
+            print("pilot-score requires --artifact, --pilot, and --output", file=sys.stderr)
+            return 2
+        try:
+            pilot_result = write_pilot_metrics(
+                args.output,
+                args.artifact,
+                args.pilot,
+                args.holdout_manifest,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (DifferentialManifestError, HoldoutManifestError, OSError) as error:
+            print(f"pilot scoring failed: {error}", file=sys.stderr)
+            return 1
+        if args.format == "json":
+            print(json.dumps(pilot_result, indent=2, sort_keys=True))
+        else:
+            print(f"Pilot metrics: {pilot_result['scope']} ({len(pilot_result['cases'])} cases)")
         return 0
     if args.format == "json":
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/scripts/differential_novelty.py
+++ b/scripts/differential_novelty.py
@@ -27,7 +27,8 @@ def _finding_key(finding: dict[str, Any]) -> str:
         )
     if not locations:
         return rule_id
-    return json.dumps([rule_id, sorted(locations)], ensure_ascii=False, separators=(",", ":"))
+    locations.sort(key=lambda item: json.dumps(item, ensure_ascii=False, separators=(",", ":")))
+    return json.dumps([rule_id, locations], ensure_ascii=False, separators=(",", ":"))
 
 
 def evidence_keys(findings: Iterable[dict[str, Any]]) -> set[str]:
@@ -46,3 +47,19 @@ def novel_evidence_keys(findings: Iterable[dict[str, Any]], base_keys: set[str])
     """Return review evidence identities absent from the base scan."""
 
     return sorted(evidence_keys(findings) - base_keys)
+
+
+def evidence_rule_ids(keys: Iterable[str]) -> set[str]:
+    """Extract rule IDs from exact evidence identities."""
+
+    rule_ids: set[str] = set()
+    for key in keys:
+        try:
+            identity = json.loads(key)
+        except json.JSONDecodeError:
+            identity = None
+        if isinstance(identity, list) and identity and isinstance(identity[0], str):
+            rule_ids.add(identity[0])
+        elif key:
+            rule_ids.add(key)
+    return rule_ids

--- a/scripts/differential_pilot.py
+++ b/scripts/differential_pilot.py
@@ -1,0 +1,240 @@
+"""Render and validate one-reviewer exploratory differential assessments."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from differential_artifact import validate_artifact
+from real_history_contract import ALLOWED_LABELS, HoldoutManifestError, validate_manifest
+
+
+PILOT_SCHEMA_VERSION = 1
+PILOT_PROTOCOL = "single-expert-pilot-v1"
+PILOT_MODE = "single-expert-exploratory"
+PILOT_FIELDS = {
+    "id",
+    "repo",
+    "pull_request",
+    "base_sha",
+    "head_sha",
+    "merge_sha",
+    "baseline_statuses",
+    "label",
+    "expected_rule_ids",
+    "rationale",
+}
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _toml_array(values: list[str]) -> str:
+    return "[" + ", ".join(_toml_string(value) for value in values) + "]"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read differential artifact {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError("differential artifact must be a JSON object")
+    return data
+
+
+def _cases_by_id(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    cases = data.get("cases")
+    if not isinstance(cases, list):
+        raise HoldoutManifestError("differential artifact cases must be an array")
+    return {
+        case["id"]: case
+        for case in cases
+        if isinstance(case, dict) and isinstance(case.get("id"), str)
+    }
+
+
+def _baseline_statuses(case: Any, observation: dict[str, Any]) -> list[str]:
+    baselines = observation.get("baselines")
+    if not isinstance(baselines, dict):
+        raise HoldoutManifestError(f"pilot case {case.case_id}: baseline observations are missing")
+    statuses = []
+    for baseline_id in case.baseline_ids:
+        runs = baselines.get(baseline_id)
+        if not isinstance(runs, list) or not runs or not isinstance(runs[0], dict):
+            raise HoldoutManifestError(f"pilot case {case.case_id}: baseline observations are incomplete")
+        statuses.append(f"{baseline_id}={runs[0].get('status', 'unknown')}")
+    return statuses
+
+
+def render_pilot_template(
+    artifact_path: Path,
+    manifest_path: Path,
+    differential_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+    reviewer: str,
+) -> str:
+    if not reviewer.strip():
+        raise HoldoutManifestError("pilot reviewer must not be empty")
+    validate_artifact(artifact_path, manifest_path, differential_path, rules_reference, zoo_manifest)
+    artifact = _load_json(artifact_path)
+    corpus, _, cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    observations = _cases_by_id(artifact)
+    lines = [
+        f"schema_version = {PILOT_SCHEMA_VERSION}",
+        f"corpus = {_toml_string(corpus)}",
+        f"protocol = {_toml_string(PILOT_PROTOCOL)}",
+        f"reviewer = {_toml_string(reviewer)}",
+        f"manifest_sha256 = {_toml_string(sha256_file(manifest_path))}",
+        f"differential_artifact_sha256 = {_toml_string(sha256_file(artifact_path))}",
+        "blinded = true",
+        f"assessment_mode = {_toml_string(PILOT_MODE)}",
+        "",
+    ]
+    for case in cases:
+        observation = observations.get(case.case_id)
+        if observation is None:
+            raise HoldoutManifestError(f"differential artifact is missing case {case.case_id}")
+        lines.extend(
+            [
+                "[[case]]",
+                f"id = {_toml_string(case.case_id)}",
+                f"repo = {_toml_string(case.repo)}",
+                f"pull_request = {case.pull_request}",
+                f"base_sha = {_toml_string(case.base_sha)}",
+                f"head_sha = {_toml_string(case.head_sha)}",
+                f"merge_sha = {_toml_string(case.merge_sha)}",
+                f"baseline_statuses = {_toml_array(_baseline_statuses(case, observation))}",
+                'label = ""',
+                "expected_rule_ids = []",
+                'rationale = ""',
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read pilot worksheet {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError("pilot worksheet must be a TOML table")
+    return data
+
+
+def _known_rules(rules_reference: Path) -> set[str]:
+    return set(re.findall(r"^### `([^`]+)`", rules_reference.read_text(encoding="utf-8"), re.MULTILINE))
+
+
+def _validate_cases(
+    data: dict[str, Any],
+    artifact: dict[str, Any],
+    cases: list[Any],
+    known_rules: set[str],
+) -> dict[str, dict[str, Any]]:
+    raw_cases = data.get("case")
+    if not isinstance(raw_cases, list):
+        raise HoldoutManifestError("pilot worksheet cases must be an array")
+    expected = {case.case_id: case for case in cases}
+    observations = _cases_by_id(artifact)
+    observed: dict[str, dict[str, Any]] = {}
+    for raw in raw_cases:
+        if not isinstance(raw, dict):
+            raise HoldoutManifestError("pilot case must be a table")
+        unknown = set(raw) - PILOT_FIELDS
+        if unknown:
+            raise HoldoutManifestError(f"pilot case has unknown fields: {', '.join(sorted(unknown))}")
+        case_id = raw.get("id")
+        if not isinstance(case_id, str) or case_id in observed or case_id not in expected:
+            raise HoldoutManifestError(f"pilot has unknown or duplicate case {case_id!r}")
+        case = expected[case_id]
+        for field in ("repo", "base_sha", "head_sha", "merge_sha"):
+            if raw.get(field) != getattr(case, field):
+                raise HoldoutManifestError(f"pilot case {case_id}: {field} does not match manifest")
+        if raw.get("pull_request") != case.pull_request:
+            raise HoldoutManifestError(f"pilot case {case_id}: pull_request does not match manifest")
+        observation = observations.get(case_id)
+        if observation is None:
+            raise HoldoutManifestError(f"differential artifact is missing case {case_id}")
+        if raw.get("baseline_statuses") != _baseline_statuses(case, observation):
+            raise HoldoutManifestError(f"pilot case {case_id}: baseline evidence drifted")
+        label = raw.get("label")
+        if label not in ALLOWED_LABELS:
+            raise HoldoutManifestError(f"pilot case {case_id}: label must be one of {sorted(ALLOWED_LABELS)}")
+        rule_ids = raw.get("expected_rule_ids")
+        if not isinstance(rule_ids, list) or not all(isinstance(item, str) for item in rule_ids):
+            raise HoldoutManifestError(f"pilot case {case_id}: expected_rule_ids must be a string array")
+        if any(rule_id not in known_rules for rule_id in rule_ids):
+            raise HoldoutManifestError(f"pilot case {case_id}: unknown rule in expected_rule_ids")
+        if label == "defect-present" and not rule_ids:
+            raise HoldoutManifestError(f"pilot case {case_id}: defect-present needs expected_rule_ids")
+        if label != "defect-present" and rule_ids:
+            raise HoldoutManifestError(f"pilot case {case_id}: non-positive label cannot name expected rules")
+        rationale = raw.get("rationale")
+        if not isinstance(rationale, str) or not rationale.strip():
+            raise HoldoutManifestError(f"pilot case {case_id}: rationale is required")
+        observed[case_id] = raw
+    if set(observed) != set(expected):
+        missing = ", ".join(sorted(set(expected) - set(observed)))
+        raise HoldoutManifestError(f"pilot is missing cases: {missing}")
+    return observed
+
+
+def validate_pilot(
+    pilot_path: Path,
+    artifact_path: Path,
+    manifest_path: Path,
+    differential_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    validate_artifact(artifact_path, manifest_path, differential_path, rules_reference, zoo_manifest)
+    artifact = _load_json(artifact_path)
+    data = _load_toml(pilot_path)
+    corpus, _, cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    if data.get("schema_version") != PILOT_SCHEMA_VERSION or data.get("protocol") != PILOT_PROTOCOL:
+        raise HoldoutManifestError("pilot schema or protocol is unsupported")
+    if data.get("corpus") != corpus or data.get("blinded") is not True:
+        raise HoldoutManifestError("pilot corpus or blinded marker is invalid")
+    if data.get("assessment_mode") != PILOT_MODE:
+        raise HoldoutManifestError("pilot assessment_mode must be single-expert-exploratory")
+    if not isinstance(data.get("reviewer"), str) or not data["reviewer"].strip():
+        raise HoldoutManifestError("pilot reviewer is required")
+    if data.get("manifest_sha256") != sha256_file(manifest_path):
+        raise HoldoutManifestError("pilot manifest_sha256 does not match manifest")
+    if data.get("differential_artifact_sha256") != sha256_file(artifact_path):
+        raise HoldoutManifestError("pilot differential_artifact_sha256 does not match artifact")
+    validated = _validate_cases(data, artifact, cases, _known_rules(rules_reference))
+    return {"status": "valid", "protocol": PILOT_PROTOCOL, "reviewer": data["reviewer"], "cases": len(validated)}
+
+
+def load_pilot(
+    pilot_path: Path,
+    artifact_path: Path,
+    manifest_path: Path,
+    differential_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    validate_pilot(pilot_path, artifact_path, manifest_path, differential_path, rules_reference, zoo_manifest)
+    data = _load_toml(pilot_path)
+    raw_cases = data.get("case")
+    if not isinstance(raw_cases, list):
+        raise HoldoutManifestError("pilot worksheet cases must be an array")
+    return data, {
+        case["id"]: case
+        for case in raw_cases
+        if isinstance(case, dict) and isinstance(case.get("id"), str)
+    }

--- a/scripts/differential_pilot_metrics.py
+++ b/scripts/differential_pilot_metrics.py
@@ -1,0 +1,192 @@
+"""Score a single-expert differential pilot as exploratory evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import statistics
+from pathlib import Path
+from typing import Any
+
+from differential_novelty import evidence_rule_ids
+from differential_pilot import load_pilot
+from real_history_contract import HoldoutManifestError
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def wilson_interval(successes: int, trials: int, z: float = 1.96) -> tuple[float, float] | None:
+    if trials < 0 or successes < 0 or successes > trials:
+        raise HoldoutManifestError("invalid pilot metric counts")
+    if trials == 0:
+        return None
+    proportion = successes / trials
+    denominator = 1 + z * z / trials
+    center = (proportion + z * z / (2 * trials)) / denominator
+    margin = z * math.sqrt(proportion * (1 - proportion) / trials + z * z / (4 * trials * trials)) / denominator
+    return max(0.0, center - margin), min(1.0, center + margin)
+
+
+def _metric(successes: int, trials: int) -> dict[str, object]:
+    interval = wilson_interval(successes, trials)
+    return {
+        "successes": successes,
+        "trials": trials,
+        "value": successes / trials if trials else None,
+        "wilson_95": list(interval) if interval else None,
+    }
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read differential artifact {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError("differential artifact must be an object")
+    return data
+
+
+def _median(values: list[float]) -> float | None:
+    return round(statistics.median(values), 3) if values else None
+
+
+def _case_measurements(observation: dict[str, Any]) -> dict[str, object]:
+    baseline_values = [
+        float(run["wall_ms"])
+        for runs in observation["baselines"].values()
+        for run in runs
+        if isinstance(run, dict) and isinstance(run.get("wall_ms"), (int, float))
+    ]
+    reviews = [run for run in observation["reviews"] if isinstance(run, dict)]
+    review_values = [float(run["wall_ms"]) for run in reviews if isinstance(run.get("wall_ms"), (int, float))]
+    rss_values = [
+        float(run["child_max_rss_kb"])
+        for run in reviews
+        if isinstance(run.get("child_max_rss_kb"), (int, float))
+    ]
+    return {
+        "median_baseline_wall_ms": _median(baseline_values),
+        "median_review_wall_ms": _median(review_values),
+        "median_review_child_max_rss_kb": _median(rss_values),
+    }
+
+
+def build_pilot_metrics(
+    artifact_path: Path,
+    pilot_path: Path,
+    manifest_path: Path,
+    differential_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    pilot_data, pilot_cases = load_pilot(
+        pilot_path, artifact_path, manifest_path, differential_path, rules_reference, zoo_manifest
+    )
+    artifact = _load_json(artifact_path)
+    observations = {case["id"]: case for case in artifact["cases"]}
+    counts = {key: 0 for key in ("tp", "fn", "tn", "fp", "excluded")}
+    cases: list[dict[str, object]] = []
+    deterministic_cases = 0
+    novel_evidence_cases = 0
+    baseline_times: list[float] = []
+    review_times: list[float] = []
+    rss_times: list[float] = []
+    for case_id, label in pilot_cases.items():
+        observation = observations.get(case_id)
+        if observation is None:
+            raise HoldoutManifestError(f"differential artifact is missing case {case_id}")
+        novel_keys = sorted(
+            {
+                key
+                for review in observation["reviews"]
+                if isinstance(review, dict)
+                for key in review.get("novel_in_diff_evidence_keys", [])
+            }
+        )
+        observed_rules = sorted(evidence_rule_ids(novel_keys))
+        if novel_keys:
+            novel_evidence_cases += 1
+        expected_rules = sorted(set(label["expected_rule_ids"]))
+        if label["label"] == "defect-present":
+            outcome = "tp" if set(expected_rules) & set(observed_rules) else "fn"
+        elif label["label"] == "no-defect":
+            outcome = "fp" if observed_rules else "tn"
+        else:
+            outcome = "excluded"
+        counts[outcome] += 1
+        if observation["determinism"].get("stable_evidence_deterministic") is True:
+            deterministic_cases += 1
+        case_measurements = _case_measurements(observation)
+        for values, key in (
+            (baseline_times, "median_baseline_wall_ms"),
+            (review_times, "median_review_wall_ms"),
+            (rss_times, "median_review_child_max_rss_kb"),
+        ):
+            value = case_measurements[key]
+            if isinstance(value, (int, float)):
+                values.append(float(value))
+        cases.append(
+            {
+                "id": case_id,
+                "label": label["label"],
+                "expected_rule_ids": expected_rules,
+                "observed_novel_rule_ids": observed_rules,
+                "novel_evidence_count": len(novel_keys),
+                "outcome": outcome,
+                "measurements": case_measurements,
+            }
+        )
+    actual_positives = counts["tp"] + counts["fn"]
+    actual_negatives = counts["tn"] + counts["fp"]
+    predicted_positives = counts["tp"] + counts["fp"]
+    return {
+        "schema_version": 1,
+        "corpus": artifact["corpus"],
+        "protocol": "single-expert-pilot-v1",
+        "scope": "single-expert exploratory pilot",
+        "limitation": "model-assisted or single-reviewer evidence; not independent validation or a production/language-wide estimate",
+        "manifest_sha256": sha256_file(manifest_path),
+        "differential_artifact_sha256": sha256_file(artifact_path),
+        "pilot_sha256": sha256_file(pilot_path),
+        "reviewer": pilot_data["reviewer"],
+        "cases": cases,
+        "counts": counts,
+        "metrics": {
+            "recall": _metric(counts["tp"], actual_positives),
+            "specificity": _metric(counts["tn"], actual_negatives),
+            "precision": _metric(counts["tp"], predicted_positives),
+            "case_coverage": _metric(actual_positives + actual_negatives, len(cases)),
+        },
+        "measurements": {
+            "deterministic_cases": deterministic_cases,
+            "novel_evidence_cases": novel_evidence_cases,
+            "case_count": len(cases),
+            "median_baseline_wall_ms": _median(baseline_times),
+            "median_review_wall_ms": _median(review_times),
+            "median_review_child_max_rss_kb": _median(rss_times),
+            "time_to_first_useful_evidence": {"status": "unavailable", "reason": "event timestamps are not captured"},
+            "decision_latency": {"status": "unavailable", "reason": "decision events are not captured"},
+            "duplicate_work": {"status": "unavailable", "reason": "baseline overlap classification is not captured"},
+        },
+    }
+
+
+def write_pilot_metrics(
+    output_path: Path,
+    artifact_path: Path,
+    pilot_path: Path,
+    manifest_path: Path,
+    differential_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    result = build_pilot_metrics(
+        artifact_path, pilot_path, manifest_path, differential_path, rules_reference, zoo_manifest
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return result

--- a/scripts/tests/test_differential.py
+++ b/scripts/tests/test_differential.py
@@ -10,6 +10,7 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from differential_contract import DifferentialManifestError, validate_differential  # noqa: E402
+import differential  # noqa: E402
 
 
 class DifferentialContractTests(unittest.TestCase):
@@ -93,6 +94,11 @@ baseline_ids = ["python.tests"]
         self.diff.write_text(text, encoding="utf-8")
         with self.assertRaisesRegex(DifferentialManifestError, "at least 2"):
             validate_differential(self.diff, self.holdout, self.rules, self.zoo)
+
+    def test_pilot_commands_require_their_artifacts(self) -> None:
+        self.assertEqual(differential.main(["pilot-template", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
+        self.assertEqual(differential.main(["pilot-validate", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
+        self.assertEqual(differential.main(["pilot-score", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_differential_novelty.py
+++ b/scripts/tests/test_differential_novelty.py
@@ -33,6 +33,18 @@ class DifferentialNoveltyTests(unittest.TestCase):
         self.assertEqual(len(base_keys), 1)
         self.assertEqual(novel, ["security.secret-candidate"])
 
+    def test_evidence_identity_orders_missing_and_present_lines(self) -> None:
+        findings = [
+            {
+                "rule_id": "demo.rule",
+                "evidence": [
+                    {"path": "demo.py", "line_start": None, "line_end": None, "snippet": "file"},
+                    {"path": "demo.py", "line_start": 1, "line_end": 1, "snippet": "line"},
+                ],
+            }
+        ]
+        self.assertEqual(len(evidence_keys(findings)), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_differential_pilot.py
+++ b/scripts/tests/test_differential_pilot.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from differential_artifact import validate_artifact  # noqa: E402
+from differential_pilot import load_pilot, render_pilot_template, validate_pilot  # noqa: E402
+from differential_pilot_metrics import build_pilot_metrics  # noqa: E402
+from real_history_runner import BASELINE_COMMANDS  # noqa: E402
+
+
+class DifferentialPilotTests(unittest.TestCase):
+    def test_template_is_blinded_and_completed_pilot_validates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            inputs = self._write_inputs(root)
+            template = root / "pilot.toml"
+            template.write_text(
+                render_pilot_template(inputs["artifact"], inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"], "expert"),
+                encoding="utf-8",
+            )
+            text = template.read_text(encoding="utf-8").replace('label = ""', 'label = "no-defect"').replace('rationale = ""', 'rationale = "reviewed exact diff"')
+            template.write_text(text, encoding="utf-8")
+            result = validate_pilot(template, inputs["artifact"], inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"])
+            rendered = template.read_text(encoding="utf-8")
+        self.assertEqual(result["status"], "valid")
+        self.assertIn("blinded = true", rendered)
+        self.assertNotIn("novel_in_diff_evidence_keys", rendered)
+
+    def test_pilot_rejects_unknown_rule(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            inputs = self._write_inputs(root)
+            template = root / "pilot.toml"
+            template.write_text(
+                render_pilot_template(inputs["artifact"], inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"], "expert").replace(
+                    'label = ""', 'label = "defect-present"', 1
+                ).replace('expected_rule_ids = []', 'expected_rule_ids = ["unknown.rule"]', 1).replace(
+                    'rationale = ""', 'rationale = "unsupported rule"', 1
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "unknown rule"):
+                validate_pilot(template, inputs["artifact"], inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"])
+
+    def test_scores_exploratory_outcomes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            inputs = self._write_inputs(root, include_novel=True)
+            pilot = root / "pilot.toml"
+            pilot.write_text(
+                render_pilot_template(inputs["artifact"], inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"], "expert")
+                .replace('label = ""', 'label = "no-defect"', 1)
+                .replace('rationale = ""', 'rationale = "reviewed first case"', 1)
+                .replace('label = ""', 'label = "uncertain"', 1)
+                .replace('rationale = ""', 'rationale = "insufficient context"', 1),
+                encoding="utf-8",
+            )
+            output = build_pilot_metrics(
+                inputs["artifact"], pilot, inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"]
+            )
+        self.assertEqual(output["scope"], "single-expert exploratory pilot")
+        self.assertEqual(output["counts"], {"tp": 0, "fn": 0, "tn": 0, "fp": 1, "excluded": 1})
+        self.assertIsNone(output["metrics"]["recall"]["value"])
+        self.assertEqual(output["measurements"]["deterministic_cases"], 2)
+
+    @staticmethod
+    def _write_inputs(root: Path, include_novel: bool = False) -> dict[str, Path]:
+        rules = root / "rules.md"
+        zoo = root / "zoo.toml"
+        manifest = root / "holdout.toml"
+        differential = root / "differential.toml"
+        artifact = root / "differential.json"
+        rules.write_text("### `demo.rule` — Demo\n### `security.secret-candidate` — Secret\n", encoding="utf-8")
+        zoo.write_text("", encoding="utf-8")
+        manifest.write_text(
+            """schema_version = 1
+corpus = "test"
+protocol = "dual-independent-adjudication-v1"
+
+[[case]]
+id = "case-one"
+repo = "owner/one"
+url = "https://github.com/owner/one.git"
+pull_request = 1
+base_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+head_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+merge_sha = "cccccccccccccccccccccccccccccccccccccccc"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile"]
+label_state = "pending"
+
+[[case]]
+id = "case-two"
+repo = "owner/two"
+url = "https://github.com/owner/two.git"
+pull_request = 2
+base_sha = "dddddddddddddddddddddddddddddddddddddddd"
+head_sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+merge_sha = "ffffffffffffffffffffffffffffffffffffffff"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.tests"]
+label_state = "pending"
+""",
+            encoding="utf-8",
+        )
+        differential.write_text(
+            """schema_version = 1
+corpus = "test"
+protocol = "differential-utility-v1"
+repetitions = 3
+measurements = ["novel-actionable-evidence", "duplicate-work", "time-to-first-useful-evidence", "decision-latency", "determinism", "resource-cost"]
+
+[[case]]
+id = "case-one"
+baseline_ids = ["python.compile"]
+
+[[case]]
+id = "case-two"
+baseline_ids = ["python.tests"]
+""",
+            encoding="utf-8",
+        )
+        cases = []
+        for case_id, repo, base_sha, head_sha, merge_sha, baseline_id in (
+            ("case-one", "owner/one", "a" * 40, "b" * 40, "c" * 40, "python.compile"),
+            ("case-two", "owner/two", "d" * 40, "e" * 40, "f" * 40, "python.tests"),
+        ):
+            novel = ["security.secret-candidate"] if include_novel and case_id == "case-one" else []
+            cases.append(
+                {
+                    "id": case_id,
+                    "repo": repo,
+                    "base_sha": base_sha,
+                    "head_sha": head_sha,
+                    "merge_sha": merge_sha,
+                    "base_scan": {"status": "collected", "wall_ms": 2.0, "evidence_keys": []},
+                    "baselines": {
+                        baseline_id: [
+                            {
+                                "command": list(BASELINE_COMMANDS[baseline_id]),
+                                "status": "passed",
+                                "wall_ms": 10.0,
+                            }
+                            for _ in range(3)
+                        ]
+                    },
+                    "reviews": [
+                        {
+                            "status": "collected",
+                            "wall_ms": 20.0,
+                            "stable_evidence_sha256": "1" * 64,
+                            "in_diff_evidence_keys": novel,
+                            "novel_in_diff_evidence_keys": novel,
+                        }
+                        for _ in range(3)
+                    ],
+                    "determinism": {"stable_evidence_deterministic": True},
+                }
+            )
+        data = {
+            "schema_version": 1,
+            "corpus": "test",
+            "protocol": "differential-utility-v1",
+            "manifest_sha256": hashlib.sha256(manifest.read_bytes()).hexdigest(),
+            "differential_manifest_sha256": hashlib.sha256(differential.read_bytes()).hexdigest(),
+            "scanner": {"mode": "explicit", "version": "0.22.0", "report_schema_version": "0.26", "workspace_version": "0.22.0"},
+            "repetitions": 3,
+            "cases": cases,
+            "label_state": "pending",
+        }
+        artifact.write_text(json.dumps(data), encoding="utf-8")
+        validate_artifact(artifact, manifest, differential, rules, zoo)
+        return {"artifact": artifact, "manifest": manifest, "differential": differential, "rules": rules, "zoo": zoo}
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -19,6 +19,14 @@ python3 scripts/differential.py collect --repo-root . \
   --output differential-run.json
 python3 scripts/differential.py validate-result \
   --artifact differential-run.json
+python3 scripts/differential.py pilot-template \
+  --artifact differential-run.json --reviewer expert \
+  --output pilot.toml
+python3 scripts/differential.py pilot-validate \
+  --artifact differential-run.json --pilot pilot.toml
+python3 scripts/differential.py pilot-score \
+  --artifact differential-run.json --pilot pilot.toml \
+  --output pilot-metrics.json
 ```
 
 It freezes the six utility measurements, the baseline set, the holdout case
@@ -66,6 +74,14 @@ RepoPilot findings. The collected artifact still needs dual-label adjudication.
 `validate-result` checks the artifact against the current manifest, including
 the manifest hash, immutable PR revisions, scanner provenance, baseline command
 allowlist, and one review observation per case.
+
+When only one expert is available, `pilot-template` creates a blinded
+`single-expert-pilot-v1` worksheet. Fill one label and rationale per case, then
+run `pilot-validate` and `pilot-score`. The resulting report is explicitly
+exploratory: it can show case-level outcomes, determinism, and captured timing
+or resource summaries, but it is not independent validation and cannot support
+a production or language-wide claim. The pilot does not modify the
+dual-review protocol or its metrics.
 
 `template` creates one deterministic worksheet per independent reviewer. It
 copies only pinned case identity and baseline statuses from the collection


### PR DESCRIPTION
## Problem
The holdout collector now produces baseline-aware repeated observations, but the project has only one available expert. The existing dual-review protocol must remain intact, while the collected data still needs a validated exploratory scoring path.

## Change
- add a separate `single-expert-pilot-v1` worksheet contract
- render blinded case worksheets that withhold RepoPilot evidence
- validate pinned identities, baseline statuses, labels, expected rules, rationales, and input hashes
- score exploratory TP/FN/TN/FP outcomes with Wilson intervals
- report deterministic cases and captured baseline/review timing/resource summaries
- explicitly mark decision latency and duplicate-work measurements unavailable when the collector has no event data
- expose `pilot-template`, `pilot-validate`, and `pilot-score` through `scripts/differential.py`
- add design/spec plan, tests, benchmark docs, changelog, and evidence-ledger boundaries

## Observed pilot
The current model-assisted pilot over the two pinned cases produces 2 TN, 0 TP/FN/FP, 0 novel-evidence cases, and deterministic reviews in 2/2 cases. Recall and precision are null because there are no positive cases. This is exploratory evidence only and is not independent validation.

## Evidence
- 121 Python tests passed
- `python3 scripts/release-contract.py check` passed
- `cargo fmt --all -- --check` passed
- `cargo clippy --all-targets --all-features -- -D warnings` passed
- self-scan passed with 0 visible P1 findings
- `npm run review:performance` passed (`changed_to_full_ratio`: 0.442)
- generated pilot worksheet and metrics validated against the collected holdout artifact
