### PR TITLE
fix: distinguish unconfigured ownership from unmatched paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   The corpus ID changed before any labels were collected while the protocol
   contract stayed the same; earlier two-case artifacts remain historical
   observation packets.
+- Added explicit ownership assessment states to review output. A missing
+  CODEOWNERS file is now reported as `not_configured` and disclosed as a
+  limitation without creating an artificial unowned-surface review reason;
+  configured but unmatched paths remain review-visible.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -32,7 +32,7 @@ check does not close an item without the required fresh evidence.
 | RP23-003 | P1 evidence-gap | verified | Compatibility / 0B2 | Directional matrix now covers released producers, exact released Rust readers, baseline movement, incompatible history, synthetic transitions, and non-reader projections. Evidence is pinned by tag, asset/crate/report SHA-256, fixture, and offline regression. |
 | RP23-004 | P2 evidence-gap | open | Performance / 0E | v0.22 scorecard lacks fresh peak RSS. Close with reproducible cold/warm measurements, units, source identity, and an approved ceiling; do not infer memory from latency. |
 | RP23-005 | P2 defect | in-progress | Documentation / 0D | Historical scorecard still describes an uncut tag, while the release is published. Platform state prose also retains already-completed migration work as missing. PR 4 adds current lifecycle and scope-boundary checks; close by reconciling the remaining scorecard claims against code and fresh evidence. |
-| RP23-006 | P2 design-risk | open | Review/readiness / A | Absent CODEOWNERS produces unowned paths and review reasons. Close with explicit absent/configured-unmatched/resolved states and regression coverage; do not claim a config policy is violated when it does not exist. |
+| RP23-006 | P2 design-risk | in-progress | Review/readiness / A | Absent CODEOWNERS produces unowned paths and review reasons. Close with explicit absent/configured-unmatched/resolved states and regression coverage; do not claim a config policy is violated when it does not exist. |
 | RP23-007 | P2 defect | open | Decision UX / 0D–A | Decision and readiness are printed separately; finding-only plan counts omit signal verification guidance. Close with accurate current copy, then one canonical Phase A obligations model and projection parity. |
 | RP23-008 | P2 limitation | open | Semantic review / B | Manifest/workflow boundary classification is path-based. Close only for supported semantic families with metadata-only safe guards; preserve unknown forms and strict recall. |
 | RP23-009 | P2 design-risk | open | Coverage UX / 0D–A | PASS and visible health scores can be read as broader proof than analyzed scope. Close with assessed-scope copy and a capability ledger; excluded files or hidden suggestions are not automatically missed defects. |
@@ -317,3 +317,17 @@ bump is needed to start.
   measurements the collector actually captured. It is explicitly model-assisted
   or single-reviewer evidence; it does not alter the dual-review protocol and
   cannot close RP23-014 by itself.
