### PR TITLE
feat: validate differential pilot metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   renders a bounded Markdown gap report, and recomputes the complete audit
   artifact before it can be circulated without turning incomplete labels into
   quality claims.
+- Added recomputing validation and a deterministic Markdown report for the
+  differential utility pilot metrics. Edited or stale scores are rejected, and
+  unavailable utility measurements remain explicit instead of being inferred.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -317,6 +317,14 @@ bump is needed to start.
   measurements the collector actually captured. It is explicitly model-assisted
   or single-reviewer evidence; it does not alter the dual-review protocol and
   cannot close RP23-014 by itself.
+- `pilot-validate-metrics` now recomputes the complete differential pilot score
+  from the immutable collection, worksheet, manifests, rules reference, and
+  zoo manifest. `pilot-metrics-report` renders case outcomes, captured timing
+  and resource summaries, and every unavailable measurement explicitly.
+- Boundary: score integrity and readable reporting do not establish reviewer
+  correctness, independent utility, or a product-wide comparison with existing
+  checks. RP23-014 remains open until the frozen dual-review and utility labels
+  are completed.
 
 ## 0H — Ownership Assessment Semantics
 

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -420,6 +420,12 @@ are still outside the measured registry. It supports pending, single-expert,
 and dual-adjudicated packets while preserving the distinction between packet
 completeness and reviewer correctness.
 
+The differential utility pilot now has the same artifact integrity boundary:
+its metrics are recomputed from the pinned collection and worksheet before a
+report is circulated, and utility dimensions without captured events remain
+explicitly unavailable. This advances RP23-014's measurement infrastructure
+without claiming independent utility or competitor superiority.
+
 Initial release discipline:
 
 - a rule cannot be described as broadly precise without labeled default evidence

--- a/scripts/differential.py
+++ b/scripts/differential.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from differential_artifact import validate_artifact, validate_data
 from differential_contract import DifferentialManifestError, validate_differential
 from differential_pilot import render_pilot_template, validate_pilot
-from differential_pilot_metrics import write_pilot_metrics
+from differential_pilot_metrics import validate_pilot_metrics, write_pilot_metrics
+from differential_metrics_report import write_differential_metrics_report
 from differential_runner import collect_differential
 from real_history_contract import HoldoutManifestError
 
@@ -21,7 +22,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=("check", "collect", "validate-result", "pilot-template", "pilot-validate", "pilot-score"),
+        choices=(
+            "check",
+            "collect",
+            "validate-result",
+            "pilot-template",
+            "pilot-validate",
+            "pilot-score",
+            "pilot-validate-metrics",
+            "pilot-metrics-report",
+        ),
         default="check",
     )
     parser.add_argument("--manifest", type=Path, default=Path("tests/benchmarks/differential.toml"))
@@ -37,6 +47,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--artifact", type=Path, help="differential artifact to validate")
     parser.add_argument("--pilot", type=Path, help="single-expert pilot worksheet")
     parser.add_argument("--reviewer", help="single-expert pilot reviewer name")
+    parser.add_argument("--metrics", type=Path, help="single-expert pilot metrics artifact")
     args = parser.parse_args(argv)
     try:
         result = validate_differential(args.manifest, args.holdout_manifest, args.rules_reference, args.zoo_manifest)
@@ -157,6 +168,36 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(pilot_result, indent=2, sort_keys=True))
         else:
             print(f"Pilot metrics: {pilot_result['scope']} ({len(pilot_result['cases'])} cases)")
