### PR TITLE
feat: scope differential budgets by verification workload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   artifact records the config hash and coverage report separately; this evidence
   can measure overlap with an executed verification check, but is never
   presented as static-review detection.
+- Bound differential RSS policies to the selected verification workload. A
+  static-review budget now fails closed when applied to an artifact that ran
+  explicit checks; a separate policy file can be pinned for that workload
+  without changing the canonical differential manifest.
 - Hardened differential resource evidence: cumulative child RSS is recorded
   only when a positive per-command sample exists; non-positive or unavailable
   deltas are explicitly marked unavailable instead of being reported as zero.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -385,6 +385,32 @@ bump is needed to start.
   checks. RP23-014 remains open until the frozen dual-review and utility labels
   are completed and the collected telemetry covers the declared dimensions.
 
+## 0U — Explicit Pytest Verification Packet
+
+- A fresh local six-case packet was collected on 2026-09-08 from the immutable
+  holdout with `/tmp/repopilot-python-tests.toml` selecting only
+  `python.tests`. The artifact remains local at
+  `/tmp/repopilot-v023-python-verification-v2.json`; it is intentionally not
+  committed as a generated benchmark result.
+- `validate-result` measured all 36/36 declared baseline runs and all 18/18
+  explicit review-verification runs. Static `python.tests` comparison stayed
+  unavailable for 18/18 runs, while the separate
+  `review-verification-v1` path recorded 60 exact keys. These are execution
+  observations with pending labels, not precision, recall, or utility claims.
+- The packet exposed a workload boundary: its explicit pytest reviews used
+  more RSS than the committed static-review packet. Differential resource
+  policies now declare `verification_checks`; applying the static policy to
+  this packet fails with `workload_mismatch` rather than mixing incompatible
+  measurements. A separately reviewed explicit-verification policy is required
+  before its resource result can become a regression gate.
+- The rule scorecard remains unchanged at 6/54 default-profile rules with
+  committed zoo evidence. An unlabeled holdout execution packet cannot add
+  precision rows or close RP23-013; it only improves the denominator and
+  provenance for the future utility measurement.
+- Boundary: this packet validates the execution adapter and its workload
+  separation. Independent labels, adjudication, and a preregistered resource
+  policy for explicit verification remain open work.
+
 ## 0H — Ownership Assessment Semantics
 
 - Review ownership now has three explicit states: `resolved` when configured

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -468,8 +468,11 @@ Repeated runs are labeled cold versus warm. `scripts/differential.py
 budget-check` enforces the review-workload RSS policy: 65,536 KiB cold and
 49,152 KiB warm from packet v10. The separate `scan:resource` gate covers full
 and changed synthetic scans in cold and warm phases and records the host
-profile. All ceilings apply to their pinned workload and must be re-baselined
-when the host or fixture changes.
+profile. The resource policy also pins the selected verification checks; a
+static-review policy cannot be applied to a packet that ran explicit pytest.
+Use a separately reviewed policy file with `--resource-policy` for that
+workload. All ceilings apply to their pinned host, fixture, and verification
+selection and must be re-baselined when any of them changes.
 
 Initial release discipline:
 

--- a/scripts/differential.py
+++ b/scripts/differential.py
@@ -66,6 +66,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--output", type=Path, help="write a differential artifact")
     parser.add_argument("--artifact", type=Path, help="differential artifact to validate")
+    parser.add_argument(
+        "--resource-policy",
+        type=Path,
+        help="optional manifest containing the resource_policy for budget-check",
+    )
     parser.add_argument("--pilot", type=Path, help="single-expert pilot worksheet")
     parser.add_argument("--reviewer", help="single-expert pilot reviewer name")
     parser.add_argument("--metrics", type=Path, help="single-expert pilot metrics artifact")
@@ -129,17 +134,20 @@ def main(argv: list[str] | None = None) -> int:
             )
             artifact = json.loads(args.artifact.read_text(encoding="utf-8"))
             manifest = load_manifest_document(args.manifest)
