### PR TITLE
feat: add semantic dependency contract deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added an additive ChangeProof capability ledger with stable IDs and explicit
   `assessed`, `limited`, and `unavailable` statuses for scope, verification,
   and supported contract-delta evidence.
+- Added the first dependency contract deltas for Cargo and npm manifests:
+  additions, removals, upgrades, downgrades, source changes, feature changes,
+  and metadata-only edits now have typed evidence. Lockfile changes remain
+  explicitly limited when a zero-context diff cannot identify the package.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -34,7 +34,7 @@ check does not close an item without the required fresh evidence.
 | RP23-005 | P2 defect | in-progress | Documentation / 0D | Historical scorecard still describes an uncut tag, while the release is published. Platform state prose also retains already-completed migration work as missing. PR 4 adds current lifecycle and scope-boundary checks; close by reconciling the remaining scorecard claims against code and fresh evidence. |
 | RP23-006 | P2 design-risk | in-progress | Review/readiness / A | Absent CODEOWNERS produces unowned paths and review reasons. Close with explicit absent/configured-unmatched/resolved states and regression coverage; do not claim a config policy is violated when it does not exist. |
 | RP23-007 | P2 defect | open | Decision UX / 0D–A | Decision and readiness are printed separately; finding-only plan counts omit signal verification guidance. Close with accurate current copy, then one canonical Phase A obligations model and projection parity. |
-| RP23-008 | P2 limitation | open | Semantic review / B | Manifest/workflow boundary classification is path-based. Close only for supported semantic families with metadata-only safe guards; preserve unknown forms and strict recall. |
+| RP23-008 | P2 limitation | in-progress | Semantic review / B | Cargo/npm manifest dependency deltas now have typed evidence and metadata-only guards; workflow semantics and stronger lockfile identity remain open. Close only for supported semantic families with metadata-only safe guards; preserve unknown forms and strict recall. |
 | RP23-009 | P2 design-risk | in-progress | Coverage UX / 0D–A | PASS and visible health scores can be read as broader proof than analyzed scope. Close with assessed-scope copy and a capability ledger; excluded files or hidden suggestions are not automatically missed defects. |
 | RP23-010 | P2 evidence-gap | open | Rule quality / E | Committed scorecard reports three strict-only dead-module false positives and many rules without zoo evidence. Close each measured issue with safe/unsafe regression and fresh labeled evidence; never label unmeasured rules clean. |
 | RP23-011 | P2 defect | in-progress | Release contract / 0D | `check_roadmap_docs()` checks v0.20 headings/links only. PR 4 adds focused v0.23 lifecycle/link and scope-boundary contract tests while retaining older supported docs. Close after the current claims and tests are merged. |
@@ -349,3 +349,24 @@ bump is needed to start.
   analyzed scope, exclusions, unsupported scope, verification state, and
   supported contract deltas. Statuses are `assessed`, `limited`, or
   `unavailable`; a zero count remains explicit rather than being omitted.
+
+## 0J — Dependency Contract Deltas
+
+- ChangeProof now recognizes supported Cargo `Cargo.toml` and npm
+  `package.json` dependency edits from the changed-line evidence already held
+  by review. A paired dependency line is classified as added, removed,
+  upgraded, downgraded, source-changed, feature-changed, or metadata-only.
+- Cargo and npm manifest metadata edits are emitted separately as
+  `metadata-only`, so a package description, license, or script edit does not
+  become a dependency transition. Dependency deltas carry the manifest path,
+  subject, evidence text, and confidence.
+- Cargo/npm-family lockfiles are disclosed as `limited` metadata-only evidence
+  when the zero-context diff cannot safely resolve the package identity. This
+  avoids inventing an upgrade or downgrade from a bare `version = ...` line.
+- Dependency deltas are impact evidence, not broken-contract proof; only the
+  existing removed-export contract can currently produce `BROKEN`. Regression
+  tests cover Cargo version/source/feature changes, npm additions plus
+  metadata, and the lockfile limitation.
+- Boundary: this slice does not yet resolve workspace aliases, dynamic package
+  metadata, lockfile package identity, or workflow/action semantics. Those are
+  the next semantic-contract slices and remain review-visible limitations.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -206,6 +206,13 @@ Initial delivery slices:
    trust boundaries to impacted entrypoints and corresponding changed tests
    without claiming coverage that static naming cannot prove.
 
