### PR TITLE
feat: measure real-history contract evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   requires paired controls, and separates synthetic fixture coverage from
   real-repository precision and recall. Added a related-test boundary fixture
   covering the limited `test-changed` contract alongside `test-missing`.
+- Extended the real-history holdout collector to retain stable contract
+  family/change IDs and an evidence hash, and extended blinded worksheets and
+  adjudicated metrics with bounded security/test contract labels. Unmeasured
+  current contract families remain visible in observations rather than being
+  silently dropped.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -469,3 +469,26 @@ bump is needed to start.
 - Boundary: this closes fixture-protocol evidence for the promoted security and
   test contract families. It does not add real-repository labels, prove runtime
   authorization, prove test execution coverage, or close RP23-013.
+
+## 0P — Real-History Contract Observation Protocol
+
+- The independent holdout collection artifact is now schema 2. Each review
+  observation records stable contract family/change IDs and a hash over those
+  IDs. The collector validates all currently emitted identities, including
+  unmeasured dependency, delivery, runtime, and public-symbol families, so a
+  broader signal is visible rather than silently discarded.
+- Blinded reviewer worksheets and adjudication templates now carry
+  `expected_contract_ids`. The first measured registry is deliberately bounded
+  to `security-boundary/*` and `test-coverage/*`; labels do not assert paths,
+  evidence prose, runtime reachability, authorization behavior, or test
+  execution.
+- A fresh collection over all six immutable cases passed `validate-result`.
+  Observed contract IDs were `security-boundary/boundary-changed` plus
+  `test-coverage/test-missing` in `flask-pr-5812`, and the unmeasured
+  `delivery/action-reference-changed` in `requests-pr-7019`; the other four
+  cases emitted no contract IDs. All six cases remain `pending`, so this is an
+  observation packet, not precision, recall, or utility evidence.
+- The metrics artifact now reports per-ID TP/FN/TN/FP and Wilson intervals after
+  two independent labels plus adjudication. No labels were invented or added
+  in this slice; RP23-013 remains open until reviewers complete the frozen
+  worksheets and the result is audited.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -392,6 +392,12 @@ The evidence protocol must:
 - compare against existing checks to show additional decision value, not merely
   more findings.
 
+The real-history holdout now carries stable ChangeProof contract family/change
+observations through collection, blinded annotation, adjudication, and metrics.
+The first measured contract registry is limited to security and test families;
+other emitted families remain visible as unmeasured observations. This keeps
+the evidence denominator explicit while labels are still pending.
+
 Initial release discipline:
 
 - a rule cannot be described as broadly precise without labeled default evidence

--- a/scripts/real_history_adjudication.py
+++ b/scripts/real_history_adjudication.py
@@ -14,16 +14,20 @@ from real_history_annotations import (
     _load_toml,
 )
 from real_history_contract import ALLOWED_LABELS, HoldoutManifestError, validate_manifest
+from real_history_contracts import ContractEvidenceError, validate_expected_contract_ids
 
 
 ADJUDICATION_FIELDS = {
     "id",
     "label_a",
     "expected_rule_ids_a",
+    "expected_contract_ids_a",
     "label_b",
     "expected_rule_ids_b",
+    "expected_contract_ids_b",
     "adjudicated",
     "expected_rule_ids",
+    "expected_contract_ids",
     "rationale",
 }
 
@@ -58,10 +62,13 @@ def render_adjudication_template(
             f"id = {_toml_string(case_id)}",
             f"label_a = {_toml_string(left['label'])}",
             f"expected_rule_ids_a = {_toml_array(left['expected_rule_ids'])}",
+            f"expected_contract_ids_a = {_toml_array(left['expected_contract_ids'])}",
             f"label_b = {_toml_string(right['label'])}",
             f"expected_rule_ids_b = {_toml_array(right['expected_rule_ids'])}",
+            f"expected_contract_ids_b = {_toml_array(right['expected_contract_ids'])}",
             'adjudicated = ""',
             "expected_rule_ids = []",
+            "expected_contract_ids = []",
             'rationale = ""',
             "",
         ])
