### PR TITLE
feat: validate contract pilot metrics artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   hash-pinned worksheets and per-contract TP/FN/TN/FP metrics plus Wilson
   intervals. The pilot is explicitly not independent validation, does not
   alter the dual-review protocol, and cannot claim production-wide quality.
+- Added a recomputing validator for pilot metrics artifacts. It pins the
+  worksheet, collection, and manifest inputs and rejects edited, stale, or
+  structurally different JSON scores before they can be used as evidence.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -510,3 +510,16 @@ bump is needed to start.
 - Boundary: this pilot is a feasibility and measurement aid for the next
   labeling step. It does not close RP23-013, promote unmeasured contract
   families, or change the dual-review/adjudication protocol.
+
+## 0R — Pilot Metrics Integrity
+
+- `validate-contract-pilot-metrics` recomputes the complete pilot score from
+  the pinned worksheet, collection artifact, manifest, rules reference, and
+  zoo manifest. It compares the canonical JSON object, including all hashes,
+  counts, intervals, case rows, and limitation fields.
+- A metrics file with edited counts, stale input hashes, unknown fields, or
+  missing fields is rejected before it can be treated as an evidence packet.
+  The round-trip and tamper tests cover both the accepted artifact and a
+  modified confusion count.
+- Boundary: this validates artifact integrity, not reviewer correctness or
+  independent scientific validity. Single-expert labels remain exploratory.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -404,6 +404,10 @@ Wilson intervals. It is a scoped feasibility measurement over the security/test
 registry, not independent validation, a production estimate, or a substitute
 for the frozen two-reviewer adjudication protocol.
 
+Pilot metrics are accepted only after a recomputing validator rebuilds the
+score from the pinned worksheet, collection, and manifest. A hand-edited or
+stale JSON result therefore remains an invalid evidence packet.
+
 Initial release discipline:
 
 - a rule cannot be described as broadly precise without labeled default evidence

--- a/scripts/real_history.py
+++ b/scripts/real_history.py
@@ -20,9 +20,8 @@ from real_history_annotations import (
     render_worksheet,
 )
 from real_history_adjudication import render_adjudication_template, validate_adjudication
-from real_history_contract_pilot import render_contract_pilot_template, validate_contract_pilot
-from real_history_contract_pilot_metrics import build_contract_pilot_metrics
 from real_history_metrics import write_metrics
+from real_history_pilot_cli import handle_contract_pilot_command
 from real_history_runner import collect_holdout
 
 
@@ -43,6 +42,7 @@ def main(argv: list[str] | None = None) -> int:
             "contract-pilot-template",
             "validate-contract-pilot",
             "contract-pilot-metrics",
+            "validate-contract-pilot-metrics",
         ),
         default="check",
     )
@@ -62,6 +62,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--reviewer", choices=("a", "b"), help="independent worksheet owner")
     parser.add_argument("--pilot", type=Path, help="single-expert contract pilot worksheet")
     parser.add_argument("--pilot-reviewer", default="expert", help="single-expert pilot reviewer label")
+    parser.add_argument("--metrics", type=Path, help="single-expert contract pilot metrics artifact")
     args = parser.parse_args(argv)
     try:
         corpus, protocol, cases = validate_manifest(args.manifest, args.rules_reference, args.zoo_manifest)
@@ -191,60 +192,9 @@ def main(argv: list[str] | None = None) -> int:
         counts = result["counts"]
         print(f"Metrics: {args.output} (TP {counts['tp']}, FN {counts['fn']}, TN {counts['tn']}, FP {counts['fp']})")
         return 0
