### PR TITLE
feat: audit differential evidence coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   kinds, unchanged-line diagnostics, and unsupported baseline failures remain
   unavailable. Validation reports comparison coverage separately from baseline
   adapter coverage.
+- Added a deterministic differential coverage audit. It partitions comparable
+  evidence by baseline, preserves unavailable mapping reasons, and emits the
+  next adapter action without turning adapter coverage into a utility claim.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -330,6 +330,10 @@ bump is needed to start.
   baseline coverage, including measured, unavailable, untracked, and mapped-key
   counts. This keeps adapter coverage from being read as duplicate-work
   evidence.
+- `coverage-audit` now partitions that denominator by baseline ID and preserves
+  unavailable mapping reasons in a deterministic report. The report identifies
+  the next adapter action while retaining the hard boundary that no exact
+  identity means no overlap measurement.
 - Boundary: these are still unlabeled observations. Frozen environments,
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -448,6 +448,9 @@ remain unavailable until an equally exact mapping is designed and tested.
 The validation summary now reports comparison coverage separately from
 baseline-diagnostic coverage, so a measured adapter run cannot be mistaken for
 a comparable overlap measurement.
+The `coverage-audit` report now breaks this denominator down by baseline ID and
+reason, making the next exact-identity adapter a reviewable work item instead
+of hiding unavailable runs inside one aggregate percentage.
 
 Initial release discipline:
 

--- a/scripts/differential.py
+++ b/scripts/differential.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from differential_artifact import validate_artifact, validate_data
 from differential_contract import DifferentialManifestError, validate_differential
+from differential_coverage import render_coverage_audit
 from differential_pilot import render_pilot_template, validate_pilot
 from differential_pilot_metrics import validate_pilot_metrics, write_pilot_metrics
 from differential_metrics_report import write_differential_metrics_report
@@ -31,6 +32,7 @@ def main(argv: list[str] | None = None) -> int:
             "pilot-score",
             "pilot-validate-metrics",
             "pilot-metrics-report",
+            "coverage-audit",
         ),
         default="check",
     )
@@ -211,6 +213,26 @@ def main(argv: list[str] | None = None) -> int:
             print(f"pilot metrics report failed: {error}", file=sys.stderr)
             return 1
         print(f"Pilot metrics report: {args.output}")
