### PR TITLE
feat: add review contract evidence scorecard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   Exact single consumers can be high confidence; ambiguous or dynamic access
   remains limited, and workspace aliases explicitly avoid claiming a resolved
   version.
+- Added a generated review-contract evidence scorecard for the safe/unsafe
+  fixture matrix. The scorecard validates contract expectation schemas,
+  requires paired controls, and separates synthetic fixture coverage from
+  real-repository precision and recall. Added a related-test boundary fixture
+  covering the limited `test-changed` contract alongside `test-missing`.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -23,6 +23,7 @@ documentation](../README.md) instead.
 ## Generated evidence and quality measurements
 
 - [Rule scorecard](rule-scorecard.md)
+- [Review contract evidence](review-contract-evidence.md)
 - [Language surface inventory](language-surface-inventory.md)
 - [v0.23 report compatibility matrix](v0.23-compatibility-matrix.md)
 - [v0.23 release evidence ledger](v0.23-evidence-ledger.md)

--- a/docs/engineering/review-contract-evidence.md
+++ b/docs/engineering/review-contract-evidence.md
@@ -1,0 +1,50 @@
+# Review Contract Evidence
+
+<!-- @generated from tests/fixtures/review-zoo/**/expected.json and tests/review_zoo.rs — do not edit by hand. -->
+<!-- Regenerate with `python3 scripts/review_contract_scorecard.py --write`. -->
+
+This scorecard reports **synthetic fixture evidence** for the contract deltas emitted by the review pipeline. It is a protocol and coverage check: the Rust `review_zoo` test runs the real CLI against every pair and matches these expectations. It does not establish real-repository precision or recall.
+
+## Coverage
+
+- Fixture pairs: 15 of 15 scenario pairs have both safe and unsafe variants.
+- Runtime controls: 15 safe variants are required to emit zero review signals and zero contract deltas.
+- Contract-positive unsafe fixtures: 2 of 15 unsafe variants; 4 contract expectations total.
+- All contract evidence is `limited` confidence; static paths do not prove runtime reachability, authorization behavior, or test execution coverage.
+- These counts describe committed fixtures and do not establish real-repository precision or recall.
+
+## Contract-family matrix
+
+| Contract family | Changes covered | Positive fixtures | Expectations | Scenario pairs |
+|---|---|---:|---:|---:|
+| `security-boundary` | `boundary-changed` | 2 | 2 | 2 |
+| `test-coverage` | `test-changed`, `test-missing` | 2 | 2 | 2 |
+
+## Fixture matrix
+
+| Review family | Scenario | Unsafe contract evidence | Safe control |
+|---|---|---|---|
+| `behavioral` | `network-call` | none | zero contract deltas |
+| `boundary` | `access-control` | `security-boundary/boundary-changed`, `test-coverage/test-missing` | zero contract deltas |
+| `boundary` | `access-control-with-test` | `security-boundary/boundary-changed`, `test-coverage/test-changed` | zero contract deltas |
+| `taint` | `array-destructuring` | none | zero contract deltas |
+| `taint` | `destructuring-provenance` | none | zero contract deltas |
+| `taint` | `exact-static-index` | none | zero contract deltas |
+| `taint` | `fastify-request` | none | zero contract deltas |
+| `taint` | `field-sensitive-local` | none | zero contract deltas |
+| `taint` | `hono-request` | none | zero contract deltas |
+| `taint` | `nestjs-controller` | none | zero contract deltas |
+| `taint` | `nestjs-pipes` | none | zero contract deltas |
+| `taint` | `nextjs-app-router` | none | zero contract deltas |
+| `taint` | `property-aware-destructuring` | none | zero contract deltas |
+| `taint` | `sql-injection` | none | zero contract deltas |
+| `taint` | `static-subscript` | none | zero contract deltas |
+
+## Reproduction
+
+```bash
+python3 scripts/review_contract_scorecard.py --check
+cargo test --test review_zoo
+```
+
+The scorecard validates fixture metadata; `cargo test --test review_zoo` is the execution evidence that the current binary satisfies it.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -449,3 +449,23 @@ bump is needed to start.
 - Boundary: this is parity and fixture evidence for deterministic static
   claims. It does not establish runtime authorization behavior, semantic
   request reachability, or test execution coverage.