-            policy = load_resource_policy(args.manifest)
+            policy_path = args.resource_policy or args.manifest
+            policy = load_resource_policy(policy_path)
             if policy is None:
                 result = {
                     "status": "unconfigured",
                     "reason": "manifest has no resource_policy",
                     "manifest_sha256": _sha256(args.manifest),
+                    "resource_policy_sha256": _sha256(policy_path),
                     "artifact_sha256": _sha256(args.artifact),
                 }
             else:
                 result = evaluate_resource_budget(artifact, manifest, policy)
                 result["manifest_sha256"] = _sha256(args.manifest)
+                result["resource_policy_sha256"] = _sha256(policy_path)
                 result["artifact_sha256"] = _sha256(args.artifact)
         except (DifferentialBudgetError, DifferentialManifestError, HoldoutManifestError, OSError, json.JSONDecodeError) as error:
             print(f"differential resource budget invalid: {error}", file=sys.stderr)

--- a/scripts/differential_budget.py
+++ b/scripts/differential_budget.py
@@ -8,6 +8,11 @@ from pathlib import Path
 from typing import Any
 
 from differential_manifest import DifferentialManifestError
+from differential_budget_workload import (
+    WorkloadPolicyError,
+    normalize_verification_checks,
+    workload_mismatch,
+)
 
 
 REQUIRED_PHASES = ("cold", "warm")
@@ -47,6 +52,12 @@ def _validate_policy(policy: object) -> dict[str, Any]:
         raise DifferentialBudgetError("resource policy must use median KiB measurements")
     if policy.get("unavailable") != "fail":
         raise DifferentialBudgetError('resource policy unavailable must be "fail"')
+    try:
+        verification_checks = normalize_verification_checks(
+            policy.get("verification_checks", []), "resource policy verification_checks"
+        )
+    except WorkloadPolicyError as error:
+        raise DifferentialBudgetError(str(error)) from error
     ceilings = policy.get("ceiling_kb_by_phase")
     if not isinstance(ceilings, dict) or set(ceilings) != set(REQUIRED_PHASES):
         raise DifferentialBudgetError("resource policy must define cold and warm ceilings")
@@ -69,6 +80,7 @@ def _validate_policy(policy: object) -> dict[str, Any]:
             for phase in REQUIRED_PHASES
         }
     normalized["case_ceiling_kb_by_phase"] = normalized_cases
+    normalized["verification_checks"] = sorted(verification_checks)
     return normalized
 
 
@@ -153,6 +165,12 @@ def evaluate_resource_budget(
     artifact: dict[str, Any], manifest: dict[str, Any], policy: dict[str, Any]
 ) -> dict[str, object]:
     normalized = _validate_policy(policy)
+    try:
+        mismatch = workload_mismatch(normalized, artifact, REQUIRED_PHASES)
+    except WorkloadPolicyError as error:
+        raise DifferentialBudgetError(str(error)) from error
+    if mismatch is not None:
+        return mismatch
     manifest_ids = _case_ids(manifest)
     raw_cases = artifact.get("cases")
     if not isinstance(raw_cases, list):

