### PR TITLE
feat: add exact pytest verification provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,10 +61,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Extended the pytest adapter to normalize conftest import failures and added
   schema-2 validation coverage summaries, separating measured, unavailable, and
   untracked baseline runs.
-- Separated baseline diagnostic IDs from review-comparable identities in the
-  differential metric contract. `duplicate-work` now stays unavailable unless
-  a baseline adapter explicitly supplies the shared `review-exact-v1` mapping,
-  preventing different namespaces from producing a false zero-overlap result.
+- Separated baseline diagnostic IDs from static-review-comparable identities in
+  the differential metric contract. Static `duplicate-work` stays unavailable
+  unless a baseline adapter explicitly supplies the shared `review-exact-v1`
+  mapping, preventing different namespaces from producing a false zero-overlap
+  result.
 - Added the first non-empty `review-exact-v1` mapping: Python `SyntaxError`
   diagnostics on changed lines now carry a deterministic path/line identity in
   review JSON, so `python.compile` can measure exact overlap. Other compiler
@@ -78,6 +79,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   baseline evidence, but comparison stays unavailable until review exposes an
   exact test-node failure identity. Path-only or changed-test-name matching is
   rejected as non-comparable.
+- Added an explicit pytest verification adapter for differential runs. When a
+  pinned review config selects `python.tests`, complete revision-compatible
+  output is normalized as `review-verification-v1` exact node evidence. The
+  artifact records the config hash and coverage report separately; this evidence
+  can measure overlap with an executed verification check, but is never
+  presented as static-review detection.
 - Hardened differential resource evidence: cumulative child RSS is recorded
   only when a positive per-command sample exists; non-positive or unavailable
   deltas are explicitly marked unavailable instead of being reported as zero.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -317,8 +317,10 @@ bump is needed to start.
   failures remain unavailable, while validation reports measured, unavailable,
   and untracked coverage separately. Diagnostic IDs remain adapter-specific;
   duplicate-work overlap is measured only when a baseline also provides an
-  explicit `review-exact-v1` comparison mapping. Command success or output
-  hashes therefore never become evidence overlap.
+  explicit comparison mapping. Static review uses `review-exact-v1`; an
+  explicitly executed compatible test check uses the separate
+  `review-verification-v1` path. Command success or output hashes therefore
+  never become evidence overlap.
 - The first non-empty comparison mapping is now covered end to end for Python
   syntax failures. The scanner records a structured `python.syntax-error`
   diagnostic with a line, review keeps it only when the line is in an added
@@ -335,8 +337,13 @@ bump is needed to start.
   the next adapter action while retaining the hard boundary that no exact
   identity means no overlap measurement.
 - The pytest boundary is now typed: node IDs are measured baseline evidence,
-  while comparison is unavailable because static review emits no exact failed
-  test-node identity. Path-only and changed-test-name matching are explicitly
+  while static review comparison remains unavailable because static analysis
+  does not emit a failed test-node identity. A differential run may opt into a
+  pinned review config with `--review-verify-python-tests`; only one explicit,
+  revision-compatible `python.tests` result with complete bounded output is
+  normalized as `review-verification-v1`. That exact evidence supports a
+  separate overlap measurement for executed verification. It is not merged
+  into static-review claims, and path-only or changed-test-name matching stays
   rejected.
 - Differential RSS is now fail-closed as well. Because `ru_maxrss` is
   cumulative child usage, only a positive per-command delta is retained as a

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -433,9 +433,11 @@ from the core timing record. The first deterministic adapters cover
 measuring clean runs as empty sets, classifying common conftest import failures,
 and leaving unsupported failures unavailable. Artifact validation now exposes
 measured, unavailable, and untracked coverage separately. The collector keeps
-process completion separate from a human decision timestamp. Duplicate-work remains unavailable
-unless an adapter supplies an explicit `review-exact-v1` identity mapping;
-baseline-specific diagnostic IDs alone do not count as overlap.
+process completion separate from a human decision timestamp. Static
+duplicate-work remains unavailable unless an adapter supplies an explicit
+`review-exact-v1` identity mapping; an explicitly executed compatible check may
+use its separate `review-verification-v1` path. Baseline-specific diagnostic
+IDs alone do not count as overlap.
 
 The first non-empty mapping is now implemented for Python syntax failures:
 RepoPilot publishes a structured `python.syntax-error` diagnostic with the
@@ -450,8 +452,13 @@ a comparable overlap measurement.
 The `coverage-audit` report now breaks this denominator down by baseline ID and
 reason. It names the next exact-identity adapter instead of hiding unavailable
 runs inside one aggregate percentage.
-For pytest, the next adapter cannot be a path heuristic: RepoPilot would need
-review-side exact failure provenance before a test-node overlap can be measured.
+For pytest, the next adapter is explicit verification rather than a path
+heuristic. `differential.py collect` can pin a review config and select the
+configured `python.tests` check. Only complete output from a
+revision-compatible verification run becomes `review-verification-v1` exact
+node evidence. That path can measure overlap with an executed check, while
+static review comparison remains unavailable and path-only or changed-test-name
+matching stays rejected.
 Resource-cost reporting follows the same evidence discipline: non-positive
 cumulative RSS deltas remain unavailable until a per-command sample exists.
 The differential collector now obtains that sample from `/usr/bin/time` on

--- a/scripts/differential.py
+++ b/scripts/differential.py
@@ -54,6 +54,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--scanner", help="use an existing repopilot binary instead of building the workspace")
     parser.add_argument("--allow-version-mismatch", action="store_true")
     parser.add_argument("--timeout", type=int, default=300)
+    parser.add_argument(
+        "--review-config",
+        type=Path,
+        help="explicit repopilot.toml used for review verification (required with --review-verify-python-tests)",
+    )
+    parser.add_argument(
+        "--review-verify-python-tests",
+        action="store_true",
+        help="run the configured python.tests check during each review for exact pytest provenance",
+    )
     parser.add_argument("--output", type=Path, help="write a differential artifact")
     parser.add_argument("--artifact", type=Path, help="differential artifact to validate")
     parser.add_argument("--pilot", type=Path, help="single-expert pilot worksheet")
