### PR TITLE
feat: expand real-history evidence holdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   determinism/timing/resource summaries. The pilot is explicitly not
   independent validation and leaves the preregistered dual-review protocol
   unchanged.
+- Expanded the pending real-history and differential holdout from two to six
+  immutable merged pull requests across four additional Python repositories.
+  The corpus ID changed before any labels were collected while the protocol
+  contract stayed the same; earlier two-case artifacts remain historical
+  observation packets.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -235,24 +235,36 @@ bump is needed to start.
 
 ## 0F — Independent Real-History Holdout Protocol
 
-- `tests/benchmarks/manifest.toml` now reserves two immutable merged pull
-  requests from `pallets/flask` and `psf/requests`, both outside the precision
-  zoo. Each case pins full base, head, and merge SHAs and declares the existing
-  compiler/test baseline IDs that the benchmark runner must compare.
+- `tests/benchmarks/manifest.toml` now reserves six immutable merged pull
+  requests across `pallets/click`, `pallets/flask`, `pydantic/pydantic`,
+  `pytest-dev/pytest`, `psf/requests`, and `urllib3/urllib3`, all outside the
+  precision zoo. Each case pins full base, head, and merge SHAs and declares
+  the existing compiler/test baseline IDs that the benchmark runner must
+  compare. The expansion happened before labels were collected; the prior
+  two-case packets remain historical and are not reinterpreted as six-case
+  results.
 - `scripts/real_history.py` validates repository separation, immutable revision
   identity, baseline allowlists, and label lifecycle. An admissible case needs
   independent annotator A/B labels plus an adjudicated label; disagreements
   require an explicit rationale. Current cases are `pending`, so no real-
   history recall or differential utility claim is made.
 - Boundary: this is the protocol and corpus reservation only. The next slice
-  must clone the pinned revisions, execute declared baselines and RepoPilot,
-  collect labels, and publish an auditable result with denominators.
+  must clone the six pinned revisions, execute declared baselines and
+  RepoPilot, collect labels, and publish an auditable result with denominators.
 - The collector now performs the first three steps in a temporary workspace:
   exact-SHA clone/worktrees, allowlisted baseline commands, and base-to-head
-  RepoPilot review. A local run collected both cases; `python.compile` passed,
-  `python.tests` returned nonzero for both repos, and the review reports were
-  recorded with raw and stable evidence hashes. These are run observations,
-  not labels or quality estimates.
+  RepoPilot review. The earlier two-case run collected both cases;
+  `python.compile` passed, `python.tests` returned nonzero for both repos, and
+  the review reports were recorded with raw and stable evidence hashes. These
+  are run observations, not labels or quality estimates.
+- After the corpus expansion, a fresh six-case collection completed and passed
+  `validate-result`: all six compilers and tests were executed, all six reviews
+  were collected, and the differential runner completed 18 review repetitions
+  plus 36 baseline observations. Three cases emitted an in-diff architectural
+  signal, but base-aware novelty remained an observation to adjudicate rather
+  than a quality label. The pydantic compiler and all six pytest baselines
+  returned their recorded statuses; these environment outcomes are retained
+  as evidence and are not treated as defects.
 - Boundary: baseline/test failures are retained for diagnosis and are not
   interpreted as RepoPilot defects. Dual independent labels and adjudication
   are still required before recall, precision, or differential utility metrics.
@@ -280,9 +292,10 @@ bump is needed to start.
 ## 0G — Differential Utility Protocol
 
 - `tests/benchmarks/differential.toml` preregisters the utility comparison for
-  the same immutable holdout: the compiler/test baseline set, six measurements
-  (novel actionable evidence, duplicate work, time to first useful evidence,
-  decision latency, determinism, and resource cost), and three repetitions.
+  the same six-case immutable holdout: the compiler/test baseline set, six
+  measurements (novel actionable evidence, duplicate work, time to first
+  useful evidence, decision latency, determinism, and resource cost), and three
+  repetitions.
 - `scripts/differential.py check` validates that the differential case set and
   baseline IDs exactly match the independent holdout manifest. It produces no
   measurements and cannot create a utility claim by itself.