+Current progress: the first dependency-contract slice is implemented for
+Cargo `Cargo.toml` and npm `package.json` changed-line evidence. It emits
+typed dependency additions, removals, version direction, source changes,
+feature changes, and metadata-only edits. Lockfile identity remains explicitly
+limited when a zero-context diff cannot resolve the package. Workflow/action
+contracts and stronger resolver-backed lockfile semantics remain future slices.
+
 Each contract delta records:
 
 - stable contract identity and family;

--- a/src/review/proof.rs
+++ b/src/review/proof.rs
@@ -9,7 +9,9 @@ mod capabilities;
 mod contracts;
 use capabilities::capability_coverage;
 pub use capabilities::{ProofCapability, ProofCapabilityStatus};
-pub use contracts::{ChangeProofContractDelta, ContractChangeKind, ContractFamily};
+pub use contracts::{
+    ChangeProofContractDelta, ContractChangeKind, ContractConfidence, ContractFamily,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -230,7 +232,10 @@ pub fn derive_change_proof_from_review(
             stale,
         },
         sufficient_policy: !report.verification.is_empty(),
-        broken_contracts: contract_deltas.len(),
+        broken_contracts: contract_deltas
+            .iter()
+            .filter(|delta| delta.is_broken())
+            .count(),
         reasons,
     });
     proof.contract_deltas = contract_deltas;

