### PR TITLE
feat: expand differential evidence coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   `python.tests`. Recognized diagnostics are reduced to path/line/error-kind or
   pytest-node identities, clean runs are measured with empty evidence, and
   unsupported failures remain explicitly unavailable rather than being guessed.
+- Extended the pytest adapter to normalize conftest import failures and added
+  schema-2 validation coverage summaries, separating measured, unavailable, and
+  untracked baseline runs.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -312,9 +312,11 @@ bump is needed to start.
   telemetry records evidence-ready and decision-ready phase events from the
   scanner's internal timings when those timings exist. Deterministic adapters
   cover `python.compile` and `python.tests`; recognized diagnostics receive
-  normalized identities, clean runs are measured with an empty set, and
-  unsupported failures remain unavailable. Duplicate-work overlap therefore
-  never treats command success or output hashes as evidence.
+  normalized identities, clean runs are measured with an empty set, and common
+  conftest import failures are classified by collection path. Unsupported
+  failures remain unavailable, while validation reports measured, unavailable,
+  and untracked coverage separately. Duplicate-work overlap therefore never
+  treats command success or output hashes as evidence.
 - Boundary: these are still unlabeled observations. Frozen environments,
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -430,9 +430,11 @@ The next collection schema adds per-run telemetry and typed baseline evidence.
 RepoPilot reviews can now expose evidence-ready and decision-ready phase events
 from the core timing record. The first deterministic adapters cover
 `python.compile` and `python.tests`, recording normalized diagnostic identities,
-measuring clean runs as empty sets, and leaving unsupported failures unavailable.
-This gives later utility scoring an auditable evidence path without converting
-process completion into a fabricated human decision timestamp.
+measuring clean runs as empty sets, classifying common conftest import failures,
+and leaving unsupported failures unavailable. Artifact validation now exposes
+measured, unavailable, and untracked coverage separately. This gives later
+utility scoring an auditable evidence path without converting process completion
+into a fabricated human decision timestamp.
 
 Initial release discipline:
 

--- a/scripts/differential.py
+++ b/scripts/differential.py
@@ -73,6 +73,12 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(artifact_result, indent=2, sort_keys=True))
         else:
             print(f"Differential artifact: {artifact_result['status']} ({artifact_result['cases']} cases)")
+            evidence = artifact_result["baseline_evidence"]
+            print(
+                "Baseline evidence: "
+                f"{evidence['measured']}/{evidence['tracked']} tracked runs measured; "
+                f"{evidence['unavailable']} unavailable; {evidence['untracked']} untracked"
+            )
         return 0
     if args.command == "collect":
         if args.output is None:

--- a/scripts/differential_artifact.py
+++ b/scripts/differential_artifact.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +39,7 @@ def validate_data(
     expected = {case.case_id: case for case in holdout_cases}
     differential_cases = {case.case_id: case for case in _load_cases(differential_path)}
     _validate_observations(observations, expected, differential_cases, data["repetitions"], schema_version)
+    baseline_evidence = baseline_evidence_summary(observations)
     return {
         "status": "valid",
         "schema_version": schema_version,
@@ -49,6 +51,42 @@ def validate_data(
             for observation in observations
         ),
         "review_observations": sum(len(observation["reviews"]) for observation in observations),
+        "baseline_evidence": baseline_evidence,
+    }
+
+
+def baseline_evidence_summary(observations: list[dict[str, Any]]) -> dict[str, object]:
+    """Summarize adapter coverage without turning missing evidence into a pass."""
+
+    total = tracked = measured = unavailable = untracked = key_count = 0
+    sources: Counter[str] = Counter()
+    for observation in observations:
+        for runs in observation.get("baselines", {}).values():
+            for run in runs:
+                total += 1
+                evidence = run.get("evidence") if isinstance(run, dict) else None
+                if not isinstance(evidence, dict):
+                    untracked += 1
+                    continue
+                tracked += 1
+                status = evidence.get("status")
+                if status == "measured":
+                    measured += 1
+                    key_count += len(evidence.get("keys", []))
+                    source = evidence.get("source")
+                    sources[str(source) if source else "<unspecified>"] += 1
+                elif status == "unavailable":
+                    unavailable += 1
+    return {
+        "total": total,
+        "tracked": tracked,
+        "measured": measured,
+        "unavailable": unavailable,
+        "untracked": untracked,
+        "tracked_rate": round(tracked / total, 3) if total else None,
+        "measurement_rate": round(measured / tracked, 3) if tracked else None,
+        "keys": key_count,
+        "sources": dict(sorted(sources.items())),
     }
 
 

--- a/scripts/differential_evidence.py
+++ b/scripts/differential_evidence.py
@@ -13,6 +13,9 @@ _PYTHON_ERROR = re.compile(r"^\s*(?P<kind>[A-Za-z_]\w*(?:Error|Warning)):")
 _PYTEST_FAILURE = re.compile(
     r"^(?P<status>FAILED|ERROR)\s+(?:(?:collecting)\s+)?(?P<node>\S+)", re.MULTILINE
 )
+_PYTEST_CONFTEST_ERROR = re.compile(
+    r"ImportError while loading conftest ['\"](?P<path>.+?)['\"]\."
+)
 
 
 def _text(value: bytes | str) -> str:
@@ -70,6 +73,9 @@ def _pytest_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> di
         return {"status": "measured", "keys": [], "source": "python.tests-v1"}
     text = "\n".join((stdout, stderr))
     keys: set[str] = set()
+    for match in _PYTEST_CONFTEST_ERROR.finditer(text):
+        path = _relative_path(match.group("path"), cwd)
+        keys.add(f"python.tests:{path}:collection-error")
     for match in _PYTEST_FAILURE.finditer(text):
         node = match.group("node")
         if "::" in node:

--- a/scripts/tests/test_differential_evidence.py
+++ b/scripts/tests/test_differential_evidence.py
@@ -59,6 +59,12 @@ ERROR collecting tests/test_import.py
         self.assertEqual(result["status"], "unavailable")
         self.assertIn("supported diagnostic", result["reason"])
 
+    def test_pytest_conftest_import_error_normalizes_collection_path(self) -> None:
+        output = b"ImportError while loading conftest '/workspace/tests/conftest.py'.\n"
+        result = normalize_baseline_evidence("python.tests", output, b"", 4, Path("/workspace"))
+        self.assertEqual(result["status"], "measured")
+        self.assertEqual(result["keys"], ["python.tests:tests/conftest.py:collection-error"])
+
     def test_unknown_baseline_is_unavailable(self) -> None:
         result = normalize_baseline_evidence("python.lint", b"", b"", 0, Path("/repo"))
         self.assertEqual(result["status"], "unavailable")

--- a/scripts/tests/test_differential_runner.py
+++ b/scripts/tests/test_differential_runner.py
@@ -110,6 +110,20 @@ class DifferentialRunnerTests(unittest.TestCase):
         self.assertEqual(result["status"], "valid")
         self.assertEqual(result["baseline_observations"], 6)
         self.assertEqual(result["review_observations"], 6)
+        self.assertEqual(
+            result["baseline_evidence"],
+            {
+                "total": 6,
+                "tracked": 0,
+                "measured": 0,
+                "unavailable": 0,
+                "untracked": 6,
+                "tracked_rate": 0.0,
+                "measurement_rate": None,
+                "keys": 0,
+                "sources": {},
+            },
+        )
 
     def test_artifact_validator_requires_base_scan_for_novelty(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -148,6 +162,8 @@ class DifferentialRunnerTests(unittest.TestCase):
                     review["telemetry"] = build_command_telemetry(1.0)
             result = validate_data(artifact, holdout, differential, rules, zoo)
         self.assertEqual(result["status"], "valid")
+        self.assertEqual(result["baseline_evidence"]["unavailable"], 6)
+        self.assertEqual(result["baseline_evidence"]["measurement_rate"], 0.0)
 
     def test_artifact_schema_two_requires_provenance_for_measured_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -49,7 +49,9 @@ record evidence-ready and decision-ready phase events from RepoPilot's internal
 timings. The first baseline adapters normalize `python.compile` diagnostics as
 `path:line:error-kind` identities and `python.tests` failures as stable pytest
 node identities. A clean successful baseline is measured with an empty evidence
-set; an unrecognized failure stays explicitly unavailable. Command success or
+set; conftest import failures are normalized to their collection path; an
+unrecognized failure stays explicitly unavailable. `validate-result` reports
+measured, unavailable, and untracked coverage separately. Command success or
 output hashes alone are not treated as evidence overlap.
 
 When one reviewer is available, `pilot-template` creates an exploratory


### PR DESCRIPTION
## Problem

After the first baseline adapters landed, a fresh six-case differential artifact still left nine pytest runs unavailable. Those runs failed while importing repository `conftest.py` files, before pytest emitted its usual `FAILED` or `ERROR` summary. The artifact also lacked a compact coverage summary, so adapter coverage required manual inspection.

## What changed

- Normalize `ImportError while loading conftest '<path>'` into a stable `python.tests:<relative-path>:collection-error` evidence ID.
- Keep unsupported output explicitly unavailable and never persist raw command output.
- Add derived schema-2 baseline evidence coverage to `validate-result` JSON and text output:
  measured, unavailable, untracked, tracked rate, measurement rate, key count, and adapter sources.
- Add regression coverage for conftest import failures and coverage summaries.
- Update the evidence ledger, roadmap, benchmark README, and changelog.

## Real collection check

The same six pinned cases were collected again after this change:

- 6 cases, 36 baseline observations, 18 RepoPilot review observations.
- 36/36 baseline runs are tracked and measured.
- Sources are 18 `python.compile-v1` and 18 `python.tests-v1` runs.
- `validate-result` reports 0 unavailable and 0 untracked runs.
- Differential duplicate-work is now structurally measurable; the exploratory exact-ID overlap in this unlabeled packet is 0. This is not a utility, recall, precision, or competitor claim because baseline labels and identity adjudication are still pending.

The generated artifact remains in `/tmp` and is intentionally not committed as release evidence until the frozen labeling/scoring workflow is complete.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 192 passed
- `python3 -m py_compile scripts/differential.py scripts/differential_artifact.py scripts/differential_evidence.py`
- `python3 scripts/differential.py validate-result --artifact /tmp/repopilot-differential-schema2-v2.json` — 36/36 measured
- `python3 scripts/release-contract.py check` — passed
- `cargo fmt --all -- --check` — passed
- `cargo run -- scan . --fail-on-priority p1 --no-progress` — PASS, 0 P0/P1 findings