--- a/scripts/tests/test_differential.py
+++ b/scripts/tests/test_differential.py
@@ -6,6 +6,7 @@ import unittest
 from pathlib import Path
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = SCRIPTS_DIR.parent
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
@@ -99,6 +100,20 @@ baseline_ids = ["python.tests"]
         self.assertEqual(differential.main(["pilot-template", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
         self.assertEqual(differential.main(["pilot-validate", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
         self.assertEqual(differential.main(["pilot-score", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
+
+
+class ProductionDifferentialManifestTests(unittest.TestCase):
+    def test_expanded_differential_manifest_matches_holdout(self) -> None:
+        result = validate_differential(
+            PROJECT_ROOT / "tests/benchmarks/differential.toml",
+            PROJECT_ROOT / "tests/benchmarks/manifest.toml",
+            PROJECT_ROOT / "docs/rules-reference.md",
+            PROJECT_ROOT / "tests/zoo/manifest.toml",
+        )
+        self.assertEqual(result["status"], "valid")
+        self.assertEqual(result["corpus"], "v0.23-real-history-holdout-expanded")
+        self.assertEqual(result["cases"], 6)
+        self.assertEqual(result["repetitions"], 3)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_real_history.py
+++ b/scripts/tests/test_real_history.py
@@ -7,6 +7,7 @@ import unittest
 from pathlib import Path
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = SCRIPTS_DIR.parent
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
@@ -106,6 +107,29 @@ class HoldoutManifestTests(unittest.TestCase):
         self.write(case(label_state='"excluded"') + "\n" + case("case-two", "other/repo"))
         with self.assertRaisesRegex(real_history.HoldoutManifestError, "excluded case needs"):
             real_history.validate_manifest(self.manifest, self.rules, self.zoo)
+
+
+class ProductionHoldoutManifestTests(unittest.TestCase):
+    def test_expanded_corpus_is_pinned_before_adjudication(self) -> None:
+        corpus, protocol, cases = real_history.validate_manifest(
+            PROJECT_ROOT / "tests/benchmarks/manifest.toml",
+            PROJECT_ROOT / "docs/rules-reference.md",
+            PROJECT_ROOT / "tests/zoo/manifest.toml",
+        )
+        self.assertEqual((corpus, protocol), ("v0.23-real-history-holdout-expanded", "dual-independent-adjudication-v1"))
+        self.assertEqual(len(cases), 6)
+        self.assertEqual(
+            {item.case_id for item in cases},
+            {
+                "click-pr-3818",
+                "flask-pr-5812",
+                "pydantic-pr-13742",
+                "pytest-pr-14954",
+                "requests-pr-7019",
+                "urllib3-pr-5209",
+            },
+        )
+        self.assertTrue(all(item.label_state == "pending" for item in cases))
 
 
 if __name__ == "__main__":

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -29,8 +29,8 @@ python3 scripts/differential.py pilot-score \
   --output pilot-metrics.json
 ```
 
-It freezes the six utility measurements, the baseline set, the holdout case
-set, and three repetitions before a benchmark run. `collect` executes the
+It freezes the six utility measurements, the baseline set, the six-case
+holdout set, and three repetitions before a benchmark run. `collect` executes the
 allowlisted checks and repeated RepoPilot reviews on exact-SHA worktrees and
 records timings, output hashes, determinism, scanner provenance, best-effort
 child-resource samples, and the base scan's exact evidence identities. Review
@@ -64,8 +64,10 @@ python3 scripts/real_history.py metrics --artifact real-history-run.json \
   --annotation adjudication.toml --output real-history-metrics.json
 ```
 
-Both entries are intentionally `pending`. This PR does not invent defect labels
-or claim real-history recall. `collect` clones the pinned revisions into a
+All six entries are intentionally `pending`. The corpus was expanded before
+any labels were collected; the earlier two-case packets remain historical and
+are not silently merged into the expanded corpus. This PR does not invent
+defect labels or claim real-history recall. `collect` clones the pinned revisions into a
 temporary workspace, runs only the allowlisted baselines and a base-to-head
 RepoPilot review, and records statuses, output hashes, and stable evidence
 hashes. Baseline failures are retained as observations; they do not become

--- a/tests/benchmarks/differential.toml
+++ b/tests/benchmarks/differential.toml
@@ -1,5 +1,5 @@
 schema_version = 1
-corpus = "v0.23-real-history-holdout"
+corpus = "v0.23-real-history-holdout-expanded"
 protocol = "differential-utility-v1"
 repetitions = 3
 
@@ -15,7 +15,23 @@ measurements = [
 ]
 
 [[case]]
+id = "click-pr-3818"
+baseline_ids = ["python.compile", "python.tests"]
+
+[[case]]
 id = "flask-pr-5812"
+baseline_ids = ["python.compile", "python.tests"]
+
+[[case]]
+id = "pydantic-pr-13742"
+baseline_ids = ["python.compile", "python.tests"]
+
+[[case]]
+id = "pytest-pr-14954"
+baseline_ids = ["python.compile", "python.tests"]
+
+[[case]]
+id = "urllib3-pr-5209"
 baseline_ids = ["python.compile", "python.tests"]
 
 [[case]]

--- a/tests/benchmarks/manifest.toml
+++ b/tests/benchmarks/manifest.toml
@@ -1,10 +1,25 @@
 schema_version = 1
-corpus = "v0.23-real-history-holdout"
+corpus = "v0.23-real-history-holdout-expanded"
 protocol = "dual-independent-adjudication-v1"
 
 # These are immutable merged pull-request revisions from repositories outside
 # tests/zoo. Labels remain pending until two independent reviewers annotate the
-# changed behavior and a third record resolves any disagreement.
+# changed behavior and a third record resolves any disagreement. The corpus
+# was expanded from two to six cases before any labels were collected; prior
+# two-case artifacts remain historical packets and are not reinterpreted.
+[[case]]
+id = "click-pr-3818"
+repo = "pallets/click"
+url = "https://github.com/pallets/click.git"
+pull_request = 3818
+base_sha = "cbb5b2df1ee3492115f8c2ee5cbb09e2271fc714"
+head_sha = "fc518e41218b447e875fe27244ae692c269bcb77"
+merge_sha = "00f257bb8e714064bea16425007543bbc0800445"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile", "python.tests"]
+label_state = "pending"
+
 [[case]]
 id = "flask-pr-5812"
 repo = "pallets/flask"
@@ -13,6 +28,45 @@ pull_request = 5812
 base_sha = "330123258e8c3dc391cbe55ab1ed94891ca83af3"
 head_sha = "c2705ffd9ce1dc8476cb29eaf5ff5d4c719852d9"
 merge_sha = "adf363679da2d9a5ddc564bb2da563c7ca083916"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile", "python.tests"]
+label_state = "pending"
+
+[[case]]
+id = "pydantic-pr-13742"
+repo = "pydantic/pydantic"
+url = "https://github.com/pydantic/pydantic.git"
+pull_request = 13742
+base_sha = "f512b087202f58ec90a9d38c9102858567d72440"
+head_sha = "b239b4ac0e171cef11fa332c4edafbbeb50100de"
+merge_sha = "5283870ccfce82fe3cf7f374ee00df9289f0c9ab"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile", "python.tests"]
+label_state = "pending"
+
+[[case]]
+id = "pytest-pr-14954"
+repo = "pytest-dev/pytest"
+url = "https://github.com/pytest-dev/pytest.git"
+pull_request = 14954
+base_sha = "eadb5a625081a1c9db58552797fecf8c88b2508c"
+head_sha = "ee08c0015ee12ec359aa04933103637f13821838"
+merge_sha = "b0ca559dd01f4f056eeefdc4f67985008d3f3ea4"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile", "python.tests"]
+label_state = "pending"
+
+[[case]]
+id = "urllib3-pr-5209"
+repo = "urllib3/urllib3"
+url = "https://github.com/urllib3/urllib3.git"
+pull_request = 5209
+base_sha = "546f5d2419ee1331cc2a22cdf80e6bad46e92dbc"
+head_sha = "19f92b7cddf45de25d5b20df037485a861868503"
+merge_sha = "7bf6c6c728a4c81a5ba710aff7cb15a58b054aa7"
 language = "python"
 source_kind = "merged-pull-request"
 baseline_ids = ["python.compile", "python.tests"]


### PR DESCRIPTION
## Problem

The v0.23 evidence protocol had only two pending real-history cases, so any future recall or differential result would be dominated by a very small, narrow holdout.

## Change

- Expand the immutable merged-PR holdout from 2 to 6 cases across Click, Flask, Pydantic, pytest, Requests, and urllib3.
- Pin full base, head, and merge SHAs and keep every case outside the precision zoo.
- Keep the dual-review/adjudication contract unchanged and all labels `pending`.
- Align the differential manifest with the six-case corpus and add production contract tests that prevent case-set drift.
- Record the corpus expansion and evidence boundary in the benchmark README, evidence ledger, and changelog.

A fresh local collection completed on all six cases:
- `real_history.py validate-result`: 6 cases, 12 baseline observations, 6 review observations.
- `differential.py validate-result`: 6 cases, 36 baseline observations, 18 review repetitions.
- Base-aware novelty remains an unlabeled observation; no recall, precision, or utility claim is made.

## Validation

- 123 Python unit tests
- `python3 scripts/release-contract.py check`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo run --quiet -- scan . --fail-on-priority p1`
- `npm run review:performance`

