### PR TITLE
feat: add proof capability coverage ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Made ChangeProof coverage explicit: known skipped files are separated from
   residual unsupported scope, incomplete coverage produces a stable review
   reason, and console/Markdown now show the same proof limits as JSON.
+- Added an additive ChangeProof capability ledger with stable IDs and explicit
+  `assessed`, `limited`, and `unavailable` statuses for scope, verification,
+  and supported contract-delta evidence.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -345,3 +345,7 @@ bump is needed to start.
 - Regression coverage includes direct proof derivation, a changed-review path
   with an excluded file, and output projection. This is scope accounting, not
   evidence that an excluded file contains or does not contain a defect.
+- ChangeProof now also emits an additive capability ledger with stable IDs for
+  analyzed scope, exclusions, unsupported scope, verification state, and
+  supported contract deltas. Statuses are `assessed`, `limited`, or
+  `unavailable`; a zero count remains explicit rather than being omitted.

--- a/src/review/proof.rs
+++ b/src/review/proof.rs
@@ -5,7 +5,10 @@ use crate::review::readiness::{MergeReadinessRecord, ReadinessReasonCode};
 use crate::scan::types::ScanMode;
 use crate::verification::VerificationStatus;
 
+mod capabilities;
 mod contracts;
+use capabilities::capability_coverage;
+pub use capabilities::{ProofCapability, ProofCapabilityStatus};
 pub use contracts::{ChangeProofContractDelta, ContractChangeKind, ContractFamily};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -117,6 +120,7 @@ pub struct ChangeProof {
     pub coverage: ProofCoverage,
     pub obligations: ProofObligations,
     pub contract_deltas: Vec<ChangeProofContractDelta>,
+    pub capability_coverage: Vec<ProofCapability>,
 }
 
 pub fn derive_change_proof(input: ChangeProofInput) -> ChangeProof {
@@ -172,12 +176,14 @@ pub fn derive_change_proof(input: ChangeProofInput) -> ChangeProof {
         }
     };
     reasons.sort_by_key(|reason| reason.code);
+    let capability_coverage = capability_coverage(&input.coverage, input.obligations);
     ChangeProof {
         verdict,
         reasons,
         coverage: input.coverage,
         obligations: input.obligations,
         contract_deltas: Vec::new(),
+        capability_coverage,
     }
 }
 
@@ -228,6 +234,12 @@ pub fn derive_change_proof_from_review(
         reasons,
     });
     proof.contract_deltas = contract_deltas;
+    proof.capability_coverage.push(ProofCapability {
+        id: "contract-deltas".to_string(),
+        status: ProofCapabilityStatus::Assessed,
+        count: proof.contract_deltas.len(),
+        message: "Supported semantic contract changes detected in the review.".to_string(),
+    });
     proof
 }
 

