### PR TITLE
feat: resolve semantic contract consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   export with a resolved local consumer is emitted as `public-symbol /
   removed-export` evidence and drives the `BROKEN` verdict. Coordinated renames
   remain free of this delta.
+- Extended semantic contract evidence to resolve unchanged runtime consumers
+  across the repository and classify Cargo/npm workspace alias transitions.
+  Exact single consumers can be high confidence; ambiguous or dynamic access
+  remains limited, and workspace aliases explicitly avoid claiming a resolved
+  version.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -34,7 +34,7 @@ check does not close an item without the required fresh evidence.
 | RP23-005 | P2 defect | in-progress | Documentation / 0D | Historical scorecard still describes an uncut tag, while the release is published. Platform state prose also retains already-completed migration work as missing. PR 4 adds current lifecycle and scope-boundary checks; close by reconciling the remaining scorecard claims against code and fresh evidence. |
 | RP23-006 | P2 design-risk | in-progress | Review/readiness / A | Absent CODEOWNERS produces unowned paths and review reasons. Close with explicit absent/configured-unmatched/resolved states and regression coverage; do not claim a config policy is violated when it does not exist. |
 | RP23-007 | P2 defect | open | Decision UX / 0D–A | Decision and readiness are printed separately; finding-only plan counts omit signal verification guidance. Close with accurate current copy, then one canonical Phase A obligations model and projection parity. |
-| RP23-008 | P2 limitation | in-progress | Semantic review / B | Dependency, delivery, and runtime-config deltas now have typed evidence with explicit limited states; workspace aliases, opaque lockfiles, unchanged consumers, and unknown workflow/config forms remain open. Close only for supported semantic families with metadata-only safe guards; preserve unknown forms and strict recall. |
+| RP23-008 | P2 limitation | in-progress | Semantic review / B | Dependency, delivery, and runtime-config deltas now have typed evidence; one exact unchanged production consumer can be resolved, and workspace alias transitions are typed without claiming version resolution. Opaque lockfiles, ambiguous/dynamic consumers, and unknown workflow/config forms remain open. Close only for supported semantic families with metadata-only safe guards; preserve unknown forms and strict recall. |
 | RP23-009 | P2 design-risk | in-progress | Coverage UX / 0D–A | PASS and visible health scores can be read as broader proof than analyzed scope. Close with assessed-scope copy and a capability ledger; excluded files or hidden suggestions are not automatically missed defects. |
 | RP23-010 | P2 evidence-gap | open | Rule quality / E | Committed scorecard reports three strict-only dead-module false positives and many rules without zoo evidence. Close each measured issue with safe/unsafe regression and fresh labeled evidence; never label unmeasured rules clean. |
 | RP23-011 | P2 defect | in-progress | Release contract / 0D | `check_roadmap_docs()` checks v0.20 headings/links only. PR 4 adds focused v0.23 lifecycle/link and scope-boundary contract tests while retaining older supported docs. Close after the current claims and tests are merged. |
@@ -393,3 +393,19 @@ bump is needed to start.
   consumers outside the diff, workspace-specific runtime aliases, or dynamic
   configuration access. Those forms remain limitations rather than invented
   contract claims.
+
+## 0L — Consumer Resolution and Workspace Alias Evidence
+
+- Runtime config proof now searches unchanged production source files after
+  checking changed-scope references. The walk is deterministic, excludes
+  documentation, tests, fixtures, vendor/generated paths, binary files, and
+  files over 1 MiB, and reports one exact reference as high confidence.
+  Multiple matches produce limited confidence with every candidate in evidence;
+  dynamic access patterns remain unclaimed.
+- Cargo `workspace = true` and npm `workspace:*`, `workspace:^`, and
+  `workspace:~` transitions are typed as `alias-changed` dependency deltas.
+  The evidence deliberately says exact workspace version resolution is not
+  established by the manifest diff.
+- Fresh unit coverage proves one unchanged consumer, ambiguous consumers,
+  Cargo alias transitions, and npm alias transitions. This closes only the
+  bounded supported forms; it is not evidence of universal resolver coverage.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -215,7 +215,11 @@ lockfiles remain explicitly limited. Workflow/action contracts now classify
 trigger, permission, secret, action-reference, artifact, and deployment
 changes. Runtime configuration contracts now classify key introduction,
 removal, rename, and value changes, with high confidence only when a consumer
