### PR TITLE
test: prove security contract pipeline parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   request-trust boundaries are connected to bounded entrypoint candidates and
   path-related changed tests, while missing or unlinked tests remain explicit
   review evidence without claiming behavioral coverage or a broken contract.
+- Added contract-level review evidence gates: review-zoo fixtures can assert
+  `ChangeProof` deltas, safe fixtures require zero deltas, and a parity fixture
+  proves security evidence is stable across working-tree, snapshot, cold-cache,
+  warm-cache, and explicit base/head review paths.
 
 ### Fixed
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -431,3 +431,21 @@ bump is needed to start.
 - Boundary: this is deterministic diff/graph evidence, not a test runner or
   authorization proof. Dynamic dispatch, generated paths, semantic request
   reachability, and behavioral coverage remain unassessed.
+
+## 0N — Contract Pipeline Parity Evidence
+
+- The review-zoo harness now reads optional `contract_expect` constraints from
+  unsafe fixtures and requires every safe fixture to emit zero ChangeProof
+  contract deltas. The access-control unsafe fixture therefore proves both the
+  existing boundary signal and its `security-boundary` plus `test-missing`
+  contract evidence through the real CLI.
+- `review_contract_parity` runs the same changed access-control boundary and
+  related test through working-tree, `--since-snapshot`, cold parsed-cache,
+  warm parsed-cache, and explicit `--base/--head` review entry points. The
+  canonical `change_proof.contract_deltas` arrays are semantically identical
+  across all five paths.
+- A paired unrelated-test case proves that a changed test with no stable path
+  relationship remains `test-missing`; it is not promoted to `test-changed`.
+- Boundary: this is parity and fixture evidence for deterministic static
+  claims. It does not establish runtime authorization behavior, semantic
+  request reachability, or test execution coverage.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -226,6 +226,9 @@ request-trust boundaries to bounded import-graph entrypoint candidates and
 related changed test paths. The projection is deliberately limited: a path
 relationship or a missing test diff does not prove request reachability or
 behavioral coverage, and no such delta can produce `BROKEN`.
+The review-zoo harness now checks these contract deltas on the unsafe boundary
+fixture and requires safe fixtures to emit none; a parity fixture compares
+working-tree, snapshot, cold-cache, warm-cache, and explicit base/head paths.
 
 Each contract delta records:
 

--- a/tests/fixtures/review-zoo/README.md
+++ b/tests/fixtures/review-zoo/README.md
@@ -16,7 +16,7 @@ tests/fixtures/review-zoo/<family>/<scenario>/{safe,unsafe}/
   patch/
     rationale.md   required, non-empty — names the exact edit and why it is/isn't expected to signal
   after/           file tree overlaid on top, left uncommitted (== the diff)