-    if args.command == "contract-pilot-template":
-        if args.artifact is None or args.output is None:
-            print("contract-pilot-template requires --artifact and --output", file=sys.stderr)
-            return 2
-        try:
-            rendered = render_contract_pilot_template(
-                args.artifact,
-                args.manifest,
-                args.rules_reference,
-                args.zoo_manifest,
-                args.pilot_reviewer,
-            )
-        except (HoldoutManifestError, OSError) as error:
-            print(f"contract pilot template failed: {error}", file=sys.stderr)
-            return 1
-        args.output.write_text(rendered, encoding="utf-8")
-        print(f"Contract pilot worksheet: {args.output}")
-        return 0
-    if args.command == "validate-contract-pilot":
-        if args.artifact is None or args.pilot is None:
-            print("validate-contract-pilot requires --artifact and --pilot", file=sys.stderr)
-            return 2
-        try:
-            result = validate_contract_pilot(
-                args.pilot,
-                args.artifact,
-                args.manifest,
-                args.rules_reference,
-                args.zoo_manifest,
-            )
-        except (HoldoutManifestError, OSError) as error:
-            print(f"contract pilot invalid: {error}", file=sys.stderr)
-            return 1
-        print(f"Contract pilot: valid ({result['cases']} cases; reviewer {result['reviewer']})")
-        return 0
-    if args.command == "contract-pilot-metrics":
-        if args.artifact is None or args.pilot is None or args.output is None:
-            print("contract-pilot-metrics requires --artifact, --pilot, and --output", file=sys.stderr)
-            return 2
-        try:
-            result = build_contract_pilot_metrics(
-                args.pilot,
-                args.artifact,
-                args.manifest,
-                args.rules_reference,
-                args.zoo_manifest,
-            )
-            args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        except (HoldoutManifestError, OSError) as error:
-            print(f"contract pilot metrics failed: {error}", file=sys.stderr)
-            return 1
-        counts = result["counts"]
-        print(f"Contract pilot metrics: {args.output} (TP {counts['tp']}, FN {counts['fn']}, TN {counts['tn']}, FP {counts['fp']})")
-        return 0
+    pilot_status = handle_contract_pilot_command(args)
+    if pilot_status is not None:
+        return pilot_status
     if args.command == "collect":
         if args.timeout <= 0:
             print("--timeout must be positive", file=sys.stderr)

--- a/scripts/real_history_contract_pilot_metrics.py
+++ b/scripts/real_history_contract_pilot_metrics.py
@@ -140,3 +140,47 @@ def build_contract_pilot_metrics(
             "case_coverage": _metric(actual_positives + actual_negatives, len(case_rows)),
         },
     }
