### PR TITLE
feat: add HTML review Change Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- Added self-contained HTML output for `repopilot review`. The local Change Map
+  leads with the canonical Proof Card, contract-to-consumer evidence, impact
+  paths, verification outcomes, findings, and explicit scope limitations.
 - Extended the GitHub Action review summary with the canonical Change Proof
   verdict, analyzed scope, verification obligation state, and proof limits.
 - Added a verification-proof line to the console and Markdown review summaries.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -313,6 +313,9 @@ repopilot review . --base origin/main --no-progress
 # Save a Markdown review report
 repopilot review . --base origin/main --format markdown --output review.md
 
+# Save a self-contained HTML Change Map
+repopilot review . --base origin/main --format html --output review.html
+
 # Preserve the previous full-repository strict review
 repopilot review . --scope full --profile strict
 
@@ -623,7 +626,7 @@ The `--min-severity` flag filters rendered findings before gate evaluation, and 
 | `console` | `scan`, `review` | Versioned terminal report with risk summary, top risk clusters, and grouped findings |
 | `json` | `scan`, `review` | Machine consumption, piping to scripts |
 | `markdown` | `scan`, `review` | Versioned human-readable report with top rules and findings index |
-| `html` | `scan` | Standalone visual report with severity, category, and rule filters |
+| `html` | `scan`, `review` | Standalone local report; review HTML adds the Proof Card and contract/consumer Change Map |
 | `sarif` | `scan` | GitHub Code Scanning, CI security tooling |
 
 See [docs/integrations/github-code-scanning.md](integrations/github-code-scanning.md) for the SARIF upload workflow.

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -289,6 +289,21 @@ signals continue to omit it. It is nevertheless a source compatibility change
 for Rust users that construct the public `ReviewSignal` with a struct literal;
 those literals must now provide `target_path`, normally as `None`.
 
+## Review HTML reports
+
+`repopilot review --format html --output review.html` writes a self-contained
+local report. Its first screen is the canonical Proof Card: Change Proof
+verdict, legacy merge readiness, analyzed scope, verification evidence, gates,
+proof limits, and one next action. The Change Map then links changed files to
+typed contract/consumer deltas and bounded impact paths, followed by review
+signals, verification outcomes, and findings.
+
+The report embeds its CSS and small navigation script. It does not load remote
+fonts, scripts, source files, or repository data. Repository-controlled paths,
+evidence, signal details, and finding text are HTML-escaped before rendering;
+large signal and finding lists remain bounded in the human report while JSON
+retains the complete machine-readable record.
+
 ## Audit receipt JSON
 
 Use `--receipt` when a CI job, release process, or audit trail needs compact

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -3,6 +3,10 @@
 Status: Phase 0 implementation in progress; ChangeProof foundation exists and
 the first additive review projection is now implemented.
 
+Current projection progress: Phase D now has console, Markdown, JSON, MCP,
+Action, and self-contained review HTML projections, including the first local
+Change Map.
+
 RepoPilot 0.23 turns change review from a collection of findings and signals
 into one bounded proof of what changed, which contracts and consumers are
 affected, what verification established, and what remains unknown.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -18,6 +18,7 @@ pub enum OutputFormatArg {
 #[derive(Clone, Copy, Debug, ValueEnum)]
 pub enum CompareOutputFormatArg {
     Console,
+    Html,
     Json,
     Markdown,
 }
@@ -107,6 +108,7 @@ impl From<CompareOutputFormatArg> for OutputFormat {
     fn from(format: CompareOutputFormatArg) -> Self {
         match format {
             CompareOutputFormatArg::Console => OutputFormat::Console,
+            CompareOutputFormatArg::Html => OutputFormat::Html,
             CompareOutputFormatArg::Json => OutputFormat::Json,
             CompareOutputFormatArg::Markdown => OutputFormat::Markdown,
         }

--- a/src/review/render.rs
+++ b/src/review/render.rs
@@ -1,6 +1,8 @@
 mod console;
 mod diagnostics;
 mod helpers;
+mod html;
+mod html_assets;
 mod json;
 mod markdown;
 mod sarif;
@@ -11,6 +13,7 @@ use crate::review::ReviewSignalGateResult;
 use crate::review::model::ReviewReport;
 
 pub use console::render_console;
+pub use html::render_review_html;
 pub use json::render_json;
 pub use markdown::render_markdown;
 pub use sarif::render_review_sarif;
@@ -74,8 +77,7 @@ pub fn render_with_options(
             ci_gate,
             review_gate,
         )),
-        OutputFormat::Html | OutputFormat::Sarif => {
-            unreachable!("HTML and SARIF are not supported for the review command")
-        }
+        OutputFormat::Html => Ok(html::render_review_html(report, ci_gate, review_gate)),
+        OutputFormat::Sarif => unreachable!("SARIF is not supported for the review command"),
     }
 }

