### PR TITLE
feat: surface verification proof in GitHub Action summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- Extended the GitHub Action review summary with the canonical Change Proof
+  verdict, analyzed scope, verification obligation state, and proof limits.
 - Added a verification-proof line to the console and Markdown review summaries.
   It reports passed, failed, unavailable, unselected, and stale obligations,
   makes revision compatibility explicit, and discloses when no verification

--- a/scripts/repopilot-action-review.sh
+++ b/scripts/repopilot-action-review.sh
@@ -88,6 +88,26 @@ write_review_summary() {
       echo "- **In-diff findings:** $(jq -r '.review.in_diff_findings' "$review_json")"
     fi
     echo "- **Merge readiness:** $(jq -r '.merge_readiness.verdict // "unavailable"' "$review_json")"
+    jq -r '
+      def verification_revision:
+        ([.merge_readiness.verification[]?] | length) as $outcomes
+        | if $outcomes > 0
+          and ([.merge_readiness.verification[]? | select(.revision_compatible != true)] | length) == 0
+          then "revision-compatible"
+          else "revision-incompatible"
+          end;
+      .change_proof as $proof
+      | "- **Change proof:** \($proof.verdict // "unavailable")",
+        "- **Proof scope:** \($proof.coverage.analyzed_files // 0)/\($proof.coverage.requested_files // 0) file(s) analyzed",
+        (if ($proof.obligations.applicable // 0) == 0 then
+          "- **Verification proof:** none selected; no verification evidence"
+        else
+          "- **Verification proof:** \($proof.obligations.satisfied // 0) passed, \($proof.obligations.failed // 0) failed, \($proof.obligations.unavailable // 0) unavailable, \($proof.obligations.unselected // 0) unselected, \($proof.obligations.stale // 0) stale (\(verification_revision))"
+        end),
+        (if (($proof.coverage.excluded_files // 0) > 0 or ($proof.coverage.unsupported_files // 0) > 0) then
+          "- **Proof limits:** \($proof.coverage.excluded_files // 0) excluded, \($proof.coverage.unsupported_files // 0) unsupported file(s)"
+        else empty end)
+    ' "$review_json"
     echo "- **Definitely-sensitive signals:** $(jq -r '.review.tiered_signals.definitely' "$review_json")"
     echo "- **Maybe-sensitive signals:** $(jq -r '.review.tiered_signals.maybe' "$review_json")"
     echo "- **Review gate:** $(jq -r '.review_gate.status // "not-configured"' "$review_json")"

--- a/tests/action_delta.rs
+++ b/tests/action_delta.rs
@@ -68,7 +68,7 @@ while (($#)); do
 done
 if [[ "$command" == "review" ]]; then
   cat > "$output" <<'JSON'
-{"merge_readiness":{"verdict":"ready"},"review":{"in_diff_findings":1,"tiered_signals":{"definitely":0,"maybe":0,"noise":0,"total":0}},"tiered_signals":{"definitely":[],"maybe":[],"noise":[]},"findings":[]}
+{"merge_readiness":{"verdict":"ready"},"change_proof":{"verdict":"REVIEW","coverage":{"requested_files":1,"analyzed_files":1,"excluded_files":0,"unsupported_files":0},"obligations":{"applicable":0,"satisfied":0,"failed":0,"unavailable":0,"unselected":0,"stale":0}},"review":{"in_diff_findings":1,"tiered_signals":{"definitely":0,"maybe":0,"noise":0,"total":0}},"tiered_signals":{"definitely":[],"maybe":[],"noise":[]},"findings":[]}
 JSON
   printf '{"version":"2.1.0","runs":[]}\n' > "$sarif"
   exit 0
@@ -145,6 +145,9 @@ fi
     assert!(summary.contains("**New findings:** 1"));
     assert!(summary.contains("**Resolved findings:** 1"));
     assert!(summary.contains("**Merge readiness:** ready"));
+    assert!(summary.contains("**Change proof:** REVIEW"));
+    assert!(summary.contains("**Proof scope:** 1/1 file(s) analyzed"));
+    assert!(summary.contains("**Verification proof:** none selected; no verification evidence"));
     assert!(
         summary.contains("New finding"),
         "the new finding's title should appear in the summary:\n{summary}"
@@ -153,4 +156,69 @@ fi
         !summary.contains("Survives a line move"),
         "an existing (unmoved-key) finding must not be listed as new:\n{summary}"
     );
+}
+
+#[test]
+fn review_action_summary_projects_verification_proof_card() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+    fs::write(
+        root.join("review.json"),
+        r#"{
+          "merge_readiness": {
+            "verdict": "blocked",
+            "verification": [{"revision_compatible": true}]
+          },
+          "change_proof": {
+            "verdict": "REVIEW",
+            "coverage": {
+              "requested_files": 4,
+              "analyzed_files": 3,
+              "excluded_files": 1,
+              "unsupported_files": 0
+            },
+            "obligations": {
+              "applicable": 1,
+              "satisfied": 1,
+              "failed": 0,
+              "unavailable": 0,
+              "unselected": 0,
+              "stale": 0
+            }
+          },
+          "review": {
+            "in_diff_findings": 0,
+            "tiered_signals": {"definitely": 0, "maybe": 0, "noise": 0, "total": 0}
+          },
+          "tiered_signals": {"definitely": [], "maybe": [], "noise": []}
+        }"#,
+    )
+    .expect("write review report");
+
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let source = manifest.join("scripts/repopilot-action-review.sh");
+    let command = format!(
+        "source \"{}\" && write_review_summary review.json",
+        source.display()
+    );
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg(command)
+        .current_dir(root)
+        .output()
+        .expect("run summary helper");
+    assert!(
+        output.status.success(),
+        "summary helper failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let summary =
+        fs::read_to_string(root.join("repopilot-review-summary.md")).expect("read review summary");
+    assert!(summary.contains("**Change proof:** REVIEW"));
+    assert!(summary.contains("**Proof scope:** 3/4 file(s) analyzed"));
+    assert!(summary.contains(
+        "**Verification proof:** 1 passed, 0 failed, 0 unavailable, 0 unselected, 0 stale (revision-compatible)"
+    ));
+    assert!(summary.contains("**Proof limits:** 1 excluded, 0 unsupported file(s)"));
 }


### PR DESCRIPTION
## Summary

- project the canonical Change Proof verdict and analyzed scope into the GitHub Action review summary
- expose verification obligation counts and revision compatibility in the same proof card
- disclose excluded or unsupported files so CI output does not overstate evidence coverage
- add regression coverage for the empty-obligation and verified-obligation paths

## Why

The console and Markdown review surfaces already show the proof state. The Action summary is a primary CI handoff surface, so it should expose the same evidence and limitations without changing the JSON contract, exit codes, or readiness decisions.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `python3 scripts/release-contract.py check`
- `npm run review:performance`
- `cargo run -- scan . --fail-on-priority p1`
- `bash -n scripts/repopilot-action-review.sh`
