### PR TITLE
feat: add differential telemetry contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added recomputing validation and a deterministic Markdown report for the
   differential utility pilot metrics. Edited or stale scores are rejected, and
   unavailable utility measurements remain explicit instead of being inferred.
+- Differential collection artifacts now carry a validated telemetry contract:
+  review phase events can measure evidence-ready and decision-ready latency,
+  while baseline evidence adapters make duplicate-work overlap measurable when
+  the baseline supplies normalized evidence identities.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -307,6 +307,12 @@ bump is needed to start.
   `validate-result` rejects manifest drift, command drift, missing repetitions,
   missing base evidence, and labeled artifacts before a result can be used
   downstream.
+- Differential artifacts emitted by the collector are schema 2. Every baseline,
+  base-scan, and review run carries monotonic start/finish telemetry. Review
+  telemetry records evidence-ready and decision-ready phase events from the
+  scanner's internal timings when those timings exist. Baseline runs expose an
+  explicit evidence-adapter status, so duplicate-work overlap is measured only
+  when a baseline provides normalized evidence identities.
 - Boundary: these are still unlabeled observations. Frozen environments,
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond
@@ -324,7 +330,7 @@ bump is needed to start.
 - Boundary: score integrity and readable reporting do not establish reviewer
   correctness, independent utility, or a product-wide comparison with existing
   checks. RP23-014 remains open until the frozen dual-review and utility labels
-  are completed.
+  are completed and the collected telemetry covers the declared dimensions.
 
 ## 0H — Ownership Assessment Semantics
 

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -426,6 +426,13 @@ report is circulated, and utility dimensions without captured events remain
 explicitly unavailable. This advances RP23-014's measurement infrastructure
 without claiming independent utility or competitor superiority.
 
+The next collection schema adds per-run telemetry. RepoPilot reviews can now
+expose evidence-ready and decision-ready phase events from the core timing
+record, while baseline overlap remains unavailable unless a baseline adapter
+supplies normalized evidence identities. This gives later utility scoring a
+typed evidence path without converting process completion into a fabricated
+human decision timestamp.
+
 Initial release discipline:
 
 - a rule cannot be described as broadly precise without labeled default evidence

--- a/scripts/differential_artifact.py
+++ b/scripts/differential_artifact.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from differential_contract import validate_differential
 from differential_manifest import DifferentialManifestError
+from differential_telemetry import validate_telemetry
 from real_history_contract import HoldoutManifestError, validate_manifest
 from real_history_runner import BASELINE_COMMANDS
 
@@ -29,7 +30,33 @@ def validate_data(
     zoo_manifest: Path,
 ) -> dict[str, object]:
     protocol = validate_differential(differential_path, manifest_path, rules_reference, zoo_manifest)
-    if data.get("schema_version") != 1:
+    schema_version = _validate_header(data, protocol, manifest_path, differential_path)
+    observations = data.get("cases")
+    if not isinstance(observations, list):
+        raise DifferentialManifestError("differential artifact cases must be an array")
+    _, _, holdout_cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
+    expected = {case.case_id: case for case in holdout_cases}
+    differential_cases = {case.case_id: case for case in _load_cases(differential_path)}
+    _validate_observations(observations, expected, differential_cases, data["repetitions"], schema_version)
+    return {
+        "status": "valid",
+        "schema_version": schema_version,
+        "corpus": protocol["corpus"],
+        "protocol": protocol["protocol"],
+        "cases": len(observations),
+        "baseline_observations": sum(
+            sum(len(runs) for runs in observation["baselines"].values())
+            for observation in observations
+        ),
+        "review_observations": sum(len(observation["reviews"]) for observation in observations),
+    }
+
+
+def _validate_header(
+    data: dict[str, Any], protocol: dict[str, Any], manifest_path: Path, differential_path: Path
+) -> int:
+    schema_version = data.get("schema_version")
+    if schema_version not in {1, 2}:
         raise DifferentialManifestError("differential artifact schema_version is unsupported")
     if data.get("corpus") != protocol["corpus"] or data.get("protocol") != protocol["protocol"]:
         raise DifferentialManifestError("differential artifact corpus/protocol does not match manifest")
