### PR TITLE
fix: make proof coverage limits explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   CODEOWNERS file is now reported as `not_configured` and disclosed as a
   limitation without creating an artificial unowned-surface review reason;
   configured but unmatched paths remain review-visible.
+- Made ChangeProof coverage explicit: known skipped files are separated from
+  residual unsupported scope, incomplete coverage produces a stable review
+  reason, and console/Markdown now show the same proof limits as JSON.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -35,7 +35,7 @@ check does not close an item without the required fresh evidence.
 | RP23-006 | P2 design-risk | in-progress | Review/readiness / A | Absent CODEOWNERS produces unowned paths and review reasons. Close with explicit absent/configured-unmatched/resolved states and regression coverage; do not claim a config policy is violated when it does not exist. |
 | RP23-007 | P2 defect | open | Decision UX / 0D–A | Decision and readiness are printed separately; finding-only plan counts omit signal verification guidance. Close with accurate current copy, then one canonical Phase A obligations model and projection parity. |
 | RP23-008 | P2 limitation | open | Semantic review / B | Manifest/workflow boundary classification is path-based. Close only for supported semantic families with metadata-only safe guards; preserve unknown forms and strict recall. |
-| RP23-009 | P2 design-risk | open | Coverage UX / 0D–A | PASS and visible health scores can be read as broader proof than analyzed scope. Close with assessed-scope copy and a capability ledger; excluded files or hidden suggestions are not automatically missed defects. |
+| RP23-009 | P2 design-risk | in-progress | Coverage UX / 0D–A | PASS and visible health scores can be read as broader proof than analyzed scope. Close with assessed-scope copy and a capability ledger; excluded files or hidden suggestions are not automatically missed defects. |
 | RP23-010 | P2 evidence-gap | open | Rule quality / E | Committed scorecard reports three strict-only dead-module false positives and many rules without zoo evidence. Close each measured issue with safe/unsafe regression and fresh labeled evidence; never label unmeasured rules clean. |
 | RP23-011 | P2 defect | in-progress | Release contract / 0D | `check_roadmap_docs()` checks v0.20 headings/links only. PR 4 adds focused v0.23 lifecycle/link and scope-boundary contract tests while retaining older supported docs. Close after the current claims and tests are merged. |
 | RP23-012 | P2 design-risk | open | Proof semantics / A | A failed lint/check is not necessarily contract breakage, and no selected checks is not sufficient proof. Roadmap wording now makes this explicit; close only when Phase A truth tables and runtime projection tests enforce it. |
@@ -331,3 +331,17 @@ bump is needed to start.
 - Regression coverage checks all three states and the JSON/console/Markdown
   projections. The implementation is ready for merge; RP23-006 remains open
   until the change is merged and the release ledger is refreshed.
+
+## 0I — Proof Coverage Ledger
+
+- ChangeProof coverage now separates known exclusions (large, binary,
+  low-signal, configured-limit, and RepoPilot-ignored files) from residual
+  unsupported or unavailable scope instead of reporting every unanalyzed file
+  as one undifferentiated exclusion.
+- Any excluded or unsupported requested file adds an explicit
+  `scope-coverage-incomplete` reason and keeps the verdict at `REVIEW` (or
+  preserves a stronger `BROKEN` verdict). JSON, console, and Markdown expose
+  the same analyzed/requested scope and proof limits.
+- Regression coverage includes direct proof derivation, a changed-review path
+  with an excluded file, and output projection. This is scope accounting, not
+  evidence that an excluded file contains or does not contain a defect.

