### PR TITLE
feat: measure Python syntax overlap exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   differential metric contract. `duplicate-work` now stays unavailable unless
   a baseline adapter explicitly supplies the shared `review-exact-v1` mapping,
   preventing different namespaces from producing a false zero-overlap result.
+- Added the first non-empty `review-exact-v1` mapping: Python `SyntaxError`
+  diagnostics on changed lines now carry a deterministic path/line identity in
+  review JSON, so `python.compile` can measure exact overlap. Other compiler
+  kinds, unchanged-line diagnostics, and unsupported baseline failures remain
+  unavailable. Validation reports comparison coverage separately from baseline
+  adapter coverage.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -319,6 +319,17 @@ bump is needed to start.
   duplicate-work overlap is measured only when a baseline also provides an
   explicit `review-exact-v1` comparison mapping. Command success or output
   hashes therefore never become evidence overlap.
+- The first non-empty comparison mapping is now covered end to end for Python
+  syntax failures. The scanner records a structured `python.syntax-error`
+  diagnostic with a line, review keeps it only when the line is in an added
+  range, and the collector maps it to the compiler adapter's exact
+  `python.compile:<path>:<line>:SyntaxError` identity. Other compiler kinds and
+  unchanged-line diagnostics stay unavailable; this does not yet produce a
+  utility score or close RP23-014.
+- Validation reports the comparison denominator separately from normalized
+  baseline coverage, including measured, unavailable, untracked, and mapped-key
+  counts. This keeps adapter coverage from being read as duplicate-work
+  evidence.
 - Boundary: these are still unlabeled observations. Frozen environments,
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -438,6 +438,17 @@ into a fabricated human decision timestamp. Duplicate-work remains unavailable
 unless an adapter supplies an explicit `review-exact-v1` identity mapping;
 baseline-specific diagnostic IDs alone do not count as overlap.
 
+The first non-empty mapping is now implemented for Python syntax failures:
+RepoPilot publishes a structured `python.syntax-error` diagnostic with the
+first parser error line, and the differential collector maps it to the exact
+`python.compile:<path>:<line>:SyntaxError` identity only when that line is in
+the added range. This is a deliberately narrow proof path; other compiler
+error kinds, unchanged-line parser errors, and unsupported baseline failures
+remain unavailable until an equally exact mapping is designed and tested.
+The validation summary now reports comparison coverage separately from
+baseline-diagnostic coverage, so a measured adapter run cannot be mistaken for
+a comparable overlap measurement.
+
 Initial release discipline:
 
 - a rule cannot be described as broadly precise without labeled default evidence

--- a/scripts/differential.py
+++ b/scripts/differential.py
@@ -79,6 +79,13 @@ def main(argv: list[str] | None = None) -> int:
                 f"{evidence['measured']}/{evidence['tracked']} tracked runs measured; "
                 f"{evidence['unavailable']} unavailable; {evidence['untracked']} untracked"
             )
+            comparison = evidence["comparison"]
+            print(
+                "Review-comparable evidence: "
+                f"{comparison['measured']} measured; "
+                f"{comparison['unavailable']} unavailable; "
+                f"{comparison['untracked']} untracked"
+            )
         return 0
     if args.command == "collect":
         if args.output is None:

--- a/scripts/differential_artifact.py
+++ b/scripts/differential_artifact.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from differential_contract import validate_differential
+from differential_identity import REVIEW_COMPARISON_SCHEME
 from differential_manifest import DifferentialManifestError
 from differential_telemetry import validate_telemetry
 from real_history_contract import HoldoutManifestError, validate_manifest
@@ -17,7 +18,6 @@ from real_history_runner import BASELINE_COMMANDS
 
 REVIEW_STATUSES = {"collected", "timeout"}
 BASE_SCAN_STATUSES = REVIEW_STATUSES
-REVIEW_COMPARISON_SCHEME = "review-exact-v1"
 
 
 def sha256_file(path: Path) -> str:
@@ -60,6 +60,7 @@ def baseline_evidence_summary(observations: list[dict[str, Any]]) -> dict[str, o
     """Summarize adapter coverage without turning missing evidence into a pass."""
 
     total = tracked = measured = unavailable = untracked = key_count = 0
+    comparison_measured = comparison_unavailable = comparison_untracked = comparison_key_count = 0
     sources: Counter[str] = Counter()
     for observation in observations:
         for runs in observation.get("baselines", {}).values():
@@ -68,6 +69,7 @@ def baseline_evidence_summary(observations: list[dict[str, Any]]) -> dict[str, o
                 evidence = run.get("evidence") if isinstance(run, dict) else None
                 if not isinstance(evidence, dict):
                     untracked += 1
+                    comparison_untracked += 1
                     continue
                 tracked += 1
                 status = evidence.get("status")
@@ -78,6 +80,14 @@ def baseline_evidence_summary(observations: list[dict[str, Any]]) -> dict[str, o
                     sources[str(source) if source else "<unspecified>"] += 1
                 elif status == "unavailable":
                     unavailable += 1
+                comparison = evidence.get("comparison")
+                if isinstance(comparison, dict) and comparison.get("status") == "measured":
+                    comparison_measured += 1
+                    comparison_key_count += len(comparison.get("keys", []))
+                elif isinstance(comparison, dict) and comparison.get("status") == "unavailable":
+                    comparison_unavailable += 1
+                else:
+                    comparison_untracked += 1
     return {
         "total": total,
         "tracked": tracked,
@@ -88,6 +98,17 @@ def baseline_evidence_summary(observations: list[dict[str, Any]]) -> dict[str, o
         "measurement_rate": round(measured / tracked, 3) if tracked else None,
         "keys": key_count,
         "sources": dict(sorted(sources.items())),
+        "comparison": {
+            "measured": comparison_measured,
+            "unavailable": comparison_unavailable,
+            "untracked": comparison_untracked,
+            "keys": comparison_key_count,
+            "measurement_rate": round(
+                comparison_measured / (comparison_measured + comparison_unavailable), 3
+            )
+            if comparison_measured + comparison_unavailable
+            else None,
+        },
     }
 
 
@@ -197,6 +218,13 @@ def validate_case(
             for field in ("in_diff_evidence_keys", "novel_in_diff_evidence_keys"):
                 if not isinstance(review.get(field), list) or not all(isinstance(item, str) for item in review[field]):
                     raise DifferentialManifestError(f"case {case.case_id}: collected review lacks {field}")
+            comparison_keys = review.get("in_diff_comparison_keys", [])
+            if not isinstance(comparison_keys, list) or not all(
+                isinstance(item, str) for item in comparison_keys
+            ):
+                raise DifferentialManifestError(
+                    f"case {case.case_id}: collected review has invalid comparison keys"
+                )
     determinism = observation.get("determinism")
     if not isinstance(determinism, dict) or not isinstance(determinism.get("stable_evidence_deterministic"), bool):
         raise DifferentialManifestError(f"case {case.case_id}: determinism summary is missing")

--- a/scripts/differential_evidence.py
+++ b/scripts/differential_evidence.py
@@ -6,6 +6,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from differential_identity import REVIEW_COMPARISON_SCHEME
+
 
 _COMPILE_FILE = re.compile(r"\*\*\* Error compiling ['\"](?P<path>.+?)['\"]")
 _PYTHON_FILE = re.compile(r'^\s*File ["\'](?P<path>.+?)["\'], line (?P<line>\d+)')
@@ -16,7 +18,8 @@ _PYTEST_FAILURE = re.compile(
 _PYTEST_CONFTEST_ERROR = re.compile(
     r"ImportError while loading conftest ['\"](?P<path>.+?)['\"]\."
 )
-_COMPARISON_SCHEME = "review-exact-v1"
+_COMPARISON_SCHEME = REVIEW_COMPARISON_SCHEME
+_COMPARABLE_COMPILE_KINDS = {"SyntaxError"}
 
 
 def _text(value: bytes | str) -> str:
@@ -39,20 +42,39 @@ def _relative_path(raw_path: str, cwd: Path) -> str:
     return normalized or "."
 
 
+def _comparison_path_is_confined(raw_path: str, cwd: Path) -> bool:
+    candidate = Path(raw_path.replace("\\", "/"))
+    if not candidate.is_absolute():
+        return True
+    try:
+        candidate.relative_to(Path(cwd))
+    except ValueError:
+        return False
+    return True
+
+
 def _unavailable(reason: str) -> dict[str, Any]:
     return {"status": "unavailable", "reason": reason}
 
 
-def _measured(source: str, keys: list[str]) -> dict[str, Any]:
+def _measured(
+    source: str, keys: list[str], comparison_keys: list[str] | None = None
+) -> dict[str, Any]:
     comparison: dict[str, Any]
-    if keys:
+    if comparison_keys is None and not keys:
+        comparison = {"status": "measured", "keys": [], "scheme": _COMPARISON_SCHEME}
+    elif comparison_keys is None:
         comparison = {
             "status": "unavailable",
             "reason": "baseline evidence has no review-comparable identity mapping",
             "scheme": _COMPARISON_SCHEME,
         }
     else:
-        comparison = {"status": "measured", "keys": [], "scheme": _COMPARISON_SCHEME}
+        comparison = {
+            "status": "measured",
+            "keys": comparison_keys,
+            "scheme": _COMPARISON_SCHEME,
+        }
     return {"status": "measured", "keys": keys, "source": source, "comparison": comparison}
 
 
@@ -62,24 +84,43 @@ def _compile_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> d
     text = "\n".join((stdout, stderr))
     current_path: str | None = None
     current_line: str | None = None
+    current_path_comparable = False
     keys: set[str] = set()
+    comparison_keys: set[str] = set()
     for line in text.splitlines():
         file_match = _COMPILE_FILE.search(line)
         if file_match:
-            current_path = _relative_path(file_match.group("path"), cwd)
+            raw_path = file_match.group("path")
+            current_path = _relative_path(raw_path, cwd)
+            current_path_comparable = _comparison_path_is_confined(raw_path, cwd)
             current_line = None
             continue
         location_match = _PYTHON_FILE.match(line)
         if location_match:
-            current_path = _relative_path(location_match.group("path"), cwd)
+            raw_path = location_match.group("path")
+            current_path = _relative_path(raw_path, cwd)
+            current_path_comparable = _comparison_path_is_confined(raw_path, cwd)
             current_line = location_match.group("line")
             continue
         error_match = _PYTHON_ERROR.match(line)
         if error_match and current_path and current_line:
-            keys.add(f"python.compile:{current_path}:{current_line}:{error_match.group('kind')}")
+            kind = error_match.group("kind")
+            key = f"python.compile:{current_path}:{current_line}:{kind}"
+            keys.add(key)
+            if current_path_comparable:
+                comparison_keys.add(key)
     if not keys:
         return _unavailable("python.compile output did not contain a supported diagnostic")
-    return _measured("python.compile-v1", sorted(keys))
+    normalized_keys = sorted(keys)
+    if comparison_keys == keys and all(
+        kind in _COMPARABLE_COMPILE_KINDS for kind in _compile_kinds(normalized_keys)
+    ):
+        return _measured("python.compile-v1", normalized_keys, normalized_keys)
+    return _measured("python.compile-v1", normalized_keys)
+
+
+def _compile_kinds(keys: list[str]) -> set[str]:
+    return {key.rsplit(":", 1)[-1] for key in keys}
 
 
 def _pytest_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> dict[str, Any]:

--- a/scripts/differential_identity.py
+++ b/scripts/differential_identity.py
@@ -1,0 +1,86 @@
+"""Review-side identities that have an explicit baseline mapping contract."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+REVIEW_COMPARISON_SCHEME = "review-exact-v1"
+
+
+def _relative_report_path(raw_path: object, root_path: object) -> str | None:
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    path = raw_path.replace("\\", "/")
+    root = root_path.replace("\\", "/") if isinstance(root_path, str) else ""
+    candidate = Path(path)
+    if candidate.is_absolute():
+        if not root:
+            return None
+        try:
+            candidate = candidate.relative_to(Path(root))
+        except ValueError:
+            return None
+    normalized = PurePosixPath(candidate.as_posix())
+    if normalized == PurePosixPath(".") or ".." in normalized.parts:
+        return None
+    return normalized.as_posix()
+
+
+def _changed_ranges(report: dict[str, Any]) -> dict[str, list[tuple[int, int]]]:
+    changed_files = report.get("changed_files")
+    if not isinstance(changed_files, list):
+        return {}
+    ranges_by_path: dict[str, list[tuple[int, int]]] = {}
+    for changed in changed_files:
+        if not isinstance(changed, dict):
+            continue
+        path = changed.get("path")
+        if not isinstance(path, str) or not path:
+            continue
+        ranges = changed.get("ranges")
+        if not isinstance(ranges, list):
+            continue
+        normalized_ranges = []
+        for changed_range in ranges:
+            if not isinstance(changed_range, dict):
+                continue
+            start = changed_range.get("start")
+            end = changed_range.get("end")
+            if isinstance(start, int) and isinstance(end, int) and 0 < start <= end:
+                normalized_ranges.append((start, end))
+        if normalized_ranges:
+            ranges_by_path[path.replace("\\", "/")] = normalized_ranges
+    return ranges_by_path
+
+
+def review_comparable_diagnostic_keys(report: dict[str, Any]) -> list[str]:
+    """Return exact baseline identities for explicitly supported review diagnostics.
+
+    The mapping is intentionally narrow: only RepoPilot's Python syntax diagnostic,
+    on a line added by the reviewed diff, maps to the Python compile adapter's
+    identity. Unknown codes, missing locations, and paths outside the review root
+    remain incomparable instead of becoming path-level guesses.
+    """
+
+    ranges_by_path = _changed_ranges(report)
+    diagnostics = report.get("diagnostics")
+    if not isinstance(diagnostics, list):
+        return []
+    keys: set[str] = set()
+    root_path = report.get("root_path")
+    for diagnostic in diagnostics:
+        if not isinstance(diagnostic, dict) or diagnostic.get("code") != "python.syntax-error":
+            continue
+        path = _relative_report_path(diagnostic.get("path"), root_path)
+        line = diagnostic.get("line")
+        if path is None or not isinstance(line, int) or line < 1:
+            continue
+        ranges = ranges_by_path.get(path)
+        if ranges is None or not any(start <= line <= end for start, end in ranges):
+            continue
+        if not path.endswith(".py"):
+            continue
+        keys.add(f"python.compile:{path}:{line}:SyntaxError")
+    return sorted(keys)

--- a/scripts/differential_pilot_metrics.py
+++ b/scripts/differential_pilot_metrics.py
@@ -120,12 +120,12 @@ def _duplicate_work_measurement(observation: dict[str, Any]) -> dict[str, object
             if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
                 return {"status": "unavailable", "reason": "baseline comparison keys are invalid"}
             baseline_keys.update(keys)
-    review_keys = {
-        key
-        for review in observation["reviews"]
-        for key in review.get("in_diff_evidence_keys", [])
-        if isinstance(key, str)
-    }
+    review_keys: set[str] = set()
+    for review in observation["reviews"]:
+        keys = review.get("in_diff_comparison_keys")
+        if not isinstance(keys, list):
+            keys = review.get("in_diff_evidence_keys", [])
+        review_keys.update(key for key in keys if isinstance(key, str))
     overlap_count = len(baseline_keys & review_keys)
     return {
         "status": "measured",

--- a/scripts/differential_runner.py
+++ b/scripts/differential_runner.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from differential_contract import validate_differential
 from differential_evidence import normalize_baseline_evidence
+from differential_identity import review_comparable_diagnostic_keys
 from differential_manifest import load_differential
 from differential_novelty import evidence_keys, novel_evidence_keys
 from differential_telemetry import build_command_telemetry, build_review_telemetry
@@ -154,6 +155,7 @@ def _review_once(
             "telemetry": build_command_telemetry(wall_ms),
             "in_diff_evidence_keys": [],
             "novel_in_diff_evidence_keys": [],
+            "in_diff_comparison_keys": [],
         }
     if process.returncode not in (0, 1):
         raise HoldoutManifestError(
@@ -186,6 +188,7 @@ def _build_review_result(
     in_diff_keys = sorted(evidence_keys(in_diff_findings))
     wall_ms = round((time.perf_counter() - started) * 1000, 3)
     novel_keys = novel_evidence_keys(in_diff_findings, base_evidence)
+    comparison_keys = review_comparable_diagnostic_keys(report)
     result = {
         **summarize_review(report, raw_output),
         "status": "collected",
@@ -194,6 +197,7 @@ def _build_review_result(
         "resource_status": resource_status,
         "in_diff_evidence_keys": in_diff_keys,
         "novel_in_diff_evidence_keys": novel_keys,
+        "in_diff_comparison_keys": comparison_keys,
     }
     result["telemetry"] = build_review_telemetry(report, wall_ms, bool(novel_keys))
     return result

--- a/scripts/tests/test_differential_evidence.py
+++ b/scripts/tests/test_differential_evidence.py
@@ -35,12 +35,28 @@ SyntaxError: '(' was never closed
         result = normalize_baseline_evidence("python.compile", b"", stderr, 1, Path("/tmp/work"))
         self.assertEqual(result["status"], "measured")
         self.assertEqual(result["keys"], ["python.compile:pkg/bad.py:7:SyntaxError"])
-        self.assertEqual(result["comparison"]["status"], "unavailable")
+        self.assertEqual(
+            result["comparison"],
+            {
+                "status": "measured",
+                "keys": ["python.compile:pkg/bad.py:7:SyntaxError"],
+                "scheme": "review-exact-v1",
+            },
+        )
 
     def test_compile_failure_without_supported_diagnostic_is_unavailable(self) -> None:
         result = normalize_baseline_evidence("python.compile", b"compiler crashed", b"", 1, Path("/repo"))
         self.assertEqual(result["status"], "unavailable")
         self.assertIn("supported diagnostic", result["reason"])
+
+    def test_compile_diagnostic_outside_workspace_is_not_review_comparable(self) -> None:
+        stderr = b"""
+  File "/outside/bad.py", line 7
+SyntaxError: invalid syntax
+"""
+        result = normalize_baseline_evidence("python.compile", b"", stderr, 1, Path("/repo"))
+        self.assertEqual(result["status"], "measured")
+        self.assertEqual(result["comparison"]["status"], "unavailable")
 
     def test_pytest_success_is_measured_with_empty_evidence(self) -> None:
         result = normalize_baseline_evidence("python.tests", b"3 passed in 0.02s\n", b"", 0, Path("/repo"))

--- a/scripts/tests/test_differential_identity.py
+++ b/scripts/tests/test_differential_identity.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from differential_identity import review_comparable_diagnostic_keys  # noqa: E402
+
+
+class DifferentialIdentityTests(unittest.TestCase):
+    def test_python_syntax_diagnostic_maps_only_to_a_changed_line(self) -> None:
+        report = {
+            "root_path": "/worktree",
+            "changed_files": [
+                {"path": "pkg/bad.py", "ranges": [{"start": 7, "end": 7}]},
+            ],
+            "diagnostics": [
+                {
+                    "code": "python.syntax-error",
+                    "path": "/worktree/pkg/bad.py",
+                    "line": 7,
+                },
+            ],
+        }
+
+        self.assertEqual(
+            review_comparable_diagnostic_keys(report),
+            ["python.compile:pkg/bad.py:7:SyntaxError"],
+        )
+
+    def test_python_syntax_diagnostic_outside_diff_is_not_comparable(self) -> None:
+        report = {
+            "root_path": "/worktree",
+            "changed_files": [
+                {"path": "pkg/bad.py", "ranges": [{"start": 8, "end": 8}]},
+            ],
+            "diagnostics": [
+                {
+                    "code": "python.syntax-error",
+                    "path": "/worktree/pkg/bad.py",
+                    "line": 7,
+                },
+            ],
+        }
+
+        self.assertEqual(review_comparable_diagnostic_keys(report), [])
+
+    def test_unknown_diagnostic_code_and_path_escape_are_ignored(self) -> None:
+        report = {
+            "root_path": "/worktree",
+            "changed_files": [
+                {"path": "pkg/bad.py", "ranges": [{"start": 7, "end": 7}]},
+            ],
+            "diagnostics": [
+                {
+                    "code": "syntax.parse-error",
+                    "path": "/worktree/pkg/bad.py",
+                    "line": 7,
+                },
+                {
+                    "code": "python.syntax-error",
+                    "path": "/outside/bad.py",
+                    "line": 7,
+                },
+            ],
+        }
+
+        self.assertEqual(review_comparable_diagnostic_keys(report), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_differential_pilot.py
+++ b/scripts/tests/test_differential_pilot.py
@@ -92,6 +92,7 @@ class DifferentialPilotTests(unittest.TestCase):
                             },
                         }
                 for review in case["reviews"]:
+                    review["in_diff_comparison_keys"] = []
                     review["telemetry"] = {
                         "schema_version": 1,
                         "events": [
@@ -119,7 +120,7 @@ class DifferentialPilotTests(unittest.TestCase):
         self.assertEqual(output["measurements"]["time_to_first_useful_evidence"]["status"], "measured")
         self.assertEqual(output["measurements"]["time_to_first_useful_evidence"]["median_ms"], 5.0)
         self.assertEqual(output["measurements"]["decision_latency"]["median_ms"], 10.0)
-        self.assertEqual(output["measurements"]["duplicate_work"]["overlap_count"], 1)
+        self.assertEqual(output["measurements"]["duplicate_work"]["overlap_count"], 0)
 
     def test_metrics_do_not_infer_overlap_from_unmapped_baseline_keys(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_differential_runner.py
+++ b/scripts/tests/test_differential_runner.py
@@ -11,12 +11,46 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from differential_artifact import validate_data  # noqa: E402
-from differential_runner import run_timed_command  # noqa: E402
+from differential_runner import _build_review_result, run_timed_command  # noqa: E402
 from differential_telemetry import build_command_telemetry  # noqa: E402
 from real_history_runner import BASELINE_COMMANDS  # noqa: E402
 
 
 class DifferentialRunnerTests(unittest.TestCase):
+    def test_review_result_keeps_comparable_diagnostic_keys_separate(self) -> None:
+        report = {
+            "root_path": "/worktree",
+            "changed_files": [
+                {"path": "pkg/bad.py", "ranges": [{"start": 7, "end": 7}]},
+            ],
+            "diagnostics": [
+                {
+                    "code": "python.syntax-error",
+                    "path": "/worktree/pkg/bad.py",
+                    "line": 7,
+                },
+            ],
+            "findings": [],
+            "schema_version": "0.26",
+            "repopilot_version": "0.23.0",
+            "change_proof": {"contract_deltas": []},
+        }
+
+        result = _build_review_result(
+            report,
+            b"report",
+            0,
+            set(),
+            "available",
+            0.0,
+        )
+
+        self.assertEqual(result["in_diff_evidence_keys"], [])
+        self.assertEqual(
+            result["in_diff_comparison_keys"],
+            ["python.compile:pkg/bad.py:7:SyntaxError"],
+        )
+
     def test_timed_command_records_pass_and_hashes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             result = run_timed_command((sys.executable, "-c", "print('ok')"), Path(tmp), 5)
@@ -122,6 +156,13 @@ class DifferentialRunnerTests(unittest.TestCase):
                 "measurement_rate": None,
                 "keys": 0,
                 "sources": {},
+                "comparison": {
+                    "measured": 0,
+                    "unavailable": 0,
+                    "untracked": 6,
+                    "keys": 0,
+                    "measurement_rate": None,
+                },
             },
         )
 

--- a/src/analysis/artifact.rs
+++ b/src/analysis/artifact.rs
@@ -14,6 +14,7 @@ pub struct SyntaxSummary {
     pub parsed: bool,
     pub root_kind: Option<String>,
     pub has_errors: bool,
+    pub first_error_line: Option<usize>,
     pub named_child_count: usize,
 }
 
@@ -196,6 +197,7 @@ mod tests {
                 parsed: true,
                 root_kind: Some("source_file".to_string()),
                 has_errors: false,
+                first_error_line: None,
                 named_child_count: 2,
             },
         );
@@ -221,6 +223,7 @@ mod tests {
                 parsed: true,
                 root_kind: Some("source_file".to_string()),
                 has_errors: false,
+                first_error_line: None,
                 named_child_count: 2,
             },
         );

--- a/src/analysis/parse.rs
+++ b/src/analysis/parse.rs
@@ -11,7 +11,7 @@ use std::cell::RefCell;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
-use tree_sitter::{Language, Parser, Tree};
+use tree_sitter::{Language, Node, Parser, Tree};
 
 /// Process-global accumulator of time spent inside tree-sitter parsing, in
 /// nanoseconds. Summed across every [`parse`] call on every worker thread, so it
@@ -173,9 +173,18 @@ impl<'a> ParsedFile<'a> {
             parsed: true,
             root_kind: Some(root.kind().to_string()),
             has_errors: root.has_error(),
+            first_error_line: first_error_line(root),
             named_child_count: root.named_child_count(),
         }
     }
+}
+
+fn first_error_line(node: Node<'_>) -> Option<usize> {
+    if node.is_error() || node.is_missing() {
+        return Some(node.start_position().row + 1);
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor).find_map(first_error_line)
 }
 
 #[cfg(test)]
@@ -282,6 +291,16 @@ fn main() {}",
         assert_eq!(first, second);
         assert!(summary.parsed);
         assert_eq!(summary.root_kind.as_deref(), Some("source_file"));
+    }
+
+    #[test]
+    fn syntax_summary_records_first_error_line() {
+        let parsed = ParsedFile::new("def broken(:\n    return 1\n", Some("Python"));
+
+        let summary = parsed.syntax_summary();
+
+        assert!(summary.has_errors);
+        assert_eq!(summary.first_error_line, Some(1));
     }
 
     #[test]

--- a/src/audits/architecture/unresolved_local_imports.rs
+++ b/src/audits/architecture/unresolved_local_imports.rs
@@ -195,6 +195,7 @@ fn limitation_diagnostics(
                 "{count} unresolved internal import(s) used ambiguous or unsupported resolution semantics and were not reported as broken code."
             ),
             path: None,
+            line: None,
         })
         .collect()
 }

--- a/src/scan/facts.rs
+++ b/src/scan/facts.rs
@@ -124,6 +124,7 @@ mod tests {
                 parsed: true,
                 root_kind: Some("source_file".to_string()),
                 has_errors: false,
+                first_error_line: None,
                 named_child_count: 2,
             },
         );

--- a/src/scan/parsed_cache.rs
+++ b/src/scan/parsed_cache.rs
@@ -9,8 +9,9 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-const PARSED_FACTS_SCHEMA_VERSION: u32 = 5;
-const PARSED_FACTS_ANALYSIS_VERSION: &str = "tree-sitter-imports-exports-symbols-spans-guarded-v4";
+const PARSED_FACTS_SCHEMA_VERSION: u32 = 6;
+const PARSED_FACTS_ANALYSIS_VERSION: &str =
+    "tree-sitter-imports-exports-symbols-spans-guarded-syntax-v5";
 const PARSED_FACTS_NAME: &str = "parsed_facts_v2.json";
 const PARSED_FACTS_BACKUP_NAME: &str = "parsed_facts_v2.backup.json";
 const PARSED_FACTS_TEMP_NAME: &str = "parsed_facts_v2.tmp.json";
@@ -47,6 +48,8 @@ pub struct CachedSyntaxSummary {
     pub parsed: bool,
     pub root_kind: Option<String>,
     pub has_errors: bool,
+    #[serde(default)]
+    pub first_error_line: Option<usize>,
     pub named_child_count: usize,
 }
 
@@ -250,6 +253,7 @@ impl From<&SyntaxSummary> for CachedSyntaxSummary {
             parsed: value.parsed,
             root_kind: value.root_kind.clone(),
             has_errors: value.has_errors,
+            first_error_line: value.first_error_line,
             named_child_count: value.named_child_count,
         }
     }
@@ -261,6 +265,7 @@ impl From<&CachedSyntaxSummary> for SyntaxSummary {
             parsed: value.parsed,
             root_kind: value.root_kind.clone(),
             has_errors: value.has_errors,
+            first_error_line: value.first_error_line,
             named_child_count: value.named_child_count,
         }
     }
@@ -319,6 +324,7 @@ mod tests {
                 parsed: true,
                 root_kind: Some("source_file".to_string()),
                 has_errors: false,
+                first_error_line: None,
                 named_child_count: 3,
             },
         );

--- a/src/scan/scanner/changed/finalize.rs
+++ b/src/scan/scanner/changed/finalize.rs
@@ -7,6 +7,7 @@ use super::{
 use crate::findings::quality::SignalQualitySummary;
 use crate::graph::context::summarize_repository_context_state;
 use crate::scan::facts::ScanFacts;
+use crate::scan::scanner::syntax_diagnostics::python_syntax_diagnostics;
 use crate::scan::types::{ScanMode, ScanSummary, ScanTimings};
 use std::io;
 use std::time::Instant;
@@ -30,6 +31,7 @@ impl<'a> ChangedScanEngine<'a> {
         );
         let mut diagnostics = repo_stage.diagnostics;
         diagnostics.extend(finding_pipeline.diagnostics);
+        diagnostics.extend(python_syntax_diagnostics(&file_stage.facts));
 
         let cache_write_start = Instant::now();
         file_stage.cache.write(&discovery.repo_root)?;

--- a/src/scan/scanner/finalize.rs
+++ b/src/scan/scanner/finalize.rs
@@ -1,4 +1,5 @@
 use super::summary::{ScanSummaryParts, build_scan_summary};
+use super::syntax_diagnostics::python_syntax_diagnostics;
 use super::{full::ProjectAnalysisStage, full::ScanEngine, summary};
 use crate::findings::quality::SignalQualitySummary;
 use crate::graph::context::{
@@ -28,6 +29,7 @@ impl<'a> ScanEngine<'a> {
         let finalization_start = Instant::now();
         let context_state = prepare_findings_and_context_state(&mut project_stage);
         let mut diagnostics = diagnostics;
+        diagnostics.extend(python_syntax_diagnostics(&project_stage.facts));
         if crate::graph::was_cycle_detection_depth_exceeded() {
             diagnostics.push(ScanDiagnostic::warning(
                 "graph.cycle-depth-exceeded",

--- a/src/scan/scanner/mod.rs
+++ b/src/scan/scanner/mod.rs
@@ -9,6 +9,7 @@ mod file_pipeline;
 mod finalize;
 mod full;
 mod summary;
+mod syntax_diagnostics;
 mod walker;
 
 pub use changed::{

--- a/src/scan/scanner/syntax_diagnostics.rs
+++ b/src/scan/scanner/syntax_diagnostics.rs
@@ -1,0 +1,65 @@
+use crate::scan::facts::ScanFacts;
+use crate::scan::types::ScanDiagnostic;
+
+pub(super) fn python_syntax_diagnostics(facts: &ScanFacts) -> Vec<ScanDiagnostic> {
+    facts
+        .artifacts()
+        .filter_map(|artifact| {
+            if artifact.language.as_deref() != Some("Python")
+                || !artifact.syntax.has_errors
+            {
+                return None;
+            }
+            let line = artifact.syntax.first_error_line?;
+            Some(
+                ScanDiagnostic::warning(
+                    "python.syntax-error",
+                    format!(
+                        "Python parser detected a syntax error at line {line}; verify with the project's compiler or test command."
+                    ),
+                )
+                .with_path(artifact.path.clone())
+                .with_line(line),
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::{FileContextFacts, ParsedArtifact, SyntaxSummary};
+    use std::path::PathBuf;
+
+    #[test]
+    fn emits_a_stable_python_diagnostic_with_location() {
+        let facts = ScanFacts {
+            artifacts: std::collections::BTreeMap::from([(
+                PathBuf::from("pkg/bad.py"),
+                ParsedArtifact::from_source(
+                    PathBuf::from("pkg/bad.py"),
+                    Some("Python".to_string()),
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    FileContextFacts::default(),
+                    SyntaxSummary {
+                        parsed: true,
+                        root_kind: Some("module".to_string()),
+                        has_errors: true,
+                        first_error_line: Some(7),
+                        named_child_count: 1,
+                    },
+                ),
+            )]),
+            ..ScanFacts::default()
+        };
+
+        let diagnostics = python_syntax_diagnostics(&facts);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "python.syntax-error");
+        assert_eq!(diagnostics[0].path, Some(PathBuf::from("pkg/bad.py")));
+        assert_eq!(diagnostics[0].line, Some(7));
+    }
+}

--- a/src/scan/types/support.rs
+++ b/src/scan/types/support.rs
@@ -174,6 +174,8 @@ pub struct ScanDiagnostic {
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
 }
 
 impl ScanDiagnostic {
@@ -183,6 +185,7 @@ impl ScanDiagnostic {
             severity: DiagnosticSeverity::Error,
             message: message.into(),
             path: None,
+            line: None,
         }
     }
 
@@ -192,11 +195,17 @@ impl ScanDiagnostic {
             severity: DiagnosticSeverity::Warning,
             message: message.into(),
             path: None,
+            line: None,
         }
     }
 
     pub fn with_path(mut self, path: impl Into<PathBuf>) -> Self {
         self.path = Some(path.into());
+        self
+    }
+
+    pub fn with_line(mut self, line: usize) -> Self {
+        self.line = Some(line);
         self
     }
 }

--- a/tests/output_json.rs
+++ b/tests/output_json.rs
@@ -234,6 +234,7 @@ fn json_scan_report_includes_structured_diagnostics() {
                 severity: DiagnosticSeverity::Warning,
                 message: "Package scan failed; results are partial.".to_string(),
                 path: Some(PathBuf::from("packages/api")),
+                line: None,
             }],
             ..Default::default()
         },

--- a/tests/review_command.rs
+++ b/tests/review_command.rs
@@ -63,6 +63,30 @@ fn review_reports_working_tree_findings_on_changed_lines() {
 }
 
 #[test]
+fn review_reports_python_syntax_diagnostic_on_the_changed_line() {
+    let temp = tempdir().expect("failed to create temp dir");
+    init_repo(temp.path());
+    fs::write(temp.path().join("bad.py"), "def ok():\n    return 1\n")
+        .expect("write valid Python source");
+    commit_all(temp.path(), "initial");
+
+    fs::write(temp.path().join("bad.py"), "def broken(:\n    return 2\n")
+        .expect("write invalid Python source");
+
+    let json = run_review_json(temp.path(), &["review", ".", "--format", "json"]);
+
+    let diagnostic = json["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array")
+        .iter()
+        .find(|item| item["code"] == "python.syntax-error")
+        .expect("changed Python syntax should be reported");
+    assert_eq!(diagnostic["path"], "bad.py");
+    assert_eq!(diagnostic["line"], 1);
+    assert_eq!(json["changed_files"][0]["ranges"][0]["start"], 1);
+}
+
+#[test]
 fn review_treats_untracked_files_as_fully_changed() {
     let temp = tempdir().expect("failed to create temp dir");
     init_repo(temp.path());

--- a/tests/scan_changed_cache_cli.rs
+++ b/tests/scan_changed_cache_cli.rs
@@ -73,7 +73,7 @@ fn changed_scan_writes_cache_and_reuses_matching_findings() {
     );
     assert_eq!(
         read_json(&cache_dir.join("parsed_facts_v2.json"))["analysis_version"],
-        "tree-sitter-imports-exports-symbols-spans-guarded-v4"
+        "tree-sitter-imports-exports-symbols-spans-guarded-syntax-v5"
     );
     assert_eq!(
         read_json(&cache_dir.join("parsed_facts_v2.json"))["entries"][0]["content_hash"]
@@ -147,10 +147,10 @@ fn typed_symbol_facts_are_persisted_and_reused_by_changed_scan() {
     scan_changed_json(temp.path(), &["--changed"]);
     let cache_path = temp.path().join(".repopilot/cache/parsed_facts_v2.json");
     let cache = read_json(&cache_path);
-    assert_eq!(cache["schema_version"], 5);
+    assert_eq!(cache["schema_version"], 6);
     assert_eq!(
         cache["analysis_version"],
-        "tree-sitter-imports-exports-symbols-spans-guarded-v4"
+        "tree-sitter-imports-exports-symbols-spans-guarded-syntax-v5"
     );
     let named_import = cache["entries"]
         .as_array()
@@ -317,7 +317,7 @@ fn changed_scan_invalidates_old_cache_schema() {
         "missing-cache-entry"
     );
     let rebuilt = read_json(&cache_dir.join("parsed_facts_v2.json"));
-    assert_eq!(rebuilt["schema_version"], 5);
+    assert_eq!(rebuilt["schema_version"], 6);
     assert!(
         rebuilt["entries"]
             .as_array()


### PR DESCRIPTION
## Summary

RepoPilot now exposes a deterministic Python syntax diagnostic and measures the first non-empty compiler-to-review overlap through the existing `review-exact-v1` contract.

## What changed

- record the first tree-sitter syntax-error line in parsed facts and invalidate older parsed caches
- publish `python.syntax-error` diagnostics with path and line in scan/review JSON
- map only `SyntaxError` identities whose line is inside an added diff range to `python.compile:<path>:<line>:SyntaxError`
- keep compiler kinds, paths outside the workspace, unchanged-line diagnostics, and pytest failures explicitly unavailable
- keep comparison keys separate from RepoPilot finding identities and report comparison coverage independently
- add unit and CLI regression coverage plus v0.23 roadmap/ledger/changelog evidence boundaries

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (200 passed)
- `cargo fmt --all -- --check`
- `cargo test --test review_command review_reports_python_syntax_diagnostic_on_the_changed_line`
- `cargo test --test scan_changed_cache_cli` (19 passed)
- `python3 scripts/release-contract.py check`
- differential v4: 36/36 baseline runs tracked/measured; 18 comparison-measured, 18 unavailable; no utility score claimed

Hosted CI is green across Rust, CodeQL, security/maintenance, and Ubuntu/macOS/Windows smoke. Targeted local Rust/Python checks pass; no utility score or RP23-014 closure is claimed.
