### PR TITLE
feat: add provenance to init suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- `repopilot init` now includes source markers for every verification and
+  critical-path proposal, so a maintainer can see which local file or declared
+  script produced the suggestion.
 - `repopilot init` now prints deterministic stack-specific verification
   proposals and existing critical-path candidates. Proposals are display-only:
   no commands run, and an existing config is preserved unless `--force` is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -544,6 +544,9 @@ After the bootstrap steps, `init` reports the detected stack, declared
 verification commands, and critical-path candidates such as existing workflow,
 authentication, migration, or deployment directories. These are deterministic
 proposals only: commands are not run and existing config is not overwritten.
+Each proposal includes a source marker for the file, directory, or declared
+script that triggered it. A source marker explains the suggestion; it is not
+proof that the check passes or that the path is exhaustive.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,9 @@ It does not execute those commands, access the network, or write the
 suggestions into `repopilot.toml`; review them before turning an accepted check
 into a bounded `[[verification.checks]]` entry. Existing config files remain
 unchanged unless `--force` is passed.
+Each proposal includes a source marker such as `Cargo.toml`,
+`package.json:scripts.test`, or `src/auth`, so the heuristic can be reviewed
+against repository evidence before it becomes policy.
 
 ## Precedence
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -689,3 +689,16 @@ bump is needed to start.
 - Boundary: these are review aids, not passed verification evidence or a
   completeness claim about a repository's architecture. They do not alter
   configuration and do not replace explicit check selection.
+
+## 0X — Init Suggestion Provenance
+
+- Every verification and critical-path proposal now carries a source marker
+  pointing to the local marker file, declared package script, or existing
+  directory that caused it.
+- Source markers make each heuristic auditable and avoid presenting an inferred
+  command or path as an unexplained architectural fact.
+- Regression coverage spans Rust, Node.js, Python, Go, unknown repositories,
+  declared-script filtering, sorted candidates, and existing-config safety.
+- Boundary: provenance identifies the input to the heuristic; it does not
+  prove that a command passes, that a path is critical, or that coverage is
+  complete.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -9,6 +9,8 @@ Change Map. Stored MCP review handles now carry the same ChangeProof into
 context, explain, and analysis-history projections. `repopilot init` now adds
 deterministic stack and critical-path proposals without executing commands or
 overwriting existing configuration.
+The proposals now retain source markers so their evidence can be audited before
+being adopted as repository policy.
 
 RepoPilot 0.23 turns change review from a collection of findings and signals
 into one bounded proof of what changed, which contracts and consumers are