-also appears in the changed scope.
+also appears in the changed scope. When no changed-scope consumer exists, a
+bounded repository search can prove one exact unchanged production consumer;
+multiple or dynamic references remain limited. Cargo `workspace = true` and
+npm `workspace:*`, `workspace:^`, and `workspace:~` transitions are typed as
+aliases without claiming exact workspace version resolution.
 
 Each contract delta records:
 

--- a/src/review/proof/contracts/dependency.rs
+++ b/src/review/proof/contracts/dependency.rs
@@ -42,19 +42,33 @@ pub(super) fn dependency_deltas(changed_files: &[ChangedFile]) -> Vec<ChangeProo
                 }
             }
             for (old, new) in paired {
-                let change = classify_pair(&old.specification, &new.specification);
-                deltas.push(delta(
-                    &path,
-                    &new.name,
-                    change,
-                    new.line.or(old.line),
-                    &format!(
+                let alias = is_workspace_alias(&old.specification)
+                    || is_workspace_alias(&new.specification);
+                let change = if alias {
+                    ContractChangeKind::AliasChanged
+                } else {
+                    classify_pair(&old.specification, &new.specification)
+                };
+                let evidence = if alias {
+                    format!(
+                        "Workspace dependency alias `{}` changed from `{}` to `{}`; exact workspace resolution is not claimed.",
+                        new.name, old.specification, new.specification
+                    )
+                } else {
+                    format!(
                         "{} dependency `{}` changed from `{}` to `{}`.",
                         manifest_label(kind),
                         new.name,
                         old.specification,
                         new.specification
-                    ),
+                    )
+                };
+                deltas.push(delta(
+                    &path,
+                    &new.name,
+                    change,
+                    new.line.or(old.line),
+                    &evidence,
                     ContractConfidence::High,
                 ));
             }
@@ -234,5 +248,30 @@ mod tests {
         assert_eq!(deltas[0].consumer_path, "beta");
         assert_eq!(deltas[0].change, ContractChangeKind::Upgraded);
         assert_eq!(deltas[0].confidence, Some(ContractConfidence::High));
+    }
+
+    #[test]
+    fn workspace_alias_transition_is_typed_for_cargo() {
+        let deltas = dependency_deltas(&[changed(
+            "crates/app/Cargo.toml",
+            &["shared = { workspace = true }"],
+            &["shared = { version = \"1.0\" }"],
+        )]);
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].change, ContractChangeKind::AliasChanged);
+        assert!(deltas[0].evidence.contains("Workspace dependency alias"));
+    }
+
+    #[test]
+    fn workspace_alias_transition_is_typed_for_npm() {
+        let deltas = dependency_deltas(&[changed(
+            "packages/app/package.json",
+            &["    \"shared\": \"workspace:^\","],
+            &["    \"shared\": \"workspace:*\","],
+        )]);
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].change, ContractChangeKind::AliasChanged);
     }
 }

--- a/src/review/proof/contracts/dependency/parse.rs
+++ b/src/review/proof/contracts/dependency/parse.rs
@@ -176,6 +176,15 @@ pub(super) fn classify_pair(old: &str, new: &str) -> ContractChangeKind {
     }
 }
 