@@ -47,12 +74,16 @@ def validate_data(
     for field in ("mode", "version", "report_schema_version", "workspace_version"):
         if not isinstance(scanner.get(field), str) or not scanner[field]:
             raise DifferentialManifestError(f"scanner provenance missing {field}")
-    observations = data.get("cases")
-    if not isinstance(observations, list):
-        raise DifferentialManifestError("differential artifact cases must be an array")
-    _, _, holdout_cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
-    expected = {case.case_id: case for case in holdout_cases}
-    differential_cases = {case.case_id: case for case in _load_cases(differential_path)}
+    return schema_version
+
+
+def _validate_observations(
+    observations: list[Any],
+    expected: dict[str, Any],
+    differential_cases: dict[str, Any],
+    repetitions: int,
+    schema_version: int,
+) -> None:
     observed: set[str] = set()
     for observation in observations:
         if not isinstance(observation, dict):
@@ -61,20 +92,16 @@ def validate_data(
         if not isinstance(case_id, str) or case_id in observed or case_id not in expected:
             raise DifferentialManifestError(f"differential artifact has unknown or duplicate case {case_id!r}")
         observed.add(case_id)
-        validate_case(observation, expected[case_id], differential_cases[case_id].baseline_ids, data["repetitions"])
+        validate_case(
+            observation,
+            expected[case_id],
+            differential_cases[case_id].baseline_ids,
+            repetitions,
+            schema_version,
+        )
     if observed != set(expected):
-        raise DifferentialManifestError(f"differential artifact is missing cases: {', '.join(sorted(set(expected) - observed))}")
-    return {
-        "status": "valid",
-        "corpus": protocol["corpus"],
-        "protocol": protocol["protocol"],
-        "cases": len(observations),
-        "baseline_observations": sum(
-            sum(len(runs) for runs in observation["baselines"].values())
-            for observation in observations
-        ),
-        "review_observations": sum(len(observation["reviews"]) for observation in observations),
-    }
+        missing = ", ".join(sorted(set(expected) - observed))
+        raise DifferentialManifestError(f"differential artifact is missing cases: {missing}")
 
 
 def _load_cases(path: Path) -> list[Any]:
@@ -88,6 +115,7 @@ def validate_case(
     case: Any,
     baseline_ids: tuple[str, ...],
     repetitions: int,
+    schema_version: int = 1,
 ) -> None:
     for field in ("repo", "base_sha", "head_sha", "merge_sha"):
         if observation.get(field) != getattr(case, field):
@@ -105,11 +133,14 @@ def validate_case(
                 raise DifferentialManifestError(f"case {case.case_id}: invalid baseline status")
             if not isinstance(run.get("wall_ms"), (int, float)) or run["wall_ms"] < 0:
                 raise DifferentialManifestError(f"case {case.case_id}: invalid baseline timing")
+            _validate_run_telemetry(run, run["wall_ms"], schema_version, f"case {case.case_id} baseline")
+            _validate_baseline_evidence(run, f"case {case.case_id} baseline")
     base_scan = observation.get("base_scan")
     if not isinstance(base_scan, dict) or base_scan.get("status") not in BASE_SCAN_STATUSES:
         raise DifferentialManifestError(f"case {case.case_id}: base scan observation is missing")
     if not isinstance(base_scan.get("wall_ms"), (int, float)) or base_scan["wall_ms"] < 0:
         raise DifferentialManifestError(f"case {case.case_id}: invalid base scan timing")
+    _validate_run_telemetry(base_scan, base_scan["wall_ms"], schema_version, f"case {case.case_id} base scan")
     if base_scan["status"] == "collected" and not isinstance(base_scan.get("evidence_keys"), list):
         raise DifferentialManifestError(f"case {case.case_id}: base scan evidence keys are missing")
     reviews = observation.get("reviews")
@@ -120,6 +151,7 @@ def validate_case(
             raise DifferentialManifestError(f"case {case.case_id}: invalid review status")
         if not isinstance(review.get("wall_ms"), (int, float)) or review["wall_ms"] < 0:
             raise DifferentialManifestError(f"case {case.case_id}: invalid review timing")
+        _validate_run_telemetry(review, review["wall_ms"], schema_version, f"case {case.case_id} review")
         if review["status"] == "collected" and not isinstance(review.get("stable_evidence_sha256"), str):
             raise DifferentialManifestError(f"case {case.case_id}: collected review lacks stable evidence hash")
         if review["status"] == "collected":
@@ -129,6 +161,32 @@ def validate_case(
     determinism = observation.get("determinism")
     if not isinstance(determinism, dict) or not isinstance(determinism.get("stable_evidence_deterministic"), bool):
         raise DifferentialManifestError(f"case {case.case_id}: determinism summary is missing")
+
+
+def _validate_run_telemetry(
+    run: dict[str, Any], wall_ms: float, schema_version: int, context: str
+) -> None:
+    telemetry = run.get("telemetry")
+    if telemetry is None and schema_version == 1:
+        return
+    try:
+        validate_telemetry(telemetry, wall_ms, context)
+    except ValueError as error:
+        raise DifferentialManifestError(str(error)) from error
+
+
+def _validate_baseline_evidence(run: dict[str, Any], context: str) -> None:
+    evidence = run.get("evidence")
+    if evidence is None:
+        return
+    if not isinstance(evidence, dict) or evidence.get("status") not in {"measured", "unavailable"}:
+        raise DifferentialManifestError(f"{context}: baseline evidence status is invalid")
+    if evidence["status"] == "measured":
+        keys = evidence.get("keys")
+        if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
+            raise DifferentialManifestError(f"{context}: measured baseline evidence keys are missing")
+    elif not isinstance(evidence.get("reason"), str) or not evidence["reason"]:
+        raise DifferentialManifestError(f"{context}: unavailable baseline evidence reason is missing")
 
 
 def validate_artifact(

--- a/scripts/differential_metrics_report.py
+++ b/scripts/differential_metrics_report.py
@@ -22,6 +22,15 @@ def _measurement_status(value: Any) -> str:
         return "unavailable"
     if value.get("status") == "unavailable":
         return f"unavailable: {value.get('reason', 'unspecified')}"
+    if value.get("status") == "measured":
+        details = []
+        if isinstance(value.get("median_ms"), (int, float)):
+            details.append(f"median {float(value['median_ms']):.3f} ms")
+        if isinstance(value.get("overlap_count"), int):
+            details.append(f"overlap {value['overlap_count']}")
+        if isinstance(value.get("overlap_rate"), (int, float)):
+            details.append(f"rate {float(value['overlap_rate']):.3f}")
+        return "measured" + (f" ({', '.join(details)})" if details else "")
     return str(value.get("status", "unknown"))
 
 

--- a/scripts/differential_pilot_metrics.py
+++ b/scripts/differential_pilot_metrics.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from differential_novelty import evidence_rule_ids
 from differential_pilot import load_pilot
+from differential_telemetry import event_elapsed_ms
 from real_history_contract import HoldoutManifestError
 
 
@@ -68,10 +69,62 @@ def _case_measurements(observation: dict[str, Any]) -> dict[str, object]:
         for run in reviews
         if isinstance(run.get("child_max_rss_kb"), (int, float))
     ]
+    first_evidence_values = []
+    decision_values = []
+    for review in reviews:
+        telemetry = review.get("telemetry")
+        evidence_ms = event_elapsed_ms(telemetry, "evidence_ready") if isinstance(telemetry, dict) else None
+        decision_ms = event_elapsed_ms(telemetry, "decision_ready") if isinstance(telemetry, dict) else None
+        if evidence_ms is not None:
+            first_evidence_values.append(evidence_ms)
+        if decision_ms is not None:
+            decision_values.append(decision_ms)
+    duplicate = _duplicate_work_measurement(observation)
     return {
         "median_baseline_wall_ms": _median(baseline_values),
         "median_review_wall_ms": _median(review_values),
         "median_review_child_max_rss_kb": _median(rss_values),
+        "time_to_first_useful_evidence": _timing_measurement(
+            first_evidence_values, "no useful-evidence event was recorded"
+        ),
+        "decision_latency": _timing_measurement(decision_values, "no decision event was recorded"),
+        "duplicate_work": duplicate,
+    }
+
+
+def _timing_measurement(values: list[float], reason: str) -> dict[str, object]:
+    if not values:
+        return {"status": "unavailable", "reason": reason}
+    return {"status": "measured", "median_ms": _median(values), "samples": len(values)}
+
+
+def _duplicate_work_measurement(observation: dict[str, Any]) -> dict[str, object]:
+    baseline_keys: set[str] = set()
+    for runs in observation["baselines"].values():
+        for run in runs:
+            evidence = run.get("evidence")
+            if not isinstance(evidence, dict) or evidence.get("status") != "measured":
+                return {
+                    "status": "unavailable",
+                    "reason": "baseline command has no normalized evidence adapter",
+                }
+            keys = evidence.get("keys")
+            if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
+                return {"status": "unavailable", "reason": "baseline evidence keys are invalid"}
+            baseline_keys.update(keys)
+    review_keys = {
+        key
+        for review in observation["reviews"]
+        for key in review.get("in_diff_evidence_keys", [])
+        if isinstance(key, str)
+    }
+    overlap_count = len(baseline_keys & review_keys)
+    return {
+        "status": "measured",
+        "overlap_count": overlap_count,
+        "baseline_evidence_count": len(baseline_keys),
+        "review_evidence_count": len(review_keys),
+        "overlap_rate": round(overlap_count / len(review_keys), 3) if review_keys else None,
     }
 
 
@@ -88,58 +141,9 @@ def build_pilot_metrics(
     )
     artifact = _load_json(artifact_path)
     observations = {case["id"]: case for case in artifact["cases"]}
-    counts = {key: 0 for key in ("tp", "fn", "tn", "fp", "excluded")}
-    cases: list[dict[str, object]] = []
-    deterministic_cases = 0
-    novel_evidence_cases = 0
-    baseline_times: list[float] = []
-    review_times: list[float] = []
-    rss_times: list[float] = []
-    for case_id, label in pilot_cases.items():
-        observation = observations.get(case_id)
-        if observation is None:
-            raise HoldoutManifestError(f"differential artifact is missing case {case_id}")
-        novel_keys = sorted(
-            {
-                key
-                for review in observation["reviews"]
-                if isinstance(review, dict)
-                for key in review.get("novel_in_diff_evidence_keys", [])
-            }
-        )
-        observed_rules = sorted(evidence_rule_ids(novel_keys))
-        if novel_keys:
-            novel_evidence_cases += 1
-        expected_rules = sorted(set(label["expected_rule_ids"]))
-        if label["label"] == "defect-present":
-            outcome = "tp" if set(expected_rules) & set(observed_rules) else "fn"
-        elif label["label"] == "no-defect":
-            outcome = "fp" if observed_rules else "tn"
-        else:
-            outcome = "excluded"
-        counts[outcome] += 1
-        if observation["determinism"].get("stable_evidence_deterministic") is True:
-            deterministic_cases += 1
-        case_measurements = _case_measurements(observation)
-        for values, key in (
-            (baseline_times, "median_baseline_wall_ms"),
-            (review_times, "median_review_wall_ms"),
-            (rss_times, "median_review_child_max_rss_kb"),
-        ):
-            value = case_measurements[key]
-            if isinstance(value, (int, float)):
-                values.append(float(value))
-        cases.append(
-            {
-                "id": case_id,
-                "label": label["label"],
-                "expected_rule_ids": expected_rules,
-                "observed_novel_rule_ids": observed_rules,
-                "novel_evidence_count": len(novel_keys),
-                "outcome": outcome,
-                "measurements": case_measurements,
-            }
-        )
+    scores = _collect_pilot_scores(pilot_cases, observations)
+    counts = scores["counts"]
+    cases = scores["cases"]
     actual_positives = counts["tp"] + counts["fn"]
     actual_negatives = counts["tn"] + counts["fp"]
     predicted_positives = counts["tp"] + counts["fp"]
@@ -164,17 +168,146 @@ def build_pilot_metrics(
             "precision": _metric(counts["tp"], predicted_positives),
             "case_coverage": _metric(actual_positives + actual_negatives, len(cases)),
         },
-        "measurements": {
-            "deterministic_cases": deterministic_cases,
-            "novel_evidence_cases": novel_evidence_cases,
-            "case_count": len(cases),
-            "median_baseline_wall_ms": _median(baseline_times),
-            "median_review_wall_ms": _median(review_times),
-            "median_review_child_max_rss_kb": _median(rss_times),
-            "time_to_first_useful_evidence": {"status": "unavailable", "reason": "event timestamps are not captured"},
-            "decision_latency": {"status": "unavailable", "reason": "decision events are not captured"},
-            "duplicate_work": {"status": "unavailable", "reason": "baseline overlap classification is not captured"},
+        "measurements": scores["measurements"],
+    }
+
+
+def _collect_pilot_scores(
+    pilot_cases: dict[str, dict[str, Any]], observations: dict[str, dict[str, Any]]
+) -> dict[str, object]:
+    counts = {key: 0 for key in ("tp", "fn", "tn", "fp", "excluded")}
+    cases: list[dict[str, object]] = []
+    deterministic_cases = 0
+    novel_evidence_cases = 0
+    baseline_times: list[float] = []
+    review_times: list[float] = []
+    rss_times: list[float] = []
+    first_evidence_times: list[float] = []
+    decision_latencies: list[float] = []
+    duplicate_measurements: list[dict[str, object]] = []
+    for case_id, label in pilot_cases.items():
+        observation = observations.get(case_id)
+        if observation is None:
+            raise HoldoutManifestError(f"differential artifact is missing case {case_id}")
+        scored = _score_pilot_case(case_id, label, observation)
+        counts[scored["outcome"]] += 1
+        if scored["novel"]:
+            novel_evidence_cases += 1
+        if scored["deterministic"]:
+            deterministic_cases += 1
+        case_measurements = scored["measurements"]
+        for values, key in (
+            (first_evidence_times, "time_to_first_useful_evidence"),
+            (decision_latencies, "decision_latency"),
+        ):
+            measurement = case_measurements[key]
+            if measurement.get("status") == "measured" and isinstance(measurement.get("median_ms"), (int, float)):
+                values.append(float(measurement["median_ms"]))
+        duplicate_measurements.append(case_measurements["duplicate_work"])
+        for values, key in (
+            (baseline_times, "median_baseline_wall_ms"),
+            (review_times, "median_review_wall_ms"),
+            (rss_times, "median_review_child_max_rss_kb"),
+        ):
+            value = case_measurements[key]
+            if isinstance(value, (int, float)):
+                values.append(float(value))
+        cases.append(scored["case"])
+    return {
+        "counts": counts,
+        "cases": cases,
+        "measurements": _build_measurement_summary(
+            cases,
+            deterministic_cases,
+            novel_evidence_cases,
+            baseline_times,
+            review_times,
+            rss_times,
+            first_evidence_times,
+            decision_latencies,
+            duplicate_measurements,
+        ),
+    }
+
+
+def _build_measurement_summary(
+    cases: list[dict[str, object]],
+    deterministic_cases: int,
+    novel_evidence_cases: int,
+    baseline_times: list[float],
+    review_times: list[float],
+    rss_times: list[float],
+    first_evidence_times: list[float],
+    decision_latencies: list[float],
+    duplicate_measurements: list[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        "deterministic_cases": deterministic_cases,
+        "novel_evidence_cases": novel_evidence_cases,
+        "case_count": len(cases),
+        "median_baseline_wall_ms": _median(baseline_times),
+        "median_review_wall_ms": _median(review_times),
+        "median_review_child_max_rss_kb": _median(rss_times),
+        "time_to_first_useful_evidence": _timing_measurement(
+            first_evidence_times, "no useful-evidence events were recorded"
+        ),
+        "decision_latency": _timing_measurement(
+            decision_latencies, "no decision events were recorded"
+        ),
+        "duplicate_work": _aggregate_duplicate_work(duplicate_measurements),
+    }
+
+
+def _score_pilot_case(
+    case_id: str, label: dict[str, Any], observation: dict[str, Any]
+) -> dict[str, object]:
+    novel_keys = sorted(
+        {
+            key
+            for review in observation["reviews"]
+            if isinstance(review, dict)
+            for key in review.get("novel_in_diff_evidence_keys", [])
+        }
+    )
+    observed_rules = sorted(evidence_rule_ids(novel_keys))
+    expected_rules = sorted(set(label["expected_rule_ids"]))
+    if label["label"] == "defect-present":
+        outcome = "tp" if set(expected_rules) & set(observed_rules) else "fn"
+    elif label["label"] == "no-defect":
+        outcome = "fp" if observed_rules else "tn"
+    else:
+        outcome = "excluded"
+    measurements = _case_measurements(observation)
+    return {
+        "outcome": outcome,
+        "novel": bool(novel_keys),
+        "deterministic": observation["determinism"].get("stable_evidence_deterministic") is True,
+        "measurements": measurements,
+        "case": {
+            "id": case_id,
+            "label": label["label"],
+            "expected_rule_ids": expected_rules,
+            "observed_novel_rule_ids": observed_rules,
+            "novel_evidence_count": len(novel_keys),
+            "outcome": outcome,
+            "measurements": measurements,
         },
+    }
+
+
+def _aggregate_duplicate_work(measurements: list[dict[str, object]]) -> dict[str, object]:
+    if not measurements or any(measurement.get("status") != "measured" for measurement in measurements):
+        return {"status": "unavailable", "reason": "baseline overlap classification is not captured"}
+    overlap_count = sum(int(measurement.get("overlap_count", 0)) for measurement in measurements)
+    baseline_count = sum(int(measurement.get("baseline_evidence_count", 0)) for measurement in measurements)
+    review_count = sum(int(measurement.get("review_evidence_count", 0)) for measurement in measurements)
+    return {
+        "status": "measured",
+        "overlap_count": overlap_count,
+        "baseline_evidence_count": baseline_count,
+        "review_evidence_count": review_count,
+        "overlap_rate": round(overlap_count / review_count, 3) if review_count else None,
+        "cases": len(measurements),
     }
 
 

--- a/scripts/differential_runner.py
+++ b/scripts/differential_runner.py
@@ -14,6 +14,7 @@ from typing import Any
 from differential_contract import validate_differential
 from differential_manifest import load_differential
 from differential_novelty import evidence_keys, novel_evidence_keys
+from differential_telemetry import build_command_telemetry, build_review_telemetry
 from real_history_contract import HoldoutCase, HoldoutManifestError, validate_manifest
 from real_history_runner import BASELINE_COMMANDS, clone_case, summarize_review
 from zoo_scanner import ScannerPreparationError, ScannerProvenanceError, prepare_scanner
@@ -24,7 +25,7 @@ except ImportError:  # pragma: no cover - Windows has no resource module.
     resource = None
 
 
-DIFFERENTIAL_ARTIFACT_SCHEMA_VERSION = 1
+DIFFERENTIAL_ARTIFACT_SCHEMA_VERSION = 2
 
 
 def sha256_bytes(value: bytes) -> str:
@@ -70,6 +71,11 @@ def run_timed_command(command: tuple[str, ...], cwd: Path, timeout_seconds: int)
         "stderr_sha256": sha256_bytes(stderr if isinstance(stderr, bytes) else stderr.encode()),
         "resource_status": resource_status,
     }
+    result["telemetry"] = build_command_telemetry(result["wall_ms"])
+    result["evidence"] = {
+        "status": "unavailable",
+        "reason": "baseline command has no normalized evidence adapter",
+    }
     if resource_before is not None and resource_after is not None:
         result["child_max_rss_kb"] = max(0, resource_after - resource_before)
     return result
@@ -81,7 +87,13 @@ def _scan_base(scanner: Any, case: HoldoutCase, base: Path, timeout_seconds: int
     try:
         process = subprocess.run(list(command), cwd=base, capture_output=True, check=False, timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return {"status": "timeout", "returncode": None, "wall_ms": round((time.perf_counter() - started) * 1000, 3)}
+        wall_ms = round((time.perf_counter() - started) * 1000, 3)
+        return {
+            "status": "timeout",
+            "returncode": None,
+            "wall_ms": wall_ms,
+            "telemetry": build_command_telemetry(wall_ms),
+        }
     if process.returncode not in (0, 1):
         raise HoldoutManifestError(
             f"differential base scan failed for {case.case_id}: {process.stderr.decode(errors='replace').strip()}"
@@ -93,12 +105,14 @@ def _scan_base(scanner: Any, case: HoldoutCase, base: Path, timeout_seconds: int
     findings = report.get("findings")
     if not isinstance(findings, list):
         raise HoldoutManifestError(f"differential base scan has no findings array for {case.case_id}")
+    wall_ms = round((time.perf_counter() - started) * 1000, 3)
     return {
         "status": "collected",
         "returncode": process.returncode,
-        "wall_ms": round((time.perf_counter() - started) * 1000, 3),
+        "wall_ms": wall_ms,
         "command": list(command),
         "evidence_keys": sorted(evidence_keys(findings)),
+        "telemetry": build_command_telemetry(wall_ms),
     }
 
 
@@ -128,10 +142,12 @@ def _review_once(
     try:
         process = subprocess.run(list(command), cwd=head, capture_output=True, check=False, timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
+        wall_ms = round((time.perf_counter() - started) * 1000, 3)
         return {
             "status": "timeout",
             "returncode": None,
-            "wall_ms": round((time.perf_counter() - started) * 1000, 3),
+            "wall_ms": wall_ms,
+            "telemetry": build_command_telemetry(wall_ms),
             "in_diff_evidence_keys": [],
             "novel_in_diff_evidence_keys": [],
         }
@@ -143,20 +159,39 @@ def _review_once(
         report = json.loads(process.stdout)
     except json.JSONDecodeError as error:
         raise HoldoutManifestError(f"differential review returned invalid JSON for {case.case_id}: {error}") from error
-    in_diff_findings = [finding for finding in report["findings"] if isinstance(finding, dict) and finding.get("in_diff") is True]
-    in_diff_keys = sorted(evidence_keys(in_diff_findings))
-    result = {
-        **summarize_review(report, process.stdout),
-        "status": "collected",
-        "returncode": process.returncode,
-        "wall_ms": round((time.perf_counter() - started) * 1000, 3),
-        "resource_status": resource_status,
-        "in_diff_evidence_keys": in_diff_keys,
-        "novel_in_diff_evidence_keys": novel_evidence_keys(in_diff_findings, base_evidence),
-    }
+    result = _build_review_result(
+        report, process.stdout, process.returncode, base_evidence, resource_status, started
+    )
     _, resource_after = _resource_snapshot()
     if resource_before is not None and resource_after is not None:
         result["child_max_rss_kb"] = max(0, resource_after - resource_before)
+    return result
+
+
+def _build_review_result(
+    report: dict[str, Any],
+    raw_output: bytes,
+    returncode: int,
+    base_evidence: set[str],
+    resource_status: str,
+    started: float,
+) -> dict[str, Any]:
+    in_diff_findings = [
+        finding for finding in report["findings"] if isinstance(finding, dict) and finding.get("in_diff") is True
+    ]
+    in_diff_keys = sorted(evidence_keys(in_diff_findings))
+    wall_ms = round((time.perf_counter() - started) * 1000, 3)
+    novel_keys = novel_evidence_keys(in_diff_findings, base_evidence)
+    result = {
+        **summarize_review(report, raw_output),
+        "status": "collected",
+        "returncode": returncode,
+        "wall_ms": wall_ms,
+        "resource_status": resource_status,
+        "in_diff_evidence_keys": in_diff_keys,
+        "novel_in_diff_evidence_keys": novel_keys,
+    }
+    result["telemetry"] = build_review_telemetry(report, wall_ms, bool(novel_keys))
     return result
 
 

--- a/scripts/differential_telemetry.py
+++ b/scripts/differential_telemetry.py
@@ -1,0 +1,109 @@
+"""Telemetry primitives for differential utility observations."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+TELEMETRY_SCHEMA_VERSION = 1
+_EVENT_NAMES = {"process_started", "evidence_ready", "decision_ready", "process_finished"}
+
+
+def _elapsed_ms(values: Any, keys: tuple[str, ...]) -> float | None:
+    if not isinstance(values, dict):
+        return None
+    micros = [values.get(key, 0) for key in keys]
+    if not all(isinstance(value, (int, float)) and value >= 0 for value in micros):
+        return None
+    return round(sum(float(value) for value in micros) / 1000, 3)
+
+
+def _event(name: str, elapsed_ms: float) -> dict[str, object]:
+    return {"name": name, "elapsed_ms": round(max(0.0, elapsed_ms), 3)}
+
+
+def build_command_telemetry(wall_ms: float) -> dict[str, object]:
+    bounded_wall_ms = round(max(0.0, float(wall_ms)), 3)
+    return {
+        "schema_version": TELEMETRY_SCHEMA_VERSION,
+        "events": [_event("process_started", 0.0), _event("process_finished", bounded_wall_ms)],
+    }
+
+
+def build_review_telemetry(
+    report: dict[str, Any], wall_ms: float, useful_evidence: bool
+) -> dict[str, object]:
+    bounded_wall_ms = round(max(0.0, float(wall_ms)), 3)
+    scan_ms = _elapsed_ms(
+        report.get("scan_timings"),
+        (
+            "discovery_us",
+            "file_analysis_us",
+            "parse_us",
+            "file_scan_us",
+            "framework_detection_us",
+            "post_scan_audits_us",
+            "enrichment_us",
+            "risk_scoring_us",
+            "contract_validation_us",
+            "report_finalization_us",
+        ),
+    )
+    review = report.get("review_timings")
+    evidence_ms = None
+    decision_ms = None
+    if scan_ms is not None:
+        diff_ms = _elapsed_ms(review, ("diff_loading_us",))
+        signal_ms = _elapsed_ms(review, ("review_signals_us",))
+        gating_ms = _elapsed_ms(review, ("gating_us",))
+        verification_ms = _elapsed_ms(review, ("verification_us",))
+        if diff_ms is not None and signal_ms is not None:
+            evidence_ms = scan_ms + diff_ms + signal_ms
+            if gating_ms is not None and verification_ms is not None:
+                decision_ms = evidence_ms + gating_ms + verification_ms
+    events = [_event("process_started", 0.0)]
+    if useful_evidence and evidence_ms is not None:
+        events.append(_event("evidence_ready", min(evidence_ms, bounded_wall_ms)))
+    if decision_ms is not None:
+        events.append(_event("decision_ready", min(decision_ms, bounded_wall_ms)))
+    events.append(_event("process_finished", bounded_wall_ms))
+    return {"schema_version": TELEMETRY_SCHEMA_VERSION, "events": events}
+
+
+def event_elapsed_ms(telemetry: dict[str, Any], name: str) -> float | None:
+    for event in telemetry.get("events", []):
+        if isinstance(event, dict) and event.get("name") == name:
+            value = event.get("elapsed_ms")
+            if isinstance(value, (int, float)):
+                return float(value)
+    return None
+
+
+def validate_telemetry(telemetry: Any, wall_ms: float, context: str) -> None:
+    if not isinstance(telemetry, dict) or telemetry.get("schema_version") != TELEMETRY_SCHEMA_VERSION:
+        raise ValueError(f"{context} telemetry schema_version is unsupported")
+    events = telemetry.get("events")
+    if not isinstance(events, list) or not events:
+        raise ValueError(f"{context} telemetry events are missing")
+    names: list[str] = []
+    elapsed: list[float] = []
+    for event in events:
+        if not isinstance(event, dict) or not isinstance(event.get("name"), str):
+            raise ValueError(f"{context} telemetry event is invalid")
+        name = event["name"]
+        value = event.get("elapsed_ms")
+        if name not in _EVENT_NAMES or name in names:
+            raise ValueError(f"{context} telemetry event name is invalid or duplicated")
+        if not isinstance(value, (int, float)) or not math.isfinite(float(value)) or value < 0:
+            raise ValueError(f"{context} telemetry elapsed_ms is invalid")
+        names.append(name)
+        elapsed.append(float(value))
+    if names[0] != "process_started" or elapsed[0] != 0:
+        raise ValueError(f"{context} telemetry must start at process_started")
+    if names[-1] != "process_finished" or abs(elapsed[-1] - float(wall_ms)) > 0.001:
+        raise ValueError(f"{context} telemetry must finish at wall_ms")
+    if any(after < before for before, after in zip(elapsed, elapsed[1:])):
+        raise ValueError(f"{context} telemetry events must be monotonic")
+    if "evidence_ready" in names and "decision_ready" in names:
+        if elapsed[names.index("evidence_ready")] > elapsed[names.index("decision_ready")]:
+            raise ValueError(f"{context} telemetry evidence must precede decision")

--- a/scripts/tests/test_differential_pilot.py
+++ b/scripts/tests/test_differential_pilot.py
@@ -14,6 +14,7 @@ if str(SCRIPTS_DIR) not in sys.path:
 from differential_artifact import validate_artifact  # noqa: E402
 from differential_pilot import load_pilot, render_pilot_template, validate_pilot  # noqa: E402
 from differential_pilot_metrics import build_pilot_metrics  # noqa: E402
+from differential_telemetry import build_command_telemetry  # noqa: E402
 from real_history_runner import BASELINE_COMMANDS  # noqa: E402
 
 
@@ -71,6 +72,49 @@ class DifferentialPilotTests(unittest.TestCase):
         self.assertEqual(output["counts"], {"tp": 0, "fn": 0, "tn": 0, "fp": 1, "excluded": 1})
         self.assertIsNone(output["metrics"]["recall"]["value"])
         self.assertEqual(output["measurements"]["deterministic_cases"], 2)
+
+    def test_metrics_use_recorded_telemetry_and_baseline_overlap(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            inputs = self._write_inputs(root, include_novel=True)
+            data = json.loads(inputs["artifact"].read_text(encoding="utf-8"))
+            for case in data["cases"]:
+                for runs in case["baselines"].values():
+                    for run in runs:
+                        run["telemetry"] = build_command_telemetry(run["wall_ms"])
+                        run["evidence"] = {
+                            "status": "measured",
+                            "keys": ["security.secret-candidate"],
+                        }
+                for review in case["reviews"]:
+                    review["telemetry"] = {
+                        "schema_version": 1,
+                        "events": [
+                            {"name": "process_started", "elapsed_ms": 0.0},
+                            {"name": "evidence_ready", "elapsed_ms": 5.0},
+                            {"name": "decision_ready", "elapsed_ms": 10.0},
+                            {"name": "process_finished", "elapsed_ms": review["wall_ms"]},
+                        ],
+                    }
+            inputs["artifact"].write_text(json.dumps(data), encoding="utf-8")
+            pilot = root / "pilot.toml"
+            pilot.write_text(
+                render_pilot_template(
+                    inputs["artifact"], inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"], "expert"
+                )
+                .replace('label = ""', 'label = "no-defect"', 1)
+                .replace('rationale = ""', 'rationale = "reviewed first case"', 1)
+                .replace('label = ""', 'label = "uncertain"', 1)
+                .replace('rationale = ""', 'rationale = "insufficient context"', 1),
+                encoding="utf-8",
+            )
+            output = build_pilot_metrics(
+                inputs["artifact"], pilot, inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"]
+            )
+        self.assertEqual(output["measurements"]["time_to_first_useful_evidence"]["status"], "measured")
+        self.assertEqual(output["measurements"]["time_to_first_useful_evidence"]["median_ms"], 5.0)
+        self.assertEqual(output["measurements"]["decision_latency"]["median_ms"], 10.0)
+        self.assertEqual(output["measurements"]["duplicate_work"]["overlap_count"], 1)
 
     @staticmethod
     def _write_inputs(root: Path, include_novel: bool = False) -> dict[str, Path]:

--- a/scripts/tests/test_differential_runner.py
+++ b/scripts/tests/test_differential_runner.py
@@ -12,6 +12,7 @@ if str(SCRIPTS_DIR) not in sys.path:
 
 from differential_artifact import validate_data  # noqa: E402
 from differential_runner import run_timed_command  # noqa: E402
+from differential_telemetry import build_command_telemetry  # noqa: E402
 from real_history_runner import BASELINE_COMMANDS  # noqa: E402
 
 
@@ -23,6 +24,8 @@ class DifferentialRunnerTests(unittest.TestCase):
         self.assertEqual(result["returncode"], 0)
         self.assertGreaterEqual(result["wall_ms"], 0)
         self.assertEqual(len(result["stdout_sha256"]), 64)
+        self.assertEqual(result["telemetry"]["events"][0]["name"], "process_started")
+        self.assertEqual(result["telemetry"]["events"][-1]["name"], "process_finished")
 
     def test_timed_command_records_failure(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -95,6 +98,35 @@ class DifferentialRunnerTests(unittest.TestCase):
             artifact["cases"][0].pop("base_scan")
             with self.assertRaisesRegex(ValueError, "base scan"):
                 validate_data(artifact, holdout, differential, rules, zoo)
+
+    def test_artifact_schema_two_requires_telemetry_for_every_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            holdout, differential, rules, zoo = self._write_manifests(root)
+            artifact = self._valid_artifact(holdout, differential)
+            artifact["schema_version"] = 2
+            with self.assertRaisesRegex(ValueError, "telemetry"):
+                validate_data(artifact, holdout, differential, rules, zoo)
+
+    def test_artifact_schema_two_accepts_valid_telemetry_and_baseline_evidence_status(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            holdout, differential, rules, zoo = self._write_manifests(root)
+            artifact = self._valid_artifact(holdout, differential)
+            artifact["schema_version"] = 2
+            for case in artifact["cases"]:
+                case["base_scan"]["telemetry"] = build_command_telemetry(1.0)
+                for runs in case["baselines"].values():
+                    for run in runs:
+                        run["telemetry"] = build_command_telemetry(1.0)
+                        run["evidence"] = {
+                            "status": "unavailable",
+                            "reason": "fixture has no baseline adapter",
+                        }
+                for review in case["reviews"]:
+                    review["telemetry"] = build_command_telemetry(1.0)
+            result = validate_data(artifact, holdout, differential, rules, zoo)
+        self.assertEqual(result["status"], "valid")
 
     @staticmethod
     def _valid_artifact(holdout: Path, differential: Path) -> dict[str, object]:

--- a/scripts/tests/test_differential_telemetry.py
+++ b/scripts/tests/test_differential_telemetry.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from differential_telemetry import (  # noqa: E402
+    build_command_telemetry,
+    build_review_telemetry,
+    validate_telemetry,
+)
+
+
+class DifferentialTelemetryTests(unittest.TestCase):
+    def test_review_telemetry_records_evidence_and_decision_events(self) -> None:
+        report = {
+            "scan_timings": {"file_analysis_us": 2500, "report_finalization_us": 500},
+            "review_timings": {
+                "diff_loading_us": 1000,
+                "review_signals_us": 2000,
+                "gating_us": 1000,
+                "verification_us": 500,
+            },
+        }
+        telemetry = build_review_telemetry(report, 12.0, useful_evidence=True)
+        self.assertEqual(
+            [event["name"] for event in telemetry["events"]],
+            ["process_started", "evidence_ready", "decision_ready", "process_finished"],
+        )
+        self.assertEqual(telemetry["events"][1]["elapsed_ms"], 6.0)
+        self.assertEqual(telemetry["events"][2]["elapsed_ms"], 7.5)
+        validate_telemetry(telemetry, 12.0, "review")
+
+    def test_command_telemetry_has_bounded_start_and_finish_events(self) -> None:
+        telemetry = build_command_telemetry(4.25)
+        self.assertEqual(telemetry["events"], [
+            {"name": "process_started", "elapsed_ms": 0.0},
+            {"name": "process_finished", "elapsed_ms": 4.25},
+        ])
+        validate_telemetry(telemetry, 4.25, "baseline")
+
+    def test_review_without_novel_evidence_does_not_invent_evidence_event(self) -> None:
+        report = {
+            "scan_timings": {"file_analysis_us": 1000},
+            "review_timings": {"diff_loading_us": 1000, "review_signals_us": 1000},
+        }
+        telemetry = build_review_telemetry(report, 8.0, useful_evidence=False)
+        self.assertNotIn("evidence_ready", [event["name"] for event in telemetry["events"]])
+        self.assertIn("decision_ready", [event["name"] for event in telemetry["events"]])
+        validate_telemetry(telemetry, 8.0, "review")
+
+    def test_validator_rejects_non_monotonic_events(self) -> None:
+        telemetry = build_command_telemetry(4.25)
+        telemetry["events"].insert(1, {"name": "decision_ready", "elapsed_ms": 5.0})
+        with self.assertRaisesRegex(ValueError, "monotonic"):
+            validate_telemetry(telemetry, 4.25, "review")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -43,6 +43,13 @@ evidence is marked novel only when its rule/path/line/snippet identity is absent
 from that base scan. The artifact remains unlabeled and makes no utility claim
 until the independent labeling and scoring step exists.
 
+The differential collection artifact is schema 2. Each baseline, base scan, and
+review run has validated monotonic start/finish telemetry. Review runs may also
+record evidence-ready and decision-ready phase events from RepoPilot's internal
+timings. Duplicate-work overlap stays unavailable until a baseline adapter
+provides normalized evidence identities; command success or output hashes alone
+are not treated as evidence overlap.
+
 When one reviewer is available, `pilot-template` creates an exploratory
 worksheet over the same pinned differential artifact. `pilot-score` reports
 only captured novel-evidence, timing, determinism, and resource fields;


### PR DESCRIPTION
## Problem

The differential utility pilot already protected score integrity, but its collection artifact did not carry typed event telemetry. Time to first useful evidence, decision latency, and duplicate work therefore remained either unavailable or vulnerable to being inferred from process completion and output hashes.

## What changed

- Added differential artifact schema 2 with validated per-run telemetry for every baseline, base scan, and review.
- Added monotonic `process_started`/`process_finished` events and review `evidence_ready`/`decision_ready` events derived from RepoPilot core timing stages.
- Added baseline evidence-adapter status. Duplicate-work overlap is measured only when a baseline supplies normalized evidence identities; command success and output hashes are not treated as evidence overlap.
- Added metric aggregation for recorded evidence-ready latency, decision latency, and baseline/review evidence overlap.
- Preserved explicit unavailable states when telemetry or normalized baseline evidence is absent.
- Split validation/scoring helpers so the telemetry path stays reviewable and keeps source functions bounded.
- Added focused telemetry, schema migration, metric, and no-fabrication regression tests.
- Updated the v0.23 evidence ledger, roadmap, benchmark instructions, and changelog.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 182 passed
- `python3 -m py_compile ...` — passed
- `python3 scripts/release-contract.py check` — passed
- `git diff --check` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo test --all` — passed; one explicit compatibility test ignored by contract
- `cargo run -- scan . --fail-on-priority p1` — PASS, 0 visible P1 findings
- `cargo run -- review .` — no visible findings; 8 maybe-sensitive signals remain visible for review

