### PR TITLE
feat: measure differential RSS by cold and warm phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Hardened differential resource evidence: cumulative child RSS is recorded
   only when a positive per-command sample exists; non-positive or unavailable
   deltas are explicitly marked unavailable instead of being reported as zero.
+- Added a portable POSIX peak-RSS sampler using `/usr/bin/time` with explicit
+  source identity and parser coverage for Linux and macOS. Unsupported
+  platforms and malformed sampler output remain unavailable.
+- Added cold/warm resource phases to repeated differential runs and metrics;
+  reports now keep first-run cold RSS separate from subsequent warm samples.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -342,6 +342,13 @@ bump is needed to start.
   cumulative child usage, only a positive per-command delta is retained as a
   sample; zero and unsupported deltas remain unavailable and cannot close
   RP23-004.
+- The collector now uses `/usr/bin/time` on Linux and macOS for a true
+  per-command peak sample and records `posix-time-v1` provenance. Unsupported
+  platforms or unparsable output remain unavailable rather than being mixed
+  into the RSS denominator.
+- Repeated differential runs now carry explicit `cold`/`warm` phases, and
+  pilot metrics/reporting keep their RSS medians separate. This prevents warm
+  process reuse from hiding first-run resource cost.
 - Boundary: these are still unlabeled observations. Frozen environments,
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -455,6 +455,11 @@ For pytest, the next adapter cannot be a path heuristic: RepoPilot would need
 review-side exact failure provenance before a test-node overlap can be measured.
 Resource-cost reporting follows the same evidence discipline: non-positive
 cumulative RSS deltas remain unavailable until a per-command sample exists.
+The differential collector now obtains that sample from `/usr/bin/time` on
+Linux and macOS with explicit provenance; unsupported platforms remain outside
+the measured RSS denominator.
+Repeated runs are labeled cold versus warm so the eventual performance budget
+can be set against both startup and steady-state behavior.
 
 Initial release discipline:
 