--- a/src/review/proof/contracts/dependency.rs
+++ b/src/review/proof/contracts/dependency.rs
@@ -1,0 +1,230 @@
+use crate::review::diff::ChangedFile;
+
+use super::*;
+
+#[path = "dependency/parse.rs"]
+mod parse;
+use parse::*;
+
+pub(super) fn dependency_deltas(changed_files: &[ChangedFile]) -> Vec<ChangeProofContractDelta> {
+    let mut deltas = Vec::new();
+    for file in changed_files {
+        let Some(kind) = manifest_kind(&file.path) else {
+            continue;
+        };
+        let path = file.path_string();
+        if kind == ManifestKind::Lockfile {
+            if file.hunks.iter().any(|hunk| {
+                hunk.added_lines
+                    .iter()
+                    .chain(&hunk.removed_lines)
+                    .any(|line| {
+                        let line = line.trim_start();
+                        line.starts_with("version =")
+                            || line.starts_with("\"version\":")
+                            || line.starts_with("version:")
+                    })
+            }) {
+                deltas.push(delta(
+                    &path,
+                    "lockfile resolution",
+                    ContractChangeKind::MetadataOnly,
+                    None,
+                    "Lockfile resolution changed, but this diff does not prove the package identity or exact dependency transition.",
+                    ContractConfidence::Limited,
+                ));
+            }
+            continue;
+        }
+
+        for hunk in &file.hunks {
+            let removed = hunk
+                .removed_lines
+                .iter()
+                .filter_map(|line| {
+                    parse_dependency_edit(kind, line, hunk.old_range.map(|r| r.start))
+                })
+                .collect::<Vec<_>>();
+            let added = hunk
+                .added_lines
+                .iter()
+                .filter_map(|line| {
+                    parse_dependency_edit(kind, line, hunk.new_range.map(|r| r.start))
+                })
+                .collect::<Vec<_>>();
+            let mut paired = Vec::new();
+            for old in &removed {
+                if let Some(index) = added.iter().position(|new| new.name == old.name) {
+                    paired.push((old.clone(), added[index].clone()));
+                }
+            }
+            for (old, new) in paired {
+                let change = classify_pair(&old.specification, &new.specification);
+                deltas.push(delta(
+                    &path,
+                    &new.name,
+                    change,
+                    new.line.or(old.line),
+                    &format!(
+                        "{} dependency `{}` changed from `{}` to `{}`.",
+                        manifest_label(kind),
+                        new.name,
+                        old.specification,
+                        new.specification
+                    ),
+                    ContractConfidence::High,
+                ));
+            }
+            for edit in removed
+                .iter()
+                .filter(|old| !added.iter().any(|new| new.name == old.name))
+            {
+                deltas.push(delta(
+                    &path,
+                    &edit.name,
+                    ContractChangeKind::Removed,
+                    edit.line,
+                    &format!(
+                        "{} dependency `{}` was removed.",
+                        manifest_label(kind),
+                        edit.name
+                    ),
+                    ContractConfidence::High,
+                ));
+            }
+            for edit in added
+                .iter()
+                .filter(|new| !removed.iter().any(|old| old.name == new.name))
+            {
+                deltas.push(delta(
+                    &path,
+                    &edit.name,
+                    ContractChangeKind::Added,
+                    edit.line,
+                    &format!(
+                        "{} dependency `{}` was added.",
+                        manifest_label(kind),
+                        edit.name
+                    ),
+                    ContractConfidence::High,
+                ));
+            }
+            if hunk
+                .added_lines
+                .iter()
+                .chain(&hunk.removed_lines)
+                .any(|line| is_metadata_line(kind, line))
+            {
+                deltas.push(delta(
+                    &path,
+                    "manifest metadata",
+                    ContractChangeKind::MetadataOnly,
+                    hunk.new_range.or(hunk.old_range).map(|range| range.start),
+                    "Manifest metadata changed without a recognized dependency transition.",
+                    ContractConfidence::High,
+                ));
+            }
+        }
+    }
+    deltas.sort_by(|left, right| {
+        left.exporter_path
+            .cmp(&right.exporter_path)
+            .then(left.consumer_path.cmp(&right.consumer_path))
+            .then(left.line_start.cmp(&right.line_start))
+            .then(left.change.cmp(&right.change))
+    });
+    deltas
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::diff::{ChangeStatus, ChangedRange, DiffHunk};
+    use std::path::PathBuf;
+
+    fn changed(path: &str, added: &[&str], removed: &[&str]) -> ChangedFile {
+        ChangedFile {
+            path: PathBuf::from(path),
+            status: ChangeStatus::Modified,
+            ranges: vec![ChangedRange { start: 4, end: 4 }],
+            hunks: vec![DiffHunk {
+                new_range: Some(ChangedRange { start: 4, end: 4 }),
+                old_range: Some(ChangedRange { start: 4, end: 4 }),
+                added_lines: added.iter().map(|line| (*line).to_string()).collect(),
+                removed_lines: removed.iter().map(|line| (*line).to_string()).collect(),
+            }],
+        }
+    }
+
+    #[test]
+    fn cargo_dependency_version_change_is_upgraded() {
+        let deltas = dependency_deltas(&[changed(
+            "Cargo.toml",
+            &["serde = { version = \"1.0.210\", features = [\"derive\"] }"],
+            &["serde = { version = \"1.0.200\", features = [\"derive\"] }"],
+        )]);
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].family, ContractFamily::Dependency);
+        assert_eq!(deltas[0].change, ContractChangeKind::Upgraded);
+        assert_eq!(deltas[0].consumer_path, "serde");
+    }
+
+    #[test]
+    fn cargo_dependency_source_and_feature_changes_are_typed() {
+        let source = dependency_deltas(&[changed(
+            "Cargo.toml",
+            &["thing = { git = \"https://example.invalid/new.git\" }"],
+            &["thing = { git = \"https://example.invalid/old.git\" }"],
+        )]);
+        let feature = dependency_deltas(&[changed(
+            "Cargo.toml",
+            &["thing = { version = \"1.0\", features = [\"serde\"] }"],
+            &["thing = { version = \"1.0\" }"],
+        )]);
+
+        assert_eq!(source[0].change, ContractChangeKind::SourceChanged);
+        assert_eq!(feature[0].change, ContractChangeKind::FeatureChanged);
+    }
+
+    #[test]
+    fn npm_dependency_addition_and_metadata_are_separate() {
+        let deltas = dependency_deltas(&[changed(
+            "package.json",
+            &[
+                "    \"react\": \"^19.0.0\",",
+                "    \"description\": \"new\",",
+            ],
+            &["    \"description\": \"old\","],
+        )]);
+
+        assert!(deltas.iter().any(
+            |delta| delta.consumer_path == "react" && delta.change == ContractChangeKind::Added
+        ));
+        assert!(deltas.iter().any(|delta| {
+            delta.consumer_path == "manifest metadata"
+                && delta.change == ContractChangeKind::MetadataOnly
+        }));
+    }
+
+    #[test]
+    fn lockfile_change_is_limited_without_package_identity() {
+        let deltas = dependency_deltas(&[changed(
+            "Cargo.lock",
+            &["version = \"1.1.0\""],
+            &["version = \"1.0.0\""],
+        )]);
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].change, ContractChangeKind::MetadataOnly);
+        assert_eq!(deltas[0].confidence, Some(ContractConfidence::Limited));
+
+        let npm_deltas = dependency_deltas(&[changed(
+            "package-lock.json",
+            &["    \"version\": \"2.0.0\","],
+            &["    \"version\": \"1.0.0\","],
+        )]);
+        assert_eq!(npm_deltas.len(), 1);
+        assert_eq!(npm_deltas[0].confidence, Some(ContractConfidence::Limited));
+    }
+}