@@ -100,6 +110,13 @@ def main(argv: list[str] | None = None) -> int:
                 f"{comparison['unavailable']} unavailable; "
                 f"{comparison['untracked']} untracked"
             )
+            verification = evidence.get("review_verification", {})
+            print(
+                "Explicit review verification: "
+                f"{verification.get('measured', 0)} measured; "
+                f"{verification.get('unavailable', 0)} unavailable; "
+                f"{verification.get('untracked', 0)} untracked"
+            )
         return 0
     if args.command == "budget-check":
         try:
@@ -142,6 +159,15 @@ def main(argv: list[str] | None = None) -> int:
         if args.timeout <= 0:
             print("--timeout must be positive", file=sys.stderr)
             return 2
+        if args.review_verify_python_tests and args.review_config is None:
+            print("--review-config is required with --review-verify-python-tests", file=sys.stderr)
+            return 2
+        if args.review_config is not None and not args.review_verify_python_tests:
+            print("--review-config requires --review-verify-python-tests", file=sys.stderr)
+            return 2
+        if args.review_config is not None and not args.review_config.is_file():
+            print(f"--review-config does not exist: {args.review_config}", file=sys.stderr)
+            return 2
         try:
             artifact = collect_differential(
                 args.repo_root.resolve(),
@@ -152,6 +178,8 @@ def main(argv: list[str] | None = None) -> int:
                 args.scanner,
                 args.allow_version_mismatch,
                 args.timeout,
+                args.review_config.resolve() if args.review_config is not None else None,
+                ("python.tests",) if args.review_verify_python_tests else (),
             )
             validate_data(
                 artifact,

--- a/scripts/differential_artifact.py
+++ b/scripts/differential_artifact.py
@@ -33,6 +33,7 @@ def validate_data(
 ) -> dict[str, object]:
     protocol = validate_differential(differential_path, manifest_path, rules_reference, zoo_manifest)
     schema_version = _validate_header(data, protocol, manifest_path, differential_path)
+    _validate_review_verification_config(data)
     observations = data.get("cases")
     if not isinstance(observations, list):
         raise DifferentialManifestError("differential artifact cases must be an array")
@@ -64,7 +65,19 @@ def baseline_evidence_summary(observations: list[dict[str, Any]]) -> dict[str, o
     sources: Counter[str] = Counter()
     comparison_by_baseline: dict[str, dict[str, object]] = {}
     comparison_reasons: Counter[str] = Counter()
+    verification_measured = verification_unavailable = verification_untracked = verification_keys = 0
+    verification_reasons: Counter[str] = Counter()
     for observation in observations:
+        for review in observation.get("reviews", []):
+            verification = review.get("verification_comparison") if isinstance(review, dict) else None
+            if not isinstance(verification, dict):
+                verification_untracked += 1
+            elif verification.get("status") == "measured":
+                verification_measured += 1
+                verification_keys += len(verification.get("keys", []))
+            elif verification.get("status") == "unavailable":
+                verification_unavailable += 1
+                verification_reasons[str(verification.get("reason") or "unspecified")] += 1
         for baseline_id, runs in observation.get("baselines", {}).items():
             coverage = comparison_by_baseline.setdefault(
                 baseline_id,
@@ -138,6 +151,13 @@ def baseline_evidence_summary(observations: list[dict[str, Any]]) -> dict[str, o
             else None,
             "by_baseline": dict(sorted(comparison_by_baseline.items())),
             "unavailable_reasons": dict(sorted(comparison_reasons.items())),
+        },
+        "review_verification": {
+            "measured": verification_measured,
+            "unavailable": verification_unavailable,
+            "untracked": verification_untracked,
+            "keys": verification_keys,
+            "unavailable_reasons": dict(sorted(verification_reasons.items())),
         },
     }
 
@@ -259,6 +279,7 @@ def validate_case(
                 raise DifferentialManifestError(
                     f"case {case.case_id}: collected review has invalid comparison keys"
                 )
+            _validate_review_verification(review, f"case {case.case_id} review")
     determinism = observation.get("determinism")
     if not isinstance(determinism, dict) or not isinstance(determinism.get("stable_evidence_deterministic"), bool):
         raise DifferentialManifestError(f"case {case.case_id}: determinism summary is missing")
@@ -339,6 +360,46 @@ def _validate_baseline_evidence(
                 raise DifferentialManifestError(f"{context}: unavailable comparison reason is missing")
     elif not isinstance(evidence.get("reason"), str) or not evidence["reason"]:
         raise DifferentialManifestError(f"{context}: unavailable baseline evidence reason is missing")
+
+
+def _validate_review_verification(review: dict[str, Any], context: str) -> None:
+    """Validate optional exact pytest evidence emitted by explicit review verification."""
+
+    evidence = review.get("verification_comparison")
+    if evidence is None:
+        return
+    if not isinstance(evidence, dict) or evidence.get("status") not in {"measured", "unavailable"}:
+        raise DifferentialManifestError(f"{context}: review verification comparison status is invalid")
+    if evidence["status"] == "measured":
+        keys = evidence.get("keys")
+        if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
+            raise DifferentialManifestError(f"{context}: review verification comparison keys are missing")
+        if evidence.get("scheme") != "review-verification-v1":
+            raise DifferentialManifestError(f"{context}: review verification comparison scheme drift")
+    elif not isinstance(evidence.get("reason"), str) or not evidence["reason"]:
+        raise DifferentialManifestError(f"{context}: review verification comparison reason is missing")
+
+
+def _validate_review_verification_config(data: dict[str, Any]) -> None:
+    config = data.get("review_verification")
+    if config is None:
+        return
+    if not isinstance(config, dict):
+        raise DifferentialManifestError("differential artifact review verification config is invalid")
+    checks = config.get("checks")
+    if not isinstance(checks, list) or not all(isinstance(check, str) for check in checks):
+        raise DifferentialManifestError("differential artifact review verification checks are invalid")
+    if len(set(checks)) != len(checks) or any(check != "python.tests" for check in checks):
+        raise DifferentialManifestError("differential artifact review verification checks are unsupported")
+    config_hash = config.get("config_sha256")
+    if config_hash is not None and (
+        not isinstance(config_hash, str)
+        or len(config_hash) != 64
+        or any(character not in "0123456789abcdef" for character in config_hash)
+    ):
+        raise DifferentialManifestError("differential artifact review verification config hash is invalid")
+    if checks and config_hash is None:
+        raise DifferentialManifestError("differential artifact review verification config hash is missing")
 
 
 def validate_artifact(

--- a/scripts/differential_coverage.py
+++ b/scripts/differential_coverage.py
@@ -23,6 +23,7 @@ def render_coverage_audit(validation: dict[str, Any]) -> str:
 
     evidence = validation["baseline_evidence"]
     comparison = evidence["comparison"]
+    verification = evidence.get("review_verification", {})
     lines = [
         "# Differential evidence coverage audit",
         "",
@@ -31,6 +32,10 @@ def render_coverage_audit(validation: dict[str, Any]) -> str:
         f"- **Baseline evidence:** {evidence['measured']}/{evidence['tracked']} tracked runs measured",
         f"- **Review-comparable evidence:** {comparison['measured']} measured, "
         f"{comparison['unavailable']} unavailable, {comparison['untracked']} untracked",
+        f"- **Explicit review verification:** {verification.get('measured', 0)} measured, "
+        f"{verification.get('unavailable', 0)} unavailable, "
+        f"{verification.get('untracked', 0)} untracked; "
+        f"{verification.get('keys', 0)} exact keys",
         "",
         "This is an adapter-coverage audit. It does not estimate precision, recall, utility, or overlap "
         "when a baseline identity mapping is unavailable.",
@@ -56,10 +61,17 @@ def render_coverage_audit(validation: dict[str, Any]) -> str:
     reasons = comparison.get("unavailable_reasons", {})
     if reasons:
         if any(_PYTEST_FAILURE_MAPPING_REASON in reason for reason in reasons):
-            lines.append(
-                "For `python.tests`, keep node failures unavailable until review emits exact test-node "
-                "failure provenance. Do not derive overlap from a test path or changed test name."
-            )
+            if verification.get("measured", 0):
+                lines.append(
+                    "Static `python.tests` overlap remains unavailable. Explicit review verification "
+                    "provides exact node evidence for the separate `review-verification-v1` path; "
+                    "do not merge it into static review claims or derive overlap from a test path."
+                )
+            else:
+                lines.append(
+                    "For `python.tests`, keep node failures unavailable until review emits exact test-node "
+                    "failure provenance. Do not derive overlap from a test path or changed test name."
+                )
         else:
             lines.append(
                 "Add or review an exact `review-exact-v1` identity adapter for the unavailable baseline "

--- a/scripts/differential_evidence.py
+++ b/scripts/differential_evidence.py
@@ -19,9 +19,13 @@ _PYTEST_CONFTEST_ERROR = re.compile(
     r"ImportError while loading conftest ['\"](?P<path>.+?)['\"]\."
 )
 _COMPARISON_SCHEME = REVIEW_COMPARISON_SCHEME
+_REVIEW_VERIFICATION_SCHEME = "review-verification-v1"
 _COMPARABLE_COMPILE_KINDS = {"SyntaxError"}
 _PYTEST_COMPARISON_UNAVAILABLE = (
     "python.tests review has no exact test-node failure identity; node paths alone are not comparable"
+)
+_PYTEST_VERIFICATION_UNAVAILABLE = (
+    "python.tests requires an explicit python.tests verification with revision-compatible, complete output"
 )
 
 
@@ -139,6 +143,17 @@ def _pytest_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> di
     if returncode == 0:
         return _measured("python.tests-v1", [])
     text = "\n".join((stdout, stderr))
+    keys = _pytest_failure_keys(text, cwd)
+    if not keys:
+        return _unavailable("python.tests output did not contain a supported diagnostic")
+    return _measured(
+        "python.tests-v1",
+        sorted(keys),
+        comparison_reason=_PYTEST_COMPARISON_UNAVAILABLE,
+    )
+
+
+def _pytest_failure_keys(text: str, cwd: Path) -> set[str]:
     keys: set[str] = set()
     for match in _PYTEST_CONFTEST_ERROR.finditer(text):
         path = _relative_path(match.group("path"), cwd)
@@ -153,13 +168,56 @@ def _pytest_evidence(stdout: str, stderr: str, returncode: int, cwd: Path) -> di
             normalized_node = _relative_path(node, cwd)
             status = "collection-error"
         keys.add(f"python.tests:{normalized_node}:{status}")
+    return keys
+
+
+def normalize_review_verification(report: dict[str, Any], cwd: Path) -> dict[str, Any]:
+    """Normalize an explicit, revision-compatible pytest verification result.
+
+    This is deliberately separate from static review identities. An exact node
+    overlap is comparable only when RepoPilot actually ran the configured
+    `python.tests` check and retained complete output for the same revision.
+    """
+
+    outcomes = report.get("verification")
+    if outcomes is None:
+        readiness = report.get("merge_readiness")
+        outcomes = readiness.get("verification") if isinstance(readiness, dict) else None
+    if not isinstance(outcomes, list):
+        return _unavailable(_PYTEST_VERIFICATION_UNAVAILABLE)
+    selected = [
+        outcome
+        for outcome in outcomes
+        if isinstance(outcome, dict) and outcome.get("check_id") == "python.tests"
+    ]
+    if len(selected) != 1:
+        return _unavailable(_PYTEST_VERIFICATION_UNAVAILABLE)
+    outcome = selected[0]
+    if outcome.get("role") != "test" or outcome.get("revision_compatible") is not True:
+        return _unavailable(_PYTEST_VERIFICATION_UNAVAILABLE)
+    if outcome.get("stdout_truncated") is not False or outcome.get("stderr_truncated") is not False:
+        return _unavailable(_PYTEST_VERIFICATION_UNAVAILABLE)
+    status = outcome.get("status")
+    if status == "passed":
+        return {
+            "status": "measured",
+            "keys": [],
+            "scheme": _REVIEW_VERIFICATION_SCHEME,
+        }
+    if status != "failed":
+        return _unavailable(_PYTEST_VERIFICATION_UNAVAILABLE)
+    stdout = outcome.get("stdout_excerpt")
+    stderr = outcome.get("stderr_excerpt")
+    if not isinstance(stdout, str) or not isinstance(stderr, str):
+        return _unavailable(_PYTEST_VERIFICATION_UNAVAILABLE)
+    keys = _pytest_failure_keys("\n".join((stdout, stderr)), cwd)
     if not keys:
-        return _unavailable("python.tests output did not contain a supported diagnostic")
-    return _measured(
-        "python.tests-v1",
-        sorted(keys),
-        comparison_reason=_PYTEST_COMPARISON_UNAVAILABLE,
-    )
+        return _unavailable("python.tests verification output did not contain a supported diagnostic")
+    return {
+        "status": "measured",
+        "keys": sorted(keys),
+        "scheme": _REVIEW_VERIFICATION_SCHEME,
+    }
 
 
 def normalize_baseline_evidence(

--- a/scripts/differential_metrics_report.py
+++ b/scripts/differential_metrics_report.py
@@ -30,6 +30,8 @@ def _measurement_status(value: Any) -> str:
             details.append(f"overlap {value['overlap_count']}")
         if isinstance(value.get("overlap_rate"), (int, float)):
             details.append(f"rate {float(value['overlap_rate']):.3f}")
+        if isinstance(value.get("identity_source"), str):
+            details.append(f"identity {value['identity_source']}")
         return "measured" + (f" ({', '.join(details)})" if details else "")
     return str(value.get("status", "unknown"))
 

--- a/scripts/differential_pilot_metrics.py
+++ b/scripts/differential_pilot_metrics.py
@@ -121,6 +121,8 @@ def _timing_measurement(values: list[float], reason: str) -> dict[str, object]:
 
 def _duplicate_work_measurement(observation: dict[str, Any]) -> dict[str, object]:
     baseline_keys: set[str] = set()
+    needs_verification = False
+    used_static_mapping = False
     for runs in observation["baselines"].values():
         for run in runs:
             evidence = run.get("evidence")
@@ -131,6 +133,20 @@ def _duplicate_work_measurement(observation: dict[str, Any]) -> dict[str, object
                 }
             comparison = evidence.get("comparison")
             if not isinstance(comparison, dict) or comparison.get("status") != "measured":
+                if (
+                    evidence.get("status") == "measured"
+                    and comparison
+                    and comparison.get("scheme") == "review-exact-v1"
+                ):
+                    needs_verification = True
+                    keys = evidence.get("keys")
+                    if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
+                        return {
+                            "status": "unavailable",
+                            "reason": "baseline evidence has invalid normalized identity keys",
+                        }
+                    baseline_keys.update(keys)
+                    continue
                 return {
                     "status": "unavailable",
                     "reason": "baseline evidence has no review-comparable identity mapping",
@@ -141,15 +157,36 @@ def _duplicate_work_measurement(observation: dict[str, Any]) -> dict[str, object
             if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
                 return {"status": "unavailable", "reason": "baseline comparison keys are invalid"}
             baseline_keys.update(keys)
+            used_static_mapping = True
     review_keys: set[str] = set()
+    verification_keys: set[str] = set()
     for review in observation["reviews"]:
         keys = review.get("in_diff_comparison_keys")
         if not isinstance(keys, list):
             keys = review.get("in_diff_evidence_keys", [])
         review_keys.update(key for key in keys if isinstance(key, str))
+        verification = review.get("verification_comparison")
+        if needs_verification:
+            if not isinstance(verification, dict) or verification.get("status") != "measured":
+                return {
+                    "status": "unavailable",
+                    "reason": "baseline evidence has no review-comparable identity mapping",
+                }
+            if verification.get("scheme") != "review-verification-v1":
+                return {"status": "unavailable", "reason": "review verification identity scheme is unsupported"}
+            keys = verification.get("keys")
+            if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
+                return {"status": "unavailable", "reason": "review verification keys are invalid"}
+            verification_keys.update(keys)
+    if needs_verification:
+        review_keys.update(verification_keys)
+        identity_source = "mixed" if used_static_mapping else "review-verification-v1"
+    else:
+        identity_source = "review-exact-v1"
     overlap_count = len(baseline_keys & review_keys)
     return {
         "status": "measured",
+        "identity_source": identity_source,
         "overlap_count": overlap_count,
         "baseline_evidence_count": len(baseline_keys),
         "review_evidence_count": len(review_keys),
@@ -353,8 +390,16 @@ def _aggregate_duplicate_work(measurements: list[dict[str, object]]) -> dict[str
     overlap_count = sum(int(measurement.get("overlap_count", 0)) for measurement in measurements)
     baseline_count = sum(int(measurement.get("baseline_evidence_count", 0)) for measurement in measurements)
     review_count = sum(int(measurement.get("review_evidence_count", 0)) for measurement in measurements)
+    identity_sources = sorted(
+        {
+            str(measurement["identity_source"])
+            for measurement in measurements
+            if isinstance(measurement.get("identity_source"), str)
+        }
+    )
     return {
         "status": "measured",
+        "identity_source": identity_sources[0] if len(identity_sources) == 1 else "mixed",
         "overlap_count": overlap_count,
         "baseline_evidence_count": baseline_count,
         "review_evidence_count": review_count,

--- a/scripts/differential_runner.py
+++ b/scripts/differential_runner.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from differential_contract import validate_differential
-from differential_evidence import normalize_baseline_evidence
+from differential_evidence import normalize_baseline_evidence, normalize_review_verification
 from differential_identity import review_comparable_diagnostic_keys
 from differential_manifest import load_differential
 from differential_novelty import evidence_keys, novel_evidence_keys
@@ -101,26 +101,52 @@ def _scan_base(scanner: Any, case: HoldoutCase, base: Path, timeout_seconds: int
     }
 
 
+def _review_command(
+    scanner: Any,
+    base_sha: str,
+    head_sha: str,
+    head: Path,
+    review_config: Path | None,
+    review_verify: tuple[str, ...],
+) -> tuple[str, ...]:
+    scanner_command = scanner.command if hasattr(scanner, "command") else scanner
+    command = (
+        *scanner_command,
+        "review",
+        str(head),
+        "--base",
+        base_sha,
+        "--head",
+        head_sha,
+        "--format",
+        "json",
+        "--profile",
+        "default",
+        "--no-progress",
+    )
+    if review_config is not None:
+        command += ("--config", str(review_config))
+    for check_id in review_verify:
+        command += ("--verify", check_id)
+    return command
+
+
 def _review_once(
     scanner: Any,
     case: HoldoutCase,
     head: Path,
     base_evidence: set[str],
     timeout_seconds: int,
+    review_config: Path | None = None,
+    review_verify: tuple[str, ...] = (),
 ) -> dict[str, Any]:
-    command = (
-        *scanner.command,
-        "review",
-        str(head),
-        "--base",
+    command = _review_command(
+        scanner,
         case.base_sha,
-        "--head",
         case.head_sha,
-        "--format",
-        "json",
-        "--profile",
-        "default",
-        "--no-progress",
+        head,
+        review_config,
+        review_verify,
     )
     observation = execute_timed_command(command, head, timeout_seconds)
     if observation["status"] == "timeout":
@@ -135,6 +161,7 @@ def _review_once(
             "in_diff_evidence_keys": [],
             "novel_in_diff_evidence_keys": [],
             "in_diff_comparison_keys": [],
+            "verification_comparison": normalize_review_verification({}, head),
         }
         if resource["status"] == "unavailable":
             result["resource_reason"] = resource["reason"]
@@ -156,6 +183,7 @@ def _review_once(
         observation["returncode"],
         base_evidence,
         observation["wall_ms"],
+        head,
     )
     resource = observation["resource"]
     result["resource_status"] = resource["status"]
@@ -173,6 +201,7 @@ def _build_review_result(
     returncode: int,
     base_evidence: set[str],
     wall_ms: float,
+    cwd: Path,
 ) -> dict[str, Any]:
     in_diff_findings = [
         finding for finding in report["findings"] if isinstance(finding, dict) and finding.get("in_diff") is True
@@ -180,6 +209,7 @@ def _build_review_result(
     in_diff_keys = sorted(evidence_keys(in_diff_findings))
     novel_keys = novel_evidence_keys(in_diff_findings, base_evidence)
     comparison_keys = review_comparable_diagnostic_keys(report)
+    verification_comparison = normalize_review_verification(report, cwd)
     result = {
         **summarize_review(report, raw_output),
         "status": "collected",
@@ -188,6 +218,7 @@ def _build_review_result(
         "in_diff_evidence_keys": in_diff_keys,
         "novel_in_diff_evidence_keys": novel_keys,
         "in_diff_comparison_keys": comparison_keys,
+        "verification_comparison": verification_comparison,
     }
     result["telemetry"] = build_review_telemetry(report, wall_ms, bool(novel_keys))
     return result
@@ -200,6 +231,8 @@ def collect_case(
     repetitions: int,
     root: Path,
     timeout_seconds: int,
+    review_config: Path | None = None,
+    review_verify: tuple[str, ...] = (),
 ) -> dict[str, Any]:
     base, head, merge = clone_case(case, root)
     base_scan = _scan_base(scanner, case, base, timeout_seconds)
@@ -212,7 +245,15 @@ def collect_case(
             result["repeat"] = repeat
             result["resource_phase"] = _resource_phase(repeat)
             baselines[baseline_id].append(result)
-        review = _review_once(scanner, case, head, base_evidence, timeout_seconds)
+        review = _review_once(
+            scanner,
+            case,
+            head,
+            base_evidence,
+            timeout_seconds,
+            review_config,
+            review_verify,
+        )
         review["repeat"] = repeat
         review["resource_phase"] = _resource_phase(repeat)
         reviews.append(review)
@@ -244,6 +285,8 @@ def collect_differential(
     scanner_path: str | None,
     allow_version_mismatch: bool,
     timeout_seconds: int,
+    review_config: Path | None = None,
+    review_verify: tuple[str, ...] = (),
 ) -> dict[str, Any]:
     summary = validate_differential(differential_path, manifest_path, rules_reference, zoo_manifest)
     corpus, _, holdout_cases = validate_manifest(manifest_path, rules_reference, zoo_manifest)
@@ -265,6 +308,8 @@ def collect_differential(
                     summary["repetitions"],
                     Path(temporary) / str(index),
                     timeout_seconds,
+                    review_config,
+                    review_verify,
                 )
             )
     return {
@@ -281,6 +326,14 @@ def collect_differential(
             "workspace_commit": scanner.workspace_commit,
             "workspace_dirty": scanner.workspace_dirty,
             "version_mismatch_allowed": scanner.version_mismatch_allowed,
+        },
+        "review_verification": {
+            "checks": list(review_verify),
+            "config_sha256": (
+                hashlib.sha256(review_config.read_bytes()).hexdigest()
+                if review_config is not None
+                else None
+            ),
         },
         "repetitions": summary["repetitions"],
         "cases": observations,

--- a/scripts/tests/test_differential.py
+++ b/scripts/tests/test_differential.py
@@ -109,6 +109,25 @@ baseline_ids = ["python.tests"]
         self.assertEqual(differential.main(["pilot-metrics-report", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
         self.assertEqual(differential.main(["coverage-audit", "--manifest", str(self.diff), "--holdout-manifest", str(self.holdout), "--rules-reference", str(self.rules), "--zoo-manifest", str(self.zoo)]), 2)
 
+    def test_collect_requires_a_pinned_config_for_pytest_verification(self) -> None:
+        result = differential.main(
+            [
+                "collect",
+                "--manifest",
+                str(self.diff),
+                "--holdout-manifest",
+                str(self.holdout),
+                "--rules-reference",
+                str(self.rules),
+                "--zoo-manifest",
+                str(self.zoo),
+                "--output",
+                str(self.root / "artifact.json"),
+                "--review-verify-python-tests",
+            ]
+        )
+        self.assertEqual(result, 2)
+
     def _budget_artifact(self, cold: int = 100, warm: int = 200) -> Path:
         self.diff.write_text(
             self.diff.read_text(encoding="utf-8")

--- a/scripts/tests/test_differential_coverage.py
+++ b/scripts/tests/test_differential_coverage.py
@@ -50,14 +50,23 @@ class DifferentialCoverageTests(unittest.TestCase):
                             "python.tests review has no exact test-node failure identity; node paths alone are not comparable": 3,
                         },
                     },
+                    "review_verification": {
+                        "measured": 3,
+                        "unavailable": 0,
+                        "untracked": 0,
+                        "keys": 2,
+                        "unavailable_reasons": {},
+                    },
                 },
             }
         )
         self.assertIn("| `python.compile` | 3 | 3 | 0 | 0 | 1 | 1.0 |", report)
         self.assertIn("test-node failure identity", report)
         self.assertIn("does not estimate precision, recall, utility, or overlap", report)
-        self.assertIn("For `python.tests`, keep node failures unavailable", report)
-        self.assertIn("Do not derive overlap from a test path", report)
+        self.assertIn("Static `python.tests` overlap remains unavailable", report)
+        self.assertIn("derive overlap from a test path", report)
+        self.assertIn("Explicit review verification", report)
+        self.assertIn("3 measured", report)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_differential_evidence.py
+++ b/scripts/tests/test_differential_evidence.py
@@ -8,7 +8,10 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
-from differential_evidence import normalize_baseline_evidence  # noqa: E402
+from differential_evidence import (  # noqa: E402
+    normalize_baseline_evidence,
+    normalize_review_verification,
+)
 
 
 class DifferentialEvidenceTests(unittest.TestCase):
@@ -105,6 +108,85 @@ ERROR collecting tests/test_import.py
         result = normalize_baseline_evidence("python.tests", output, b"", 4, Path("/workspace"))
         self.assertEqual(result["status"], "measured")
         self.assertEqual(result["keys"], ["python.tests:tests/conftest.py:collection-error"])
+
+    def test_review_verification_exposes_exact_pytest_failure_identity(self) -> None:
+        report = {
+            "merge_readiness": {
+                "verification": [
+                    {
+                        "check_id": "python.tests",
+                        "role": "test",
+                        "status": "failed",
+                        "revision_compatible": True,
+                        "stdout_excerpt": "FAILED tests/test_api.py::test_create - AssertionError\n",
+                        "stderr_excerpt": "",
+                        "stdout_truncated": False,
+                        "stderr_truncated": False,
+                    }
+                ]
+            }
+        }
+
+        result = normalize_review_verification(report, Path("/workspace"))
+
+        self.assertEqual(
+            result,
+            {
+                "status": "measured",
+                "keys": ["python.tests:tests/test_api.py::test_create:failed"],
+                "scheme": "review-verification-v1",
+            },
+        )
+
+    def test_review_verification_rejects_truncated_or_incompatible_output(self) -> None:
+        report = {
+            "verification": [
+                {
+                    "check_id": "python.tests",
+                    "role": "test",
+                    "status": "failed",
+                    "revision_compatible": False,
+                    "stdout_excerpt": "FAILED tests/test_api.py::test_create - AssertionError\n",
+                    "stderr_excerpt": "",
+                    "stdout_truncated": True,
+                    "stderr_truncated": False,
+                }
+            ]
+        }
+
+        result = normalize_review_verification(report, Path("/workspace"))
+
+        self.assertEqual(result["status"], "unavailable")
+        self.assertIn("revision-compatible", result["reason"])
+
+    def test_review_verification_pass_is_measured_with_empty_failure_set(self) -> None:
+        report = {
+            "merge_readiness": {
+                "verification": [
+                    {
+                        "check_id": "python.tests",
+                        "role": "test",
+                        "status": "passed",
+                        "revision_compatible": True,
+                        "stdout_excerpt": "3 passed in 0.01s\n",
+                        "stderr_excerpt": "",
+                        "stdout_truncated": False,
+                        "stderr_truncated": False,
+                    }
+                ]
+            }
+        }
+
+        self.assertEqual(
+            normalize_review_verification(report, Path("/workspace")),
+            {"status": "measured", "keys": [], "scheme": "review-verification-v1"},
+        )
+
+    def test_review_verification_without_selected_python_check_is_unavailable(self) -> None:
+        result = normalize_review_verification({"verification": []}, Path("/workspace"))
+
+        self.assertEqual(result["status"], "unavailable")
+        self.assertIn("explicit python.tests verification", result["reason"])
 
     def test_unknown_baseline_is_unavailable(self) -> None:
         result = normalize_baseline_evidence("python.lint", b"", b"", 0, Path("/repo"))

--- a/scripts/tests/test_differential_metrics_report.py
+++ b/scripts/tests/test_differential_metrics_report.py
@@ -31,7 +31,12 @@ class DifferentialMetricsReportTests(unittest.TestCase):
                     "median_review_child_max_rss_kb_by_phase": {"cold": 150.0, "warm": 100.0},
                     "time_to_first_useful_evidence": {"status": "unavailable", "reason": "not recorded"},
                     "decision_latency": {"status": "unavailable", "reason": "not recorded"},
-                    "duplicate_work": {"status": "unavailable", "reason": "unlabeled"},
+                    "duplicate_work": {
+                        "status": "measured",
+                        "identity_source": "review-verification-v1",
+                        "overlap_count": 1,
+                        "overlap_rate": 1.0,
+                    },
                 },
                 "cases": [
                     {
@@ -52,6 +57,7 @@ class DifferentialMetricsReportTests(unittest.TestCase):
         self.assertIn("Median review peak RSS warm (KiB)", report)
         self.assertIn("RSS cold KiB", report)
         self.assertIn("| 0 | 20.000 | 150.000 | 100.000 |", report)
+        self.assertIn("review-verification-v1", report)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_differential_pilot.py
+++ b/scripts/tests/test_differential_pilot.py
@@ -168,6 +168,61 @@ class DifferentialPilotTests(unittest.TestCase):
             "baseline evidence has no review-comparable identity mapping",
         )
 
+    def test_metrics_use_explicit_review_verification_for_pytest_overlap(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            inputs = self._write_inputs(root, include_novel=True)
+            data = json.loads(inputs["artifact"].read_text(encoding="utf-8"))
+            for case in data["cases"]:
+                for runs in case["baselines"].values():
+                    for run in runs:
+                        run["evidence"] = {
+                            "status": "measured",
+                            "keys": [
+                                "python.tests:tests/test_api.py::test_create:failed"
+                            ]
+                            if case["id"] == "case-two"
+                            else ["python.compile:pkg/api.py:4:SyntaxError"],
+                            "comparison": {
+                                "status": "unavailable",
+                                "reason": "baseline evidence has no review-comparable identity mapping",
+                                "scheme": "review-exact-v1",
+                            }
+                            if case["id"] == "case-two"
+                            else {
+                                "status": "measured",
+                                "keys": ["python.compile:pkg/api.py:4:SyntaxError"],
+                                "scheme": "review-exact-v1",
+                            },
+                        }
+                if case["id"] == "case-two":
+                    for review in case["reviews"]:
+                        review["verification_comparison"] = {
+                            "status": "measured",
+                            "keys": [
+                                "python.tests:tests/test_api.py::test_create:failed"
+                            ],
+                            "scheme": "review-verification-v1",
+                        }
+            inputs["artifact"].write_text(json.dumps(data), encoding="utf-8")
+            pilot = root / "pilot.toml"
+            pilot.write_text(
+                render_pilot_template(
+                    inputs["artifact"], inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"], "expert"
+                )
+                .replace('label = ""', 'label = "no-defect"', 1)
+                .replace('rationale = ""', 'rationale = "reviewed first case"', 1)
+                .replace('label = ""', 'label = "uncertain"', 1)
+                .replace('rationale = ""', 'rationale = "verification evidence"', 1),
+                encoding="utf-8",
+            )
+            output = build_pilot_metrics(
+                inputs["artifact"], pilot, inputs["manifest"], inputs["differential"], inputs["rules"], inputs["zoo"]
+            )
+        duplicate = output["measurements"]["duplicate_work"]
+        self.assertEqual(duplicate["status"], "measured")
+        self.assertEqual(duplicate["overlap_count"], 1)
+
     @staticmethod
     def _write_inputs(root: Path, include_novel: bool = False) -> dict[str, Path]:
         rules = root / "rules.md"

--- a/scripts/tests/test_differential_runner.py
+++ b/scripts/tests/test_differential_runner.py
@@ -11,12 +11,49 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from differential_artifact import validate_data  # noqa: E402
-from differential_runner import _build_review_result, _resource_phase, run_timed_command  # noqa: E402
+from differential_runner import (  # noqa: E402
+    _build_review_result,
+    _resource_phase,
+    _review_command,
+    run_timed_command,
+)
 from differential_telemetry import build_command_telemetry  # noqa: E402
 from real_history_runner import BASELINE_COMMANDS  # noqa: E402
 
 
 class DifferentialRunnerTests(unittest.TestCase):
+    def test_review_command_can_pin_explicit_verification_config_and_checks(self) -> None:
+        command = _review_command(
+            ("repopilot",),
+            "base-sha",
+            "head-sha",
+            Path("/tmp/worktree"),
+            Path("/tmp/review.toml"),
+            ("python.tests",),
+        )
+
+        self.assertEqual(
+            command,
+            (
+                "repopilot",
+                "review",
+                "/tmp/worktree",
+                "--base",
+                "base-sha",
+                "--head",
+                "head-sha",
+                "--format",
+                "json",
+                "--profile",
+                "default",
+                "--no-progress",
+                "--config",
+                "/tmp/review.toml",
+                "--verify",
+                "python.tests",
+            ),
+        )
+
     def test_repeated_runs_have_explicit_cold_and_warm_phases(self) -> None:
         self.assertEqual(_resource_phase(1), "cold")
         self.assertEqual(_resource_phase(2), "warm")
@@ -46,12 +83,56 @@ class DifferentialRunnerTests(unittest.TestCase):
             0,
             set(),
             1.0,
+            Path("/worktree"),
         )
 
         self.assertEqual(result["in_diff_evidence_keys"], [])
         self.assertEqual(
             result["in_diff_comparison_keys"],
             ["python.compile:pkg/bad.py:7:SyntaxError"],
+        )
+
+    def test_review_result_records_exact_verification_comparison_keys(self) -> None:
+        report = {
+            "root_path": "/worktree",
+            "changed_files": [],
+            "diagnostics": [],
+            "merge_readiness": {
+                "verification": [
+                    {
+                        "check_id": "python.tests",
+                        "role": "test",
+                        "status": "failed",
+                        "revision_compatible": True,
+                        "stdout_excerpt": "FAILED tests/test_api.py::test_create - AssertionError\n",
+                        "stderr_excerpt": "",
+                        "stdout_truncated": False,
+                        "stderr_truncated": False,
+                    }
+                ]
+            },
+            "findings": [],
+            "schema_version": "0.26",
+            "repopilot_version": "0.23.0",
+            "change_proof": {"contract_deltas": []},
+        }
+
+        result = _build_review_result(
+            report,
+            b"report",
+            0,
+            set(),
+            1.0,
+            Path("/worktree"),
+        )
+
+        self.assertEqual(
+            result["verification_comparison"],
+            {
+                "status": "measured",
+                "keys": ["python.tests:tests/test_api.py::test_create:failed"],
+                "scheme": "review-verification-v1",
+            },
         )
 
     def test_timed_command_records_pass_and_hashes(self) -> None:
@@ -193,6 +274,13 @@ class DifferentialRunnerTests(unittest.TestCase):
                     },
                     "unavailable_reasons": {},
                 },
+                "review_verification": {
+                    "measured": 0,
+                    "unavailable": 0,
+                    "untracked": 6,
+                    "keys": 0,
+                    "unavailable_reasons": {},
+                },
             },
         )
 
@@ -320,6 +408,43 @@ class DifferentialRunnerTests(unittest.TestCase):
                 for review in case["reviews"]:
                     review["telemetry"] = build_command_telemetry(1.0)
             with self.assertRaisesRegex(ValueError, "comparison"):
+                validate_data(artifact, holdout, differential, rules, zoo)
+
+    def test_artifact_rejects_invalid_review_verification_comparison(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            holdout, differential, rules, zoo = self._write_manifests(root)
+            artifact = self._valid_artifact(holdout, differential)
+            artifact["schema_version"] = 2
+            for case in artifact["cases"]:
+                case["base_scan"]["telemetry"] = build_command_telemetry(1.0)
+                for runs in case["baselines"].values():
+                    for run in runs:
+                        run["telemetry"] = build_command_telemetry(1.0)
+                        run["evidence"] = {
+                            "status": "unavailable",
+                            "reason": "fixture has no baseline adapter",
+                        }
+                for review in case["reviews"]:
+                    review["telemetry"] = build_command_telemetry(1.0)
+                    review["verification_comparison"] = {
+                        "status": "measured",
+                        "keys": [],
+                        "scheme": "wrong-scheme",
+                    }
+            with self.assertRaisesRegex(ValueError, "verification comparison scheme"):
+                validate_data(artifact, holdout, differential, rules, zoo)
+
+    def test_artifact_rejects_unpinned_review_verification_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            holdout, differential, rules, zoo = self._write_manifests(root)
+            artifact = self._valid_artifact(holdout, differential)
+            artifact["review_verification"] = {
+                "checks": ["python.tests"],
+                "config_sha256": None,
+            }
+            with self.assertRaisesRegex(ValueError, "config hash is missing"):
                 validate_data(artifact, holdout, differential, rules, zoo)
 
     @staticmethod

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -68,9 +68,9 @@ set; conftest import failures are normalized to their collection path; an
 unrecognized failure stays explicitly unavailable. `validate-result` reports
 measured, unavailable, and untracked coverage separately. Command success or
 output hashes alone are not treated as evidence overlap. A baseline diagnostic
-ID is not automatically comparable to a RepoPilot finding ID: duplicate-work
-requires an explicit `review-exact-v1` comparison mapping, otherwise the
-measurement remains unavailable.
+ID is not automatically comparable to a RepoPilot finding ID: static
+duplicate-work requires an explicit `review-exact-v1` comparison mapping,
+otherwise that measurement remains unavailable.
 
 `coverage-audit` renders the same validated denominators by baseline ID. It
 keeps unavailable reasons visible and points to the next adapter work without
@@ -91,18 +91,40 @@ regression gate for the pinned packet-v9 host and workload; changing either
 requires a new measurement and an explicit policy change. An unavailable
 sample fails the check.
 
-For `python.tests`, a failed pytest node remains baseline-only. RepoPilot does
-not execute tests during review, so a test path or changed test name cannot
-prove the same failure identity; the comparison stays unavailable until a
-review-side exact failure provenance exists.
+For `python.tests`, a failed pytest node remains baseline-only in the default
+static review run. A path or changed test name cannot prove the same failure
+identity. To collect an explicit verification comparison, provide a temporary
+config that defines the exact check and pin it in the artifact:
+
+```toml
+[[verification.checks]]
+id = "python.tests"
+role = "test"
+program = "python3"
+args = ["-m", "pytest", "-q"]
+```
+
+```bash
+python3 scripts/differential.py collect \
+  --scanner target/release/repopilot \
+  --review-config /tmp/repopilot-python-tests.toml \
+  --review-verify-python-tests \
+  --output differential-run.json
+```
+
+Only complete, revision-compatible output from that explicit check is recorded
+as `review-verification-v1` exact node evidence. The artifact stores the config
+hash and the coverage audit reports it separately. Any resulting overlap is
+evidence about executed verification work; it is not static-review detection
+and cannot be used to claim precision or recall.
 
 When one reviewer is available, `pilot-template` creates an exploratory
 worksheet over the same pinned differential artifact. `pilot-score` reports
 only captured novel-evidence, timing, determinism, and resource fields;
 decision latency and time to first useful evidence remain unavailable until the
 collector records the required events. Duplicate work additionally requires
-the explicit review-comparable identity mapping. Validate the metrics artifact
-before rendering or circulating its report.
+an explicit `review-exact-v1` or `review-verification-v1` identity mapping.
+Validate the metrics artifact before rendering or circulating its report.
 
 Validate the protocol contract without cloning repositories:
 


### PR DESCRIPTION
## Problem

The differential evidence pipeline could parse static pytest output, but it could not turn a real RepoPilot review verification into an exact, revision-safe test-node identity. That left `python.tests` execution evidence separate from duplicate-work measurements even when the configured check had actually run.

## What changed

- Add an opt-in review adapter for `python.tests` via `--review-config <path> --review-verify-python-tests`.
- Require one selected test check, `role = "test"`, a revision-compatible review, and complete stdout/stderr before recording exact evidence.
- Emit `review-verification-v1` keys such as `python.tests:test_example.py::test_value:failed`; pass results are measured with an empty key set.
- Store the verification check selection and SHA-256 of the config in the differential artifact without storing a local path.
- Keep static pytest comparison explicitly unavailable under `review-exact-v1`; only explicit execution evidence can power the separate verification path.
- Teach artifact validation, coverage, pilot metrics, and reports to keep measured, unavailable, and untracked verification evidence distinct.
- Add focused regression coverage and document the workflow in the v0.23 roadmap, evidence ledger, changelog, and benchmark guide.

## Why this matters

This gives v0.23 a stronger scientific boundary: an exact pytest overlap can be measured only when RepoPilot executed the configured check against a compatible revision and retained complete output. It does not turn static review output into recall or precision claims, and it does not infer identities from file paths alone.

## Verification

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 240 passed
- `cargo test --all` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `python3 scripts/release-contract.py check` — passed
- `npm run review:performance` — passed (`changed_to_full_ratio = 0.439`, budget `<= 0.6`)
- `cargo run -- scan . --fail-on-priority p1` — passed
- Manual integration proof produced `python.tests:test_example.py::test_value:failed` from a revision-compatible review.
