### PR TITLE
feat: add security and test contract evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   classify trigger, permission, secret, action-reference, artifact, and deploy
   changes, and runtime configuration edits classify introduced, removed,
   renamed, or changed keys with changed-diff consumer evidence.
+- Added limited security and test contract deltas: changed access-control or
+  request-trust boundaries are connected to bounded entrypoint candidates and
+  path-related changed tests, while missing or unlinked tests remain explicit
+  review evidence without claiming behavioral coverage or a broken contract.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -409,3 +409,25 @@ bump is needed to start.
 - Fresh unit coverage proves one unchanged consumer, ambiguous consumers,
   Cargo alias transitions, and npm alias transitions. This closes only the
   bounded supported forms; it is not evidence of universal resolver coverage.
+
+## 0M — Security and Test Contract Evidence
+
+- ChangeProof now emits `security-boundary` deltas for changed access-control
+  and request-trust boundaries. The bounded impact graph contributes only
+  entrypoint candidates whose paths match explicit API, route, handler,
+  controller, command, or application conventions; it does not infer runtime
+  request reachability from a filename.
+- `test-coverage` deltas record a changed test only when its path has a stable
+  component relationship to the boundary path. If no such path evidence exists
+  (including a completely test-free diff), the result is `test-missing` with a
+  limitation explaining that static naming cannot prove behavioral coverage.
+- All new security/test deltas carry `limited` confidence and cannot satisfy
+  the `BROKEN` contract. Existing removed-export evidence remains the only
+  broken-contract proof in this slice.
+- Regression evidence: focused contract unit tests cover bounded entrypoint
+  selection, related-test matching, missing-test limitations, and the invariant
+  that every emitted delta is limited; `review_boundary_signals` covers the
+  real JSON pipeline for both safe and unsafe test-change shapes.
+- Boundary: this is deterministic diff/graph evidence, not a test runner or
+  authorization proof. Dynamic dispatch, generated paths, semantic request
+  reachability, and behavioral coverage remain unassessed.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -221,6 +221,12 @@ multiple or dynamic references remain limited. Cargo `workspace = true` and
 npm `workspace:*`, `workspace:^`, and `workspace:~` transitions are typed as
 aliases without claiming exact workspace version resolution.
 
+Security and test contract evidence now connects changed access-control and
+request-trust boundaries to bounded import-graph entrypoint candidates and
+related changed test paths. The projection is deliberately limited: a path
+relationship or a missing test diff does not prove request reachability or
+behavioral coverage, and no such delta can produce `BROKEN`.
+
 Each contract delta records:
 
 - stable contract identity and family;

--- a/src/review/proof/contracts/mod.rs
+++ b/src/review/proof/contracts/mod.rs
@@ -5,6 +5,7 @@ use crate::review::model::ReviewReport;
 mod delivery;
 mod dependency;
 mod runtime;
+mod security;
 
 const REMOVED_EXPORT_SIGNAL: &str = "behavioral.removed-export-still-imported";
 
@@ -15,6 +16,8 @@ pub enum ContractFamily {
     Dependency,
     Delivery,
     RuntimeConfiguration,
+    SecurityBoundary,
+    TestCoverage,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
@@ -38,6 +41,10 @@ pub enum ContractChangeKind {
     Introduced,
     Renamed,
     Changed,
+    BoundaryChanged,
+    EntryPointImpacted,
+    TestChanged,
+    TestMissing,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -98,6 +105,7 @@ pub(crate) fn from_review(report: &ReviewReport) -> Vec<ChangeProofContractDelta
         &report.repo_root,
         &report.changed_files,
     ));