--- a/src/review/render/html.rs
+++ b/src/review/render/html.rs
@@ -1,0 +1,178 @@
+use super::helpers::verification_proof_summary;
+use super::html_assets::{SCRIPT, STYLE};
+use crate::baseline::gate::CiGateResult;
+use crate::review::ReviewSignalGateResult;
+use crate::review::model::ReviewReport;
+use crate::review::proof::{ChangeProof, derive_change_proof_from_review};
+use crate::review::readiness::{MergeReadinessRecord, derive_readiness};
+#[path = "html_sections.rs"]
+mod html_sections;
+
+pub fn render_review_html(
+    report: &ReviewReport,
+    ci_gate: Option<&CiGateResult>,
+    review_gate: Option<&ReviewSignalGateResult>,
+) -> String {
+    let readiness = derive_readiness(
+        report,
+        ci_gate,
+        review_gate,
+        report.summary.artifacts.risk_delta.as_ref(),
+    );
+    let proof = derive_change_proof_from_review(report, &readiness);
+    let verdict_class = proof.verdict.label().to_ascii_lowercase().replace(' ', "-");
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>RepoPilot Review Report</title><style>{STYLE}</style></head>
+<body><main>
+<header>
+  <h1>RepoPilot Review Report</h1>
+  <p class="meta">Path: <code>{path}</code></p>
+  <p class="meta">Git root: <code>{root}</code></p>
+</header>
+{proof_card}
+{change_map}
+{impact}
+{signals}
+{verification}
+{findings}
+<script>{SCRIPT}</script>
+</main></body></html>"#,
+        path = escape(&report.summary.root_path.to_string_lossy()),
+        root = escape(&report.repo_root.to_string_lossy()),
+        proof_card = render_proof_card(
+            report,
+            &readiness,
+            &proof,
+            verdict_class,
+            ci_gate,
+            review_gate,
+        ),
+        change_map = html_sections::render_change_map(report, &proof),
+        impact = html_sections::render_impact(report),
+        signals = html_sections::render_signals(&report.tiered_signals),
+        verification = html_sections::render_verification(report, &proof),
+        findings = html_sections::render_findings(report),
+    )
+}
+
+fn render_proof_card(
+    report: &ReviewReport,
+    readiness: &MergeReadinessRecord,
+    proof: &ChangeProof,
+    verdict_class: String,
+    ci_gate: Option<&CiGateResult>,
+    review_gate: Option<&ReviewSignalGateResult>,
+) -> String {
+    let limits = if proof.coverage.excluded_files > 0 || proof.coverage.unsupported_files > 0 {
+        format!(
+            "<ul class=\"limits\"><li>{} excluded, {} unsupported file(s)</li></ul>",
+            proof.coverage.excluded_files, proof.coverage.unsupported_files
+        )
+    } else {
+        String::new()
+    };
+    let readiness_limits = readiness
+        .limitations
+        .iter()
+        .take(5)
+        .map(|limitation| format!("<li>{}</li>", escape(limitation)))
+        .collect::<Vec<_>>()
+        .join("");
+    let readiness_limits = if readiness_limits.is_empty() {
+        String::new()
+    } else {
+        format!("<h3>Limitations</h3><ul class=\"limits\">{readiness_limits}</ul>")
+    };
+    let reasons = proof
+        .reasons
+        .iter()
+        .take(5)
+        .map(|reason| format!("<li>{}</li>", escape(&reason.message)))
+        .collect::<Vec<_>>()
+        .join("");
+    let reasons = if reasons.is_empty() {
+        String::new()
+    } else {
+        format!("<h3>Why this verdict</h3><ul class=\"reasons\">{reasons}</ul>")
+    };
+    let next_action = next_action(proof);
+    let gate = gate_label(ci_gate, review_gate);
+    format!(
+        r#"<section class="proof-card verdict-{verdict_class}" id="proof-card" aria-labelledby="proof-heading">
+  <div class="proof-header"><h2 id="proof-heading">Proof Card</h2><span class="badge {verdict_class}">{verdict}</span></div>
+  <div class="proof-grid">
+    <dl class="metric"><dt>Change proof</dt><dd><span class="badge {verdict_class}">{verdict}</span></dd></dl>
+    <dl class="metric"><dt>Merge readiness</dt><dd><span class="badge {readiness_class}">{readiness}</span></dd></dl>
+    <dl class="metric"><dt>Proof scope</dt><dd>{analyzed}/{requested} file(s) analyzed</dd></dl>
+    <dl class="metric"><dt>Verification proof</dt><dd>{verification}</dd></dl>
+    <dl class="metric"><dt>Gate</dt><dd>{gate}</dd></dl>
+  </div>
+  <div class="next-action"><strong>Next action:</strong> {next_action}</div>
+  {limits}{readiness_limits}{reasons}
+</section>"#,
+        verdict = proof.verdict.label(),
+        readiness = readiness.verdict.label(),
+        readiness_class = readiness.verdict.label(),
+        analyzed = proof.coverage.analyzed_files,
+        requested = proof.coverage.requested_files,
+        verification = escape(&verification_proof_summary(report, proof.obligations)),
+        gate = escape(&gate),
+        next_action = escape(next_action),
+    )
+}
+
+fn next_action(proof: &ChangeProof) -> &'static str {
+    match proof.verdict {
+        crate::review::proof::ChangeProofVerdict::Broken => {
+            "Inspect the broken contract and its listed consumer before merge."
+        }
+        crate::review::proof::ChangeProofVerdict::Review => {
+            "Review the listed evidence, close the proof limits, or run the required checks."
+        }
+        crate::review::proof::ChangeProofVerdict::Verified => {
+            "Proceed with the normal merge review; the reported scope has compatible proof."
+        }
+        crate::review::proof::ChangeProofVerdict::NotAssessed => {
+            "Expand the analyzable scope before treating this review as evidence."
+        }
+    }
+}
+
+fn gate_label(
+    ci_gate: Option<&CiGateResult>,
+    review_gate: Option<&ReviewSignalGateResult>,
+) -> String {
+    let mut gates = Vec::new();
+    if let Some(gate) = ci_gate {
+        gates.push(format!(
+            "finding gate {} ({})",
+            if gate.passed() { "passed" } else { "failed" },
+            gate.label()
+        ));
+    }
+    if let Some(gate) = review_gate.filter(|gate| gate.enabled()) {
+        gates.push(format!(
+            "review gate {} ({}, {} failed)",
+            if gate.passed() { "passed" } else { "failed" },
+            gate.label(),
+            gate.failed_signals
+        ));
+    }
+    if gates.is_empty() {
+        "not configured".to_string()
+    } else {
+        gates.join("; ")
+    }
+}
+
+fn escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}

