### PR TITLE
feat: preserve ChangeProof across MCP projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added self-contained HTML output for `repopilot review`. The local Change Map
   leads with the canonical Proof Card, contract-to-consumer evidence, impact
   paths, verification outcomes, findings, and explicit scope limitations.
+- Extended MCP ChangeProof parity: stored review handles now expose the same
+  proof in `repopilot_context`, explain tools, and the analyses resource while
+  preserving Markdown content for agents.
 - Extended the GitHub Action review summary with the canonical Change Proof
   verdict, analyzed scope, verification obligation state, and proof limits.
 - Added a verification-proof line to the console and Markdown review summaries.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -656,3 +656,21 @@ bump is needed to start.
   inputs plus deterministic report rendering. The audit measures packet
   completeness and unresolved work; it does not judge reviewer correctness,
   runtime behavior, or production-wide quality.
+
+## 0V — MCP ChangeProof Projection Parity
+
+- Stored review handles now preserve the canonical `change_proof` record across
+  MCP context, finding/signal explanations, and the `repopilot://analyses`
+  resource. These projections reuse the review artifact instead of deriving a
+  second verdict.
+- `repopilot_context` keeps its Markdown content contract and adds the proof to
+  `structuredContent` only when a revision-compatible review handle is
+  explicitly supplied. This prevents a stale review from being presented as
+  current repository context.
+- An end-to-end MCP fixture proves that review, context, signal explanation,
+  and stored-analysis summaries expose byte-equivalent ChangeProof values for
+  one handle. The finding explanation unit test covers the same additive
+  lineage for replayed findings.
+- Boundary: this is projection and provenance parity, not runtime verification,
+  independent correctness evidence, or a precision/recall result. The proof
+  remains bounded by the original review scope and limitations.

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -304,6 +304,16 @@ evidence, signal details, and finding text are HTML-escaped before rendering;
 large signal and finding lists remain bounded in the human report while JSON
 retains the complete machine-readable record.
 
+### MCP ChangeProof parity
+
+When an MCP review returns an `analysisHandle`, pass that handle to
+`repopilot_context`, `repopilot_explain_finding`, or
+`repopilot_explain_review_signal`. The returned structured content includes the
+same canonical `change_proof` object that was emitted by the review. The
+`repopilot://analyses` resource exposes that object in its stored-analysis
+summary as well. Context content remains Markdown, while the proof stays
+machine-readable in `structuredContent`.
+
 ## Audit receipt JSON
 
 Use `--receipt` when a CI job, release process, or audit trail needs compact

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -5,7 +5,8 @@ the first additive review projection is now implemented.
 
 Current projection progress: Phase D now has console, Markdown, JSON, MCP,
 Action, and self-contained review HTML projections, including the first local
-Change Map.
+Change Map. Stored MCP review handles now carry the same ChangeProof into
+context, explain, and analysis-history projections.
 
 RepoPilot 0.23 turns change review from a collection of findings and signals
 into one bounded proof of what changed, which contracts and consumers are

--- a/src/commands/mcp/analysis_store.rs
+++ b/src/commands/mcp/analysis_store.rs
@@ -91,13 +91,19 @@ impl AnalysisStore {
                     .and_then(|value| value.get("tiered_signals"))
                     .map(count_review_signals)
                     .unwrap_or(0);
-                Some(json!({
+                let mut summary = json!({
                     "analysis_handle": handle,
                     "kind": record.kind.label(),
                     "workspace_revision": record.workspace_revision,
                     "findings": findings,
                     "review_signals": review_signals
-                }))
+                });
+                if let Some(change_proof) =
+                    report.as_ref().and_then(|value| value.get("change_proof"))
+                {
+                    summary["change_proof"] = change_proof.clone();
+                }
+                Some(summary)
             })
             .collect()
     }

--- a/src/commands/mcp/context.rs
+++ b/src/commands/mcp/context.rs
@@ -16,6 +16,11 @@ use std::path::PathBuf;
 
 pub const TOOL_NAME: &str = "repopilot_context";
 
