### PR TITLE
feat: export reviewable init suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - `repopilot init` now includes source markers for every verification and
   critical-path proposal, so a maintainer can see which local file or declared
   script produced the suggestion.
+- Added an explicit `--suggestions-output` export for reviewable TOML snippets.
+  Exported checks remain inactive until a maintainer copies them into the active
+  config; critical paths stay comments and existing files are preserved.
 - `repopilot init` now prints deterministic stack-specific verification
   proposals and existing critical-path candidates. Proposals are display-only:
   no commands run, and an existing config is preserved unless `--force` is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -520,6 +520,7 @@ repopilot init [OPTIONS]
 |------|------|---------|-------------|
 | `--force` | flag | — | Overwrite an existing config file |
 | `--path` | path | Git root `repopilot.toml` | Explicit config path; relative paths stay relative to the invocation directory |
+| `--suggestions-output` | path | — | Write a reviewable TOML suggestion snippet; existing output is preserved unless `--force` is passed |
 
 ### Examples
 
@@ -527,6 +528,7 @@ repopilot init [OPTIONS]
 repopilot init
 repopilot init --force
 repopilot init --path ./config/repopilot.toml
+repopilot init --suggestions-output .repopilot/init-suggestions.toml
 repopilot init --github-action
 repopilot init --mcp-client claude
 repopilot init --mcp-client cursor

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,17 @@ Each proposal includes a source marker such as `Cargo.toml`,
 `package.json:scripts.test`, or `src/auth`, so the heuristic can be reviewed
 against repository evidence before it becomes policy.
 
+To create a reviewable snippet without changing the active config:
+
+```bash
+repopilot init --suggestions-output .repopilot/init-suggestions.toml
+```
+
+The snippet contains explicit verification entries and keeps critical-path
+candidates as comments. RepoPilot never loads it automatically; copy reviewed
+entries into `repopilot.toml` deliberately. The output path cannot be the active
+config path.
+
 ## Precedence
 
 Configuration is resolved in this order:

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -702,3 +702,15 @@ bump is needed to start.
 - Boundary: provenance identifies the input to the heuristic; it does not
   prove that a command passes, that a path is critical, or that coverage is
   complete.
+
+## 0Y — Reviewable Suggestion Export
+
+- `init --suggestions-output PATH` writes a separate TOML artifact only when
+  explicitly requested. Existing output is preserved unless `--force` is passed.
+- Verification entries are active TOML records in the artifact, while critical
+  paths remain comments so architectural policy cannot be enabled accidentally.
+- The active config path is rejected as an output target. The artifact is never
+  loaded automatically, and integration coverage parses it as TOML and verifies
+  the no-overwrite and collision boundaries.
+- Boundary: export creates a review aid, not executable verification evidence or
+  an accepted policy. A maintainer must review and copy entries deliberately.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -11,6 +11,8 @@ deterministic stack and critical-path proposals without executing commands or
 overwriting existing configuration.
 The proposals now retain source markers so their evidence can be audited before
 being adopted as repository policy.
+`init --suggestions-output` now creates a separate reviewable TOML artifact; it
+never applies suggestions automatically.
 
 RepoPilot 0.23 turns change review from a collection of findings and signals
 into one bounded proof of what changed, which contracts and consumers are

