### PR TITLE
feat: audit real-history label coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added the same recomputing integrity check for dual-review real-history
   metrics and a deterministic Markdown report for validated pilot or
   adjudicated packets. Reports retain scope, denominators, and limitations.
+- Added a deterministic real-history label coverage audit. It separates pending,
+  single-expert, and dual-adjudicated packets; exposes unreviewed measured
+  observations and observed contract families outside the measured registry;
+  renders a bounded Markdown gap report, and recomputes the complete audit
+  artifact before it can be circulated without turning incomplete labels into
+  quality claims.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -540,3 +540,26 @@ bump is needed to start.
 - Boundary: artifact integrity and readable reporting do not establish label
   correctness, reviewer independence, runtime authorization behavior, or
   production-wide precision/recall.
+
+## 0T — Label Coverage Audit
+
+- `label-coverage` validates an optional single-expert pilot or complete
+  dual-review packet against the pinned collection and manifest. With no label
+  packet it reports the holdout as pending rather than treating empty labels as
+  negative evidence.
+- The audit reports per-case measured observations, expected contract IDs,
+  unreviewed observations, and emitted IDs outside the measured security/test
+  registry. The full emitted registry remains visible, so an observed delivery,
+  dependency, runtime, or public-symbol contract cannot disappear from the
+  denominator by accident.
+- `coverage-report` renders a deterministic Markdown gap table showing observed,
+  labeled, expected, and unreviewed case counts. `ready_for_dual_metrics` is
+  true only for a validated dual-adjudication packet; a single-expert packet is
+  explicitly exploratory.
+- `validate-label-coverage` recomputes the complete JSON audit from the pinned
+  collection and supplied label inputs, rejecting edited counts, stale hashes,
+  or extra fields before the gap report is circulated.
+- Regression coverage exercises pending, dual-adjudicated, and single-expert
+  inputs plus deterministic report rendering. The audit measures packet
+  completeness and unresolved work; it does not judge reviewer correctness,
+  runtime behavior, or production-wide quality.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -413,6 +413,13 @@ adjudicated and exploratory packets can render a deterministic Markdown audit
 summary. The summary carries its scope and limitation beside the counts so a
 small corpus cannot be read as a product-wide estimate.
 
+The label coverage audit now makes the next evidence action explicit before a
+score is circulated: it reports how many holdout cases are labeled, which
+measured observations remain unreviewed, and which emitted contract families
+are still outside the measured registry. It supports pending, single-expert,
+and dual-adjudicated packets while preserving the distinction between packet
+completeness and reviewer correctness.
+
 Initial release discipline:
 
 - a rule cannot be described as broadly precise without labeled default evidence

