### PR TITLE
feat: gate scan RSS across cold and warm matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,17 @@ jobs:
       - name: Changed review performance gate
         run: npm run review:performance
 
+      - name: Scan resource matrix gate
+        run: npm run scan:resource
+
+      - name: Upload scan resource matrix
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: repopilot-scan-resource-matrix
+          path: /tmp/repopilot-scan-resource-matrix.json
+          if-no-files-found: ignore
+
       - name: RepoPilot CI gate
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added `differential.py budget-check` with a pinned review-workload RSS policy;
   it requires both phases, checks the sampler source, and fails on unavailable
   samples instead of treating them as zero.
+- Added the `scan:resource` matrix gate for full and changed synthetic scans;
+  it records cold/warm RSS, host profile, and the JSON result as a CI artifact.
 - Made the generated rule scorecard report evidence denominators directly:
   default-profile coverage, labeled findings, repository coverage, strict
   samples, and the explicit boundary that these labels do not establish recall.

--- a/docs/engineering/performance-budgets.md
+++ b/docs/engineering/performance-budgets.md
@@ -108,6 +108,29 @@ as a practical proxy. Record the result alongside the benchmark run. A hard
 memory budget should be set only after baseline data from the pinned environment
 is available.
 
+### v0.23 scan resource matrix
+
+The release binary can run the synthetic medium matrix with one cold and three
+warm samples for full scans, plus one cold and three warm samples for changed
+scans:
+
+```bash
+npm run scan:resource
+```
+
+The command writes `/tmp/repopilot-scan-resource-matrix.json` and records the
+host profile, sampler source, workload, medians, maxima, and ceilings. The
+checked-in `tests/benchmarks/scan-resource.toml` policy uses 65,536 KiB for
+full cold, full warm, and changed cold, and 49,152 KiB for changed warm. The
+gate runs on the Ubuntu CI job; unsupported samplers or missing samples fail
+the command instead of becoming zeroes.
+
+The reference local run on `darwin-arm64` (2026-09-08, 250 files per language)
+reported maxima of 40,240 KiB full cold, 41,664 KiB full warm, 45,664 KiB
+changed cold, and 38,400 KiB changed warm. These numbers describe this host
+and fixture; changing either requires a new measurement before changing a
+ceiling.
+
 ### Thread determinism
 
 Output determinism must be verified for 1-thread and multi-thread runs. The

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -350,10 +350,15 @@ bump is needed to start.
   pilot metrics/reporting keep their RSS medians separate. Keeping the phases
   separate preserves the startup signal.
 - `differential-rss-v1` now checks the six-case review packet with
-  `scripts/differential.py budget-check`. The packet-v9 host budget is 65,536
+  `scripts/differential.py budget-check`. The packet-v10 host budget is 65,536
   KiB cold and 49,152 KiB warm; a missing or unavailable sample fails the
   check. This is a pinned workload regression gate, not a universal memory
   claim.