--- a/src/cli/options/init.rs
+++ b/src/cli/options/init.rs
@@ -18,6 +18,10 @@ pub struct InitOptions {
     #[arg(long)]
     pub path: Option<PathBuf>,
 
+    /// Write a reviewable TOML snippet with the detected suggestions
+    #[arg(long)]
+    pub suggestions_output: Option<PathBuf>,
+
     /// Generate a review-first GitHub Actions workflow
     #[arg(long)]
     pub github_action: bool,

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,5 +1,6 @@
 use crate::cli::{InitOptions, McpClientArg};
-use crate::commands::init_suggestions::render as render_init_suggestions;
+use crate::commands::init_suggestions::{detect, render as render_init_suggestions};
+use crate::commands::init_suggestions_export::render as render_init_suggestions_toml;
 use repopilot::config::template::default_config_toml;
 use repopilot::review::diff::resolve_git_root;
 use std::fs;
@@ -22,6 +23,13 @@ fn run_at(options: InitOptions, invocation_dir: &Path) -> Result<(), Box<dyn std
 
     let config_path =
         explicit_or_default_config_path(options.path.as_deref(), invocation_dir, &root);
+    let suggestions_path = options
+        .suggestions_output
+        .as_deref()
+        .map(|path| explicit_or_default_config_path(Some(path), invocation_dir, &root));
+    if suggestions_path.as_ref() == Some(&config_path) {
+        return Err("suggestions output must be different from the RepoPilot config path".into());
+    }
     let config = default_config_toml();
     write_owned_file(&config_path, &config, options.force, "RepoPilot config")?;
 
@@ -44,6 +52,16 @@ fn run_at(options: InitOptions, invocation_dir: &Path) -> Result<(), Box<dyn std
         )?;
     }
 
+    let suggestions = detect(&root);
+    if let Some(path) = suggestions_path {
+        write_owned_file(
+            &path,
+            &render_init_suggestions_toml(&suggestions),
+            options.force,
+            "init suggestions",
+        )?;
+    }
+
     print_next_steps(
         &config_path,
         &root,
@@ -52,7 +70,7 @@ fn run_at(options: InitOptions, invocation_dir: &Path) -> Result<(), Box<dyn std
         mcp_client,
     );
     println!();
-    print!("{}", render_init_suggestions(&root));
+    print!("{}", render_init_suggestions(&suggestions));
     Ok(())
 }
 
