### PR TITLE
feat: harden and report real-history evidence metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added a recomputing validator for pilot metrics artifacts. It pins the
   worksheet, collection, and manifest inputs and rejects edited, stale, or
   structurally different JSON scores before they can be used as evidence.
+- Added the same recomputing integrity check for dual-review real-history
+  metrics and a deterministic Markdown report for validated pilot or
+  adjudicated packets. Reports retain scope, denominators, and limitations.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -523,3 +523,20 @@ bump is needed to start.
   modified confusion count.
 - Boundary: this validates artifact integrity, not reviewer correctness or
   independent scientific validity. Single-expert labels remain exploratory.
+
+## 0S — Dual Metrics Integrity and Audit Report
+
+- `validate-metrics` recomputes the dual-review metrics artifact from both
+  blinded worksheets, the adjudication, the collection, and the pinned
+  manifest/rule/zoo inputs. It rejects edited counts, stale hashes, missing
+  fields, and extra fields by comparing the complete canonical JSON object.
+- `metrics-report` renders deterministic Markdown for either an adjudicated
+  metrics artifact or the single-expert pilot artifact. It shows case and
+  contract confusion counts, bounded metric values, scope, and limitations;
+  it does not add new evidence or infer a broader estimate.
+- Regression coverage proves dual metrics round-trip validation, tampered
+  counts rejection, and deterministic report output. The validator must run
+  before the report is circulated as an evidence packet.
+- Boundary: artifact integrity and readable reporting do not establish label
+  correctness, reviewer independence, runtime authorization behavior, or
+  production-wide precision/recall.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -408,6 +408,11 @@ Pilot metrics are accepted only after a recomputing validator rebuilds the
 score from the pinned worksheet, collection, and manifest. A hand-edited or
 stale JSON result therefore remains an invalid evidence packet.
 
+The dual-review metrics path now has the same recomputing check, and both
+adjudicated and exploratory packets can render a deterministic Markdown audit
+summary. The summary carries its scope and limitation beside the counts so a
+small corpus cannot be read as a product-wide estimate.
+
 Initial release discipline:
 
 - a rule cannot be described as broadly precise without labeled default evidence

--- a/scripts/real_history.py
+++ b/scripts/real_history.py
@@ -21,6 +21,7 @@ from real_history_annotations import (
 )
 from real_history_adjudication import render_adjudication_template, validate_adjudication
 from real_history_metrics import write_metrics
+from real_history_metrics_cli import handle_metrics_command
 from real_history_pilot_cli import handle_contract_pilot_command
 from real_history_runner import collect_holdout
 
@@ -39,6 +40,8 @@ def main(argv: list[str] | None = None) -> int:
             "adjudication-template",
             "validate-adjudication",
             "metrics",
+            "validate-metrics",
+            "metrics-report",
             "contract-pilot-template",
             "validate-contract-pilot",
             "contract-pilot-metrics",
@@ -195,6 +198,9 @@ def main(argv: list[str] | None = None) -> int:
     pilot_status = handle_contract_pilot_command(args)
     if pilot_status is not None:
         return pilot_status
+    metrics_status = handle_metrics_command(args)
+    if metrics_status is not None:
+        return metrics_status
     if args.command == "collect":
         if args.timeout <= 0:
             print("--timeout must be positive", file=sys.stderr)

--- a/scripts/real_history_metrics.py
+++ b/scripts/real_history_metrics.py
@@ -192,3 +192,40 @@ def write_metrics(
     )
     output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return result