--- a/src/review/proof.rs
+++ b/src/review/proof.rs
@@ -33,6 +33,7 @@ impl ChangeProofVerdict {
 pub enum ChangeProofReasonCode {
     BrokenContract,
     ScopeNotAssessed,
+    ScopeCoverageIncomplete,
     RequiredVerificationFailed,
     RequiredVerificationUnavailable,
     RequiredVerificationUnselected,
@@ -139,8 +140,10 @@ pub fn derive_change_proof(input: ChangeProofInput) -> ChangeProof {
                 "Supported evidence proves a changed contract is broken.",
             ),
         );
+        add_scope_coverage_reason(&mut reasons, &input.coverage);
         ChangeProofVerdict::Broken
     } else {
+        add_scope_coverage_reason(&mut reasons, &input.coverage);
         add_obligation_reasons(&mut reasons, input.obligations);
         if !input.obligations.accounted_for() {
             add_reason(
@@ -190,6 +193,9 @@ pub fn derive_change_proof_from_review(
         ScanMode::Full => report.summary.metrics.files_discovered,
     };
     let analyzed_files = report.summary.metrics.files_analyzed;
+    let excluded_files = known_excluded_files(report, requested_files);
+    let unsupported_files =
+        requested_files.saturating_sub(analyzed_files.saturating_add(excluded_files));
     let (satisfied, failed, unavailable, unselected, stale) = verification_counts(report);
     let reasons = readiness
         .reasons
@@ -206,8 +212,8 @@ pub fn derive_change_proof_from_review(
             },
             requested_files,
             analyzed_files,
-            excluded_files: requested_files.saturating_sub(analyzed_files),
-            unsupported_files: 0,
+            excluded_files,
+            unsupported_files,
         },
         obligations: ProofObligations {
             applicable: report.verification.len(),
@@ -223,6 +229,17 @@ pub fn derive_change_proof_from_review(
     });
     proof.contract_deltas = contract_deltas;
     proof
+}
+
+fn known_excluded_files(report: &ReviewReport, requested_files: usize) -> usize {
+    let metrics = &report.summary.metrics;
+    metrics
+        .large_files_skipped
+        .saturating_add(metrics.files_skipped_low_signal)
+        .saturating_add(metrics.binary_files_skipped)
+        .saturating_add(metrics.files_skipped_by_limit)
+        .saturating_add(metrics.files_skipped_repopilotignore)
+        .min(requested_files)
 }
 
 fn verification_counts(report: &ReviewReport) -> (usize, usize, usize, usize, usize) {
@@ -317,6 +334,22 @@ impl ProofObligations {
     fn accounted_for(self) -> bool {
         self.satisfied + self.failed + self.unavailable + self.unselected + self.stale
             == self.applicable
+    }
+}
+
+fn add_scope_coverage_reason(reasons: &mut Vec<ChangeProofReason>, coverage: &ProofCoverage) {
+    let count = coverage
+        .excluded_files
+        .saturating_add(coverage.unsupported_files);
+    if count > 0 {
+        add_reason(
+            reasons,
+            ChangeProofReason::new(
+                ChangeProofReasonCode::ScopeCoverageIncomplete,
+                count,
+                "Some requested files were excluded or unsupported, so the proof does not cover the full scope.",
+            ),
+        );
     }
 }
 

--- a/src/review/proof_tests.rs
+++ b/src/review/proof_tests.rs
@@ -99,6 +99,28 @@ fn complete_sufficient_policy_is_verified() {
 }
 
 #[test]
+fn incomplete_scope_coverage_keeps_proof_at_review() {
+    let proof = derive_change_proof(ChangeProofInput {
+        coverage: ProofCoverage {
+            scope: ProofScope::Changed,
+            requested_files: 3,
+            analyzed_files: 2,
+            excluded_files: 1,
+            unsupported_files: 0,
+        },
+        obligations: obligations(),
+        sufficient_policy: true,
+        broken_contracts: 0,
+        reasons: Vec::new(),
+    });
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::Review);
+    assert!(proof.reasons.iter().any(|reason| {
+        reason.code == ChangeProofReasonCode::ScopeCoverageIncomplete && reason.count == 1
+    }));
+}
+
+#[test]
 fn static_only_policy_cannot_claim_verified() {
     let proof = derive_change_proof(ChangeProofInput {
         coverage: coverage(1),

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -64,6 +64,12 @@ fn render_console_header(
         proof.obligations.satisfied,
         proof.obligations.applicable,
     ));
+    if proof.coverage.excluded_files > 0 || proof.coverage.unsupported_files > 0 {
+        output.push_str(&format!(
+            "Proof limits: {} excluded, {} unsupported file(s)\n",
+            proof.coverage.excluded_files, proof.coverage.unsupported_files
+        ));
+    }
     output.push_str(&format!(
         "Merge readiness: {}\n",
         readiness.verdict.label().to_uppercase()

--- a/src/review/render/markdown.rs
+++ b/src/review/render/markdown.rs
@@ -7,6 +7,7 @@ use crate::review::ReviewSignalGateResult;
 use crate::review::derive_readiness;
 use crate::review::model::ReviewReport;
 use crate::review::ownership::OwnershipAssessment;
+use crate::review::proof::derive_change_proof_from_review;
 use crate::review::render::helpers::verification_duration_evidence;
 use crate::review::render::helpers::{render_ranges, status_for_finding};
 use crate::review::signals::tiered::ReviewSignal;
@@ -32,10 +33,28 @@ pub fn render_markdown_with_gates(
         review_gate,
         report.summary.artifacts.risk_delta.as_ref(),
     );
+    let proof = derive_change_proof_from_review(report, &readiness);
     output.push_str(&format!(
         "- **Merge readiness:** `{}`\n",
         readiness.verdict.label()
     ));
+    output.push_str(&format!(
+        "- **Change proof:** `{}`\n",
+        proof.verdict.label()
+    ));
+    output.push_str(&format!(
+        "- **Proof scope:** {}/{} file(s) analyzed; obligations: {}/{} satisfied\n",
+        proof.coverage.analyzed_files,
+        proof.coverage.requested_files,
+        proof.obligations.satisfied,
+        proof.obligations.applicable,
+    ));
+    if proof.coverage.excluded_files > 0 || proof.coverage.unsupported_files > 0 {
+        output.push_str(&format!(
+            "- **Proof limits:** {} excluded, {} unsupported file(s)\n",
+            proof.coverage.excluded_files, proof.coverage.unsupported_files
+        ));
+    }
     let ownership_status = match readiness.ownership.assessment {
         OwnershipAssessment::Resolved => "resolved".to_string(),
         OwnershipAssessment::ConfiguredButUnmatched => format!(

--- a/tests/change_proof_pipeline.rs
+++ b/tests/change_proof_pipeline.rs
@@ -41,6 +41,34 @@ fn real_changed_review_keeps_static_only_at_review() {
 }
 
 #[test]
+fn partial_scope_is_review_with_explicit_coverage_limits() {
+    let temp = prepared_repo();
+    fs::write(
+        temp.path().join("src/lib.rs"),
+        "pub fn answer() -> u8 { 42 }\n",
+    )
+    .unwrap();
+
+    let mut report = review_report(&temp);
+    let extra_changed_file = report.changed_files[0].clone();
+    report.changed_files.push(extra_changed_file);
+    report.summary.metrics.large_files_skipped = 1;
+    let readiness = derive_readiness(&report, None, None, None);
+    let proof = derive_change_proof_from_review(&report, &readiness);
+
+    assert_eq!(proof.verdict, ChangeProofVerdict::Review);
+    assert_eq!(proof.coverage.requested_files, 2);
+    assert_eq!(proof.coverage.analyzed_files, 1);
+    assert_eq!(proof.coverage.excluded_files, 1);
+    assert_eq!(proof.coverage.unsupported_files, 0);
+    assert!(proof.reasons.iter().any(|reason| {
+        reason.code == ChangeProofReasonCode::ScopeCoverageIncomplete && reason.count == 1
+    }));
+    let console = repopilot::review::render::render_console(&report, None);
+    assert!(console.contains("Proof limits: 1 excluded, 0 unsupported file(s)"));
+}
+
+#[test]
 fn real_failed_verification_stays_review_not_broken() {
     let temp = prepared_repo();
     fs::write(

--- a/tests/review_readiness.rs
+++ b/tests/review_readiness.rs
@@ -150,6 +150,8 @@ fn human_reports_project_readiness_and_owners() {
     assert!(console.contains("Suggested owners: @team"));
     assert!(console.contains("Ownership: resolved"));
     assert!(markdown.contains("**Merge readiness:** `ready`"));
+    assert!(markdown.contains("**Change proof:** `REVIEW`"));
+    assert!(markdown.contains("**Proof scope:** 1/1 file(s) analyzed"));
     assert!(markdown.contains("**Ownership:** `resolved`"));
     assert!(markdown.contains("**Suggested owners:** `@team`"));
 }


### PR DESCRIPTION
## Problem

ChangeProof exposed analyzed/requested counts, but it collapsed every unanalyzed file into one exclusion count and could leave the proof scope too easy to overread.

## Change

- Separate known exclusions (large, binary, low-signal, configured-limit, and RepoPilot-ignored files) from residual unsupported scope.
- Add the stable `scope-coverage-incomplete` reason when requested coverage is partial.
- Keep partial coverage at `REVIEW`; a stronger `BROKEN` verdict remains stronger while still carrying the limitation.
- Project the same proof verdict, scope, and limits through JSON, console, and Markdown.
- Add direct, changed-review, and projection regression coverage.
- Record the boundary in the v0.23 evidence ledger and changelog.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo run --quiet -- scan . --fail-on-priority p1`
- `python3 scripts/release-contract.py check`
- `npm run review:performance`

