### PR TITLE
feat: normalize differential baseline evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   review phase events can measure evidence-ready and decision-ready latency,
   while baseline evidence adapters make duplicate-work overlap measurable when
   the baseline supplies normalized evidence identities.
+- Added deterministic baseline evidence adapters for `python.compile` and
+  `python.tests`. Recognized diagnostics are reduced to path/line/error-kind or
+  pytest-node identities, clean runs are measured with empty evidence, and
+  unsupported failures remain explicitly unavailable rather than being guessed.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -310,9 +310,11 @@ bump is needed to start.
 - Differential artifacts emitted by the collector are schema 2. Every baseline,
   base-scan, and review run carries monotonic start/finish telemetry. Review
   telemetry records evidence-ready and decision-ready phase events from the
-  scanner's internal timings when those timings exist. Baseline runs expose an
-  explicit evidence-adapter status, so duplicate-work overlap is measured only
-  when a baseline provides normalized evidence identities.
+  scanner's internal timings when those timings exist. Deterministic adapters
+  cover `python.compile` and `python.tests`; recognized diagnostics receive
+  normalized identities, clean runs are measured with an empty set, and
+  unsupported failures remain unavailable. Duplicate-work overlap therefore
+  never treats command success or output hashes as evidence.
 - Boundary: these are still unlabeled observations. Frozen environments,
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -426,12 +426,13 @@ report is circulated, and utility dimensions without captured events remain
 explicitly unavailable. This advances RP23-014's measurement infrastructure
 without claiming independent utility or competitor superiority.
 
-The next collection schema adds per-run telemetry. RepoPilot reviews can now
-expose evidence-ready and decision-ready phase events from the core timing
-record, while baseline overlap remains unavailable unless a baseline adapter
-supplies normalized evidence identities. This gives later utility scoring a
-typed evidence path without converting process completion into a fabricated
-human decision timestamp.
+The next collection schema adds per-run telemetry and typed baseline evidence.
+RepoPilot reviews can now expose evidence-ready and decision-ready phase events
+from the core timing record. The first deterministic adapters cover
+`python.compile` and `python.tests`, recording normalized diagnostic identities,
+measuring clean runs as empty sets, and leaving unsupported failures unavailable.
+This gives later utility scoring an auditable evidence path without converting
+process completion into a fabricated human decision timestamp.
 
 Initial release discipline:
 

