### PR TITLE
fix: keep differential RSS evidence honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   baseline evidence, but comparison stays unavailable until review exposes an
   exact test-node failure identity. Path-only or changed-test-name matching is
   rejected as non-comparable.
+- Hardened differential resource evidence: cumulative child RSS is recorded
+  only when a positive per-command sample exists; non-positive or unavailable
+  deltas are explicitly marked unavailable instead of being reported as zero.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -338,6 +338,10 @@ bump is needed to start.
   while comparison is unavailable because static review emits no exact failed
   test-node identity. Path-only and changed-test-name matching are explicitly
   rejected.
+- Differential RSS is now fail-closed as well. Because `ru_maxrss` is
+  cumulative child usage, only a positive per-command delta is retained as a
+  sample; zero and unsupported deltas remain unavailable and cannot close
+  RP23-004.
 - Boundary: these are still unlabeled observations. Frozen environments,
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -453,6 +453,8 @@ reason, making the next exact-identity adapter a reviewable work item instead
 of hiding unavailable runs inside one aggregate percentage.
 For pytest, the next adapter cannot be a path heuristic: RepoPilot would need
 review-side exact failure provenance before a test-node overlap can be measured.
+Resource-cost reporting follows the same evidence discipline: non-positive
+cumulative RSS deltas remain unavailable until a per-command sample exists.
 
 Initial release discipline:
 

