### PR TITLE
feat: surface verification proof in review summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- Added a verification-proof line to the console and Markdown review summaries.
+  It reports passed, failed, unavailable, unselected, and stale obligations,
+  makes revision compatibility explicit, and discloses when no verification
+  evidence was selected.
 - Projected the canonical `ChangeProof` into review JSON, MCP review results,
   and the console Proof Card while preserving legacy readiness, gates, and exit
   behavior. The additive projection reports verdict, analyzed scope, and proof

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -294,6 +294,9 @@ Deliverables:
 - a compact CLI Proof Card showing verdict, changed contracts, proven broken
   consumers, impacted consumers, coverage, verification, intent drift, gate,
   exit behavior, and one next action;
+- the first-screen console and Markdown summaries explicitly disclose
+  verification obligation counts, revision compatibility, and the no-selection
+  evidence boundary;
 - full detail that expands contract-to-consumer chains and proof obligations
   without duplicating the summary conclusion;
 - a local, self-contained HTML Change Map with contract/consumer navigation,

--- a/src/review/render/console.rs
+++ b/src/review/render/console.rs
@@ -9,7 +9,7 @@ use crate::review::model::ReviewReport;
 use crate::review::ownership::OwnershipAssessment;
 use crate::review::proof::derive_change_proof_from_review;
 use crate::review::render::ReviewRenderOptions;
-use crate::review::render::helpers::verification_duration_evidence;
+use crate::review::render::helpers::{verification_duration_evidence, verification_proof_summary};
 use crate::review::signals::tiered::ReviewSignal;
 use crate::verification::VerificationStatus;
 
@@ -70,6 +70,10 @@ fn render_console_header(
             proof.coverage.excluded_files, proof.coverage.unsupported_files
         ));
     }
+    output.push_str(&format!(
+        "Verification proof: {}\n",
+        verification_proof_summary(report, proof.obligations)
+    ));
     output.push_str(&format!(
         "Merge readiness: {}\n",
         readiness.verdict.label().to_uppercase()

--- a/src/review/render/helpers.rs
+++ b/src/review/render/helpers.rs
@@ -2,6 +2,7 @@ use crate::baseline::diff::BaselineStatus;
 use crate::findings::types::Finding;
 use crate::review::diff::ChangedFile;
 use crate::review::model::ReviewReport;
+use crate::review::proof::ProofObligations;
 use crate::verification::VerificationOutcome;
 
 pub(super) fn verification_duration_evidence(outcome: &VerificationOutcome) -> String {
@@ -10,6 +11,33 @@ pub(super) fn verification_duration_evidence(outcome: &VerificationOutcome) -> S
     } else {
         format!("{} ms", outcome.duration_ms)
     }
+}
+
+pub(super) fn verification_proof_summary(
+    report: &ReviewReport,
+    obligations: ProofObligations,
+) -> String {
+    if report.verification.is_empty() {
+        return "none selected; no verification evidence".to_string();
+    }
+
+    let revision = if report
+        .verification
+        .iter()
+        .all(|outcome| outcome.revision_compatible)
+    {
+        "revision-compatible"
+    } else {
+        "revision-incompatible"
+    };
+    format!(
+        "{} passed, {} failed, {} unavailable, {} unselected, {} stale ({revision})",
+        obligations.satisfied,
+        obligations.failed,
+        obligations.unavailable,
+        obligations.unselected,
+        obligations.stale,
+    )
 }
 
 pub(super) fn status_for_finding(

--- a/src/review/render/markdown.rs
+++ b/src/review/render/markdown.rs
@@ -9,7 +9,9 @@ use crate::review::model::ReviewReport;
 use crate::review::ownership::OwnershipAssessment;
 use crate::review::proof::derive_change_proof_from_review;
 use crate::review::render::helpers::verification_duration_evidence;
-use crate::review::render::helpers::{render_ranges, status_for_finding};
+use crate::review::render::helpers::{
+    render_ranges, status_for_finding, verification_proof_summary,
+};
 use crate::review::signals::tiered::ReviewSignal;
 
 const REVIEW_SIGNAL_DETAIL_LIMIT: usize = 20;
@@ -55,6 +57,10 @@ pub fn render_markdown_with_gates(
             proof.coverage.excluded_files, proof.coverage.unsupported_files
         ));
     }