--- a/scripts/real_history.py
+++ b/scripts/real_history.py
@@ -22,6 +22,7 @@ from real_history_annotations import (
 from real_history_adjudication import render_adjudication_template, validate_adjudication
 from real_history_metrics import write_metrics
 from real_history_metrics_cli import handle_metrics_command
+from real_history_coverage_cli import handle_coverage_command
 from real_history_pilot_cli import handle_contract_pilot_command
 from real_history_runner import collect_holdout
 
@@ -42,6 +43,9 @@ def main(argv: list[str] | None = None) -> int:
             "metrics",
             "validate-metrics",
             "metrics-report",
+            "label-coverage",
+            "validate-label-coverage",
+            "coverage-report",
             "contract-pilot-template",
             "validate-contract-pilot",
             "contract-pilot-metrics",
@@ -66,6 +70,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--pilot", type=Path, help="single-expert contract pilot worksheet")
     parser.add_argument("--pilot-reviewer", default="expert", help="single-expert pilot reviewer label")
     parser.add_argument("--metrics", type=Path, help="single-expert contract pilot metrics artifact")
+    parser.add_argument("--coverage", type=Path, help="label coverage audit artifact")
     args = parser.parse_args(argv)
     try:
         corpus, protocol, cases = validate_manifest(args.manifest, args.rules_reference, args.zoo_manifest)
@@ -198,6 +203,9 @@ def main(argv: list[str] | None = None) -> int:
     pilot_status = handle_contract_pilot_command(args)
     if pilot_status is not None:
         return pilot_status
+    coverage_status = handle_coverage_command(args)
+    if coverage_status is not None:
+        return coverage_status
     metrics_status = handle_metrics_command(args)
     if metrics_status is not None:
         return metrics_status

--- a/scripts/real_history_coverage_cli.py
+++ b/scripts/real_history_coverage_cli.py
@@ -1,0 +1,97 @@
+"""CLI handlers for real-history label coverage audits."""
+
+from __future__ import annotations
+
+import json
+import sys
+from argparse import Namespace
+
+from real_history_contract import HoldoutManifestError
+from real_history_label_coverage import (
+    build_label_coverage,
+    validate_label_coverage,
+    write_label_coverage,
+)
+from real_history_label_coverage_report import write_label_coverage_report
+
+
+def handle_coverage_command(args: Namespace) -> int | None:
+    if args.command == "label-coverage":
+        if args.artifact is None:
+            print("label-coverage requires --artifact", file=sys.stderr)
+            return 2
+        try:
+            if args.output is None:
+                result = build_label_coverage(
+                    args.artifact,
+                    args.manifest,
+                    args.rules_reference,
+                    args.zoo_manifest,
+                    adjudication_path=args.annotation,
+                    annotation_a_path=args.annotation_a,
+                    annotation_b_path=args.annotation_b,
+                    pilot_path=args.pilot,
+                )
+            else:
+                result = write_label_coverage(
+                    args.output,
+                    args.artifact,
+                    args.manifest,
+                    args.rules_reference,
+                    args.zoo_manifest,
+                    adjudication_path=args.annotation,
+                    annotation_a_path=args.annotation_a,
+                    annotation_b_path=args.annotation_b,
+                    pilot_path=args.pilot,
+                )
+        except (HoldoutManifestError, OSError) as error:
+            print(f"label coverage failed: {error}", file=sys.stderr)
+            return 1
+        if args.output is not None:
+            print(f"Label coverage: {args.output} ({result['label_source']})")
+        elif args.format == "json":
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print(
+                f"Label coverage: {result['cases_labeled']}/{result['cases_total']} cases labeled; "
+                f"source {result['label_source']}"
+            )
+            print(
+                "Unmeasured observed contracts: "
+                + (", ".join(result["unmeasured_observed_contract_ids"]) or "none")
+            )
+            print(f"Unreviewed measured observations: {len(result['unreviewed_observations'])}")
+        return 0
+    if args.command == "validate-label-coverage":
+        if args.coverage is None or args.artifact is None:
+            print("validate-label-coverage requires --coverage and --artifact", file=sys.stderr)
+            return 2
+        try:
+            result = validate_label_coverage(
+                args.coverage,
+                args.artifact,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+                adjudication_path=args.annotation,
+                annotation_a_path=args.annotation_a,
+                annotation_b_path=args.annotation_b,
+                pilot_path=args.pilot,
+            )
+        except (HoldoutManifestError, OSError) as error:
+            print(f"label coverage invalid: {error}", file=sys.stderr)
+            return 1
+        print(f"Label coverage: valid ({result['cases']} cases; {result['label_source']})")
+        return 0
+    if args.command == "coverage-report":
+        if args.coverage is None or args.output is None:
+            print("coverage-report requires --coverage and --output", file=sys.stderr)
+            return 2
+        try:
+            write_label_coverage_report(args.coverage, args.output)
+        except (HoldoutManifestError, OSError, ValueError, json.JSONDecodeError) as error:
+            print(f"coverage report failed: {error}", file=sys.stderr)
+            return 1
+        print(f"Label coverage report: {args.output}")
+        return 0
+    return None

--- a/scripts/real_history_label_coverage.py
+++ b/scripts/real_history_label_coverage.py
@@ -1,0 +1,253 @@
+"""Audit label coverage and unresolved contract observations in a holdout."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from real_history_adjudication import validate_adjudication
+from real_history_annotations import load_collection
+from real_history_contract import HoldoutManifestError, validate_manifest
+from real_history_contract_pilot import validate_contract_pilot
+from real_history_contracts import ALL_CONTRACT_IDS, CONTRACT_IDS
+
+
+COVERAGE_SCHEMA_VERSION = 1
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_toml(path: Path, name: str) -> dict[str, Any]:
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read {name} {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError(f"{name} must be a TOML table")
+    return data
+
+
+def _source_records(
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+    adjudication_path: Path | None,
+    annotation_a_path: Path | None,
+    annotation_b_path: Path | None,
+    pilot_path: Path | None,
+) -> tuple[str, dict[str, dict[str, Any]]]:
+    dual = (adjudication_path, annotation_a_path, annotation_b_path)
+    if pilot_path is not None and any(value is not None for value in dual):
+        raise HoldoutManifestError("coverage audit accepts either a pilot or a complete dual packet")
+    if pilot_path is not None:
+        validate_contract_pilot(pilot_path, collection_path, manifest_path, rules_reference, zoo_manifest)
+        data = _load_toml(pilot_path, "contract pilot")
+        return "single-expert-pilot", {
+            case["id"]: {
+                "label": case["contract_label"],
+                "expected_contract_ids": sorted(case["expected_contract_ids"]),
+            }
+            for case in data["case"]
+        }
+    if any(value is not None for value in dual):
+        if any(value is None for value in dual):
+            raise HoldoutManifestError("coverage audit requires annotation, annotation-a, and annotation-b together")
+        assert adjudication_path is not None
+        assert annotation_a_path is not None
+        assert annotation_b_path is not None
+        validate_adjudication(
+            adjudication_path,
+            annotation_a_path,
+            annotation_b_path,
+            collection_path,
+            manifest_path,
+            rules_reference,
+            zoo_manifest,
+        )
+        data = _load_toml(adjudication_path, "adjudication")
+        return "dual-adjudication", {
+            case["id"]: {
+                "label": case["adjudicated"],
+                "expected_contract_ids": sorted(case["expected_contract_ids"]),
+            }
+            for case in data["case"]
+        }
+    return "pending", {}
+
+
+def _case_rows(
+    collection: dict[str, Any],
+    labels: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], set[str]]:
+    rows: list[dict[str, Any]] = []
+    unreviewed: list[dict[str, Any]] = []
+    observed_ids: set[str] = set()
+    for case in sorted(collection["cases"], key=lambda item: item["id"]):
+        review = case["review"]
+        observed = sorted(set(review.get("contract_delta_ids", [])))
+        observed_ids.update(observed)
+        measured_observed = sorted(set(observed) & set(CONTRACT_IDS))
+        label = labels.get(case["id"])
+        expected = sorted(label["expected_contract_ids"]) if label else []
+        if label is None:
+            label_state = "unlabeled"
+            observed_without_expected: list[str] = []
+            expected_without_observation: list[str] = []
+            if measured_observed:
+                unreviewed.append({"case_id": case["id"], "contract_ids": measured_observed})
+        else:
+            label_state = "uncertain" if label["label"] == "uncertain" else "labeled"
+            observed_without_expected = sorted(set(measured_observed) - set(expected))
+            expected_without_observation = sorted(set(expected) - set(measured_observed))
+        rows.append(
+            {
+                "id": case["id"],
+                "label_state": label_state,
+                "label": label["label"] if label else None,
+                "observed_contract_ids": observed,
+                "measured_observed_contract_ids": measured_observed,
+                "unmeasured_observed_contract_ids": sorted(set(observed) - set(CONTRACT_IDS)),
+                "expected_contract_ids": expected,
+                "observed_without_expected_ids": observed_without_expected,
+                "expected_without_observation_ids": expected_without_observation,
+            }
+        )
+    return rows, unreviewed, observed_ids
+
+
+def _contract_coverage(rows: list[dict[str, Any]], labels_count: int) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for contract_id in ALL_CONTRACT_IDS:
+        observed_cases = [row for row in rows if contract_id in row["observed_contract_ids"]]
+        expected_cases = [row for row in rows if contract_id in row["expected_contract_ids"]]
+        unreviewed_cases = [row for row in observed_cases if row["label_state"] == "unlabeled"]
+        result[contract_id] = {
+            "measured": contract_id in CONTRACT_IDS,
+            "unmeasured": contract_id not in CONTRACT_IDS,
+            "observed_cases": len(observed_cases),
+            "observed_labeled_cases": len(observed_cases) - len(unreviewed_cases),
+            "expected_cases": len(expected_cases),
+            "unreviewed_cases": len(unreviewed_cases),
+            "labels_available": labels_count,
+        }
+    return result
+
+
+def build_label_coverage(
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+    *,
+    adjudication_path: Path | None = None,
+    annotation_a_path: Path | None = None,
+    annotation_b_path: Path | None = None,
+    pilot_path: Path | None = None,
+) -> dict[str, Any]:
+    collection = load_collection(collection_path, manifest_path, rules_reference, zoo_manifest)
+    _, _, manifest_cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    source, labels = _source_records(
+        collection_path,
+        manifest_path,
+        rules_reference,
+        zoo_manifest,
+        adjudication_path,
+        annotation_a_path,
+        annotation_b_path,
+        pilot_path,
+    )
+    rows, unreviewed, observed_ids = _case_rows(collection, labels)
+    if source != "pending" and set(labels) != {case.case_id for case in manifest_cases}:
+        raise HoldoutManifestError("label packet does not cover the manifest cases")
+    limitation = {
+        "pending": "no human labels supplied; observed contract deltas remain unresolved",
+        "single-expert-pilot": "one reviewer only; coverage is exploratory and not independent validation",
+        "dual-adjudication": "coverage compares a bounded holdout packet; it does not prove runtime semantics",
+    }[source]
+    cases_labeled = len(labels)
+    label_inputs: dict[str, str] = {}
+    if pilot_path is not None:
+        label_inputs["pilot"] = _sha256_file(pilot_path)
+    elif adjudication_path is not None:
+        label_inputs = {
+            "adjudication": _sha256_file(adjudication_path),
+            "annotation_a": _sha256_file(annotation_a_path),
+            "annotation_b": _sha256_file(annotation_b_path),
+        }
+    return {
+        "schema_version": COVERAGE_SCHEMA_VERSION,
+        "corpus": collection["corpus"],
+        "protocol": "real-history-label-coverage-audit-v1",
+        "label_source": source,
+        "independent_validation": source == "dual-adjudication",
+        "ready_for_dual_metrics": source == "dual-adjudication",
+        "limitation": limitation,
+        "manifest_sha256": collection["manifest_sha256"],
+        "collection_sha256": collection["collection_sha256"],
+        "label_inputs": label_inputs,
+        "cases_total": len(rows),
+        "cases_labeled": cases_labeled,
+        "cases_unlabeled": len(rows) - cases_labeled,
+        "cases_uncertain": sum(row["label_state"] == "uncertain" for row in rows),
+        "observed_contract_ids": sorted(observed_ids),
+        "unmeasured_observed_contract_ids": sorted(observed_ids - set(CONTRACT_IDS)),
+        "unreviewed_observations": unreviewed,
+        "contract_coverage": _contract_coverage(rows, cases_labeled),
+        "cases": rows,
+    }
+
+
+def write_label_coverage(
+    output_path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+    **sources: Path | None,
+) -> dict[str, Any]:
+    result = build_label_coverage(
+        collection_path,
+        manifest_path,
+        rules_reference,
+        zoo_manifest,
+        **sources,
+    )
+    output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return result
+
+
+def validate_label_coverage(
+    coverage_path: Path,
+    collection_path: Path,
+    manifest_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+    **sources: Path | None,
+) -> dict[str, Any]:
+    try:
+        actual = json.loads(coverage_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read label coverage artifact {coverage_path}: {error}") from error
+    if not isinstance(actual, dict):
+        raise HoldoutManifestError("label coverage artifact must be a JSON object")
+    expected = build_label_coverage(
+        collection_path,
+        manifest_path,
+        rules_reference,
+        zoo_manifest,
+        **sources,
+    )
+    if actual != expected:
+        raise HoldoutManifestError("label coverage artifact does not match recomputed audit")
+    return {
+        "status": "valid",
+        "label_source": expected["label_source"],
+        "cases": expected["cases_total"],
+        "unreviewed_observations": len(expected["unreviewed_observations"]),
+    }

--- a/scripts/real_history_label_coverage_report.py
+++ b/scripts/real_history_label_coverage_report.py
@@ -1,0 +1,72 @@
+"""Render deterministic Markdown for a label coverage audit."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from real_history_contract import HoldoutManifestError
+
+
+def _ids(values: list[str]) -> str:
+    return ", ".join(f"`{value}`" for value in values) if values else "—"
+
+
+def render_label_coverage_report(data: dict[str, Any]) -> str:
+    lines = [
+        "# Real-history label coverage audit",
+        "",
+        f"- **Corpus:** {data.get('corpus', 'unknown')}",
+        f"- **Label source:** {data.get('label_source', 'unknown')}",
+        f"- **Cases:** {data.get('cases_labeled', 0)}/{data.get('cases_total', 0)} labeled",
+        f"- **Dual metrics ready:** {'yes' if data.get('ready_for_dual_metrics') else 'no'}",
+        f"- **Limitation:** {data.get('limitation', 'unspecified')}",
+        "",
+        "## Contract coverage",
+        "",
+        "| Contract ID | Measured | Observed cases | Observed in labeled cases | Expected cases | Unreviewed cases |",
+        "| --- | :---: | ---: | ---: | ---: | ---: |",
+    ]
+    for contract_id in sorted(data.get("contract_coverage", {})):
+        item = data["contract_coverage"][contract_id]
+        lines.append(
+            f"| `{contract_id}` | {'yes' if item['measured'] else 'no'} | "
+            f"{item['observed_cases']} | {item['observed_labeled_cases']} | "
+            f"{item['expected_cases']} | {item['unreviewed_cases']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Case gaps",
+            "",
+            "| Case | Label state | Observed without expected | Expected without observation | Unmeasured observed |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in data.get("cases", []):
+        lines.append(
+            f"| `{row['id']}` | {row['label_state']} | {_ids(row['observed_without_expected_ids'])} | "
+            f"{_ids(row['expected_without_observation_ids'])} | {_ids(row['unmeasured_observed_contract_ids'])} |"
+        )
+    lines.extend(
+        [
+            "",
+            "This report audits packet completeness and unresolved observations. "
+            "It does not infer label correctness or broaden the measured contract registry.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_label_coverage_report(coverage_path: Path, output_path: Path) -> str:
+    try:
+        data = json.loads(coverage_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read label coverage artifact {coverage_path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError("label coverage artifact must be a JSON object")
+    report = render_label_coverage_report(data)
+    output_path.write_text(report, encoding="utf-8")
+    return report

--- a/scripts/tests/test_real_history_label_coverage.py
+++ b/scripts/tests/test_real_history_label_coverage.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+TESTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from real_history_annotations import render_worksheet  # noqa: E402
+from real_history_adjudication import render_adjudication_template  # noqa: E402
+from real_history_contract_pilot import render_contract_pilot_template  # noqa: E402
+from real_history_contracts import contract_evidence_hash  # noqa: E402
+from real_history_label_coverage import (  # noqa: E402
+    build_label_coverage,
+    validate_label_coverage,
+    write_label_coverage,
+)
+from real_history_label_coverage_report import render_label_coverage_report  # noqa: E402
+from test_real_history_annotations import AnnotationWorkflowTests  # noqa: E402
+
+
+class LabelCoverageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = AnnotationWorkflowTests()
+        self.fixture.setUp()
+
+    def tearDown(self) -> None:
+        self.fixture.tearDown()
+
+    def _add_observations(self) -> None:
+        collection = json.loads(self.fixture.collection.read_text(encoding="utf-8"))
+        measured = "security-boundary/boundary-changed"
+        unmeasured = "delivery/action-reference-changed"
+        for case, contract_ids in zip(collection["cases"], ([measured], [unmeasured])):
+            review = case["review"]
+            review["contract_delta_ids"] = contract_ids
+            review["contract_delta_count"] = len(contract_ids)
+            review["contract_evidence_sha256"] = contract_evidence_hash(contract_ids)
+        self.fixture.collection.write_text(json.dumps(collection), encoding="utf-8")
+
+    def test_pending_audit_exposes_unmeasured_and_unreviewed_observations(self) -> None:
+        self._add_observations()
+        result = build_label_coverage(
+            self.fixture.collection, self.fixture.manifest, self.fixture.rules, self.fixture.zoo
+        )
+
+        self.assertEqual(result["label_source"], "pending")
+        self.assertEqual(result["cases_labeled"], 0)
+        self.assertEqual(result["unmeasured_observed_contract_ids"], ["delivery/action-reference-changed"])
+        self.assertEqual(result["unreviewed_observations"], [
+            {"case_id": "case-one", "contract_ids": ["security-boundary/boundary-changed"]},
+        ])
+        self.assertEqual(
+            result["contract_coverage"]["security-boundary/boundary-changed"]["observed_cases"],
+            1,
+        )
+        self.assertTrue(result["contract_coverage"]["delivery/action-reference-changed"]["unmeasured"])
+
+    def test_dual_audit_reports_expected_and_observed_contract_gaps(self) -> None:
+        self._add_observations()
+        left = self.fixture.root / "a.toml"
+        right = self.fixture.root / "b.toml"
+        left.write_text(
+            render_worksheet(self.fixture.collection, self.fixture.manifest, self.fixture.rules, self.fixture.zoo, "a"),
+            encoding="utf-8",
+        )
+        right.write_text(
+            render_worksheet(self.fixture.collection, self.fixture.manifest, self.fixture.rules, self.fixture.zoo, "b"),
+            encoding="utf-8",
+        )
+        for path in (left, right):
+            text = path.read_text(encoding="utf-8")
+            text = text.replace('label = ""', 'label = "defect-present"', 1)
+            text = text.replace('expected_rule_ids = []', 'expected_rule_ids = ["demo.rule"]', 1)
+            text = text.replace(
+                "expected_contract_ids = []",
+                'expected_contract_ids = ["security-boundary/boundary-changed"]',
+                1,
+            )
+            text = text.replace('rationale = ""', 'rationale = "reviewed"', 1)
+            text = text.replace('label = ""', 'label = "no-defect"', 1)
+            text = text.replace('rationale = ""', 'rationale = "reviewed"', 1)
+            path.write_text(text, encoding="utf-8")
+        adjudication = self.fixture.root / "adjudication.toml"
+        adjudication.write_text(
+            render_adjudication_template(
+                left, right, self.fixture.collection, self.fixture.manifest, self.fixture.rules, self.fixture.zoo
+            ).replace('adjudicated = ""', 'adjudicated = "defect-present"', 1)
+            .replace('expected_rule_ids = []', 'expected_rule_ids = ["demo.rule"]', 1)
+            .replace('expected_contract_ids = []', 'expected_contract_ids = ["security-boundary/boundary-changed"]', 1)
+            .replace('rationale = ""', 'rationale = "confirmed"', 1)
+            .replace('adjudicated = ""', 'adjudicated = "no-defect"', 1)
+            .replace('rationale = ""', 'rationale = "confirmed"', 1),
+            encoding="utf-8",
+        )
+        result = build_label_coverage(
+            self.fixture.collection,
+            self.fixture.manifest,
+            self.fixture.rules,
+            self.fixture.zoo,
+            adjudication_path=adjudication,
+            annotation_a_path=left,
+            annotation_b_path=right,
+        )
+
+        self.assertEqual(result["label_source"], "dual-adjudication")
+        self.assertEqual(result["cases_labeled"], 2)
+        self.assertEqual(result["unreviewed_observations"], [])
+        self.assertEqual(result["cases"][0]["unmeasured_observed_contract_ids"], [])
+        self.assertIn("delivery/action-reference-changed", result["cases"][1]["unmeasured_observed_contract_ids"])
+
+    def test_pilot_audit_is_explicitly_single_expert(self) -> None:
+        pilot = self.fixture.root / "pilot.toml"
+        pilot.write_text(
+            render_contract_pilot_template(
+                self.fixture.collection, self.fixture.manifest, self.fixture.rules, self.fixture.zoo, "expert"
+            ),
+            encoding="utf-8",
+        )
+        text = pilot.read_text(encoding="utf-8")
+        text = text.replace('contract_label = ""', 'contract_label = "no-contract"')
+        text = text.replace('rationale = ""', 'rationale = "reviewed"')
+        pilot.write_text(text, encoding="utf-8")
+        result = build_label_coverage(
+            self.fixture.collection,
+            self.fixture.manifest,
+            self.fixture.rules,
+            self.fixture.zoo,
+            pilot_path=pilot,
+        )
+
+        self.assertEqual(result["label_source"], "single-expert-pilot")
+        self.assertFalse(result["independent_validation"])
+        self.assertEqual(result["cases_labeled"], 2)
+
+    def test_report_is_deterministic_and_scope_explicit(self) -> None:
+        result = build_label_coverage(
+            self.fixture.collection, self.fixture.manifest, self.fixture.rules, self.fixture.zoo
+        )
+        report = render_label_coverage_report(result)
+        self.assertEqual(report, render_label_coverage_report(result))
+        self.assertIn("pending", report)
+        self.assertIn("delivery/action-reference-changed", report)
+        self.assertIn("unreviewed", report.lower())
+
+    def test_coverage_validator_rejects_tampering(self) -> None:
+        coverage = self.fixture.root / "coverage.json"
+        write_label_coverage(
+            coverage,
+            self.fixture.collection,
+            self.fixture.manifest,
+            self.fixture.rules,
+            self.fixture.zoo,
+        )
+        validated = validate_label_coverage(
+            coverage,
+            self.fixture.collection,
+            self.fixture.manifest,
+            self.fixture.rules,
+            self.fixture.zoo,
+        )
+        self.assertEqual(validated["status"], "valid")
+        data = json.loads(coverage.read_text(encoding="utf-8"))
+        data["cases_labeled"] = 1
+        coverage.write_text(json.dumps(data), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "coverage artifact does not match"):
+            validate_label_coverage(
+                coverage,
+                self.fixture.collection,
+                self.fixture.manifest,
+                self.fixture.rules,
+                self.fixture.zoo,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -67,6 +67,12 @@ python3 scripts/real_history.py validate-metrics --artifact real-history-run.jso
   --annotation adjudication.toml --metrics real-history-metrics.json
 python3 scripts/real_history.py metrics-report \
   --metrics real-history-metrics.json --output real-history-metrics.md
+python3 scripts/real_history.py label-coverage \
+  --artifact real-history-run.json --output label-coverage.json
+python3 scripts/real_history.py validate-label-coverage \
+  --artifact real-history-run.json --coverage label-coverage.json
+python3 scripts/real_history.py coverage-report \
+  --coverage label-coverage.json --output label-coverage.md
 ```
 
 All six entries are intentionally `pending`. The corpus was expanded before
@@ -143,6 +149,16 @@ hand-edited or stale JSON artifact. `metrics-report` renders a deterministic
 Markdown summary for a validated dual-review or exploratory pilot metrics file;
 the report repeats the scope and limitation so it cannot be mistaken for a
 broader quality claim.
+
+`label-coverage` audits the evidence packet before scoring. With no worksheet
+arguments it reports the collected holdout as pending; with `--pilot` it marks
+the packet as single-expert exploratory; with `--annotation`, `--annotation-a`,
+and `--annotation-b` it validates the dual-adjudicated packet. The output lists
+unreviewed measured observations and emitted contract IDs outside the measured
+registry. `coverage-report` renders the same gaps as deterministic Markdown.
+Run `validate-label-coverage` before circulating the JSON or Markdown packet;
+it recomputes the complete audit and rejects edits or stale label inputs. This
+is a completeness audit, not a recall or precision estimate.
 
 The same metrics artifact now includes per-ID contract confusion counts and
 Wilson intervals for `security-boundary/*` and `test-coverage/*`. A reviewer


### PR DESCRIPTION
## Problem

The real-history packet now has collection, pilot/adjudication, metrics, and report artifacts, but there was no deterministic view of what evidence is still missing. Empty labels could be mistaken for negative evidence, and contract observations outside the measured registry were easy to overlook.

## What changed

- Add `label-coverage` for pending collections, single-expert pilots, and complete dual-adjudication packets.
- Add per-case coverage rows showing measured observations, expected IDs, unresolved measured observations, and emitted IDs outside the measured registry.
- Keep the full emitted contract registry visible, including currently unmeasured dependency, delivery, runtime, and public-symbol families.
- Add `validate-label-coverage`, which recomputes the complete JSON audit from the pinned collection and label inputs and rejects edits, stale hashes, missing fields, or extra fields.
- Add `coverage-report` for deterministic Markdown gap tables.
- Document the workflow in the v0.23 roadmap, evidence ledger, changelog, and benchmark README.

## Validation

- 169 Python tests passed.
- `python3 scripts/release-contract.py check` passed.
- Python compilation and `git diff --check` passed.
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` passed.
- `cargo test --all` passed: 924 library tests, 80 binary tests, and all integration/doc suites (one explicit compatibility test ignored).
- `cargo run -- scan . --fail-on-priority p1` passed with 0 visible P1 findings; existing informational/contract warnings remain disclosed.