--- a/scripts/differential_artifact.py
+++ b/scripts/differential_artifact.py
@@ -224,6 +224,7 @@ def validate_case(
             if not isinstance(run.get("wall_ms"), (int, float)) or run["wall_ms"] < 0:
                 raise DifferentialManifestError(f"case {case.case_id}: invalid baseline timing")
             _validate_run_telemetry(run, run["wall_ms"], schema_version, f"case {case.case_id} baseline")
+            _validate_resource_usage(run, f"case {case.case_id} baseline")
             _validate_baseline_evidence(run, f"case {case.case_id} baseline", schema_version, baseline_id)
     base_scan = observation.get("base_scan")
     if not isinstance(base_scan, dict) or base_scan.get("status") not in BASE_SCAN_STATUSES:
@@ -242,6 +243,7 @@ def validate_case(
         if not isinstance(review.get("wall_ms"), (int, float)) or review["wall_ms"] < 0:
             raise DifferentialManifestError(f"case {case.case_id}: invalid review timing")
         _validate_run_telemetry(review, review["wall_ms"], schema_version, f"case {case.case_id} review")
+        _validate_resource_usage(review, f"case {case.case_id} review")
         if review["status"] == "collected" and not isinstance(review.get("stable_evidence_sha256"), str):
             raise DifferentialManifestError(f"case {case.case_id}: collected review lacks stable evidence hash")
         if review["status"] == "collected":
@@ -270,6 +272,24 @@ def _validate_run_telemetry(
         validate_telemetry(telemetry, wall_ms, context)
     except ValueError as error:
         raise DifferentialManifestError(str(error)) from error
+
+
+def _validate_resource_usage(run: dict[str, Any], context: str) -> None:
+    status = run.get("resource_status")
+    if status is None:
+        return
+    if status not in {"available", "unavailable"}:
+        raise DifferentialManifestError(f"{context}: resource status is invalid")
+    sample = run.get("child_max_rss_kb")
+    if status == "available":
+        if not isinstance(sample, (int, float)) or sample < 0:
+            raise DifferentialManifestError(f"{context}: available resource sample is missing")
+        if "resource_reason" in run:
+            raise DifferentialManifestError(f"{context}: available resource sample has a reason")
+    elif not isinstance(run.get("resource_reason"), str) or not run["resource_reason"]:
+        raise DifferentialManifestError(f"{context}: unavailable resource reason is missing")
+    if status == "unavailable" and sample is not None:
+        raise DifferentialManifestError(f"{context}: unavailable resource sample must be omitted")
 
 
 def _validate_baseline_evidence(

--- a/scripts/differential_runner.py
+++ b/scripts/differential_runner.py
@@ -47,6 +47,27 @@ def _resource_snapshot() -> tuple[str, int | None]:
     return "available", max_rss
 
 
+def _record_resource_usage(
+    result: dict[str, Any],
+    resource_status: str,
+    resource_before: int | None,
+    resource_after: int | None,
+) -> None:
+    """Record only a positive per-command RSS sample from cumulative child usage."""
+
+    if resource_status != "available" or resource_before is None or resource_after is None:
+        result["resource_status"] = "unavailable"
+        result["resource_reason"] = "per-command child RSS sample is unavailable"
+        return
+    delta = resource_after - resource_before
+    if delta <= 0:
+        result["resource_status"] = "unavailable"
+        result["resource_reason"] = "cumulative child RSS delta was non-positive"
+        return
+    result["resource_status"] = "available"
+    result["child_max_rss_kb"] = delta
+
+
 def run_timed_command(
     command: tuple[str, ...], cwd: Path, timeout_seconds: int, baseline_id: str | None = None
 ) -> dict[str, Any]:
@@ -81,8 +102,7 @@ def run_timed_command(
         if baseline_id is not None and status in {"passed", "failed"}
         else {"status": "unavailable", "reason": "baseline command did not complete"}
     )
-    if resource_before is not None and resource_after is not None:
-        result["child_max_rss_kb"] = max(0, resource_after - resource_before)
+    _record_resource_usage(result, resource_status, resource_before, resource_after)
     return result
 
 
@@ -169,8 +189,7 @@ def _review_once(
         report, process.stdout, process.returncode, base_evidence, resource_status, started
     )
     _, resource_after = _resource_snapshot()
-    if resource_before is not None and resource_after is not None:
-        result["child_max_rss_kb"] = max(0, resource_after - resource_before)
+    _record_resource_usage(result, resource_status, resource_before, resource_after)
     return result
 
 

--- a/scripts/tests/test_differential_runner.py
+++ b/scripts/tests/test_differential_runner.py
@@ -11,12 +11,30 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from differential_artifact import validate_data  # noqa: E402
-from differential_runner import _build_review_result, run_timed_command  # noqa: E402
+from differential_runner import _build_review_result, _record_resource_usage, run_timed_command  # noqa: E402
 from differential_telemetry import build_command_telemetry  # noqa: E402
 from real_history_runner import BASELINE_COMMANDS  # noqa: E402
 
 
 class DifferentialRunnerTests(unittest.TestCase):
+    def test_resource_usage_rejects_non_positive_cumulative_delta(self) -> None:
+        result = {"resource_status": "available"}
+
+        _record_resource_usage(result, "available", 4096, 4096)
+
+        self.assertEqual(result["resource_status"], "unavailable")
+        self.assertNotIn("child_max_rss_kb", result)
+        self.assertIn("cumulative", result["resource_reason"])
+
+    def test_resource_usage_keeps_positive_delta_as_a_measured_sample(self) -> None:
+        result = {"resource_status": "available"}
+
+        _record_resource_usage(result, "available", 4096, 5120)
+
+        self.assertEqual(result["resource_status"], "available")
+        self.assertEqual(result["child_max_rss_kb"], 1024)
+        self.assertNotIn("resource_reason", result)
+
     def test_review_result_keeps_comparable_diagnostic_keys_separate(self) -> None:
         report = {
             "root_path": "/worktree",
@@ -226,6 +244,27 @@ class DifferentialRunnerTests(unittest.TestCase):
         self.assertEqual(result["status"], "valid")
         self.assertEqual(result["baseline_evidence"]["unavailable"], 6)
         self.assertEqual(result["baseline_evidence"]["measurement_rate"], 0.0)
+
+    def test_artifact_rejects_available_resource_without_a_sample(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            holdout, differential, rules, zoo = self._write_manifests(root)
+            artifact = self._valid_artifact(holdout, differential)
+            artifact["schema_version"] = 2
+            for case in artifact["cases"]:
+                case["base_scan"]["telemetry"] = build_command_telemetry(1.0)
+                for runs in case["baselines"].values():
+                    for run in runs:
+                        run["telemetry"] = build_command_telemetry(1.0)
+                        run["evidence"] = {
+                            "status": "unavailable",
+                            "reason": "fixture has no baseline adapter",
+                        }
+                        run["resource_status"] = "available"
+                for review in case["reviews"]:
+                    review["telemetry"] = build_command_telemetry(1.0)
+            with self.assertRaisesRegex(ValueError, "available resource sample"):
+                validate_data(artifact, holdout, differential, rules, zoo)
 
     def test_artifact_schema_two_requires_provenance_for_measured_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -63,6 +63,10 @@ measurement remains unavailable.
 keeps unavailable reasons visible and points to the next adapter work without
 scoring precision, recall, utility, or overlap.
 
+Resource samples follow the same boundary: cumulative child RSS is measured
+only when a positive per-command delta is available. A zero or unsupported
+delta is reported as unavailable, never as proof of zero memory use.
+
 For `python.tests`, a failed pytest node remains baseline-only. RepoPilot does
 not execute tests during review, so a test path or changed test name cannot
 prove the same failure identity; the comparison stays unavailable until a


### PR DESCRIPTION
## Problem

Differential collection used the difference between cumulative `RUSAGE_CHILDREN.ru_maxrss` values as if it were a per-command peak RSS sample. When the delta was zero, reports could imply zero memory use even though the sample was not attributable to the command.

## What changed

- retain `child_max_rss_kb` only for a positive per-command delta;
- mark non-positive or unsupported samples `resource_status = unavailable` with a reason;
- validate available/unavailable resource records in schema artifacts;
- keep resource summaries unavailable instead of treating zero as measured memory;
- add regression tests and document the boundary for RP23-004.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (204 passed)
- `python3 scripts/release-contract.py check` (passed)
- `python3 -m py_compile scripts/differential_runner.py scripts/differential_artifact.py scripts/tests/test_differential_runner.py`
- `git diff --check`
- direct command probe records a positive RSS sample; non-positive deltas are rejected by unit tests.