+
+## 0O — Review Contract Evidence Protocol
+
+- The generated [review contract evidence scorecard](review-contract-evidence.md)
+  validates all 15 committed review-zoo scenario pairs. Every pair has a safe
+  and unsafe variant; safe variants are required by the runtime harness to emit
+  zero review signals and zero ChangeProof contract deltas.
+- Two unsafe boundary fixtures now cover four contract expectations: limited
+  `security-boundary/boundary-changed`, `test-coverage/test-missing`, and
+  `test-coverage/test-changed`. The second fixture changes an access-control
+  file together with a related test, so the positive and safe-control shapes
+  are both exercised.
+- The scorecard rejects missing pair variants, malformed or duplicate contract
+  expectations, unknown family/change values, and confidence stronger than the
+  current bounded `limited` claim. `cargo test --test review_zoo` executes the
+  real CLI against the matrix; the Python scorecard only validates metadata and
+  renders deterministic denominators.
+- Boundary: this closes fixture-protocol evidence for the promoted security and
+  test contract families. It does not add real-repository labels, prove runtime
+  authorization, prove test execution coverage, or close RP23-013.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -229,6 +229,11 @@ behavioral coverage, and no such delta can produce `BROKEN`.
 The review-zoo harness now checks these contract deltas on the unsafe boundary
 fixture and requires safe fixtures to emit none; a parity fixture compares
 working-tree, snapshot, cold-cache, warm-cache, and explicit base/head paths.
+The generated review-contract evidence scorecard now validates the fixture
+protocol itself: every scenario has a safe/unsafe pair, contract expectations
+use the bounded family/change/confidence schema, and both `test-missing` and
+`test-changed` are covered. These are synthetic fixture counts, not
+real-repository precision or recall.
 
 Each contract delta records:
 

--- a/scripts/release-contract.py
+++ b/scripts/release-contract.py
@@ -21,6 +21,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
+import review_contract_scorecard as rcs  # noqa: E402  (after the sys.path fix above)
 import zoo_scorecard as zs  # noqa: E402  (after the sys.path fix above)
 
 
@@ -654,6 +655,28 @@ def check_rule_scorecard() -> None:
         raise ContractError("engineering index does not link to the rule scorecard")
 
 