+        return 0
+    if args.command == "pilot-validate-metrics":
+        if args.artifact is None or args.pilot is None or args.metrics is None:
+            print("pilot-validate-metrics requires --artifact, --pilot, and --metrics", file=sys.stderr)
+            return 2
+        try:
+            metrics_result = validate_pilot_metrics(
+                args.metrics,
+                args.artifact,
+                args.pilot,
+                args.holdout_manifest,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+        except (DifferentialManifestError, HoldoutManifestError, OSError) as error:
+            print(f"pilot metrics invalid: {error}", file=sys.stderr)
+            return 1
+        print(f"Pilot metrics: valid ({metrics_result['cases']} cases; reviewer {metrics_result['reviewer']})")
+        return 0
+    if args.command == "pilot-metrics-report":
+        if args.metrics is None or args.output is None:
+            print("pilot-metrics-report requires --metrics and --output", file=sys.stderr)
+            return 2
+        try:
+            write_differential_metrics_report(args.metrics, args.output)
+        except (HoldoutManifestError, OSError, ValueError, json.JSONDecodeError) as error:
+            print(f"pilot metrics report failed: {error}", file=sys.stderr)
+            return 1
+        print(f"Pilot metrics report: {args.output}")
         return 0
     if args.format == "json":
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/scripts/differential_metrics_report.py
+++ b/scripts/differential_metrics_report.py
@@ -1,0 +1,93 @@
+"""Render deterministic Markdown for a differential pilot metrics artifact."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from real_history_contract import HoldoutManifestError
+
+
+def _number(value: Any) -> str:
+    return "—" if value is None else f"{float(value):.3f}"
+
+
+def _ids(values: list[str]) -> str:
+    return ", ".join(f"`{value}`" for value in values) if values else "—"
+
+
+def _measurement_status(value: Any) -> str:
+    if not isinstance(value, dict):
+        return "unavailable"
+    if value.get("status") == "unavailable":
+        return f"unavailable: {value.get('reason', 'unspecified')}"
+    return str(value.get("status", "unknown"))
+
+
+def render_differential_metrics_report(data: dict[str, Any]) -> str:
+    counts = data.get("counts", {})
+    measurements = data.get("measurements", {})
+    lines = [
+        "# Differential utility pilot metrics",
+        "",
+        f"- **Corpus:** {data.get('corpus', 'unknown')}",
+        f"- **Protocol:** {data.get('protocol', 'unknown')}",
+        f"- **Reviewer:** {data.get('reviewer', 'unknown')}",
+        f"- **Scope:** {data.get('scope', 'unknown')}",
+        f"- **Limitation:** {data.get('limitation', 'unspecified')}",
+        "",
+        "## Case outcomes",
+        "",
+        "| TP | FN | TN | FP | Excluded |",
+        "| ---: | ---: | ---: | ---: | ---: |",
+        f"| {counts.get('tp', 0)} | {counts.get('fn', 0)} | {counts.get('tn', 0)} | "
+        f"{counts.get('fp', 0)} | {counts.get('excluded', 0)} |",
+        "",
+        "## Utility measurements",
+        "",
+        "| Measurement | Result |",
+        "| --- | --- |",
+        f"| Deterministic cases | {measurements.get('deterministic_cases', 0)}/{measurements.get('case_count', 0)} |",
+        f"| Novel evidence cases | {measurements.get('novel_evidence_cases', 0)} |",
+        f"| Median baseline wall time (ms) | {_number(measurements.get('median_baseline_wall_ms'))} |",
+        f"| Median review wall time (ms) | {_number(measurements.get('median_review_wall_ms'))} |",
+        f"| Median review child max RSS (KiB) | {_number(measurements.get('median_review_child_max_rss_kb'))} |",
+        f"| Time to first useful evidence | {_measurement_status(measurements.get('time_to_first_useful_evidence'))} |",
+        f"| Decision latency | {_measurement_status(measurements.get('decision_latency'))} |",
+        f"| Duplicate work | {_measurement_status(measurements.get('duplicate_work'))} |",
+        "",
+        "## Case detail",
+        "",
+        "| Case | Outcome | Expected rules | Observed novel rules | Novel evidence | Review ms | RSS KiB |",
+        "| --- | --- | --- | --- | ---: | ---: | ---: |",
+    ]
+    for case in data.get("cases", []):
+        case_measurements = case.get("measurements", {})
+        lines.append(
+            f"| `{case.get('id', 'unknown')}` | {case.get('outcome', 'unknown')} | "
+            f"{_ids(case.get('expected_rule_ids', []))} | {_ids(case.get('observed_novel_rule_ids', []))} | "
+            f"{case.get('novel_evidence_count', 0)} | {_number(case_measurements.get('median_review_wall_ms'))} | "
+            f"{_number(case_measurements.get('median_review_child_max_rss_kb'))} |"
+        )
+    lines.extend(
+        [
+            "",
+            "This report is a deterministic rendering of a differential pilot metrics artifact. "
+            "Validate the artifact before treating it as evidence; unavailable measurements remain unavailable.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_differential_metrics_report(metrics_path: Path, output_path: Path) -> str:
+    try:
+        data = json.loads(metrics_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read differential pilot metrics {metrics_path}: {error}") from error
+    if not isinstance(data, dict):
+        raise HoldoutManifestError("differential pilot metrics must be a JSON object")
+    report = render_differential_metrics_report(data)
+    output_path.write_text(report, encoding="utf-8")
+    return report

--- a/scripts/differential_pilot_metrics.py
+++ b/scripts/differential_pilot_metrics.py
@@ -148,7 +148,10 @@ def build_pilot_metrics(
         "corpus": artifact["corpus"],
         "protocol": "single-expert-pilot-v1",
         "scope": "single-expert exploratory pilot",
-        "limitation": "model-assisted or single-reviewer evidence; not independent validation or a production/language-wide estimate",
+        "limitation": (
+            "model-assisted or single-reviewer evidence; not independent validation "
+            "or a production/language-wide estimate"
+        ),
         "manifest_sha256": sha256_file(manifest_path),
         "differential_artifact_sha256": sha256_file(artifact_path),
         "pilot_sha256": sha256_file(pilot_path),
@@ -190,3 +193,39 @@ def write_pilot_metrics(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return result
+
+
+def validate_pilot_metrics(
+    metrics_path: Path,
+    artifact_path: Path,
+    pilot_path: Path,
+    manifest_path: Path,
+    differential_path: Path,
+    rules_reference: Path,
+    zoo_manifest: Path,
+) -> dict[str, object]:
+    try:
+        actual = json.loads(metrics_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HoldoutManifestError(f"cannot read differential pilot metrics {metrics_path}: {error}") from error
+    if not isinstance(actual, dict):
+        raise HoldoutManifestError("differential pilot metrics must be a JSON object")
+    expected = build_pilot_metrics(
+        artifact_path,
+        pilot_path,
+        manifest_path,
+        differential_path,
+        rules_reference,
+        zoo_manifest,
+    )
+    if actual != expected:
+        raise HoldoutManifestError("differential pilot metrics artifact does not match recomputed score")
+    return {
+        "status": "valid",
+        "protocol": expected["protocol"],
+        "scope": expected["scope"],
+        "reviewer": expected["reviewer"],
+        "cases": len(expected["cases"]),
+        "counts": expected["counts"],
+        "measurements": expected["measurements"],
+    }

--- a/scripts/tests/test_differential.py
+++ b/scripts/tests/test_differential.py
@@ -100,6 +100,8 @@ baseline_ids = ["python.tests"]
         self.assertEqual(differential.main(["pilot-template", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
         self.assertEqual(differential.main(["pilot-validate", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
         self.assertEqual(differential.main(["pilot-score", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
+        self.assertEqual(differential.main(["pilot-validate-metrics", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
+        self.assertEqual(differential.main(["pilot-metrics-report", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
 
 
 class ProductionDifferentialManifestTests(unittest.TestCase):

--- a/scripts/tests/test_differential_pilot_metrics_integrity.py
+++ b/scripts/tests/test_differential_pilot_metrics_integrity.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+TESTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from differential_pilot import render_pilot_template  # noqa: E402
+from differential_pilot_metrics import (  # noqa: E402
+    build_pilot_metrics,
+    validate_pilot_metrics,
+    write_pilot_metrics,
+)
+from differential_metrics_report import render_differential_metrics_report  # noqa: E402
+from test_differential_pilot import DifferentialPilotTests  # noqa: E402
+
+
+class DifferentialPilotMetricsIntegrityTests(unittest.TestCase):
+    def _inputs(self, root: Path) -> tuple[dict[str, Path], Path]:
+        inputs = DifferentialPilotTests._write_inputs(root, include_novel=True)
+        pilot = root / "pilot.toml"
+        pilot.write_text(
+            render_pilot_template(
+                inputs["artifact"],
+                inputs["manifest"],
+                inputs["differential"],
+                inputs["rules"],
+                inputs["zoo"],
+                "expert",
+            )
+            .replace('label = ""', 'label = "no-defect"', 1)
+            .replace('rationale = ""', 'rationale = "reviewed first case"', 1)
+            .replace('label = ""', 'label = "uncertain"', 1)
+            .replace('rationale = ""', 'rationale = "insufficient context"', 1),
+            encoding="utf-8",
+        )
+        return inputs, pilot
+
+    def test_validator_recomputes_and_rejects_tampered_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs, pilot = self._inputs(Path(tmp))
+            metrics = Path(tmp) / "metrics.json"
+            write_pilot_metrics(
+                metrics,
+                inputs["artifact"],
+                pilot,
+                inputs["manifest"],
+                inputs["differential"],
+                inputs["rules"],
+                inputs["zoo"],
+            )
+            validated = validate_pilot_metrics(
+                metrics,
+                inputs["artifact"],
+                pilot,
+                inputs["manifest"],
+                inputs["differential"],
+                inputs["rules"],
+                inputs["zoo"],
+            )
+            self.assertEqual(validated["status"], "valid")
+            data = json.loads(metrics.read_text(encoding="utf-8"))
+            data["counts"]["fp"] += 1
+            metrics.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "does not match recomputed score"):
+                validate_pilot_metrics(
+                    metrics,
+                    inputs["artifact"],
+                    pilot,
+                    inputs["manifest"],
+                    inputs["differential"],
+                    inputs["rules"],
+                    inputs["zoo"],
+                )
+
+    def test_report_is_deterministic_and_keeps_unavailable_measurements_explicit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs, pilot = self._inputs(Path(tmp))
+            data = build_pilot_metrics(
+                inputs["artifact"],
+                pilot,
+                inputs["manifest"],
+                inputs["differential"],
+                inputs["rules"],
+                inputs["zoo"],
+            )
+        report = render_differential_metrics_report(data)
+        self.assertEqual(report, render_differential_metrics_report(data))
+        self.assertIn("single-expert exploratory pilot", report)
+        self.assertIn("decision latency", report.lower())
+        self.assertIn("unavailable", report.lower())
+        self.assertIn("security.secret-candidate", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -27,6 +27,11 @@ python3 scripts/differential.py pilot-validate \
 python3 scripts/differential.py pilot-score \
   --artifact differential-run.json --pilot pilot.toml \
   --output pilot-metrics.json
+python3 scripts/differential.py pilot-validate-metrics \
+  --artifact differential-run.json --pilot pilot.toml \
+  --metrics pilot-metrics.json
+python3 scripts/differential.py pilot-metrics-report \
+  --metrics pilot-metrics.json --output pilot-metrics.md
 ```
 
 It freezes the six utility measurements, the baseline set, the six-case
@@ -37,6 +42,13 @@ child-resource samples, and the base scan's exact evidence identities. Review
 evidence is marked novel only when its rule/path/line/snippet identity is absent
 from that base scan. The artifact remains unlabeled and makes no utility claim
 until the independent labeling and scoring step exists.
+
+When one reviewer is available, `pilot-template` creates an exploratory
+worksheet over the same pinned differential artifact. `pilot-score` reports
+only captured novel-evidence, timing, determinism, and resource fields;
+decision latency, time to first useful evidence, and duplicate work remain
+unavailable until the collector records the required events. Validate the
+metrics artifact before rendering or circulating its report.
 
 Validate the protocol contract without cloning repositories:
 
@@ -120,6 +132,13 @@ inputs and rejects edited or stale metrics. Its scope is explicitly
 single-expert exploratory evidence over the measured security/test subset; it
 is not independent validation, a production estimate, or evidence for the
 unmeasured contract families.
+
+The differential pilot follows the same integrity rule. Run
+`pilot-validate-metrics` before circulating `pilot-metrics.json`; it rejects
+edited counts, stale hashes, missing fields, and extra fields. The
+`pilot-metrics-report` output keeps unavailable measurements visible, so missing
+event instrumentation cannot become an invented latency or duplicate-work
+result.
 
 When only one expert is available, `pilot-template` creates a blinded
 `single-expert-pilot-v1` worksheet. Fill one label and rationale per case, then


### PR DESCRIPTION
## Problem

The differential utility pilot could produce a JSON score, but there was no integrity boundary proving that the score still matched the pinned collection, worksheet, manifests, and rule metadata. A manually edited or stale metrics file could therefore be circulated as if it were a recomputed result.

## What changed

- Added `pilot-validate-metrics`, which recomputes the complete pilot score and rejects edited, stale, missing, or extra fields.
- Added `pilot-metrics-report`, a deterministic Markdown renderer for case outcomes, evidence novelty, timing, resource summaries, and limitations.
- Kept event-dependent dimensions explicit as unavailable until the collector records the required events: time to first useful evidence, decision latency, and duplicate work.
- Added regression coverage for tampering rejection and deterministic/unavailable reporting.
- Updated the v0.23 evidence ledger, roadmap, benchmark instructions, and changelog.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 174 passed
- `python3 -m py_compile ...` — passed
- `python3 scripts/release-contract.py check` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo test --all` — passed; one explicit compatibility test ignored by contract
- `cargo run -- scan . --fail-on-priority p1` — PASS, 0 visible P1 findings
- Synthetic CLI round trip `pilot-score -> pilot-validate-metrics -> pilot-metrics-report` — passed