+
+## 0H — Ownership Assessment Semantics
+
+- Review ownership now has three explicit states: `resolved` when configured
+  rules name all assessed paths, `configured_but_unmatched` when a CODEOWNERS
+  source exists but leaves paths without a match, and `not_configured` when no
+  CODEOWNERS source exists.
+- A missing CODEOWNERS file is disclosed in JSON, console, and Markdown output
+  and added to limitations. It no longer creates an `UnownedSurface` reason or
+  changes a clean review to `REVIEW`; configured unmatched paths retain that
+  review reason.
+- Regression coverage checks all three states and the JSON/console/Markdown
+  projections. The implementation is ready for merge; RP23-006 remains open
+  until the change is merged and the release ledger is refreshed.

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -23,7 +23,8 @@ pub use ci::review_report_for_ci;
 pub use gate::{ReviewSignalGatePolicy, ReviewSignalGateResult};
 pub use impact::{AffectedSurface, FileImpact, ImpactPaths, compute_impact_paths};
 pub use ownership::{
-    Owner, OwnershipDiagnostic, OwnershipDiscovery, OwnershipIndex, OwnershipSummary, PathOwnership,
+    Owner, OwnershipAssessment, OwnershipDiagnostic, OwnershipDiscovery, OwnershipIndex,
+    OwnershipSummary, PathOwnership,
 };
 pub use readiness::{
     MergeReadinessRecord, ReadinessReason, ReadinessReasonCode, ReadinessVerdict, derive_readiness,

--- a/src/review/ownership/mod.rs
+++ b/src/review/ownership/mod.rs
@@ -2,4 +2,4 @@ mod codeowners;
 mod model;
 
 pub use codeowners::{OwnershipDiscovery, OwnershipIndex};
-pub use model::{Owner, OwnershipDiagnostic, OwnershipSummary, PathOwnership};
+pub use model::{Owner, OwnershipAssessment, OwnershipDiagnostic, OwnershipSummary, PathOwnership};

--- a/src/review/ownership/model.rs
+++ b/src/review/ownership/model.rs
@@ -24,8 +24,19 @@ pub struct PathOwnership {
     pub fallback_boundary: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OwnershipAssessment {
+    Resolved,
+    ConfiguredButUnmatched,
+    #[default]
+    NotConfigured,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct OwnershipSummary {
+    #[serde(default)]
+    pub assessment: OwnershipAssessment,
     pub paths: Vec<PathOwnership>,
     pub suggested_owners: Vec<Owner>,
     pub unowned_paths: Vec<String>,
@@ -61,10 +72,11 @@ impl OwnershipSummary {
         let mut summary = Self::default();
         let mut owners = BTreeSet::new();
         let mut boundaries = BTreeSet::new();
+        let configured = index.source().is_some();
         for path in normalized {
             let matched = index.owners_for(path.as_ref());
             let boundary = matched.is_empty().then(|| fallback_boundary(&path));
-            if matched.is_empty() {
+            if configured && matched.is_empty() {
                 summary.unowned_paths.push(path.clone());
             }
             if let Some(boundary) = &boundary {
@@ -79,6 +91,13 @@ impl OwnershipSummary {
         }
         summary.suggested_owners = owners.into_iter().collect();
         summary.fallback_boundaries = boundaries.into_iter().collect();
+        summary.assessment = if !configured {
+            OwnershipAssessment::NotConfigured
+        } else if summary.unowned_paths.is_empty() {
+            OwnershipAssessment::Resolved
+        } else {
+            OwnershipAssessment::ConfiguredButUnmatched
+        };
         summary
     }
 }

--- a/src/review/readiness/derive.rs
+++ b/src/review/readiness/derive.rs
@@ -5,6 +5,7 @@ use crate::findings::redaction::human_verification_step;
 use crate::history::RiskDelta;
 use crate::review::gate::ReviewSignalGateResult;
 use crate::review::model::ReviewReport;
+use crate::review::ownership::OwnershipAssessment;
 use crate::risk::RiskPriority;
 use crate::verification::VerificationStatus;
 use std::collections::BTreeSet;
@@ -205,6 +206,12 @@ fn limitations(report: &ReviewReport) -> Vec<String> {
         vec!["Selected local checks do not resolve or suppress static evidence; unselected checks remain unverified."
             .to_string()]
     };
+    if report.ownership.assessment == OwnershipAssessment::NotConfigured {
+        limitations.push(
+            "Ownership is not assessed because the repository has no CODEOWNERS configuration."
+                .to_string(),
+        );
+    }
     if !report.ownership.unowned_paths.is_empty() {
         limitations.push(
             "Unowned paths use package or directory boundaries, not inferred people.".to_string(),

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -6,6 +6,7 @@ use crate::output::{DetailLevel, FindingRenderLimit};
 use crate::review::ReviewSignalGateResult;
 use crate::review::derive_readiness;
 use crate::review::model::ReviewReport;
+use crate::review::ownership::OwnershipAssessment;
 use crate::review::proof::derive_change_proof_from_review;
 use crate::review::render::ReviewRenderOptions;
 use crate::review::render::helpers::verification_duration_evidence;
@@ -67,6 +68,16 @@ fn render_console_header(
         "Merge readiness: {}\n",
         readiness.verdict.label().to_uppercase()
     ));
+    match readiness.ownership.assessment {
+        OwnershipAssessment::Resolved => output.push_str("Ownership: resolved\n"),
+        OwnershipAssessment::ConfiguredButUnmatched => output.push_str(&format!(
+            "Ownership: configured, {} path(s) unmatched\n",
+            readiness.ownership.unowned_paths.len()
+        )),
+        OwnershipAssessment::NotConfigured => {
+            output.push_str("Ownership: not configured (not assessed)\n")
+        }
+    }
     if !readiness.ownership.suggested_owners.is_empty() {
         output.push_str(&format!(
             "Suggested owners: {}\n",

--- a/src/review/render/markdown.rs
+++ b/src/review/render/markdown.rs
@@ -6,6 +6,7 @@ use crate::output::render_helpers::escape_table_cell;
 use crate::review::ReviewSignalGateResult;
 use crate::review::derive_readiness;
 use crate::review::model::ReviewReport;
+use crate::review::ownership::OwnershipAssessment;
 use crate::review::render::helpers::verification_duration_evidence;
 use crate::review::render::helpers::{render_ranges, status_for_finding};
 use crate::review::signals::tiered::ReviewSignal;
@@ -35,6 +36,15 @@ pub fn render_markdown_with_gates(
         "- **Merge readiness:** `{}`\n",
         readiness.verdict.label()
     ));
+    let ownership_status = match readiness.ownership.assessment {
+        OwnershipAssessment::Resolved => "resolved".to_string(),
+        OwnershipAssessment::ConfiguredButUnmatched => format!(
+            "configured, {} path(s) unmatched",
+            readiness.ownership.unowned_paths.len()
+        ),
+        OwnershipAssessment::NotConfigured => "not configured (not assessed)".to_string(),
+    };
+    output.push_str(&format!("- **Ownership:** `{ownership_status}`\n"));
     if !readiness.ownership.suggested_owners.is_empty() {
         output.push_str(&format!(
             "- **Suggested owners:** {}\n",

--- a/tests/review_ownership.rs
+++ b/tests/review_ownership.rs
@@ -1,5 +1,7 @@
 use repopilot::review::diff::{ChangeStatus, ChangedFile};
-use repopilot::review::{FileImpact, ImpactPaths, OwnershipIndex, OwnershipSummary};
+use repopilot::review::{
+    FileImpact, ImpactPaths, OwnershipAssessment, OwnershipIndex, OwnershipSummary,
+};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -55,7 +57,8 @@ fn missing_codeowners_reports_stable_boundaries_without_inventing_people() {
     );
 
     assert!(summary.suggested_owners.is_empty());
-    assert_eq!(summary.unowned_paths.len(), 3);
+    assert_eq!(summary.assessment, OwnershipAssessment::NotConfigured);
+    assert!(summary.unowned_paths.is_empty());
     assert_eq!(summary.fallback_boundaries, vec![".", "src"]);
 }
 

--- a/tests/review_readiness.rs
+++ b/tests/review_readiness.rs
@@ -3,7 +3,8 @@ use repopilot::findings::types::Severity;
 use repopilot::review::diff::{ChangeStatus, ChangedFile};
 use repopilot::review::model::ReviewReport;
 use repopilot::review::{
-    MergeReadinessRecord, OwnershipSummary, ReadinessReasonCode, ReadinessVerdict, derive_readiness,
+    MergeReadinessRecord, OwnershipAssessment, OwnershipSummary, ReadinessReasonCode,
+    ReadinessVerdict, derive_readiness,
 };
 use repopilot::scan::types::{ScanMetadata, ScanMetrics, ScanMode, ScanSummary};
 use repopilot::verification::{VerificationOutcome, VerificationRole, VerificationStatus};
@@ -27,18 +28,57 @@ fn failed_finding_gate_is_blocked_with_stable_reason_code() {
 
 #[test]
 fn unowned_changed_surface_requires_review() {
+    let index = repopilot::review::OwnershipIndex::from_codeowners(
+        "/src/ @team\n",
+        PathBuf::from("CODEOWNERS"),
+    )
+    .unwrap();
+    let ownership = OwnershipSummary::for_paths([PathBuf::from("docs/architecture.md")], &index);
+    let readiness = derive_readiness(&report_with_ownership(ownership), None, None, None);
+
+    assert_eq!(readiness.verdict, ReadinessVerdict::Review);
+    assert_eq!(
+        readiness.ownership.assessment,
+        OwnershipAssessment::ConfiguredButUnmatched
+    );
+    assert!(
+        readiness.reasons.iter().any(|reason| {
+            reason.code == ReadinessReasonCode::UnownedSurface && reason.count == 1
+        })
+    );
+}
+
+#[test]
+fn missing_codeowners_is_disclosed_without_becoming_a_review_reason() {
     let ownership = OwnershipSummary::for_paths(
         [PathBuf::from("src/auth/session.rs")],
         &repopilot::review::OwnershipIndex::empty(),
     );
     let readiness = derive_readiness(&report_with_ownership(ownership), None, None, None);
 
-    assert_eq!(readiness.verdict, ReadinessVerdict::Review);
-    assert!(
-        readiness.reasons.iter().any(|reason| {
-            reason.code == ReadinessReasonCode::UnownedSurface && reason.count == 1
-        })
+    assert_eq!(readiness.verdict, ReadinessVerdict::Ready);
+    assert_eq!(
+        readiness.ownership.assessment,
+        OwnershipAssessment::NotConfigured
     );
+    assert!(readiness.ownership.unowned_paths.is_empty());
+    assert!(
+        !readiness
+            .reasons
+            .iter()
+            .any(|reason| { reason.code == ReadinessReasonCode::UnownedSurface })
+    );
+    assert!(
+        readiness
+            .limitations
+            .iter()
+            .any(|item| { item.contains("Ownership is not assessed") })
+    );
+    let report = report_with_ownership(readiness.ownership.clone());
+    let console = repopilot::review::render::render_console(&report, None);
+    let markdown = repopilot::review::render::render_markdown(&report, None);
+    assert!(console.contains("Ownership: not configured (not assessed)"));
+    assert!(markdown.contains("**Ownership:** `not configured (not assessed)`"));
 }
 
 #[test]
@@ -52,6 +92,10 @@ fn clean_owned_change_is_ready() {
     let readiness = derive_readiness(&report_with_ownership(ownership), None, None, None);
 
     assert_eq!(readiness.verdict, ReadinessVerdict::Ready);
+    assert_eq!(
+        readiness.ownership.assessment,
+        OwnershipAssessment::Resolved
+    );
     assert!(readiness.reasons.is_empty());
 }
 
@@ -79,6 +123,10 @@ fn review_json_projects_the_canonical_readiness_record() {
         json["merge_readiness"]["ownership"]["suggested_owners"][0]["value"],
         "@team"
     );
+    assert_eq!(
+        json["merge_readiness"]["ownership"]["assessment"],
+        "resolved"
+    );
     assert!(json["merge_readiness"]["limitations"].is_array());
 }
 
@@ -100,7 +148,9 @@ fn human_reports_project_readiness_and_owners() {
     assert!(console.contains("Change Proof: REVIEW"));
     assert!(console.contains("Proof scope: 1/1 file(s) analyzed"));
     assert!(console.contains("Suggested owners: @team"));
+    assert!(console.contains("Ownership: resolved"));
     assert!(markdown.contains("**Merge readiness:** `ready`"));
+    assert!(markdown.contains("**Ownership:** `resolved`"));
     assert!(markdown.contains("**Suggested owners:** `@team`"));
 }
 


### PR DESCRIPTION
## Problem

A repository without CODEOWNERS was represented as an unowned surface. That made a clean change look like a review requirement even though no ownership policy existed.

## Change

- Add explicit ownership states: `resolved`, `configured_but_unmatched`, and `not_configured`.
- Keep unmatched paths review-visible when CODEOWNERS exists.
- Treat missing CODEOWNERS as a disclosed limitation, without emitting an artificial `UnownedSurface` reason.
- Project the state consistently through JSON, console, and Markdown output.
- Add regression coverage for all three states and update the v0.23 evidence ledger.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo run --quiet -- scan . --fail-on-priority p1`
- `python3 scripts/release-contract.py check`
- `npm run review:performance`