--- a/src/review/render/html_assets.rs
+++ b/src/review/render/html_assets.rs
@@ -1,0 +1,58 @@
+pub(super) const STYLE: &str = r#"
+  :root { color-scheme: light; }
+  body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; color: #18202f; background: #f6f7f9; }
+  main { max-width: 1180px; margin: 0 auto; padding: 28px; }
+  header { margin-bottom: 24px; }
+  h1 { font-size: 1.75rem; margin: 0 0 .35rem; }
+  h2 { font-size: 1.08rem; margin: 28px 0 12px; }
+  h3 { font-size: .96rem; margin: 18px 0 10px; }
+  .meta { color: #5f6b7a; font-size: .9rem; margin: .25rem 0; }
+  .proof-card, .panel { background: #fff; border: 1px solid #dde2ea; border-radius: 8px; padding: 16px 18px; margin-bottom: 14px; }
+  .proof-card { border-left: 5px solid #667085; }
+  .proof-card.verdict-broken { border-left-color: #b42318; }
+  .proof-card.verdict-review { border-left-color: #b54708; }
+  .proof-card.verdict-verified { border-left-color: #067647; }
+  .proof-card.verdict-not-assessed { border-left-color: #667085; }
+  .proof-header { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .proof-header h2 { margin: 0; }
+  .badge { display: inline-block; padding: .15rem .5rem; border-radius: 999px; font-size: .72rem; font-weight: 700; text-transform: uppercase; }
+  .badge.broken, .badge.blocked { background: #fef3f2; color: #b42318; }
+  .badge.review { background: #fffaeb; color: #b54708; }
+  .badge.verified, .badge.ready { background: #ecfdf3; color: #067647; }
+  .badge.not-assessed, .badge.disabled { background: #eef1f5; color: #475467; }
+  .proof-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 10px; margin: 16px 0; }
+  .metric { background: #f8fafc; border: 1px solid #edf0f4; border-radius: 6px; padding: 10px 12px; }
+  .metric dt { color: #667085; font-size: .72rem; text-transform: uppercase; letter-spacing: .04em; }
+  .metric dd { margin: 4px 0 0; font-size: .92rem; }
+  .next-action { background: #f0f7ff; border: 1px solid #cfe5ff; border-radius: 6px; padding: 10px 12px; }
+  .next-action strong { color: #155eef; }
+  .limits, .reasons { margin: 8px 0 0; padding-left: 20px; }
+  table { width: 100%; border-collapse: collapse; background: #fff; border: 1px solid #dde2ea; border-radius: 8px; overflow: hidden; }
+  th { text-align: left; padding: .6rem .75rem; background: #eef1f5; color: #475467; font-size: .74rem; text-transform: uppercase; letter-spacing: .04em; }
+  td { padding: .62rem .75rem; border-top: 1px solid #edf0f4; vertical-align: top; font-size: .86rem; }
+  details { margin: 0; }
+  summary { color: #155eef; cursor: pointer; }
+  .diff-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-top: 8px; }
+  .diff-side { min-width: 0; }
+  .diff-side strong { color: #475467; font-size: .76rem; text-transform: uppercase; }
+  pre { margin: 4px 0 0; padding: 8px; background: #f3f5f7; border-radius: 5px; overflow: auto; white-space: pre-wrap; }
+  .status { font-size: .72rem; font-weight: 700; text-transform: uppercase; }
+  .status.added, .status.modified, .status.renamed, .status.untracked { color: #067647; }
+  .status.deleted { color: #b42318; }
+  .signal { border: 1px solid #dde2ea; border-radius: 6px; padding: 10px 12px; margin: 8px 0; background: #fff; }
+  .signal strong { font-size: .9rem; }
+  .signal-meta, .muted { color: #667085; font-size: .82rem; }
+  .empty { color: #667085; font-style: italic; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .9em; }
+  a { color: #155eef; }
+  @media (max-width: 680px) { main { padding: 16px; } table { display: block; overflow-x: auto; } .diff-grid { grid-template-columns: 1fr; } }
+"#;
+
+pub(super) const SCRIPT: &str = r#"
+  document.querySelectorAll('[data-jump]').forEach(link => {
+    link.addEventListener('click', event => {
+      const target = document.getElementById(link.dataset.jump);
+      if (target) { event.preventDefault(); target.scrollIntoView({ behavior: 'smooth' }); }
+    });
+  });
+"#;

--- a/src/review/render/html_sections.rs
+++ b/src/review/render/html_sections.rs
@@ -1,0 +1,292 @@
+use super::super::helpers::{
+    render_ranges, verification_duration_evidence, verification_proof_summary,
+};
+use super::escape;
+use crate::review::model::ReviewReport;
+use crate::review::proof::ChangeProof;
+use crate::review::signals::tiered::TieredSignals;
+
+const DETAIL_LIMIT: usize = 20;
+
+pub(super) fn render_change_map(report: &ReviewReport, proof: &ChangeProof) -> String {
+    let files = if report.changed_files.is_empty() {
+        "<p class=\"empty\">No changed files found.</p>".to_string()
+    } else {
+        let rows = report
+            .changed_files
+            .iter()
+            .map(|file| {
+                format!(
+                    "<tr><td><span class=\"status {}\">{:?}</span></td><td><code>{}</code></td><td>{}</td><td>{}</td></tr>",
+                    format!("{:?}", file.status).to_ascii_lowercase(),
+                    file.status,
+                    escape(&file.path.to_string_lossy()),
+                    escape(&render_ranges(file)),
+                    render_hunks(file)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        format!(
+            "<table><thead><tr><th>Status</th><th>Changed file</th><th>Ranges</th><th>Before / after</th></tr></thead><tbody>{rows}</tbody></table>"
+        )
+    };
+    let contracts = if proof.contract_deltas.is_empty() {
+        "<p class=\"empty\">No typed contract deltas were detected in this scope.</p>".to_string()
+    } else {
+        let rows = proof
+            .contract_deltas
+            .iter()
+            .map(|delta| {
+                format!(
+                    "<tr><td>{:?}</td><td>{:?}</td><td><code>{}</code></td><td><code>{}</code></td><td>{}</td></tr>",
+                    delta.family,
+                    delta.change,
+                    escape(&delta.exporter_path),
+                    escape(&delta.consumer_path),
+                    escape(&delta.evidence)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        format!(
+            "<table><thead><tr><th>Family</th><th>Change</th><th>Contract</th><th>Consumer</th><th>Evidence</th></tr></thead><tbody>{rows}</tbody></table>"
+        )
+    };
+    format!(
+        r###"<section id="change-map"><h2>Change Map</h2>
+<p class="muted"><a href="#proof-card" data-jump="proof-card">Back to Proof Card</a> · <a href="#contract-map" data-jump="contract-map">Contract / consumer map</a> · <a href="#impact-paths" data-jump="impact-paths">Impact paths</a></p>
+<h3 id="changed-files">Changed files</h3>{files}
+<h3 id="contract-map">Contract / consumer map</h3>{contracts}
+</section>"###
+    )
+}
+
+fn render_hunks(file: &crate::review::diff::ChangedFile) -> String {
+    if file.hunks.is_empty() {
+        return "<span class=\"muted\">n/a</span>".to_string();
+    }
+    let details = file
+        .hunks
+        .iter()
+        .map(|hunk| {
+            let before = if hunk.removed_lines.is_empty() {
+                "(none)".to_string()
+            } else {
+                hunk.removed_lines
+                    .iter()
+                    .map(|line| escape(line))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            };
+            let after = if hunk.added_lines.is_empty() {
+                "(none)".to_string()
+            } else {
+                hunk.added_lines
+                    .iter()
+                    .map(|line| escape(line))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            };
+            let header = hunk
+                .header
+                .as_deref()
+                .map(|header| format!(" · {}", escape(header)))
+                .unwrap_or_default();
+            format!(
+                "<details><summary>hunk{header}</summary><div class=\"diff-grid\"><div class=\"diff-side\"><strong>Before</strong><pre>{before}</pre></div><div class=\"diff-side\"><strong>After</strong><pre>{after}</pre></div></div></details>"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    format!("<div>{details}</div>")
+}
+
+pub(super) fn render_impact(report: &ReviewReport) -> String {
+    let impact = &report.impact_paths;
+    if impact.files.is_empty() && report.blast_radius.is_empty() {
+        return String::new();
+    }
+    let paths = impact
+        .files
+        .iter()
+        .map(|file| {
+            let direct = file
+                .direct_dependents
+                .iter()
+                .map(|path| {
+                    format!(
+                        "<li>direct: <code>{}</code></li>",
+                        escape(&path.to_string_lossy())
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            let transitive = file
+                .transitive_dependents
+                .iter()
+                .map(|path| {
+                    format!(
+                        "<li>transitive: <code>{}</code></li>",
+                        escape(&path.to_string_lossy())
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            format!(
+                "<li><code>{}</code><ul>{direct}{transitive}</ul></li>",
+                escape(&file.path.to_string_lossy())
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    let blast = report
+        .blast_radius
+        .iter()
+        .map(|path| format!("<li><code>{}</code></li>", escape(&path.to_string_lossy())))
+        .collect::<Vec<_>>()
+        .join("");
+    format!(
+        r#"<section class="panel" id="impact-paths"><h2>Impact Paths</h2>
+<p>{} impacted file(s) across {} director{} (depth {}).</p>
+<ul>{paths}</ul>
+{}{}
+</section>"#,
+        impact.affected_surface.impacted_files,
+        impact.affected_surface.affected_directories.len(),
+        if impact.affected_surface.affected_directories.len() == 1 {
+            "y"
+        } else {
+            "ies"
+        },
+        impact.depth,
+        if blast.is_empty() {
+            ""
+        } else {
+            "<h3>Blast radius</h3><ul>"
+        },
+        if blast.is_empty() {
+            "".to_string()
+        } else {
+            format!("{blast}</ul>")
+        },
+    )
+}
+
+pub(super) fn render_signals(tiered: &TieredSignals) -> String {
+    if tiered.is_empty() {
+        return String::new();
+    }
+    let mut remaining = DETAIL_LIMIT;
+    let mut sections = String::new();
+    for (label, signals) in [
+        ("Definitely sensitive", &tiered.definitely),
+        ("Maybe sensitive", &tiered.maybe),
+        ("Large diff / noise", &tiered.noise),
+    ] {
+        if remaining == 0 || signals.is_empty() {
+            continue;
+        }
+        sections.push_str(&format!("<h3>{label}</h3>"));
+        for signal in signals
+            .iter()
+            .filter(|signal| !signal.suppressed)
+            .take(remaining)
+        {
+            let location = signal.line.map_or_else(
+                || signal.path.clone(),
+                |line| format!("{}:{line}", signal.path),
+            );
+            sections.push_str(&format!(
+                "<article class=\"signal\"><strong>{}</strong><div class=\"signal-meta\"><code>{}</code> · {} · reach {}</div><div>{}</div></article>",
+                escape(&signal.headline),
+                escape(&location),
+                escape(&format!("{:?}", signal.family)),
+                signal.blast_radius,
+                escape(signal.detail.as_deref().unwrap_or("No further detail."))
+            ));
+            remaining -= 1;
+        }
+    }
+    if sections.is_empty() {
+        return String::new();
+    }
+    let total_visible = tiered
+        .definitely
+        .iter()
+        .chain(tiered.maybe.iter())
+        .chain(tiered.noise.iter())
+        .filter(|signal| !signal.suppressed)
+        .count();
+    if total_visible > DETAIL_LIMIT {
+        sections.push_str(&format!(
+            "<p class=\"muted\">{} additional signal(s) omitted; use JSON for the full list.</p>",
+            total_visible - DETAIL_LIMIT
+        ));
+    }
+    format!(
+        "<section class=\"panel\" id=\"review-signals\"><h2>Review Signals</h2>{sections}</section>"
+    )
+}
+
+pub(super) fn render_verification(report: &ReviewReport, proof: &ChangeProof) -> String {
+    if report.verification.is_empty() {
+        return String::new();
+    }
+    let rows = report
+        .verification
+        .iter()
+        .map(|outcome| {
+            let source = if outcome.reused { "cached" } else { "executed" };
+            format!(
+                "<tr><td><code>{}</code></td><td>{:?}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+                escape(&outcome.check_id),
+                outcome.status,
+                source,
+                verification_duration_evidence(outcome),
+                outcome.exit_code.map_or_else(|| "-".to_string(), |code| code.to_string()),
+                if outcome.revision_compatible { "compatible" } else { "changed" }
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    format!(
+        "<section class=\"panel\" id=\"verification\"><h2>Verification</h2><p class=\"muted\">{}</p><table><thead><tr><th>Check</th><th>Status</th><th>Source</th><th>Duration</th><th>Exit</th><th>Revision</th></tr></thead><tbody>{rows}</tbody></table></section>",
+        escape(&verification_proof_summary(report, proof.obligations))
+    )
+}
+
+pub(super) fn render_findings(report: &ReviewReport) -> String {
+    let total = report.summary.artifacts.findings.len();
+    let findings = report
+        .summary
+        .artifacts
+        .findings
+        .iter()
+        .take(DETAIL_LIMIT)
+        .map(|finding| {
+            format!(
+                "<article class=\"signal\"><strong>{}</strong><div class=\"signal-meta\">{} · {} · <code>{}</code></div></article>",
+                escape(&finding.title),
+                escape(finding.severity_label()),
+                escape(finding.confidence_label()),
+                escape(&finding.rule_id)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    if findings.is_empty() {
+        return "<section class=\"panel\" id=\"findings\"><h2>Findings</h2><p class=\"empty\">No findings.</p></section>".to_string();
+    }
+    let omitted = if total > DETAIL_LIMIT {
+        format!(
+            "<p class=\"muted\">{} additional finding(s) omitted; use JSON for the full list.</p>",
+            total - DETAIL_LIMIT
+        )
+    } else {
+        String::new()
+    };
+    format!(
+        "<section class=\"panel\" id=\"findings\"><h2>Findings</h2>{findings}{omitted}</section>"
+    )
+}

--- a/tests/review_html.rs
+++ b/tests/review_html.rs
@@ -1,0 +1,204 @@
+use repopilot::review::diff::{ChangeStatus, ChangedFile, ChangedRange, DiffHunk};
+use repopilot::review::model::ReviewReport;
+use repopilot::review::render::render_review_html;
+use repopilot::scan::types::{ScanMetadata, ScanMetrics, ScanMode, ScanSummary};
+use repopilot::verification::{VerificationOutcome, VerificationRole, VerificationStatus};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn review_html_renders_proof_card_change_map_and_escaped_scope() {
+    let report = ReviewReport {
+        summary: ScanSummary {
+            metadata: ScanMetadata {
+                mode: ScanMode::Changed,
+                root_path: PathBuf::from("<repo>"),
+                ..Default::default()
+            },
+            metrics: ScanMetrics {
+                files_discovered: 2,
+                files_analyzed: 1,
+                large_files_skipped: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        repo_root: PathBuf::from("<repo>"),
+        baseline_path: None,
+        changed_files: vec![ChangedFile {
+            path: PathBuf::from("src/<auth>.rs"),
+            status: ChangeStatus::Modified,
+            ranges: vec![ChangedRange { start: 4, end: 6 }],
+            hunks: vec![DiffHunk {
+                header: Some("auth policy".to_string()),
+                new_range: Some(ChangedRange { start: 4, end: 4 }),
+                old_range: Some(ChangedRange { start: 4, end: 4 }),
+                added_lines: vec!["after <change>".to_string()],
+                removed_lines: vec!["before <change>".to_string()],
+            }],
+        }],
+        blast_radius: vec![PathBuf::from("src/consumer.rs")],
+        impact_paths: Default::default(),
+        ownership: Default::default(),
+        ownership_diagnostics: Vec::new(),
+        boundary_signals: Vec::new(),
+        boundary_missing_test: false,
+        tiered_signals: Default::default(),
+        timings: Default::default(),
+        verification: Vec::new(),
+        findings: Vec::new(),
+    };
+
+    let html = render_review_html(&report, None, None);
+
+    assert!(html.contains("RepoPilot Review Report"));
+    assert!(html.contains("class=\"proof-card verdict-review\""));
+    assert!(html.contains("Change proof"));
+    assert!(html.contains("REVIEW"));
+    assert!(html.contains("1/1 file(s) analyzed"));
+    assert!(html.contains("none selected; no verification evidence"));
+    assert!(html.contains("1 excluded, 0 unsupported file(s)"));
+    assert!(html.contains("<h2>Change Map</h2>"));
+    assert!(html.contains("Before"));
+    assert!(html.contains("After"));
+    assert!(html.contains("after &lt;change&gt;"));
+    assert!(!html.contains("after <change>"));
+    assert!(html.contains("src/&lt;auth&gt;.rs"));
+    assert!(!html.contains("src/<auth>.rs"));
+    assert!(html.contains("src/consumer.rs"));
+}
+
+#[test]
+fn review_cli_writes_html_contract_consumer_map() {
+    let temp = TempDir::new().expect("temp dir");
+    init_repo(temp.path());
+    write(
+        temp.path(),
+        "src/api.ts",
+        "export const policy = () => true;\n",
+    );
+    write(
+        temp.path(),
+        "src/app.ts",
+        "import { policy } from \"./api\";\nexport const app = () => policy();\n",
+    );
+    git(temp.path(), &["add", "."]);
+    git(temp.path(), &["commit", "-m", "before"]);
+
+    write(temp.path(), "src/api.ts", "const policy = () => true;\n");
+    let output_path = temp.path().join("review.html");
+    let output = Command::new(env!("CARGO_BIN_EXE_repopilot"))
+        .args([
+            "review",
+            ".",
+            "--format",
+            "html",
+            "--output",
+            output_path.to_str().expect("output path"),
+            "--no-progress",
+        ])
+        .current_dir(temp.path())
+        .output()
+        .expect("run HTML review");
+
+    assert!(
+        output.status.success(),
+        "review failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let html = fs::read_to_string(output_path).expect("read HTML review");
+    assert!(html.contains("Contract / consumer map"));
+    assert!(html.contains("src/api.ts"));
+    assert!(html.contains("src/app.ts"));
+    assert!(html.contains("RemovedExport"));
+}
+
+#[test]
+fn review_html_renders_verification_outcomes_and_revision_state() {
+    let mut report = ReviewReport {
+        summary: ScanSummary {
+            metadata: ScanMetadata {
+                mode: ScanMode::Changed,
+                ..Default::default()
+            },
+            metrics: ScanMetrics {
+                files_discovered: 1,
+                files_analyzed: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        repo_root: PathBuf::from("/repo"),
+        baseline_path: None,
+        changed_files: vec![ChangedFile {
+            path: PathBuf::from("src/lib.rs"),
+            status: ChangeStatus::Modified,
+            ranges: Vec::new(),
+            hunks: Vec::new(),
+        }],
+        blast_radius: Vec::new(),
+        impact_paths: Default::default(),
+        ownership: Default::default(),
+        ownership_diagnostics: Vec::new(),
+        boundary_signals: Vec::new(),
+        boundary_missing_test: false,
+        tiered_signals: Default::default(),
+        timings: Default::default(),
+        verification: Vec::new(),
+        findings: Vec::new(),
+    };
+    report.verification.push(VerificationOutcome {
+        check_id: "unit".to_string(),
+        role: VerificationRole::Test,
+        status: VerificationStatus::Passed,
+        duration_ms: 12,
+        exit_code: Some(0),
+        working_directory: ".".to_string(),
+        stdout_excerpt: String::new(),
+        stderr_excerpt: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+        revision_before: "same".to_string(),
+        revision_after: "same".to_string(),
+        revision_compatible: true,
+        limitations: Vec::new(),
+        reused: true,
+    });
+
+    let html = render_review_html(&report, None, None);
+
+    assert!(html.contains("<h2>Verification</h2>"));
+    assert!(html.contains("<code>unit</code>"));
+    assert!(html.contains("Passed"));
+    assert!(html.contains("cached"));
+    assert!(html.contains("compatible"));
+    assert!(html.contains("1 passed, 0 failed"));
+}
+
+fn init_repo(root: &Path) {
+    git(root, &["init"]);
+    git(root, &["config", "user.email", "test@example.com"]);
+    git(root, &["config", "user.name", "RepoPilot Test"]);
+}
+
+fn write(root: &Path, path: &str, content: &str) {
+    let path = root.join(path);
+    fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+    fs::write(path, content).expect("write fixture");
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- add `repopilot review --format html` as a self-contained local report
- surface canonical ChangeProof and merge readiness in a first-screen Proof Card
- add a Change Map for changed files, before/after hunks, typed contract-to-consumer deltas, impact paths, signals, verification outcomes, findings, and bounded limitations
- add escaping, responsive local assets, and integration coverage for the HTML contract

## Why

Review HTML was previously unavailable. This closes the Phase D local HTML Change Map gap while reusing the canonical proof adapter and preserving the existing JSON, readiness, gates, and exit behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `python3 scripts/release-contract.py check`
- `npm run review:performance`
- `cargo run -- scan . --fail-on-priority p1`
- `cargo test --test review_html -- --nocapture`