+def check_review_contract_scorecard() -> None:
+    """The review-zoo contract evidence document must match its fixtures."""
+    fixture_dir = ROOT / "tests" / "fixtures" / "review-zoo"
+    scorecard_path = ROOT / "docs" / "engineering" / "review-contract-evidence.md"
+    if not fixture_dir.is_dir():
+        raise ContractError("Missing review-zoo fixture directory")
+    if not scorecard_path.is_file():
+        raise ContractError("Missing review contract evidence scorecard")
+    try:
+        rendered = rcs.render_scorecard(rcs.collect_score(fixture_dir))
+    except rcs.ScorecardError as exc:
+        raise ContractError(f"review contract evidence protocol is invalid: {exc}") from exc
+    if read_text(scorecard_path) != rendered:
+        raise ContractError(
+            "docs/engineering/review-contract-evidence.md is stale; "
+            "regenerate with `python3 scripts/review_contract_scorecard.py --write`"
+        )
+    engineering_index = read_text(ROOT / "docs" / "engineering" / "README.md")
+    if "review-contract-evidence.md" not in engineering_index:
+        raise ContractError("engineering index does not link to review contract evidence")
+
+
 def check_zoo_gate() -> None:
     """Fail the release contract if the real-repo zoo gate fails, when available.
 
@@ -705,6 +728,7 @@ def check_contract(tag: str | None) -> None:
     check_v023_docs()
     check_docs_parity()
     check_rule_scorecard()
+    check_review_contract_scorecard()
     check_zoo_gate()
     print(f"Release contract passed for {version}")
 

--- a/scripts/review_contract_scorecard.py
+++ b/scripts/review_contract_scorecard.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Validate and render the review-zoo contract evidence protocol.
+
+This scorecard is intentionally separate from the real-repository rule
+scorecard. It measures the committed safe/unsafe fixture matrix and the
+contract expectations that the Rust review-zoo harness checks at runtime. It
+does not run the scanner and cannot establish production precision or recall.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_ROOT = REPO_ROOT / "tests" / "fixtures" / "review-zoo"
+SCORECARD_PATH = REPO_ROOT / "docs" / "engineering" / "review-contract-evidence.md"
+
+GENERATED_BANNER = (
+    "<!-- @generated from tests/fixtures/review-zoo/**/expected.json and "
+    "tests/review_zoo.rs — do not edit by hand. -->\n"
+    "<!-- Regenerate with `python3 scripts/review_contract_scorecard.py --write`. -->"
+)
+
+CONTRACT_CHANGES: dict[str, set[str]] = {
+    "security-boundary": {"boundary-changed", "entrypoint-impacted"},
+    "test-coverage": {"test-changed", "test-missing"},
+}
+REQUIRED_CONTRACT_FIELDS = {
+    "family",
+    "change",
+    "exporter_path",
+    "consumer_path",
+    "confidence",
+}
+
+
+class ScorecardError(ValueError):
+    """Raised when the committed fixture protocol is incomplete or malformed."""
+
+
+@dataclass
+class ContractFamilyScore:
+    family: str
+    positive_fixtures: int = 0
+    expectation_count: int = 0
+    changes: set[str] = field(default_factory=set)
+    scenarios: set[str] = field(default_factory=set)
+
+
+@dataclass(frozen=True)
+class FixtureRecord:
+    family: str
+    scenario: str
+    variant: str
+    description: str
+    contract_expectations: tuple[dict[str, str], ...]
+
+
+@dataclass
+class ContractScorecard:
+    fixtures: list[FixtureRecord]
+    by_contract_family: dict[str, ContractFamilyScore]
+
+    @property
+    def scenario_keys(self) -> set[tuple[str, str]]:
+        return {(fixture.family, fixture.scenario) for fixture in self.fixtures}
+
+    @property
+    def scenario_count(self) -> int:
+        return len(self.scenario_keys)
+
+    @property
+    def safe_variant_count(self) -> int:
+        return sum(fixture.variant == "safe" for fixture in self.fixtures)
+
+    @property
+    def unsafe_variant_count(self) -> int:
+        return sum(fixture.variant == "unsafe" for fixture in self.fixtures)
+
+    @property
+    def contract_positive_fixture_count(self) -> int:
+        return sum(bool(fixture.contract_expectations) for fixture in self.fixtures)
+
+    @property
+    def contract_expectation_count(self) -> int:
+        return sum(len(fixture.contract_expectations) for fixture in self.fixtures)
+
+
+def _read_expected(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ScorecardError(f"{path}: invalid expected.json: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ScorecardError(f"{path}: expected.json must contain an object")
+    description = payload.get("description")
+    if not isinstance(description, str) or not description.strip():
+        raise ScorecardError(f"{path}: description must be a non-empty string")
+    return payload
+
+
+def _contract_expectations(payload: dict[str, Any], path: Path, variant: str) -> tuple[dict[str, str], ...]:
+    raw = payload.get("contract_expect", [])
+    if not isinstance(raw, list):
+        raise ScorecardError(f"{path}: contract_expect must be an array")
+    if variant == "safe" and raw:
+        raise ScorecardError(f"{path}: safe fixture must not declare contract_expect")
+
+    normalized: list[dict[str, str]] = []
+    seen: set[tuple[tuple[str, str], ...]] = set()
+    for index, value in enumerate(raw):
+        if not isinstance(value, dict):
+            raise ScorecardError(f"{path}: contract_expect[{index}] must be an object")
+        missing = REQUIRED_CONTRACT_FIELDS - value.keys()
+        if missing:
+            names = ", ".join(sorted(missing))
+            raise ScorecardError(f"{path}: contract_expect[{index}] missing {names}")
+        if set(value) - REQUIRED_CONTRACT_FIELDS:
+            unknown = ", ".join(sorted(set(value) - REQUIRED_CONTRACT_FIELDS))
+            raise ScorecardError(f"{path}: contract_expect[{index}] has unknown fields {unknown}")
+        if any(not isinstance(value[key], str) or not value[key].strip() for key in REQUIRED_CONTRACT_FIELDS):
+            raise ScorecardError(f"{path}: contract_expect[{index}] fields must be non-empty strings")
+        family = value["family"]
+        change = value["change"]
+        if family not in CONTRACT_CHANGES:
+            raise ScorecardError(f"{path}: unknown contract family {family!r}")
+        if change not in CONTRACT_CHANGES[family]:
+            raise ScorecardError(f"{path}: unknown change {change!r} for {family!r}")
+        if value["confidence"] != "limited":
+            raise ScorecardError(f"{path}: contract evidence must remain limited confidence")
+        identity = tuple(sorted(value.items()))
+        if identity in seen:
+            raise ScorecardError(f"{path}: duplicate contract expectation {family}/{change}")
+        seen.add(identity)
+        normalized.append({key: value[key] for key in sorted(value)})
+    return tuple(normalized)
+
+
+def collect_score(fixture_root: Path = FIXTURE_ROOT) -> ContractScorecard:
+    """Validate every review-zoo pair and return deterministic contract counts."""
+    if not fixture_root.is_dir():
+        raise ScorecardError(f"fixture root not found: {fixture_root}")
+
+    records: list[FixtureRecord] = []
+    pairs: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for family_dir in sorted(path for path in fixture_root.iterdir() if path.is_dir()):
+        for scenario_dir in sorted(path for path in family_dir.iterdir() if path.is_dir()):
+            key = (family_dir.name, scenario_dir.name)
+            for variant in ("safe", "unsafe"):
+                variant_dir = scenario_dir / variant
+                if not variant_dir.is_dir():
+                    raise ScorecardError(f"{scenario_dir}: missing {variant} variant")
+                expected_path = variant_dir / "expected.json"
+                if not expected_path.is_file():
+                    raise ScorecardError(f"{variant_dir}: missing expected.json")
+                payload = _read_expected(expected_path)
+                expectations = payload.get("expect", [])
+                if not isinstance(expectations, list):
+                    raise ScorecardError(f"{expected_path}: expect must be an array")
+                if variant == "unsafe" and not expectations:
+                    raise ScorecardError(f"{expected_path}: unsafe fixture must declare expect")
+                if variant == "safe" and expectations:
+                    raise ScorecardError(f"{expected_path}: safe fixture must not declare expect")
+                contract_expectations = _contract_expectations(payload, expected_path, variant)
+                pairs[key].add(variant)
+                records.append(
+                    FixtureRecord(
+                        family=family_dir.name,
+                        scenario=scenario_dir.name,
+                        variant=variant,
+                        description=payload["description"].strip(),
+                        contract_expectations=contract_expectations,
+                    )
+                )
+
+    if not records:
+        raise ScorecardError(f"{fixture_root}: no fixture pairs found")
+    for key, variants in pairs.items():
+        if variants != {"safe", "unsafe"}:
+            raise ScorecardError(f"{key[0]}/{key[1]}: missing safe variant or unsafe variant")
+
+    by_family: dict[str, ContractFamilyScore] = {}
+    for record in records:
+        families_in_fixture: set[str] = set()
+        for expectation in record.contract_expectations:
+            family_score = by_family.setdefault(
+                expectation["family"], ContractFamilyScore(expectation["family"])
+            )
+            if expectation["family"] not in families_in_fixture:
+                family_score.positive_fixtures += 1
+                families_in_fixture.add(expectation["family"])
+            family_score.expectation_count += 1
+            family_score.changes.add(expectation["change"])
+            family_score.scenarios.add(f"{record.family}/{record.scenario}")
+    missing_families = sorted(set(CONTRACT_CHANGES) - set(by_family))
+    if missing_families:
+        raise ScorecardError(
+            "promoted contract families have no fixture evidence: "
+            + ", ".join(missing_families)
+        )
+    return ContractScorecard(sorted(records, key=lambda item: (item.family, item.scenario, item.variant)), by_family)
+
+
+def render_scorecard(score: ContractScorecard) -> str:
+    """Render the committed, deterministic fixture evidence document."""
+    lines = [
+        "# Review Contract Evidence",
+        "",
+        GENERATED_BANNER,
+        "",
+        "This scorecard reports **synthetic fixture evidence** for the contract "
+        "deltas emitted by the review pipeline. It is a protocol and coverage "
+        "check: the Rust `review_zoo` test runs the real CLI against every pair "
+        "and matches these expectations. It does not establish real-repository "
+        "precision or recall.",
+        "",
+        "## Coverage",
+        "",
+        f"- Fixture pairs: {score.scenario_count} of {score.scenario_count} scenario pairs "
+        f"have both safe and unsafe variants.",
+        f"- Runtime controls: {score.safe_variant_count} safe variants are required to "
+        "emit zero review signals and zero contract deltas.",
+        f"- Contract-positive unsafe fixtures: {score.contract_positive_fixture_count} "
+        f"of {score.unsafe_variant_count} unsafe variants; "
+        f"{score.contract_expectation_count} contract expectations total.",
+        "- All contract evidence is `limited` confidence; static paths do not prove "
+        "runtime reachability, authorization behavior, or test execution coverage.",
+        "- These counts describe committed fixtures and do not establish "
+        "real-repository precision or recall.",
+        "",
+        "## Contract-family matrix",
+        "",
+        "| Contract family | Changes covered | Positive fixtures | Expectations | Scenario pairs |",
+        "|---|---|---:|---:|---:|",
+    ]
+    for family in sorted(score.by_contract_family):
+        family_score = score.by_contract_family[family]
+        lines.append(
+            f"| `{family}` | {', '.join(f'`{change}`' for change in sorted(family_score.changes))} | "
+            f"{family_score.positive_fixtures} | {family_score.expectation_count} | "
+            f"{len(family_score.scenarios)} |"
+        )
+    if not score.by_contract_family:
+        lines.append("| _none_ | — | 0 | 0 | 0 |")
+
+    lines += ["", "## Fixture matrix", "", "| Review family | Scenario | Unsafe contract evidence | Safe control |", "|---|---|---|---|"]
+    for family, scenario in sorted(score.scenario_keys):
+        unsafe = next(item for item in score.fixtures if item.family == family and item.scenario == scenario and item.variant == "unsafe")
+        labels = sorted({f"{item['family']}/{item['change']}" for item in unsafe.contract_expectations})
+        contract_label = ", ".join(f"`{label}`" for label in labels) if labels else "none"
+        lines.append(f"| `{family}` | `{scenario}` | {contract_label} | zero contract deltas |")
+    lines += [
+        "",
+        "## Reproduction",
+        "",
+        "```bash",
+        "python3 scripts/review_contract_scorecard.py --check",
+        "cargo test --test review_zoo",
+        "```",
+        "",
+        "The scorecard validates fixture metadata; `cargo test --test review_zoo` is "
+        "the execution evidence that the current binary satisfies it.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write", action="store_true", help="write the generated scorecard")
+    parser.add_argument("--check", action="store_true", help="fail when the scorecard is stale")
+    args = parser.parse_args()
+    try:
+        rendered = render_scorecard(collect_score())
+    except ScorecardError as exc:
+        parser.error(str(exc))
+    if args.write:
+        SCORECARD_PATH.write_text(rendered, encoding="utf-8")
+        print(f"wrote {SCORECARD_PATH.relative_to(REPO_ROOT)}")
+    elif args.check:
+        if not SCORECARD_PATH.is_file() or SCORECARD_PATH.read_text(encoding="utf-8") != rendered:
+            print(f"STALE {SCORECARD_PATH.relative_to(REPO_ROOT)}; run with --write")
+            return 1
+        print(f"fresh {SCORECARD_PATH.relative_to(REPO_ROOT)}")
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_release_contract.py
+++ b/scripts/tests/test_release_contract.py
@@ -516,6 +516,75 @@ class ReleaseContractTests(unittest.TestCase):
 
         release_contract.check_rule_scorecard()
 
+    def _write_review_contract_fixture(self) -> None:
+        root = release_contract.ROOT / "tests/fixtures/review-zoo/boundary/access-control"
+        for variant in ("safe", "unsafe"):
+            (root / variant).mkdir(parents=True, exist_ok=True)
+            (root / variant / "expected.json").write_text(
+                json.dumps(
+                    {
+                        "description": variant,
+                        "expect": [] if variant == "safe" else [{}],
+                        "contract_expect": [] if variant == "safe" else [
+                            {
+                                "family": "security-boundary",
+                                "change": "boundary-changed",
+                                "exporter_path": "src/auth/session.ts",
+                                "consumer_path": "src/auth/session.ts",
+                                "confidence": "limited",
+                            },
+                            {
+                                "family": "test-coverage",
+                                "change": "test-missing",
+                                "exporter_path": "src/auth/session.ts",
+                                "consumer_path": "src/auth/session.ts",
+                                "confidence": "limited",
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+    def _fresh_review_contract_scorecard(self) -> str:
+        fixture_dir = release_contract.ROOT / "tests/fixtures/review-zoo"
+        return release_contract.rcs.render_scorecard(
+            release_contract.rcs.collect_score(fixture_dir)
+        )
+
+    def test_review_contract_scorecard_requires_committed_files(self) -> None:
+        with self.assertRaisesRegex(release_contract.ContractError, "Missing review-zoo"):
+            release_contract.check_review_contract_scorecard()
+
+    def test_review_contract_scorecard_fails_when_stale(self) -> None:
+        self._write_review_contract_fixture()
+        self.write("docs/engineering/review-contract-evidence.md", "stale\n")
+        self.write("docs/engineering/README.md", "review-contract-evidence.md\n")
+
+        with self.assertRaisesRegex(release_contract.ContractError, "stale"):
+            release_contract.check_review_contract_scorecard()
+
+    def test_review_contract_scorecard_requires_docs_index_link(self) -> None:
+        self._write_review_contract_fixture()
+        self.write(
+            "docs/engineering/review-contract-evidence.md",
+            self._fresh_review_contract_scorecard(),
+        )
+        self.write("docs/engineering/README.md", "no scorecard link\n")
+
+        with self.assertRaisesRegex(release_contract.ContractError, "does not link"):
+            release_contract.check_review_contract_scorecard()
+
+    def test_review_contract_scorecard_passes_when_fresh(self) -> None:
+        self._write_review_contract_fixture()
+        self.write(
+            "docs/engineering/review-contract-evidence.md",
+            self._fresh_review_contract_scorecard(),
+        )
+        self.write("docs/engineering/README.md", "review-contract-evidence.md\n")
+
+        release_contract.check_review_contract_scorecard()
+
     def test_zoo_gate_skips_when_not_cloned(self) -> None:
         self.write("tests/zoo/manifest.toml", '[[repo]]\nname = "repo-a"\n')
 

--- a/scripts/tests/test_review_contract_scorecard.py
+++ b/scripts/tests/test_review_contract_scorecard.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import review_contract_scorecard as rcs  # noqa: E402
+
+
+def write_fixture(root: Path, relative: str, payload: dict) -> None:
+    path = root / relative / "expected.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def contract(family: str, change: str, exporter: str = "src/auth/session.ts") -> dict[str, str]:
+    return {
+        "family": family,
+        "change": change,
+        "exporter_path": exporter,
+        "consumer_path": exporter,
+        "confidence": "limited",
+    }
+
+
+class DiscoverAndValidateTests(unittest.TestCase):
+    def test_discovers_pairs_and_counts_contract_dimensions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_fixture(root, "boundary/access-control/safe", {"description": "safe"})
+            write_fixture(
+                root,
+                "boundary/access-control/unsafe",
+                {
+                    "description": "unsafe",
+                    "expect": [{"family": "boundary", "kind": "boundary.access-control"}],
+                    "contract_expect": [
+                        contract("security-boundary", "boundary-changed"),
+                        contract("test-coverage", "test-missing"),
+                    ],
+                },
+            )
+            write_fixture(root, "behavioral/network-call/safe", {"description": "safe"})
+            write_fixture(
+                root,
+                "behavioral/network-call/unsafe",
+                {"description": "unsafe", "expect": [{"family": "behavioral"}]},
+            )
+
+            score = rcs.collect_score(root)
+
+        self.assertEqual(score.scenario_count, 2)
+        self.assertEqual(score.safe_variant_count, 2)
+        self.assertEqual(score.unsafe_variant_count, 2)
+        self.assertEqual(score.contract_positive_fixture_count, 1)
+        self.assertEqual(score.contract_expectation_count, 2)
+        self.assertEqual(score.by_contract_family["security-boundary"].positive_fixtures, 1)
+        self.assertEqual(
+            score.by_contract_family["security-boundary"].changes,
+            {"boundary-changed"},
+        )
+        self.assertEqual(score.by_contract_family["test-coverage"].positive_fixtures, 1)
+
+    def test_rejects_unknown_contract_change(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_fixture(root, "boundary/access-control/safe", {"description": "safe"})
+            write_fixture(
+                root,
+                "boundary/access-control/unsafe",
+                {
+                    "description": "unsafe",
+                    "expect": [{}],
+                    "contract_expect": [contract("security-boundary", "invented")],
+                },
+            )
+
+            with self.assertRaisesRegex(rcs.ScorecardError, "unknown change"):
+                rcs.collect_score(root)
+
+    def test_requires_safe_and_unsafe_pair(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_fixture(
+                root,
+                "boundary/access-control/unsafe",
+                {"description": "unsafe", "expect": [{}]},
+            )
+
+            with self.assertRaisesRegex(rcs.ScorecardError, "missing safe variant"):
+                rcs.collect_score(root)
+
+    def test_rejects_duplicate_contract_expectation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_fixture(root, "boundary/access-control/safe", {"description": "safe"})
+            item = contract("security-boundary", "boundary-changed")
+            write_fixture(
+                root,
+                "boundary/access-control/unsafe",
+                {"description": "unsafe", "expect": [{}], "contract_expect": [item, item]},
+            )
+
+            with self.assertRaisesRegex(rcs.ScorecardError, "duplicate contract expectation"):
+                rcs.collect_score(root)
+
+    def test_requires_evidence_for_each_promoted_contract_family(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_fixture(root, "boundary/access-control/safe", {"description": "safe"})
+            write_fixture(
+                root,
+                "boundary/access-control/unsafe",
+                {
+                    "description": "unsafe",
+                    "expect": [{}],
+                    "contract_expect": [
+                        contract("security-boundary", "boundary-changed"),
+                    ],
+                },
+            )
+
+            with self.assertRaisesRegex(rcs.ScorecardError, "test-coverage"):
+                rcs.collect_score(root)
+
+
+class RenderTests(unittest.TestCase):
+    def test_render_is_deterministic_and_states_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_fixture(root, "boundary/access-control/safe", {"description": "safe"})
+            write_fixture(
+                root,
+                "boundary/access-control/unsafe",
+                {
+                    "description": "unsafe",
+                    "expect": [{}],
+                    "contract_expect": [
+                        contract("security-boundary", "boundary-changed"),
+                        contract("test-coverage", "test-missing"),
+                    ],
+                },
+            )
+            score = rcs.collect_score(root)
+
+        first = rcs.render_scorecard(score)
+        second = rcs.render_scorecard(score)
+        self.assertEqual(first, second)
+        self.assertIn("synthetic fixture evidence", first)
+        self.assertIn("1 of 1 scenario pairs", first)
+        self.assertIn("security-boundary", first)
+        self.assertIn("does not establish real-repository precision or recall", first)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fixtures/review-zoo/README.md
+++ b/tests/fixtures/review-zoo/README.md
@@ -45,9 +45,15 @@ diff, exactly as in the golden-fixture harness).
 | Family | Scenario | Safe reaches | Unsafe reaches |
 |--------|----------|--------------|-----------------|
 | `boundary` | `access-control` | new file at an ordinary path (`src/utils/format.ts`) | new file under `src/auth/**` |
+| `boundary` | `access-control-with-test` | related utility and test change | changed access-control boundary plus related test |
 | `behavioral` | `network-call` | a pure helper with no I/O | an added `fetch()` call |
 | `taint` | `sql-injection` | tainted input reaches a safe ORM call | tainted input reaches raw SQL via string concatenation |
 
 New fixtures are discovered automatically — drop a `<family>/<scenario>/{safe,unsafe}/`
 directory in and it's picked up, no registration needed. A dedicated test
 asserts the family set stays a superset of `{boundary, behavioral, taint}`.
+
+The generated [review contract evidence scorecard](../../../docs/engineering/review-contract-evidence.md)
+counts contract expectations separately from real-repository rule labels. It is
+fixture protocol evidence only; `cargo test --test review_zoo` is required to
+prove the current binary satisfies the expectations.

--- a/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/after/src/utils/format.ts
+++ b/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/after/src/utils/format.ts
@@ -1,0 +1,3 @@
+export function format(x: number): string {
+  return `${x.toFixed(2)}%`;
+}

--- a/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/after/tests/utils/format.test.ts
+++ b/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/after/tests/utils/format.test.ts
@@ -1,0 +1,3 @@
+test('format', () => {
+  expect(format(1)).toBe('1.00%');
+});

--- a/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/before/src/utils/format.ts
+++ b/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/before/src/utils/format.ts
@@ -1,0 +1,3 @@
+export function format(x: number): string {
+  return x.toFixed(2);
+}

--- a/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/before/tests/utils/format.test.ts
+++ b/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/before/tests/utils/format.test.ts
@@ -1,0 +1,3 @@
+test('format', () => {
+  expect(true).toBe(true);
+});

--- a/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/expected.json
+++ b/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/expected.json
@@ -1,0 +1,3 @@
+{
+  "description": "A utility and its related test change outside a security boundary must remain free of boundary and contract signals."
+}

--- a/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/boundary/access-control-with-test/safe/patch/rationale.md
@@ -1,0 +1,7 @@
+# Rationale — boundary/access-control-with-test (safe)
+
+The utility and its test both change under ordinary `src/utils/` and
+`tests/utils/` paths. The edit has no access-control or request-trust boundary,
+so the related test must not create a security or test-coverage contract delta.
+This is the safe twin of the unsafe variant, which changes `src/auth/session.ts`
+and its related test.

--- a/tests/fixtures/review-zoo/boundary/access-control-with-test/unsafe/after/src/auth/session.ts
+++ b/tests/fixtures/review-zoo/boundary/access-control-with-test/unsafe/after/src/auth/session.ts
@@ -1,0 +1,3 @@
+export function allowed(user: { role: string }): boolean {
+  return user.role === 'member' || user.role === 'admin';
+}

--- a/tests/fixtures/review-zoo/boundary/access-control-with-test/unsafe/after/tests/auth/session.test.ts
+++ b/tests/fixtures/review-zoo/boundary/access-control-with-test/unsafe/after/tests/auth/session.test.ts
@@ -1,0 +1,3 @@
+test('admin access-control boundary', () => {
+  expect(true).toBe(true);
+});

--- a/tests/fixtures/review-zoo/boundary/access-control-with-test/unsafe/before/src/auth/session.ts
+++ b/tests/fixtures/review-zoo/boundary/access-control-with-test/unsafe/before/src/auth/session.ts
@@ -1,0 +1,3 @@
+export function allowed(user: { role: string }): boolean {
+  return user.role === 'member';
+}

--- a/tests/fixtures/review-zoo/boundary/access-control-with-test/unsafe/expected.json
+++ b/tests/fixtures/review-zoo/boundary/access-control-with-test/unsafe/expected.json
@@ -1,0 +1,27 @@
+{
+  "description": "An access-control boundary change with a related test must emit both the boundary contract and the limited test-changed contract.",
+  "expect": [
+    {
+      "bucket": "definitely",
+      "family": "boundary",
+      "kind": "boundary.access-control",
+      "path": "src/auth/session.ts"
+    }
+  ],
+  "contract_expect": [
+    {
+      "family": "security-boundary",
+      "change": "boundary-changed",
+      "exporter_path": "src/auth/session.ts",
+      "consumer_path": "src/auth/session.ts",
+      "confidence": "limited"
+    },
+    {
+      "family": "test-coverage",
+      "change": "test-changed",
+      "exporter_path": "src/auth/session.ts",
+      "consumer_path": "tests/auth/session.test.ts",
+      "confidence": "limited"
+    }
+  ]
+}

--- a/tests/fixtures/review-zoo/boundary/access-control-with-test/unsafe/patch/rationale.md
+++ b/tests/fixtures/review-zoo/boundary/access-control-with-test/unsafe/patch/rationale.md
@@ -1,0 +1,7 @@
+# Rationale — boundary/access-control-with-test (unsafe)
+
+The changed `src/auth/session.ts` file is an access-control boundary. Its
+related `tests/auth/session.test.ts` file changes in the same diff, and the
+stable `auth`/`session` path relationship is the bounded evidence for
+`test-changed`. Static naming still does not prove that the test executes the
+authorization behavior, so both contract deltas remain limited confidence.


### PR DESCRIPTION
## Problem
The review-zoo already exercised security/test contract deltas, but its evidence was only implicit in the Rust harness. The repository had no deterministic denominator for contract fixture coverage and no guard against losing all evidence for a promoted contract family.

## What changed
- Added `scripts/review_contract_scorecard.py` to validate and render a deterministic synthetic contract-evidence scorecard.
- Enforced safe/unsafe pairing, required contract fields, known family/change values, limited confidence, duplicate rejection, and evidence for every promoted contract family.
- Added a boundary fixture with a related test change, covering `test-coverage/test-changed` alongside the existing `test-missing` case.
- Wired scorecard freshness into `scripts/release-contract.py` and linked the generated document from engineering docs.
- Updated the v0.23 evidence ledger, roadmap, fixture README, and changelog with the measured scope and limitations.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (924 unit tests, 80 main tests, all integration/doc tests passed; one explicit compatibility test remains ignored by policy)
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (132 passed)
- `python3 scripts/review_contract_scorecard.py --check`
- `python3 scripts/release-contract.py check`
- `cargo test --test review_boundary_signals --test review_contract_parity --test review_zoo`