+pub(super) fn is_workspace_alias(specification: &str) -> bool {
+    let normalized = specification
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    normalized.contains("workspace=true") || normalized.starts_with("workspace:")
+}
+
 fn source_part(specification: &str) -> String {
     specification
         .split([',', '}'])

--- a/src/review/proof/contracts/mod.rs
+++ b/src/review/proof/contracts/mod.rs
@@ -27,6 +27,7 @@ pub enum ContractChangeKind {
     Downgraded,
     SourceChanged,
     FeatureChanged,
+    AliasChanged,
     MetadataOnly,
     TriggerChanged,
     PermissionChanged,
@@ -93,7 +94,10 @@ pub(crate) fn from_review(report: &ReviewReport) -> Vec<ChangeProofContractDelta
         .collect::<Vec<_>>();
     deltas.extend(dependency::dependency_deltas(&report.changed_files));
     deltas.extend(delivery::delivery_deltas(&report.changed_files));
-    deltas.extend(runtime::runtime_deltas(&report.changed_files));
+    deltas.extend(runtime::runtime_deltas_in_repo(
+        &report.repo_root,
+        &report.changed_files,
+    ));
     deltas.sort_by(|left, right| {
         left.exporter_path
             .cmp(&right.exporter_path)

--- a/src/review/proof/contracts/runtime.rs
+++ b/src/review/proof/contracts/runtime.rs
@@ -1,8 +1,27 @@
 use crate::review::diff::ChangedFile;
+use std::path::Path;
 
 use super::*;
 
-pub(super) fn runtime_deltas(changed_files: &[ChangedFile]) -> Vec<ChangeProofContractDelta> {
+#[path = "runtime/consumer.rs"]
+mod consumer;
+
+#[cfg(test)]
+fn runtime_deltas(changed_files: &[ChangedFile]) -> Vec<ChangeProofContractDelta> {
+    runtime_deltas_with_root(None, changed_files)
+}
+
+pub(super) fn runtime_deltas_in_repo(
+    repo_root: &Path,
+    changed_files: &[ChangedFile],
+) -> Vec<ChangeProofContractDelta> {
+    runtime_deltas_with_root(Some(repo_root), changed_files)
+}
+
+fn runtime_deltas_with_root(
+    repo_root: Option<&Path>,
+    changed_files: &[ChangedFile],
+) -> Vec<ChangeProofContractDelta> {
     let config_edits = changed_files
         .iter()
         .filter(|file| is_runtime_config_path(&file.path_string()))
@@ -46,7 +65,7 @@ pub(super) fn runtime_deltas(changed_files: &[ChangedFile]) -> Vec<ChangeProofCo
                     "Runtime key `{}` changed from `{}` to `{}`.",
                     edit.key, edit.value, other.value
                 ),
-                consumer_path(changed_files, &edit.key),
+                consumer::find(repo_root, changed_files, &edit.key),
             ));
             continue;
         }
@@ -68,7 +87,7 @@ pub(super) fn runtime_deltas(changed_files: &[ChangedFile]) -> Vec<ChangeProofCo
                 ContractChangeKind::Renamed,
                 other.line.or(edit.line),
                 format!("Runtime key `{}` was renamed to `{}`.", edit.key, other.key),
-                consumer_path(changed_files, &other.key),
+                consumer::find(repo_root, changed_files, &other.key),
             ));
             continue;
         }
@@ -79,7 +98,7 @@ pub(super) fn runtime_deltas(changed_files: &[ChangedFile]) -> Vec<ChangeProofCo
             ContractChangeKind::Removed,
             edit.line,
             format!("Runtime key `{}` was removed.", edit.key),
-            consumer_path(changed_files, &edit.key),
+            consumer::find(repo_root, changed_files, &edit.key),
         ));
     }
     for (index, (path, added, edit)) in config_edits.iter().enumerate() {
@@ -93,7 +112,7 @@ pub(super) fn runtime_deltas(changed_files: &[ChangedFile]) -> Vec<ChangeProofCo
             ContractChangeKind::Introduced,
             edit.line,
             format!("Runtime key `{}` was introduced.", edit.key),
-            consumer_path(changed_files, &edit.key),
+            consumer::find(repo_root, changed_files, &edit.key),
         ));
     }
     deltas.sort_by(|left, right| {
@@ -149,51 +168,27 @@ fn is_runtime_key(key: &str) -> bool {
         && key.chars().any(|character| character.is_ascii_uppercase())
 }
 
-fn consumer_path(changed_files: &[ChangedFile], key: &str) -> Option<String> {
-    changed_files
-        .iter()
-        .filter(|file| !is_runtime_config_path(&file.path_string()))
-        .find(|file| {
-            file.hunks.iter().any(|hunk| {
-                hunk.added_lines
-                    .iter()
-                    .chain(&hunk.removed_lines)
-                    .any(|line| line_uses_key(line, key))
-            })
-        })
-        .map(ChangedFile::path_string)
-}
-
-fn line_uses_key(line: &str, key: &str) -> bool {
-    [
-        format!("process.env.{key}"),
-        format!("os.getenv(\"{key}\""),
-        format!("getenv(\"{key}\""),
-        format!("System.getenv(\"{key}\""),
-        format!("config.{key}"),
-        format!("${{{key}}}"),
-    ]
-    .iter()
-    .any(|needle| line.contains(needle))
-}
-
 fn runtime_delta(
     path: &str,
     key: &str,
     change: ContractChangeKind,
     line: Option<usize>,
     evidence: String,
-    consumer: Option<String>,
+    consumer: Option<consumer::ConsumerMatch>,
 ) -> ChangeProofContractDelta {
-    let confidence = consumer
-        .as_ref()
-        .map(|_| ContractConfidence::High)
-        .unwrap_or(ContractConfidence::Limited);
+    let (consumer_path, confidence, evidence) = match consumer {
+        Some(match_) => (
+            match_.path,
+            match_.confidence,
+            format!("{evidence} {}", match_.evidence),
+        ),
+        None => (key.to_string(), ContractConfidence::Limited, evidence),
+    };
     ChangeProofContractDelta {
         family: ContractFamily::RuntimeConfiguration,
         change,
         exporter_path: path.to_string(),
-        consumer_path: consumer.unwrap_or_else(|| key.to_string()),
+        consumer_path,
         line_start: line,
         line_end: line,
         evidence,
@@ -258,5 +253,48 @@ mod tests {
 
         assert_eq!(deltas.len(), 1);
         assert_eq!(deltas[0].change, ContractChangeKind::Renamed);
+    }
+
+    #[test]
+    fn unchanged_consumer_is_found_with_high_confidence() {
+        let root = tempfile::tempdir().expect("temp root");
+        std::fs::create_dir_all(root.path().join("src")).expect("src directory");
+        std::fs::write(
+            root.path().join("src/server.ts"),
+            "const url = process.env.DATABASE_URL;\n",
+        )
+        .expect("consumer source");
+
+        let deltas = runtime_deltas_in_repo(
+            root.path(),
+            &[changed(".env", &["DATABASE_URL=postgres://new"], &[])],
+        );
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].consumer_path, "src/server.ts");
+        assert_eq!(deltas[0].confidence, Some(ContractConfidence::High));
+        assert!(deltas[0].evidence.contains("unchanged consumer"));
+    }
+
+    #[test]
+    fn ambiguous_unchanged_consumers_remain_limited() {
+        let root = tempfile::tempdir().expect("temp root");
+        std::fs::create_dir_all(root.path().join("src")).expect("src directory");
+        for path in ["src/a.ts", "src/b.ts"] {
+            std::fs::write(
+                root.path().join(path),
+                "const url = process.env.DATABASE_URL;\n",
+            )
+            .expect("consumer source");
+        }
+
+        let deltas = runtime_deltas_in_repo(
+            root.path(),
+            &[changed(".env", &["DATABASE_URL=postgres://new"], &[])],
+        );
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].confidence, Some(ContractConfidence::Limited));
+        assert!(deltas[0].evidence.contains("multiple consumers"));
     }
 }