@@ -116,6 +123,9 @@ def validate_adjudication(
                 raise HoldoutManifestError(f"adjudication case {case_id}: {label_key} does not match worksheet")
             if raw.get(rules_key) != source[case_id]["expected_rule_ids"]:
                 raise HoldoutManifestError(f"adjudication case {case_id}: {rules_key} does not match worksheet")
+            contracts_key = f"expected_contract_ids_{side}"
+            if raw.get(contracts_key) != source[case_id]["expected_contract_ids"]:
+                raise HoldoutManifestError(f"adjudication case {case_id}: {contracts_key} does not match worksheet")
         label = raw.get("adjudicated")
         if label not in ALLOWED_LABELS:
             raise HoldoutManifestError(f"adjudication case {case_id}: adjudicated label is required")
@@ -126,6 +136,13 @@ def validate_adjudication(
             raise HoldoutManifestError(f"adjudication case {case_id}: expected_rule_ids contains an unknown rule")
         if label == "defect-present" and not rules:
             raise HoldoutManifestError(f"adjudication case {case_id}: defect-present needs expected_rule_ids")
+        try:
+            validate_expected_contract_ids(
+                raw.get("expected_contract_ids"),
+                f"adjudication case {case_id} expected_contract_ids",
+            )
+        except ContractEvidenceError as error:
+            raise HoldoutManifestError(str(error)) from error
         if not isinstance(raw.get("rationale"), str) or not raw["rationale"].strip():
             raise HoldoutManifestError(f"adjudication case {case_id}: rationale is required")
     if observed != expected_ids:

--- a/scripts/real_history_annotations.py
+++ b/scripts/real_history_annotations.py
@@ -16,9 +16,10 @@ from real_history_contract import (
     HoldoutManifestError,
     validate_manifest,
 )
+from real_history_contracts import ContractEvidenceError, validate_expected_contract_ids
 
 
-ANNOTATION_SCHEMA_VERSION = 2
+ANNOTATION_SCHEMA_VERSION = 3
 ANNOTATION_PROTOCOL = "dual-independent-adjudication-v1"
 ANNOTATION_FIELDS = {
     "id",
@@ -30,6 +31,7 @@ ANNOTATION_FIELDS = {
     "baseline_statuses",
     "label",
     "expected_rule_ids",
+    "expected_contract_ids",
     "rationale",
 }
 
@@ -97,6 +99,7 @@ def _worksheet_case(case: HoldoutCase, observation: dict[str, Any]) -> list[str]
         f"baseline_statuses = {_toml_array(statuses)}",
         'label = ""',
         "expected_rule_ids = []",
+        "expected_contract_ids = []",
         'rationale = ""',
         "",
     ]
@@ -198,6 +201,13 @@ def _validate_context(
             raise HoldoutManifestError(f"annotation case {case_id}: expected_rule_ids contains an unknown rule")
         if raw["label"] == "defect-present" and not raw["expected_rule_ids"]:
             raise HoldoutManifestError(f"annotation case {case_id}: defect-present needs expected_rule_ids")
+        try:
+            validate_expected_contract_ids(
+                raw.get("expected_contract_ids"),
+                f"annotation case {case_id} expected_contract_ids",
+            )
+        except ContractEvidenceError as error:
+            raise HoldoutManifestError(str(error)) from error
         if not isinstance(raw.get("rationale"), str) or not raw["rationale"].strip():
             raise HoldoutManifestError(f"annotation case {case_id}: rationale is required")
         observed[case_id] = raw

--- a/scripts/real_history_artifact.py
+++ b/scripts/real_history_artifact.py
@@ -4,14 +4,20 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
 from real_history_contract import HoldoutCase, HoldoutManifestError, validate_manifest
+from real_history_contracts import (
+    ContractEvidenceError,
+    contract_evidence_hash,
+    validate_observed_contract_ids,
+)
 from real_history_runner import BASELINE_COMMANDS
 
 
-COLLECTION_SCHEMA_VERSION = 1
+COLLECTION_SCHEMA_VERSION = 2
 BASELINE_STATUSES = {"passed", "failed", "unavailable", "timeout"}
 REVIEW_STATUSES = {"collected", "timeout"}
 
@@ -63,6 +69,15 @@ def validate_collection_data(
         "cases": len(observations),
         "baseline_observations": sum(len(observation["baselines"]) for observation in observations),
         "review_observations": len(observations),
+        "contract_id_counts": dict(
+            sorted(
+                Counter(
+                    contract_id
+                    for observation in observations
+                    for contract_id in observation["review"]["contract_delta_ids"]
+                ).items()
+            )
+        ),
         "status": "valid",
     }
 
@@ -86,6 +101,17 @@ def validate_observation(observation: dict[str, Any], case: HoldoutCase) -> None
     review = observation.get("review")
     if not isinstance(review, dict) or review.get("status") not in REVIEW_STATUSES:
         raise HoldoutManifestError(f"collection case {case.case_id}: invalid review result")
+    try:
+        contract_ids = validate_observed_contract_ids(
+            review.get("contract_delta_ids"),
+            f"collection case {case.case_id} contract_delta_ids",
+        )
+    except ContractEvidenceError as error:
+        raise HoldoutManifestError(str(error)) from error
+    if review.get("contract_delta_count") != len(contract_ids):
+        raise HoldoutManifestError(f"collection case {case.case_id}: contract delta count drift")
+    if review.get("contract_evidence_sha256") != contract_evidence_hash(contract_ids):
+        raise HoldoutManifestError(f"collection case {case.case_id}: contract evidence hash drift")
 
 
 def validate_collection_artifact(

--- a/scripts/real_history_contracts.py
+++ b/scripts/real_history_contracts.py
@@ -1,0 +1,104 @@
+"""Bounded contract identities used by the real-history evidence protocol."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Iterable
+
+
+ALL_CONTRACT_IDS = (
+    "public-symbol/removed-export",
+    "dependency/added",
+    "dependency/removed",
+    "dependency/upgraded",
+    "dependency/downgraded",
+    "dependency/source-changed",
+    "dependency/feature-changed",
+    "dependency/alias-changed",
+    "dependency/metadata-only",
+    "delivery/trigger-changed",
+    "delivery/permission-changed",
+    "delivery/secret-use-changed",
+    "delivery/action-reference-changed",
+    "delivery/artifact-changed",
+    "delivery/deployment-changed",
+    "runtime-configuration/introduced",
+    "runtime-configuration/removed",
+    "runtime-configuration/renamed",
+    "runtime-configuration/changed",
+    "security-boundary/boundary-changed",
+    "security-boundary/entrypoint-impacted",
+    "test-coverage/test-changed",
+    "test-coverage/test-missing",
+)
+CONTRACT_IDS = (
+    "security-boundary/boundary-changed",
+    "security-boundary/entrypoint-impacted",
+    "test-coverage/test-changed",
+    "test-coverage/test-missing",
+)
+_ALL_CONTRACT_ID_SET = set(ALL_CONTRACT_IDS)
+_MEASURED_CONTRACT_ID_SET = set(CONTRACT_IDS)
+
+
+class ContractEvidenceError(ValueError):
+    """Raised when a contract observation or human label leaves the protocol."""
+
+
+def _contract_id(value: Any, context: str) -> str:
+    if not isinstance(value, dict):
+        raise ContractEvidenceError(f"{context} must be an object")
+    family = value.get("family")
+    change = value.get("change")
+    if not isinstance(family, str) or not family.strip() or not isinstance(change, str) or not change.strip():
+        raise ContractEvidenceError(f"{context} needs non-empty family and change")
+    identity = f"{family.strip()}/{change.strip()}"
+    if identity not in _ALL_CONTRACT_ID_SET:
+        raise ContractEvidenceError(f"{context}: unknown contract ID {identity!r}")
+    return identity
+
+
+def observed_contract_ids(report: dict[str, Any]) -> tuple[str, ...]:
+    """Extract stable family/change IDs while discarding evidence prose and paths."""
+    proof = report.get("change_proof")
+    if proof is None:
+        return ()
+    if not isinstance(proof, dict):
+        raise ContractEvidenceError("change_proof must be an object")
+    raw = proof.get("contract_deltas", [])
+    if not isinstance(raw, list):
+        raise ContractEvidenceError("change_proof.contract_deltas must be an array")
+    return tuple(sorted({_contract_id(delta, f"contract_deltas[{index}]") for index, delta in enumerate(raw)}))
+
+
+def validate_expected_contract_ids(values: Iterable[Any], context: str = "expected_contract_ids") -> tuple[str, ...]:
+    """Validate independent labels against the frozen contract registry."""
+    if not isinstance(values, (list, tuple)) or not all(isinstance(value, str) for value in values):
+        raise ContractEvidenceError(f"{context} must be a string array")
+    normalized = tuple(sorted(value.strip() for value in values))
+    if len(set(normalized)) != len(normalized):
+        raise ContractEvidenceError(f"{context} contains duplicate contract IDs")
+    unknown = sorted(set(normalized) - _MEASURED_CONTRACT_ID_SET)
+    if unknown:
+        raise ContractEvidenceError(f"{context}: unknown contract ID {unknown[0]!r}")
+    return normalized
+
+
+def validate_observed_contract_ids(values: Iterable[Any], context: str = "contract_delta_ids") -> tuple[str, ...]:
+    """Validate collector output against every currently emitted contract identity."""
+    if not isinstance(values, (list, tuple)) or not all(isinstance(value, str) for value in values):
+        raise ContractEvidenceError(f"{context} must be a string array")
+    normalized = tuple(sorted(value.strip() for value in values))
+    if len(set(normalized)) != len(normalized):
+        raise ContractEvidenceError(f"{context} contains duplicate contract IDs")
+    unknown = sorted(set(normalized) - _ALL_CONTRACT_ID_SET)
+    if unknown:
+        raise ContractEvidenceError(f"{context}: unknown contract ID {unknown[0]!r}")
+    return normalized
+
+
+def contract_evidence_hash(contract_ids: Iterable[str]) -> str:
+    """Hash the sorted stable IDs, excluding paths and explanatory evidence."""
+    payload = json.dumps(sorted(set(contract_ids)), separators=(",", ":"))
+    return hashlib.sha256(payload.encode()).hexdigest()

--- a/scripts/real_history_metrics.py
+++ b/scripts/real_history_metrics.py
@@ -12,9 +12,10 @@ from typing import Any
 from real_history_adjudication import validate_adjudication
 from real_history_annotations import load_collection
 from real_history_contract import HoldoutManifestError
+from real_history_contracts import CONTRACT_IDS, ContractEvidenceError, validate_expected_contract_ids
 
 
-METRICS_SCHEMA_VERSION = 1
+METRICS_SCHEMA_VERSION = 2
 
 
 def sha256_file(path: Path) -> str:
@@ -62,6 +63,18 @@ def _case_outcome(gold_label: str, expected_rules: list[str], observed_rules: li
     return "excluded"
 
 
+def _contract_outcome(expected: bool, observed: bool, excluded: bool) -> str:
+    if excluded:
+        return "excluded"
+    if expected and observed:
+        return "tp"
+    if expected:
+        return "fn"
+    if observed:
+        return "fp"
+    return "tn"
+
+
 def build_metrics(
     adjudication_path: Path,
     annotation_a_path: Path,
@@ -87,6 +100,10 @@ def build_metrics(
     }
     cases: list[dict[str, object]] = []
     counts = {key: 0 for key in ("tp", "fn", "tn", "fp", "excluded")}
+    contract_counts = {
+        contract_id: {key: 0 for key in ("tp", "fn", "tn", "fp", "excluded")}
+        for contract_id in CONTRACT_IDS
+    }
     for labeled in adjudication["case"]:
         case_id = labeled["id"]
         observation = observations.get(case_id)
@@ -96,18 +113,41 @@ def build_metrics(
         expected_rules = sorted(set(labeled["expected_rule_ids"]))
         outcome = _case_outcome(labeled["adjudicated"], expected_rules, observed_rules)
         counts[outcome] += 1
+        observed_contracts = sorted(set(observation["review"].get("contract_delta_ids", [])))
+        try:
+            expected_contracts = list(validate_expected_contract_ids(labeled["expected_contract_ids"]))
+        except ContractEvidenceError as error:
+            raise HoldoutManifestError(str(error)) from error
+        for contract_id in CONTRACT_IDS:
+            contract_counts[contract_id][_contract_outcome(
+                contract_id in expected_contracts,
+                contract_id in observed_contracts,
+                labeled["adjudicated"] == "uncertain",
+            )] += 1
         cases.append(
             {
                 "id": case_id,
                 "gold_label": labeled["adjudicated"],
                 "expected_rule_ids": expected_rules,
                 "observed_in_diff_rule_ids": observed_rules,
+                "expected_contract_ids": expected_contracts,
+                "observed_contract_ids": observed_contracts,
                 "outcome": outcome,
             }
         )
-    positive_predictions = counts["tp"] + counts["fp"]
-    actual_positives = counts["tp"] + counts["fn"]
-    actual_negatives = counts["tn"] + counts["fp"]
+    rule_positive_predictions = counts["tp"] + counts["fp"]
+    rule_actual_positives = counts["tp"] + counts["fn"]
+    rule_actual_negatives = counts["tn"] + counts["fp"]
+    contract_metrics = {}
+    for contract_id, contract_result in contract_counts.items():
+        contract_positive_predictions = contract_result["tp"] + contract_result["fp"]
+        contract_actual_positives = contract_result["tp"] + contract_result["fn"]
+        contract_actual_negatives = contract_result["tn"] + contract_result["fp"]
+        contract_metrics[contract_id] = {
+            "recall": _metric(contract_result["tp"], contract_actual_positives),
+            "specificity": _metric(contract_result["tn"], contract_actual_negatives),
+            "precision": _metric(contract_result["tp"], contract_positive_predictions),
+        }
     return {
         "schema_version": METRICS_SCHEMA_VERSION,
         "corpus": adjudication["corpus"],
@@ -119,11 +159,14 @@ def build_metrics(
         "limitation": "descriptive corpus evidence; not a production or language-wide estimate",
         "cases": cases,
         "counts": counts,
+        "contract_ids": list(CONTRACT_IDS),
+        "contract_counts": contract_counts,
+        "contract_metrics": contract_metrics,
         "metrics": {
-            "recall": _metric(counts["tp"], actual_positives),
-            "specificity": _metric(counts["tn"], actual_negatives),
-            "precision": _metric(counts["tp"], positive_predictions),
-            "case_coverage": _metric(actual_positives + actual_negatives, len(cases)),
+            "recall": _metric(counts["tp"], rule_actual_positives),
+            "specificity": _metric(counts["tn"], rule_actual_negatives),
+            "precision": _metric(counts["tp"], rule_positive_predictions),
+            "case_coverage": _metric(rule_actual_positives + rule_actual_negatives, len(cases)),
         },
     }
 

--- a/scripts/real_history_runner.py
+++ b/scripts/real_history_runner.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from real_history_contract import HoldoutCase, HoldoutManifestError
+from real_history_contracts import ContractEvidenceError, contract_evidence_hash, observed_contract_ids
 from zoo_scanner import ScannerPreparationError, ScannerProvenanceError, prepare_scanner
 
 
@@ -57,6 +58,10 @@ def summarize_review(report: dict[str, Any], raw_output: bytes) -> dict[str, Any
         finding for finding in findings
         if isinstance(finding, dict) and finding.get("in_diff") is True
     ]
+    try:
+        contract_ids = observed_contract_ids(report)
+    except ContractEvidenceError as error:
+        raise HoldoutManifestError(f"review report has invalid contract evidence: {error}") from error
     evidence = {
         "schema_version": report.get("schema_version"),
         "repopilot_version": report.get("repopilot_version"),
@@ -65,6 +70,8 @@ def summarize_review(report: dict[str, Any], raw_output: bytes) -> dict[str, Any
         "in_diff_rule_ids": sorted(
             finding["rule_id"] for finding in in_diff if isinstance(finding.get("rule_id"), str)
         ),
+        "contract_delta_ids": list(contract_ids),
+        "contract_delta_count": len(contract_ids),
     }
     return {
         "report_sha256": sha256_bytes(raw_output),
@@ -72,6 +79,16 @@ def summarize_review(report: dict[str, Any], raw_output: bytes) -> dict[str, Any
             json.dumps(evidence, sort_keys=True, separators=(",", ":")).encode()
         ),
         **evidence,
+        "contract_evidence_sha256": contract_evidence_hash(contract_ids),
+    }
+
+
+def empty_contract_observation() -> dict[str, Any]:
+    """Return a deterministic no-delta observation for a timed-out review."""
+    return {
+        "contract_delta_ids": [],
+        "contract_delta_count": 0,
+        "contract_evidence_sha256": contract_evidence_hash(()),
     }
 
 
@@ -138,7 +155,11 @@ def collect_case(scanner: Any, case: HoldoutCase, root: Path, timeout_seconds: i
             list(review_command), cwd=head, capture_output=True, check=False, timeout=timeout_seconds
         )
     except subprocess.TimeoutExpired:
-        review_result: dict[str, Any] = {"status": "timeout", "returncode": None}
+        review_result: dict[str, Any] = {
+            "status": "timeout",
+            "returncode": None,
+            **empty_contract_observation(),
+        }
     else:
         if review.returncode not in (0, 1):
             raise HoldoutManifestError(
@@ -184,7 +205,7 @@ def collect_holdout(
         for index, case in enumerate(cases):
             observations.append(collect_case(scanner, case, root / str(index), timeout_seconds))
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "corpus": corpus,
         "protocol": protocol,
         "manifest_sha256": sha256_bytes(manifest_path.read_bytes()),

--- a/scripts/tests/test_real_history_annotations.py
+++ b/scripts/tests/test_real_history_annotations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sys
 import tempfile
 import tomllib
@@ -19,7 +20,8 @@ from real_history_adjudication import (  # noqa: E402
     render_adjudication_template,
     validate_adjudication,
 )
-from real_history_metrics import _case_outcome, build_metrics, wilson_interval  # noqa: E402
+from real_history_metrics import _case_outcome, _contract_outcome, build_metrics, wilson_interval  # noqa: E402
+from real_history_contracts import contract_evidence_hash  # noqa: E402
 from real_history_contract import validate_manifest  # noqa: E402
 from real_history_runner import BASELINE_COMMANDS  # noqa: E402
 
@@ -88,11 +90,14 @@ label_state = "pending"
                     "review": {
                         "status": "collected",
                         "in_diff_rule_ids": ["demo.rule"] if case.case_id == "case-one" else [],
+                        "contract_delta_ids": [],
+                        "contract_delta_count": 0,
+                        "contract_evidence_sha256": hashlib.sha256(b"[]").hexdigest(),
                     },
                 }
             )
         data = {
-            "schema_version": 1,
+            "schema_version": 2,
             "corpus": "test",
             "protocol": "dual-independent-adjudication-v1",
             "manifest_sha256": hashlib.sha256(self.manifest.read_bytes()).hexdigest(),
@@ -105,7 +110,7 @@ label_state = "pending"
             "cases": observations,
             "label_state": "pending",
         }
-        self.collection.write_text(__import__("json").dumps(data), encoding="utf-8")
+        self.collection.write_text(json.dumps(data), encoding="utf-8")
 
     def tearDown(self) -> None:
         self.tmp.cleanup()
@@ -157,6 +162,18 @@ label_state = "pending"
         with self.assertRaisesRegex(ValueError, "base_sha does not match"):
             load_annotation(path, self.collection, self.manifest, self.rules, self.zoo, "a")
 
+    def test_annotation_rejects_unknown_contract_identity(self) -> None:
+        path = self.worksheet("a")
+        self.complete(path, "no-defect")
+        text = path.read_text(encoding="utf-8").replace(
+            "expected_contract_ids = []",
+            'expected_contract_ids = ["security-boundary/not-supported"]',
+            1,
+        )
+        path.write_text(text, encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "unknown contract ID"):
+            load_annotation(path, self.collection, self.manifest, self.rules, self.zoo, "a")
+
     def test_adjudication_template_preserves_disagreement(self) -> None:
         left, right = self.worksheet("a"), self.worksheet("b")
         self.complete(left, "defect-present")
@@ -197,9 +214,28 @@ label_state = "pending"
         )
 
     def test_metrics_are_corpus_scoped_and_include_intervals(self) -> None:
+        collection = json.loads(self.collection.read_text(encoding="utf-8"))
+        collection["cases"][0]["review"].update(
+            {
+                "contract_delta_ids": ["security-boundary/boundary-changed"],
+                "contract_delta_count": 1,
+                "contract_evidence_sha256": contract_evidence_hash(
+                    ("security-boundary/boundary-changed",)
+                ),
+            }
+        )
+        self.collection.write_text(json.dumps(collection), encoding="utf-8")
         left, right = self.worksheet("a"), self.worksheet("b")
         self.complete(left, "defect-present")
         self.complete(right, "defect-present")
+        for path in (left, right):
+            text = path.read_text(encoding="utf-8")
+            text = text.replace(
+                "expected_contract_ids = []",
+                'expected_contract_ids = ["security-boundary/boundary-changed"]',
+                1,
+            )
+            path.write_text(text, encoding="utf-8")
         for path in (left, right):
             text = path.read_text(encoding="utf-8")
             marker = '[[case]]\nid = "case-two"'
@@ -217,6 +253,11 @@ label_state = "pending"
         text = adjudication.read_text(encoding="utf-8")
         text = text.replace('adjudicated = ""', 'adjudicated = "defect-present"', 1)
         text = text.replace('expected_rule_ids = []', 'expected_rule_ids = ["demo.rule"]', 1)
+        text = text.replace(
+            "expected_contract_ids = []",
+            'expected_contract_ids = ["security-boundary/boundary-changed"]',
+            1,
+        )
         text = text.replace('rationale = ""', 'rationale = "confirmed"', 1)
         text = text.replace('adjudicated = ""', 'adjudicated = "no-defect"', 1)
         text = text.replace('rationale = ""', 'rationale = "confirmed"', 1)
@@ -226,6 +267,10 @@ label_state = "pending"
         )
         self.assertEqual(result["counts"], {"tp": 1, "fn": 0, "tn": 1, "fp": 0, "excluded": 0})
         self.assertEqual(result["metrics"]["recall"]["trials"], 1)
+        self.assertEqual(
+            result["contract_counts"]["security-boundary/boundary-changed"],
+            {"tp": 1, "fn": 0, "tn": 1, "fp": 0, "excluded": 0},
+        )
         self.assertEqual(result["scope"], "adjudicated real-history holdout cases only")
         self.assertIsNotNone(result["metrics"]["recall"]["wilson_95"])
         self.assertIsNone(wilson_interval(0, 0))
@@ -236,6 +281,11 @@ label_state = "pending"
         self.assertEqual(_case_outcome("no-defect", [], []), "tn")
         self.assertEqual(_case_outcome("no-defect", [], ["demo.rule"]), "fp")
         self.assertEqual(_case_outcome("uncertain", [], ["demo.rule"]), "excluded")
+        self.assertEqual(_contract_outcome(True, True, False), "tp")
+        self.assertEqual(_contract_outcome(True, False, False), "fn")
+        self.assertEqual(_contract_outcome(False, True, False), "fp")
+        self.assertEqual(_contract_outcome(False, False, False), "tn")
+        self.assertEqual(_contract_outcome(True, True, True), "excluded")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_real_history_artifact.py
+++ b/scripts/tests/test_real_history_artifact.py
@@ -76,11 +76,16 @@ label_state = "pending"
                     "merge_sha": case.merge_sha,
                     "label_state": case.label_state,
                     "baselines": {"python.compile": {"status": "passed", "command": command}},
-                    "review": {"status": "collected"},
+                    "review": {
+                        "status": "collected",
+                        "contract_delta_ids": [],
+                        "contract_delta_count": 0,
+                        "contract_evidence_sha256": hashlib.sha256(b"[]").hexdigest(),
+                    },
                 }
             )
         return {
-            "schema_version": 1,
+            "schema_version": 2,
             "corpus": corpus,
             "protocol": protocol,
             "manifest_sha256": hashlib.sha256(self.manifest.read_bytes()).hexdigest(),
@@ -98,6 +103,7 @@ label_state = "pending"
         result = validate_collection_data(self.artifact(), self.manifest, self.rules, self.zoo)
         self.assertEqual(result["status"], "valid")
         self.assertEqual(result["cases"], 2)
+        self.assertEqual(result["contract_id_counts"], {})
 
     def test_rejects_manifest_hash_drift(self) -> None:
         artifact = self.artifact()
@@ -109,6 +115,12 @@ label_state = "pending"
         artifact = self.artifact()
         artifact["cases"][0]["baselines"]["python.compile"]["command"] = ["sh", "-c", "unsafe"]
         with self.assertRaisesRegex(ValueError, "baseline command drift"):
+            validate_collection_data(artifact, self.manifest, self.rules, self.zoo)
+
+    def test_rejects_contract_evidence_hash_drift(self) -> None:
+        artifact = self.artifact()
+        artifact["cases"][0]["review"]["contract_evidence_sha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "contract evidence hash drift"):
             validate_collection_data(artifact, self.manifest, self.rules, self.zoo)
 
 

--- a/scripts/tests/test_real_history_contracts.py
+++ b/scripts/tests/test_real_history_contracts.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from real_history_contracts import (  # noqa: E402
+    CONTRACT_IDS,
+    ALL_CONTRACT_IDS,
+    ContractEvidenceError,
+    contract_evidence_hash,
+    observed_contract_ids,
+    validate_expected_contract_ids,
+)
+
+
+class ContractEvidenceTests(unittest.TestCase):
+    def test_normalizes_observed_contract_ids_and_hashes_only_stable_identity(self) -> None:
+        report = {
+            "change_proof": {
+                "contract_deltas": [
+                    {"family": "test-coverage", "change": "test-missing", "evidence": "run one"},
+                    {"family": "security-boundary", "change": "boundary-changed", "evidence": "run two"},
+                    {"family": "test-coverage", "change": "test-missing", "evidence": "run three"},
+                ]
+            }
+        }
+
+        ids = observed_contract_ids(report)
+
+        self.assertEqual(
+            ids,
+            ("security-boundary/boundary-changed", "test-coverage/test-missing"),
+        )
+        self.assertEqual(len(contract_evidence_hash(ids)), 64)
+        self.assertEqual(contract_evidence_hash(ids), contract_evidence_hash(tuple(reversed(ids))))
+
+    def test_missing_change_proof_is_an_empty_observation(self) -> None:
+        self.assertEqual(observed_contract_ids({}), ())
+
+    def test_rejects_unknown_observed_contract(self) -> None:
+        with self.assertRaisesRegex(ContractEvidenceError, "unknown contract ID"):
+            observed_contract_ids(
+                {"change_proof": {"contract_deltas": [{"family": "new", "change": "new"}]}}
+            )
+
+    def test_observed_registry_keeps_unmeasured_current_families_visible(self) -> None:
+        self.assertIn("dependency/upgraded", ALL_CONTRACT_IDS)
+        self.assertEqual(
+            observed_contract_ids(
+                {"change_proof": {"contract_deltas": [{"family": "dependency", "change": "upgraded"}]}}
+            ),
+            ("dependency/upgraded",),
+        )
+
+    def test_expected_ids_are_unique_and_protocol_bounded(self) -> None:
+        self.assertEqual(
+            validate_expected_contract_ids(
+                ["test-coverage/test-missing", "security-boundary/boundary-changed"]
+            ),
+            ("security-boundary/boundary-changed", "test-coverage/test-missing"),
+        )
+        with self.assertRaisesRegex(ContractEvidenceError, "duplicate"):
+            validate_expected_contract_ids(["test-coverage/test-missing"] * 2)
+        with self.assertRaisesRegex(ContractEvidenceError, "unknown contract ID"):
+            validate_expected_contract_ids(["security-boundary/not-supported"])
+
+    def test_registry_is_explicit_and_sorted(self) -> None:
+        self.assertEqual(
+            CONTRACT_IDS,
+            (
+                "security-boundary/boundary-changed",
+                "security-boundary/entrypoint-impacted",
+                "test-coverage/test-changed",
+                "test-coverage/test-missing",
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_real_history_runner.py
+++ b/scripts/tests/test_real_history_runner.py
@@ -32,11 +32,18 @@ class RealHistoryRunnerTests(unittest.TestCase):
                 {"rule_id": "security.secret-candidate", "in_diff": True},
                 {"rule_id": "architecture.large-file", "in_diff": False},
             ],
+            "change_proof": {
+                "contract_deltas": [
+                    {"family": "security-boundary", "change": "boundary-changed"}
+                ]
+            },
         }
         summary = summarize_review(report, b"report")
         self.assertEqual(summary["in_diff_findings"], 1)
         self.assertEqual(summary["out_of_diff_findings"], 1)
         self.assertEqual(summary["in_diff_rule_ids"], ["security.secret-candidate"])
+        self.assertEqual(summary["contract_delta_ids"], ["security-boundary/boundary-changed"])
+        self.assertEqual(summary["contract_delta_count"], 1)
         self.assertEqual(len(summary["report_sha256"]), 64)
         self.assertEqual(len(summary["stable_evidence_sha256"]), 64)
 

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -77,6 +77,13 @@ RepoPilot findings. The collected artifact still needs dual-label adjudication.
 the manifest hash, immutable PR revisions, scanner provenance, baseline command
 allowlist, and one review observation per case.
 
+Collection schema 2 also records the stable `change_proof.contract_deltas`
+family/change IDs and a hash over those IDs. The collector preserves all
+currently emitted contract identities, while the first independent labeling
+metric is intentionally limited to the security and test IDs. Paths, evidence
+prose, and runtime semantics are not treated as independently validated by
+this family/change measurement.
+
 When only one expert is available, `pilot-template` creates a blinded
 `single-expert-pilot-v1` worksheet. Fill one label and rationale per case, then
 run `pilot-validate` and `pilot-score`. The resulting report is explicitly
@@ -99,3 +106,9 @@ and verifies that the copied independent labels still match both worksheets.
 recall, specificity, and precision with Wilson 95% intervals. Its output pins
 all three input hashes and states that the result is descriptive evidence for
 this holdout, not a production or language-wide estimate.
+
+The same metrics artifact now includes per-ID contract confusion counts and
+Wilson intervals for `security-boundary/*` and `test-coverage/*`. A reviewer
+labels `expected_contract_ids` from the diff and repository evidence; the
+machine observation remains in the collection artifact and is not copied into
+the blinded worksheet.


### PR DESCRIPTION
## What changed

This PR makes the real-history contract evidence packet reproducible and adds a bounded next step for the one-expert case.

- Retain stable `family/change` contract IDs and a canonical evidence hash in collection schema 2.
- Validate every currently emitted contract identity so dependency, delivery, runtime, public-symbol, security, and test observations are not silently dropped.
- Carry measured security/test contract IDs through blinded dual-review worksheets, adjudication, and per-ID metrics.
- Add a separate blinded, hash-pinned `single-expert-contract-pilot-v1` workflow with explicit `contract-present`, `no-contract`, and `uncertain` labels.
- Report case-level and per-contract TP/FN/TN/FP counts with Wilson 95% intervals and provenance hashes.
- Document the measured subset and evidence boundaries in the benchmark README, roadmap, changelog, and evidence ledger.

## Commands

```bash
python3 scripts/real_history.py contract-pilot-template \
  --artifact real-history-run.json --pilot-reviewer expert \
  --output contract-pilot.toml
python3 scripts/real_history.py validate-contract-pilot \
  --artifact real-history-run.json --pilot contract-pilot.toml
python3 scripts/real_history.py contract-pilot-metrics \
  --artifact real-history-run.json --pilot contract-pilot.toml \
  --output contract-pilot-metrics.json
```

The pilot is exploratory evidence from one reviewer. It does not close RP23-013, does not promote unmeasured families, and does not replace the frozen dual-review/adjudication protocol.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 144 passed
- `python3 scripts/release-contract.py check` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo test --all` — passed (924 library, 80 binary, and integration/doc suites)
- `cargo run -- scan . --fail-on-priority p1` — `Decision: PASS`, zero visible P1 findings