--- a/src/commands/init_suggestions.rs
+++ b/src/commands/init_suggestions.rs
@@ -4,16 +4,29 @@ use std::fs;
 use std::path::Path;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DetectedStack {
+    pub(crate) name: String,
+    pub(crate) source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SuggestedCheck {
     pub(crate) id: String,
     pub(crate) command: String,
+    pub(crate) source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CriticalPathCandidate {
+    pub(crate) pattern: String,
+    pub(crate) source: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct InitSuggestions {
-    pub(crate) stacks: Vec<String>,
+    pub(crate) stacks: Vec<DetectedStack>,
     pub(crate) checks: Vec<SuggestedCheck>,
-    pub(crate) critical_paths: Vec<String>,
+    pub(crate) critical_paths: Vec<CriticalPathCandidate>,
 }
 
 pub(crate) fn render(root: &Path) -> String {
@@ -25,7 +38,12 @@ pub(crate) fn render(root: &Path) -> String {
     } else {
         output.push_str(&format!(
             "Detected stack: {}\n",
-            suggestions.stacks.join(", ")
+            suggestions
+                .stacks
+                .iter()
+                .map(|stack| format!("{} ({})", stack.name, stack.source))
+                .collect::<Vec<_>>()
+                .join(", ")
         ));
     }
 
@@ -34,7 +52,10 @@ pub(crate) fn render(root: &Path) -> String {
     } else {
         output.push_str("Suggested verification checks (not run):\n");
         for check in suggestions.checks {
-            output.push_str(&format!("  - {}: {}\n", check.id, check.command));
+            output.push_str(&format!(
+                "  - {}: {} (source: {})\n",
+                check.id, check.command, check.source
+            ));
         }
     }
 
@@ -43,7 +64,7 @@ pub(crate) fn render(root: &Path) -> String {
     } else {
         output.push_str("Critical path candidates (review before committing):\n");
         for path in suggestions.critical_paths {
-            output.push_str(&format!("  - {path}\n"));
+            output.push_str(&format!("  - {} (source: {})\n", path.pattern, path.source));
         }
     }
 
@@ -56,46 +77,75 @@ fn detect(root: &Path) -> InitSuggestions {
     let mut checks = Vec::new();
 
     if root.join("Cargo.toml").is_file() {
-        stacks.push("Rust".to_string());
+        stacks.push(DetectedStack {
+            name: "Rust".to_string(),
+            source: "Cargo.toml".to_string(),
+        });
         checks.push(SuggestedCheck {
             id: "rust.test".to_string(),
             command: "cargo test --all".to_string(),
+            source: "Cargo.toml".to_string(),
         });
     }
 
     if root.join("package.json").is_file() {
-        stacks.push("Node.js".to_string());
+        stacks.push(DetectedStack {
+            name: "Node.js".to_string(),
+            source: "package.json".to_string(),
+        });
         checks.extend(node_checks(root));
     }
 
-    if has_python_marker(root) {
-        stacks.push("Python".to_string());
-        if has_pytest_evidence(root) {
+    if let Some(source) = python_marker(root) {
+        stacks.push(DetectedStack {
+            name: "Python".to_string(),
+            source,
+        });
+        if let Some(source) = pytest_evidence(root) {
             checks.push(SuggestedCheck {
                 id: "python.test".to_string(),
                 command: "python3 -m pytest -q".to_string(),
+                source,
             });
         }
     }
 
     if root.join("go.mod").is_file() {
-        stacks.push("Go".to_string());
+        stacks.push(DetectedStack {
+            name: "Go".to_string(),
+            source: "go.mod".to_string(),
+        });
         checks.push(SuggestedCheck {
             id: "go.test".to_string(),
             command: "go test ./...".to_string(),
+            source: "go.mod".to_string(),
         });
     }
 
     if root.join("pom.xml").is_file() {
-        stacks.push("Java/Maven".to_string());
+        stacks.push(DetectedStack {
+            name: "Java/Maven".to_string(),
+            source: "pom.xml".to_string(),
+        });
         checks.push(SuggestedCheck {
             id: "maven.test".to_string(),
             command: "mvn test".to_string(),
+            source: "pom.xml".to_string(),
         });
     }
 
-    if root.join("build.gradle").is_file() || root.join("build.gradle.kts").is_file() {
-        stacks.push("Java/Gradle".to_string());
+    let gradle_source = if root.join("build.gradle").is_file() {
+        Some("build.gradle")
+    } else if root.join("build.gradle.kts").is_file() {
+        Some("build.gradle.kts")
+    } else {
+        None
+    };
+    if let Some(source) = gradle_source {
+        stacks.push(DetectedStack {
+            name: "Java/Gradle".to_string(),
+            source: source.to_string(),
+        });
         let command = if root.join("gradlew").is_file() {
             "./gradlew test"
         } else {
@@ -104,6 +154,7 @@ fn detect(root: &Path) -> InitSuggestions {
         checks.push(SuggestedCheck {
             id: "gradle.test".to_string(),
             command: command.to_string(),
+            source: source.to_string(),
         });
     }
 
@@ -137,14 +188,15 @@ fn node_checks(root: &Path) -> Vec<SuggestedCheck> {
             .and_then(Value::as_str)
             .is_some_and(|command| !command.trim().is_empty())
     })
-    .map(|(_, id, command)| SuggestedCheck {
+    .map(|(script, id, command)| SuggestedCheck {
         id: id.to_string(),
         command: command.to_string(),
+        source: format!("package.json:scripts.{script}"),
     })
     .collect()
 }
 
-fn has_python_marker(root: &Path) -> bool {
+fn python_marker(root: &Path) -> Option<String> {
     [
         "pyproject.toml",
         "pytest.ini",
@@ -152,10 +204,11 @@ fn has_python_marker(root: &Path) -> bool {
         "requirements.txt",
     ]
     .into_iter()
-    .any(|name| root.join(name).is_file())
+    .find(|name| root.join(name).is_file())
+    .map(str::to_string)
 }
 
-fn has_pytest_evidence(root: &Path) -> bool {
+fn pytest_evidence(root: &Path) -> Option<String> {
     [
         "pytest.ini",
         "pyproject.toml",
@@ -164,11 +217,15 @@ fn has_pytest_evidence(root: &Path) -> bool {
         "requirements-dev.txt",
     ]
     .into_iter()
-    .filter_map(|name| fs::read_to_string(root.join(name)).ok())
-    .any(|contents| contents.to_ascii_lowercase().contains("pytest"))
+    .find(|name| {
+        fs::read_to_string(root.join(name))
+            .ok()
+            .is_some_and(|contents| contents.to_ascii_lowercase().contains("pytest"))
+    })
+    .map(str::to_string)
 }
 
-fn critical_path_candidates(root: &Path) -> Vec<String> {
+fn critical_path_candidates(root: &Path) -> Vec<CriticalPathCandidate> {
     const DIRECTORIES: &[(&str, &str)] = &[
         (".github/workflows", ".github/workflows/**"),
         ("config", "config/**"),
@@ -186,7 +243,7 @@ fn critical_path_candidates(root: &Path) -> Vec<String> {
 
     for (directory, pattern) in DIRECTORIES {
         if root.join(directory).is_dir() {
-            candidates.insert((*pattern).to_string());
+            candidates.insert(((*pattern).to_string(), (*directory).to_string()));
         }
     }
 
@@ -199,90 +256,14 @@ fn critical_path_candidates(root: &Path) -> Vec<String> {
                     .is_some_and(|name| name == ".env" || name.starts_with(".env."))
         })
     {
-        candidates.insert(".env*".to_string());
+        candidates.insert((".env*".to_string(), "root .env* marker".to_string()));
     }
 
-    candidates.into_iter().collect()
+    candidates
+        .into_iter()
+        .map(|(pattern, source)| CriticalPathCandidate { pattern, source })
+        .collect()
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use tempfile::tempdir;
-
-    #[test]
-    fn node_proposals_use_only_declared_scripts() {
-        let temp = tempdir().expect("temp dir");
-        fs::write(
-            temp.path().join("package.json"),
-            r#"{"scripts":{"test":"vitest","build":"vite build"}}"#,
-        )
-        .expect("package");
-
-        let suggestions = detect(temp.path());
-
-        assert_eq!(suggestions.stacks, vec!["Node.js"]);
-        assert_eq!(
-            suggestions.checks,
-            vec![
-                SuggestedCheck {
-                    id: "node.test".to_string(),
-                    command: "npm test".to_string(),
-                },
-                SuggestedCheck {
-                    id: "node.build".to_string(),
-                    command: "npm run build".to_string(),
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn critical_paths_are_existing_and_sorted() {
-        let temp = tempdir().expect("temp dir");
-        fs::create_dir_all(temp.path().join("src/security")).expect("security");
-        fs::create_dir_all(temp.path().join("migrations")).expect("migrations");
-        fs::write(temp.path().join(".env.local"), "SECRET=redacted\n").expect("env");
-
-        let suggestions = detect(temp.path());
-
-        assert_eq!(
-            suggestions.critical_paths,
-            vec![".env*", "migrations/**", "src/security/**"]
-        );
-    }
-
-    #[test]
-    fn stack_markers_are_deterministic_and_python_requires_pytest_evidence() {
-        let temp = tempdir().expect("temp dir");
-        fs::write(
-            temp.path().join("Cargo.toml"),
-            "[package]\nname = \"demo\"\n",
-        )
-        .expect("cargo");
-        fs::write(temp.path().join("go.mod"), "module example.test\n").expect("go");
-        fs::write(
-            temp.path().join("pyproject.toml"),
-            "[project]\nname = \"demo\"\n",
-        )
-        .expect("python");
-
-        let suggestions = detect(temp.path());
-
-        assert_eq!(suggestions.stacks, vec!["Rust", "Python", "Go"]);
-        assert_eq!(
-            suggestions.checks,
-            vec![
-                SuggestedCheck {
-                    id: "rust.test".to_string(),
-                    command: "cargo test --all".to_string(),
-                },
-                SuggestedCheck {
-                    id: "go.test".to_string(),
-                    command: "go test ./...".to_string(),
-                },
-            ]
-        );
-    }
-}
+mod tests;

--- a/src/commands/init_suggestions/tests.rs
+++ b/src/commands/init_suggestions/tests.rs
@@ -1,0 +1,117 @@
+use super::*;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn node_proposals_use_only_declared_scripts() {
+    let temp = tempdir().expect("temp dir");
+    fs::write(
+        temp.path().join("package.json"),
+        r#"{"scripts":{"test":"vitest","build":"vite build"}}"#,
+    )
+    .expect("package");
+
+    let suggestions = detect(temp.path());
+
+    assert_eq!(
+        suggestions.stacks,
+        vec![DetectedStack {
+            name: "Node.js".to_string(),
+            source: "package.json".to_string(),
+        }]
+    );
+    assert_eq!(
+        suggestions.checks,
+        vec![
+            SuggestedCheck {
+                id: "node.test".to_string(),
+                command: "npm test".to_string(),
+                source: "package.json:scripts.test".to_string(),
+            },
+            SuggestedCheck {
+                id: "node.build".to_string(),
+                command: "npm run build".to_string(),
+                source: "package.json:scripts.build".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn critical_paths_are_existing_and_sorted() {
+    let temp = tempdir().expect("temp dir");
+    fs::create_dir_all(temp.path().join("src/security")).expect("security");
+    fs::create_dir_all(temp.path().join("migrations")).expect("migrations");
+    fs::write(temp.path().join(".env.local"), "SECRET=redacted\n").expect("env");
+
+    let suggestions = detect(temp.path());
+
+    assert_eq!(
+        suggestions.critical_paths,
+        vec![
+            CriticalPathCandidate {
+                pattern: ".env*".to_string(),
+                source: "root .env* marker".to_string(),
+            },
+            CriticalPathCandidate {
+                pattern: "migrations/**".to_string(),
+                source: "migrations".to_string(),
+            },
+            CriticalPathCandidate {
+                pattern: "src/security/**".to_string(),
+                source: "src/security".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn stack_markers_are_deterministic_and_python_requires_pytest_evidence() {
+    let temp = tempdir().expect("temp dir");
+    fs::write(
+        temp.path().join("Cargo.toml"),
+        "[package]\nname = \"demo\"\n",
+    )
+    .expect("cargo");
+    fs::write(temp.path().join("go.mod"), "module example.test\n").expect("go");
+    fs::write(
+        temp.path().join("pyproject.toml"),
+        "[project]\nname = \"demo\"\n",
+    )
+    .expect("python");
+
+    let suggestions = detect(temp.path());
+
+    assert_eq!(
+        suggestions.stacks,
+        vec![
+            DetectedStack {
+                name: "Rust".to_string(),
+                source: "Cargo.toml".to_string(),
+            },
+            DetectedStack {
+                name: "Python".to_string(),
+                source: "pyproject.toml".to_string(),
+            },
+            DetectedStack {
+                name: "Go".to_string(),
+                source: "go.mod".to_string(),
+            },
+        ]
+    );
+    assert_eq!(
+        suggestions.checks,
+        vec![
+            SuggestedCheck {
+                id: "rust.test".to_string(),
+                command: "cargo test --all".to_string(),
+                source: "Cargo.toml".to_string(),
+            },
+            SuggestedCheck {
+                id: "go.test".to_string(),
+                command: "go test ./...".to_string(),
+                source: "go.mod".to_string(),
+            },
+        ]
+    );
+}

--- a/tests/init_suggestions.rs
+++ b/tests/init_suggestions.rs
@@ -37,14 +37,26 @@ fn init_suggests_rust_checks_and_existing_critical_paths_without_running_them() 
     let output = run_init(temp.path());
 
     assert!(output.contains("Detected stack: Rust"), "{output}");
-    assert!(output.contains("cargo test --all"), "{output}");
+    assert!(
+        output.contains("cargo test --all (source: Cargo.toml)"),
+        "{output}"
+    );
     assert!(
         output.contains("Suggested verification checks (not run):"),
         "{output}"
     );
-    assert!(output.contains("src/auth/**"), "{output}");
-    assert!(output.contains("migrations/**"), "{output}");
-    assert!(output.contains(".github/workflows/**"), "{output}");
+    assert!(
+        output.contains("src/auth/** (source: src/auth)"),
+        "{output}"
+    );
+    assert!(
+        output.contains("migrations/** (source: migrations)"),
+        "{output}"
+    );
+    assert!(
+        output.contains(".github/workflows/** (source: .github/workflows)"),
+        "{output}"
+    );
     assert!(output.contains("No commands were run"), "{output}");
     assert!(!temp.path().join("verification-ran").exists());
 }
@@ -69,12 +81,70 @@ fn init_suggests_only_declared_npm_scripts_and_preserves_config() {
     let output = run_init(temp.path());
 
     assert!(output.contains("Detected stack: Node.js"), "{output}");
-    assert!(output.contains("npm test"), "{output}");
-    assert!(output.contains("npm run lint"), "{output}");
-    assert!(output.contains("npm run build"), "{output}");
-    assert!(output.contains("src/routes/**"), "{output}");
+    assert!(
+        output.contains("npm test (source: package.json:scripts.test)"),
+        "{output}"
+    );
+    assert!(
+        output.contains("npm run lint (source: package.json:scripts.lint)"),
+        "{output}"
+    );
+    assert!(
+        output.contains("npm run build (source: package.json:scripts.build)"),
+        "{output}"
+    );
+    assert!(
+        output.contains("src/routes/** (source: src/routes)"),
+        "{output}"
+    );
     assert_eq!(
         fs::read_to_string(config).expect("config"),
         "custom = true\n"
     );
+}
+
+#[test]
+fn init_reports_python_and_go_provenance_without_claiming_python_without_pytest() {
+    let temp = tempdir().expect("tempdir");
+    fs::write(
+        temp.path().join("pyproject.toml"),
+        "[project]\nname = \"demo\"\ndependencies = [\"pytest\"]\n",
+    )
+    .expect("pyproject");
+    fs::write(temp.path().join("go.mod"), "module example.test\n").expect("go.mod");
+
+    let output = run_init(temp.path());
+
+    assert!(
+        output.contains("Detected stack: Python (pyproject.toml), Go (go.mod)"),
+        "{output}"
+    );
+    assert!(
+        output.contains("python3 -m pytest -q (source: pyproject.toml)"),
+        "{output}"
+    );
+    assert!(
+        output.contains("go test ./... (source: go.mod)"),
+        "{output}"
+    );
+    assert!(output.contains("No commands were run"), "{output}");
+}
+
+#[test]
+fn init_stays_explicitly_unknown_without_stack_or_path_inference() {
+    let temp = tempdir().expect("tempdir");
+    fs::write(temp.path().join("README.md"), "# Demo\n").expect("readme");
+
+    let output = run_init(temp.path());
+
+    assert!(output.contains("Detected stack: unknown"), "{output}");
+    assert!(
+        output.contains("No stack-specific verification checks detected."),
+        "{output}"
+    );
+    assert!(
+        output.contains("No critical path candidates detected."),
+        "{output}"
+    );
+    assert!(output.contains("No commands were run"), "{output}");
 }


### PR DESCRIPTION
## What

Make init suggestions auditable by retaining the local evidence that produced each proposal.

## Why

PR #469 added deterministic stack and critical-path suggestions. Without provenance, a maintainer could see a recommendation but not the input that triggered it. This slice makes the heuristic inspectable and adds a clear boundary between source evidence and passed verification.

## What changed

- verification proposals now include a source marker such as Cargo.toml, go.mod, or package.json:scripts.test;
- critical-path candidates include the existing directory or a redaction-safe root .env* marker;
- stack detection keeps deterministic source metadata for Rust, Node.js, Python, Go, Maven, and Gradle;
- malformed or undeclared npm scripts stay out of the proposal list;
- Python test proposals require pytest evidence in a recognized local file;
- unit tests moved into a focused submodule so production files stay below the repository size convention;
- integration coverage now spans Rust/Node.js provenance, Python/Go, unknown repositories, config preservation, and the no-command boundary;
- roadmap, CLI, configuration, changelog, and evidence ledger document provenance and limits.

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --bin repopilot init_suggestions -- --nocapture
- cargo test --test init_suggestions -- --nocapture
- full pre-handoff gate is running on this commit

## Boundary

Source markers explain which local input triggered a proposal. They do not prove a command passes, establish that a path is critical, or claim exhaustive architectural coverage.
