### PR TITLE
feat: clarify differential adapter boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added a deterministic differential coverage audit. It partitions comparable
   evidence by baseline, preserves unavailable mapping reasons, and emits the
   next adapter action without turning adapter coverage into a utility claim.
+- Clarified the pytest comparison boundary: normalized node IDs remain
+  baseline evidence, but comparison stays unavailable until review exposes an
+  exact test-node failure identity. Path-only or changed-test-name matching is
+  rejected as non-comparable.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -334,6 +334,10 @@ bump is needed to start.
   unavailable mapping reasons in a deterministic report. The report identifies
   the next adapter action while retaining the hard boundary that no exact
   identity means no overlap measurement.
+- The pytest boundary is now typed: node IDs are measured baseline evidence,
+  while comparison is unavailable because static review emits no exact failed
+  test-node identity. Path-only and changed-test-name matching are explicitly
+  rejected.
 - Boundary: these are still unlabeled observations. Frozen environments,
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -451,6 +451,8 @@ a comparable overlap measurement.
 The `coverage-audit` report now breaks this denominator down by baseline ID and
 reason, making the next exact-identity adapter a reviewable work item instead
 of hiding unavailable runs inside one aggregate percentage.
+For pytest, the next adapter cannot be a path heuristic: RepoPilot would need
+review-side exact failure provenance before a test-node overlap can be measured.
 
 Initial release discipline:
 

--- a/scripts/differential_coverage.py
+++ b/scripts/differential_coverage.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from typing import Any
 
 
+_PYTEST_FAILURE_MAPPING_REASON = "python.tests review has no exact test-node failure identity"
+
+
 def _number(value: Any) -> str:
     return "—" if value is None else str(value)
 
@@ -52,11 +55,17 @@ def render_coverage_audit(validation: dict[str, Any]) -> str:
     )
     reasons = comparison.get("unavailable_reasons", {})
     if reasons:
-        lines.append(
-            "Add or review an exact `review-exact-v1` identity adapter for the unavailable baseline "
-            "reasons above before interpreting duplicate work. Keep those runs unavailable until the "
-            "mapping is proven against changed-line provenance."
-        )
+        if any(_PYTEST_FAILURE_MAPPING_REASON in reason for reason in reasons):
+            lines.append(
+                "For `python.tests`, keep node failures unavailable until review emits exact test-node "
+                "failure provenance. Do not derive overlap from a test path or changed test name."
+            )
+        else:
+            lines.append(
+                "Add or review an exact `review-exact-v1` identity adapter for the unavailable baseline "
+                "reasons above before interpreting duplicate work. Keep those runs unavailable until the "
+                "mapping is proven against changed-line provenance."
+            )
     else:
         lines.append(
             "No unavailable comparison reasons were recorded; inspect the measured keys before scoring overlap."

--- a/scripts/differential_evidence.py
+++ b/scripts/differential_evidence.py
@@ -20,6 +20,9 @@ _PYTEST_CONFTEST_ERROR = re.compile(
 )
 _COMPARISON_SCHEME = REVIEW_COMPARISON_SCHEME
 _COMPARABLE_COMPILE_KINDS = {"SyntaxError"}
+_PYTEST_COMPARISON_UNAVAILABLE = (
+    "python.tests review has no exact test-node failure identity; node paths alone are not comparable"
+)
 
 
 def _text(value: bytes | str) -> str:
@@ -58,10 +61,19 @@ def _unavailable(reason: str) -> dict[str, Any]:
 
 
 def _measured(
-    source: str, keys: list[str], comparison_keys: list[str] | None = None
+    source: str,
+    keys: list[str],
+    comparison_keys: list[str] | None = None,
+    comparison_reason: str | None = None,
 ) -> dict[str, Any]:
     comparison: dict[str, Any]
-    if comparison_keys is None and not keys:
+    if comparison_reason is not None:
+        comparison = {
+            "status": "unavailable",
+            "reason": comparison_reason,
+            "scheme": _COMPARISON_SCHEME,
+        }
+    elif comparison_keys is None and not keys:
         comparison = {"status": "measured", "keys": [], "scheme": _COMPARISON_SCHEME}
     elif comparison_keys is None:
         comparison = {
@@ -143,7 +155,11 @@ def _pytest_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> di
         keys.add(f"python.tests:{normalized_node}:{status}")
     if not keys:
         return _unavailable("python.tests output did not contain a supported diagnostic")
-    return _measured("python.tests-v1", sorted(keys))
+    return _measured(
+        "python.tests-v1",
+        sorted(keys),
+        comparison_reason=_PYTEST_COMPARISON_UNAVAILABLE,
+    )
 
 
 def normalize_baseline_evidence(

--- a/scripts/tests/test_differential_coverage.py
+++ b/scripts/tests/test_differential_coverage.py
@@ -42,21 +42,22 @@ class DifferentialCoverageTests(unittest.TestCase):
                                 "keys": 0,
                                 "measurement_rate": 0.0,
                                 "unavailable_reasons": {
-                                    "baseline evidence has no review-comparable identity mapping": 3,
+                                    "python.tests review has no exact test-node failure identity; node paths alone are not comparable": 3,
                                 },
                             },
                         },
                         "unavailable_reasons": {
-                            "baseline evidence has no review-comparable identity mapping": 3,
+                            "python.tests review has no exact test-node failure identity; node paths alone are not comparable": 3,
                         },
                     },
                 },
             }
         )
         self.assertIn("| `python.compile` | 3 | 3 | 0 | 0 | 1 | 1.0 |", report)