--- a/scripts/differential_artifact.py
+++ b/scripts/differential_artifact.py
@@ -225,6 +225,7 @@ def validate_case(
                 raise DifferentialManifestError(f"case {case.case_id}: invalid baseline timing")
             _validate_run_telemetry(run, run["wall_ms"], schema_version, f"case {case.case_id} baseline")
             _validate_resource_usage(run, f"case {case.case_id} baseline")
+            _validate_resource_phase(run, f"case {case.case_id} baseline")
             _validate_baseline_evidence(run, f"case {case.case_id} baseline", schema_version, baseline_id)
     base_scan = observation.get("base_scan")
     if not isinstance(base_scan, dict) or base_scan.get("status") not in BASE_SCAN_STATUSES:
@@ -244,6 +245,7 @@ def validate_case(
             raise DifferentialManifestError(f"case {case.case_id}: invalid review timing")
         _validate_run_telemetry(review, review["wall_ms"], schema_version, f"case {case.case_id} review")
         _validate_resource_usage(review, f"case {case.case_id} review")
+        _validate_resource_phase(review, f"case {case.case_id} review")
         if review["status"] == "collected" and not isinstance(review.get("stable_evidence_sha256"), str):
             raise DifferentialManifestError(f"case {case.case_id}: collected review lacks stable evidence hash")
         if review["status"] == "collected":
@@ -278,6 +280,9 @@ def _validate_resource_usage(run: dict[str, Any], context: str) -> None:
     status = run.get("resource_status")
     if status is None:
         return
+    source = run.get("resource_source")
+    if source is not None and (not isinstance(source, str) or not source):
+        raise DifferentialManifestError(f"{context}: resource source is invalid")
     if status not in {"available", "unavailable"}:
         raise DifferentialManifestError(f"{context}: resource status is invalid")
     sample = run.get("child_max_rss_kb")
@@ -286,10 +291,18 @@ def _validate_resource_usage(run: dict[str, Any], context: str) -> None:
             raise DifferentialManifestError(f"{context}: available resource sample is missing")
         if "resource_reason" in run:
             raise DifferentialManifestError(f"{context}: available resource sample has a reason")
+        if source == "unavailable":
+            raise DifferentialManifestError(f"{context}: available resource sample has an unavailable source")
     elif not isinstance(run.get("resource_reason"), str) or not run["resource_reason"]:
         raise DifferentialManifestError(f"{context}: unavailable resource reason is missing")
     if status == "unavailable" and sample is not None:
         raise DifferentialManifestError(f"{context}: unavailable resource sample must be omitted")
+
+
+def _validate_resource_phase(run: dict[str, Any], context: str) -> None:
+    phase = run.get("resource_phase")
+    if phase is not None and phase not in {"cold", "warm"}:
+        raise DifferentialManifestError(f"{context}: resource phase is invalid")
 
 
 def _validate_baseline_evidence(

--- a/scripts/differential_metrics_report.py
+++ b/scripts/differential_metrics_report.py
@@ -62,14 +62,19 @@ def render_differential_metrics_report(data: dict[str, Any]) -> str:
         f"| Median baseline wall time (ms) | {_number(measurements.get('median_baseline_wall_ms'))} |",
         f"| Median review wall time (ms) | {_number(measurements.get('median_review_wall_ms'))} |",
         f"| Median review child max RSS (KiB) | {_number(measurements.get('median_review_child_max_rss_kb'))} |",
+        "| Median review peak RSS cold (KiB) | "
+        f"{_number(measurements.get('median_review_child_max_rss_kb_by_phase', {}).get('cold'))} |",
+        "| Median review peak RSS warm (KiB) | "
+        f"{_number(measurements.get('median_review_child_max_rss_kb_by_phase', {}).get('warm'))} |",
         f"| Time to first useful evidence | {_measurement_status(measurements.get('time_to_first_useful_evidence'))} |",
         f"| Decision latency | {_measurement_status(measurements.get('decision_latency'))} |",
         f"| Duplicate work | {_measurement_status(measurements.get('duplicate_work'))} |",
         "",
         "## Case detail",
         "",
-        "| Case | Outcome | Expected rules | Observed novel rules | Novel evidence | Review ms | RSS KiB |",
-        "| --- | --- | --- | --- | ---: | ---: | ---: |",
+        "| Case | Outcome | Expected rules | Observed novel rules | Novel evidence | Review ms | "
+        "RSS cold KiB | RSS warm KiB |",
+        "| --- | --- | --- | --- | ---: | ---: | ---: | ---: |",
     ]
     for case in data.get("cases", []):
         case_measurements = case.get("measurements", {})
@@ -77,7 +82,10 @@ def render_differential_metrics_report(data: dict[str, Any]) -> str:
             f"| `{case.get('id', 'unknown')}` | {case.get('outcome', 'unknown')} | "
             f"{_ids(case.get('expected_rule_ids', []))} | {_ids(case.get('observed_novel_rule_ids', []))} | "
             f"{case.get('novel_evidence_count', 0)} | {_number(case_measurements.get('median_review_wall_ms'))} | "
-            f"{_number(case_measurements.get('median_review_child_max_rss_kb'))} |"
+            "{cold} | {warm} |".format(
+                cold=_number(case_measurements.get("median_review_child_max_rss_kb_by_phase", {}).get("cold")),
+                warm=_number(case_measurements.get("median_review_child_max_rss_kb_by_phase", {}).get("warm")),
+            )
         )
     lines.extend(
         [

--- a/scripts/differential_pilot_metrics.py
+++ b/scripts/differential_pilot_metrics.py
@@ -55,6 +55,18 @@ def _median(values: list[float]) -> float | None:
     return round(statistics.median(values), 3) if values else None
 
 
+def _resource_phase(run: dict[str, Any]) -> str | None:
+    phase = run.get("resource_phase")
+    if phase in {"cold", "warm"}:
+        return phase
+    repeat = run.get("repeat")
+    if repeat == 1:
+        return "cold"
+    if isinstance(repeat, int) and repeat > 1:
+        return "warm"
+    return None
+
+
 def _case_measurements(observation: dict[str, Any]) -> dict[str, object]:
     baseline_values = [
         float(run["wall_ms"])
@@ -69,6 +81,12 @@ def _case_measurements(observation: dict[str, Any]) -> dict[str, object]:
         for run in reviews
         if isinstance(run.get("child_max_rss_kb"), (int, float))
     ]
+    rss_by_phase: dict[str, list[float]] = {"cold": [], "warm": []}
+    for review in reviews:
+        sample = review.get("child_max_rss_kb")
+        phase = _resource_phase(review)
+        if isinstance(sample, (int, float)) and phase is not None:
+            rss_by_phase[phase].append(float(sample))
     first_evidence_values = []
     decision_values = []
     for review in reviews:
@@ -84,6 +102,9 @@ def _case_measurements(observation: dict[str, Any]) -> dict[str, object]:
         "median_baseline_wall_ms": _median(baseline_values),
         "median_review_wall_ms": _median(review_values),
         "median_review_child_max_rss_kb": _median(rss_values),
+        "median_review_child_max_rss_kb_by_phase": {
+            phase: _median(values) for phase, values in rss_by_phase.items()
+        },
         "time_to_first_useful_evidence": _timing_measurement(
             first_evidence_values, "no useful-evidence event was recorded"
         ),
@@ -190,6 +211,7 @@ def _collect_pilot_scores(
     baseline_times: list[float] = []
     review_times: list[float] = []
     rss_times: list[float] = []
+    rss_times_by_phase: dict[str, list[float]] = {"cold": [], "warm": []}
     first_evidence_times: list[float] = []
     decision_latencies: list[float] = []
     duplicate_measurements: list[dict[str, object]] = []
@@ -220,6 +242,10 @@ def _collect_pilot_scores(
             value = case_measurements[key]
             if isinstance(value, (int, float)):
                 values.append(float(value))
+        for phase, values in rss_times_by_phase.items():
+            value = case_measurements["median_review_child_max_rss_kb_by_phase"][phase]
+            if isinstance(value, (int, float)):
+                values.append(float(value))
         cases.append(scored["case"])
     return {
         "counts": counts,
@@ -231,6 +257,7 @@ def _collect_pilot_scores(
             baseline_times,
             review_times,
             rss_times,
+            rss_times_by_phase,
             first_evidence_times,
             decision_latencies,
             duplicate_measurements,
@@ -245,6 +272,7 @@ def _build_measurement_summary(
     baseline_times: list[float],
     review_times: list[float],
     rss_times: list[float],
+    rss_times_by_phase: dict[str, list[float]],
     first_evidence_times: list[float],
     decision_latencies: list[float],
     duplicate_measurements: list[dict[str, object]],
@@ -256,6 +284,9 @@ def _build_measurement_summary(
         "median_baseline_wall_ms": _median(baseline_times),
         "median_review_wall_ms": _median(review_times),
         "median_review_child_max_rss_kb": _median(rss_times),
+        "median_review_child_max_rss_kb_by_phase": {
+            phase: _median(values) for phase, values in rss_times_by_phase.items()
+        },
         "time_to_first_useful_evidence": _timing_measurement(
             first_evidence_times, "no useful-evidence events were recorded"
         ),

--- a/scripts/differential_resource.py
+++ b/scripts/differential_resource.py
@@ -1,0 +1,118 @@
+"""Portable best-effort peak RSS sampling for differential commands."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+RESOURCE_SOURCE = "posix-time-v1"
+_LINUX_RSS = re.compile(r"Maximum resident set size \(kbytes\):\s*(?P<rss>\d+)")
+_DARWIN_RSS = re.compile(r"^\s*(?P<rss>\d+)\s+maximum resident set size\s*$", re.MULTILINE)
+
+
+def parse_peak_rss_kb(output: str, platform: str) -> int | None:
+    """Parse `/usr/bin/time` peak RSS output into KiB."""
+
+    pattern = _DARWIN_RSS if platform == "darwin" else _LINUX_RSS if platform == "linux" else None
+    if pattern is None:
+        return None
+    match = pattern.search(output)
+    if match is None:
+        return None
+    value = int(match.group("rss"))
+    return (value + 1023) // 1024 if platform == "darwin" else value
+
+
+def resource_command(
+    command: tuple[str, ...], output_path: Path, platform: str | None = None
+) -> list[str] | None:
+    """Return a `/usr/bin/time` command, or None when the platform cannot sample RSS."""
+
+    system = platform or sys.platform
+    if system not in {"darwin", "linux"} or not Path("/usr/bin/time").is_file():
+        return None
+    flags = ["-l"] if system == "darwin" else ["-v"]
+    return ["/usr/bin/time", *flags, "-o", str(output_path), *command]
+
+
+def resource_sample_from_file(path: Path, platform: str | None = None) -> dict[str, Any]:
+    """Read a sampler output file and return an explicit measured/unavailable record."""
+
+    try:
+        output = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {
+            "status": "unavailable",
+            "reason": "portable peak RSS sampler output is unavailable",
+            "source": RESOURCE_SOURCE,
+        }
+    sample = parse_peak_rss_kb(output, platform or sys.platform)
+    if sample is None or sample <= 0:
+        return {
+            "status": "unavailable",
+            "reason": "portable peak RSS sampler emitted no positive sample",
+            "source": RESOURCE_SOURCE,
+        }
+    return {"status": "available", "peak_rss_kb": sample, "source": RESOURCE_SOURCE}
+
+
+def unavailable_resource(reason: str) -> dict[str, Any]:
+    return {"status": "unavailable", "reason": reason, "source": "unavailable"}
+
+
+def execute_timed_command(
+    command: tuple[str, ...], cwd: Path, timeout_seconds: float
+) -> dict[str, Any]:
+    """Run a command and return process, timing, and resource observations."""
+
+    sampler_path: Path | None = None
+    wrapped_command: list[str] | None = None
+    if resource_command(command, Path("/tmp/repopilot-rss.txt")) is not None:
+        with tempfile.NamedTemporaryFile(prefix="repopilot-rss-", suffix=".txt", delete=False) as handle:
+            sampler_path = Path(handle.name)
+        wrapped_command = resource_command(command, sampler_path)
+    started = time.perf_counter()
+    try:
+        process = subprocess.run(
+            wrapped_command or list(command),
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError:
+        status, returncode, stdout, stderr = "unavailable", None, b"", b""
+    except subprocess.TimeoutExpired as error:
+        status, returncode = "timeout", None
+        stdout = error.stdout or b""
+        stderr = error.stderr or b""
+    else:
+        status = "passed" if process.returncode == 0 else "failed"
+        returncode, stdout, stderr = process.returncode, process.stdout, process.stderr
+    finally:
+        wall_ms = round((time.perf_counter() - started) * 1000, 3)
+    if sampler_path is None:
+        resource = unavailable_resource("portable peak RSS sampler is unavailable on this platform")
+    elif status == "timeout":
+        resource = unavailable_resource("command timed out before peak RSS sampling completed")
+    else:
+        resource = resource_sample_from_file(sampler_path)
+    if sampler_path is not None:
+        try:
+            sampler_path.unlink()
+        except OSError:
+            pass
+    return {
+        "status": status,
+        "returncode": returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "wall_ms": wall_ms,
+        "resource": resource,
+    }

--- a/scripts/differential_runner.py
+++ b/scripts/differential_runner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
-import sys
 import tempfile
 import time
 from pathlib import Path
@@ -16,93 +15,52 @@ from differential_evidence import normalize_baseline_evidence
 from differential_identity import review_comparable_diagnostic_keys
 from differential_manifest import load_differential
 from differential_novelty import evidence_keys, novel_evidence_keys
+from differential_resource import execute_timed_command
 from differential_telemetry import build_command_telemetry, build_review_telemetry
 from real_history_contract import HoldoutCase, HoldoutManifestError, validate_manifest
 from real_history_runner import BASELINE_COMMANDS, clone_case, summarize_review
 from zoo_scanner import ScannerPreparationError, ScannerProvenanceError, prepare_scanner
 
-try:
-    import resource
-except ImportError:  # pragma: no cover - Windows has no resource module.
-    resource = None
-
-
 DIFFERENTIAL_ARTIFACT_SCHEMA_VERSION = 2
+
+
+def _resource_phase(repeat: int) -> str:
+    return "cold" if repeat == 1 else "warm"
 
 
 def sha256_bytes(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
-def _resource_snapshot() -> tuple[str, int | None]:
-    if resource is None:
-        return "unavailable", None
-    try:
-        usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-    except (AttributeError, OSError):
-        return "unavailable", None
-    max_rss = int(usage.ru_maxrss)
-    if sys.platform == "darwin":
-        max_rss //= 1024
-    return "available", max_rss
-
-
-def _record_resource_usage(
-    result: dict[str, Any],
-    resource_status: str,
-    resource_before: int | None,
-    resource_after: int | None,
-) -> None:
-    """Record only a positive per-command RSS sample from cumulative child usage."""
-
-    if resource_status != "available" or resource_before is None or resource_after is None:
-        result["resource_status"] = "unavailable"
-        result["resource_reason"] = "per-command child RSS sample is unavailable"
-        return
-    delta = resource_after - resource_before
-    if delta <= 0:
-        result["resource_status"] = "unavailable"
-        result["resource_reason"] = "cumulative child RSS delta was non-positive"
-        return
-    result["resource_status"] = "available"
-    result["child_max_rss_kb"] = delta
-
-
 def run_timed_command(
     command: tuple[str, ...], cwd: Path, timeout_seconds: int, baseline_id: str | None = None
 ) -> dict[str, Any]:
-    resource_status, resource_before = _resource_snapshot()
-    started = time.perf_counter()
-    try:
-        process = subprocess.run(
-            list(command), cwd=cwd, capture_output=True, check=False, timeout=timeout_seconds
-        )
-    except FileNotFoundError:
-        status, returncode, stdout, stderr = "unavailable", None, b"", b""
-    except subprocess.TimeoutExpired as error:
-        status, returncode = "timeout", None
-        stdout = error.stdout or b""
-        stderr = error.stderr or b""
-    else:
-        status = "passed" if process.returncode == 0 else "failed"
-        returncode, stdout, stderr = process.returncode, process.stdout, process.stderr
-    _, resource_after = _resource_snapshot()
+    observation = execute_timed_command(command, cwd, timeout_seconds)
+    status = observation["status"]
+    returncode = observation["returncode"]
+    stdout = observation["stdout"]
+    stderr = observation["stderr"]
+    resource = observation["resource"]
     result: dict[str, Any] = {
         "status": status,
         "returncode": returncode,
         "command": list(command),
-        "wall_ms": round((time.perf_counter() - started) * 1000, 3),
+        "wall_ms": observation["wall_ms"],
         "stdout_sha256": sha256_bytes(stdout if isinstance(stdout, bytes) else stdout.encode()),
         "stderr_sha256": sha256_bytes(stderr if isinstance(stderr, bytes) else stderr.encode()),
-        "resource_status": resource_status,
+        "resource_status": resource["status"],
+        "resource_source": resource["source"],
     }
+    if resource["status"] == "available":
+        result["child_max_rss_kb"] = resource["peak_rss_kb"]
+    else:
+        result["resource_reason"] = resource["reason"]
     result["telemetry"] = build_command_telemetry(result["wall_ms"])
     result["evidence"] = (
         normalize_baseline_evidence(baseline_id, stdout, stderr, returncode, cwd)
         if baseline_id is not None and status in {"passed", "failed"}
         else {"status": "unavailable", "reason": "baseline command did not complete"}
     )
-    _record_resource_usage(result, resource_status, resource_before, resource_after)
     return result
 
 
@@ -126,7 +84,9 @@ def _scan_base(scanner: Any, case: HoldoutCase, base: Path, timeout_seconds: int
     try:
         report = json.loads(process.stdout)
     except json.JSONDecodeError as error:
-        raise HoldoutManifestError(f"differential base scan returned invalid JSON for {case.case_id}: {error}") from error
+        raise HoldoutManifestError(
+            f"differential base scan returned invalid JSON for {case.case_id}: {error}"
+        ) from error
     findings = report.get("findings")
     if not isinstance(findings, list):
         raise HoldoutManifestError(f"differential base scan has no findings array for {case.case_id}")
@@ -162,34 +122,48 @@ def _review_once(
         "default",
         "--no-progress",
     )
-    resource_status, resource_before = _resource_snapshot()
-    started = time.perf_counter()
-    try:
-        process = subprocess.run(list(command), cwd=head, capture_output=True, check=False, timeout=timeout_seconds)
-    except subprocess.TimeoutExpired:
-        wall_ms = round((time.perf_counter() - started) * 1000, 3)
-        return {
+    observation = execute_timed_command(command, head, timeout_seconds)
+    if observation["status"] == "timeout":
+        resource = observation["resource"]
+        result = {
             "status": "timeout",
             "returncode": None,
-            "wall_ms": wall_ms,
-            "telemetry": build_command_telemetry(wall_ms),
+            "wall_ms": observation["wall_ms"],
+            "telemetry": build_command_telemetry(observation["wall_ms"]),
+            "resource_status": resource["status"],
+            "resource_source": resource["source"],
             "in_diff_evidence_keys": [],
             "novel_in_diff_evidence_keys": [],
             "in_diff_comparison_keys": [],
         }
-    if process.returncode not in (0, 1):
+        if resource["status"] == "unavailable":
+            result["resource_reason"] = resource["reason"]
+        return result
+    if observation["status"] == "unavailable":
+        raise HoldoutManifestError(f"differential review command was unavailable for {case.case_id}")
+    if observation["returncode"] not in (0, 1):
         raise HoldoutManifestError(
-            f"differential review failed for {case.case_id}: {process.stderr.decode(errors='replace').strip()}"
+            f"differential review failed for {case.case_id}: "
+            f"{observation['stderr'].decode(errors='replace').strip()}"
         )
     try:
-        report = json.loads(process.stdout)
+        report = json.loads(observation["stdout"])
     except json.JSONDecodeError as error:
         raise HoldoutManifestError(f"differential review returned invalid JSON for {case.case_id}: {error}") from error
     result = _build_review_result(
-        report, process.stdout, process.returncode, base_evidence, resource_status, started
+        report,
+        observation["stdout"],
+        observation["returncode"],
+        base_evidence,
+        observation["wall_ms"],
     )
-    _, resource_after = _resource_snapshot()
-    _record_resource_usage(result, resource_status, resource_before, resource_after)
+    resource = observation["resource"]
+    result["resource_status"] = resource["status"]
+    result["resource_source"] = resource["source"]
+    if resource["status"] == "available":
+        result["child_max_rss_kb"] = resource["peak_rss_kb"]
+    else:
+        result["resource_reason"] = resource["reason"]
     return result
 
 
@@ -198,14 +172,12 @@ def _build_review_result(
     raw_output: bytes,
     returncode: int,
     base_evidence: set[str],
-    resource_status: str,
-    started: float,
+    wall_ms: float,
 ) -> dict[str, Any]:
     in_diff_findings = [
         finding for finding in report["findings"] if isinstance(finding, dict) and finding.get("in_diff") is True
     ]
     in_diff_keys = sorted(evidence_keys(in_diff_findings))
-    wall_ms = round((time.perf_counter() - started) * 1000, 3)
     novel_keys = novel_evidence_keys(in_diff_findings, base_evidence)
     comparison_keys = review_comparable_diagnostic_keys(report)
     result = {
@@ -213,7 +185,6 @@ def _build_review_result(
         "status": "collected",
         "returncode": returncode,
         "wall_ms": wall_ms,
-        "resource_status": resource_status,
         "in_diff_evidence_keys": in_diff_keys,
         "novel_in_diff_evidence_keys": novel_keys,
         "in_diff_comparison_keys": comparison_keys,
@@ -239,9 +210,11 @@ def collect_case(
         for baseline_id in baseline_ids:
             result = run_timed_command(BASELINE_COMMANDS[baseline_id], merge, timeout_seconds, baseline_id)
             result["repeat"] = repeat
+            result["resource_phase"] = _resource_phase(repeat)
             baselines[baseline_id].append(result)
         review = _review_once(scanner, case, head, base_evidence, timeout_seconds)
         review["repeat"] = repeat
+        review["resource_phase"] = _resource_phase(repeat)
         reviews.append(review)
     stable_hashes = [run["stable_evidence_sha256"] for run in reviews if run["status"] == "collected"]
     return {

--- a/scripts/tests/test_differential_metrics_report.py
+++ b/scripts/tests/test_differential_metrics_report.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from differential_metrics_report import render_differential_metrics_report  # noqa: E402
+
+
+class DifferentialMetricsReportTests(unittest.TestCase):
+    def test_render_exposes_cold_and_warm_rss_separately(self) -> None:
+        report = render_differential_metrics_report(
+            {
+                "corpus": "holdout",
+                "protocol": "single-expert-pilot-v1",
+                "reviewer": "expert",
+                "scope": "exploratory",
+                "limitation": "limited corpus",
+                "counts": {"tp": 0, "fn": 0, "tn": 1, "fp": 0, "excluded": 0},
+                "measurements": {
+                    "case_count": 1,
+                    "deterministic_cases": 1,
+                    "novel_evidence_cases": 0,
+                    "median_baseline_wall_ms": 10.0,
+                    "median_review_wall_ms": 20.0,
+                    "median_review_child_max_rss_kb": 120.0,
+                    "median_review_child_max_rss_kb_by_phase": {"cold": 150.0, "warm": 100.0},
+                    "time_to_first_useful_evidence": {"status": "unavailable", "reason": "not recorded"},
+                    "decision_latency": {"status": "unavailable", "reason": "not recorded"},
+                    "duplicate_work": {"status": "unavailable", "reason": "unlabeled"},
+                },
+                "cases": [
+                    {
+                        "id": "case-one",
+                        "outcome": "tn",
+                        "expected_rule_ids": [],
+                        "observed_novel_rule_ids": [],
+                        "novel_evidence_count": 0,
+                        "measurements": {
+                            "median_review_wall_ms": 20.0,
+                            "median_review_child_max_rss_kb_by_phase": {"cold": 150.0, "warm": 100.0},
+                        },
+                    }
+                ],
+            }
+        )
+        self.assertIn("Median review peak RSS cold (KiB)", report)
+        self.assertIn("Median review peak RSS warm (KiB)", report)
+        self.assertIn("RSS cold KiB", report)
+        self.assertIn("| 0 | 20.000 | 150.000 | 100.000 |", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_differential_pilot.py
+++ b/scripts/tests/test_differential_pilot.py
@@ -91,8 +91,12 @@ class DifferentialPilotTests(unittest.TestCase):
                                 "scheme": "review-exact-v1",
                             },
                         }
-                for review in case["reviews"]:
+                for index, review in enumerate(case["reviews"]):
                     review["in_diff_comparison_keys"] = []
+                    review["resource_status"] = "available"
+                    review["resource_source"] = "posix-time-v1"
+                    review["resource_phase"] = "cold" if index == 0 else "warm"
+                    review["child_max_rss_kb"] = 100 + index * 10
                     review["telemetry"] = {
                         "schema_version": 1,
                         "events": [
@@ -121,6 +125,10 @@ class DifferentialPilotTests(unittest.TestCase):
         self.assertEqual(output["measurements"]["time_to_first_useful_evidence"]["median_ms"], 5.0)
         self.assertEqual(output["measurements"]["decision_latency"]["median_ms"], 10.0)
         self.assertEqual(output["measurements"]["duplicate_work"]["overlap_count"], 0)
+        self.assertEqual(
+            output["measurements"]["median_review_child_max_rss_kb_by_phase"],
+            {"cold": 100.0, "warm": 115.0},
+        )
 
     def test_metrics_do_not_infer_overlap_from_unmapped_baseline_keys(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_differential_resource.py
+++ b/scripts/tests/test_differential_resource.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from differential_resource import (  # noqa: E402
+    execute_timed_command,
+    parse_peak_rss_kb,
+    resource_command,
+    resource_sample_from_file,
+)
+
+
+class DifferentialResourceTests(unittest.TestCase):
+    def test_parses_linux_peak_rss_in_kib(self) -> None:
+        self.assertEqual(
+            parse_peak_rss_kb("Maximum resident set size (kbytes): 12345\n", "linux"),
+            12345,
+        )
+
+    def test_parses_macos_peak_rss_bytes_as_kib(self) -> None:
+        self.assertEqual(
+            parse_peak_rss_kb("  12582912  maximum resident set size\n", "darwin"),
+            12288,
+        )
+
+    def test_unsupported_or_malformed_time_output_is_unavailable(self) -> None:
+        self.assertIsNone(parse_peak_rss_kb("time failed\n", "linux"))
+        self.assertEqual(resource_sample_from_file(Path("/does/not/exist"))["status"], "unavailable")
+
+    def test_resource_command_keeps_the_original_command_as_the_suffix(self) -> None:
+        command = (sys.executable, "-c", "print('ok')")
+        wrapped = resource_command(command, Path("/tmp/repopilot-time.txt"), "linux")
+        if wrapped is None:
+            self.skipTest("portable POSIX time sampler is unavailable")
+        self.assertEqual(tuple(wrapped[-len(command) :]), command)
+
+    def test_timeout_keeps_resource_measurement_unavailable(self) -> None:
+        result = execute_timed_command(
+            (sys.executable, "-c", "import time; time.sleep(0.2)"),
+            Path("."),
+            0.01,
+        )
+        self.assertEqual(result["status"], "timeout")
+        self.assertEqual(result["resource"]["status"], "unavailable")
+        self.assertIn("timed out", result["resource"]["reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_differential_runner.py
+++ b/scripts/tests/test_differential_runner.py
@@ -11,29 +11,15 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from differential_artifact import validate_data  # noqa: E402
-from differential_runner import _build_review_result, _record_resource_usage, run_timed_command  # noqa: E402
+from differential_runner import _build_review_result, _resource_phase, run_timed_command  # noqa: E402
 from differential_telemetry import build_command_telemetry  # noqa: E402
 from real_history_runner import BASELINE_COMMANDS  # noqa: E402
 
 
 class DifferentialRunnerTests(unittest.TestCase):
-    def test_resource_usage_rejects_non_positive_cumulative_delta(self) -> None:
-        result = {"resource_status": "available"}
-
-        _record_resource_usage(result, "available", 4096, 4096)
-
-        self.assertEqual(result["resource_status"], "unavailable")
-        self.assertNotIn("child_max_rss_kb", result)
-        self.assertIn("cumulative", result["resource_reason"])
-
-    def test_resource_usage_keeps_positive_delta_as_a_measured_sample(self) -> None:
-        result = {"resource_status": "available"}
-
-        _record_resource_usage(result, "available", 4096, 5120)
-
-        self.assertEqual(result["resource_status"], "available")
-        self.assertEqual(result["child_max_rss_kb"], 1024)
-        self.assertNotIn("resource_reason", result)
+    def test_repeated_runs_have_explicit_cold_and_warm_phases(self) -> None:
+        self.assertEqual(_resource_phase(1), "cold")
+        self.assertEqual(_resource_phase(2), "warm")
 
     def test_review_result_keeps_comparable_diagnostic_keys_separate(self) -> None:
         report = {
@@ -59,8 +45,7 @@ class DifferentialRunnerTests(unittest.TestCase):
             b"report",
             0,
             set(),
-            "available",
-            0.0,
+            1.0,
         )
 
         self.assertEqual(result["in_diff_evidence_keys"], [])
@@ -78,6 +63,12 @@ class DifferentialRunnerTests(unittest.TestCase):
         self.assertEqual(len(result["stdout_sha256"]), 64)
         self.assertEqual(result["telemetry"]["events"][0]["name"], "process_started")
         self.assertEqual(result["telemetry"]["events"][-1]["name"], "process_finished")
+        self.assertIn(result["resource_status"], {"available", "unavailable"})
+        if result["resource_status"] == "available":
+            self.assertGreater(result["child_max_rss_kb"], 0)
+            self.assertEqual(result["resource_source"], "posix-time-v1")
+        else:
+            self.assertTrue(result["resource_reason"])
 
     def test_timed_command_records_failure(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -264,6 +255,27 @@ class DifferentialRunnerTests(unittest.TestCase):
                 for review in case["reviews"]:
                     review["telemetry"] = build_command_telemetry(1.0)
             with self.assertRaisesRegex(ValueError, "available resource sample"):
+                validate_data(artifact, holdout, differential, rules, zoo)
+
+    def test_artifact_rejects_unknown_resource_phase(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            holdout, differential, rules, zoo = self._write_manifests(root)
+            artifact = self._valid_artifact(holdout, differential)
+            artifact["schema_version"] = 2
+            for case in artifact["cases"]:
+                case["base_scan"]["telemetry"] = build_command_telemetry(1.0)
+                for runs in case["baselines"].values():
+                    for run in runs:
+                        run["telemetry"] = build_command_telemetry(1.0)
+                        run["evidence"] = {
+                            "status": "unavailable",
+                            "reason": "fixture has no baseline adapter",
+                        }
+                        run["resource_phase"] = "invalid"
+                for review in case["reviews"]:
+                    review["telemetry"] = build_command_telemetry(1.0)
+            with self.assertRaisesRegex(ValueError, "resource phase"):
                 validate_data(artifact, holdout, differential, rules, zoo)
 
     def test_artifact_schema_two_requires_provenance_for_measured_evidence(self) -> None:

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -66,6 +66,10 @@ scoring precision, recall, utility, or overlap.
 Resource samples follow the same boundary: cumulative child RSS is measured
 only when a positive per-command delta is available. A zero or unsupported
 delta is reported as unavailable, never as proof of zero memory use.
+On Linux and macOS the collector uses `/usr/bin/time` and records the sampler
+source; Windows and systems without a supported time format stay unavailable.
+Repeated runs are labeled `cold` for the first execution and `warm` for later
+executions, and pilot reports preserve those RSS medians separately.
 
 For `python.tests`, a failed pytest node remains baseline-only. RepoPilot does
 not execute tests during review, so a test path or changed test name cannot


### PR DESCRIPTION
## Problem

Differential resource evidence was based on cumulative child RSS deltas. That could report misleading zero memory use, and repeated runs did not distinguish startup cost from warm steady-state cost.

## What changed

- add a dedicated `differential_resource.py` runner using `/usr/bin/time` on Linux and macOS;
- parse peak RSS in KiB with explicit `posix-time-v1` provenance;
- keep Windows, unsupported platforms, timeouts, and malformed output explicitly unavailable;
- validate resource status, source, sample, and cold/warm phase fields;
- label repetition 1 as `cold` and later repetitions as `warm`;
- aggregate and render cold/warm RSS medians in pilot metrics;
- preserve backward compatibility for older artifacts without the new fields;
- add parser, timeout, artifact, metrics, report, and integration regression tests;
- document the evidence boundary and RP23-004 limitation.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (208 passed)
- `python3 scripts/release-contract.py check` (passed)
- `python3 -m py_compile ...` (passed)
- `git diff --check` (passed)
- differential packet v9: valid, 36/36 baseline runs measured, 18/18 reviews measured, all with `posix-time-v1` samples;
  review RSS median was 30,200 KiB cold and 25,312 KiB warm on the six-case packet.