--- a/scripts/differential_budget_workload.py
+++ b/scripts/differential_budget_workload.py
@@ -1,0 +1,71 @@
+"""Keep differential RSS policies bound to the checks they measure."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from differential_manifest import DifferentialManifestError
+
+
+class WorkloadPolicyError(DifferentialManifestError):
+    """Raised when a resource policy and artifact describe different work."""
+
+
+def normalize_verification_checks(value: object, label: str) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or not all(isinstance(check_id, str) and check_id.strip() for check_id in value)
+        or len(set(value)) != len(value)
+    ):
+        raise WorkloadPolicyError(f"{label} must be unique non-empty strings")
+    return sorted(value)
+
+
+def artifact_verification_checks(artifact: dict[str, Any]) -> list[str]:
+    verification = artifact.get("review_verification")
+    if verification is None:
+        return []
+    if not isinstance(verification, dict):
+        raise WorkloadPolicyError("artifact review_verification must be an object")
+    return normalize_verification_checks(verification.get("checks", []), "artifact review_verification checks")
+
+
+def workload_mismatch(
+    policy: dict[str, Any], artifact: dict[str, Any], required_phases: tuple[str, ...]
+) -> dict[str, object] | None:
+    policy_checks = policy["verification_checks"]
+    artifact_checks = artifact_verification_checks(artifact)
+    if artifact_checks == policy_checks:
+        return None
+    phase_summary = {
+        phase: {
+            "status": "not_applicable",
+            "samples": 0,
+            "median_kb": None,
+            "max_kb": None,
+            "ceiling_kb": policy["ceiling_kb_by_phase"][phase],
+        }
+        for phase in required_phases
+    }
+    return {
+        "status": "fail",
+        "policy_id": policy["policy_id"],
+        "workload": policy["workload"],
+        "source": policy["source"],
+        "unit": policy["unit"],
+        "statistic": policy["statistic"],
+        "required_phases": list(required_phases),
+        "case_count": 0,
+        "phase_summary": phase_summary,
+        "cases": [],
+        "violations": [
+            {
+                "case": "artifact",
+                "phase": None,
+                "kind": "workload_mismatch",
+                "message": "resource policy verification checks do not match artifact workload",
+                "policy_verification_checks": policy_checks,
+                "artifact_verification_checks": artifact_checks,
+            }
+        ],
+    }

--- a/scripts/tests/test_differential.py
+++ b/scripts/tests/test_differential.py
@@ -198,6 +198,50 @@ unavailable = "fail"
         self.assertEqual(result, 0)
         self.assertEqual(json.loads(output.getvalue())["status"], "pass")
 
+    def test_budget_check_accepts_a_separate_resource_policy(self) -> None:
+        artifact = self._budget_artifact()
+        policy = self.root / "resource-policy.toml"
+        policy.write_text(
+            """[resource_policy]
+schema_version = 1
+policy_id = "differential-rss-explicit-v1"
+workload = "explicit-tests"
+source = "posix-time-v1"
+unit = "KiB"
+statistic = "median"
+required_phases = ["cold", "warm"]
+ceiling_kb_by_phase = { cold = 500, warm = 400 }
+unavailable = "fail"
+verification_checks = []
+""",
+            encoding="utf-8",
+        )
+        output = io.StringIO()
+        with patch.object(differential, "validate_differential", return_value={"status": "valid"}), patch.object(
+            differential, "validate_artifact", return_value={"status": "valid"}
+        ), redirect_stdout(output):
+            result = differential.main(
+                [
+                    "budget-check",
+                    "--manifest",
+                    str(self.diff),
+                    "--resource-policy",
+                    str(policy),
+                    "--holdout-manifest",
+                    str(self.holdout),
+                    "--rules-reference",
+                    str(self.rules),
+                    "--zoo-manifest",
+                    str(self.zoo),
+                    "--artifact",
+                    str(artifact),
+                    "--format",
+                    "json",
+                ]
+            )
+        self.assertEqual(result, 0)
+        self.assertEqual(json.loads(output.getvalue())["policy_id"], "differential-rss-explicit-v1")
+
     def test_budget_check_returns_failure_for_over_budget_artifact(self) -> None:
         artifact = self._budget_artifact(cold=600)
         output = io.StringIO()
@@ -300,6 +344,7 @@ class ProductionDifferentialManifestTests(unittest.TestCase):
         self.assertEqual(policy["source"], "posix-time-v1")
         self.assertEqual(policy["required_phases"], ["cold", "warm"])
         self.assertEqual(policy["ceiling_kb_by_phase"], {"cold": 65536.0, "warm": 49152.0})
+        self.assertEqual(policy["verification_checks"], [])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_differential_budget.py
+++ b/scripts/tests/test_differential_budget.py
@@ -29,6 +29,7 @@ def _policy() -> dict[str, object]:
         "required_phases": ["cold", "warm"],
         "ceiling_kb_by_phase": {"cold": 500, "warm": 400},
         "unavailable": "fail",
+        "verification_checks": [],
     }
 
 
@@ -108,6 +109,21 @@ class DifferentialBudgetTests(unittest.TestCase):
     def test_rejects_manifest_case_drift(self) -> None:
         with self.assertRaisesRegex(DifferentialBudgetError, "case set mismatch"):
             evaluate_resource_budget(_artifact("one"), _manifest("two"), _policy())
+
+    def test_rejects_policy_for_a_different_verification_workload(self) -> None:
+        artifact = _artifact("one")
+        artifact["review_verification"] = {"checks": ["python.tests"]}
+        result = evaluate_resource_budget(artifact, _manifest("one"), _policy())
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["violations"][0]["kind"], "workload_mismatch")
+
+    def test_accepts_matching_explicit_verification_workload(self) -> None:
+        artifact = _artifact("one")
+        artifact["review_verification"] = {"checks": ["python.tests"]}
+        policy = _policy()
+        policy["verification_checks"] = ["python.tests"]
+        result = evaluate_resource_budget(artifact, _manifest("one"), policy)
+        self.assertEqual(result["status"], "pass")
 
     def test_render_is_deterministic_and_json_safe(self) -> None:
         result = evaluate_resource_budget(_artifact("one"), _manifest("one"), _policy())

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -118,6 +118,31 @@ hash and the coverage audit reports it separately. Any resulting overlap is
 evidence about executed verification work; it is not static-review detection
 and cannot be used to claim precision or recall.
 
+Resource budgets are workload-bound. The committed `differential-rss-v1`
+policy declares `verification_checks = []`, so it applies to static review
+only. A packet collected with explicit verification must use a separately
+reviewed policy file whose `verification_checks` exactly match the artifact;
+otherwise `budget-check` fails with `workload_mismatch` instead of comparing
+incompatible RSS samples:
+
+```toml
+[resource_policy]
+schema_version = 1
+policy_id = "differential-rss-python-tests-v1"
+workload = "v0.23-real-history-expanded-review-python-tests"
+source = "posix-time-v1"
+unit = "KiB"
+statistic = "median"
+required_phases = ["cold", "warm"]
+ceiling_kb_by_phase = { cold = 65536, warm = 49152 }
+unavailable = "fail"
+verification_checks = ["python.tests"]
+```
+
+Pass a temporary policy with `--resource-policy /tmp/python-tests-policy.toml`;
+do not reuse the static policy or treat one local packet as a universal memory
+claim.
+
 When one reviewer is available, `pilot-template` creates an exploratory
 worksheet over the same pinned differential artifact. `pilot-score` reports
 only captured novel-evidence, timing, determinism, and resource fields;

--- a/tests/benchmarks/differential.toml
+++ b/tests/benchmarks/differential.toml
@@ -24,6 +24,7 @@ statistic = "median"
 required_phases = ["cold", "warm"]
 ceiling_kb_by_phase = { cold = 65536, warm = 49152 }
 unavailable = "fail"
+verification_checks = []
 
 [[case]]
 id = "click-pr-3818"


### PR DESCRIPTION
## Problem

The new explicit `python.tests` verification path produces valid exact evidence, but its RSS profile is a different workload from static review. Applying the existing static-review budget to that artifact would mix incompatible measurements and hide the resource boundary.

## What changed

- Bind differential resource policies to the exact `verification_checks` selected by the artifact.
- Fail closed with `workload_mismatch` when a static policy is applied to an explicit-verification packet.
- Add `--resource-policy` so a separately reviewed local policy can be used without changing the canonical differential manifest.
- Keep the resource-policy helper below the repository's source-file size limit.
- Add regression coverage for matching and mismatched workloads and update the benchmark documentation, changelog, roadmap, and evidence ledger.
- Record the fresh six-case local execution packet in the evidence ledger without committing generated JSON or temporary config files.

## Observed packet

The local artifact remains outside Git at `/tmp/repopilot-v023-python-verification-v2.json`:

- 6 immutable holdout cases
- 36/36 baseline observations measured
- 18/18 explicit review-verification observations measured
- 60 exact `review-verification-v1` keys
- 18/18 static `python.tests` comparisons remain unavailable
- The committed static RSS policy rejects this artifact with `workload_mismatch`; an explicit-verification policy still needs a separate reviewed baseline.

These are unlabeled execution observations. They do not change the rule scorecard or establish precision, recall, utility, or a universal memory claim.

## Verification

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 243 passed
- `cargo test --all` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `python3 scripts/release-contract.py check` — passed
- `npm run review:performance` — passed (`changed_to_full_ratio = 0.39`, budget `<= 0.6`)
- `cargo run -- scan . --fail-on-priority p1` — passed
