### PR TITLE
feat: add deterministic init suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- `repopilot init` now prints deterministic stack-specific verification
+  proposals and existing critical-path candidates. Proposals are display-only:
+  no commands run, and an existing config is preserved unless `--force` is
+  passed.
 - Added self-contained HTML output for `repopilot review`. The local Change Map
   leads with the canonical Proof Card, contract-to-consumer evidence, impact
   paths, verification outcomes, findings, and explicit scope limitations.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -540,6 +540,11 @@ When invoked below a Git worktree root, the default config, Action workflow, and
 MCP bootstrap are created at that root. Outside Git they remain rooted at the
 current directory.
 
+After the bootstrap steps, `init` reports the detected stack, declared
+verification commands, and critical-path candidates such as existing workflow,
+authentication, migration, or deployment directories. These are deterministic
+proposals only: commands are not run and existing config is not overwritten.
+
 ---
 
 ## `mcp`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,13 @@ Write to a custom path:
 repopilot init --path ./config/repopilot.toml
 ```
 
+`init` also inspects local marker files and declared package scripts to print
+stack-specific verification proposals and existing critical-path candidates.
+It does not execute those commands, access the network, or write the
+suggestions into `repopilot.toml`; review them before turning an accepted check
+into a bounded `[[verification.checks]]` entry. Existing config files remain
+unchanged unless `--force` is passed.
+
 ## Precedence
 
 Configuration is resolved in this order:

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -674,3 +674,18 @@ bump is needed to start.
 - Boundary: this is projection and provenance parity, not runtime verification,
   independent correctness evidence, or a precision/recall result. The proof
   remains bounded by the original review scope and limitations.
+
+## 0W — Deterministic Init Suggestions
+
+- `repopilot init` detects common stack markers and only proposes Node.js
+  commands that are declared in `package.json`; the proposals are rendered in a
+  stable order and are never executed.
+- Critical-path candidates are emitted only for existing conventional paths
+  such as workflows, authentication, security, migrations, deployment, and
+  configuration directories. Candidate globs are sorted and deduplicated.
+- Integration coverage proves Rust and Node.js output, preservation of an
+  existing config, and the explicit no-commands boundary. Unit coverage covers
+  declared-script filtering and deterministic candidate ordering.
+- Boundary: these are review aids, not passed verification evidence or a
+  completeness claim about a repository's architecture. They do not alter
+  configuration and do not replace explicit check selection.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -6,7 +6,9 @@ the first additive review projection is now implemented.
 Current projection progress: Phase D now has console, Markdown, JSON, MCP,
 Action, and self-contained review HTML projections, including the first local
 Change Map. Stored MCP review handles now carry the same ChangeProof into
-context, explain, and analysis-history projections.
+context, explain, and analysis-history projections. `repopilot init` now adds
+deterministic stack and critical-path proposals without executing commands or
+overwriting existing configuration.
 
 RepoPilot 0.23 turns change review from a collection of findings and signals
 into one bounded proof of what changed, which contracts and consumers are

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,4 +1,5 @@
 use crate::cli::{InitOptions, McpClientArg};
+use crate::commands::init_suggestions::render as render_init_suggestions;
 use repopilot::config::template::default_config_toml;
 use repopilot::review::diff::resolve_git_root;
 use std::fs;
@@ -50,6 +51,8 @@ fn run_at(options: InitOptions, invocation_dir: &Path) -> Result<(), Box<dyn std
         generate_action,
         mcp_client,
     );
+    println!();
+    print!("{}", render_init_suggestions(&root));
     Ok(())
 }
 

--- a/src/commands/init_suggestions.rs
+++ b/src/commands/init_suggestions.rs
@@ -1,0 +1,288 @@
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SuggestedCheck {
+    pub(crate) id: String,
+    pub(crate) command: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InitSuggestions {
+    pub(crate) stacks: Vec<String>,
+    pub(crate) checks: Vec<SuggestedCheck>,
+    pub(crate) critical_paths: Vec<String>,
+}
+
+pub(crate) fn render(root: &Path) -> String {
+    let suggestions = detect(root);
+    let mut output = String::new();
+
+    if suggestions.stacks.is_empty() {
+        output.push_str("Detected stack: unknown\n");
+    } else {
+        output.push_str(&format!(
+            "Detected stack: {}\n",
+            suggestions.stacks.join(", ")
+        ));
+    }
+
+    if suggestions.checks.is_empty() {
+        output.push_str("No stack-specific verification checks detected.\n");
+    } else {
+        output.push_str("Suggested verification checks (not run):\n");
+        for check in suggestions.checks {
+            output.push_str(&format!("  - {}: {}\n", check.id, check.command));
+        }
+    }
+
+    if suggestions.critical_paths.is_empty() {
+        output.push_str("No critical path candidates detected.\n");
+    } else {
+        output.push_str("Critical path candidates (review before committing):\n");
+        for path in suggestions.critical_paths {
+            output.push_str(&format!("  - {path}\n"));
+        }
+    }
+
+    output.push_str("No commands were run; these are deterministic suggestions only.\n");
+    output
+}
+
+fn detect(root: &Path) -> InitSuggestions {
+    let mut stacks = Vec::new();
+    let mut checks = Vec::new();
+
+    if root.join("Cargo.toml").is_file() {
+        stacks.push("Rust".to_string());
+        checks.push(SuggestedCheck {
+            id: "rust.test".to_string(),
+            command: "cargo test --all".to_string(),
+        });
+    }
+
+    if root.join("package.json").is_file() {
+        stacks.push("Node.js".to_string());
+        checks.extend(node_checks(root));
+    }
+
+    if has_python_marker(root) {
+        stacks.push("Python".to_string());
+        if has_pytest_evidence(root) {
+            checks.push(SuggestedCheck {
+                id: "python.test".to_string(),
+                command: "python3 -m pytest -q".to_string(),
+            });
+        }
+    }
+
+    if root.join("go.mod").is_file() {
+        stacks.push("Go".to_string());
+        checks.push(SuggestedCheck {
+            id: "go.test".to_string(),
+            command: "go test ./...".to_string(),
+        });
+    }
+
+    if root.join("pom.xml").is_file() {
+        stacks.push("Java/Maven".to_string());
+        checks.push(SuggestedCheck {
+            id: "maven.test".to_string(),
+            command: "mvn test".to_string(),
+        });
+    }
+
+    if root.join("build.gradle").is_file() || root.join("build.gradle.kts").is_file() {
+        stacks.push("Java/Gradle".to_string());
+        let command = if root.join("gradlew").is_file() {
+            "./gradlew test"
+        } else {
+            "gradle test"
+        };
+        checks.push(SuggestedCheck {
+            id: "gradle.test".to_string(),
+            command: command.to_string(),
+        });
+    }
+
+    InitSuggestions {
+        stacks,
+        checks,
+        critical_paths: critical_path_candidates(root),
+    }
+}
+
+fn node_checks(root: &Path) -> Vec<SuggestedCheck> {
+    let Ok(contents) = fs::read_to_string(root.join("package.json")) else {
+        return Vec::new();
+    };
+    let Ok(package): Result<Value, _> = serde_json::from_str(&contents) else {
+        return Vec::new();
+    };
+    let Some(scripts) = package.get("scripts").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+
+    [
+        ("test", "node.test", "npm test"),
+        ("lint", "node.lint", "npm run lint"),
+        ("build", "node.build", "npm run build"),
+    ]
+    .into_iter()
+    .filter(|(script, _, _)| {
+        scripts
+            .get(*script)
+            .and_then(Value::as_str)
+            .is_some_and(|command| !command.trim().is_empty())
+    })
+    .map(|(_, id, command)| SuggestedCheck {
+        id: id.to_string(),
+        command: command.to_string(),
+    })
+    .collect()
+}
+
+fn has_python_marker(root: &Path) -> bool {
+    [
+        "pyproject.toml",
+        "pytest.ini",
+        "setup.cfg",
+        "requirements.txt",
+    ]
+    .into_iter()
+    .any(|name| root.join(name).is_file())
+}
+
+fn has_pytest_evidence(root: &Path) -> bool {
+    [
+        "pytest.ini",
+        "pyproject.toml",
+        "setup.cfg",
+        "requirements.txt",
+        "requirements-dev.txt",
+    ]
+    .into_iter()
+    .filter_map(|name| fs::read_to_string(root.join(name)).ok())
+    .any(|contents| contents.to_ascii_lowercase().contains("pytest"))
+}
+
+fn critical_path_candidates(root: &Path) -> Vec<String> {
+    const DIRECTORIES: &[(&str, &str)] = &[
+        (".github/workflows", ".github/workflows/**"),
+        ("config", "config/**"),
+        ("db/migrations", "db/migrations/**"),
+        ("deploy", "deploy/**"),
+        ("infra", "infra/**"),
+        ("migrations", "migrations/**"),
+        ("security", "security/**"),
+        ("src/auth", "src/auth/**"),
+        ("src/routes", "src/routes/**"),
+        ("src/security", "src/security/**"),
+        ("auth", "auth/**"),
+    ];
+    let mut candidates = BTreeSet::new();
+
+    for (directory, pattern) in DIRECTORIES {
+        if root.join(directory).is_dir() {
+            candidates.insert((*pattern).to_string());
+        }
+    }
+
+    if let Ok(entries) = fs::read_dir(root)
+        && entries.flatten().any(|entry| {
+            entry.file_type().is_ok_and(|file_type| file_type.is_file())
+                && entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name == ".env" || name.starts_with(".env."))
+        })
+    {
+        candidates.insert(".env*".to_string());
+    }
+
+    candidates.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn node_proposals_use_only_declared_scripts() {
+        let temp = tempdir().expect("temp dir");
+        fs::write(
+            temp.path().join("package.json"),
+            r#"{"scripts":{"test":"vitest","build":"vite build"}}"#,
+        )
+        .expect("package");
+
+        let suggestions = detect(temp.path());
+
+        assert_eq!(suggestions.stacks, vec!["Node.js"]);
+        assert_eq!(
+            suggestions.checks,
+            vec![
+                SuggestedCheck {
+                    id: "node.test".to_string(),
+                    command: "npm test".to_string(),
+                },
+                SuggestedCheck {
+                    id: "node.build".to_string(),
+                    command: "npm run build".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn critical_paths_are_existing_and_sorted() {
+        let temp = tempdir().expect("temp dir");
+        fs::create_dir_all(temp.path().join("src/security")).expect("security");
+        fs::create_dir_all(temp.path().join("migrations")).expect("migrations");
+        fs::write(temp.path().join(".env.local"), "SECRET=redacted\n").expect("env");
+
+        let suggestions = detect(temp.path());
+
+        assert_eq!(
+            suggestions.critical_paths,
+            vec![".env*", "migrations/**", "src/security/**"]
+        );
+    }
+
+    #[test]
+    fn stack_markers_are_deterministic_and_python_requires_pytest_evidence() {
+        let temp = tempdir().expect("temp dir");
+        fs::write(
+            temp.path().join("Cargo.toml"),
+            "[package]\nname = \"demo\"\n",
+        )
+        .expect("cargo");
+        fs::write(temp.path().join("go.mod"), "module example.test\n").expect("go");
+        fs::write(
+            temp.path().join("pyproject.toml"),
+            "[project]\nname = \"demo\"\n",
+        )
+        .expect("python");
+
+        let suggestions = detect(temp.path());
+
+        assert_eq!(suggestions.stacks, vec!["Rust", "Python", "Go"]);
+        assert_eq!(
+            suggestions.checks,
+            vec![
+                SuggestedCheck {
+                    id: "rust.test".to_string(),
+                    command: "cargo test --all".to_string(),
+                },
+                SuggestedCheck {
+                    id: "go.test".to_string(),
+                    command: "go test ./...".to_string(),
+                },
+            ]
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ mod dispatch;
 pub(crate) mod filters;
 pub(crate) mod focus;
 pub mod init;
+mod init_suggestions;
 mod llm;
 pub mod mcp;
 pub(crate) mod product_scan;

--- a/tests/init_suggestions.rs
+++ b/tests/init_suggestions.rs
@@ -1,0 +1,80 @@
+//! End-to-end contract for deterministic, non-executing `init` suggestions.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn run_init(root: &Path) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_repopilot"))
+        .arg("init")
+        .current_dir(root)
+        .output()
+        .expect("run repopilot init");
+    assert!(output.status.success(), "init failed: {:?}", output.status);
+    String::from_utf8(output.stdout).expect("init stdout is UTF-8")
+}
+
+#[test]
+fn init_suggests_rust_checks_and_existing_critical_paths_without_running_them() {
+    let temp = tempdir().expect("tempdir");
+    fs::write(
+        temp.path().join("Cargo.toml"),
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("Cargo.toml");
+    fs::create_dir_all(temp.path().join("src/auth")).expect("auth directory");
+    fs::write(temp.path().join("src/auth/mod.rs"), "pub fn login() {}\n").expect("auth");
+    fs::create_dir_all(temp.path().join("migrations")).expect("migrations directory");
+    fs::write(
+        temp.path().join("migrations/001_init.sql"),
+        "-- migration\n",
+    )
+    .expect("migration");
+    fs::create_dir_all(temp.path().join(".github/workflows")).expect("workflow directory");
+    fs::write(temp.path().join(".github/workflows/ci.yml"), "name: CI\n").expect("workflow");
+
+    let output = run_init(temp.path());
+
+    assert!(output.contains("Detected stack: Rust"), "{output}");
+    assert!(output.contains("cargo test --all"), "{output}");
+    assert!(
+        output.contains("Suggested verification checks (not run):"),
+        "{output}"
+    );
+    assert!(output.contains("src/auth/**"), "{output}");
+    assert!(output.contains("migrations/**"), "{output}");
+    assert!(output.contains(".github/workflows/**"), "{output}");
+    assert!(output.contains("No commands were run"), "{output}");
+    assert!(!temp.path().join("verification-ran").exists());
+}
+
+#[test]
+fn init_suggests_only_declared_npm_scripts_and_preserves_config() {
+    let temp = tempdir().expect("tempdir");
+    fs::write(
+        temp.path().join("package.json"),
+        r#"{
+  "name": "demo",
+  "scripts": { "test": "vitest", "lint": "eslint .", "build": "vite build" }
+}
+"#,
+    )
+    .expect("package.json");
+    fs::create_dir_all(temp.path().join("src/routes")).expect("routes directory");
+    fs::write(temp.path().join("src/routes/index.ts"), "export {}\n").expect("route");
+    let config = temp.path().join("repopilot.toml");
+    fs::write(&config, "custom = true\n").expect("existing config");
+
+    let output = run_init(temp.path());
+
+    assert!(output.contains("Detected stack: Node.js"), "{output}");
+    assert!(output.contains("npm test"), "{output}");
+    assert!(output.contains("npm run lint"), "{output}");
+    assert!(output.contains("npm run build"), "{output}");
+    assert!(output.contains("src/routes/**"), "{output}");
+    assert_eq!(
+        fs::read_to_string(config).expect("config"),
+        "custom = true\n"
+    );
+}


### PR DESCRIPTION
## What

Add a deterministic initialization guidance slice for first-time RepoPilot users.

## Why

init previously created the default config and bootstrap files but gave no evidence-led way to identify the local stack, candidate checks, or high-impact paths. This made the next verification step depend on manual repository inspection.

## What changed

- detect Rust, Node.js, Python, Go, Maven, and Gradle markers without executing commands or using the network;
- propose only declared test/lint/build npm scripts and conservative stack checks;
- list sorted critical-path candidates only when the corresponding workflow, auth, security, migration, deployment, infrastructure, config, or env paths already exist;
- keep the suggestions display-only and preserve an existing repopilot.toml unless --force is passed;
- add unit and CLI integration coverage for determinism, config preservation, and the no-command boundary;
- document the behavior and its evidence limitations in the CLI/configuration/roadmap/evidence ledger.

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all (926 unit tests plus integration/doc tests passed; one explicit compatibility test ignored)
- python3 scripts/release-contract.py check
- npm run review:performance (changed/full ratio 0.414, budget 0.6)
- cargo run -- scan . --fail-on-priority p1 (PASS; 0 visible P1 findings)

The self-scan retains the repository's existing warning about three high-severity complex-file contract violations in scripts; the P1 gate still passes.

## Boundary

These are review aids, not passed verification evidence or a completeness claim. They do not edit configuration and do not execute proposed commands.