-  expected.json    { description, expect[] }   (expect[] only required for unsafe/)
+  expected.json    { description, expect[], contract_expect[] }
 ```
 
 The harness commits `before/`, overlays `after/` uncommitted (exactly like the
@@ -27,6 +27,11 @@ fixtures are asserted against `expected.json`'s `expect` array using the same
 partial-match contract as the golden harness (see
 [`tests/fixtures/review/README.md`](../review/README.md#expectedjson-contract)):
 match only on stable fields (`bucket`, `family`, `kind`, `path`, `headline`).
+
+Unsafe fixtures may also declare `contract_expect[]`. Each entry is a partial
+match against `change_proof.contract_deltas`, so a semantic contract claim is
+required to survive the same real CLI fixture that proves its review signal.
+Safe fixtures require zero contract deltas as well as zero review signals.
 
 `patch/rationale.md` is the fixture's documentation — why this exact edit is
 safe or unsafe for this delta family, and (for `safe/`) why no *other* family

--- a/tests/fixtures/review-zoo/boundary/access-control/unsafe/expected.json
+++ b/tests/fixtures/review-zoo/boundary/access-control/unsafe/expected.json
@@ -7,5 +7,21 @@
       "kind": "boundary.access-control",
       "path": "src/auth/session.ts"
     }
+  ],
+  "contract_expect": [
+    {
+      "family": "security-boundary",
+      "change": "boundary-changed",
+      "exporter_path": "src/auth/session.ts",
+      "consumer_path": "src/auth/session.ts",
+      "confidence": "limited"
+    },
+    {
+      "family": "test-coverage",
+      "change": "test-missing",
+      "exporter_path": "src/auth/session.ts",
+      "consumer_path": "src/auth/session.ts",
+      "confidence": "limited"
+    }
   ]
 }

--- a/tests/review_contract_parity.rs
+++ b/tests/review_contract_parity.rs
@@ -1,0 +1,200 @@
+//! Pipeline parity for ChangeProof contract deltas.
+//!
+//! A semantic contract is useful only if its evidence survives the supported
+//! review entry points and cache states. This fixture compares the canonical
+//! contract array across the working tree, snapshot, cold-cache, warm-cache,
+//! and explicit base/head review paths.
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn repopilot() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_repopilot"))
+}
+
+#[test]
+fn security_contracts_are_stable_across_review_entry_points_and_cache_states() {
+    let temp = TempDir::new().expect("temp dir");
+    let root = temp.path();
+    init_repo(root);
+    write(
+        root,
+        "src/auth/policy.ts",
+        "export const policy = () => true;\n",
+    );
+    write(
+        root,
+        "src/routes/users.ts",
+        "import { policy } from \"../auth/policy\";\nexport const users = () => policy();\n",
+    );
+    write(root, "tests/auth.test.ts", "test('auth', () => {});\n");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-m", "before"]);
+    let base = git_output(root, &["rev-parse", "HEAD"]);
+    run(root, &["snapshot"]);
+
+    write(
+        root,
+        "src/auth/policy.ts",
+        "export const policy = () => false;\n",
+    );
+    write(
+        root,
+        "tests/auth.test.ts",
+        "test('auth', () => expect(true).toBe(true));\n",
+    );
+
+    let working = review_json(root, &["review", "."]);
+    let snapshot = review_json(root, &["review", ".", "--since-snapshot"]);
+
+    let _ = fs::remove_dir_all(root.join(".repopilot/cache"));
+    let cold = review_json(root, &["review", "."]);
+    let warm = review_json(root, &["review", "."]);
+
+    git(root, &["add", "src/auth/policy.ts", "tests/auth.test.ts"]);
+    git(root, &["commit", "-m", "after"]);
+    let refs = review_json(root, &["review", ".", "--base", &base, "--head", "HEAD"]);
+
+    let expected = contract_deltas(&working);
+    for (label, report) in [
+        ("snapshot", &snapshot),
+        ("cold", &cold),
+        ("warm", &warm),
+        ("refs", &refs),
+    ] {
+        assert_eq!(
+            contract_deltas(report),
+            expected,
+            "{label} review changed ChangeProof contract evidence"
+        );
+    }
+
+    assert!(expected.iter().any(|delta| {
+        delta["family"] == "security-boundary" && delta["change"] == "boundary-changed"
+    }));
+    assert!(expected.iter().any(|delta| {
+        delta["family"] == "security-boundary"
+            && delta["change"] == "entry-point-impacted"
+            && delta["consumer_path"] == "src/routes/users.ts"
+    }));
+    assert!(expected.iter().any(|delta| {
+        delta["family"] == "test-coverage"
+            && delta["change"] == "test-changed"
+            && delta["consumer_path"] == "tests/auth.test.ts"
+    }));
+}
+
+#[test]
+fn unrelated_changed_test_stays_explicitly_unlinked() {
+    let temp = TempDir::new().expect("temp dir");
+    let root = temp.path();
+    init_repo(root);
+    write(
+        root,
+        "src/auth/policy.ts",
+        "export const policy = () => true;\n",
+    );
+    write(root, "tests/other.test.ts", "test('other', () => {});\n");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-m", "before"]);
+
+    write(
+        root,
+        "src/auth/policy.ts",
+        "export const policy = () => false;\n",
+    );
+    write(
+        root,
+        "tests/other.test.ts",
+        "test('other', () => expect(true).toBe(true));\n",
+    );
+    let json = review_json(root, &["review", "."]);
+    let deltas = contract_deltas(&json);
+    assert!(
+        deltas.iter().any(|delta| {
+            delta["family"] == "test-coverage" && delta["change"] == "test-missing"
+        })
+    );
+    assert!(
+        !deltas.iter().any(|delta| {
+            delta["family"] == "test-coverage" && delta["change"] == "test-changed"
+        })
+    );
+}
+
+fn contract_deltas(json: &Value) -> Vec<Value> {
+    json["change_proof"]["contract_deltas"]
+        .as_array()
+        .cloned()
+        .expect("change_proof.contract_deltas array")
+}
+
+fn review_json(root: &Path, args: &[&str]) -> Value {
+    let mut command = repopilot();
+    command
+        .args(args)
+        .args(["--format", "json"])
+        .current_dir(root);
+    let output = command.output().expect("run review");
+    assert!(
+        output.status.success(),
+        "review failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("review JSON")
+}
+
+fn init_repo(root: &Path) {
+    git(root, &["init"]);
+    git(root, &["config", "user.email", "repopilot@example.invalid"]);
+    git(root, &["config", "user.name", "RepoPilot Test"]);
+}
+
+fn write(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+    fs::write(path, content).expect("write fixture");
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_output(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run git");
+    assert!(output.status.success(), "git {args:?} failed");
+    String::from_utf8(output.stdout)
+        .expect("git output utf8")
+        .trim()
+        .to_string()
+}
+
+fn run(root: &Path, args: &[&str]) {
+    let output = repopilot()
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run repopilot");
+    assert!(
+        output.status.success(),
+        "command {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tests/review_zoo.rs
+++ b/tests/review_zoo.rs
@@ -112,6 +112,10 @@ fn run_variant(dir: &Path, variant: &str) {
         .unwrap_or_else(|err| panic!("[{name}] review did not emit JSON: {err}"));
 
     let signals = flatten_signals(&json);
+    let contracts = json["change_proof"]["contract_deltas"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
 
     match variant {
         "safe" => {
@@ -128,6 +132,10 @@ fn run_variant(dir: &Path, variant: &str) {
                 boundary_signals.is_empty(),
                 "[{name}] safe fixture must produce zero boundary_signals, got {boundary_signals:?}"
             );
+            assert!(
+                contracts.is_empty(),
+                "[{name}] safe fixture must produce zero contract deltas, got {contracts:?}"
+            );
         }
         "unsafe" => {
             let expected = read_expected(dir, &name);
@@ -143,6 +151,14 @@ fn run_variant(dir: &Path, variant: &str) {
                         .any(|signal| signal_matches(signal, constraint)),
                     "[{name}] no signal matched expect {constraint}\nobserved:\n{}",
                     describe(&signals)
+                );
+            }
+            for constraint in expected["contract_expect"].as_array().into_iter().flatten() {
+                assert!(
+                    contracts
+                        .iter()
+                        .any(|contract| value_matches(contract, constraint)),
+                    "[{name}] no contract delta matched expect {constraint}\nobserved: {contracts:?}"
                 );
             }
         }
@@ -187,6 +203,16 @@ fn signal_matches(signal: &Value, constraint: &Value) -> bool {
     fields
         .iter()
         .all(|(key, value)| signal.get(key) == Some(value))
+}
+
+/// Partial match for additive ChangeProof contract fields.
+fn value_matches(value: &Value, constraint: &Value) -> bool {
+    let Some(fields) = constraint.as_object() else {
+        return false;
+    };
+    fields
+        .iter()
+        .all(|(key, expected)| value.get(key) == Some(expected))
 }
 
 fn read_expected(dir: &Path, name: &str) -> Value {


### PR DESCRIPTION
## Problem
The new security and test contract deltas were covered by unit and one real-pipeline tests, but the release evidence did not yet prove that the canonical ChangeProof survived every supported review entry point or cache state. Review-zoo also validated review signals without asserting the contract projection.

## What changed
- extend review-zoo with optional `contract_expect` partial matches against `change_proof.contract_deltas`;
- require every safe review-zoo fixture to emit zero contract deltas;
- pin the unsafe access-control fixture to `security-boundary / boundary-changed` and `test-coverage / test-missing` evidence;
- add `review_contract_parity` covering working-tree, `--since-snapshot`, cold cache, warm cache, and explicit `--base/--head` review paths;
- add an unrelated-test guard proving path-unrelated tests remain `test-missing`;
- update the roadmap, evidence ledger, fixture contract, and changelog.
- 
## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (924 unit tests, 80 main tests, integration suite passed; 1 explicit compatibility test ignored by design)
- `python3 scripts/release-contract.py check`
- `cargo run -- scan . --fail-on-priority p1` (`Decision: PASS`, 0 visible findings)
- `git diff --check`