+pub struct ContextCallResult {
+    pub markdown: String,
+    pub change_proof: Option<Value>,
+}
+
 pub fn definition() -> Value {
     json!({
         "name": TOOL_NAME,
@@ -46,7 +51,13 @@ pub fn definition() -> Value {
         },
         "outputSchema": {
             "type": "object",
-            "properties": { "markdown": { "type": "string" } },
+            "properties": {
+                "markdown": { "type": "string" },
+                "change_proof": {
+                    "type": "object",
+                    "description": "Canonical ChangeProof from the referenced review handle, when selected."
+                }
+            },
             "required": ["markdown"],
             "additionalProperties": false
         },
@@ -59,7 +70,10 @@ pub fn definition() -> Value {
     })
 }
 
-pub fn call(arguments: &Value) -> Result<String, String> {
+pub fn call(
+    arguments: &Value,
+    stored_review_report: Option<&str>,
+) -> Result<ContextCallResult, String> {
     let path = PathBuf::from(arguments.get("path").and_then(Value::as_str).unwrap_or("."));
     let focus = parse_focus_category(arguments.get("focus").and_then(Value::as_str))
         .map_err(|error| error.to_string())?;
@@ -108,5 +122,16 @@ pub fn call(arguments: &Value) -> Result<String, String> {
         scan_result.repo_facts_summary.as_ref(),
         &options,
     );
-    Ok(content)
+    let change_proof = stored_review_report
+        .map(|report| {
+            serde_json::from_str::<Value>(report)
+                .map_err(|error| format!("stored review report is invalid: {error}"))
+        })
+        .transpose()?
+        .and_then(|report| report.get("change_proof").cloned());
+
+    Ok(ContextCallResult {
+        markdown: content,
+        change_proof,
+    })
 }

--- a/src/commands/mcp/explain_finding.rs
+++ b/src/commands/mcp/explain_finding.rs
@@ -102,8 +102,9 @@ pub fn call(
             return stored_fallback(report, finding_id, source, locator.as_ref(), &reason);
         }
     };
-    serde_json::to_string_pretty(&selection)
-        .map_err(|error| format!("render finding explanation failed: {error}"))
+    let rendered = serde_json::to_string_pretty(&selection)
+        .map_err(|error| format!("render finding explanation failed: {error}"))?;
+    with_change_proof(&rendered, report)
 }
 
 fn stored_fallback(
@@ -133,6 +134,7 @@ fn stored_fallback(
         "message": "The finding is available, but a safe live decision replay is unavailable.",
         "replay": { "status": "unavailable", "reason": reason },
         "finding": finding,
+        "change_proof": report.get("change_proof").cloned().unwrap_or(Value::Null),
         "decision": finding.get("decision").cloned().unwrap_or(Value::Null),
         "limitations": [
             "This fallback preserves stored analysis evidence and does not claim a live replay.",
@@ -141,6 +143,20 @@ fn stored_fallback(
     });
     serde_json::to_string_pretty(&fallback)
         .map_err(|error| format!("render finding fallback failed: {error}"))
+}
+
+fn with_change_proof(rendered: &str, report: &str) -> Result<String, String> {
+    let mut explanation: Value =
+        serde_json::from_str(rendered).map_err(|error| format!("invalid explanation: {error}"))?;
+    let report: Value =
+        serde_json::from_str(report).map_err(|error| format!("invalid session report: {error}"))?;
+    if let Some(change_proof) = report.get("change_proof")
+        && let Some(object) = explanation.as_object_mut()
+    {
+        object.insert("change_proof".to_string(), change_proof.clone());
+    }
+    serde_json::to_string_pretty(&explanation)
+        .map_err(|error| format!("render finding explanation failed: {error}"))
 }
 
 fn fallback_matches_locator(finding: &Value, locator: &FindingOccurrenceLocator) -> bool {
@@ -304,6 +320,27 @@ mod tests {
         assert_eq!(value["replay"]["status"], "unavailable");
         assert_eq!(value["finding"]["id"], "project-wide");
         assert_eq!(value["decision"]["severity"], "medium");
+    }
+
+    #[test]
+    fn explanation_preserves_the_stored_change_proof() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (report, finding_id) = report_fixture(temp.path());
+        let mut report_value: Value = serde_json::from_str(&report).expect("report JSON");
+        report_value["change_proof"] = json!({
+            "verdict": "REVIEW",
+            "coverage": { "scope": "full" }
+        });
+
+        let rendered = call(
+            &json!({ "finding_id": finding_id, "source": "last-scan" }),
+            temp.path(),
+            Some(&report_value.to_string()),
+            None,
+        )
+        .expect("explain finding");
+        let value: Value = serde_json::from_str(&rendered).expect("valid JSON");
+        assert_eq!(value["change_proof"]["verdict"], "REVIEW");
     }
 
     fn duplicate_report(report: &str) -> String {

--- a/src/commands/mcp/explain_review_signal.rs
+++ b/src/commands/mcp/explain_review_signal.rs
@@ -52,6 +52,7 @@ pub fn call(arguments: &Value, review_report: Option<&str>) -> Result<String, St
         "status": "explained",
         "signal_id": signal_id,
         "signal": signal,
+        "change_proof": report.get("change_proof").cloned().unwrap_or(Value::Null),
         "why_it_matters": why_it_matters(signal),
         "impact": impact_for_path(&report, impact_path),
         "gate": {

--- a/src/commands/mcp/publication.rs
+++ b/src/commands/mcp/publication.rs
@@ -39,6 +39,7 @@ pub(super) fn prepare_tool_result(
     state: &ServerState,
     workspace_revision: &str,
     publishable: bool,
+    structured_content: Option<Value>,
 ) -> PreparedToolResult {
     let kind = match name {
         scan::TOOL_NAME => Some(AnalysisKind::Scan),
@@ -54,6 +55,7 @@ pub(super) fn prepare_tool_result(
                 None,
                 None,
                 state.max_response_bytes,
+                structured_content,
             ),
             publication: None,
         };
@@ -88,6 +90,7 @@ pub(super) fn prepare_tool_result(
         handle.as_deref(),
         page.metadata,
         state.max_response_bytes,
+        structured_content,
     );
     if result["isError"] == true {
         return PreparedToolResult {
@@ -120,6 +123,7 @@ fn error_result(
             None,
             None,
             max_response_bytes,
+            None,
         ),
         publication: None,
     }
@@ -148,9 +152,10 @@ pub(super) fn tool_result(
     analysis_handle: Option<&str>,
     pagination: Option<Value>,
     max_response_bytes: usize,
+    structured_content: Option<Value>,
 ) -> Value {
     let mut result = match outcome {
-        Ok(text) => success_result(name, text),
+        Ok(text) => success_result(name, text, structured_content),
         Err(message) => {
             json!({ "content": [{ "type": "text", "text": message }], "isError": true })
         }
@@ -168,13 +173,15 @@ pub(super) fn tool_result(
     oversized_result(workspace_revision, max_response_bytes)
 }
 
-fn success_result(name: &str, text: String) -> Value {
-    let structured = serde_json::from_str::<Value>(&text).unwrap_or_else(|_| {
-        if name == context::TOOL_NAME {
-            json!({ "markdown": text })
-        } else {
-            json!({ "text": text })
-        }
+fn success_result(name: &str, text: String, structured_content: Option<Value>) -> Value {
+    let structured = structured_content.unwrap_or_else(|| {
+        serde_json::from_str::<Value>(&text).unwrap_or_else(|_| {
+            if name == context::TOOL_NAME {
+                json!({ "markdown": text })
+            } else {
+                json!({ "text": text })
+            }
+        })
     });
     json!({
         "content": [{ "type": "text", "text": text }],

--- a/src/commands/mcp/tests.rs
+++ b/src/commands/mcp/tests.rs
@@ -690,6 +690,7 @@ fn oversized_tool_result_is_replaced_by_a_bounded_error() {
         Some("scan-handle"),
         None,
         1024,
+        None,
     );
 
     assert_eq!(result["isError"], true);

--- a/src/commands/mcp/tool_call.rs
+++ b/src/commands/mcp/tool_call.rs
@@ -59,14 +59,18 @@ pub(super) fn handle_tools_call_with_context(
     // Analysis may update RepoPilot-owned cache files. Capture the revision at
     // response time so a handle never becomes stale because of its own call.
     let workspace_revision = WorkspaceRevision::capture(&state.root).id().to_string();
-    let (outcome, publishable) = match outcome {
+    let (outcome, structured_content, publishable) = match outcome {
         Ok(execution) => {
             let publishable = execution.review_revision.as_ref().is_none_or(|revision| {
                 revision.revision_compatible && revision.analysis_revision == workspace_revision
             });
-            (Ok(execution.rendered), publishable)
+            (
+                Ok(execution.rendered),
+                execution.structured_content,
+                publishable,
+            )
         }
-        Err(message) => (Err(message), false),
+        Err(message) => (Err(message), None, false),
     };
     let prepared = prepare_tool_result(
         name,
@@ -75,6 +79,7 @@ pub(super) fn handle_tools_call_with_context(
         state,
         &workspace_revision,
         publishable,
+        structured_content,
     );
     if cancellation.is_cancelled() {
         return Response::error(id, -32800, "request cancelled");
@@ -98,6 +103,7 @@ fn tool_response(
             None,
             None,
             state.max_response_bytes,
+            None,
         ),
     )
 }
@@ -123,6 +129,7 @@ fn dispatch_tool(
             )
             .map(|result| ToolExecution {
                 rendered: result.rendered,
+                structured_content: None,
                 review_revision: Some(ReviewRevision {
                     analysis_revision: result.analysis_revision,
                     revision_compatible: result.revision_compatible,
@@ -136,9 +143,26 @@ fn dispatch_tool(
         scan::TOOL_NAME => scan::call(arguments)
             .map(ToolExecution::plain)
             .map_err(DispatchError::Message),
-        context::TOOL_NAME => context::call(arguments)
-            .map(ToolExecution::plain)
-            .map_err(DispatchError::Message),
+        context::TOOL_NAME => {
+            let stored_review = referenced
+                .filter(|record| record.kind == AnalysisKind::Review)
+                .map(|record| record.report.as_str());
+            context::call(arguments, stored_review)
+                .map(|result| {
+                    let context::ContextCallResult {
+                        markdown,
+                        change_proof,
+                    } = result;
+                    let structured_content = change_proof.map(|change_proof| {
+                        json!({
+                            "markdown": markdown.clone(),
+                            "change_proof": change_proof
+                        })
+                    });
+                    ToolExecution::with_structured(markdown, structured_content)
+                })
+                .map_err(DispatchError::Message)
+        }
         explain_file::TOOL_NAME => explain_file::call(arguments, &state.root)
             .map(ToolExecution::plain)
             .map_err(DispatchError::Message),
@@ -165,6 +189,7 @@ enum DispatchError {
 
 struct ToolExecution {
     rendered: String,
+    structured_content: Option<Value>,
     review_revision: Option<ReviewRevision>,
 }
 
@@ -172,6 +197,15 @@ impl ToolExecution {
     fn plain(rendered: String) -> Self {
         Self {
             rendered,
+            structured_content: None,
+            review_revision: None,
+        }
+    }
+
+    fn with_structured(rendered: String, structured_content: Option<Value>) -> Self {
+        Self {
+            rendered,
+            structured_content,
             review_revision: None,
         }
     }

--- a/tests/mcp_change_proof.rs
+++ b/tests/mcp_change_proof.rs
@@ -1,0 +1,184 @@
+//! End-to-end contract for ChangeProof parity across stored MCP projections.
+
+use serde_json::{Value, json};
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+fn start_mcp(root: &Path) -> (Child, ChildStdin, BufReader<ChildStdout>) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_repopilot"))
+        .arg("mcp")
+        .current_dir(root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn repopilot mcp");
+    let stdin = child.stdin.take().expect("child stdin");
+    let stdout = BufReader::new(child.stdout.take().expect("child stdout"));
+    (child, stdin, stdout)
+}
+
+fn send(stdin: &mut ChildStdin, request: &Value) {
+    writeln!(stdin, "{request}").expect("write MCP request");
+    stdin.flush().expect("flush MCP request");
+}
+
+fn receive(stdout: &mut BufReader<ChildStdout>) -> Value {
+    let mut line = String::new();
+    stdout.read_line(&mut line).expect("read MCP response");
+    assert!(!line.is_empty(), "MCP server closed before responding");
+    serde_json::from_str(&line).expect("MCP response JSON")
+}
+
+fn initialize(stdin: &mut ChildStdin, stdout: &mut BufReader<ChildStdout>) {
+    send(
+        stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": "initialize",
+            "method": "initialize",
+            "params": { "protocolVersion": "2025-11-25" }
+        }),
+    );
+    let _ = receive(stdout);
+    send(
+        stdin,
+        &json!({"jsonrpc":"2.0","method":"notifications/initialized"}),
+    );
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .status()
+        .expect("git available");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn setup_removed_export_change(root: &Path) {
+    git(root, &["init", "-q"]);
+    git(root, &["config", "user.email", "test@example.com"]);
+    git(root, &["config", "user.name", "Test"]);
+    fs::create_dir_all(root.join("src")).expect("src directory");
+    fs::write(root.join("src/api.ts"), "export function loadUser() {}\n").expect("api");
+    fs::write(
+        root.join("src/caller.ts"),
+        "import { loadUser } from \"./api.ts\";\nloadUser();\n",
+    )
+    .expect("caller");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-qm", "before"]);
+    fs::write(
+        root.join("src/api.ts"),
+        "export function saveUserAccount() {}\n",
+    )
+    .expect("changed api");
+}
+
+fn removed_export_signal(report: &Value) -> &Value {
+    report["tiered_signals"]["definitely"]
+        .as_array()
+        .expect("definitely signals")
+        .iter()
+        .find(|signal| signal["kind"] == "behavioral.removed-export-still-imported")
+        .expect("removed export signal")
+}
+
+#[test]
+fn stored_mcp_projections_share_the_canonical_change_proof() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    setup_removed_export_change(temp.path());
+    let (mut child, mut stdin, mut stdout) = start_mcp(temp.path());
+    initialize(&mut stdin, &mut stdout);
+
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": "review",
+            "method": "tools/call",
+            "params": {
+                "name": "repopilot_review_change",
+                "arguments": { "path": ".", "detail": "full" }
+            }
+        }),
+    );
+    let review = receive(&mut stdout);
+    let report = &review["result"]["structuredContent"];
+    let proof = report["change_proof"].clone();
+    assert!(proof.is_object(), "review publishes ChangeProof");
+    let handle = review["result"]["analysisHandle"]
+        .as_str()
+        .expect("review analysis handle");
+
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": "context",
+            "method": "tools/call",
+            "params": {
+                "name": "repopilot_context",
+                "arguments": { "path": ".", "analysis_handle": handle }
+            }
+        }),
+    );
+    let context = receive(&mut stdout);
+    assert_eq!(context["result"]["isError"], false);
+    assert_eq!(
+        context["result"]["structuredContent"]["change_proof"],
+        proof
+    );
+    assert!(
+        context["result"]["content"][0]["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("Repository Facts Summary")),
+        "context content remains Markdown"
+    );
+
+    let signal_id = removed_export_signal(report)["signal_id"]
+        .as_str()
+        .expect("signal id");
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": "explain",
+            "method": "tools/call",
+            "params": {
+                "name": "repopilot_explain_review_signal",
+                "arguments": { "signal_id": signal_id, "analysis_handle": handle }
+            }
+        }),
+    );
+    let explanation = receive(&mut stdout);
+    assert_eq!(
+        explanation["result"]["structuredContent"]["change_proof"],
+        proof
+    );
+
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": "analyses",
+            "method": "resources/read",
+            "params": { "uri": "repopilot://analyses" }
+        }),
+    );
+    let analyses = receive(&mut stdout);
+    let summary: Value = serde_json::from_str(
+        analyses["result"]["contents"][0]["text"]
+            .as_str()
+            .expect("analysis summaries"),
+    )
+    .expect("analysis summary JSON");
+    assert_eq!(summary[0]["change_proof"], proof);
+
+    drop(stdin);
+    assert!(child.wait().expect("wait for MCP server").success());
+}


### PR DESCRIPTION
## Summary

- preserve the canonical `change_proof` through stored MCP review handles
- expose the same proof in `repopilot_context` structured content without changing its Markdown content contract
- attach proof lineage to `repopilot_explain_finding` and `repopilot_explain_review_signal`
- include proof in the `repopilot://analyses` resource summaries
- add an end-to-end MCP parity fixture plus replay coverage and documentation

## Why

The review tool already emitted ChangeProof, but follow-up MCP tools could not carry that same evidence forward. This slice makes the review handle an auditable reference: context, explanations, and stored-analysis summaries reuse the original proof and cannot silently derive a different verdict.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin repopilot mcp -- --nocapture`
- `cargo test --test mcp_change_proof --test mcp_cli -- --nocapture`
- `cargo test --all`
- `python3 scripts/release-contract.py check`
- `npm run review:performance`
- `cargo run -- scan . --fail-on-priority p1`