--- a/src/review/proof/capabilities.rs
+++ b/src/review/proof/capabilities.rs
@@ -1,0 +1,79 @@
+use serde::Serialize;
+
+use super::{ProofCoverage, ProofObligations};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProofCapabilityStatus {
+    Assessed,
+    Limited,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProofCapability {
+    pub id: String,
+    pub status: ProofCapabilityStatus,
+    pub count: usize,
+    pub message: String,
+}
+
+pub(super) fn capability_coverage(
+    coverage: &ProofCoverage,
+    obligations: ProofObligations,
+) -> Vec<ProofCapability> {
+    let mut capabilities = vec![
+        ProofCapability {
+            id: "scope.analyzed-files".to_string(),
+            status: ProofCapabilityStatus::Assessed,
+            count: coverage.analyzed_files,
+            message: "Files included in the supported analysis scope.".to_string(),
+        },
+        ProofCapability {
+            id: "scope.excluded-files".to_string(),
+            status: if coverage.excluded_files > 0 {
+                ProofCapabilityStatus::Limited
+            } else {
+                ProofCapabilityStatus::Assessed
+            },
+            count: coverage.excluded_files,
+            message: "Files skipped by an explicit repository or scanner exclusion.".to_string(),
+        },
+        ProofCapability {
+            id: "scope.unsupported-files".to_string(),
+            status: if coverage.unsupported_files > 0 {
+                ProofCapabilityStatus::Unavailable
+            } else {
+                ProofCapabilityStatus::Assessed
+            },
+            count: coverage.unsupported_files,
+            message: "Requested files without a supported analysis result.".to_string(),
+        },
+    ];
+    let unresolved = obligations
+        .failed
+        .saturating_add(obligations.unavailable)
+        .saturating_add(obligations.unselected)
+        .saturating_add(obligations.stale);
+    capabilities.push(ProofCapability {
+        id: "verification".to_string(),
+        status: if obligations.applicable == 0 {
+            ProofCapabilityStatus::Unavailable
+        } else if unresolved > 0 {
+            ProofCapabilityStatus::Limited
+        } else {
+            ProofCapabilityStatus::Assessed
+        },
+        count: if unresolved > 0 {
+            unresolved
+        } else {
+            obligations.satisfied
+        },
+        message: if obligations.applicable == 0 {
+            "No verification obligation was selected for this assessment.".to_string()
+        } else {
+            "Selected verification obligations and their revision state.".to_string()
+        },
+    });
+    capabilities
+}

--- a/src/review/proof_tests.rs
+++ b/src/review/proof_tests.rs
@@ -96,6 +96,16 @@ fn complete_sufficient_policy_is_verified() {
 
     assert_eq!(proof.verdict, ChangeProofVerdict::Verified);
     assert!(proof.reasons.is_empty());
+    assert!(proof.capability_coverage.iter().any(|item| {
+        item.id == "scope.analyzed-files"
+            && item.status == ProofCapabilityStatus::Assessed
+            && item.count == 1
+    }));
+    assert!(proof.capability_coverage.iter().any(|item| {
+        item.id == "verification"
+            && item.status == ProofCapabilityStatus::Assessed
+            && item.count == 1
+    }));
 }
 
 #[test]
@@ -117,6 +127,11 @@ fn incomplete_scope_coverage_keeps_proof_at_review() {
     assert_eq!(proof.verdict, ChangeProofVerdict::Review);
     assert!(proof.reasons.iter().any(|reason| {
         reason.code == ChangeProofReasonCode::ScopeCoverageIncomplete && reason.count == 1
+    }));
+    assert!(proof.capability_coverage.iter().any(|item| {
+        item.id == "scope.excluded-files"
+            && item.status == ProofCapabilityStatus::Limited
+            && item.count == 1
     }));
 }
 

--- a/tests/review_readiness.rs
+++ b/tests/review_readiness.rs
@@ -118,6 +118,7 @@ fn review_json_projects_the_canonical_readiness_record() {
     assert_eq!(json["change_proof"]["coverage"]["scope"], "changed");
     assert_eq!(json["change_proof"]["coverage"]["analyzed_files"], 1);
     assert_eq!(json["change_proof"]["obligations"]["applicable"], 0);
+    assert!(json["change_proof"]["capability_coverage"].is_array());
     assert_eq!(json["merge_readiness"]["impact"]["depth"], 0);
     assert_eq!(
         json["merge_readiness"]["ownership"]["suggested_owners"][0]["value"],


### PR DESCRIPTION
## Problem

ChangeProof now reports scope limits, but the JSON record did not identify each capability and its evidence status in a stable form.

## Change

- Add an additive capability ledger to ChangeProof with stable IDs.
- Report explicit `assessed`, `limited`, and `unavailable` statuses.
- Cover analyzed files, excluded files, unsupported files, verification state, and supported contract deltas.
- Keep zero-count scope categories explicit instead of omitting them.
- Add regression coverage for complete and partial proof states.
- Keep the contract local, deterministic, and compatible with existing fields.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo run --quiet -- scan . --fail-on-priority p1`
- `python3 scripts/release-contract.py check`
- `npm run review:performance`