--- a/scripts/differential_artifact.py
+++ b/scripts/differential_artifact.py
@@ -134,7 +134,7 @@ def validate_case(
             if not isinstance(run.get("wall_ms"), (int, float)) or run["wall_ms"] < 0:
                 raise DifferentialManifestError(f"case {case.case_id}: invalid baseline timing")
             _validate_run_telemetry(run, run["wall_ms"], schema_version, f"case {case.case_id} baseline")
-            _validate_baseline_evidence(run, f"case {case.case_id} baseline")
+            _validate_baseline_evidence(run, f"case {case.case_id} baseline", schema_version, baseline_id)
     base_scan = observation.get("base_scan")
     if not isinstance(base_scan, dict) or base_scan.get("status") not in BASE_SCAN_STATUSES:
         raise DifferentialManifestError(f"case {case.case_id}: base scan observation is missing")
@@ -175,7 +175,9 @@ def _validate_run_telemetry(
         raise DifferentialManifestError(str(error)) from error
 
 
-def _validate_baseline_evidence(run: dict[str, Any], context: str) -> None:
+def _validate_baseline_evidence(
+    run: dict[str, Any], context: str, schema_version: int = 1, baseline_id: str | None = None
+) -> None:
     evidence = run.get("evidence")
     if evidence is None:
         return
@@ -185,6 +187,13 @@ def _validate_baseline_evidence(run: dict[str, Any], context: str) -> None:
         keys = evidence.get("keys")
         if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
             raise DifferentialManifestError(f"{context}: measured baseline evidence keys are missing")
+        if schema_version >= 2:
+            source = evidence.get("source")
+            if not isinstance(source, str) or not source:
+                raise DifferentialManifestError(f"{context}: measured baseline evidence source is missing")
+            expected_source = f"{baseline_id}-v1" if baseline_id else None
+            if expected_source and source != expected_source:
+                raise DifferentialManifestError(f"{context}: measured baseline evidence source drift")
     elif not isinstance(evidence.get("reason"), str) or not evidence["reason"]:
         raise DifferentialManifestError(f"{context}: unavailable baseline evidence reason is missing")
 

--- a/scripts/differential_evidence.py
+++ b/scripts/differential_evidence.py
@@ -1,0 +1,109 @@
+"""Normalize allowlisted baseline diagnostics into deterministic evidence IDs."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+
+_COMPILE_FILE = re.compile(r"\*\*\* Error compiling ['\"](?P<path>.+?)['\"]")
+_PYTHON_FILE = re.compile(r'^\s*File ["\'](?P<path>.+?)["\'], line (?P<line>\d+)')
+_PYTHON_ERROR = re.compile(r"^\s*(?P<kind>[A-Za-z_]\w*(?:Error|Warning)):")
+_PYTEST_FAILURE = re.compile(
+    r"^(?P<status>FAILED|ERROR)\s+(?:(?:collecting)\s+)?(?P<node>\S+)", re.MULTILINE
+)
+
+
+def _text(value: bytes | str) -> str:
+    return value.decode("utf-8", errors="replace") if isinstance(value, bytes) else value
+
+
+def _relative_path(raw_path: str, cwd: Path) -> str:
+    candidate = Path(raw_path.replace("\\", "/"))
+    try:
+        if candidate.is_absolute():
+            # Keep lexical paths stable even when the host exposes `/tmp` via
+            # a symlink (as macOS does); resolving one side would lose that
+            # relationship and collapse the evidence to a basename.
+            candidate = candidate.relative_to(Path(cwd))
+    except ValueError:
+        candidate = Path(candidate.name)
+    normalized = candidate.as_posix()
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized or "."
+
+
+def _unavailable(reason: str) -> dict[str, Any]:
+    return {"status": "unavailable", "reason": reason}
+
+
+def _compile_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> dict[str, Any]:
+    if returncode == 0:
+        return {"status": "measured", "keys": [], "source": "python.compile-v1"}
+    text = "\n".join((stdout, stderr))
+    current_path: str | None = None
+    current_line: str | None = None
+    keys: set[str] = set()
+    for line in text.splitlines():
+        file_match = _COMPILE_FILE.search(line)
+        if file_match:
+            current_path = _relative_path(file_match.group("path"), cwd)
+            current_line = None
+            continue
+        location_match = _PYTHON_FILE.match(line)
+        if location_match:
+            current_path = _relative_path(location_match.group("path"), cwd)
+            current_line = location_match.group("line")
+            continue
+        error_match = _PYTHON_ERROR.match(line)
+        if error_match and current_path and current_line:
+            keys.add(f"python.compile:{current_path}:{current_line}:{error_match.group('kind')}")
+    if not keys:
+        return _unavailable("python.compile output did not contain a supported diagnostic")
+    return {"status": "measured", "keys": sorted(keys), "source": "python.compile-v1"}
+
+
+def _pytest_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> dict[str, Any]:
+    if returncode == 0:
+        return {"status": "measured", "keys": [], "source": "python.tests-v1"}
+    text = "\n".join((stdout, stderr))
+    keys: set[str] = set()
+    for match in _PYTEST_FAILURE.finditer(text):
+        node = match.group("node")
+        if "::" in node:
+            path, test_name = node.split("::", 1)
+            normalized_node = f"{_relative_path(path, cwd)}::{test_name}"
+            status = "failed"
+        else:
+            normalized_node = _relative_path(node, cwd)
+            status = "collection-error"
+        keys.add(f"python.tests:{normalized_node}:{status}")
+    if not keys:
+        return _unavailable("python.tests output did not contain a supported diagnostic")
+    return {"status": "measured", "keys": sorted(keys), "source": "python.tests-v1"}
+
+
+def normalize_baseline_evidence(
+    baseline_id: str,
+    stdout: bytes | str,
+    stderr: bytes | str,
+    returncode: int | None,
+    cwd: Path,
+) -> dict[str, Any]:
+    """Return measured normalized IDs or an explicit unavailable status.
+
+    A successful check with no diagnostics is still measured with an empty set.
+    Non-zero output is measured only when the adapter can identify a stable
+    path/node diagnostic; raw command output is never persisted in the artifact.
+    """
+
+    if baseline_id not in {"python.compile", "python.tests"}:
+        return _unavailable(f"no adapter registered for baseline {baseline_id}")
+    if returncode is None:
+        return _unavailable("baseline command did not complete")
+    text_stdout, text_stderr = _text(stdout), _text(stderr)
+    if baseline_id == "python.compile":
+        return _compile_evidence(text_stdout, text_stderr, returncode, cwd)
+    return _pytest_evidence(text_stdout, text_stderr, returncode, cwd)

--- a/scripts/differential_runner.py
+++ b/scripts/differential_runner.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from differential_contract import validate_differential
+from differential_evidence import normalize_baseline_evidence
 from differential_manifest import load_differential
 from differential_novelty import evidence_keys, novel_evidence_keys
 from differential_telemetry import build_command_telemetry, build_review_telemetry
@@ -45,7 +46,9 @@ def _resource_snapshot() -> tuple[str, int | None]:
     return "available", max_rss
 
 
-def run_timed_command(command: tuple[str, ...], cwd: Path, timeout_seconds: int) -> dict[str, Any]:
+def run_timed_command(
+    command: tuple[str, ...], cwd: Path, timeout_seconds: int, baseline_id: str | None = None
+) -> dict[str, Any]:
     resource_status, resource_before = _resource_snapshot()
     started = time.perf_counter()
     try:
@@ -72,10 +75,11 @@ def run_timed_command(command: tuple[str, ...], cwd: Path, timeout_seconds: int)
         "resource_status": resource_status,
     }
     result["telemetry"] = build_command_telemetry(result["wall_ms"])
-    result["evidence"] = {
-        "status": "unavailable",
-        "reason": "baseline command has no normalized evidence adapter",
-    }
+    result["evidence"] = (
+        normalize_baseline_evidence(baseline_id, stdout, stderr, returncode, cwd)
+        if baseline_id is not None and status in {"passed", "failed"}
+        else {"status": "unavailable", "reason": "baseline command did not complete"}
+    )
     if resource_before is not None and resource_after is not None:
         result["child_max_rss_kb"] = max(0, resource_after - resource_before)
     return result
@@ -210,7 +214,7 @@ def collect_case(
     reviews = []
     for repeat in range(1, repetitions + 1):
         for baseline_id in baseline_ids:
-            result = run_timed_command(BASELINE_COMMANDS[baseline_id], merge, timeout_seconds)
+            result = run_timed_command(BASELINE_COMMANDS[baseline_id], merge, timeout_seconds, baseline_id)
             result["repeat"] = repeat
             baselines[baseline_id].append(result)
         review = _review_once(scanner, case, head, base_evidence, timeout_seconds)

--- a/scripts/tests/test_differential_evidence.py
+++ b/scripts/tests/test_differential_evidence.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from differential_evidence import normalize_baseline_evidence  # noqa: E402
+
+
+class DifferentialEvidenceTests(unittest.TestCase):
+    def test_compile_success_is_measured_with_empty_evidence(self) -> None:
+        result = normalize_baseline_evidence("python.compile", b"", b"", 0, Path("/repo"))
+        self.assertEqual(result, {"status": "measured", "keys": [], "source": "python.compile-v1"})
+
+    def test_compile_failure_normalizes_path_line_and_error_kind(self) -> None:
+        stderr = b"""
+*** Error compiling '/tmp/work/pkg/bad.py'...
+  File "/tmp/work/pkg/bad.py", line 7
+    broken(
+          ^
+SyntaxError: '(' was never closed
+"""
+        result = normalize_baseline_evidence("python.compile", b"", stderr, 1, Path("/tmp/work"))
+        self.assertEqual(result["status"], "measured")
+        self.assertEqual(result["keys"], ["python.compile:pkg/bad.py:7:SyntaxError"])
+
+    def test_compile_failure_without_supported_diagnostic_is_unavailable(self) -> None:
+        result = normalize_baseline_evidence("python.compile", b"compiler crashed", b"", 1, Path("/repo"))
+        self.assertEqual(result["status"], "unavailable")
+        self.assertIn("supported diagnostic", result["reason"])
+
+    def test_pytest_success_is_measured_with_empty_evidence(self) -> None:
+        result = normalize_baseline_evidence("python.tests", b"3 passed in 0.02s\n", b"", 0, Path("/repo"))
+        self.assertEqual(result, {"status": "measured", "keys": [], "source": "python.tests-v1"})
+
+    def test_pytest_failure_normalizes_node_ids_and_is_order_stable(self) -> None:
+        output = b"""
+FAILED tests/test_api.py::test_create - AssertionError
+ERROR tests/test_db.py - ImportError: missing dependency
+ERROR collecting tests/test_import.py
+"""
+        result = normalize_baseline_evidence("python.tests", output, b"", 1, Path("/repo"))
+        self.assertEqual(result["status"], "measured")
+        self.assertEqual(
+            result["keys"],
+            [
+                "python.tests:tests/test_api.py::test_create:failed",
+                "python.tests:tests/test_db.py:collection-error",
+                "python.tests:tests/test_import.py:collection-error",
+            ],
+        )
+
+    def test_pytest_unknown_failure_is_unavailable(self) -> None:
+        result = normalize_baseline_evidence("python.tests", b"pytest crashed", b"", 2, Path("/repo"))
+        self.assertEqual(result["status"], "unavailable")
+        self.assertIn("supported diagnostic", result["reason"])
+
+    def test_unknown_baseline_is_unavailable(self) -> None:
+        result = normalize_baseline_evidence("python.lint", b"", b"", 0, Path("/repo"))
+        self.assertEqual(result["status"], "unavailable")
+        self.assertIn("no adapter", result["reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_differential_runner.py
+++ b/scripts/tests/test_differential_runner.py
@@ -33,6 +33,27 @@ class DifferentialRunnerTests(unittest.TestCase):
         self.assertEqual(result["status"], "failed")
         self.assertEqual(result["returncode"], 3)
 
+    def test_timed_baseline_command_records_normalized_evidence(self) -> None:
+        diagnostic = (
+            "*** Error compiling '/workspace/pkg/bad.py'...\n"
+            "  File '/workspace/pkg/bad.py', line 4\n"
+            "SyntaxError: invalid syntax\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_timed_command(
+                (
+                    sys.executable,
+                    "-c",
+                    "import sys; print(sys.argv[1], file=sys.stderr); raise SystemExit(1)",
+                    diagnostic,
+                ),
+                Path(tmp),
+                5,
+                "python.compile",
+            )
+        self.assertEqual(result["evidence"]["status"], "measured")
+        self.assertEqual(result["evidence"]["keys"], ["python.compile:bad.py:4:SyntaxError"])
+
     def test_artifact_validator_accepts_complete_pending_observations(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -127,6 +148,29 @@ class DifferentialRunnerTests(unittest.TestCase):
                     review["telemetry"] = build_command_telemetry(1.0)
             result = validate_data(artifact, holdout, differential, rules, zoo)
         self.assertEqual(result["status"], "valid")
+
+    def test_artifact_schema_two_requires_provenance_for_measured_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            holdout, differential, rules, zoo = self._write_manifests(root)
+            artifact = self._valid_artifact(holdout, differential)
+            artifact["schema_version"] = 2
+            for case in artifact["cases"]:
+                case["base_scan"]["telemetry"] = build_command_telemetry(1.0)
+                for runs in case["baselines"].values():
+                    for run in runs:
+                        run["telemetry"] = build_command_telemetry(1.0)
+                        run["evidence"] = {"status": "measured", "keys": []}
+                for review in case["reviews"]:
+                    review["telemetry"] = build_command_telemetry(1.0)
+            with self.assertRaisesRegex(ValueError, "evidence source"):
+                validate_data(artifact, holdout, differential, rules, zoo)
+            for case in artifact["cases"]:
+                for runs in case["baselines"].values():
+                    for run in runs:
+                        run["evidence"]["source"] = "unrelated-adapter-v1"
+            with self.assertRaisesRegex(ValueError, "source drift"):
+                validate_data(artifact, holdout, differential, rules, zoo)
 
     @staticmethod
     def _valid_artifact(holdout: Path, differential: Path) -> dict[str, object]:

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -46,9 +46,11 @@ until the independent labeling and scoring step exists.
 The differential collection artifact is schema 2. Each baseline, base scan, and
 review run has validated monotonic start/finish telemetry. Review runs may also
 record evidence-ready and decision-ready phase events from RepoPilot's internal
-timings. Duplicate-work overlap stays unavailable until a baseline adapter
-provides normalized evidence identities; command success or output hashes alone
-are not treated as evidence overlap.
+timings. The first baseline adapters normalize `python.compile` diagnostics as
+`path:line:error-kind` identities and `python.tests` failures as stable pytest
+node identities. A clean successful baseline is measured with an empty evidence
+set; an unrecognized failure stays explicitly unavailable. Command success or
+output hashes alone are not treated as evidence overlap.
 
 When one reviewer is available, `pilot-template` creates an exploratory
 worksheet over the same pinned differential artifact. `pilot-score` reports


### PR DESCRIPTION
## Problem

The differential utility protocol had schema-2 telemetry, but baseline runs still carried only an unavailable evidence marker. That kept `duplicate_work` unavailable even when compiler or test checks completed successfully, and it gave no auditable boundary for unsupported diagnostics.

## What changed

- Add deterministic `python.compile` and `python.tests` evidence adapters.
- Normalize compiler failures to `path:line:error-kind` IDs and pytest failures to stable node IDs.
- Treat clean successful checks as measured empty evidence instead of unavailable.
- Keep unrecognized failures and incomplete commands explicitly unavailable.
- Record adapter provenance and validate the expected source in schema-2 artifacts.
- Add focused regression coverage for success, diagnostic normalization, path stability, ordering, unsupported output, timeout behavior, and schema provenance.
- Update the v0.23 evidence ledger, roadmap, benchmark README, and changelog with the measurement boundary.

## Real collection check

A fresh six-case exact-SHA collection completed and passed schema-2 validation:

- 6 cases, 36 baseline observations, 18 RepoPilot review observations.
- 27/36 baseline runs produced measured evidence (including clean empty sets).
- 9/36 pytest runs remained explicitly unavailable because their failure output had no supported stable diagnostic.
- The artifact remains an unlabeled observation packet; it makes no recall, precision, utility, or competitor claim.

The generated artifact was validated from `/tmp` and is intentionally not committed as release evidence until the frozen labeling/scoring workflow is completed.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 191 passed
- `python3 -m py_compile scripts/differential_evidence.py scripts/differential_runner.py scripts/differential_artifact.py`
- `python3 scripts/differential.py check --format json` — valid six-case protocol
- `python3 scripts/differential.py validate-result --artifact /tmp/repopilot-differential-schema2.json --format json` — valid schema 2
- `python3 scripts/release-contract.py check` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo test --all` — passed (924 library + 80 binary + integration tests; one explicit compatibility test ignored)
- `cargo run -- scan . --fail-on-priority p1 --no-progress` — PASS, 0 P0/P1 findings
