### PR TITLE
feat: add statistical boundaries to rule scorecard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Added
 
+- Extended the generated rule scorecard with separate validity, actionability,
+  and false-positive rates, 95% Wilson intervals, and an explicit
+  `insufficient evidence` status for small labeled samples. The scorecard still
+  keeps unmeasured rules visible and does not turn zoo labels into a production
+  precision claim.
 - `repopilot init` now includes source markers for every verification and
   critical-path proposal, so a maintainer can see which local file or declared
   script produced the suggestion.

--- a/docs/engineering/rule-scorecard.md
+++ b/docs/engineering/rule-scorecard.md
@@ -3,86 +3,87 @@
 <!-- @generated from tests/zoo/expectations/*.toml and docs/rules-reference.md — do not edit by hand. -->
 <!-- Regenerate with `python3 scripts/zoo.py scorecard --write`. -->
 
-Per-rule signal quality derived from the real-repo validation zoo (`tests/zoo/expectations/*.toml`) and each rule's lifecycle (`docs/rules-reference.md`). Precision estimate is `(actionable + valid-but-accepted) / labeled` default-profile zoo findings — a proxy from human-reviewed dispositions, not measured precision. False-positive debt is the count of zoo findings a reviewer explicitly dispositioned `false-positive`; labels never suppress the finding, so debt reflects outstanding calibration work, not detector correctness at large.
+Per-rule signal quality derived from the real-repo validation zoo (`tests/zoo/expectations/*.toml`) and each rule's lifecycle (`docs/rules-reference.md`). Validity estimate is `(actionable + valid-but-accepted) / labeled` default-profile zoo findings — a proxy from human-reviewed dispositions, not measured production precision. The validity column includes a 95% Wilson interval for the labeled sample; actionability and false-positive rate remain separate descriptive proportions. False-positive debt is the count of zoo findings a reviewer explicitly dispositioned `false-positive`; labels never suppress the finding, so debt reflects outstanding calibration work, not detector correctness at large.
 
 ## Default-profile evidence
 
 Every default-visible zoo finding is labeled, so these rows are exhaustive for the pinned repositories. `no zoo evidence` means the rule never fired in the default profile on any of them — the rule is unmeasured, which is not the same as clean.
 
-| Rule | Lifecycle | Zoo Evidence | Precision Estimate | False-Positive Debt |
-|---|---|---|---:|---:|
-| `architecture.barrel-file-risk` | experimental | no zoo evidence | n/a | 0 |
-| `architecture.circular-dependency` | stable | 11 labeled across 4 repo(s) | 1.00 | 0 |
-| `architecture.dead-module` | experimental | no zoo evidence | n/a | 0 |
-| `architecture.deep-directory-nesting` | experimental | no zoo evidence | n/a | 0 |
-| `architecture.deep-relative-imports` | preview | no zoo evidence | n/a | 0 |
-| `architecture.excessive-fan-out` | stable | no zoo evidence | n/a | 0 |
-| `architecture.high-instability-hub` | stable | no zoo evidence | n/a | 0 |
-| `architecture.large-file` | experimental | no zoo evidence | n/a | 0 |
-| `architecture.layer-violation` | experimental | no zoo evidence | n/a | 0 |
-| `architecture.package-boundary-violation` | experimental | no zoo evidence | n/a | 0 |
-| `architecture.test-leak` | experimental | no zoo evidence | n/a | 0 |
-| `architecture.too-many-modules` | experimental | no zoo evidence | n/a | 0 |
-| `architecture.unresolved-local-import` | preview | no zoo evidence | n/a | 0 |
-| `behavioral.removed-export-still-imported` | preview | no zoo evidence | n/a | 0 |
-| `code-marker.fixme` | experimental | no zoo evidence | n/a | 0 |
-| `code-marker.hack` | experimental | no zoo evidence | n/a | 0 |
-| `code-marker.todo` | experimental | no zoo evidence | n/a | 0 |
-| `code-quality.complex-file` | preview | no zoo evidence | n/a | 0 |
-| `code-quality.complex-function` | preview | no zoo evidence | n/a | 0 |
-| `code-quality.deep-control-flow` | preview | no zoo evidence | n/a | 0 |
-| `code-quality.long-function` | preview | no zoo evidence | n/a | 0 |
-| `framework.django.debug-true` | preview | no zoo evidence | n/a | 0 |
-| `framework.django.missing-allowed-hosts` | preview | no zoo evidence | n/a | 0 |
-| `framework.django.raw-sql-query` | preview | no zoo evidence | n/a | 0 |
-| `framework.js.console-log` | experimental | no zoo evidence | n/a | 0 |
-| `framework.js.var-declaration` | preview | no zoo evidence | n/a | 0 |
-| `framework.react-native.architecture-mismatch` | preview | no zoo evidence | n/a | 0 |
-| `framework.react-native.async-storage-from-core` | preview | no zoo evidence | n/a | 0 |
-| `framework.react-native.codegen-missing` | preview | no zoo evidence | n/a | 0 |
-| `framework.react-native.deprecated-api` | preview | no zoo evidence | n/a | 0 |
-| `framework.react-native.direct-state-mutation` | preview | no zoo evidence | n/a | 0 |
-| `framework.react-native.flatlist-missing-key` | preview | no zoo evidence | n/a | 0 |
-| `framework.react-native.hermes-disabled` | preview | no zoo evidence | n/a | 0 |
-| `framework.react-native.hermes-mismatch` | preview | no zoo evidence | n/a | 0 |
-| `framework.react-native.inline-style` | preview | no zoo evidence | n/a | 0 |
-| `framework.react-native.old-architecture` | preview | no zoo evidence | n/a | 0 |
-| `framework.react-native.old-react-navigation` | preview | no zoo evidence | n/a | 0 |
-| `framework.react.class-component` | preview | no zoo evidence | n/a | 0 |
-| `framework.react.prop-types` | preview | no zoo evidence | n/a | 0 |
-| `framework.rn-async-storage-legacy` | preview | no zoo evidence | n/a | 0 |
-| `framework.rn-gesture-handler-old` | preview | no zoo evidence | n/a | 0 |
-| `framework.rn-navigation-compat` | preview | no zoo evidence | n/a | 0 |
-| `framework.rn-new-arch-incompatible-dep` | preview | no zoo evidence | n/a | 0 |
-| `framework.rn-reanimated-compat` | preview | no zoo evidence | n/a | 0 |
-| `language.go.panic-exit-risk` | preview | no zoo evidence | n/a | 0 |
-| `language.javascript.runtime-exit-risk` | preview | 1 labeled across 1 repo(s) | 1.00 | 0 |
-| `language.managed.fatal-exception-risk` | preview | 1 labeled across 1 repo(s) | 1.00 | 0 |
-| `language.python.exception-risk` | preview | 1 labeled across 1 repo(s) | 1.00 | 0 |
-| `language.rust.panic-risk` | preview | 4 labeled across 1 repo(s) | 1.00 | 0 |
-| `security.env-file-committed` | stable | no zoo evidence | n/a | 0 |
-| `security.private-key-candidate` | stable | no zoo evidence | n/a | 0 |
-| `security.secret-candidate` | preview | 7 labeled across 1 repo(s) | 1.00 | 0 |
-| `testing.missing-test-folder` | experimental | no zoo evidence | n/a | 0 |
-| `testing.source-without-test` | experimental | no zoo evidence | n/a | 0 |
+| Rule | Lifecycle | Zoo Evidence | Evidence Status | Validity (95% Wilson) | Actionability | False-Positive Rate | False-Positive Debt |
+|---|---|---|---|---:|---:|---:|---:|
+| `architecture.barrel-file-risk` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `architecture.circular-dependency` | stable | 11 labeled across 4 repo(s) | descriptive | 1.00 (0.74–1.00) | 0.45 | 0.00 | 0 |
+| `architecture.dead-module` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `architecture.deep-directory-nesting` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `architecture.deep-relative-imports` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `architecture.excessive-fan-out` | stable | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `architecture.high-instability-hub` | stable | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `architecture.large-file` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `architecture.layer-violation` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `architecture.package-boundary-violation` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `architecture.test-leak` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `architecture.too-many-modules` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `architecture.unresolved-local-import` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `behavioral.removed-export-still-imported` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `code-marker.fixme` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `code-marker.hack` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `code-marker.todo` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `code-quality.complex-file` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `code-quality.complex-function` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `code-quality.deep-control-flow` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `code-quality.long-function` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.django.debug-true` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.django.missing-allowed-hosts` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.django.raw-sql-query` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.js.console-log` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.js.var-declaration` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react-native.architecture-mismatch` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react-native.async-storage-from-core` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react-native.codegen-missing` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react-native.deprecated-api` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react-native.direct-state-mutation` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react-native.flatlist-missing-key` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react-native.hermes-disabled` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react-native.hermes-mismatch` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react-native.inline-style` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react-native.old-architecture` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react-native.old-react-navigation` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react.class-component` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.react.prop-types` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.rn-async-storage-legacy` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.rn-gesture-handler-old` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.rn-navigation-compat` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.rn-new-arch-incompatible-dep` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `framework.rn-reanimated-compat` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `language.go.panic-exit-risk` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `language.javascript.runtime-exit-risk` | preview | 1 labeled across 1 repo(s) | insufficient evidence | 1.00 (0.21–1.00) | 1.00 | 0.00 | 0 |
+| `language.managed.fatal-exception-risk` | preview | 1 labeled across 1 repo(s) | insufficient evidence | 1.00 (0.21–1.00) | 1.00 | 0.00 | 0 |
+| `language.python.exception-risk` | preview | 1 labeled across 1 repo(s) | insufficient evidence | 1.00 (0.21–1.00) | 0.00 | 0.00 | 0 |
+| `language.rust.panic-risk` | preview | 4 labeled across 1 repo(s) | insufficient evidence | 1.00 (0.51–1.00) | 0.50 | 0.00 | 0 |
+| `security.env-file-committed` | stable | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `security.private-key-candidate` | stable | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `security.secret-candidate` | preview | 7 labeled across 1 repo(s) | insufficient evidence | 1.00 (0.65–1.00) | 0.00 | 0.00 | 0 |
+| `testing.missing-test-folder` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
+| `testing.source-without-test` | experimental | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |
 
 ## Evidence coverage
 
 - Default-profile evidence: 6 of 54 rules (11.1%), 25 labeled findings across 7 repo(s).
 - Default-profile rules without evidence: 48 (unmeasured, not clean).
 - Strict-profile sampled evidence: 6 rules, 14 sampled findings across 5 repo(s).
+- Evidence status is `insufficient evidence` below 10 labeled findings; `descriptive` is a sample-size label, not a production precision claim.
 - These coverage counts describe committed labels and do not establish recall.
 
 
 ## Strict-profile sampled evidence
 
-Rules that fire only in the strict profile are too numerous to label exhaustively. These rows come from deterministic per-rule samples (`python3 scripts/zoo.py sample --rule <id>`), so the precision estimate describes the sampled findings, not the rule's full strict-profile population. A rule missing from this table has no sampled evidence at all.
+Rules that fire only in the strict profile are too numerous to label exhaustively. These rows come from deterministic per-rule samples (`python3 scripts/zoo.py sample --rule <id>`), so the validity estimate describes the sampled findings, not the rule's full strict-profile population. A rule missing from this table has no sampled evidence at all.
 
-| Rule | Lifecycle | Sampled | Precision Estimate | False-Positive Debt |
-|---|---|---|---:|---:|
-| `architecture.dead-module` | experimental | 3 sampled across 2 repo(s) | 0.00 | 3 |
-| `architecture.excessive-fan-out` | stable | 1 sampled across 1 repo(s) | 1.00 | 0 |
-| `architecture.large-file` | experimental | 3 sampled across 3 repo(s) | 1.00 | 0 |
-| `code-quality.complex-function` | preview | 3 sampled across 3 repo(s) | 1.00 | 0 |
-| `code-quality.long-function` | preview | 3 sampled across 3 repo(s) | 1.00 | 0 |
-| `security.env-file-committed` | stable | 1 sampled across 1 repo(s) | 1.00 | 0 |
+| Rule | Lifecycle | Sampled | Evidence Status | Validity (95% Wilson) | Actionability | False-Positive Rate | False-Positive Debt |
+|---|---|---|---|---:|---:|---:|---:|
+| `architecture.dead-module` | experimental | 3 sampled across 2 repo(s) | insufficient evidence | 0.00 (0.00–0.56) | 0.00 | 1.00 | 3 |
+| `architecture.excessive-fan-out` | stable | 1 sampled across 1 repo(s) | insufficient evidence | 1.00 (0.21–1.00) | 0.00 | 0.00 | 0 |
+| `architecture.large-file` | experimental | 3 sampled across 3 repo(s) | insufficient evidence | 1.00 (0.44–1.00) | 0.00 | 0.00 | 0 |
+| `code-quality.complex-function` | preview | 3 sampled across 3 repo(s) | insufficient evidence | 1.00 (0.44–1.00) | 1.00 | 0.00 | 0 |
+| `code-quality.long-function` | preview | 3 sampled across 3 repo(s) | insufficient evidence | 1.00 (0.44–1.00) | 0.33 | 0.00 | 0 |
+| `security.env-file-committed` | stable | 1 sampled across 1 repo(s) | insufficient evidence | 1.00 (0.21–1.00) | 0.00 | 0.00 | 0 |

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -714,3 +714,18 @@ bump is needed to start.
   the no-overwrite and collision boundaries.
 - Boundary: export creates a review aid, not executable verification evidence or
   an accepted policy. A maintainer must review and copy entries deliberately.
+
+## 0Z — Rule Scorecard Statistical Boundaries
+
+- The generated scorecard now reports reviewed validity, actionability, and
+  false-positive rate as separate proportions. Validity includes a deterministic
+  95% Wilson interval over the labeled observations.
+- Rows with fewer than ten labeled findings are marked `insufficient evidence`;
+  ten is the release-policy sample-size boundary, not a claim that the rule is
+  broadly precise. Rules with no labeled findings remain `unmeasured`.
+- Default-profile exhaustive labels and strict-profile sampled labels remain in
+  separate tables. The interval is descriptive evidence for the pinned sample,
+  not recall, production precision, or a lifecycle promotion decision by itself.
+- Regression coverage exercises empty, small, and descriptive samples and keeps
+  the generated artifact reproducible from committed expectations and lifecycle
+  metadata.

--- a/docs/roadmap/v0.23.md
+++ b/docs/roadmap/v0.23.md
@@ -13,6 +13,9 @@ The proposals now retain source markers so their evidence can be audited before
 being adopted as repository policy.
 `init --suggestions-output` now creates a separate reviewable TOML artifact; it
 never applies suggestions automatically.
+The generated rule scorecard now separates validity, actionability, and
+false-positive rate, and reports Wilson intervals plus an explicit small-sample
+boundary instead of presenting a point estimate as broad precision evidence.
 
 RepoPilot 0.23 turns change review from a collection of findings and signals
 into one bounded proof of what changed, which contracts and consumers are

--- a/scripts/tests/test_zoo_scorecard.py
+++ b/scripts/tests/test_zoo_scorecard.py
@@ -111,6 +111,39 @@ class AggregateRuleScoresTests(unittest.TestCase):
         self.assertEqual(score.repos, {"repo-a", "repo-b"})
         self.assertAlmostEqual(score.precision_estimate, 2 / 3)
 
+
+class RuleScoreStatisticsTests(unittest.TestCase):
+    def test_wilson_interval_is_bounded_and_reproducible(self) -> None:
+        lower, upper = zs.wilson_interval(8, 10)
+        self.assertAlmostEqual(lower, 0.490, places=3)
+        self.assertAlmostEqual(upper, 0.943, places=3)
+
+    def test_empty_sample_has_no_interval(self) -> None:
+        self.assertIsNone(zs.wilson_interval(0, 0))
+
+    def test_invalid_interval_counts_fail_closed(self) -> None:
+        with self.assertRaises(ValueError):
+            zs.wilson_interval(11, 10)
+        with self.assertRaises(ValueError):
+            zs.wilson_interval(1, 0)
+
+    def test_rule_score_exposes_distinct_quality_rates(self) -> None:
+        score = zs.RuleScore(
+            rule_id="x.rule",
+            labeled=10,
+            actionable=4,
+            valid_but_accepted=3,
+            false_positive=3,
+        )
+        self.assertAlmostEqual(score.validity_estimate, 0.7)
+        self.assertAlmostEqual(score.actionability_estimate, 0.4)
+        self.assertAlmostEqual(score.false_positive_rate, 0.3)
+        self.assertEqual(score.evidence_status, "descriptive")
+
+    def test_small_sample_is_explicitly_limited(self) -> None:
+        score = zs.RuleScore(rule_id="x.rule", labeled=9, actionable=9)
+        self.assertEqual(score.evidence_status, "insufficient evidence")
+
     def test_missing_expectation_file_is_skipped_not_raised(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             scores = zs.aggregate_rule_scores([{"name": "no-such-repo"}], Path(tmp))
@@ -135,10 +168,29 @@ class RenderScorecardMarkdownTests(unittest.TestCase):
 
         self.assertIn("<!-- @generated", rendered)
         self.assertIn(
-            "| `architecture.circular-dependency` | stable | 4 labeled across 1 repo(s) | 0.75 | 1 |",
+            "| `architecture.circular-dependency` | stable | 4 labeled across 1 repo(s) | insufficient evidence",
             rendered,
         )
-        self.assertIn("| `architecture.dead-module` | experimental | no zoo evidence | n/a | 0 |", rendered)
+        self.assertIn("| `architecture.dead-module` | experimental | no zoo evidence | unmeasured |", rendered)
+
+    def test_scorecard_renders_interval_and_separate_rates_for_descriptive_sample(self) -> None:
+        score = zs.RuleScore(
+            rule_id="architecture.circular-dependency",
+            labeled=10,
+            actionable=4,
+            valid_but_accepted=3,
+            false_positive=3,
+            repos={"repo-a", "repo-b", "repo-c"},
+        )
+        rendered = zs.render_scorecard_markdown(
+            {"architecture.circular-dependency": score},
+            {"architecture.circular-dependency": "stable"},
+        )
+        self.assertIn("Validity (95% Wilson)", rendered)
+        self.assertIn("0.70 (0.40–0.89)", rendered)
+        self.assertIn("0.40", rendered)
+        self.assertIn("0.30", rendered)
+        self.assertIn("descriptive", rendered)
 
     def test_evidence_summary_reports_denominator_and_unmeasured_rules(self) -> None:
         lifecycles = {
@@ -177,7 +229,10 @@ class RenderScorecardMarkdownTests(unittest.TestCase):
         rendered = zs.render_scorecard_markdown(
             {"x.rule": score}, {"x.rule": "preview"}
         )
-        self.assertIn("| `x.rule` | preview | no zoo evidence | n/a | 0 |", rendered)
+        self.assertIn(
+            "| `x.rule` | preview | no zoo evidence | unmeasured | n/a | n/a | n/a | 0 |",
+            rendered,
+        )
 
     def test_output_is_deterministic_and_sorted(self) -> None:
         lifecycles = {"z.rule": "stable", "a.rule": "preview"}
@@ -219,7 +274,7 @@ class StrictEvidenceKindTests(unittest.TestCase):
     def test_hand_picked_anchors_are_excluded_from_sampled_precision(self) -> None:
         # Catches counting recall anchors as measurement: an anchor is chosen
         # *because* it is a known true positive, so aggregating it would report
-        # selection bias as a precision estimate.
+        # selection bias as a validity estimate.
         with tempfile.TemporaryDirectory() as tmp:
             expectation_dir = Path(tmp)
             (expectation_dir / "repo-a.toml").write_text(

--- a/scripts/zoo_scorecard.py
+++ b/scripts/zoo_scorecard.py
@@ -14,11 +14,17 @@ This module has no network access and never runs the scanner; it is driven by
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import zoo_expectations as ze
+from zoo_scorecard_stats import (
+    MIN_DESCRIPTIVE_LABELS,
+    RuleScore,
+    format_rate,
+    format_validity,
+    wilson_interval,
+)
 
 GENERATED_BANNER = (
     "<!-- @generated from tests/zoo/expectations/*.toml and docs/rules-reference.md "
@@ -28,30 +34,6 @@ GENERATED_BANNER = (
 
 _RULE_HEADING = re.compile(r"^### `(?P<rule_id>[^`]+)`", re.MULTILINE)
 _LIFECYCLE_LINE = re.compile(r"^- \*\*Lifecycle:\*\* (?P<lifecycle>\S+)", re.MULTILINE)
-
-
-@dataclass
-class RuleScore:
-    """Aggregated default-profile zoo evidence for one rule."""
-
-    rule_id: str
-    labeled: int = 0
-    actionable: int = 0
-    valid_but_accepted: int = 0
-    false_positive: int = 0
-    repos: set[str] = field(default_factory=set)
-
-    @property
-    def precision_estimate(self) -> float | None:
-        """`(actionable + valid-but-accepted) / labeled`; `None` if never labeled.
-
-        A proxy derived from reviewed dispositions, not measured precision.
-        """
-        if self.labeled == 0:
-            return None
-        return (self.actionable + self.valid_but_accepted) / self.labeled
-
-
 def load_rule_lifecycles(rules_reference_path: Path) -> dict[str, str]:
     """Parse `rule_id -> lifecycle` out of the generated rules reference doc."""
     text = rules_reference_path.read_text(encoding="utf-8")
@@ -79,7 +61,7 @@ def aggregate_rule_scores(
     to record, and averaging the two would present partial coverage as measured
     coverage. Passing `evidence` narrows a strict aggregate to one kind — only
     `sample` entries are drawn without looking at the finding, so only they can
-    support a precision estimate.
+    support a validity estimate.
     """
     scores: dict[str, RuleScore] = {}
     for repo in manifest:
@@ -118,7 +100,7 @@ def render_strict_sample_section(scores: dict[str, RuleScore], lifecycles: dict[
         "",
         "Rules that fire only in the strict profile are too numerous to label "
         "exhaustively. These rows come from deterministic per-rule samples "
-        "(`python3 scripts/zoo.py sample --rule <id>`), so the precision "
+        "(`python3 scripts/zoo.py sample --rule <id>`), so the validity "
         "estimate describes the sampled findings, not the rule's full "
         "strict-profile population. A rule missing from this table has no "
         "sampled evidence at all.",
@@ -129,15 +111,19 @@ def render_strict_sample_section(scores: dict[str, RuleScore], lifecycles: dict[
         lines.append("No rule has strict-profile sampled evidence yet.")
         lines.append("")
         return lines
-    lines.append("| Rule | Lifecycle | Sampled | Precision Estimate | False-Positive Debt |")
-    lines.append("|---|---|---|---:|---:|")
+    lines.append(
+        "| Rule | Lifecycle | Sampled | Evidence Status | Validity (95% Wilson) | "
+        "Actionability | False-Positive Rate | False-Positive Debt |"
+    )
+    lines.append("|---|---|---|---|---:|---:|---:|---:|")
     for rule_id in sorted(sampled):
         score = sampled[rule_id]
         lifecycle = lifecycles.get(rule_id, "unknown")
         sample = f"{score.labeled} sampled across {len(score.repos)} repo(s)"
         lines.append(
-            f"| `{rule_id}` | {lifecycle} | {sample} | "
-            f"{score.precision_estimate:.2f} | {score.false_positive} |"
+            f"| `{rule_id}` | {lifecycle} | {sample} | {score.evidence_status} | "
+            f"{format_validity(score)} | {format_rate(score.actionability_estimate)} | "
+            f"{format_rate(score.false_positive_rate)} | {score.false_positive} |"
         )
     lines.append("")
     return lines
@@ -168,6 +154,8 @@ def render_evidence_summary(
         "(unmeasured, not clean).",
         f"- Strict-profile sampled evidence: {len(sampled)} rules, {strict_labeled} "
         f"sampled findings across {len(strict_repos)} repo(s).",
+        f"- Evidence status is `insufficient evidence` below {MIN_DESCRIPTIVE_LABELS} "
+        "labeled findings; `descriptive` is a sample-size label, not a production precision claim.",
         "- These coverage counts describe committed labels and do not establish recall.",
         "",
     ]
@@ -192,10 +180,12 @@ def render_scorecard_markdown(
         "",
         "Per-rule signal quality derived from the real-repo validation zoo "
         "(`tests/zoo/expectations/*.toml`) and each rule's lifecycle "
-        "(`docs/rules-reference.md`). Precision estimate is "
+        "(`docs/rules-reference.md`). Validity estimate is "
         "`(actionable + valid-but-accepted) / labeled` default-profile zoo "
         "findings — a proxy from human-reviewed dispositions, not measured "
-        "precision. False-positive debt is the count of zoo findings a "
+        "production precision. The validity column includes a 95% Wilson "
+        "interval for the labeled sample; actionability and false-positive "
+        "rate remain separate descriptive proportions. False-positive debt is the count of zoo findings a "
         "reviewer explicitly dispositioned `false-positive`; labels never "
         "suppress the finding, so debt reflects outstanding calibration work, "
         "not detector correctness at large.",
@@ -207,19 +197,33 @@ def render_scorecard_markdown(
         "rule never fired in the default profile on any of them — the rule is "
         "unmeasured, which is not the same as clean.",
         "",
-        "| Rule | Lifecycle | Zoo Evidence | Precision Estimate | False-Positive Debt |",
-        "|---|---|---|---:|---:|",
+        "| Rule | Lifecycle | Zoo Evidence | Evidence Status | Validity (95% Wilson) | "
+        "Actionability | False-Positive Rate | False-Positive Debt |",
+        "|---|---|---|---|---:|---:|---:|---:|",
     ]
     for rule_id in sorted(set(lifecycles) | set(scores)):
         lifecycle = lifecycles.get(rule_id, "unknown")
         score = scores.get(rule_id)
         if score is None or score.labeled == 0:
-            evidence, precision, debt = "no zoo evidence", "n/a", "0"
+            evidence, status, validity, actionability, fp_rate, debt = (
+                "no zoo evidence",
+                "unmeasured",
+                "n/a",
+                "n/a",
+                "n/a",
+                "0",
+            )
         else:
             evidence = f"{score.labeled} labeled across {len(score.repos)} repo(s)"
-            precision = f"{score.precision_estimate:.2f}"
+            status = score.evidence_status
+            validity = format_validity(score)
+            actionability = format_rate(score.actionability_estimate)
+            fp_rate = format_rate(score.false_positive_rate)
             debt = str(score.false_positive)
-        lines.append(f"| `{rule_id}` | {lifecycle} | {evidence} | {precision} | {debt} |")
+        lines.append(
+            f"| `{rule_id}` | {lifecycle} | {evidence} | {status} | {validity} | "
+            f"{actionability} | {fp_rate} | {debt} |"
+        )
     strict_scores = strict_scores or {}
     lines += render_evidence_summary(scores, lifecycles, strict_scores)
     lines += render_strict_sample_section(strict_scores, lifecycles)

--- a/scripts/zoo_scorecard_stats.py
+++ b/scripts/zoo_scorecard_stats.py
@@ -1,0 +1,93 @@
+"""Statistics and formatting helpers for the per-rule zoo scorecard."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+
+MIN_DESCRIPTIVE_LABELS = 10
+WILSON_Z = 1.96
+
+
+def wilson_interval(successes: int, trials: int) -> tuple[float, float] | None:
+    """Return a deterministic 95% Wilson interval for a bounded proportion.
+
+    A missing interval means there were no labeled observations. The interval
+    describes the reviewed sample only; it is not a production precision claim.
+    """
+    if trials < 0 or successes < 0 or successes > trials:
+        raise ValueError("successes must be between zero and trials")
+    if trials == 0:
+        return None
+    proportion = successes / trials
+    z_squared = WILSON_Z**2
+    denominator = 1 + z_squared / trials
+    center = (proportion + z_squared / (2 * trials)) / denominator
+    margin = (
+        WILSON_Z
+        * math.sqrt((proportion * (1 - proportion) + z_squared / (4 * trials)) / trials)
+        / denominator
+    )
+    return max(0.0, center - margin), min(1.0, center + margin)
+
+
+@dataclass
+class RuleScore:
+    """Aggregated zoo evidence for one rule and one profile."""
+
+    rule_id: str
+    labeled: int = 0
+    actionable: int = 0
+    valid_but_accepted: int = 0
+    false_positive: int = 0
+    repos: set[str] = field(default_factory=set)
+
+    @property
+    def precision_estimate(self) -> float | None:
+        """Backward-compatible alias for the reviewed validity estimate."""
+        if self.labeled == 0:
+            return None
+        return (self.actionable + self.valid_but_accepted) / self.labeled
+
+    @property
+    def validity_estimate(self) -> float | None:
+        """Reviewed-valid proportion used by the scorecard."""
+        return self.precision_estimate
+
+    @property
+    def actionability_estimate(self) -> float | None:
+        if self.labeled == 0:
+            return None
+        return self.actionable / self.labeled
+
+    @property
+    def false_positive_rate(self) -> float | None:
+        if self.labeled == 0:
+            return None
+        return self.false_positive / self.labeled
+
+    @property
+    def validity_interval(self) -> tuple[float, float] | None:
+        return wilson_interval(self.actionable + self.valid_but_accepted, self.labeled)
+
+    @property
+    def evidence_status(self) -> str:
+        if self.labeled == 0:
+            return "unmeasured"
+        if self.labeled < MIN_DESCRIPTIVE_LABELS:
+            return "insufficient evidence"
+        return "descriptive"
+
+
+def format_rate(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.2f}"
+
+
+def format_validity(score: RuleScore | None) -> str:
+    if score is None or score.validity_estimate is None:
+        return "n/a"
+    interval = score.validity_interval
+    if interval is None:
+        return "n/a"
+    return f"{score.validity_estimate:.2f} ({interval[0]:.2f}–{interval[1]:.2f})"

--- a/tests/zoo/README.md
+++ b/tests/zoo/README.md
@@ -101,7 +101,7 @@ A strict entry declares *why* it exists through the optional `evidence` field:
   nothing about how often the rule is right.
 - **`sample`** — drawn by `zoo.py sample`, which selects by position in a sorted
   population without looking at the finding. Only these feed the scorecard's
-  strict precision estimate.
+  strict validity estimate and Wilson interval.
 
 `sample` is strict-only: the default profile is already exhaustive, so a sample
 of it would be a coverage regression rather than new evidence.

--- a/tests/zoo_runner_contract.rs
+++ b/tests/zoo_runner_contract.rs
@@ -33,6 +33,7 @@ impl Harness {
         copy_script(&root, "zoo_expectations.py");
         copy_script(&root, "zoo_sample.py");
         copy_script(&root, "zoo_scorecard.py");
+        copy_script(&root, "zoo_scorecard_stats.py");
         copy_script(&root, "zoo_triage.py");
         fs::write(root.join("Cargo.toml"), CARGO_TOML).expect("Cargo.toml");
         fs::write(root.join("tests/zoo/manifest.toml"), MANIFEST).expect("manifest");


### PR DESCRIPTION
## What changed

The rule scorecard previously showed a single reviewed-valid point estimate even when a rule had only one or two labeled findings. That made small samples look more conclusive than the evidence supports.

This slice adds statistical boundaries and keeps the generated artifact reproducible:

- adds a deterministic 95% Wilson interval for reviewed validity;
- reports validity, actionability, and false-positive rate as separate proportions;
- marks rows as `unmeasured`, `insufficient evidence`, or `descriptive`, with ten labels as the explicit sample-size boundary;
- preserves separate exhaustive default-profile and sampled strict-profile tables;
- moves scorecard statistics into a focused helper module and updates the temporary zoo harness to copy it;
- regenerates the committed scorecard and records the limits in the v0.23 roadmap/evidence ledger and changelog.

The scorecard remains evidence about pinned reviewed observations. It does not claim production precision, recall, utility, or lifecycle promotion by itself.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` — all tests passed; one explicit released-reader compatibility test is ignored by design
- `python3 -m unittest discover -s scripts/tests` — 249 passed
- `python3 -m unittest scripts.tests.test_zoo_scorecard` — 17 passed
- `cargo test --test zoo_runner_contract -- --nocapture` — 5 passed
- `python3 scripts/zoo.py scorecard` — generated scorecard is current
- `python3 scripts/release-contract.py check` — release contract passed; the zoo gate is skipped locally because real repositories are not cloned under `.zoo/`
- `git diff --check`