+        return 0
+    if args.command == "coverage-audit":
+        if args.artifact is None or args.output is None:
+            print("coverage-audit requires --artifact and --output", file=sys.stderr)
+            return 2
+        try:
+            validation = validate_artifact(
+                args.artifact,
+                args.holdout_manifest,
+                args.manifest,
+                args.rules_reference,
+                args.zoo_manifest,
+            )
+            report = render_coverage_audit(validation)
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(report, encoding="utf-8")
+        except (DifferentialManifestError, HoldoutManifestError, OSError, KeyError, TypeError) as error:
+            print(f"coverage audit failed: {error}", file=sys.stderr)
+            return 1
+        print(f"Differential coverage audit: {args.output}")
         return 0
     if args.format == "json":
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/scripts/differential_artifact.py
+++ b/scripts/differential_artifact.py
@@ -62,14 +62,29 @@ def baseline_evidence_summary(observations: list[dict[str, Any]]) -> dict[str, o
     total = tracked = measured = unavailable = untracked = key_count = 0
     comparison_measured = comparison_unavailable = comparison_untracked = comparison_key_count = 0
     sources: Counter[str] = Counter()
+    comparison_by_baseline: dict[str, dict[str, object]] = {}
+    comparison_reasons: Counter[str] = Counter()
     for observation in observations:
-        for runs in observation.get("baselines", {}).values():
+        for baseline_id, runs in observation.get("baselines", {}).items():
+            coverage = comparison_by_baseline.setdefault(
+                baseline_id,
+                {
+                    "total": 0,
+                    "measured": 0,
+                    "unavailable": 0,
+                    "untracked": 0,
+                    "keys": 0,
+                    "unavailable_reasons": Counter(),
+                },
+            )
             for run in runs:
                 total += 1
+                coverage["total"] += 1
                 evidence = run.get("evidence") if isinstance(run, dict) else None
                 if not isinstance(evidence, dict):
                     untracked += 1
                     comparison_untracked += 1
+                    coverage["untracked"] += 1
                     continue
                 tracked += 1
                 status = evidence.get("status")
@@ -83,11 +98,24 @@ def baseline_evidence_summary(observations: list[dict[str, Any]]) -> dict[str, o
                 comparison = evidence.get("comparison")
                 if isinstance(comparison, dict) and comparison.get("status") == "measured":
                     comparison_measured += 1
-                    comparison_key_count += len(comparison.get("keys", []))
+                    keys = comparison.get("keys", [])
+                    comparison_key_count += len(keys)
+                    coverage["measured"] += 1
+                    coverage["keys"] += len(keys)
                 elif isinstance(comparison, dict) and comparison.get("status") == "unavailable":
                     comparison_unavailable += 1
+                    coverage["unavailable"] += 1
+                    reason = str(comparison.get("reason") or "unspecified")
+                    comparison_reasons[reason] += 1
+                    coverage["unavailable_reasons"][reason] += 1
                 else:
                     comparison_untracked += 1
+                    coverage["untracked"] += 1
+    for coverage in comparison_by_baseline.values():
+        reasons = coverage["unavailable_reasons"]
+        coverage["unavailable_reasons"] = dict(sorted(reasons.items()))
+        denominator = coverage["measured"] + coverage["unavailable"]
+        coverage["measurement_rate"] = round(coverage["measured"] / denominator, 3) if denominator else None
     return {
         "total": total,
         "tracked": tracked,
@@ -108,6 +136,8 @@ def baseline_evidence_summary(observations: list[dict[str, Any]]) -> dict[str, o
             )
             if comparison_measured + comparison_unavailable
             else None,
+            "by_baseline": dict(sorted(comparison_by_baseline.items())),
+            "unavailable_reasons": dict(sorted(comparison_reasons.items())),
         },
     }
 

--- a/scripts/differential_coverage.py
+++ b/scripts/differential_coverage.py
@@ -1,0 +1,65 @@
+"""Render an evidence coverage audit for a validated differential artifact."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _number(value: Any) -> str:
+    return "—" if value is None else str(value)
+
+
+def _reasons(value: Any) -> str:
+    if not isinstance(value, dict) or not value:
+        return "—"
+    return "; ".join(f"{reason} ({count})" for reason, count in sorted(value.items()))
+
+
+def render_coverage_audit(validation: dict[str, Any]) -> str:
+    """Render coverage denominators and explicit next actions, without scoring utility."""
+
+    evidence = validation["baseline_evidence"]
+    comparison = evidence["comparison"]
+    lines = [
+        "# Differential evidence coverage audit",
+        "",
+        f"- **Corpus:** {validation['corpus']}",
+        f"- **Protocol:** {validation['protocol']}",
+        f"- **Baseline evidence:** {evidence['measured']}/{evidence['tracked']} tracked runs measured",
+        f"- **Review-comparable evidence:** {comparison['measured']} measured, "
+        f"{comparison['unavailable']} unavailable, {comparison['untracked']} untracked",
+        "",
+        "This is an adapter-coverage audit. It does not estimate precision, recall, utility, or overlap "
+        "when a baseline identity mapping is unavailable.",
+        "",
+        "## Coverage by baseline",
+        "",
+        "| Baseline | Runs | Comparable measured | Unavailable | Untracked | Keys | Rate | Reasons |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for baseline_id, details in comparison.get("by_baseline", {}).items():
+        lines.append(
+            f"| `{baseline_id}` | {details['total']} | {details['measured']} | "
+            f"{details['unavailable']} | {details['untracked']} | {details['keys']} | "
+            f"{_number(details['measurement_rate'])} | {_reasons(details['unavailable_reasons'])} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Next measurement action",
+            "",
+        ]
+    )
+    reasons = comparison.get("unavailable_reasons", {})
+    if reasons:
+        lines.append(
+            "Add or review an exact `review-exact-v1` identity adapter for the unavailable baseline "
+            "reasons above before interpreting duplicate work. Keep those runs unavailable until the "
+            "mapping is proven against changed-line provenance."
+        )
+    else:
+        lines.append(
+            "No unavailable comparison reasons were recorded; inspect the measured keys before scoring overlap."
+        )
+    lines.extend(["", "The report is deterministic and derived from a validated artifact.", ""])
+    return "\n".join(lines)

--- a/scripts/tests/test_differential.py
+++ b/scripts/tests/test_differential.py
@@ -102,6 +102,7 @@ baseline_ids = ["python.tests"]
         self.assertEqual(differential.main(["pilot-score", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
         self.assertEqual(differential.main(["pilot-validate-metrics", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
         self.assertEqual(differential.main(["pilot-metrics-report", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
+        self.assertEqual(differential.main(["coverage-audit", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
 
 
 class ProductionDifferentialManifestTests(unittest.TestCase):

--- a/scripts/tests/test_differential_coverage.py
+++ b/scripts/tests/test_differential_coverage.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from differential_coverage import render_coverage_audit  # noqa: E402
+
+
+class DifferentialCoverageTests(unittest.TestCase):
+    def test_render_keeps_unavailable_reasons_and_measurement_boundary(self) -> None:
+        report = render_coverage_audit(
+            {
+                "corpus": "holdout",
+                "protocol": "differential-utility-v1",
+                "baseline_evidence": {
+                    "tracked": 6,
+                    "measured": 6,
+                    "comparison": {
+                        "measured": 3,
+                        "unavailable": 3,
+                        "untracked": 0,
+                        "by_baseline": {
+                            "python.compile": {
+                                "total": 3,
+                                "measured": 3,
+                                "unavailable": 0,
+                                "untracked": 0,
+                                "keys": 1,
+                                "measurement_rate": 1.0,
+                                "unavailable_reasons": {},
+                            },
+                            "python.tests": {
+                                "total": 3,
+                                "measured": 0,
+                                "unavailable": 3,
+                                "untracked": 0,
+                                "keys": 0,
+                                "measurement_rate": 0.0,
+                                "unavailable_reasons": {
+                                    "baseline evidence has no review-comparable identity mapping": 3,
+                                },
+                            },
+                        },
+                        "unavailable_reasons": {
+                            "baseline evidence has no review-comparable identity mapping": 3,
+                        },
+                    },
+                },
+            }
+        )
+        self.assertIn("| `python.compile` | 3 | 3 | 0 | 0 | 1 | 1.0 |", report)
+        self.assertIn("identity mapping (3)", report)
+        self.assertIn("does not estimate precision, recall, utility, or overlap", report)
+        self.assertIn("Add or review an exact `review-exact-v1` identity adapter", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_differential_runner.py
+++ b/scripts/tests/test_differential_runner.py
@@ -162,6 +162,27 @@ class DifferentialRunnerTests(unittest.TestCase):
                     "untracked": 6,
                     "keys": 0,
                     "measurement_rate": None,
+                    "by_baseline": {
+                        "python.compile": {
+                            "total": 3,
+                            "measured": 0,
+                            "unavailable": 0,
+                            "untracked": 3,
+                            "keys": 0,
+                            "unavailable_reasons": {},
+                            "measurement_rate": None,
+                        },
+                        "python.tests": {
+                            "total": 3,
+                            "measured": 0,
+                            "unavailable": 0,
+                            "untracked": 3,
+                            "keys": 0,
+                            "unavailable_reasons": {},
+                            "measurement_rate": None,
+                        },
+                    },
+                    "unavailable_reasons": {},
                 },
             },
         )

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -19,6 +19,8 @@ python3 scripts/differential.py collect --repo-root . \
   --output differential-run.json
 python3 scripts/differential.py validate-result \
   --artifact differential-run.json
+python3 scripts/differential.py coverage-audit \
+  --artifact differential-run.json --output coverage-audit.md
 python3 scripts/differential.py pilot-template \
   --artifact differential-run.json --reviewer expert \
   --output pilot.toml
@@ -56,6 +58,10 @@ output hashes alone are not treated as evidence overlap. A baseline diagnostic
 ID is not automatically comparable to a RepoPilot finding ID: duplicate-work
 requires an explicit `review-exact-v1` comparison mapping, otherwise the
 measurement remains unavailable.
+
+`coverage-audit` renders the same validated denominators by baseline ID. It
+keeps unavailable reasons visible and points to the next adapter work without
+scoring precision, recall, utility, or overlap.
 
 When one reviewer is available, `pilot-template` creates an exploratory
 worksheet over the same pinned differential artifact. `pilot-score` reports


### PR DESCRIPTION
## Problem

Differential validation reported only one aggregate comparison denominator. That showed how many baseline runs were comparable, but not which baseline caused the gap or why an adapter remained unavailable.

## What changed

- add per-baseline comparison coverage to the validated artifact summary;
- preserve deterministic unavailable reasons and mapped-key counts;
- add `scripts/differential.py coverage-audit` to render a reviewable Markdown audit;
- keep the hard evidence boundary: missing `review-exact-v1` identity remains unavailable and never becomes a utility or overlap claim;
- document the workflow in the benchmark README, roadmap, evidence ledger, and changelog.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (201 passed)
- `python3 scripts/release-contract.py check` (passed)
- `python3 -m py_compile scripts/differential.py scripts/differential_artifact.py scripts/differential_coverage.py`
- `git diff --check`
- v5 packet remains valid: 36/36 baseline runs measured; 18 comparable and 18 unavailable with explicit reasons.