+- The synthetic scan matrix now has its own `scan-rss-v1` policy and Ubuntu CI
+  gate. It covers full and changed scans in cold and warm phases, records the
+  host profile, and stores the JSON result as a CI artifact. A reference local
+  `darwin-arm64` run passed with maxima of 40,240 KiB full cold, 41,664 KiB
+  full warm, 45,664 KiB changed cold, and 38,400 KiB changed warm.
 - Boundary: these are still unlabeled observations. Frozen environments,
   completed independent labels, and a preregistered scoring artifact remain
   required before RP23-014 can close or RepoPilot can claim value beyond

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -458,9 +458,11 @@ The differential collector now obtains that sample from `/usr/bin/time` on
 Linux and macOS with explicit provenance; unsupported platforms remain outside
 the measured RSS denominator.
 Repeated runs are labeled cold versus warm. `scripts/differential.py
-budget-check` enforces the first review-workload RSS policy: 65,536 KiB cold
-and 49,152 KiB warm from packet v9. Those ceilings apply to that pinned host
-and workload and must be re-baselined when either changes.
+budget-check` enforces the review-workload RSS policy: 65,536 KiB cold and
+49,152 KiB warm from packet v10. The separate `scan:resource` gate covers full
+and changed synthetic scans in cold and warm phases and records the host
+profile. All ceilings apply to their pinned workload and must be re-baselined
+when the host or fixture changes.
 
 Initial release discipline:
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"release:contract": "python3 scripts/release-contract.py check",
 		"test:release-contract": "python3 -m unittest discover -s scripts/tests -p 'test_*.py'",
 		"review:performance": "node scripts/check-review-performance.js",
-		"scan:performance": "node scripts/check-scan-performance.js"
+		"scan:performance": "node scripts/check-scan-performance.js",
+		"scan:resource": "python3 scripts/scan_resource_matrix.py"
 	},
 	"files": [
 		"bin",

--- a/scripts/scan_resource_matrix.py
+++ b/scripts/scan_resource_matrix.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Run the synthetic full/changed scan RSS matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import subprocess
+import tempfile
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from differential_resource import execute_timed_command
+
+
+SCENARIOS = ("full_cold", "full_warm", "changed_cold", "changed_warm")
+
+
+class ScanResourcePolicyError(ValueError):
+    """Raised when the scan resource policy or matrix is invalid."""
+
+
+def _positive(value: object, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        raise ScanResourcePolicyError(f"{label} must be positive")
+    return float(value)
+
+
+def _validate_policy(policy: object) -> dict[str, Any]:
+    if not isinstance(policy, dict) or policy.get("schema_version") != 1:
+        raise ScanResourcePolicyError("scan resource policy schema_version must be 1")
+    for key in ("policy_id", "workload", "source", "unit"):
+        if not isinstance(policy.get(key), str) or not policy[key].strip():
+            raise ScanResourcePolicyError(f"scan resource policy {key} must be a non-empty string")
+    if policy["source"] != "posix-time-v1" or policy["unit"] != "KiB":
+        raise ScanResourcePolicyError("scan resource policy must use posix-time-v1 KiB samples")
+    if policy.get("unavailable") != "fail":
+        raise ScanResourcePolicyError('scan resource policy unavailable must be "fail"')
+    scenarios = policy.get("required_scenarios")
+    if not isinstance(scenarios, list) or set(scenarios) != set(SCENARIOS) or len(scenarios) != len(SCENARIOS):
+        raise ScanResourcePolicyError("scan resource policy must list all four matrix scenarios")
+    ceilings = policy.get("ceiling_kb_by_scenario")
+    if not isinstance(ceilings, dict) or set(ceilings) != set(SCENARIOS):
+        raise ScanResourcePolicyError("scan resource policy must define four scenario ceilings")
+    normalized = dict(policy)
+    normalized["required_scenarios"] = list(SCENARIOS)
+    normalized["ceiling_kb_by_scenario"] = {
+        scenario: _positive(ceilings[scenario], f"{scenario} ceiling") for scenario in SCENARIOS
+    }
+    return normalized
+
+
+def load_scan_resource_policy(path: Path) -> dict[str, Any]:
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ScanResourcePolicyError(f"cannot read scan resource policy {path}: {error}") from error
+    return _validate_policy(raw)
+
+
+def _violation(kind: str, scenario: str, message: str, **values: object) -> dict[str, object]:
+    item: dict[str, object] = {"scenario": scenario, "kind": kind, "message": message}
+    item.update(values)
+    return item
+
+
+def evaluate_matrix(samples: dict[str, list[dict[str, object]]], policy: dict[str, Any]) -> dict[str, object]:
+    normalized = _validate_policy(policy)
+    if set(samples) != set(SCENARIOS):
+        raise ScanResourcePolicyError("scenario set mismatch")
+    violations: list[dict[str, object]] = []
+    summaries: dict[str, dict[str, object]] = {}
+    for scenario in SCENARIOS:
+        values: list[float] = []
+        for sample in samples[scenario]:
+            if sample.get("resource_status") != "available":
+                kind = "unavailable" if sample.get("resource_status") == "unavailable" else "invalid_status"
+                violations.append(
+                    _violation(kind, scenario, str(sample.get("resource_reason", "RSS sample unavailable")))
+                )
+                continue
+            if sample.get("resource_source") != normalized["source"]:
+                violations.append(_violation("source_mismatch", scenario, "RSS source does not match policy"))
+                continue
+            value = sample.get("child_max_rss_kb")
+            if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+                violations.append(_violation("invalid_sample", scenario, "RSS sample must be positive"))
+                continue
+            values.append(float(value))
+        ceiling = normalized["ceiling_kb_by_scenario"][scenario]
+        if not values:
+            violations.append(_violation("missing_scenario", scenario, "no valid RSS samples"))
+            summaries[scenario] = {
+                "status": "fail", "samples": 0, "median_kb": None, "max_kb": None, "ceiling_kb": ceiling
+            }
+            continue
+        median = round(statistics.median(values), 3)
+        maximum = round(max(values), 3)
+        summaries[scenario] = {
+            "status": "pass", "samples": len(values), "median_kb": median, "max_kb": maximum, "ceiling_kb": ceiling
+        }
+        if median > ceiling:
+            violations.append(_violation("median_over_ceiling", scenario, "median exceeds ceiling", observed_kb=median, ceiling_kb=ceiling))
+        if maximum > ceiling:
+            violations.append(_violation("max_over_ceiling", scenario, "maximum exceeds ceiling", observed_kb=maximum, ceiling_kb=ceiling))
+    violations.sort(key=lambda item: (str(item["scenario"]), str(item["kind"]), str(item["message"])))
+    return {
+        "status": "fail" if violations else "pass",
+        "policy_id": normalized["policy_id"],
+        "workload": normalized["workload"],
+        "source": normalized["source"],
+        "unit": normalized["unit"],
+        "scenarios": summaries,
+        "violations": violations,
+    }
+
+
+def render_matrix(result: dict[str, object]) -> str:
+    lines = [f"Scan resource matrix: {result['status']}", f"Policy: {result['policy_id']} ({result['workload']})"]
+    for scenario in SCENARIOS:
+        summary = result["scenarios"][scenario]
+        lines.append(
+            f"{scenario}: median={summary['median_kb']} KiB; max={summary['max_kb']} KiB; "
+            f"ceiling={summary['ceiling_kb']} KiB; samples={summary['samples']}"
+        )
+    for item in result["violations"]:
+        lines.append(f"violation: {item['scenario']} {item['kind']}: {item['message']}")
+    return "\n".join(lines) + "\n"
+
+
+def _write_file(root: Path, relative: str, contents: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents, encoding="utf-8")
+
+
+def _build_corpus(root: Path, files_per_language: int) -> None:
+    _write_file(root, "go.mod", "module benchmod\n\ngo 1.22\n")
+    for index in range(files_per_language):
+        previous = max(0, index - 1)
+        _write_file(root, f"src/file_{index}.rs", f"use crate::file_{previous};\n\npub fn compute_{index}(input: i64) -> i64 {{\n    (0..input).sum()\n}}\n")
+        _write_file(root, f"web/file_{index}.ts", f'import {{ compute }} from "./file_{previous}";\nexport function run_{index}(input: number): number {{ return input + compute; }}\n')
+        _write_file(root, f"py/file_{index}.py", f"from .file_{previous} import compute\n\ndef run_{index}(value):\n    return value + compute\n")
+        _write_file(root, f"gopkg/file_{index}.go", f"package gopkg\n\nfunc Run{index}(value int) int {{ return value }}\n")
+
+
+def _git_baseline(root: Path) -> None:
+    for args in (("git", "init", "-q"), ("git", "config", "user.email", "benchmark@repopilot.local"), ("git", "config", "user.name", "RepoPilot Benchmark"), ("git", "add", "."), ("git", "commit", "-qm", "benchmark baseline")):
+        subprocess.run(args, cwd=root, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+
+
+def _scan(scanner: Path, root: Path, output: Path, changed: bool) -> dict[str, object]:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    args = [str(scanner), "scan", ".", "--format", "json", "--output", str(output), "--no-progress"]
+    if changed:
+        args.append("--changed")
+    result = execute_timed_command(tuple(args), root, 300)
+    if result["status"] != "passed":
+        raise RuntimeError(f"scan command failed: {result.get('resource_reason', result['status'])}")
+    resource = result["resource"]
+    sample = {
+        "resource_status": resource.get("status"),
+        "resource_source": resource.get("source"),
+        "child_max_rss_kb": resource.get("peak_rss_kb"),
+        "wall_ms": result["wall_ms"],
+    }
+    if resource.get("reason"):
+        sample["resource_reason"] = resource["reason"]
+    return sample
+
+
+def collect_matrix(scanner: Path, files_per_language: int) -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="repopilot-scan-resource-") as tmp:
+        root = Path(tmp)
+        results = root / "results"
+        full_root = root / "full"
+        changed_root = root / "changed"
+        _build_corpus(full_root, files_per_language)
+        full_samples = {"full_cold": [_scan(scanner, full_root, results / "full-cold.json", False)], "full_warm": []}
+        for index in range(3):
+            full_samples["full_warm"].append(_scan(scanner, full_root, results / f"full-warm-{index}.json", False))
+        _build_corpus(changed_root, files_per_language)
+        _git_baseline(changed_root)
+        with (changed_root / "src/file_0.rs").open("a", encoding="utf-8") as handle:
+            handle.write("\n// benchmark edit\n")
+        changed_samples = {"changed_cold": [_scan(scanner, changed_root, results / "changed-cold.json", True)], "changed_warm": []}
+        for index in range(3):
+            changed_samples["changed_warm"].append(_scan(scanner, changed_root, results / f"changed-warm-{index}.json", True))
+        return {**full_samples, **changed_samples}
+
+
+def run_matrix(scanner: Path, policy_path: Path, output: Path, files_per_language: int) -> dict[str, object]:
+    policy = load_scan_resource_policy(policy_path)
+    samples = collect_matrix(scanner, files_per_language)
+    result = evaluate_matrix(samples, policy)
+    result["host_profile"] = f"{platform.system().lower()}-{platform.machine().lower()}"
+    result["files_per_language"] = files_per_language
+    result["scanner"] = str(scanner)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scanner", type=Path, default=Path("target/release/repopilot"))
+    parser.add_argument("--policy", type=Path, default=Path("tests/benchmarks/scan-resource.toml"))
+    parser.add_argument("--output", type=Path, default=Path("/tmp/repopilot-scan-resource-matrix.json"))
+    parser.add_argument("--files-per-language", type=int, default=250)
+    args = parser.parse_args(argv)
+    if args.files_per_language <= 0:
+        parser.error("--files-per-language must be positive")
+    try:
+        result = run_matrix(args.scanner.resolve(), args.policy, args.output, args.files_per_language)
+    except (OSError, RuntimeError, ScanResourcePolicyError) as error:
+        print(f"scan resource matrix failed: {error}")
+        return 1
+    print(render_matrix(result), end="")
+    return 0 if result["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_scan_resource_matrix.py
+++ b/scripts/tests/test_scan_resource_matrix.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from scan_resource_matrix import (  # noqa: E402
+    ScanResourcePolicyError,
+    evaluate_matrix,
+    load_scan_resource_policy,
+    render_matrix,
+)
+
+
+def _policy() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "policy_id": "scan-rss-v1",
+        "workload": "synthetic-medium-v1",
+        "source": "posix-time-v1",
+        "unit": "KiB",
+        "required_scenarios": ["full_cold", "full_warm", "changed_cold", "changed_warm"],
+        "ceiling_kb_by_scenario": {
+            "full_cold": 500,
+            "full_warm": 400,
+            "changed_cold": 450,
+            "changed_warm": 350,
+        },
+        "unavailable": "fail",
+    }
+
+
+def _samples(value: int = 100) -> dict[str, list[dict[str, object]]]:
+    return {
+        scenario: [
+            {
+                "resource_status": "available",
+                "resource_source": "posix-time-v1",
+                "child_max_rss_kb": value,
+            }
+            for _ in range(3)
+        ]
+        for scenario in ("full_cold", "full_warm", "changed_cold", "changed_warm")
+    }
+
+
+class ScanResourceMatrixTests(unittest.TestCase):
+    def test_loads_and_validates_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "policy.toml"
+            path.write_text(
+                """schema_version = 1
+policy_id = "scan-rss-v1"
+workload = "synthetic-medium-v1"
+source = "posix-time-v1"
+unit = "KiB"
+required_scenarios = ["full_cold", "full_warm", "changed_cold", "changed_warm"]
+ceiling_kb_by_scenario = { full_cold = 500, full_warm = 400, changed_cold = 450, changed_warm = 350 }
+unavailable = "fail"
+""",
+                encoding="utf-8",
+            )
+            policy = load_scan_resource_policy(path)
+        self.assertEqual(policy["policy_id"], "scan-rss-v1")
+        self.assertEqual(policy["ceiling_kb_by_scenario"]["full_warm"], 400.0)
+
+    def test_passes_and_renders_deterministically(self) -> None:
+        result = evaluate_matrix(_samples(), _policy())
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["scenarios"]["full_cold"]["median_kb"], 100.0)
+        self.assertEqual(render_matrix(result), render_matrix(result))
+        json.dumps(result, sort_keys=True)
+
+    def test_rejects_over_budget_and_unavailable_samples(self) -> None:
+        samples = _samples(value=100)
+        samples["full_cold"][0]["child_max_rss_kb"] = 600
+        samples["changed_warm"][1] = {
+            "resource_status": "unavailable",
+            "resource_reason": "unsupported platform",
+        }
+        result = evaluate_matrix(samples, _policy())
+        self.assertEqual(result["status"], "fail")
+        kinds = {item["kind"] for item in result["violations"]}
+        self.assertIn("max_over_ceiling", kinds)
+        self.assertIn("unavailable", kinds)
+
+    def test_rejects_missing_scenario_and_invalid_policy(self) -> None:
+        samples = _samples()
+        samples.pop("changed_cold")
+        with self.assertRaisesRegex(ScanResourcePolicyError, "scenario set mismatch"):
+            evaluate_matrix(samples, _policy())
+        policy = _policy()
+        policy["source"] = "other-v1"
+        with self.assertRaisesRegex(ScanResourcePolicyError, "posix-time-v1"):
+            evaluate_matrix(_samples(), policy)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -47,6 +47,17 @@ evidence is marked novel only when its rule/path/line/snippet identity is absent
 from that base scan. The artifact remains unlabeled and makes no utility claim
 until the independent labeling and scoring step exists.
 
+The release binary's synthetic scan resource matrix uses the separate
+`scan-rss-v1` policy:
+
+```bash
+npm run scan:resource
+```
+
+It runs full and changed scans in cold and warm phases, writes the host profile
+and RSS samples to `/tmp/repopilot-scan-resource-matrix.json`, and fails when a
+required sample is unavailable or over its ceiling.
+
 The differential collection artifact is schema 2. Each baseline, base scan, and
 review run has validated monotonic start/finish telemetry. Review runs may also
 record evidence-ready and decision-ready phase events from RepoPilot's internal

--- a/tests/benchmarks/scan-resource.toml
+++ b/tests/benchmarks/scan-resource.toml
@@ -1,0 +1,8 @@
+schema_version = 1
+policy_id = "scan-rss-v1"
+workload = "synthetic-medium-v1"
+source = "posix-time-v1"
+unit = "KiB"
+required_scenarios = ["full_cold", "full_warm", "changed_cold", "changed_warm"]
+ceiling_kb_by_scenario = { full_cold = 65536, full_warm = 65536, changed_cold = 65536, changed_warm = 49152 }
+unavailable = "fail"


### PR DESCRIPTION
## Problem

The RSS policy covered the six-case review packet, but full and changed scans had no matching resource gate. The existing scan performance script checked wall time only, so CI could miss a memory regression in the main scan paths.

## Change

- add `scan_resource_matrix.py` for a synthetic medium workload;
- measure `full_cold`, `full_warm`, `changed_cold`, and `changed_warm` with the existing `posix-time-v1` sampler;
- record host profile, sampler source, samples, medians, maxima, and ceilings in a JSON artifact;
- fail closed on unsupported samplers, unavailable samples, source drift, and over-budget values;
- register `scan-rss-v1` with 65,536 KiB ceilings for full cold, full warm, and changed cold, plus 49,152 KiB for changed warm;
- add `npm run scan:resource` to the Ubuntu Rust CI job and upload its result;
- add focused policy/evaluation tests and update the performance and v0.23 evidence docs.

## Evidence

- `npm run scan:resource` — pass on `darwin-arm64`, 250 files per language;
- latest local maxima: 40,512 KiB full cold, 41,856 KiB full warm, 45,856 KiB changed cold, 38,544 KiB changed warm;
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 229 passed;
- `python3 scripts/release-contract.py check` — passed;
- changed Python files compile with `py_compile`; `git diff --check` passes.

## Scope

The policy is tied to the synthetic medium fixture and the host profile recorded in the artifact. It is a regression gate for this workload, not a universal memory claim.