+
+
+def write_contract_pilot_metrics(
+    output_path: Path,
+    pilot_path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    result = build_contract_pilot_metrics(
+        pilot_path, collection_path, manifest_path, rules_reference, zoo_manifest
+    )
+    output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return result
+
+
+def validate_contract_pilot_metrics(
+    metrics_path: Path,
+    pilot_path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    try:
+        actual = json.loads(metrics_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read contract pilot metrics {metrics_path}: {error}") from error
+    if not isinstance(actual, dict):
+        raise HoldoutManifestError("contract pilot metrics must be a JSON object")
+    expected = build_contract_pilot_metrics(
+        pilot_path, collection_path, manifest_path, rules_reference, zoo_manifest
+    )
+    if actual != expected:
+        raise HoldoutManifestError("contract pilot metrics artifact does not match recomputed score")
+    return {
+        "status": "valid",
+        "protocol": expected["protocol"],
+        "scope": expected["scope"],
+        "reviewer": expected["reviewer"],
+        "cases": len(expected["cases"]),
+        "contract_ids": expected["contract_ids"],
+    }

--- a/scripts/real_history_pilot_cli.py
+++ b/scripts/real_history_pilot_cli.py
@@ -1,0 +1,92 @@
+"""CLI handlers for the single-expert real-history contract pilot."""
+
+from __future__ import annotations
+
+import sys
+from argparse import Namespace
+
+from real_history_contract import HoldoutManifestError
+from real_history_contract_pilot import render_contract_pilot_template, validate_contract_pilot
+from real_history_contract_pilot_metrics import (
+    validate_contract_pilot_metrics,
+    write_contract_pilot_metrics,
+)
+
+
+def handle_contract_pilot_command(args: Namespace) -> int | None:
+    if args.command == "contract-pilot-template":
+        if args.artifact is None or args.output is None:
+            print("contract-pilot-template requires --artifact and --output", file=sys.stderr)
+            return 2
+        try:
+            rendered = render_contract_pilot_template(
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+                args.pilot_reviewer,
+            )
+        except (HoldoutManifestError, OSError) as error:
+            print(f"contract pilot template failed: {error}", file=sys.stderr)
+            return 1
+        args.output.write_text(rendered, encoding="utf-8")
+        print(f"Contract pilot worksheet: {args.output}")
+        return 0
+    if args.command == "validate-contract-pilot":
+        if args.artifact is None or args.pilot is None:
+            print("validate-contract-pilot requires --artifact and --pilot", file=sys.stderr)
+            return 2
+        try:
+            result = validate_contract_pilot(
+                args.pilot,
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (HoldoutManifestError, OSError) as error:
+            print(f"contract pilot invalid: {error}", file=sys.stderr)
+            return 1
+        print(f"Contract pilot: valid ({result['cases']} cases; reviewer {result['reviewer']})")
+        return 0
+    if args.command == "contract-pilot-metrics":
+        if args.artifact is None or args.pilot is None or args.output is None:
+            print("contract-pilot-metrics requires --artifact, --pilot, and --output", file=sys.stderr)
+            return 2
+        try:
+            result = write_contract_pilot_metrics(
+                args.output,
+                args.pilot,
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (HoldoutManifestError, OSError) as error:
+            print(f"contract pilot metrics failed: {error}", file=sys.stderr)
+            return 1
+        counts = result["counts"]
+        print(
+            f"Contract pilot metrics: {args.output} "
+            f"(TP {counts['tp']}, FN {counts['fn']}, TN {counts['tn']}, FP {counts['fp']})"
+        )
+        return 0
+    if args.command == "validate-contract-pilot-metrics":
+        if args.artifact is None or args.pilot is None or args.metrics is None:
+            print("validate-contract-pilot-metrics requires --artifact, --pilot, and --metrics", file=sys.stderr)
+            return 2
+        try:
+            result = validate_contract_pilot_metrics(
+                args.metrics,
+                args.pilot,
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (HoldoutManifestError, OSError) as error:
+            print(f"contract pilot metrics invalid: {error}", file=sys.stderr)
+            return 1
+        print(f"Contract pilot metrics: valid ({result['cases']} cases; reviewer {result['reviewer']})")
+        return 0
+    return None

--- a/scripts/tests/test_real_history_contract_pilot.py
+++ b/scripts/tests/test_real_history_contract_pilot.py
@@ -13,7 +13,11 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from real_history_contract_pilot import render_contract_pilot_template, validate_contract_pilot  # noqa: E402
-from real_history_contract_pilot_metrics import build_contract_pilot_metrics  # noqa: E402
+from real_history_contract_pilot_metrics import (  # noqa: E402
+    build_contract_pilot_metrics,
+    validate_contract_pilot_metrics,
+    write_contract_pilot_metrics,
+)
 from real_history_contracts import contract_evidence_hash  # noqa: E402
 from real_history_contract import validate_manifest  # noqa: E402
 from real_history_runner import BASELINE_COMMANDS  # noqa: E402
@@ -113,6 +117,23 @@ label_state = "pending"
     def tearDown(self) -> None:
         self.tmp.cleanup()
 
+    def _completed_pilot(self) -> Path:
+        pilot = self.root / "pilot.toml"
+        rendered = render_contract_pilot_template(
+            self.collection, self.manifest, self.rules, self.zoo, "expert"
+        )
+        rendered = rendered.replace('contract_label = ""', 'contract_label = "contract-present"', 1)
+        rendered = rendered.replace(
+            "expected_contract_ids = []",
+            'expected_contract_ids = ["security-boundary/boundary-changed"]',
+            1,
+        )
+        rendered = rendered.replace('rationale = ""', 'rationale = "confirmed boundary change"', 1)
+        rendered = rendered.replace('contract_label = ""', 'contract_label = "no-contract"', 1)
+        rendered = rendered.replace('rationale = ""', 'rationale = "no measured contract"', 1)
+        pilot.write_text(rendered, encoding="utf-8")
+        return pilot
+
     def test_template_is_blinded_and_validates_after_labels(self) -> None:
         pilot = self.root / "pilot.toml"
         pilot.write_text(
@@ -178,6 +199,32 @@ label_state = "pending"
         pilot.write_text(rendered, encoding="utf-8")
         with self.assertRaisesRegex(ValueError, "unknown contract ID"):
             validate_contract_pilot(pilot, self.collection, self.manifest, self.rules, self.zoo)
+
+    def test_metrics_artifact_round_trips_through_validator(self) -> None:
+        pilot = self._completed_pilot()
+        metrics = self.root / "metrics.json"
+        write_contract_pilot_metrics(
+            metrics, pilot, self.collection, self.manifest, self.rules, self.zoo
+        )
+        result = validate_contract_pilot_metrics(
+            metrics, pilot, self.collection, self.manifest, self.rules, self.zoo
+        )
+        self.assertEqual(result["status"], "valid")
+        self.assertEqual(result["cases"], 2)
+
+    def test_metrics_validator_rejects_tampered_counts(self) -> None:
+        pilot = self._completed_pilot()
+        metrics = self.root / "metrics.json"
+        write_contract_pilot_metrics(
+            metrics, pilot, self.collection, self.manifest, self.rules, self.zoo
+        )
+        data = json.loads(metrics.read_text(encoding="utf-8"))
+        data["counts"]["tp"] += 1
+        metrics.write_text(json.dumps(data), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "metrics artifact does not match"):
+            validate_contract_pilot_metrics(
+                metrics, pilot, self.collection, self.manifest, self.rules, self.zoo
+            )
 
 
 if __name__ == "__main__":

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -98,12 +98,17 @@ python3 scripts/real_history.py validate-contract-pilot \
 python3 scripts/real_history.py contract-pilot-metrics \
   --artifact real-history-run.json --pilot contract-pilot.toml \
   --output contract-pilot-metrics.json
+python3 scripts/real_history.py validate-contract-pilot-metrics \
+  --artifact real-history-run.json --pilot contract-pilot.toml \
+  --metrics contract-pilot-metrics.json
 ```
 
 The pilot reports case outcomes and per-ID confusion counts with Wilson
-intervals. Its scope is explicitly single-expert exploratory evidence over the
-measured security/test subset; it is not independent validation, a production
-estimate, or evidence for the unmeasured contract families.
+intervals. The final validation command recomputes the score from the pinned
+inputs and rejects edited or stale metrics. Its scope is explicitly
+single-expert exploratory evidence over the measured security/test subset; it
+is not independent validation, a production estimate, or evidence for the
+unmeasured contract families.
 
 When only one expert is available, `pilot-template` creates a blinded
 `single-expert-pilot-v1` worksheet. Fill one label and rationale per case, then


### PR DESCRIPTION
## What changed

This PR makes the single-expert contract pilot result auditable after scoring.

- Add `validate-contract-pilot-metrics`, which recomputes the score from the pinned worksheet, collection, manifest, rules reference, and zoo manifest.
- Compare the complete canonical JSON artifact, including hashes, counts, intervals, case rows, contract IDs, and limitation fields.
- Reject edited, stale, structurally different, or otherwise non-reproducible metrics JSON.
- Split the pilot CLI handlers into a focused module so the holdout command remains small and maintainable.
- Add round-trip and tamper regression tests plus benchmark, roadmap, changelog, and evidence-ledger documentation.

The validator checks artifact integrity. It does not establish reviewer correctness, independent validation, or production-wide quality.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 146 passed
- `python3 scripts/release-contract.py check` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo test --all` — passed
- `cargo run -- scan . --fail-on-priority p1` — `Decision: PASS`, zero visible P1 findings
