### PR TITLE
feat: add exploratory real-history contract pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   adjudicated metrics with bounded security/test contract labels. Unmeasured
   current contract families remain visible in observations rather than being
   silently dropped.
+- Added a separate single-expert exploratory contract pilot with blinded,
+  hash-pinned worksheets and per-contract TP/FN/TN/FP metrics plus Wilson
+  intervals. The pilot is explicitly not independent validation, does not
+  alter the dual-review protocol, and cannot claim production-wide quality.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -492,3 +492,21 @@ bump is needed to start.
   two independent labels plus adjudication. No labels were invented or added
   in this slice; RP23-013 remains open until reviewers complete the frozen
   worksheets and the result is audited.
+
+## 0Q — Single-Expert Contract Pilot
+
+- `contract-pilot-template` creates a separate blinded worksheet for one
+  named expert. It pins the same manifest and collection hashes, copies only
+  case identity and baseline status, and leaves the observed contract IDs in
+  the collection artifact rather than showing them to the reviewer.
+- `validate-contract-pilot` accepts only the measured security/test contract
+  IDs and requires an explicit `contract-present`, `no-contract`, or
+  `uncertain` label plus rationale. The schema and assessment mode identify
+  the result as `single-expert-exploratory`.
+- `contract-pilot-metrics` reports case-level and per-contract confusion
+  counts, Wilson 95% intervals, observed counts, and input hashes. The output
+  states that it is exploratory evidence from one reviewer and is not
+  independent validation or a production estimate.
+- Boundary: this pilot is a feasibility and measurement aid for the next
+  labeling step. It does not close RP23-013, promote unmeasured contract
+  families, or change the dual-review/adjudication protocol.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -398,6 +398,12 @@ The first measured contract registry is limited to security and test families;
 other emitted families remain visible as unmeasured observations. This keeps
 the evidence denominator explicit while labels are still pending.
 
+If only one expert is available, the separate contract pilot can produce a
+blinded, hash-pinned exploratory packet with per-contract confusion counts and
+Wilson intervals. It is a scoped feasibility measurement over the security/test
+registry, not independent validation, a production estimate, or a substitute
+for the frozen two-reviewer adjudication protocol.
+
 Initial release discipline:
 
 - a rule cannot be described as broadly precise without labeled default evidence

--- a/scripts/real_history.py
+++ b/scripts/real_history.py
@@ -20,6 +20,8 @@ from real_history_annotations import (
     render_worksheet,
 )
 from real_history_adjudication import render_adjudication_template, validate_adjudication
+from real_history_contract_pilot import render_contract_pilot_template, validate_contract_pilot
+from real_history_contract_pilot_metrics import build_contract_pilot_metrics
 from real_history_metrics import write_metrics
 from real_history_runner import collect_holdout
 
@@ -38,6 +40,9 @@ def main(argv: list[str] | None = None) -> int:
             "adjudication-template",
             "validate-adjudication",
             "metrics",
+            "contract-pilot-template",
+            "validate-contract-pilot",
+            "contract-pilot-metrics",
         ),
         default="check",
     )
@@ -55,6 +60,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--annotation-a", type=Path, help="reviewer A worksheet")
     parser.add_argument("--annotation-b", type=Path, help="reviewer B worksheet")
     parser.add_argument("--reviewer", choices=("a", "b"), help="independent worksheet owner")
+    parser.add_argument("--pilot", type=Path, help="single-expert contract pilot worksheet")
+    parser.add_argument("--pilot-reviewer", default="expert", help="single-expert pilot reviewer label")
     args = parser.parse_args(argv)
     try:
         corpus, protocol, cases = validate_manifest(args.manifest, args.rules_reference, args.zoo_manifest)
@@ -183,6 +190,60 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         counts = result["counts"]
         print(f"Metrics: {args.output} (TP {counts['tp']}, FN {counts['fn']}, TN {counts['tn']}, FP {counts['fp']})")