--- a/src/review/proof/contracts/runtime/consumer.rs
+++ b/src/review/proof/contracts/runtime/consumer.rs
@@ -1,0 +1,186 @@
+use crate::review::diff::ChangedFile;
+use ignore::WalkBuilder;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use super::super::ContractConfidence;
+
+const MAX_SOURCE_BYTES: u64 = 1_048_576;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ConsumerMatch {
+    pub(super) path: String,
+    pub(super) confidence: ContractConfidence,
+    pub(super) evidence: String,
+}
+
+pub(super) fn find(
+    repo_root: Option<&Path>,
+    changed_files: &[ChangedFile],
+    key: &str,
+) -> Option<ConsumerMatch> {
+    let changed = changed_matches(changed_files, key);
+    if !changed.is_empty() {
+        return summarize(changed, "changed consumer");
+    }
+
+    let root = repo_root?;
+    let changed_paths = changed_files
+        .iter()
+        .map(|file| file.path_string())
+        .collect::<BTreeSet<_>>();
+    let mut matches = Vec::new();
+    let mut paths = WalkBuilder::new(root)
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .build()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_some_and(|kind| kind.is_file()))
+        .map(|entry| entry.into_path())
+        .filter(|path| is_candidate_path(path, root, &changed_paths))
+        .collect::<Vec<_>>();
+    paths.sort();
+
+    for path in paths {
+        let Ok(metadata) = fs::metadata(&path) else {
+            continue;
+        };
+        if metadata.len() > MAX_SOURCE_BYTES {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        for (line_index, line) in content.lines().enumerate() {
+            if line_uses_key(line, key) {
+                matches.push((relative_path(root, &path), line_index + 1));
+            }
+        }
+    }
+    summarize(matches, "unchanged consumer")
+}
+
+fn changed_matches(changed_files: &[ChangedFile], key: &str) -> Vec<(String, usize)> {
+    let mut matches = Vec::new();
+    for file in changed_files {
+        if super::is_runtime_config_path(&file.path_string()) {
+            continue;
+        }
+        for hunk in &file.hunks {
+            let new_start = hunk.new_range.map(|range| range.start).unwrap_or(1);
+            for (offset, line) in hunk.added_lines.iter().enumerate() {
+                if line_uses_key(line, key) {
+                    matches.push((file.path_string(), new_start + offset));
+                }
+            }
+            let old_start = hunk.old_range.map(|range| range.start).unwrap_or(1);
+            for (offset, line) in hunk.removed_lines.iter().enumerate() {
+                if line_uses_key(line, key) {
+                    matches.push((file.path_string(), old_start + offset));
+                }
+            }
+        }
+    }
+    matches.sort();
+    matches
+}
+
+fn summarize(matches: Vec<(String, usize)>, label: &str) -> Option<ConsumerMatch> {
+    let first = matches.first()?.clone();
+    let confidence = (matches.len() == 1).then_some(ContractConfidence::High);
+    let evidence = if matches.len() == 1 {
+        format!("Found {label} at `{}:{}`.", first.0, first.1)
+    } else {
+        format!(
+            "Found multiple consumers ({}); exact runtime consumer is ambiguous.",
+            matches
+                .iter()
+                .map(|(path, line)| format!("`{path}:{line}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    Some(ConsumerMatch {
+        path: first.0,
+        confidence: confidence.unwrap_or(ContractConfidence::Limited),
+        evidence,
+    })
+}
+
+fn is_candidate_path(path: &Path, root: &Path, changed_paths: &BTreeSet<String>) -> bool {
+    let relative = relative_path(root, path);
+    if changed_paths.contains(&relative) || super::is_runtime_config_path(&relative) {
+        return false;
+    }
+    if relative.split('/').any(|part| {
+        matches!(
+            part,
+            ".git"
+                | "target"
+                | "node_modules"
+                | "vendor"
+                | "docs"
+                | "examples"
+                | "fixtures"
+                | "tests"
+                | "test"
+                | "__tests__"
+        )
+    }) {
+        return false;
+    }
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            matches!(
+                extension,
+                "cjs"
+                    | "cs"
+                    | "go"
+                    | "java"
+                    | "js"
+                    | "json"
+                    | "jsx"
+                    | "kt"
+                    | "kts"
+                    | "py"
+                    | "rs"
+                    | "sh"
+                    | "ts"
+                    | "tsx"
+                    | "toml"
+                    | "yaml"
+                    | "yml"
+            )
+        })
+}
+
+fn relative_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn line_uses_key(line: &str, key: &str) -> bool {
+    [
+        format!("process.env.{key}"),
+        format!("os.getenv(\"{key}\""),
+        format!("getenv(\"{key}\""),
+        format!("System.getenv(\"{key}\""),
+        format!("config.{key}"),
+        format!("${{{key}}}"),
+    ]
+    .iter()
+    .any(|needle| {
+        line.match_indices(needle).any(|(start, _)| {
+            let end = start + needle.len();
+            line.as_bytes()
+                .get(end)
+                .is_none_or(|byte| !byte.is_ascii_alphanumeric() && *byte != b'_')
+        })
+    })
+}