@@ -191,6 +209,7 @@ mod tests {
         InitOptions {
             force: false,
             path: Some(root.join("repopilot.toml")),
+            suggestions_output: None,
             github_action: false,
             mcp_client: None,
             all: false,

--- a/src/commands/init_suggestions.rs
+++ b/src/commands/init_suggestions.rs
@@ -29,8 +29,7 @@ pub(crate) struct InitSuggestions {
     pub(crate) critical_paths: Vec<CriticalPathCandidate>,
 }
 
-pub(crate) fn render(root: &Path) -> String {
-    let suggestions = detect(root);
+pub(crate) fn render(suggestions: &InitSuggestions) -> String {
     let mut output = String::new();
 
     if suggestions.stacks.is_empty() {
@@ -51,7 +50,7 @@ pub(crate) fn render(root: &Path) -> String {
         output.push_str("No stack-specific verification checks detected.\n");
     } else {
         output.push_str("Suggested verification checks (not run):\n");
-        for check in suggestions.checks {
+        for check in &suggestions.checks {
             output.push_str(&format!(
                 "  - {}: {} (source: {})\n",
                 check.id, check.command, check.source
@@ -63,7 +62,7 @@ pub(crate) fn render(root: &Path) -> String {
         output.push_str("No critical path candidates detected.\n");
     } else {
         output.push_str("Critical path candidates (review before committing):\n");
-        for path in suggestions.critical_paths {
+        for path in &suggestions.critical_paths {
             output.push_str(&format!("  - {} (source: {})\n", path.pattern, path.source));
         }
     }
@@ -72,7 +71,7 @@ pub(crate) fn render(root: &Path) -> String {
     output
 }
 
-fn detect(root: &Path) -> InitSuggestions {
+pub(crate) fn detect(root: &Path) -> InitSuggestions {
     let mut stacks = Vec::new();
     let mut checks = Vec::new();
 

--- a/src/commands/init_suggestions_export.rs
+++ b/src/commands/init_suggestions_export.rs
@@ -1,0 +1,118 @@
+use super::init_suggestions::{CriticalPathCandidate, InitSuggestions, SuggestedCheck};
+
+pub(crate) fn render(suggestions: &InitSuggestions) -> String {
+    let mut output = String::from(
+        "# RepoPilot init suggestions\n\
+# Review this file before copying it into repopilot.toml.\n\
+# Suggestions are not executed or loaded automatically.\n\n",
+    );
+
+    if suggestions.checks.is_empty() {
+        output.push_str("# No executable stack-specific checks were detected.\n");
+    } else {
+        for check in &suggestions.checks {
+            render_check(&mut output, check);
+        }
+    }
+
+    output.push_str(
+        "\n# Critical path candidates are comments only. Add reviewed paths to a\n\
+# verification check or repository policy explicitly.\n",
+    );
+    if suggestions.critical_paths.is_empty() {
+        output.push_str("# No critical path candidates were detected.\n");
+    } else {
+        for candidate in &suggestions.critical_paths {
+            render_critical_path(&mut output, candidate);
+        }
+    }
+    output
+}
+
+fn render_check(output: &mut String, check: &SuggestedCheck) {
+    let Some((program, args, role)) = command_spec(check) else {
+        output.push_str(&format!(
+            "# Unsupported suggestion {} was not exported (source: {}).\n",
+            toml_string(&check.id),
+            toml_string(&check.source)
+        ));
+        return;
+    };
+    let args = args
+        .into_iter()
+        .map(toml_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    output.push_str(&format!(
+        "# source: {}\n\
+[[verification.checks]]\n\
+id = {}\n\
+role = {}\n\
+program = {}\n\
+args = [{}]\n\
+working_directory = \".\"\n\
+# paths = [\"...\"] # Add only after reviewing the applicable scope.\n\n",
+        toml_string(&check.source),
+        toml_string(&check.id),
+        toml_string(role),
+        toml_string(program),
+        args
+    ));
+}
+
+fn command_spec(check: &SuggestedCheck) -> Option<(&'static str, Vec<&'static str>, &'static str)> {
+    match check.id.as_str() {
+        "rust.test" => Some(("cargo", vec!["test", "--all"], "test")),
+        "node.test" => Some(("npm", vec!["test"], "test")),
+        "node.lint" => Some(("npm", vec!["run", "lint"], "lint")),
+        "node.build" => Some(("npm", vec!["run", "build"], "build")),
+        "python.test" => Some(("python3", vec!["-m", "pytest", "-q"], "test")),
+        "go.test" => Some(("go", vec!["test", "./..."], "test")),
+        "maven.test" => Some(("mvn", vec!["test"], "test")),
+        "gradle.test" if check.command.starts_with("./gradlew") => {
+            Some(("./gradlew", vec!["test"], "test"))
+        }
+        "gradle.test" => Some(("gradle", vec!["test"], "test")),
+        _ => None,
+    }
+}
+
+fn render_critical_path(output: &mut String, candidate: &CriticalPathCandidate) {
+    output.push_str(&format!(
+        "# - {} (source: {})\n",
+        candidate.pattern, candidate.source
+    ));
+}
+
+fn toml_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('\"', "\\\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::init_suggestions::detect;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn export_is_reviewable_toml_and_keeps_paths_as_comments() {
+        let temp = tempdir().expect("temp dir");
+        fs::write(
+            temp.path().join("Cargo.toml"),
+            "[package]\nname = \"demo\"\n",
+        )
+        .expect("cargo");
+        fs::create_dir_all(temp.path().join("src/auth")).expect("auth");
+
+        let rendered = render(&detect(temp.path()));
+        let parsed: toml::Value = toml::from_str(&rendered).expect("valid TOML");
+
+        assert_eq!(
+            parsed["verification"]["checks"][0]["id"].as_str(),
+            Some("rust.test")
+        );
+        assert!(rendered.contains("# - src/auth/** (source: src/auth)"));
+        assert!(rendered.contains("# Suggestions are not executed"));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod filters;
 pub(crate) mod focus;
 pub mod init;
 mod init_suggestions;
+mod init_suggestions_export;
 mod llm;
 pub mod mcp;
 pub(crate) mod product_scan;

--- a/tests/init_suggestions.rs
+++ b/tests/init_suggestions.rs
@@ -6,8 +6,13 @@ use std::process::Command;
 use tempfile::tempdir;
 
 fn run_init(root: &Path) -> String {
+    run_init_with_args(root, &[])
+}
+
+fn run_init_with_args(root: &Path, args: &[&str]) -> String {
     let output = Command::new(env!("CARGO_BIN_EXE_repopilot"))
         .arg("init")
+        .args(args)
         .current_dir(root)
         .output()
         .expect("run repopilot init");
@@ -128,6 +133,58 @@ fn init_reports_python_and_go_provenance_without_claiming_python_without_pytest(
         "{output}"
     );
     assert!(output.contains("No commands were run"), "{output}");
+}
+
+#[test]
+fn init_exports_reviewable_toml_without_applying_it_to_config() {
+    let temp = tempdir().expect("tempdir");
+    fs::write(
+        temp.path().join("Cargo.toml"),
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("Cargo.toml");
+    fs::create_dir_all(temp.path().join("src/auth")).expect("auth directory");
+    let output = run_init_with_args(temp.path(), &["--suggestions-output", "suggestions.toml"]);
+
+    let suggestions_path = temp.path().join("suggestions.toml");
+    let rendered = fs::read_to_string(&suggestions_path).expect("suggestions file");
+    let parsed: toml::Value = toml::from_str(&rendered).expect("valid suggestions TOML");
+    repopilot::config::loader::parse_config(&rendered, Some(&suggestions_path))
+        .expect("suggestions are valid RepoPilot config");
+
+    assert!(output.contains("Created init suggestions"), "{output}");
+    assert_eq!(
+        parsed["verification"]["checks"][0]["id"].as_str(),
+        Some("rust.test")
+    );
+    assert!(rendered.contains("# source: \"Cargo.toml\""));
+    assert!(rendered.contains("# - src/auth/** (source: src/auth)"));
+    assert!(temp.path().join("repopilot.toml").is_file());
+}
+
+#[test]
+fn init_preserves_existing_suggestions_and_rejects_config_collision() {
+    let temp = tempdir().expect("tempdir");
+    let suggestions_path = temp.path().join("suggestions.toml");
+    fs::write(&suggestions_path, "sentinel = true\n").expect("existing suggestions");
+
+    let output = run_init_with_args(temp.path(), &["--suggestions-output", "suggestions.toml"]);
+    assert!(
+        output.contains("init suggestions already exists"),
+        "{output}"
+    );
+    assert_eq!(
+        fs::read_to_string(&suggestions_path).expect("suggestions"),
+        "sentinel = true\n"
+    );
+
+    let collision = Command::new(env!("CARGO_BIN_EXE_repopilot"))
+        .args(["init", "--suggestions-output", "repopilot.toml"])
+        .current_dir(temp.path())
+        .output()
+        .expect("run collision");
+    assert!(!collision.status.success());
+    assert!(String::from_utf8_lossy(&collision.stderr).contains("different"));
 }
 
 #[test]


### PR DESCRIPTION
## What

Add an explicit export path for reviewing and adopting init suggestions safely.

## Why

Init suggestions are now deterministic and carry provenance, but maintainers still had to copy verification proposals manually. This adds a separate reviewable artifact without activating policy or modifying the live config.

## What changed

- add init --suggestions-output PATH;
- emit valid RepoPilot TOML verification entries with source comments;
- keep critical-path candidates as comments for deliberate review;
- preserve an existing suggestions file unless --force is passed;
- reject using the active repopilot.toml path as the export target;
- never load or execute the exported artifact automatically;
- add integration coverage for TOML parsing, config preservation, and collision safety;
- document the workflow and evidence boundary.

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all: 1,713 passed, 0 failed, 1 ignored
- python3 scripts/release-contract.py check
- cargo run -- scan . --fail-on-priority p1: PASS

Self-scan retains the repository's non-blocking warnings about ambiguous unresolved imports and three undocumented complex-file findings.

## Boundary

The exported file is a review aid. RepoPilot does not load it automatically, run its checks, or treat it as accepted policy.