+        return 0
+    if args.command == "contract-pilot-template":
+        if args.artifact is None or args.output is None:
+            print("contract-pilot-template requires --artifact and --output", file=sys.stderr)
+            return 2
+        try:
+            rendered = render_contract_pilot_template(
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+                args.pilot_reviewer,
+            )
+        except (HoldoutManifestError, OSError) as error:
+            print(f"contract pilot template failed: {error}", file=sys.stderr)
+            return 1
+        args.output.write_text(rendered, encoding="utf-8")
+        print(f"Contract pilot worksheet: {args.output}")
+        return 0
+    if args.command == "validate-contract-pilot":
+        if args.artifact is None or args.pilot is None:
+            print("validate-contract-pilot requires --artifact and --pilot", file=sys.stderr)
+            return 2
+        try:
+            result = validate_contract_pilot(
+                args.pilot,
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (HoldoutManifestError, OSError) as error:
+            print(f"contract pilot invalid: {error}", file=sys.stderr)
+            return 1
+        print(f"Contract pilot: valid ({result['cases']} cases; reviewer {result['reviewer']})")
+        return 0
+    if args.command == "contract-pilot-metrics":
+        if args.artifact is None or args.pilot is None or args.output is None:
+            print("contract-pilot-metrics requires --artifact, --pilot, and --output", file=sys.stderr)
+            return 2
+        try:
+            result = build_contract_pilot_metrics(
+                args.pilot,
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+            args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        except (HoldoutManifestError, OSError) as error:
+            print(f"contract pilot metrics failed: {error}", file=sys.stderr)
+            return 1
+        counts = result["counts"]
+        print(f"Contract pilot metrics: {args.output} (TP {counts['tp']}, FN {counts['fn']}, TN {counts['tn']}, FP {counts['fp']})")
         return 0
     if args.command == "collect":
         if args.timeout <= 0:

--- a/scripts/real_history_contract_pilot.py
+++ b/scripts/real_history_contract_pilot.py
@@ -1,0 +1,210 @@
+"""Generate, validate, and score a single-expert contract pilot."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from real_history_annotations import load_collection
+from real_history_contract import HoldoutCase, HoldoutManifestError, validate_manifest
+from real_history_contracts import ContractEvidenceError, validate_expected_contract_ids
+
+
+PILOT_SCHEMA_VERSION = 1
+PILOT_PROTOCOL = "single-expert-contract-pilot-v1"
+PILOT_MODE = "single-expert-exploratory"
+CONTRACT_LABELS = {"contract-present", "no-contract", "uncertain"}
+PILOT_FIELDS = {
+    "id",
+    "repo",
+    "pull_request",
+    "base_sha",
+    "head_sha",
+    "merge_sha",
+    "baseline_statuses",
+    "contract_label",
+    "expected_contract_ids",
+    "rationale",
+}
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _toml_array(values: list[str]) -> str:
+    return "[" + ", ".join(_toml_string(value) for value in values) + "]"
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read contract pilot {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError("contract pilot must be a TOML table")
+    return data
+
+
+def _cases_by_id(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    cases = data.get("cases")
+    if not isinstance(cases, list):
+        raise HoldoutManifestError("collection cases must be an array")
+    return {
+        case["id"]: case
+        for case in cases
+        if isinstance(case, dict) and isinstance(case.get("id"), str)
+    }
+
+
+def _baseline_statuses(case: HoldoutCase, observation: dict[str, Any]) -> list[str]:
+    baselines = observation.get("baselines")
+    if not isinstance(baselines, dict):
+        raise HoldoutManifestError(f"pilot case {case.case_id}: baselines are missing")
+    return [f"{baseline_id}={baselines[baseline_id]['status']}" for baseline_id in case.baseline_ids]
+
+
+def render_contract_pilot_template(
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+    reviewer: str,
+) -> str:
+    if not reviewer.strip():
+        raise HoldoutManifestError("contract pilot reviewer must not be empty")
+    data = load_collection(collection_path, manifest_path, rules_reference, zoo_manifest)
+    corpus, _, cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    observations = _cases_by_id(data)
+    if data["label_state"] != "pending" or any(case.label_state != "pending" for case in cases):
+        raise HoldoutManifestError("contract pilot requires a pending collection")
+    lines = [
+        f"schema_version = {PILOT_SCHEMA_VERSION}",
+        f"corpus = {_toml_string(corpus)}",
+        f"protocol = {_toml_string(PILOT_PROTOCOL)}",
+        f"reviewer = {_toml_string(reviewer)}",
+        f"manifest_sha256 = {_toml_string(sha256_file(manifest_path))}",
+        f"collection_sha256 = {_toml_string(data['collection_sha256'])}",
+        "blinded = true",
+        f"assessment_mode = {_toml_string(PILOT_MODE)}",
+        "",
+    ]
+    for case in cases:
+        observation = observations.get(case.case_id)
+        if observation is None:
+            raise HoldoutManifestError(f"collection is missing case {case.case_id}")
+        lines.extend(
+            [
+                "[[case]]",
+                f"id = {_toml_string(case.case_id)}",
+                f"repo = {_toml_string(case.repo)}",
+                f"pull_request = {case.pull_request}",
+                f"base_sha = {_toml_string(case.base_sha)}",
+                f"head_sha = {_toml_string(case.head_sha)}",
+                f"merge_sha = {_toml_string(case.merge_sha)}",
+                f"baseline_statuses = {_toml_array(_baseline_statuses(case, observation))}",
+                'contract_label = ""',
+                "expected_contract_ids = []",
+                'rationale = ""',
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _validate_case_context(
+    data: dict[str, Any],
+    collection: dict[str, Any],
+    cases: list[HoldoutCase],
+) -> dict[str, dict[str, Any]]:
+    raw_cases = data.get("case")
+    if not isinstance(raw_cases, list):
+        raise HoldoutManifestError("contract pilot cases must be an array")
+    expected = {case.case_id: case for case in cases}
+    observations = _cases_by_id(collection)
+    validated: dict[str, dict[str, Any]] = {}
+    for raw in raw_cases:
+        if not isinstance(raw, dict):
+            raise HoldoutManifestError("contract pilot case must be a table")
+        unknown = set(raw) - PILOT_FIELDS
+        if unknown:
+            raise HoldoutManifestError(f"contract pilot case has unknown fields: {', '.join(sorted(unknown))}")
+        case_id = raw.get("id")
+        if not isinstance(case_id, str) or case_id in validated or case_id not in expected:
+            raise HoldoutManifestError(f"contract pilot has unknown or duplicate case {case_id!r}")
+        case = expected[case_id]
+        for field in ("repo", "base_sha", "head_sha", "merge_sha"):
+            if raw.get(field) != getattr(case, field):
+                raise HoldoutManifestError(f"contract pilot case {case_id}: {field} does not match manifest")
+        if raw.get("pull_request") != case.pull_request:
+            raise HoldoutManifestError(f"contract pilot case {case_id}: pull_request does not match manifest")
+        observation = observations.get(case_id)
+        if observation is None:
+            raise HoldoutManifestError(f"collection is missing case {case_id}")
+        statuses = raw.get("baseline_statuses")
+        if statuses != _baseline_statuses(case, observation):
+            raise HoldoutManifestError(f"contract pilot case {case_id}: baseline evidence drifted")
+        label = raw.get("contract_label")
+        if label not in CONTRACT_LABELS:
+            raise HoldoutManifestError(
+                f"contract pilot case {case_id}: contract_label must be one of {sorted(CONTRACT_LABELS)}"
+            )
+        try:
+            expected_ids = validate_expected_contract_ids(
+                raw.get("expected_contract_ids"),
+                f"contract pilot case {case_id} expected_contract_ids",
+            )
+        except ContractEvidenceError as error:
+            raise HoldoutManifestError(str(error)) from error
+        if label == "contract-present" and not expected_ids:
+            raise HoldoutManifestError(f"contract pilot case {case_id}: contract-present needs expected_contract_ids")
+        if label != "contract-present" and expected_ids:
+            raise HoldoutManifestError(f"contract pilot case {case_id}: only contract-present may name contracts")
+        rationale = raw.get("rationale")
+        if not isinstance(rationale, str) or not rationale.strip():
+            raise HoldoutManifestError(f"contract pilot case {case_id}: rationale is required")
+        validated[case_id] = raw
+    if set(validated) != set(expected):
+        missing = ", ".join(sorted(set(expected) - set(validated)))
+        raise HoldoutManifestError(f"contract pilot is missing cases: {missing}")
+    return validated
+
+
+def validate_contract_pilot(
+    pilot_path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    collection = load_collection(collection_path, manifest_path, rules_reference, zoo_manifest)
+    corpus, _, cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    data = _load_toml(pilot_path)
+    if data.get("schema_version") != PILOT_SCHEMA_VERSION or data.get("protocol") != PILOT_PROTOCOL:
+        raise HoldoutManifestError("contract pilot schema or protocol is unsupported")
+    if data.get("corpus") != corpus or data.get("blinded") is not True:
+        raise HoldoutManifestError("contract pilot corpus or blinded marker is invalid")
+    if data.get("assessment_mode") != PILOT_MODE:
+        raise HoldoutManifestError("contract pilot assessment_mode must be single-expert-exploratory")
+    if not isinstance(data.get("reviewer"), str) or not data["reviewer"].strip():
+        raise HoldoutManifestError("contract pilot reviewer is required")
+    if data.get("manifest_sha256") != sha256_file(manifest_path):
+        raise HoldoutManifestError("contract pilot manifest_sha256 does not match manifest")
+    if data.get("collection_sha256") != sha256_file(collection_path):
+        raise HoldoutManifestError("contract pilot collection_sha256 does not match collection")
+    validated = _validate_case_context(data, collection, cases)
+    return {
+        "status": "valid",
+        "protocol": PILOT_PROTOCOL,
+        "scope": "single-expert exploratory real-history contract pilot",
+        "reviewer": data["reviewer"],
+        "cases": len(validated),
+    }
+

--- a/scripts/real_history_contract_pilot_metrics.py
+++ b/scripts/real_history_contract_pilot_metrics.py
@@ -1,0 +1,142 @@
+"""Score a single-expert real-history contract pilot as exploratory evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from real_history_contract import HoldoutManifestError
+from real_history_contract_pilot import (
+    PILOT_PROTOCOL,
+    _cases_by_id,
+    _load_toml,
+    validate_contract_pilot,
+)
+from real_history_contracts import CONTRACT_IDS
+
+
+def _load_collection_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read collection artifact {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError("collection artifact must be a JSON object")
+    return data
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _metric(successes: int, trials: int) -> dict[str, object]:
+    if trials < 0 or successes < 0 or successes > trials:
+        raise HoldoutManifestError("invalid contract pilot metric counts")
+    if trials == 0:
+        interval = None
+    else:
+        z = 1.96
+        proportion = successes / trials
+        denominator = 1 + z * z / trials
+        center = (proportion + z * z / (2 * trials)) / denominator
+        margin = z * math.sqrt(proportion * (1 - proportion) / trials + z * z / (4 * trials * trials)) / denominator
+        interval = [max(0.0, center - margin), min(1.0, center + margin)]
+    return {
+        "successes": successes,
+        "trials": trials,
+        "value": successes / trials if trials else None,
+        "wilson_95": interval,
+    }
+
+
+def _outcome(expected: bool, observed: bool, excluded: bool) -> str:
+    if excluded:
+        return "excluded"
+    if expected and observed:
+        return "tp"
+    if expected:
+        return "fn"
+    if observed:
+        return "fp"
+    return "tn"
+
+
+def build_contract_pilot_metrics(
+    pilot_path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    validation = validate_contract_pilot(pilot_path, collection_path, manifest_path, rules_reference, zoo_manifest)
+    pilot = _load_toml(pilot_path)
+    collection = _load_collection_json(collection_path)
+    observations = _cases_by_id(collection)
+    raw_cases = {case["id"]: case for case in pilot["case"]}
+    counts = {key: 0 for key in ("tp", "fn", "tn", "fp", "excluded")}
+    contract_counts = {contract_id: dict(counts) for contract_id in CONTRACT_IDS}
+    case_rows: list[dict[str, object]] = []
+    observed_counts = {contract_id: 0 for contract_id in CONTRACT_IDS}
+    for case_id, labeled in raw_cases.items():
+        observation = observations[case_id]
+        observed = sorted(set(observation["review"]["contract_delta_ids"]) & set(CONTRACT_IDS))
+        expected = sorted(set(labeled["expected_contract_ids"]))
+        label = labeled["contract_label"]
+        case_outcome = (
+            "excluded" if label == "uncertain" else
+            "tp" if label == "contract-present" and set(expected) <= set(observed) else
+            "fn" if label == "contract-present" else
+            "fp" if observed else "tn"
+        )
+        counts[case_outcome] += 1
+        for contract_id in observed:
+            observed_counts[contract_id] += 1
+        for contract_id in CONTRACT_IDS:
+            contract_counts[contract_id][_outcome(
+                contract_id in expected, contract_id in observed, label == "uncertain"
+            )] += 1
+        case_rows.append({
+            "id": case_id,
+            "contract_label": label,
+            "expected_contract_ids": expected,
+            "observed_contract_ids": observed,
+            "outcome": case_outcome,
+        })
+    contract_metrics: dict[str, object] = {}
+    for contract_id, result in contract_counts.items():
+        actual_positives = result["tp"] + result["fn"]
+        actual_negatives = result["tn"] + result["fp"]
+        predicted_positives = result["tp"] + result["fp"]
+        contract_metrics[contract_id] = {
+            "recall": _metric(result["tp"], actual_positives),
+            "specificity": _metric(result["tn"], actual_negatives),
+            "precision": _metric(result["tp"], predicted_positives),
+        }
+    actual_positives = counts["tp"] + counts["fn"]
+    actual_negatives = counts["tn"] + counts["fp"]
+    return {
+        "schema_version": 1,
+        "corpus": pilot["corpus"],
+        "protocol": PILOT_PROTOCOL,
+        "scope": validation["scope"],
+        "limitation": "single reviewer and bounded measured contract subset; not independent validation or a production estimate",
+        "manifest_sha256": _sha256_file(manifest_path),
+        "collection_sha256": _sha256_file(collection_path),
+        "pilot_sha256": _sha256_file(pilot_path),
+        "reviewer": pilot["reviewer"],
+        "contract_ids": list(CONTRACT_IDS),
+        "cases": case_rows,
+        "counts": counts,
+        "contract_counts": contract_counts,
+        "contract_metrics": contract_metrics,
+        "observed_contract_counts": observed_counts,
+        "metrics": {
+            "recall": _metric(counts["tp"], actual_positives),
+            "specificity": _metric(counts["tn"], actual_negatives),
+            "precision": _metric(counts["tp"], counts["tp"] + counts["fp"]),
+            "case_coverage": _metric(actual_positives + actual_negatives, len(case_rows)),
+        },
+    }

--- a/scripts/tests/test_real_history_contract_pilot.py
+++ b/scripts/tests/test_real_history_contract_pilot.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from real_history_contract_pilot import render_contract_pilot_template, validate_contract_pilot  # noqa: E402
+from real_history_contract_pilot_metrics import build_contract_pilot_metrics  # noqa: E402
+from real_history_contracts import contract_evidence_hash  # noqa: E402
+from real_history_contract import validate_manifest  # noqa: E402
+from real_history_runner import BASELINE_COMMANDS  # noqa: E402
+
+
+class ContractPilotTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.manifest = self.root / "manifest.toml"
+        self.rules = self.root / "rules.md"
+        self.zoo = self.root / "zoo.toml"
+        self.collection = self.root / "collection.json"
+        self.rules.write_text("### `demo.rule` — Demo\n", encoding="utf-8")
+        self.zoo.write_text("", encoding="utf-8")
+        self.manifest.write_text(
+            """schema_version = 1
+corpus = "test"
+protocol = "dual-independent-adjudication-v1"
+
+[[case]]
+id = "case-one"
+repo = "owner/one"
+url = "https://github.com/owner/one.git"
+pull_request = 1
+base_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+head_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+merge_sha = "cccccccccccccccccccccccccccccccccccccccc"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile"]
+label_state = "pending"
+
+[[case]]
+id = "case-two"
+repo = "owner/two"
+url = "https://github.com/owner/two.git"
+pull_request = 2
+base_sha = "dddddddddddddddddddddddddddddddddddddddd"
+head_sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+merge_sha = "ffffffffffffffffffffffffffffffffffffffff"
+language = "python"
+source_kind = "merged-pull-request"
+baseline_ids = ["python.compile"]
+label_state = "pending"
+""",
+            encoding="utf-8",
+        )
+        _, protocol, cases = validate_manifest(self.manifest, self.rules, self.zoo)
+        observations = []
+        contract_id = "security-boundary/boundary-changed"
+        for case in cases:
+            ids = [contract_id] if case.case_id == "case-one" else []
+            observations.append(
+                {
+                    "id": case.case_id,
+                    "repo": case.repo,
+                    "pull_request": case.pull_request,
+                    "base_sha": case.base_sha,
+                    "head_sha": case.head_sha,
+                    "merge_sha": case.merge_sha,
+                    "label_state": "pending",
+                    "baselines": {
+                        "python.compile": {
+                            "status": "passed",
+                            "command": list(BASELINE_COMMANDS["python.compile"]),
+                        }
+                    },
+                    "review": {
+                        "status": "collected",
+                        "contract_delta_ids": ids,
+                        "contract_delta_count": len(ids),
+                        "contract_evidence_sha256": contract_evidence_hash(ids),
+                    },
+                }
+            )
+        self.collection.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "corpus": "test",
+                    "protocol": protocol,
+                    "manifest_sha256": hashlib.sha256(self.manifest.read_bytes()).hexdigest(),
+                    "scanner": {
+                        "mode": "explicit",
+                        "version": "0.23.0",
+                        "report_schema_version": "0.26",
+                        "workspace_version": "0.23.0",
+                    },
+                    "cases": observations,
+                    "label_state": "pending",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_template_is_blinded_and_validates_after_labels(self) -> None:
+        pilot = self.root / "pilot.toml"
+        pilot.write_text(
+            render_contract_pilot_template(
+                self.collection, self.manifest, self.rules, self.zoo, "expert"
+            ),
+            encoding="utf-8",
+        )
+        rendered = pilot.read_text(encoding="utf-8")
+        self.assertIn("blinded = true", rendered)
+        self.assertNotIn("contract_delta_ids", rendered)
+        rendered = rendered.replace('contract_label = ""', 'contract_label = "contract-present"', 1)
+        rendered = rendered.replace(
+            "expected_contract_ids = []",
+            'expected_contract_ids = ["security-boundary/boundary-changed"]',
+            1,
+        )
+        rendered = rendered.replace('rationale = ""', 'rationale = "reviewed the change"', 1)
+        rendered = rendered.replace('contract_label = ""', 'contract_label = "no-contract"', 1)
+        rendered = rendered.replace('rationale = ""', 'rationale = "reviewed the change"', 1)
+        pilot.write_text(rendered, encoding="utf-8")
+        result = validate_contract_pilot(
+            pilot, self.collection, self.manifest, self.rules, self.zoo
+        )
+        self.assertEqual(result["status"], "valid")
+        self.assertEqual(result["cases"], 2)
+
+    def test_metrics_are_contract_scoped_and_exploratory(self) -> None:
+        pilot = self.root / "pilot.toml"
+        rendered = render_contract_pilot_template(
+            self.collection, self.manifest, self.rules, self.zoo, "expert"
+        )
+        rendered = rendered.replace('contract_label = ""', 'contract_label = "contract-present"', 1)
+        rendered = rendered.replace(
+            "expected_contract_ids = []",
+            'expected_contract_ids = ["security-boundary/boundary-changed"]',
+            1,
+        )
+        rendered = rendered.replace('rationale = ""', 'rationale = "confirmed boundary change"', 1)
+        rendered = rendered.replace('contract_label = ""', 'contract_label = "no-contract"', 1)
+        rendered = rendered.replace('rationale = ""', 'rationale = "no measured contract"', 1)
+        pilot.write_text(rendered, encoding="utf-8")
+        result = build_contract_pilot_metrics(
+            pilot, self.collection, self.manifest, self.rules, self.zoo
+        )
+        counts = result["contract_counts"]["security-boundary/boundary-changed"]
+        self.assertEqual(counts, {"tp": 1, "fn": 0, "tn": 1, "fp": 0, "excluded": 0})
+        self.assertEqual(result["scope"], "single-expert exploratory real-history contract pilot")
+        self.assertIn("not independent validation", result["limitation"])
+        self.assertEqual(result["metrics"]["case_coverage"]["value"], 1.0)
+
+    def test_pilot_rejects_unmeasured_contract(self) -> None:
+        pilot = self.root / "pilot.toml"
+        rendered = render_contract_pilot_template(
+            self.collection, self.manifest, self.rules, self.zoo, "expert"
+        ).replace('contract_label = ""', 'contract_label = "contract-present"', 1)
+        rendered = rendered.replace(
+            "expected_contract_ids = []",
+            'expected_contract_ids = ["delivery/action-reference-changed"]',
+            1,
+        )
+        rendered = rendered.replace('rationale = ""', 'rationale = "unsupported"', 1)
+        pilot.write_text(rendered, encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "unknown contract ID"):
+            validate_contract_pilot(pilot, self.collection, self.manifest, self.rules, self.zoo)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -84,6 +84,27 @@ metric is intentionally limited to the security and test IDs. Paths, evidence
 prose, and runtime semantics are not treated as independently validated by
 this family/change measurement.
 
+When only one expert is available for the contract surface, use the separate
+exploratory pilot. It is blinded and hash-pinned, but it does not weaken the
+dual-review protocol or its metrics:
+
+```bash
+python3 scripts/real_history.py contract-pilot-template \
+  --artifact real-history-run.json --pilot-reviewer expert \
+  --output contract-pilot.toml
+# Fill contract_label, expected_contract_ids, and rationale from the pinned diff.
+python3 scripts/real_history.py validate-contract-pilot \
+  --artifact real-history-run.json --pilot contract-pilot.toml
+python3 scripts/real_history.py contract-pilot-metrics \
+  --artifact real-history-run.json --pilot contract-pilot.toml \
+  --output contract-pilot-metrics.json
+```
+
+The pilot reports case outcomes and per-ID confusion counts with Wilson
+intervals. Its scope is explicitly single-expert exploratory evidence over the
+measured security/test subset; it is not independent validation, a production
+estimate, or evidence for the unmeasured contract families.
+
 When only one expert is available, `pilot-template` creates a blinded
 `single-expert-pilot-v1` worksheet. Fill one label and rationale per case, then
 run `pilot-validate` and `pilot-score`. The resulting report is explicitly


### PR DESCRIPTION
## What changed

This PR makes the real-history contract evidence packet reproducible and adds a bounded next step for the one-expert case.

- Retain stable `family/change` contract IDs and a canonical evidence hash in collection schema 2.
- Validate every currently emitted contract identity so dependency, delivery, runtime, public-symbol, security, and test observations are not silently dropped.
- Carry measured security/test contract IDs through blinded dual-review worksheets, adjudication, and per-ID metrics.
- Add a separate blinded, hash-pinned `single-expert-contract-pilot-v1` workflow with explicit `contract-present`, `no-contract`, and `uncertain` labels.
- Report case-level and per-contract TP/FN/TN/FP counts with Wilson 95% intervals and provenance hashes.
- Document the measured subset and evidence boundaries in the benchmark README, roadmap, changelog, and evidence ledger.

## Commands

```bash
python3 scripts/real_history.py contract-pilot-template \
  --artifact real-history-run.json --pilot-reviewer expert \
  --output contract-pilot.toml
python3 scripts/real_history.py validate-contract-pilot \
  --artifact real-history-run.json --pilot contract-pilot.toml
python3 scripts/real_history.py contract-pilot-metrics \
  --artifact real-history-run.json --pilot contract-pilot.toml \
  --output contract-pilot-metrics.json
```

The pilot is exploratory evidence from one reviewer. It does not close RP23-013, does not promote unmeasured families, and does not replace the frozen dual-review/adjudication protocol.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 144 passed
- `python3 scripts/release-contract.py check` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo test --all` — passed (924 library, 80 binary, and integration/doc suites)
- `cargo run -- scan . --fail-on-priority p1` — `Decision: PASS`, zero visible P1 findings