-        self.assertIn("identity mapping (3)", report)
+        self.assertIn("test-node failure identity", report)
         self.assertIn("does not estimate precision, recall, utility, or overlap", report)
-        self.assertIn("Add or review an exact `review-exact-v1` identity adapter", report)
+        self.assertIn("For `python.tests`, keep node failures unavailable", report)
+        self.assertIn("Do not derive overlap from a test path", report)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_differential_evidence.py
+++ b/scripts/tests/test_differential_evidence.py
@@ -86,6 +86,14 @@ ERROR collecting tests/test_import.py
                 "python.tests:tests/test_import.py:collection-error",
             ],
         )
+        self.assertEqual(
+            result["comparison"],
+            {
+                "status": "unavailable",
+                "reason": "python.tests review has no exact test-node failure identity; node paths alone are not comparable",
+                "scheme": "review-exact-v1",
+            },
+        )
 
     def test_pytest_unknown_failure_is_unavailable(self) -> None:
         result = normalize_baseline_evidence("python.tests", b"pytest crashed", b"", 2, Path("/repo"))

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -63,6 +63,11 @@ measurement remains unavailable.
 keeps unavailable reasons visible and points to the next adapter work without
 scoring precision, recall, utility, or overlap.
 
+For `python.tests`, a failed pytest node remains baseline-only. RepoPilot does
+not execute tests during review, so a test path or changed test name cannot
+prove the same failure identity; the comparison stays unavailable until a
+review-side exact failure provenance exists.
+
 When one reviewer is available, `pilot-template` creates an exploratory
 worksheet over the same pinned differential artifact. `pilot-score` reports
 only captured novel-evidence, timing, determinism, and resource fields;


### PR DESCRIPTION
## Problem

The pytest adapter measured stable node IDs, but its generic unavailable reason did not explain why overlap could not be compared. A path or changed test name cannot prove that a static review found the same failed test.

## What changed

- give recognized `python.tests` failures a typed `review-exact-v1` unavailable reason;
- keep pytest node IDs as baseline evidence while refusing path-only or test-name matching;
- make `coverage-audit` render the next action: review-side exact failed-node provenance is required before overlap can be measured;
- document the boundary and add regression coverage.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (201 passed)
- `python3 scripts/release-contract.py check` (passed)
- `python3 -m py_compile ...` (passed)
- `git diff --check` (passed)