### PR TITLE
feat: expand semantic contract map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   additions, removals, upgrades, downgrades, source changes, feature changes,
   and metadata-only edits now have typed evidence. Lockfile changes remain
   explicitly limited when a zero-context diff cannot identify the package.
+- Expanded the semantic contract map across three review surfaces: Cargo
+  lockfile hunk context can now retain package identity, workflow/action edits
+  classify trigger, permission, secret, action-reference, artifact, and deploy
+  changes, and runtime configuration edits classify introduced, removed,
+  renamed, or changed keys with changed-diff consumer evidence.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -34,7 +34,7 @@ check does not close an item without the required fresh evidence.
 | RP23-005 | P2 defect | in-progress | Documentation / 0D | Historical scorecard still describes an uncut tag, while the release is published. Platform state prose also retains already-completed migration work as missing. PR 4 adds current lifecycle and scope-boundary checks; close by reconciling the remaining scorecard claims against code and fresh evidence. |
 | RP23-006 | P2 design-risk | in-progress | Review/readiness / A | Absent CODEOWNERS produces unowned paths and review reasons. Close with explicit absent/configured-unmatched/resolved states and regression coverage; do not claim a config policy is violated when it does not exist. |
 | RP23-007 | P2 defect | open | Decision UX / 0D–A | Decision and readiness are printed separately; finding-only plan counts omit signal verification guidance. Close with accurate current copy, then one canonical Phase A obligations model and projection parity. |
-| RP23-008 | P2 limitation | in-progress | Semantic review / B | Cargo/npm manifest dependency deltas now have typed evidence and metadata-only guards; workflow semantics and stronger lockfile identity remain open. Close only for supported semantic families with metadata-only safe guards; preserve unknown forms and strict recall. |
+| RP23-008 | P2 limitation | in-progress | Semantic review / B | Dependency, delivery, and runtime-config deltas now have typed evidence with explicit limited states; workspace aliases, opaque lockfiles, unchanged consumers, and unknown workflow/config forms remain open. Close only for supported semantic families with metadata-only safe guards; preserve unknown forms and strict recall. |
 | RP23-009 | P2 design-risk | in-progress | Coverage UX / 0D–A | PASS and visible health scores can be read as broader proof than analyzed scope. Close with assessed-scope copy and a capability ledger; excluded files or hidden suggestions are not automatically missed defects. |
 | RP23-010 | P2 evidence-gap | open | Rule quality / E | Committed scorecard reports three strict-only dead-module false positives and many rules without zoo evidence. Close each measured issue with safe/unsafe regression and fresh labeled evidence; never label unmeasured rules clean. |
 | RP23-011 | P2 defect | in-progress | Release contract / 0D | `check_roadmap_docs()` checks v0.20 headings/links only. PR 4 adds focused v0.23 lifecycle/link and scope-boundary contract tests while retaining older supported docs. Close after the current claims and tests are merged. |
@@ -368,5 +368,28 @@ bump is needed to start.
   tests cover Cargo version/source/feature changes, npm additions plus
   metadata, and the lockfile limitation.
 - Boundary: this slice does not yet resolve workspace aliases, dynamic package
-  metadata, lockfile package identity, or workflow/action semantics. Those are
-  the next semantic-contract slices and remain review-visible limitations.
+  metadata, or opaque lockfile package identity. Those forms remain
+  review-visible limitations.
+
+## 0K — Delivery and Runtime Contract Deltas
+
+- Git hunk headers are retained as internal diff evidence. Cargo lockfile
+  version changes with a structural `name = ...` header now produce a typed
+  package-level upgrade/downgrade or source change. When the header is absent,
+  the result remains `metadata-only` with `limited` confidence.
+- Workflow and action changes are classified for supported paths under
+  `.github/workflows/` and `action.yml`: trigger, permission, secret use,
+  action reference, artifact, and deployment behavior. The detector emits only
+  recognized semantic lines and leaves unknown YAML forms unclaimed.
+- Runtime configuration changes in `.env*` and `config/` paths are classified
+  as introduced, removed, renamed, or changed keys. A changed-scope consumer
+  such as `process.env.KEY`, `getenv("KEY")`, or `System.getenv("KEY")` raises
+  confidence; without one, the delta is retained as `limited` evidence.
+- These families are impact evidence and do not create `BROKEN`; only the
+  existing removed-public-export contract currently proves a broken contract.
+  Tests cover lockfile identity, workflow permissions/action refs/triggers, and
+  runtime key introduction/removal/rename guards.
+- Boundary: this slice does not resolve all YAML/TOML/JSON nesting, unchanged
+  consumers outside the diff, workspace-specific runtime aliases, or dynamic
+  configuration access. Those forms remain limitations rather than invented
+  contract claims.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -209,9 +209,13 @@ Initial delivery slices:
 Current progress: the first dependency-contract slice is implemented for
 Cargo `Cargo.toml` and npm `package.json` changed-line evidence. It emits
 typed dependency additions, removals, version direction, source changes,