+    output.push_str(&format!(
+        "- **Verification proof:** {}\n",
+        verification_proof_summary(report, proof.obligations)
+    ));
     let ownership_status = match readiness.ownership.assessment {
         OwnershipAssessment::Resolved => "resolved".to_string(),
         OwnershipAssessment::ConfiguredButUnmatched => format!(

--- a/tests/review_readiness.rs
+++ b/tests/review_readiness.rs
@@ -182,6 +182,70 @@ fn human_reports_show_when_verification_was_reused() {
 }
 
 #[test]
+fn human_summary_discloses_when_no_verification_was_selected() {
+    let report = report_with_ownership(OwnershipSummary::default());
+
+    let console = repopilot::review::render::render_console(&report, None);
+    let markdown = repopilot::review::render::render_markdown(&report, None);
+
+    assert!(console.contains("Verification proof: none selected; no verification evidence"));
+    assert!(markdown.contains("- **Verification proof:** none selected; no verification evidence"));
+}
+
+#[test]
+fn human_summary_reports_revision_compatible_passed_verification() {
+    let mut report = report_with_ownership(OwnershipSummary::default());
+    report.verification = vec![verification_outcome(VerificationStatus::Passed, true)];
+
+    let console = repopilot::review::render::render_console(&report, None);
+    let markdown = repopilot::review::render::render_markdown(&report, None);
+
+    let summary = "1 passed, 0 failed, 0 unavailable, 0 unselected, 0 stale (revision-compatible)";
+    assert!(console.contains(&format!("Verification proof: {summary}")));
+    assert!(markdown.contains(&format!("- **Verification proof:** {summary}")));
+}
+
+#[test]
+fn human_summary_reports_failed_verification() {
+    let mut report = report_with_ownership(OwnershipSummary::default());
+    report.verification = vec![verification_outcome(VerificationStatus::Failed, true)];
+
+    let console = repopilot::review::render::render_console(&report, None);
+    let markdown = repopilot::review::render::render_markdown(&report, None);
+
+    let summary = "0 passed, 1 failed, 0 unavailable, 0 unselected, 0 stale (revision-compatible)";
+    assert!(console.contains(&format!("Verification proof: {summary}")));
+    assert!(markdown.contains(&format!("- **Verification proof:** {summary}")));
+}
+
+#[test]
+fn human_summary_reports_unavailable_verification() {
+    let mut report = report_with_ownership(OwnershipSummary::default());
+    report.verification = vec![verification_outcome(VerificationStatus::Unavailable, true)];
+
+    let console = repopilot::review::render::render_console(&report, None);
+    let markdown = repopilot::review::render::render_markdown(&report, None);
+
+    let summary = "0 passed, 0 failed, 1 unavailable, 0 unselected, 0 stale (revision-compatible)";
+    assert!(console.contains(&format!("Verification proof: {summary}")));
+    assert!(markdown.contains(&format!("- **Verification proof:** {summary}")));
+}
+
+#[test]
+fn human_summary_reports_revision_incompatible_verification() {
+    let mut report = report_with_ownership(OwnershipSummary::default());
+    report.verification = vec![verification_outcome(VerificationStatus::Passed, false)];
+
+    let console = repopilot::review::render::render_console(&report, None);
+    let markdown = repopilot::review::render::render_markdown(&report, None);
+
+    let summary =
+        "0 passed, 0 failed, 0 unavailable, 0 unselected, 1 stale (revision-incompatible)";
+    assert!(console.contains(&format!("Verification proof: {summary}")));
+    assert!(markdown.contains(&format!("- **Verification proof:** {summary}")));
+}
+
+#[test]
 fn failed_verification_blocks_canonical_readiness() {
     let mut report = report_with_ownership(OwnershipSummary::default());
     report.verification = vec![verification_outcome(VerificationStatus::Failed, true)];


### PR DESCRIPTION
## What changed

Review summaries now show a compact verification-proof line next to the canonical Change Proof verdict in both console and Markdown output.

The line reports passed, failed, unavailable, unselected, and stale obligations, states whether the evidence is revision-compatible, and explicitly discloses when no verification evidence was selected. It reuses the existing `ChangeProof` obligation counts, so JSON/MCP schemas and exit-code behavior remain unchanged.

## Why

A reviewer could previously see the verdict and the detailed verification section separately, but the first-screen summary did not state what verification evidence supported that verdict or where the evidence boundary was. This makes the proof card actionable without duplicating the detailed outcomes.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (926 unit tests and all integration suites passed; 1 compatibility test ignored by design)
- `python3 scripts/release-contract.py check`
- `npm run review:performance`
- `cargo run -- scan . --fail-on-priority p1` (0 visible P1 findings)
- `cargo test --test review_readiness human_summary_` (5 summary scenarios)
