### PR TITLE
feat: require comparable differential identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Extended the pytest adapter to normalize conftest import failures and added
   schema-2 validation coverage summaries, separating measured, unavailable, and
   untracked baseline runs.
+- Separated baseline diagnostic IDs from review-comparable identities in the
+  differential metric contract. `duplicate-work` now stays unavailable unless
+  a baseline adapter explicitly supplies the shared `review-exact-v1` mapping,
+  preventing different namespaces from producing a false zero-overlap result.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -315,8 +315,10 @@ bump is needed to start.
   normalized identities, clean runs are measured with an empty set, and common
   conftest import failures are classified by collection path. Unsupported
   failures remain unavailable, while validation reports measured, unavailable,
-  and untracked coverage separately. Duplicate-work overlap therefore never
-  treats command success or output hashes as evidence.
+  and untracked coverage separately. Diagnostic IDs remain adapter-specific;
+  duplicate-work overlap is measured only when a baseline also provides an
+  explicit `review-exact-v1` comparison mapping. Command success or output
+  hashes therefore never become evidence overlap.
 - Boundary: these are still unlabeled observations. Frozen environments,
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -434,7 +434,9 @@ measuring clean runs as empty sets, classifying common conftest import failures,
 and leaving unsupported failures unavailable. Artifact validation now exposes
 measured, unavailable, and untracked coverage separately. This gives later
 utility scoring an auditable evidence path without converting process completion
-into a fabricated human decision timestamp.
+into a fabricated human decision timestamp. Duplicate-work remains unavailable
+unless an adapter supplies an explicit `review-exact-v1` identity mapping;
+baseline-specific diagnostic IDs alone do not count as overlap.
 
 Initial release discipline:
 

--- a/scripts/differential_artifact.py
+++ b/scripts/differential_artifact.py
@@ -17,6 +17,7 @@ from real_history_runner import BASELINE_COMMANDS
 
 REVIEW_STATUSES = {"collected", "timeout"}
 BASE_SCAN_STATUSES = REVIEW_STATUSES
+REVIEW_COMPARISON_SCHEME = "review-exact-v1"
 
 
 def sha256_file(path: Path) -> str:
@@ -232,6 +233,19 @@ def _validate_baseline_evidence(
             expected_source = f"{baseline_id}-v1" if baseline_id else None
             if expected_source and source != expected_source:
                 raise DifferentialManifestError(f"{context}: measured baseline evidence source drift")
+            comparison = evidence.get("comparison")
+            if not isinstance(comparison, dict) or comparison.get("status") not in {"measured", "unavailable"}:
+                raise DifferentialManifestError(f"{context}: baseline evidence comparison is missing")
+            if comparison.get("scheme") != REVIEW_COMPARISON_SCHEME:
+                raise DifferentialManifestError(f"{context}: baseline evidence comparison scheme drift")
+            if comparison["status"] == "measured":
+                comparison_keys = comparison.get("keys")
+                if not isinstance(comparison_keys, list) or not all(
+                    isinstance(key, str) for key in comparison_keys
+                ):
+                    raise DifferentialManifestError(f"{context}: measured comparison keys are missing")
+            elif not isinstance(comparison.get("reason"), str) or not comparison["reason"]:
+                raise DifferentialManifestError(f"{context}: unavailable comparison reason is missing")
     elif not isinstance(evidence.get("reason"), str) or not evidence["reason"]:
         raise DifferentialManifestError(f"{context}: unavailable baseline evidence reason is missing")
 

--- a/scripts/differential_evidence.py
+++ b/scripts/differential_evidence.py
@@ -16,6 +16,7 @@ _PYTEST_FAILURE = re.compile(
 _PYTEST_CONFTEST_ERROR = re.compile(
     r"ImportError while loading conftest ['\"](?P<path>.+?)['\"]\."
 )
+_COMPARISON_SCHEME = "review-exact-v1"
 
 
 def _text(value: bytes | str) -> str:
@@ -42,9 +43,22 @@ def _unavailable(reason: str) -> dict[str, Any]:
     return {"status": "unavailable", "reason": reason}
 
 
+def _measured(source: str, keys: list[str]) -> dict[str, Any]:
+    comparison: dict[str, Any]
+    if keys:
+        comparison = {
+            "status": "unavailable",
+            "reason": "baseline evidence has no review-comparable identity mapping",
+            "scheme": _COMPARISON_SCHEME,
+        }
+    else:
+        comparison = {"status": "measured", "keys": [], "scheme": _COMPARISON_SCHEME}
+    return {"status": "measured", "keys": keys, "source": source, "comparison": comparison}
+
+
 def _compile_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> dict[str, Any]:
     if returncode == 0:
-        return {"status": "measured", "keys": [], "source": "python.compile-v1"}
+        return _measured("python.compile-v1", [])
     text = "\n".join((stdout, stderr))
     current_path: str | None = None
     current_line: str | None = None
@@ -65,12 +79,12 @@ def _compile_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> d
             keys.add(f"python.compile:{current_path}:{current_line}:{error_match.group('kind')}")
     if not keys:
         return _unavailable("python.compile output did not contain a supported diagnostic")
-    return {"status": "measured", "keys": sorted(keys), "source": "python.compile-v1"}
+    return _measured("python.compile-v1", sorted(keys))
 
 
 def _pytest_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> dict[str, Any]:
     if returncode == 0:
-        return {"status": "measured", "keys": [], "source": "python.tests-v1"}
+        return _measured("python.tests-v1", [])
     text = "\n".join((stdout, stderr))
     keys: set[str] = set()
     for match in _PYTEST_CONFTEST_ERROR.finditer(text):
@@ -88,7 +102,7 @@ def _pytest_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> di
         keys.add(f"python.tests:{normalized_node}:{status}")
     if not keys:
         return _unavailable("python.tests output did not contain a supported diagnostic")
-    return {"status": "measured", "keys": sorted(keys), "source": "python.tests-v1"}
+    return _measured("python.tests-v1", sorted(keys))
 
 
 def normalize_baseline_evidence(

--- a/scripts/differential_pilot_metrics.py
+++ b/scripts/differential_pilot_metrics.py
@@ -108,9 +108,17 @@ def _duplicate_work_measurement(observation: dict[str, Any]) -> dict[str, object
                     "status": "unavailable",
                     "reason": "baseline command has no normalized evidence adapter",
                 }
-            keys = evidence.get("keys")
+            comparison = evidence.get("comparison")
+            if not isinstance(comparison, dict) or comparison.get("status") != "measured":
+                return {
+                    "status": "unavailable",
+                    "reason": "baseline evidence has no review-comparable identity mapping",
+                }
+            if comparison.get("scheme") != "review-exact-v1":
+                return {"status": "unavailable", "reason": "baseline comparison identity scheme is unsupported"}
+            keys = comparison.get("keys")
             if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
-                return {"status": "unavailable", "reason": "baseline evidence keys are invalid"}
+                return {"status": "unavailable", "reason": "baseline comparison keys are invalid"}
             baseline_keys.update(keys)
     review_keys = {
         key
@@ -296,8 +304,21 @@ def _score_pilot_case(
 
 
 def _aggregate_duplicate_work(measurements: list[dict[str, object]]) -> dict[str, object]:
-    if not measurements or any(measurement.get("status") != "measured" for measurement in measurements):
-        return {"status": "unavailable", "reason": "baseline overlap classification is not captured"}
+    unavailable = [measurement for measurement in measurements if measurement.get("status") != "measured"]
+    if not measurements or unavailable:
+        reasons = sorted(
+            {
+                str(measurement.get("reason"))
+                for measurement in unavailable
+                if isinstance(measurement.get("reason"), str) and measurement["reason"]
+            }
+        )
+        return {
+            "status": "unavailable",
+            "reason": reasons[0] if len(reasons) == 1 else "baseline overlap classification is not captured",
+            "cases_measured": len(measurements) - len(unavailable),
+            "cases_unavailable": len(unavailable),
+        }
     overlap_count = sum(int(measurement.get("overlap_count", 0)) for measurement in measurements)
     baseline_count = sum(int(measurement.get("baseline_evidence_count", 0)) for measurement in measurements)
     review_count = sum(int(measurement.get("review_evidence_count", 0)) for measurement in measurements)

--- a/scripts/tests/test_differential_evidence.py
+++ b/scripts/tests/test_differential_evidence.py
@@ -14,7 +14,15 @@ from differential_evidence import normalize_baseline_evidence  # noqa: E402
 class DifferentialEvidenceTests(unittest.TestCase):
     def test_compile_success_is_measured_with_empty_evidence(self) -> None:
         result = normalize_baseline_evidence("python.compile", b"", b"", 0, Path("/repo"))
-        self.assertEqual(result, {"status": "measured", "keys": [], "source": "python.compile-v1"})
+        self.assertEqual(
+            result,
+            {
+                "status": "measured",
+                "keys": [],
+                "source": "python.compile-v1",
+                "comparison": {"status": "measured", "keys": [], "scheme": "review-exact-v1"},
+            },
+        )
 
     def test_compile_failure_normalizes_path_line_and_error_kind(self) -> None:
         stderr = b"""
@@ -27,6 +35,7 @@ SyntaxError: '(' was never closed
         result = normalize_baseline_evidence("python.compile", b"", stderr, 1, Path("/tmp/work"))
         self.assertEqual(result["status"], "measured")
         self.assertEqual(result["keys"], ["python.compile:pkg/bad.py:7:SyntaxError"])
+        self.assertEqual(result["comparison"]["status"], "unavailable")
 
     def test_compile_failure_without_supported_diagnostic_is_unavailable(self) -> None:
         result = normalize_baseline_evidence("python.compile", b"compiler crashed", b"", 1, Path("/repo"))
@@ -35,7 +44,15 @@ SyntaxError: '(' was never closed
 
     def test_pytest_success_is_measured_with_empty_evidence(self) -> None:
         result = normalize_baseline_evidence("python.tests", b"3 passed in 0.02s\n", b"", 0, Path("/repo"))
-        self.assertEqual(result, {"status": "measured", "keys": [], "source": "python.tests-v1"})
+        self.assertEqual(
+            result,
+            {
+                "status": "measured",
+                "keys": [],
+                "source": "python.tests-v1",
+                "comparison": {"status": "measured", "keys": [], "scheme": "review-exact-v1"},
+            },
+        )
 
     def test_pytest_failure_normalizes_node_ids_and_is_order_stable(self) -> None:
         output = b"""

--- a/scripts/tests/test_differential_pilot.py
+++ b/scripts/tests/test_differential_pilot.py
@@ -85,6 +85,11 @@ class DifferentialPilotTests(unittest.TestCase):
                         run["evidence"] = {
                             "status": "measured",
                             "keys": ["security.secret-candidate"],
+                            "comparison": {
+                                "status": "measured",
+                                "keys": ["security.secret-candidate"],
+                                "scheme": "review-exact-v1",
+                            },
                         }
                 for review in case["reviews"]:
                     review["telemetry"] = {
@@ -115,6 +120,44 @@ class DifferentialPilotTests(unittest.TestCase):
         self.assertEqual(output["measurements"]["time_to_first_useful_evidence"]["median_ms"], 5.0)
         self.assertEqual(output["measurements"]["decision_latency"]["median_ms"], 10.0)
         self.assertEqual(output["measurements"]["duplicate_work"]["overlap_count"], 1)
+
+    def test_metrics_do_not_infer_overlap_from_unmapped_baseline_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            inputs = self._write_inputs(root, include_novel=True)
+            data = json.loads(inputs["artifact"].read_text(encoding="utf-8"))
+            for case in data["cases"]:
+                for runs in case["baselines"].values():
+                    for run in runs:
+                        run["evidence"] = {
+                            "status": "measured",
+                            "keys": ["python.tests:tests/test_api.py::test_create:failed"],
+                            "comparison": {
+                                "status": "unavailable",
+                                "reason": "baseline evidence has no review-comparable identity mapping",
+                                "scheme": "review-exact-v1",
+                            },
+                        }
+            inputs["artifact"].write_text(json.dumps(data), encoding="utf-8")
+            pilot = root / "pilot.toml"
+            pilot.write_text(
+                render_pilot_template(
+                    inputs["artifact"], inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"], "expert"
+                )
+                .replace('label = ""', 'label = "no-defect"', 1)
+                .replace('rationale = ""', 'rationale = "reviewed first case"', 1)
+                .replace('label = ""', 'label = "uncertain"', 1)
+                .replace('rationale = ""', 'rationale = "insufficient context"', 1),
+                encoding="utf-8",
+            )
+            output = build_pilot_metrics(
+                inputs["artifact"], pilot, inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"]
+            )
+        self.assertEqual(output["measurements"]["duplicate_work"]["status"], "unavailable")
+        self.assertEqual(
+            output["measurements"]["duplicate_work"]["reason"],
+            "baseline evidence has no review-comparable identity mapping",
+        )
 
     @staticmethod
     def _write_inputs(root: Path, include_novel: bool = False) -> dict[str, Path]:

--- a/scripts/tests/test_differential_runner.py
+++ b/scripts/tests/test_differential_runner.py
@@ -188,6 +188,27 @@ class DifferentialRunnerTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "source drift"):
                 validate_data(artifact, holdout, differential, rules, zoo)
 
+    def test_artifact_schema_two_requires_review_comparison_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            holdout, differential, rules, zoo = self._write_manifests(root)
+            artifact = self._valid_artifact(holdout, differential)
+            artifact["schema_version"] = 2
+            for case in artifact["cases"]:
+                case["base_scan"]["telemetry"] = build_command_telemetry(1.0)
+                for baseline_id, runs in case["baselines"].items():
+                    for run in runs:
+                        run["telemetry"] = build_command_telemetry(1.0)
+                        run["evidence"] = {
+                            "status": "measured",
+                            "keys": [],
+                            "source": f"{baseline_id}-v1",
+                        }
+                for review in case["reviews"]:
+                    review["telemetry"] = build_command_telemetry(1.0)
+            with self.assertRaisesRegex(ValueError, "comparison"):
+                validate_data(artifact, holdout, differential, rules, zoo)
+
     @staticmethod
     def _valid_artifact(holdout: Path, differential: Path) -> dict[str, object]:
         cases = []

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -52,14 +52,18 @@ node identities. A clean successful baseline is measured with an empty evidence
 set; conftest import failures are normalized to their collection path; an
 unrecognized failure stays explicitly unavailable. `validate-result` reports
 measured, unavailable, and untracked coverage separately. Command success or
-output hashes alone are not treated as evidence overlap.
+output hashes alone are not treated as evidence overlap. A baseline diagnostic
+ID is not automatically comparable to a RepoPilot finding ID: duplicate-work
+requires an explicit `review-exact-v1` comparison mapping, otherwise the
+measurement remains unavailable.
 
 When one reviewer is available, `pilot-template` creates an exploratory
 worksheet over the same pinned differential artifact. `pilot-score` reports
 only captured novel-evidence, timing, determinism, and resource fields;
-decision latency, time to first useful evidence, and duplicate work remain
-unavailable until the collector records the required events. Validate the
-metrics artifact before rendering or circulating its report.
+decision latency and time to first useful evidence remain unavailable until the
+collector records the required events. Duplicate work additionally requires
+the explicit review-comparable identity mapping. Validate the metrics artifact
+before rendering or circulating its report.
 
 Validate the protocol contract without cloning repositories:
 


### PR DESCRIPTION
## Problem

The differential pilot was intersecting baseline-specific diagnostic IDs with RepoPilot's exact finding IDs. A zero intersection could therefore mean either no duplicated evidence or simply that the two tools used different identity namespaces.

## What changed

- Add an explicit `review-exact-v1` comparison contract beside each measured baseline evidence record.
- Keep adapter-native diagnostic IDs for coverage and diagnostics.
- Require schema-2 artifacts to declare comparison status, scheme, keys, or an explicit unavailable reason.
- Make duplicate-work consume only review-comparable keys.
- Preserve fail-closed behavior: mapped evidence can be measured; baseline evidence without a shared mapping remains unavailable.
- Propagate the precise unavailable reason and measured/unavailable case counts into aggregate metrics.
- Add regression coverage proving that tool-specific keys cannot fabricate overlap.
- Update the benchmark README, roadmap, evidence ledger, and changelog.

## Real collection check

A fresh six-case exact-SHA schema-2 collection passed validation:

- 6 cases, 36 baseline observations, 18 RepoPilot review observations.
- Baseline evidence coverage: 36/36 tracked and measured, 0 unavailable, 0 untracked.
- Duplicate-work: explicitly unavailable for all 6 cases because no baseline adapter currently provides a shared `review-exact-v1` identity mapping.
- This is the intended scientific boundary; it is not a zero-overlap utility result and makes no recall, precision, or competitor claim.

The generated artifact remains in `/tmp` and is not committed as release evidence until the frozen labels/scoring packet is complete.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 195 passed
- `python3 -m py_compile scripts/differential.py scripts/differential_artifact.py scripts/differential_evidence.py scripts/differential_pilot_metrics.py`
- `python3 scripts/release-contract.py check` — passed
- `cargo fmt --all -- --check` — passed
- `cargo run -- scan . --fail-on-priority p1 --no-progress` — PASS, 0 P0/P1 findings
