### PR TITLE
fix: close offline recall and self-scan quality gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
   `code-quality.complex-file` findings, removing the self-scan contract warning
   while preserving the existing complexity signal.
 
+- Made the differential benchmark's optional RSS sampler fail open when the
+  host denies `/usr/bin/time` telemetry, so unavailable resource data cannot
+  mask the measured command exit status.
+
 - Hardened `security.secret-candidate` evidence redaction: connection strings
   now mask the matched credential segment instead of the first assignment, and
   Unicode secrets no longer risk a byte-boundary panic. Real demo/Docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- Added rule-reference documentation metadata for high-severity
+  `code-quality.complex-file` findings, removing the self-scan contract warning
+  while preserving the existing complexity signal.
+
 - Hardened `security.secret-candidate` evidence redaction: connection strings
   now mask the matched credential segment instead of the first assignment, and
   Unicode secrets no longer risk a byte-boundary panic. Real demo/Docker

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -244,6 +244,10 @@ bump is needed to start.
   approximately 0.44–1.00, so the result remains a small synthetic checkpoint.
 - The real-history holdout remains pending at six unreviewed cases. No network
   collection or human labels were invented in this offline run.
+- The offline quality pass also exposed a macOS sandbox limitation in
+  `/usr/bin/time -l`: the benchmark runner now probes sampler support once and
+  falls back to direct execution when RSS is unavailable, preserving the
+  child's real exit status. The full Python harness remains green at 249 tests.
 
 ## 0F — Independent Real-History Holdout Protocol
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -233,6 +233,18 @@ bump is needed to start.
   true-positive/false-negative/specificity analysis remain required before
   RP23-013 can close or a broad recall claim is made.
 
+## 0EA — Offline Recall Re-run (2026-09-10)
+
+- The held-out runner was repeated twice from the merged scorecard tree. Both
+  artifacts were byte-identical and pinned the same manifest, rules reference,
+  scanner config, workspace revision, and report schema.
+- All six cases passed: three seeded defects were detected and three safe guards
+  stayed silent. The corpus-only counts were TP=3, TN=3, FP=0, FN=0; recall and
+  specificity were both 1.00. A Wilson 95% interval for each 3/3 proportion is
+  approximately 0.44–1.00, so the result remains a small synthetic checkpoint.
+- The real-history holdout remains pending at six unreviewed cases. No network
+  collection or human labels were invented in this offline run.
+
 ## 0F — Independent Real-History Holdout Protocol
 
 - `tests/benchmarks/manifest.toml` now reserves six immutable merged pull

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -303,6 +303,8 @@ The file's branch count density exceeds the complexity threshold, indicating too
 
 **Recommendation:** Extract conditionals into well-named helper functions. Prefer early returns to deeply nested if/else chains.
 
+**Reference:** <https://github.com/MykytaStel/repopilot/blob/main/docs/rules-reference.md>
+
 ### `code-quality.complex-function` — Function has high cognitive complexity
 
 - **Severity:** MEDIUM

--- a/scripts/differential_resource.py
+++ b/scripts/differential_resource.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -66,6 +67,29 @@ def unavailable_resource(reason: str) -> dict[str, Any]:
     return {"status": "unavailable", "reason": reason, "source": "unavailable"}
 
 
+@lru_cache(maxsize=1)
+def _resource_sampler_supported() -> bool:
+    """Probe the optional sampler without allowing it to mask child status."""
+
+    probe_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(prefix="repopilot-rss-probe-", suffix=".txt", delete=False) as handle:
+            probe_path = Path(handle.name)
+        wrapped = resource_command((sys.executable, "-c", "pass"), probe_path)
+        if wrapped is None:
+            return False
+        process = subprocess.run(wrapped, capture_output=True, check=False, timeout=5)
+        return process.returncode == 0 and resource_sample_from_file(probe_path)["status"] == "available"
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    finally:
+        if probe_path is not None:
+            try:
+                probe_path.unlink()
+            except OSError:
+                pass
+
+
 def execute_timed_command(
     command: tuple[str, ...], cwd: Path, timeout_seconds: float
 ) -> dict[str, Any]:
@@ -73,7 +97,7 @@ def execute_timed_command(
 
     sampler_path: Path | None = None
     wrapped_command: list[str] | None = None
-    if resource_command(command, Path("/tmp/repopilot-rss.txt")) is not None:
+    if _resource_sampler_supported():
         with tempfile.NamedTemporaryFile(prefix="repopilot-rss-", suffix=".txt", delete=False) as handle:
             sampler_path = Path(handle.name)
         wrapped_command = resource_command(command, sampler_path)
@@ -97,10 +121,10 @@ def execute_timed_command(
         returncode, stdout, stderr = process.returncode, process.stdout, process.stderr
     finally:
         wall_ms = round((time.perf_counter() - started) * 1000, 3)
-    if sampler_path is None:
-        resource = unavailable_resource("portable peak RSS sampler is unavailable on this platform")
-    elif status == "timeout":
+    if status == "timeout":
         resource = unavailable_resource("command timed out before peak RSS sampling completed")
+    elif sampler_path is None:
+        resource = unavailable_resource("portable peak RSS sampler is unavailable on this platform")
     else:
         resource = resource_sample_from_file(sampler_path)
     if sampler_path is not None:

--- a/src/rules/registry/code_quality.rs
+++ b/src/rules/registry/code_quality.rs
@@ -14,7 +14,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
         signal_source: SignalSource::TextHeuristic,
 
         requirements: RuleRequirements::file_text(RuleLifecycle::Preview),
-        docs_url: None,
+        docs_url: Some("https://github.com/MykytaStel/repopilot/blob/main/docs/rules-reference.md"),
         description: "The file's branch count density exceeds the complexity threshold, indicating too many execution paths. High complexity increases the defect rate and testing burden.",
         recommendation: Some(
             "Extract conditionals into well-named helper functions. Prefer early returns to deeply nested if/else chains.",

--- a/tests/rule_registry.rs
+++ b/tests/rule_registry.rs
@@ -102,6 +102,15 @@ fn direct_state_mutation_severity_is_high() {
     assert_eq!(meta.default_severity, Severity::High);
 }
 
+#[test]
+fn complex_file_has_docs_url_for_high_severity_emissions() {
+    let meta = lookup_rule_metadata("code-quality.complex-file").unwrap();
+    assert_eq!(
+        meta.docs_url,
+        Some("https://github.com/MykytaStel/repopilot/blob/main/docs/rules-reference.md")
+    );
+}
+
 // ── SARIF integration ─────────────────────────────────────────────────────────
 
 fn make_finding(rule_id: &str) -> Finding {


### PR DESCRIPTION
## What changed

This slice executes the offline held-out recall checkpoint and closes two quality gaps found by the audit.

- records a repeated, deterministic six-case recall run in the v0.23 evidence ledger;
- pins the corpus-only TP/TN/FP/FN result and Wilson boundary without claiming broad recall;
- adds the rule-reference URL required for high-severity `code-quality.complex-file` findings;
- synchronizes the generated rules reference and adds a registry regression test;
- makes the optional differential RSS sampler fail open when `/usr/bin/time` telemetry is denied, preserving the child command's real exit status;
- keeps raw audit JSON and the quality report local under `/tmp`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` — all pass; one explicit released-reader compatibility test ignored by design
- `python3 -m unittest discover -s scripts/tests` — 249 passed
- `python3 scripts/recall.py run` — 6/6 pass, TP=3/TN=3/FP=0/FN=0
- `python3 scripts/zoo.py scorecard`
- `python3 scripts/release-contract.py check`
- `npm run review:performance`
- `npm run scan:performance`
- default self-scan — PASS, no contract warning