### PR DESCRIPTION
## Problem

The semantic contract map could describe changed runtime keys only when their consumer also appeared in the diff. It also treated Cargo and npm workspace aliases as generic source/version transitions, which could overstate what a manifest diff proves.

## What changed

- Add a deterministic repository-aware consumer resolver for runtime configuration contracts.
  - Changed-scope exact references remain preferred.
  - If no changed consumer exists, one exact unchanged production reference can raise confidence.
  - Multiple candidates remain `limited` and list every candidate in evidence.
  - Dynamic access is left unclaimed; documentation, tests, fixtures, vendor/generated paths, binary files, and files over 1 MiB are bounded out.
- Add `alias-changed` dependency evidence for:
  - Cargo `workspace = true` transitions.
  - npm `workspace:*`, `workspace:^`, and `workspace:~` transitions.
- Explicitly state that alias evidence does not claim exact workspace version resolution.
- Keep all additions additive to `ChangeProof`; new families cannot produce `BROKEN`.
- Update the v0.23 roadmap, evidence ledger, and changelog with the supported scope and limitations.

## Why this matters

A runtime config change can now point to the real unchanged production consumer instead of stopping at “no consumer in diff.” At the same time, workspace dependencies are represented as aliases rather than guessed upgrades or source changes, so the proof becomes more useful without becoming more confident than the evidence allows.

## Validation

- `cargo test --all` — 921 unit tests plus the full integration suite passed; one explicit released-reader compatibility test remains ignored by design.
- `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `cargo run -- scan . --fail-on-priority p1` — `Decision: PASS`, 0 visible findings, 416 strict-only suggestions hidden by the default profile; existing unresolved-import and finding-contract warnings remain disclosed.
- `python3 scripts/release-contract.py check` — passed for 0.22.0.