--- a/src/review/proof/contracts/dependency/parse.rs
+++ b/src/review/proof/contracts/dependency/parse.rs
@@ -1,0 +1,246 @@
+use super::super::{
+    ChangeProofContractDelta, ContractChangeKind, ContractConfidence, ContractFamily,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ManifestKind {
+    Cargo,
+    Npm,
+    Lockfile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DependencyEdit {
+    pub(super) name: String,
+    pub(super) specification: String,
+    pub(super) line: Option<usize>,
+}
+
+pub(super) fn manifest_kind(path: &std::path::Path) -> Option<ManifestKind> {
+    match path.file_name()?.to_str()? {
+        "Cargo.toml" => Some(ManifestKind::Cargo),
+        "package.json" => Some(ManifestKind::Npm),
+        "Cargo.lock" | "package-lock.json" | "pnpm-lock.yaml" | "yarn.lock" => {
+            Some(ManifestKind::Lockfile)
+        }
+        _ => None,
+    }
+}
+
+pub(super) fn parse_dependency_edit(
+    kind: ManifestKind,
+    line: &str,
+    line_start: Option<usize>,
+) -> Option<DependencyEdit> {
+    let trimmed = line.trim();
+    if kind == ManifestKind::Cargo {
+        let (name, specification) = trimmed.split_once('=')?;
+        let name = name.trim();
+        let specification = specification.trim().trim_end_matches(',').to_string();
+        if !is_cargo_dependency_name(name) || !looks_like_cargo_specification(&specification) {
+            return None;
+        }
+        return Some(DependencyEdit {
+            name: name.to_string(),
+            specification,
+            line: line_start,
+        });
+    }
+    let trimmed = trimmed.strip_prefix('"')?;
+    let (name, specification) = trimmed.split_once("\":")?;
+    let name = name.trim();
+    let specification = specification
+        .trim()
+        .trim_end_matches(',')
+        .trim_matches('"')
+        .to_string();
+    if !is_npm_dependency_name(name) || !looks_like_npm_specification(&specification) {
+        return None;
+    }
+    Some(DependencyEdit {
+        name: name.to_string(),
+        specification,
+        line: line_start,
+    })
+}
+
+fn is_cargo_dependency_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+        && !matches!(
+            name,
+            "name"
+                | "version"
+                | "edition"
+                | "authors"
+                | "description"
+                | "license"
+                | "repository"
+                | "homepage"
+                | "documentation"
+                | "readme"
+                | "build"
+                | "rust-version"
+                | "resolver"
+                | "workspace"
+                | "members"
+                | "default-members"
+                | "default"
+                | "publish"
+                | "links"
+        )
+}
+
+fn is_npm_dependency_name(name: &str) -> bool {
+    !name.is_empty()
+        && !matches!(
+            name,
+            "name"
+                | "version"
+                | "description"
+                | "private"
+                | "scripts"
+                | "main"
+                | "module"
+                | "types"
+                | "type"
+                | "license"
+                | "repository"
+                | "homepage"
+                | "engines"
+                | "files"
+                | "keywords"
+                | "author"
+                | "contributors"
+        )
+        && (name.starts_with('@') || name.contains('-') || name.contains('/') || name.len() > 1)
+}
+
+fn looks_like_cargo_specification(specification: &str) -> bool {
+    specification.starts_with('{')
+        || specification == "*"
+        || version_number(specification).is_some()
+}
+
+fn looks_like_npm_specification(specification: &str) -> bool {
+    specification
+        .chars()
+        .next()
+        .is_some_and(|character| matches!(character, '^' | '~' | '>' | '<' | '=' | '*'))
+        || specification == "latest"
+        || specification.starts_with("workspace:")
+        || specification.starts_with("file:")
+        || specification.starts_with("git")
+        || version_number(specification).is_some()
+}
+
+pub(super) fn is_metadata_line(kind: ManifestKind, line: &str) -> bool {
+    let trimmed = line.trim();
+    match kind {
+        ManifestKind::Cargo => {
+            trimmed.starts_with("description =")
+                || trimmed.starts_with("license =")
+                || trimmed.starts_with("repository =")
+                || trimmed.starts_with("homepage =")
+                || trimmed.starts_with("readme =")
+        }
+        ManifestKind::Npm => {
+            trimmed.starts_with("\"description\":")
+                || trimmed.starts_with("\"homepage\":")
+                || trimmed.starts_with("\"repository\":")
+                || trimmed.starts_with("\"license\":")
+                || trimmed.starts_with("\"private\":")
+                || trimmed.starts_with("\"version\":")
+                || trimmed.starts_with("\"scripts\":")
+        }
+        ManifestKind::Lockfile => false,
+    }
+}
+
+pub(super) fn classify_pair(old: &str, new: &str) -> ContractChangeKind {
+    if source_part(old) != source_part(new) {
+        ContractChangeKind::SourceChanged
+    } else if feature_part(old) != feature_part(new) {
+        ContractChangeKind::FeatureChanged
+    } else {
+        match (version_number(old), version_number(new)) {
+            (Some(old), Some(new)) if new > old => ContractChangeKind::Upgraded,
+            (Some(old), Some(new)) if new < old => ContractChangeKind::Downgraded,
+            _ if normalize_specification(old) == normalize_specification(new) => {
+                ContractChangeKind::MetadataOnly
+            }
+            _ => ContractChangeKind::MetadataOnly,
+        }
+    }
+}
+
+fn source_part(specification: &str) -> String {
+    specification
+        .split([',', '}'])
+        .filter(|part| {
+            part.contains("git")
+                || part.contains("path")
+                || part.contains("workspace")
+                || part.contains("file:")
+                || part.contains("https://")
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn feature_part(specification: &str) -> String {
+    specification
+        .split([',', '}', ']'])
+        .filter(|part| part.contains("feature") || part.contains("optional"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn version_number(specification: &str) -> Option<(u64, u64, u64)> {
+    let digits = specification
+        .split(|character: char| !character.is_ascii_digit() && character != '.')
+        .find(|part| !part.is_empty() && part.chars().any(|c| c.is_ascii_digit()))?;
+    let mut parts = digits.split('.').map(|part| part.parse::<u64>().ok());
+    Some((
+        parts.next()??,
+        parts.next()??,
+        parts.next().unwrap_or(Some(0))?,
+    ))
+}
+
+fn normalize_specification(specification: &str) -> String {
+    specification
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect()
+}
+
+pub(super) fn manifest_label(kind: ManifestKind) -> &'static str {
+    match kind {
+        ManifestKind::Cargo => "Cargo",
+        ManifestKind::Npm => "npm",
+        ManifestKind::Lockfile => "lockfile",
+    }
+}
+
+pub(super) fn delta(
+    path: &str,
+    subject: &str,
+    change: ContractChangeKind,
+    line: Option<usize>,
+    evidence: &str,
+    confidence: ContractConfidence,
+) -> ChangeProofContractDelta {
+    ChangeProofContractDelta {
+        family: ContractFamily::Dependency,
+        change,
+        exporter_path: path.to_string(),
+        consumer_path: subject.to_string(),
+        line_start: line,
+        line_end: line,
+        evidence: evidence.to_string(),
+        confidence: Some(confidence),
+    }
+}

--- a/src/review/proof/contracts/mod.rs
+++ b/src/review/proof/contracts/mod.rs
@@ -2,18 +2,28 @@ use serde::Serialize;
 
 use crate::review::model::ReviewReport;
 
+mod dependency;
+
 const REMOVED_EXPORT_SIGNAL: &str = "behavioral.removed-export-still-imported";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ContractFamily {
     PublicSymbol,
+    Dependency,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ContractChangeKind {
     RemovedExport,
+    Added,
+    Removed,
+    Upgraded,
+    Downgraded,
+    SourceChanged,
+    FeatureChanged,
+    MetadataOnly,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -28,6 +38,22 @@ pub struct ChangeProofContractDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_end: Option<usize>,
     pub evidence: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<ContractConfidence>,
+}
+
+impl ChangeProofContractDelta {
+    pub(crate) fn is_broken(&self) -> bool {
+        self.family == ContractFamily::PublicSymbol
+            && self.change == ContractChangeKind::RemovedExport
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContractConfidence {
+    High,
+    Limited,
 }
 
 pub(crate) fn from_review(report: &ReviewReport) -> Vec<ChangeProofContractDelta> {
@@ -48,9 +74,11 @@ pub(crate) fn from_review(report: &ReviewReport) -> Vec<ChangeProofContractDelta
                     .detail
                     .clone()
                     .unwrap_or_else(|| signal.headline.clone()),
+                confidence: Some(ContractConfidence::High),
             })
         })
         .collect::<Vec<_>>();
+    deltas.extend(dependency::dependency_deltas(&report.changed_files));
     deltas.sort_by(|left, right| {
         left.exporter_path
             .cmp(&right.exporter_path)


### PR DESCRIPTION
## Problem

Review currently recognizes a dependency-sensitive manifest mostly by path. That says a package surface changed, but not whether the dependency was added, removed, upgraded, downgraded, moved to another source, had features changed, or only had metadata edited.

## Change

- add a typed `dependency` contract family to `ChangeProof`;
- classify supported Cargo `Cargo.toml` and npm `package.json` changed-line pairs as `added`, `removed`, `upgraded`, `downgraded`, `source-changed`, `feature-changed`, or `metadata-only`;
- keep dependency deltas as impact evidence rather than treating them as broken contracts;
- emit explicit `limited` lockfile evidence when a zero-context diff cannot prove package identity;
- preserve the existing removed-public-export `BROKEN` behavior and add confidence to contract evidence;
- add regression tests and update the v0.23 roadmap/evidence ledger/changelog.

## Validation

- `cargo test --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- scan . --fail-on-priority p1`
- `python3 scripts/release-contract.py check`

All passed. The self-scan still reports the repository's pre-existing contract warnings for three evidence scripts; it reports zero visible findings and passes the P1 gate.

## Follow-up

This is the first dependency-contract slice. The next slice will resolve lockfile package identity where the revision evidence supports it, then add workflow/action contracts while preserving explicit unsupported/limited states.