-feature changes, and metadata-only edits. Lockfile identity remains explicitly
-limited when a zero-context diff cannot resolve the package. Workflow/action
-contracts and stronger resolver-backed lockfile semantics remain future slices.
+feature changes, and metadata-only edits. Cargo lockfile hunk context now
+retains package identity when Git provides a structural header; opaque
+lockfiles remain explicitly limited. Workflow/action contracts now classify
+trigger, permission, secret, action-reference, artifact, and deployment
+changes. Runtime configuration contracts now classify key introduction,
+removal, rename, and value changes, with high confidence only when a consumer
+also appears in the changed scope.
 
 Each contract delta records:
 

--- a/src/review/diff.rs
+++ b/src/review/diff.rs
@@ -72,6 +72,9 @@ pub struct ChangedFile {
 /// body line is either an addition or a removal — there are no context lines.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiffHunk {
+    /// Optional text after the hunk marker. Git uses this to expose a nearby
+    /// structural header such as `name = "beta"` in Cargo.lock.
+    pub header: Option<String>,
     /// Added-line range in the post-change file. `None` for a pure-deletion
     /// hunk (`@@ -a,b +c,0 @@`), which carries only removed lines.
     pub new_range: Option<ChangedRange>,
@@ -355,6 +358,7 @@ fn consume_diff_line(
     if line.starts_with("@@") {
         finish_hunk(file, hunk);
         *hunk = Some(DiffHunk {
+            header: parse_hunk_header(line),
             new_range: parse_hunk_added_range(line),
             old_range: parse_hunk_removed_range(line),
             added_lines: Vec::new(),
@@ -363,6 +367,12 @@ fn consume_diff_line(
         return;
     }
     append_hunk_line(line, hunk);
+}
+
+fn parse_hunk_header(line: &str) -> Option<String> {
+    let (_, suffix) = line.strip_prefix("@@")?.split_once("@@")?;
+    let header = suffix.trim();
+    (!header.is_empty()).then(|| header.to_string())
 }
 
 fn finish_current_file(

--- a/src/review/diff/tests.rs
+++ b/src/review/diff/tests.rs
@@ -35,6 +35,7 @@ index 1111111..2222222 100644
     assert_eq!(file.ranges, vec![ChangedRange { start: 10, end: 12 }]);
     assert_eq!(file.hunks.len(), 1);
     let hunk = &file.hunks[0];
+    assert_eq!(hunk.header.as_deref(), Some("fn main()"));
     assert_eq!(hunk.new_range, Some(ChangedRange { start: 10, end: 12 }));
     assert_eq!(hunk.added_lines, vec!["new one", "new two", "new three"]);
     assert_eq!(hunk.removed_lines, vec!["old one", "old two"]);

--- a/src/review/proof/contracts/delivery.rs
+++ b/src/review/proof/contracts/delivery.rs
@@ -1,0 +1,231 @@
+use crate::review::diff::ChangedFile;
+
+use super::*;
+
+pub(super) fn delivery_deltas(changed_files: &[ChangedFile]) -> Vec<ChangeProofContractDelta> {
+    let mut deltas = Vec::new();
+    for file in changed_files {
+        if !is_delivery_path(&file.path_string()) {
+            continue;
+        }
+        let path = file.path_string();
+        for hunk in &file.hunks {
+            let removed = hunk
+                .removed_lines
+                .iter()
+                .filter_map(|line| classify_line(line))
+                .collect::<Vec<_>>();
+            let added = hunk
+                .added_lines
+                .iter()
+                .filter_map(|line| classify_line(line))
+                .collect::<Vec<_>>();
+            for kind in [
+                DeliveryChange::Trigger,
+                DeliveryChange::Permission,
+                DeliveryChange::Secret,
+                DeliveryChange::Action,
+                DeliveryChange::Artifact,
+                DeliveryChange::Deployment,
+            ] {
+                let old = removed.iter().find(|item| item.kind == kind);
+                let new = added.iter().find(|item| item.kind == kind);
+                let Some(current) = new.or(old) else {
+                    continue;
+                };
+                let evidence = match (old, new) {
+                    (Some(old), Some(new)) => format!(
+                        "Delivery {} changed from `{}` to `{}`.",
+                        kind.label(),
+                        old.subject,
+                        new.subject
+                    ),
+                    (None, Some(new)) => {
+                        format!("Delivery {} introduced as `{}`.", kind.label(), new.subject)
+                    }
+                    (Some(old), None) => {
+                        format!("Delivery {} removed from `{}`.", kind.label(), old.subject)
+                    }
+                    _ => unreachable!(),
+                };
+                deltas.push(delta(
+                    &path,
+                    &current.subject,
+                    kind.change_kind(),
+                    hunk.new_range.or(hunk.old_range).map(|range| range.start),
+                    &evidence,
+                ));
+            }
+        }
+    }
+    deltas.sort_by(|left, right| {
+        left.exporter_path
+            .cmp(&right.exporter_path)
+            .then(left.consumer_path.cmp(&right.consumer_path))
+            .then(left.line_start.cmp(&right.line_start))
+    });
+    deltas
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeliveryChange {
+    Trigger,
+    Permission,
+    Secret,
+    Action,
+    Artifact,
+    Deployment,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DeliveryEdit {
+    kind: DeliveryChange,
+    subject: String,
+}
+
+impl DeliveryChange {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Trigger => "trigger",
+            Self::Permission => "permission",
+            Self::Secret => "secret use",
+            Self::Action => "action reference",
+            Self::Artifact => "artifact behavior",
+            Self::Deployment => "deployment behavior",
+        }
+    }
+
+    fn change_kind(self) -> ContractChangeKind {
+        match self {
+            Self::Trigger => ContractChangeKind::TriggerChanged,
+            Self::Permission => ContractChangeKind::PermissionChanged,
+            Self::Secret => ContractChangeKind::SecretUseChanged,
+            Self::Action => ContractChangeKind::ActionReferenceChanged,
+            Self::Artifact => ContractChangeKind::ArtifactChanged,
+            Self::Deployment => ContractChangeKind::DeploymentChanged,
+        }
+    }
+}
+
+fn is_delivery_path(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    lower.contains(".github/workflows/")
+        || lower.ends_with("/action.yml")
+        || lower.ends_with("/action.yaml")
+        || lower == "action.yml"
+        || lower == "action.yaml"
+}
+
+fn classify_line(line: &str) -> Option<DeliveryEdit> {
+    let trimmed = line.trim();
+    let normalized = trimmed.strip_prefix("- ").unwrap_or(trimmed);
+    let lower = normalized.to_ascii_lowercase();
+    let (kind, subject) = if lower.starts_with("permissions:") || lower.starts_with("permissions.")
+    {
+        (DeliveryChange::Permission, normalized.to_string())
+    } else if lower.starts_with("on:") || lower.starts_with("\"on\":") {
+        (DeliveryChange::Trigger, normalized.to_string())
+    } else if lower.starts_with("uses:") {
+        (
+            DeliveryChange::Action,
+            trimmed
+                .split_once(':')
+                .map(|(_, value)| value.trim().to_string())
+                .unwrap_or_else(|| trimmed.to_string()),
+        )
+    } else if lower.starts_with("secrets:")
+        || lower.contains("secrets.")
+        || lower.contains("secretname")
+    {
+        (DeliveryChange::Secret, normalized.to_string())
+    } else if lower.contains("upload-artifact")
+        || lower.contains("download-artifact")
+        || lower.contains("artifact")
+    {
+        (DeliveryChange::Artifact, normalized.to_string())
+    } else if lower.contains("deploy")
+        || lower.contains("kubectl")
+        || lower.contains("helm ")
+        || lower.contains("docker push")
+        || lower.contains("aws ")
+        || lower.contains("gcloud")
+        || lower.contains("azure/login")
+        || lower.starts_with("environment:")
+    {
+        (DeliveryChange::Deployment, normalized.to_string())
+    } else {
+        return None;
+    };
+    Some(DeliveryEdit { kind, subject })
+}
+
+fn delta(
+    path: &str,
+    subject: &str,
+    change: ContractChangeKind,
+    line: Option<usize>,
+    evidence: &str,
+) -> ChangeProofContractDelta {
+    ChangeProofContractDelta {
+        family: ContractFamily::Delivery,
+        change,
+        exporter_path: path.to_string(),
+        consumer_path: subject.to_string(),
+        line_start: line,
+        line_end: line,
+        evidence: evidence.to_string(),
+        confidence: Some(ContractConfidence::High),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::diff::{ChangeStatus, ChangedRange, DiffHunk};
+    use std::path::PathBuf;
+
+    fn changed(path: &str, added: &[&str], removed: &[&str]) -> ChangedFile {
+        ChangedFile {
+            path: PathBuf::from(path),
+            status: ChangeStatus::Modified,
+            ranges: vec![ChangedRange { start: 4, end: 4 }],
+            hunks: vec![DiffHunk {
+                header: None,
+                new_range: Some(ChangedRange { start: 4, end: 4 }),
+                old_range: Some(ChangedRange { start: 4, end: 4 }),
+                added_lines: added.iter().map(|line| (*line).to_string()).collect(),
+                removed_lines: removed.iter().map(|line| (*line).to_string()).collect(),
+            }],
+        }
+    }
+
+    #[test]
+    fn workflow_permission_change_is_typed() {
+        let deltas = delivery_deltas(&[changed(
+            ".github/workflows/ci.yml",
+            &["permissions: write-all"],
+            &["permissions: read-all"],
+        )]);
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].family, ContractFamily::Delivery);
+        assert_eq!(deltas[0].change, ContractChangeKind::PermissionChanged);
+    }
+
+    #[test]
+    fn workflow_action_and_trigger_changes_are_typed() {
+        let action = delivery_deltas(&[changed(
+            ".github/workflows/ci.yml",
+            &["- uses: actions/checkout@v5"],
+            &["- uses: actions/checkout@v4"],
+        )]);
+        let trigger = delivery_deltas(&[changed(
+            ".github/workflows/ci.yml",
+            &["on: [push, pull_request]"],
+            &["on: push"],
+        )]);
+
+        assert_eq!(action[0].change, ContractChangeKind::ActionReferenceChanged);
+        assert_eq!(trigger[0].change, ContractChangeKind::TriggerChanged);
+    }
+}

--- a/src/review/proof/contracts/dependency.rs
+++ b/src/review/proof/contracts/dependency.rs
@@ -2,6 +2,8 @@ use crate::review::diff::ChangedFile;
 
 use super::*;
 
+#[path = "dependency/lockfile.rs"]
+mod lockfile;
 #[path = "dependency/parse.rs"]
 mod parse;
 use parse::*;
@@ -14,26 +16,7 @@ pub(super) fn dependency_deltas(changed_files: &[ChangedFile]) -> Vec<ChangeProo
         };
         let path = file.path_string();
         if kind == ManifestKind::Lockfile {
-            if file.hunks.iter().any(|hunk| {
-                hunk.added_lines
-                    .iter()
-                    .chain(&hunk.removed_lines)
-                    .any(|line| {
-                        let line = line.trim_start();
-                        line.starts_with("version =")
-                            || line.starts_with("\"version\":")
-                            || line.starts_with("version:")
-                    })
-            }) {
-                deltas.push(delta(
-                    &path,
-                    "lockfile resolution",
-                    ContractChangeKind::MetadataOnly,
-                    None,
-                    "Lockfile resolution changed, but this diff does not prove the package identity or exact dependency transition.",
-                    ContractConfidence::Limited,
-                ));
-            }
+            deltas.extend(lockfile::deltas(file, &path));
             continue;
         }
 
@@ -143,11 +126,21 @@ mod tests {
     use std::path::PathBuf;
 
     fn changed(path: &str, added: &[&str], removed: &[&str]) -> ChangedFile {
+        changed_with_header(path, added, removed, None)
+    }
+
+    fn changed_with_header(
+        path: &str,
+        added: &[&str],
+        removed: &[&str],
+        header: Option<&str>,
+    ) -> ChangedFile {
         ChangedFile {
             path: PathBuf::from(path),
             status: ChangeStatus::Modified,
             ranges: vec![ChangedRange { start: 4, end: 4 }],
             hunks: vec![DiffHunk {
+                header: header.map(str::to_string),
                 new_range: Some(ChangedRange { start: 4, end: 4 }),
                 old_range: Some(ChangedRange { start: 4, end: 4 }),
                 added_lines: added.iter().map(|line| (*line).to_string()).collect(),
@@ -226,5 +219,20 @@ mod tests {
         )]);
         assert_eq!(npm_deltas.len(), 1);
         assert_eq!(npm_deltas[0].confidence, Some(ContractConfidence::Limited));
+    }
+
+    #[test]
+    fn cargo_lockfile_version_change_keeps_package_identity() {
+        let deltas = dependency_deltas(&[changed_with_header(
+            "Cargo.lock",
+            &["version = \"2.1.0\""],
+            &["version = \"2.0.0\""],
+            Some("name = \"beta\""),
+        )]);
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].consumer_path, "beta");
+        assert_eq!(deltas[0].change, ContractChangeKind::Upgraded);
+        assert_eq!(deltas[0].confidence, Some(ContractConfidence::High));
     }
 }

--- a/src/review/proof/contracts/dependency/lockfile.rs
+++ b/src/review/proof/contracts/dependency/lockfile.rs
@@ -1,0 +1,98 @@
+use crate::review::diff::ChangedFile;
+
+use super::parse::{classify_pair, delta};
+use super::{ChangeProofContractDelta, ContractChangeKind, ContractConfidence};
+
+pub(super) fn deltas(file: &ChangedFile, path: &str) -> Vec<ChangeProofContractDelta> {
+    let mut deltas = Vec::new();
+    for hunk in &file.hunks {
+        let old = hunk
+            .removed_lines
+            .iter()
+            .find_map(|line| parse_lockfile_value(line, "version"));
+        let new = hunk
+            .added_lines
+            .iter()
+            .find_map(|line| parse_lockfile_value(line, "version"));
+        let old_source = hunk
+            .removed_lines
+            .iter()
+            .find_map(|line| parse_lockfile_value(line, "source"));
+        let new_source = hunk
+            .added_lines
+            .iter()
+            .find_map(|line| parse_lockfile_value(line, "source"));
+        let subject = hunk.header.as_deref().and_then(lockfile_subject);
+        let line = hunk.new_range.or(hunk.old_range).map(|range| range.start);
+        let (change, evidence) = match (old, new, old_source, new_source) {
+            (Some(old), Some(new), _, _) if subject.is_some() => (
+                classify_pair(&old, &new),
+                format!(
+                    "Lockfile package `{}` changed version from `{old}` to `{new}`.",
+                    subject.as_deref().unwrap_or("unknown")
+                ),
+            ),
+            (Some(old), Some(new), _, _) => (
+                ContractChangeKind::MetadataOnly,
+                format!(
+                    "Lockfile version changed from `{old}` to `{new}`, but package identity is unavailable."
+                ),
+            ),
+            (_, _, Some(old), Some(new)) if subject.is_some() => (
+                ContractChangeKind::SourceChanged,
+                format!(
+                    "Lockfile package `{}` changed source from `{old}` to `{new}`.",
+                    subject.as_deref().unwrap_or("unknown")
+                ),
+            ),
+            (_, _, Some(old), Some(new)) => (
+                ContractChangeKind::MetadataOnly,
+                format!(
+                    "Lockfile source changed from `{old}` to `{new}`, but package identity is unavailable."
+                ),
+            ),
+            _ => continue,
+        };
+        deltas.push(delta(
+            path,
+            subject.as_deref().unwrap_or("lockfile resolution"),
+            change,
+            line,
+            &evidence,
+            if subject.is_some() {
+                ContractConfidence::High
+            } else {
+                ContractConfidence::Limited
+            },
+        ));
+    }
+    deltas
+}
+
+fn parse_lockfile_value(line: &str, key: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if let Some((lhs, value)) = trimmed.split_once('=')
+        && lhs.trim() == key
+    {
+        return Some(value.trim().trim_matches('"').to_string());
+    }
+    let json_key = format!("\"{key}\":");
+    if let Some(value) = trimmed.strip_prefix(&json_key) {
+        return Some(
+            value
+                .trim()
+                .trim_end_matches(',')
+                .trim_matches('"')
+                .to_string(),
+        );
+    }
+    let yaml_key = format!("{key}:");
+    trimmed
+        .strip_prefix(&yaml_key)
+        .map(|value| value.trim().trim_matches('"').to_string())
+}
+
+fn lockfile_subject(header: &str) -> Option<String> {
+    let value = header.strip_prefix("name = ")?;
+    Some(value.trim().trim_matches('"').to_string())
+}

--- a/src/review/proof/contracts/mod.rs
+++ b/src/review/proof/contracts/mod.rs
@@ -2,7 +2,9 @@ use serde::Serialize;
 
 use crate::review::model::ReviewReport;
 
+mod delivery;
 mod dependency;
+mod runtime;
 
 const REMOVED_EXPORT_SIGNAL: &str = "behavioral.removed-export-still-imported";
 
@@ -11,6 +13,8 @@ const REMOVED_EXPORT_SIGNAL: &str = "behavioral.removed-export-still-imported";
 pub enum ContractFamily {
     PublicSymbol,
     Dependency,
+    Delivery,
+    RuntimeConfiguration,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
@@ -24,6 +28,15 @@ pub enum ContractChangeKind {
     SourceChanged,
     FeatureChanged,
     MetadataOnly,
+    TriggerChanged,
+    PermissionChanged,
+    SecretUseChanged,
+    ActionReferenceChanged,
+    ArtifactChanged,
+    DeploymentChanged,
+    Introduced,
+    Renamed,
+    Changed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -79,6 +92,8 @@ pub(crate) fn from_review(report: &ReviewReport) -> Vec<ChangeProofContractDelta
         })
         .collect::<Vec<_>>();
     deltas.extend(dependency::dependency_deltas(&report.changed_files));
+    deltas.extend(delivery::delivery_deltas(&report.changed_files));
+    deltas.extend(runtime::runtime_deltas(&report.changed_files));
     deltas.sort_by(|left, right| {
         left.exporter_path
             .cmp(&right.exporter_path)

--- a/src/review/proof/contracts/runtime.rs
+++ b/src/review/proof/contracts/runtime.rs
@@ -1,0 +1,262 @@
+use crate::review::diff::ChangedFile;
+
+use super::*;
+
+pub(super) fn runtime_deltas(changed_files: &[ChangedFile]) -> Vec<ChangeProofContractDelta> {
+    let config_edits = changed_files
+        .iter()
+        .filter(|file| is_runtime_config_path(&file.path_string()))
+        .flat_map(|file| {
+            file.hunks.iter().flat_map(move |hunk| {
+                let removed = hunk
+                    .removed_lines
+                    .iter()
+                    .filter_map(|line| parse_runtime_edit(line, hunk.old_range.map(|r| r.start)))
+                    .map(|edit| (file.path_string(), false, edit));
+                let added = hunk
+                    .added_lines
+                    .iter()
+                    .filter_map(|line| parse_runtime_edit(line, hunk.new_range.map(|r| r.start)))
+                    .map(|edit| (file.path_string(), true, edit));
+                removed.chain(added).collect::<Vec<_>>()
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut deltas = Vec::new();
+    let mut consumed = Vec::new();
+    for (index, (path, added, edit)) in config_edits.iter().enumerate() {
+        if *added || consumed.contains(&index) {
+            continue;
+        }
+        if let Some((other_index, (_, true, other))) =
+            config_edits
+                .iter()
+                .enumerate()
+                .find(|(other_index, (_, added, other))| {
+                    !consumed.contains(other_index) && *added && other.key == edit.key
+                })
+        {
+            consumed.extend([index, other_index]);
+            deltas.push(runtime_delta(
+                path,
+                &edit.key,
+                ContractChangeKind::Changed,
+                edit.line,
+                format!(
+                    "Runtime key `{}` changed from `{}` to `{}`.",
+                    edit.key, edit.value, other.value
+                ),
+                consumer_path(changed_files, &edit.key),
+            ));
+            continue;
+        }
+        if let Some((other_index, (_, true, other))) =
+            config_edits
+                .iter()
+                .enumerate()
+                .find(|(other_index, (_, added, other))| {
+                    !consumed.contains(other_index)
+                        && *added
+                        && other.key != edit.key
+                        && other.value == edit.value
+                })
+        {
+            consumed.extend([index, other_index]);
+            deltas.push(runtime_delta(
+                path,
+                &other.key,
+                ContractChangeKind::Renamed,
+                other.line.or(edit.line),
+                format!("Runtime key `{}` was renamed to `{}`.", edit.key, other.key),
+                consumer_path(changed_files, &other.key),
+            ));
+            continue;
+        }
+        consumed.push(index);
+        deltas.push(runtime_delta(
+            path,
+            &edit.key,
+            ContractChangeKind::Removed,
+            edit.line,
+            format!("Runtime key `{}` was removed.", edit.key),
+            consumer_path(changed_files, &edit.key),
+        ));
+    }
+    for (index, (path, added, edit)) in config_edits.iter().enumerate() {
+        if !*added || consumed.contains(&index) {
+            continue;
+        }
+        consumed.push(index);
+        deltas.push(runtime_delta(
+            path,
+            &edit.key,
+            ContractChangeKind::Introduced,
+            edit.line,
+            format!("Runtime key `{}` was introduced.", edit.key),
+            consumer_path(changed_files, &edit.key),
+        ));
+    }
+    deltas.sort_by(|left, right| {
+        left.exporter_path
+            .cmp(&right.exporter_path)
+            .then(left.consumer_path.cmp(&right.consumer_path))
+            .then(left.line_start.cmp(&right.line_start))
+    });
+    deltas
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeEdit {
+    key: String,
+    value: String,
+    line: Option<usize>,
+}
+
+fn is_runtime_config_path(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    let file = lower.rsplit('/').next().unwrap_or(lower.as_str());
+    file == ".env"
+        || file.starts_with(".env.")
+        || lower.contains("/config/")
+        || lower.starts_with("config/")
+}
+
+fn parse_runtime_edit(line: &str, line_start: Option<usize>) -> Option<RuntimeEdit> {
+    let trimmed = line.trim();
+    let (key, value) = trimmed
+        .split_once('=')
+        .or_else(|| trimmed.split_once(':'))?;
+    let key = key.trim().trim_matches('"');
+    if !is_runtime_key(key) {
+        return None;
+    }
+    Some(RuntimeEdit {
+        key: key.to_string(),
+        value: value
+            .trim()
+            .trim_end_matches(',')
+            .trim_matches('"')
+            .to_string(),
+        line: line_start,
+    })
+}
+
+fn is_runtime_key(key: &str) -> bool {
+    !key.is_empty()
+        && key
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+        && key.chars().any(|character| character.is_ascii_uppercase())
+}
+
+fn consumer_path(changed_files: &[ChangedFile], key: &str) -> Option<String> {
+    changed_files
+        .iter()
+        .filter(|file| !is_runtime_config_path(&file.path_string()))
+        .find(|file| {
+            file.hunks.iter().any(|hunk| {
+                hunk.added_lines
+                    .iter()
+                    .chain(&hunk.removed_lines)
+                    .any(|line| line_uses_key(line, key))
+            })
+        })
+        .map(ChangedFile::path_string)
+}
+
+fn line_uses_key(line: &str, key: &str) -> bool {
+    [
+        format!("process.env.{key}"),
+        format!("os.getenv(\"{key}\""),
+        format!("getenv(\"{key}\""),
+        format!("System.getenv(\"{key}\""),
+        format!("config.{key}"),
+        format!("${{{key}}}"),
+    ]
+    .iter()
+    .any(|needle| line.contains(needle))
+}
+
+fn runtime_delta(
+    path: &str,
+    key: &str,
+    change: ContractChangeKind,
+    line: Option<usize>,
+    evidence: String,
+    consumer: Option<String>,
+) -> ChangeProofContractDelta {
+    let confidence = consumer
+        .as_ref()
+        .map(|_| ContractConfidence::High)
+        .unwrap_or(ContractConfidence::Limited);
+    ChangeProofContractDelta {
+        family: ContractFamily::RuntimeConfiguration,
+        change,
+        exporter_path: path.to_string(),
+        consumer_path: consumer.unwrap_or_else(|| key.to_string()),
+        line_start: line,
+        line_end: line,
+        evidence,
+        confidence: Some(confidence),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::diff::{ChangeStatus, ChangedRange, DiffHunk};
+    use std::path::PathBuf;
+
+    fn changed(path: &str, added: &[&str], removed: &[&str]) -> ChangedFile {
+        ChangedFile {
+            path: PathBuf::from(path),
+            status: ChangeStatus::Modified,
+            ranges: vec![ChangedRange { start: 4, end: 4 }],
+            hunks: vec![DiffHunk {
+                header: None,
+                new_range: Some(ChangedRange { start: 4, end: 4 }),
+                old_range: Some(ChangedRange { start: 4, end: 4 }),
+                added_lines: added.iter().map(|line| (*line).to_string()).collect(),
+                removed_lines: removed.iter().map(|line| (*line).to_string()).collect(),
+            }],
+        }
+    }
+
+    #[test]
+    fn introduced_runtime_key_requires_a_changed_consumer_for_high_confidence() {
+        let deltas = runtime_deltas(&[
+            changed(".env", &["DATABASE_URL=postgres://new"], &[]),
+            changed(
+                "src/config.ts",
+                &["const url = process.env.DATABASE_URL"],
+                &[],
+            ),
+        ]);
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].family, ContractFamily::RuntimeConfiguration);
+        assert_eq!(deltas[0].change, ContractChangeKind::Introduced);
+        assert_eq!(deltas[0].confidence, Some(ContractConfidence::High));
+    }
+
+    #[test]
+    fn removed_runtime_key_without_a_consumer_is_limited() {
+        let deltas = runtime_deltas(&[changed(".env", &[], &["OLD_URL=https://old"])]);
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].change, ContractChangeKind::Removed);
+        assert_eq!(deltas[0].confidence, Some(ContractConfidence::Limited));
+    }
+
+    #[test]
+    fn paired_runtime_key_values_can_be_classified_as_renamed() {
+        let deltas = runtime_deltas(&[changed(
+            ".env",
+            &["SERVICE_URL=https://example"],
+            &["API_URL=https://example"],
+        )]);
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].change, ContractChangeKind::Renamed);
+    }
+}

--- a/src/review/signals/behavioral_tests.rs
+++ b/src/review/signals/behavioral_tests.rs
@@ -238,6 +238,7 @@ fn file_with_hunk(
         status,
         ranges: new_range.map(|r| vec![r]).unwrap_or_default(),
         hunks: vec![DiffHunk {
+            header: None,
             new_range,
             old_range,
             added_lines: added_lines.into_iter().map(String::from).collect(),


### PR DESCRIPTION
## Problem

The v0.23 semantic contract map could already describe removed public symbols and manifest-level dependency changes, but it still lost package identity in common lockfile hunks and treated delivery/runtime configuration edits as path-only changes. That limited the evidence available to reviewers and made the contract map less useful for real change analysis.

## What changed

- Preserve the Git hunk header in the internal diff model so Cargo.lock package context such as `name = "beta"` survives zero-context diffs.
- Add lockfile contract deltas for version upgrades/downgrades and source changes when package identity is provable; retain an explicit limited-confidence metadata result when it is not.
- Add typed delivery contracts for workflow/action trigger, permission, secret-use, action-reference, artifact, and deployment changes, including the common `- uses:` YAML form.
- Add runtime configuration lifecycle contracts for introduced, removed, renamed, and changed keys in bounded `.env`/`config/` paths.
- Raise runtime configuration confidence only when a changed file in the same review scope demonstrates a consumer for the key.
- Keep new contract families additive to the semantic proof map; they do not change `BROKEN` verdict behavior.
- Document the measured scope and known limits in the v0.23 roadmap and evidence ledger.

## Validation

- `cargo test --all` — 917 unit tests plus the full integration suite passed; one explicit released-reader compatibility test remains ignored by design.
- `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `cargo run -- scan . --fail-on-priority p1` — `Decision: PASS`, 0 visible findings, 415 strict-only suggestions hidden by the default profile; existing unresolved-import and finding-contract warnings remain disclosed.
- `python3 scripts/release-contract.py check` — passed for 0.22.0.
- `git diff --check` — passed.