+    deltas.extend(security::security_deltas(report));
     deltas.sort_by(|left, right| {
         left.exporter_path
             .cmp(&right.exporter_path)

--- a/src/review/proof/contracts/security.rs
+++ b/src/review/proof/contracts/security.rs
@@ -1,0 +1,280 @@
+use super::{ChangeProofContractDelta, ContractChangeKind, ContractConfidence, ContractFamily};
+use crate::audits::context::classify::helpers::is_test_file;
+use crate::review::model::ReviewReport;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+pub(super) fn security_deltas(report: &ReviewReport) -> Vec<ChangeProofContractDelta> {
+    let changed_tests = report
+        .changed_files
+        .iter()
+        .filter(|file| is_test_file(&file.path))
+        .map(|file| file.path_string())
+        .collect::<Vec<_>>();
+
+    let mut deltas = Vec::new();
+    for boundary in report
+        .boundary_signals
+        .iter()
+        .filter(|signal| signal.category.is_code_boundary())
+    {
+        let category = boundary.category.label();
+        let impacted_entrypoints = impacted_entrypoints(report, &boundary.path);
+        let impact_evidence = if impacted_entrypoints.is_empty() {
+            format!("Changed {category} boundary; no bounded entrypoint consumer was established.")
+        } else {
+            format!(
+                "Changed {category} boundary; import graph reaches {} entrypoint candidate(s).",
+                impacted_entrypoints.len()
+            )
+        };
+        deltas.push(ChangeProofContractDelta {
+            family: ContractFamily::SecurityBoundary,
+            change: ContractChangeKind::BoundaryChanged,
+            exporter_path: boundary.path.clone(),
+            consumer_path: boundary.path.clone(),
+            line_start: None,
+            line_end: None,
+            evidence: impact_evidence,
+            confidence: Some(ContractConfidence::Limited),
+        });
+
+        for entrypoint in impacted_entrypoints {
+            deltas.push(ChangeProofContractDelta {
+                family: ContractFamily::SecurityBoundary,
+                change: ContractChangeKind::EntryPointImpacted,
+                exporter_path: boundary.path.clone(),
+                consumer_path: entrypoint,
+                line_start: None,
+                line_end: None,
+                evidence: "Bounded import graph identifies an entrypoint candidate; static analysis does not prove request reachability.".to_string(),
+                confidence: Some(ContractConfidence::Limited),
+            });
+        }
+
+        let related_tests = changed_tests
+            .iter()
+            .filter(|path| test_matches_boundary(path, &boundary.path))
+            .collect::<Vec<_>>();
+        if related_tests.is_empty() {
+            deltas.push(test_delta(
+                &boundary.path,
+                &boundary.path,
+                ContractChangeKind::TestMissing,
+                if changed_tests.is_empty() {
+                    "No test file changed alongside the security boundary; static analysis cannot prove missing behavioral coverage."
+                } else {
+                    "Changed tests could not be linked to this boundary by stable path evidence; static naming cannot prove coverage."
+                },
+            ));
+        } else {
+            for test_path in related_tests {
+                deltas.push(test_delta(
+                    &boundary.path,
+                    test_path,
+                    ContractChangeKind::TestChanged,
+                    "A changed test has a stable path relationship to this boundary; static naming still cannot prove behavioral coverage.",
+                ));
+            }
+        }
+    }
+    deltas
+}
+
+fn test_delta(
+    boundary_path: &str,
+    test_path: &str,
+    change: ContractChangeKind,
+    evidence: &str,
+) -> ChangeProofContractDelta {
+    ChangeProofContractDelta {
+        family: ContractFamily::TestCoverage,
+        change,
+        exporter_path: boundary_path.to_string(),
+        consumer_path: test_path.to_string(),
+        line_start: None,
+        line_end: None,
+        evidence: evidence.to_string(),
+        confidence: Some(ContractConfidence::Limited),
+    }
+}
+
+fn impacted_entrypoints(report: &ReviewReport, boundary_path: &str) -> Vec<String> {
+    let Some(impact) = report
+        .impact_paths
+        .files
+        .iter()
+        .find(|impact| impact.path == Path::new(boundary_path))
+    else {
+        return Vec::new();
+    };
+
+    impact
+        .direct_dependents
+        .iter()
+        .chain(impact.transitive_dependents.iter())
+        .filter(|path| is_entrypoint_path(path))
+        .map(|path| path.to_string_lossy().to_string())
+        .collect()
+}
+
+fn is_entrypoint_path(path: &Path) -> bool {
+    let lower = path.to_string_lossy().to_ascii_lowercase();
+    if is_test_file(path) {
+        return false;
+    }
+    let component_match = lower.split(['/', '\\']).any(|component| {
+        matches!(
+            component,
+            "api"
+                | "bin"
+                | "cli"
+                | "commands"
+                | "controllers"
+                | "endpoints"
+                | "handlers"
+                | "routes"
+        )
+    });
+    let stem_match = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .map(|stem| {
+            matches!(
+                stem.to_ascii_lowercase().as_str(),
+                "app"
+                    | "application"
+                    | "cli"
+                    | "command"
+                    | "handler"
+                    | "index"
+                    | "main"
+                    | "router"
+                    | "routes"
+                    | "server"
+            )
+        })
+        .unwrap_or(false);
+    component_match || stem_match
+}
+
+fn test_matches_boundary(test_path: &str, boundary_path: &str) -> bool {
+    let boundary_tokens = path_tokens(boundary_path);
+    let test_tokens = path_tokens(test_path);
+    boundary_tokens
+        .iter()
+        .any(|token| test_tokens.contains(token))
+}
+
+fn path_tokens(path: &str) -> BTreeSet<String> {
+    path.replace('\\', "/")
+        .split(['/', '.', '_', '-'])
+        .map(str::to_ascii_lowercase)
+        .filter(|token| {
+            token.len() >= 3 && !matches!(token.as_str(), "src" | "lib" | "test" | "tests")
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::diff::{ChangeStatus, ChangedFile};
+    use crate::review::impact::{FileImpact, ImpactPaths};
+    use crate::review::model::ReviewReport;
+    use crate::review::signals::{BoundaryCategory, BoundarySignal};
+    use std::path::PathBuf;
+
+    fn changed(path: &str) -> ChangedFile {
+        ChangedFile {
+            path: PathBuf::from(path),
+            status: ChangeStatus::Modified,
+            ranges: Vec::new(),
+            hunks: Vec::new(),
+        }
+    }
+
+    fn report(changed_files: Vec<ChangedFile>, impact: ImpactPaths) -> ReviewReport {
+        ReviewReport {
+            summary: Default::default(),
+            repo_root: PathBuf::from("/repo"),
+            baseline_path: None,
+            changed_files,
+            blast_radius: Vec::new(),
+            impact_paths: impact,
+            ownership: Default::default(),
+            ownership_diagnostics: Vec::new(),
+            boundary_signals: vec![BoundarySignal {
+                category: BoundaryCategory::AccessControl,
+                path: "src/auth/policy.ts".to_string(),
+                status: ChangeStatus::Modified,
+                blast_radius: 1,
+            }],
+            boundary_missing_test: false,
+            tiered_signals: Default::default(),
+            timings: Default::default(),
+            verification: Vec::new(),
+            findings: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn emits_boundary_entrypoint_and_test_contracts_with_bounded_evidence() {
+        let report = report(
+            vec![changed("src/auth/policy.ts"), changed("tests/auth.test.ts")],
+            ImpactPaths {
+                depth: 2,
+                files: vec![FileImpact {
+                    path: PathBuf::from("src/auth/policy.ts"),
+                    direct_dependents: vec![PathBuf::from("src/routes/users.ts")],
+                    transitive_dependents: vec![PathBuf::from("src/domain/user.ts")],
+                }],
+                ..Default::default()
+            },
+        );
+
+        let deltas = security_deltas(&report);
+        assert!(deltas.iter().any(|delta| {
+            delta.family == ContractFamily::SecurityBoundary
+                && delta.change == ContractChangeKind::BoundaryChanged
+        }));
+        assert!(deltas.iter().any(|delta| {
+            delta.change == ContractChangeKind::EntryPointImpacted
+                && delta.consumer_path == "src/routes/users.ts"
+        }));
+        assert!(deltas.iter().any(|delta| {
+            delta.family == ContractFamily::TestCoverage
+                && delta.change == ContractChangeKind::TestChanged
+                && delta.consumer_path == "tests/auth.test.ts"
+        }));
+        assert!(
+            deltas
+                .iter()
+                .all(|delta| { delta.confidence == Some(ContractConfidence::Limited) })
+        );
+    }
+
+    #[test]
+    fn missing_test_contract_is_explicit_and_never_broken() {
+        let deltas = security_deltas(&report(
+            vec![changed("src/auth/policy.ts")],
+            ImpactPaths::default(),
+        ));
+
+        let missing = deltas
+            .iter()
+            .find(|delta| delta.change == ContractChangeKind::TestMissing)
+            .expect("missing test contract");
+        assert_eq!(missing.family, ContractFamily::TestCoverage);
+        assert!(!missing.is_broken());
+        assert!(missing.evidence.contains("cannot prove"));
+    }
+
+    #[test]
+    fn similar_but_unrelated_test_name_is_not_claimed_as_coverage() {
+        assert!(!test_matches_boundary(
+            "tests/author.test.ts",
+            "src/auth/policy.ts"
+        ));
+    }
+}

--- a/tests/review_boundary_signals.rs
+++ b/tests/review_boundary_signals.rs
@@ -176,6 +176,15 @@ fn review_flags_code_boundary_without_a_test_change() {
 
     let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
     assert_eq!(json["review"]["boundary_missing_test"], true);
+    assert!(
+        json["change_proof"]["contract_deltas"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|delta| {
+                delta["family"] == "test-coverage" && delta["change"] == "test-missing"
+            })
+    );
 }
 
 #[test]
@@ -198,6 +207,73 @@ fn review_silent_when_boundary_change_includes_a_test() {
 
     let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
     assert_eq!(json["review"]["boundary_missing_test"], false);
+    assert!(
+        json["change_proof"]["contract_deltas"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|delta| {
+                delta["family"] == "test-coverage" && delta["change"] == "test-changed"
+            })
+    );
+}
+
+#[test]
+fn review_connects_security_boundary_to_bounded_entrypoint_and_related_test() {
+    let temp = tempdir().expect("failed to create temp dir");
+    init_repo(temp.path());
+    write_covered_source(temp.path(), "lib", "pub fn live() {}\n");
+    write(
+        temp.path(),
+        "src/auth/policy.ts",
+        "export const policy = () => true;\n",
+    );
+    write(
+        temp.path(),
+        "src/routes/users.ts",
+        "import { policy } from \"../auth/policy\";\nexport const users = () => policy();\n",
+    );
+    write(
+        temp.path(),
+        "tests/auth.test.ts",
+        "test('auth', () => {});\n",
+    );
+    commit_all(temp.path(), "initial");
+
+    write(
+        temp.path(),
+        "src/auth/policy.ts",
+        "export const policy = () => false;\n",
+    );
+    write(
+        temp.path(),
+        "tests/auth.test.ts",
+        "test('auth', () => expect(true).toBe(true));\n",
+    );
+
+    let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
+    let deltas = json["change_proof"]["contract_deltas"]
+        .as_array()
+        .expect("contract delta array");
+    assert!(deltas.iter().any(|delta| {
+        delta["family"] == "security-boundary" && delta["change"] == "boundary-changed"
+    }));
+    assert!(deltas.iter().any(|delta| {
+        delta["family"] == "security-boundary"
+            && delta["change"] == "entry-point-impacted"
+            && delta["consumer_path"] == "src/routes/users.ts"
+    }));
+    assert!(deltas.iter().any(|delta| {
+        delta["family"] == "test-coverage"
+            && delta["change"] == "test-changed"
+            && delta["consumer_path"] == "tests/auth.test.ts"
+    }));
+    assert!(
+        deltas
+            .iter()
+            .filter(|delta| delta["family"] == "security-boundary")
+            .all(|delta| delta["confidence"] == "limited")
+    );
 }
 
 fn run_review_json(root: &Path, args: &[&str]) -> Value {


### PR DESCRIPTION
## Problem
Phase B had typed dependency, delivery, and runtime configuration contracts, but security-boundary changes still stopped at a path signal and `boundary_missing_test`. The ChangeProof did not connect those boundaries to bounded consumers or preserve the difference between a changed test path and actual behavioral coverage.

## What changed
- add `security-boundary` contract deltas for changed access-control and request-trust boundaries;
- connect those boundaries to bounded import-graph entrypoint candidates using explicit path conventions;
- add `test-coverage` deltas for stable boundary/test path relationships and explicit `test-missing` limitations when no relationship can be established;
- keep every new delta at `limited` confidence and out of `BROKEN` verdict derivation;
- add focused unit and real `review --format json` coverage for entrypoint impact, related tests, unrelated test names, missing tests, and legacy projection safety;
- update the v0.23 roadmap, evidence ledger, and changelog with the evidence scope and limitations.

## Evidence boundary
This is deterministic diff and graph evidence. It does not prove runtime request reachability, authorization correctness, or behavioral test coverage. Dynamic dispatch, generated paths, and semantic coverage remain unassessed.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (923 unit tests, 80 main tests, integration suite passed; 1 explicit compatibility test ignored by design)
- `python3 scripts/release-contract.py check`
- `cargo run -- scan . --fail-on-priority p1` (`Decision: PASS`, 0 visible findings)
- `git diff --check`