+
+
+def validate_metrics(
+    metrics_path: Path,
+    adjudication_path: Path,
+    annotation_a_path: Path,
+    annotation_b_path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    try:
+        actual = json.loads(metrics_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read real-history metrics {metrics_path}: {error}") from error
+    if not isinstance(actual, dict):
+        raise HoldoutManifestError("real-history metrics must be a JSON object")
+    expected = build_metrics(
+        adjudication_path,
+        annotation_a_path,
+        annotation_b_path,
+        collection_path,
+        manifest_path,
+        rules_reference,
+        zoo_manifest,
+    )
+    if actual != expected:
+        raise HoldoutManifestError("real-history metrics artifact does not match recomputed score")
+    return {
+        "status": "valid",
+        "schema_version": expected["schema_version"],
+        "protocol": expected["protocol"],
+        "scope": expected["scope"],
+        "cases": len(expected["cases"]),
+        "counts": expected["counts"],
+    }

--- a/scripts/real_history_metrics_cli.py
+++ b/scripts/real_history_metrics_cli.py
@@ -1,0 +1,50 @@
+"""CLI handlers for dual-review metrics integrity and reports."""
+
+from __future__ import annotations
+
+import json
+import sys
+from argparse import Namespace
+
+from real_history_contract import HoldoutManifestError
+from real_history_metrics import validate_metrics
+from real_history_metrics_report import write_metrics_report
+
+
+def handle_metrics_command(args: Namespace) -> int | None:
+    if args.command == "validate-metrics":
+        required = (args.metrics, args.annotation, args.annotation_a, args.annotation_b, args.artifact)
+        if any(value is None for value in required):
+            print(
+                "validate-metrics requires --metrics, --artifact, --annotation-a, --annotation-b, and --annotation",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            result = validate_metrics(
+                args.metrics,
+                args.annotation,
+                args.annotation_a,
+                args.annotation_b,
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (HoldoutManifestError, OSError) as error:
+            print(f"metrics invalid: {error}", file=sys.stderr)
+            return 1
+        print(f"Metrics: valid ({result['cases']} cases)")
+        return 0
+    if args.command == "metrics-report":
+        if args.metrics is None or args.output is None:
+            print("metrics-report requires --metrics and --output", file=sys.stderr)
+            return 2
+        try:
+            write_metrics_report(args.metrics, args.output)
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            print(f"metrics report failed: {error}", file=sys.stderr)
+            return 1
+        print(f"Metrics report: {args.output}")
+        return 0
+    return None

--- a/scripts/real_history_metrics_report.py
+++ b/scripts/real_history_metrics_report.py
@@ -1,0 +1,83 @@
+"""Render deterministic Markdown for a validated evidence metrics artifact."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _metric_value(metrics: dict[str, Any], key: str) -> str:
+    value = metrics.get(key, {}).get("value")
+    return "—" if value is None else f"{value:.3f}"
+
+
+def _counts_cells(counts: dict[str, Any]) -> str:
+    return "{tp} | {fn} | {tn} | {fp} | {excluded}".format(
+        tp=counts.get("tp", 0),
+        fn=counts.get("fn", 0),
+        tn=counts.get("tn", 0),
+        fp=counts.get("fp", 0),
+        excluded=counts.get("excluded", 0),
+    )
+
+
+def _counts_row(counts: dict[str, Any]) -> str:
+    return f"| {_counts_cells(counts)} |"
+
+
+def render_metrics_report(data: dict[str, Any]) -> str:
+    counts = data.get("counts", {})
+    lines = [
+        "# Real-history evidence metrics",
+        "",
+        f"- **Corpus:** {data.get('corpus', 'unknown')}",
+        f"- **Protocol:** {data.get('protocol', 'unknown')}",
+        f"- **Scope:** {data.get('scope', 'unknown')}",
+        f"- **Limitation:** {data.get('limitation', 'unspecified')}",
+        "",
+        "## Case outcomes",
+        "",
+        "| TP | FN | TN | FP | Excluded |",
+        "| ---: | ---: | ---: | ---: | ---: |",
+        _counts_row(counts),
+        "",
+    ]
+    contract_counts = data.get("contract_counts", {})
+    contract_metrics = data.get("contract_metrics", {})
+    if contract_counts:
+        lines.extend(
+            [
+                "## Contract outcomes",
+                "",
+                "| Contract ID | TP | FN | TN | FP | Excluded | Recall | Specificity | Precision |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        for contract_id in sorted(contract_counts):
+            counts_for_id = contract_counts[contract_id]
+            metrics_for_id = contract_metrics.get(contract_id, {})
+            lines.append(
+                f"| `{contract_id}` | {_counts_cells(counts_for_id)} | "
+                f"{_metric_value(metrics_for_id, 'recall')} | "
+                f"{_metric_value(metrics_for_id, 'specificity')} | "
+                f"{_metric_value(metrics_for_id, 'precision')} |"
+            )
+        lines.append("")
+    lines.extend(
+        [
+            "This report is a deterministic rendering of a metrics artifact. "
+            "Run the corresponding validator before treating it as evidence.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_metrics_report(metrics_path: Path, output_path: Path) -> str:
+    data = json.loads(metrics_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("metrics artifact must be a JSON object")
+    report = render_metrics_report(data)
+    output_path.write_text(report, encoding="utf-8")
+    return report

--- a/scripts/tests/test_real_history_annotations.py
+++ b/scripts/tests/test_real_history_annotations.py
@@ -20,7 +20,12 @@ from real_history_adjudication import (  # noqa: E402
     render_adjudication_template,
     validate_adjudication,
 )
-from real_history_metrics import _case_outcome, _contract_outcome, build_metrics, wilson_interval  # noqa: E402
+from real_history_metrics import (  # noqa: E402
+    _case_outcome,
+    _contract_outcome,
+    build_metrics,
+    wilson_interval,
+)
 from real_history_contracts import contract_evidence_hash  # noqa: E402
 from real_history_contract import validate_manifest  # noqa: E402
 from real_history_runner import BASELINE_COMMANDS  # noqa: E402
@@ -286,7 +291,6 @@ label_state = "pending"
         self.assertEqual(_contract_outcome(False, True, False), "fp")
         self.assertEqual(_contract_outcome(False, False, False), "tn")
         self.assertEqual(_contract_outcome(True, True, True), "excluded")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_real_history_metrics_integrity.py
+++ b/scripts/tests/test_real_history_metrics_integrity.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+TESTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from real_history_adjudication import render_adjudication_template  # noqa: E402
+from real_history_contracts import contract_evidence_hash  # noqa: E402
+from real_history_metrics import validate_metrics, write_metrics  # noqa: E402
+from real_history_metrics_report import render_metrics_report  # noqa: E402
+from test_real_history_annotations import AnnotationWorkflowTests  # noqa: E402
+
+
+class MetricsIntegrityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = AnnotationWorkflowTests()
+        self.fixture.setUp()
+
+    def tearDown(self) -> None:
+        self.fixture.tearDown()
+
+    def _adjudicated_inputs(self) -> tuple[Path, Path, Path]:
+        fixture = self.fixture
+        collection = json.loads(fixture.collection.read_text(encoding="utf-8"))
+        collection["cases"][0]["review"]["contract_delta_ids"] = [
+            "security-boundary/boundary-changed"
+        ]
+        collection["cases"][0]["review"]["contract_delta_count"] = 1
+        collection["cases"][0]["review"]["contract_evidence_sha256"] = contract_evidence_hash(
+            ("security-boundary/boundary-changed",)
+        )
+        fixture.collection.write_text(json.dumps(collection), encoding="utf-8")
+        left, right = fixture.worksheet("a"), fixture.worksheet("b")
+        fixture.complete(left, "defect-present")
+        fixture.complete(right, "defect-present")
+        for path in (left, right):
+            text = path.read_text(encoding="utf-8").replace(
+                "expected_contract_ids = []",
+                'expected_contract_ids = ["security-boundary/boundary-changed"]',
+                1,
+            )
+            marker = '[[case]]\nid = "case-two"'
+            head, tail = text.split(marker, 1)
+            tail = tail.replace('label = "defect-present"', 'label = "no-defect"', 1)
+            tail = tail.replace('expected_rule_ids = ["demo.rule"]', "expected_rule_ids = []", 1)
+            path.write_text(head + marker + tail, encoding="utf-8")
+        adjudication = fixture.root / "adjudication.toml"
+        adjudication.write_text(
+            render_adjudication_template(
+                left, right, fixture.collection, fixture.manifest, fixture.rules, fixture.zoo
+            ),
+            encoding="utf-8",
+        )
+        text = adjudication.read_text(encoding="utf-8")
+        text = text.replace('adjudicated = ""', 'adjudicated = "defect-present"', 1)
+        text = text.replace('expected_rule_ids = []', 'expected_rule_ids = ["demo.rule"]', 1)
+        text = text.replace(
+            "expected_contract_ids = []",
+            'expected_contract_ids = ["security-boundary/boundary-changed"]',
+            1,
+        )
+        text = text.replace('rationale = ""', 'rationale = "confirmed"', 1)
+        text = text.replace('adjudicated = ""', 'adjudicated = "no-defect"', 1)
+        text = text.replace('rationale = ""', 'rationale = "confirmed"', 1)
+        adjudication.write_text(text, encoding="utf-8")
+        return adjudication, left, right
+
+    def test_metrics_artifact_validator_rejects_tampering(self) -> None:
+        fixture = self.fixture
+        adjudication, left, right = self._adjudicated_inputs()
+        metrics = fixture.root / "metrics.json"
+        write_metrics(
+            metrics, adjudication, left, right, fixture.collection, fixture.manifest, fixture.rules, fixture.zoo
+        )
+        validated = validate_metrics(
+            metrics, adjudication, left, right, fixture.collection, fixture.manifest, fixture.rules, fixture.zoo
+        )
+        self.assertEqual(validated["status"], "valid")
+        tampered = json.loads(metrics.read_text(encoding="utf-8"))
+        tampered["counts"]["tp"] += 1
+        metrics.write_text(json.dumps(tampered), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "metrics artifact does not match"):
+            validate_metrics(
+                metrics, adjudication, left, right, fixture.collection, fixture.manifest, fixture.rules, fixture.zoo
+            )
+
+    def test_metrics_report_is_deterministic_and_scope_explicit(self) -> None:
+        data = {
+            "schema_version": 2,
+            "corpus": "test",
+            "protocol": "dual-independent-adjudication-v1",
+            "scope": "adjudicated real-history holdout cases only",
+            "limitation": "descriptive corpus evidence",
+            "counts": {"tp": 1, "fn": 0, "tn": 1, "fp": 0, "excluded": 0},
+            "contract_counts": {
+                "security-boundary/boundary-changed": {
+                    "tp": 1,
+                    "fn": 0,
+                    "tn": 1,
+                    "fp": 0,
+                    "excluded": 0,
+                }
+            },
+            "contract_metrics": {
+                "security-boundary/boundary-changed": {
+                    "recall": {"value": 1.0},
+                    "specificity": {"value": 1.0},
+                    "precision": {"value": 1.0},
+                }
+            },
+        }
+        report = render_metrics_report(data)
+        self.assertEqual(report, render_metrics_report(data))
+        self.assertIn("adjudicated real-history holdout cases only", report)
+        self.assertIn("security-boundary/boundary-changed", report)
+        self.assertIn("descriptive corpus evidence", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -62,6 +62,11 @@ python3 scripts/real_history.py validate-adjudication \
 python3 scripts/real_history.py metrics --artifact real-history-run.json \
   --annotation-a annotation-a.toml --annotation-b annotation-b.toml \
   --annotation adjudication.toml --output real-history-metrics.json
+python3 scripts/real_history.py validate-metrics --artifact real-history-run.json \
+  --annotation-a annotation-a.toml --annotation-b annotation-b.toml \
+  --annotation adjudication.toml --metrics real-history-metrics.json
+python3 scripts/real_history.py metrics-report \
+  --metrics real-history-metrics.json --output real-history-metrics.md
 ```
 
 All six entries are intentionally `pending`. The corpus was expanded before
@@ -132,6 +137,12 @@ and verifies that the copied independent labels still match both worksheets.
 recall, specificity, and precision with Wilson 95% intervals. Its output pins
 all three input hashes and states that the result is descriptive evidence for
 this holdout, not a production or language-wide estimate.
+
+`validate-metrics` recomputes that score from the pinned inputs and rejects a
+hand-edited or stale JSON artifact. `metrics-report` renders a deterministic
+Markdown summary for a validated dual-review or exploratory pilot metrics file;
+the report repeats the scope and limitation so it cannot be mistaken for a
+broader quality claim.
 
 The same metrics artifact now includes per-ID contract confusion counts and
 Wilson intervals for `security-boundary/*` and `test-coverage/*`. A reviewer


### PR DESCRIPTION
## What changed

- Add `validate-metrics`, which recomputes adjudicated real-history metrics from both blinded worksheets, the adjudication, collection artifact, manifest, rules reference, and zoo manifest.
- Reject edited, stale, structurally different, or otherwise non-reproducible dual-review metrics JSON.
- Add `metrics-report`, a deterministic Markdown renderer for adjudicated metrics and single-expert pilot metrics.
- Keep counts, contract-level outcomes, scope, denominators, and limitations visible in the report.
- Split the CLI handlers and integrity tests into focused modules/files.

The validator protects artifact integrity. The report improves auditability; neither establishes label correctness, reviewer independence, or production-wide quality.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 156 passed
- `python3 scripts/release-contract.py check` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo test --all` — passed
- `cargo run -- scan . --fail-on-priority p1` — `Decision: PASS`, zero visible P1 findings
