### PR TITLE
feat: add bounded Rust file-backed import evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -368,9 +368,12 @@ instead of a separate Python implementation.
 - Add the first v0.22 broken-code detector,
   `architecture.unresolved-local-import`. It reports only explicit local
   TypeScript/JavaScript file imports and Python relative modules whose complete,
-  root-confined candidate set is absent. Ambiguous aliases, extensionless
-  imports, workspace packages, Rust module forms, and unsupported semantics stay
-  as bounded informational diagnostics instead of false broken-code claims.
+  root-confined candidate set is absent. Plain Rust `mod` declarations and
+  literal `#[path = "..."]`/`include!("...")` file references now use the same
+  high-confidence missing-target evidence; Rust `use` paths, ambiguous aliases,
+  extensionless imports, computed Rust paths, workspace packages, and
+  unsupported semantics stay as bounded informational diagnostics instead of
+  false broken-code claims.
   A Python `from <package> import name` candidate is one of those bounded
   limitations: `name` may be a submodule or a member defined in the package's
   `__init__.py`, and the two are indistinguishable from the import alone. Only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added recomputing validation and a deterministic Markdown report for the
   differential utility pilot metrics. Edited or stale scores are rejected, and
   unavailable utility measurements remain explicit instead of being inferred.
+- Documented the first six-case real-history and differential evidence packet,
+  including exact pytest verification provenance and a separate workload-bound
+  RSS calibration result; raw packets remain local.
 - Differential collection artifacts now carry a validated telemetry contract:
   review phase events can measure evidence-ready and decision-ready latency,
   while baseline evidence adapters make duplicate-work overlap measurable when

--- a/docs/agent-guardrail.md
+++ b/docs/agent-guardrail.md
@@ -131,8 +131,9 @@ findings count. See
 Two review-first checks look for provably broken code rather than risky
 patterns, so an agent's own edits get caught before a human does:
 
-- **`architecture.unresolved-local-import`** — an explicit local TypeScript/
-  JavaScript or Python relative import whose complete candidate set is absent.
+- **`architecture.unresolved-local-import`** — an explicit local file-backed
+  Rust, TypeScript/JavaScript or Python relative import whose complete candidate
+  set is absent.
   Ambiguous forms (aliases, extensionless imports, workspace packages) stay
   bounded diagnostics, never a false broken-code claim.
 - **`behavioral.removed-export-still-imported`** — a named export an agent

--- a/docs/architecture-antipatterns.md
+++ b/docs/architecture-antipatterns.md
@@ -41,7 +41,7 @@ from broad architecture structure heuristics.
 | `architecture.test-leak` | Does production code import a test or fixture file? | On by default; evidence cites the import line. |
 | `architecture.layer-violation` | Does a module import against the declared layer order? | Strictly opt-in via `[[architecture.layers]]`. |
 | `architecture.package-boundary-violation` | Does one package reach into another's internals instead of its public API? | Auto-enabled on a detected workspace (manifest boundaries → High confidence); also configurable via `[architecture] package_roots` (→ Medium). |
-| `architecture.unresolved-local-import` | Does a supported explicit local import point to a module that is absent? | High/High only for bounded TS/JS file candidates and Python relative modules; ambiguous semantics produce an informational limitation, not a finding. |
+| `architecture.unresolved-local-import` | Does a supported explicit local import point to a module that is absent? | High/High only for bounded TS/JS file candidates, Python relative modules, and file-backed Rust `mod`/`#[path]`/`include!` forms; ambiguous semantics produce an informational limitation, not a finding. |
 
 ## Broken local import boundary
 
@@ -53,6 +53,8 @@ only:
   or `.jsx` target; and
 - Python relative modules such as `.payments` when neither the module file nor
   package initializer exists.
+- file-backed Rust `mod name;` declarations and literal `#[path = "..."]` /
+  `include!("...")` references when the target path is absent.
 
 Python imports inside a `try` body are not reported when an explicit
 `ImportError` or `ModuleNotFoundError` handler absorbs the failure. A handler
@@ -63,7 +65,7 @@ reparse source text.
 
 RepoPilot checks every bounded candidate on disk before reporting, so a valid
 target omitted by ignore or scan-size policy remains quiet. Extensionless
-imports, path aliases, workspace packages, generated targets, Rust module forms,
+imports, path aliases, workspace packages, generated targets, Rust `use` paths,
 root escapes, and unsupported language semantics remain uncertainty. They are
 counted in an aggregated informational diagnostic and are never described as a
 proven build failure.

--- a/docs/engineering/v0.22-broken-import-evidence-spec.md
+++ b/docs/engineering/v0.22-broken-import-evidence-spec.md
@@ -39,10 +39,13 @@ or explain the broken-code evidence.
     as the current resolver;
   - explicit Python relative modules with a non-empty module name, using the
     same module/package candidates as the current resolver.
+  - Rust `mod name;` declarations (`name.rs` or `name/mod.rs`) and literal
+    `#[path = "..."] mod ...;` / `include!("...")` file references, whose
+    source path is fixed by the syntax.
 - Before emitting a finding, verify that no candidate exists on disk, including
   candidates omitted from the scan by ignore or size policy.
-- Keep aliases, workspace packages, extensionless JS/TS imports, Rust module
-  forms, unsupported languages, targets outside the repository root, and other
+- Keep aliases, workspace packages, extensionless JS/TS imports, Rust `use`
+  paths, unsupported languages, targets outside the repository root, and other
   ambiguous cases as limited evidence only.
 - Emit one High-severity, High-confidence finding per unresolved source/import
   occurrence, with the source line, import text, impact, and verification
@@ -59,8 +62,9 @@ or explain the broken-code evidence.
 - Missing exported-symbol analysis, compiler/type-checker execution, manifest
   dependency mismatch, generated-code discovery, or alias inference beyond the
   resolver's current configuration support.
-- Treating extensionless JavaScript/TypeScript imports or Rust `mod`/`use`
-  statements as definitive failures.
+- Treating extensionless JavaScript/TypeScript imports or Rust `use` statements
+  as definitive failures. Rust file-backed `mod`/`#[path]`/`include!` forms are
+  covered by the bounded definitive subset above.
 - Adding a new top-level command, a new public finding category, or a second
   health score.
 - Network access, clock-dependent output, randomness, or unbounded diagnostics.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -764,3 +764,23 @@ bump is needed to start.
 - Raw packets, worksheets, and coverage reports stay under `/tmp`. The next
   evidence step is dual independent labeling plus adjudication; a single-expert
   pilot remains exploratory.
+
+## 0ZB — Rust File-Backed Import Evidence (2026-09-10)
+
+- `architecture.unresolved-local-import` now emits the existing High/High
+  missing-target finding for Rust `mod name;` declarations and literal
+  `#[path = "..."]` / `include!("...")` references. The resolver enumerates
+  only the file forms fixed by those constructs (`name.rs` / `name/mod.rs`, or
+  the literal relative path) and rejects repository escapes and malformed
+  module names.
+- Rust `use crate::...` and other symbol/re-export forms remain limited. An
+  import is recorded as unresolved only for the synthetic file-backed forms,
+  which carry their own `RustFileBacked` evidence kind; the knowledge
+  applicability gate now includes Rust so the evidence is retained by full and
+  changed scans.
+- Evidence is pinned by unit tests, a true-positive/false-positive fixture pair,
+  and an end-to-end full/cold/warm changed-scan parity test. This proves the
+  bounded detector contract; it does not claim compiler-equivalent Rust module
+  resolution or repository-wide recall. Computed `include!`/`#[path]`
+  expressions are intentionally declined, so a nested string cannot become a
+  fabricated file edge.

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -745,3 +745,22 @@ bump is needed to start.
 - Regression coverage exercises empty, small, and descriptive samples and keeps
   the generated artifact reproducible from committed expectations and lifecycle
   metadata.
+
+## 0ZA — Real-History Collection and Workload-Bound Verification (2026-09-10)
+
+- The six pinned real-history cases were collected into a schema-1 packet and
+  passed `validate-result`. All cases remain pending labels; the packet records
+  exact revisions, baseline statuses, RepoPilot evidence hashes, and scanner
+  provenance without making a recall or utility claim.
+- The static differential packet passed validation and its RSS policy: 6 cases
+  × 3 repetitions, 36/36 baseline runs measured, 18/18 review-comparable runs
+  measured, and aggregate cold/warm medians of 30,336/27,600 KiB below the
+  65,536/49,152 KiB ceilings.
+- A separate packet with explicit `python.tests` verification measured all
+  18/18 exact `review-verification-v1` comparisons. Its heavier workload failed
+  the separate RSS policy (cold median 68,240 KiB; warm median 57,600 KiB), so
+  the result is a calibration signal and is not compared with the static
+  workload budget.
+- Raw packets, worksheets, and coverage reports stay under `/tmp`. The next
+  evidence step is dual independent labeling plus adjudication; a single-expert
+  pilot remains exploratory.

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -218,7 +218,7 @@ A supported explicit local import does not resolve to any bounded source-file ca
 
 **Recommendation:** Restore the imported module, update the import path, or run the project compiler to confirm the intended generated target.
 
-**Known false positives:** Only explicit supported TypeScript/JavaScript file extensions and explicit Python relative modules are reported. Python imports guarded by an absorbing ImportError or ModuleNotFoundError handler are excluded; broad or unrelated handlers and bare re-raises do not qualify. Extensionless imports, aliases, workspace packages, Rust module forms, generated targets, and unsupported semantics remain limitations rather than findings.
+**Known false positives:** Only explicit supported TypeScript/JavaScript file extensions, explicit Python relative modules, and file-backed Rust mod/path/include forms are reported. Python imports guarded by an absorbing ImportError or ModuleNotFoundError handler are excluded; broad or unrelated handlers and bare re-raises do not qualify. Extensionless imports, aliases, workspace packages, computed Rust paths, generated targets, and unsupported semantics remain limitations rather than findings.
 
 **Reference:** <https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture>
 

--- a/src/audits/architecture/unresolved_local_imports/tests.rs
+++ b/src/audits/architecture/unresolved_local_imports/tests.rs
@@ -92,6 +92,55 @@ fn missing_explicit_python_relative_module_emits_finding() {
 }
 
 #[test]
+fn missing_rust_module_declaration_emits_high_confidence_finding() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let source = root.join("src/lib.rs");
+    let facts = facts(
+        source.clone(),
+        "Rust",
+        "mod missing;\n\nfn main() {}\n",
+        &["mod::missing"],
+    );
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record_classified(&source, "mod::missing", root);
+
+    let result = analyze(root, &facts, &resolution);
+
+    assert_eq!(result.findings.len(), 1, "{:#?}", result.findings);
+    assert_eq!(result.findings[0].severity, Severity::High);
+    assert_eq!(result.findings[0].confidence, Confidence::High);
+    assert_eq!(result.findings[0].evidence[0].line_start, 1);
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn missing_rust_literal_file_reference_emits_high_confidence_finding() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let source = root.join("src/lib.rs");
+    let facts = facts(
+        source.clone(),
+        "Rust",
+        "include!(\"sections/missing.rs\");\n",
+        &["relfile::sections/missing.rs"],
+    );
+    let mut resolution = ImportResolutionStats::default();
+    resolution.record_classified(&source, "relfile::sections/missing.rs", root);
+
+    let result = analyze(root, &facts, &resolution);
+
+    assert_eq!(result.findings.len(), 1, "{:#?}", result.findings);
+    assert_eq!(result.findings[0].confidence, Confidence::High);
+    assert_eq!(result.findings[0].evidence[0].line_start, 1);
+    assert!(
+        result.findings[0].evidence[0]
+            .snippet
+            .contains("sections/missing.rs")
+    );
+}
+
+#[test]
 fn guarded_optional_python_import_is_not_reported_as_broken() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path();

--- a/src/graph/resolution_stats.rs
+++ b/src/graph/resolution_stats.rs
@@ -7,17 +7,23 @@
 //! weakens absence-based claims (dead modules, fan-in-derived instability).
 //! Genuine third-party packages (`react`, `numpy`) are real external
 //! dependencies and are not recorded; only imports that *should* have resolved
-//! to a scanned file are — relative imports, recognized local path aliases, and
-//! bare imports whose leading segment names a directory that exists in the
-//! repository (a monorepo/workspace package the resolver did not wire up).
+//! to a scanned file are — relative imports, recognized local path aliases,
+//! Rust file-backed module references, and bare imports whose leading segment
+//! names a directory that exists in the repository (a monorepo/workspace
+//! package the resolver did not wire up).
 
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum UnresolvedImportKind {
+    /// A `.`/`..` relative module or path import.
     RelativePath,
+    /// A configured local path alias such as `@/` or `~/`.
     LocalAlias,
+    /// A Rust `mod`/`#[path]`/`include!` reference represented by the parser.
+    RustFileBacked,
+    /// A bare import that resembles a workspace package.
     WorkspacePackage,
 }
 
@@ -142,6 +148,8 @@ fn unresolved_import_kind(raw_import: &str) -> UnresolvedImportKind {
         UnresolvedImportKind::RelativePath
     } else if raw_import.starts_with("@/") || raw_import.starts_with("~/") || raw_import == "~" {
         UnresolvedImportKind::LocalAlias
+    } else if raw_import.starts_with("mod::") || raw_import.starts_with("relfile::") {
+        UnresolvedImportKind::RustFileBacked
     } else {
         UnresolvedImportKind::WorkspacePackage
     }
@@ -182,9 +190,10 @@ pub(crate) fn is_relative_import(import: &str) -> bool {
 }
 
 /// Whether an unresolved import should weaken absence claims (dead module,
-/// instability). Relative imports and recognizable local path aliases always
-/// count. JVM imports require a matching local package; other bare imports count
-/// when their leading segment names a repository directory.
+/// instability). Relative imports, recognizable local path aliases, and
+/// file-backed Rust module references always count. JVM imports require a
+/// matching local package; other bare imports count when their leading segment
+/// names a repository directory.
 pub(crate) fn is_unresolved_internal_import(
     import: &str,
     source: &Path,
@@ -200,6 +209,14 @@ pub(crate) fn is_unresolved_internal_import(
     }
     // Common bundler/tsconfig path aliases for the project's own source root.
     if import.starts_with("@/") || import.starts_with("~/") || import == "~" {
+        return true;
+    }
+    if source
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension == "rs")
+        && (import.starts_with("mod::") || import.starts_with("relfile::"))
+    {
         return true;
     }
     if source

--- a/src/graph/resolution_stats/tests.rs
+++ b/src/graph/resolution_stats/tests.rs
@@ -87,6 +87,37 @@ fn internal_import_classifier_separates_workspace_from_third_party() {
 }
 
 #[test]
+fn internal_import_classifier_recognizes_rust_file_backed_forms() {
+    let repo_dirs = HashSet::new();
+    let repo_jvm_packages = HashSet::new();
+    let source = Path::new("src/lib.rs");
+
+    assert!(is_unresolved_internal_import(
+        "mod::missing",
+        source,
+        &repo_jvm_packages,
+        &repo_dirs,
+    ));
+    assert!(is_unresolved_internal_import(
+        "relfile::sections/header.rs",
+        source,
+        &repo_jvm_packages,
+        &repo_dirs,
+    ));
+}
+
+#[test]
+fn rust_file_backed_evidence_has_its_own_kind() {
+    let mut stats = ImportResolutionStats::default();
+    stats.record(Path::new("src/lib.rs"), "mod::missing");
+
+    assert_eq!(
+        stats.evidence().next().map(|evidence| evidence.kind),
+        Some(UnresolvedImportKind::RustFileBacked)
+    );
+}
+
+#[test]
 fn repo_directory_names_collects_parent_segments_only() {
     let paths = [
         Path::new("apps/ml/app/train.py"),

--- a/src/graph/resolver/mod.rs
+++ b/src/graph/resolver/mod.rs
@@ -93,6 +93,7 @@ pub(crate) fn definitive_local_candidates(
             ts::definitive_relative_candidates(raw_import, &source)?
         }
         "py" => python::definitive_relative_candidates(raw_import, &source)?,
+        "rs" => rust::definitive_local_candidates(raw_import, &source, &root)?,
         _ => return None,
     };
     let candidates = candidates
@@ -210,10 +211,55 @@ mod definitive_candidates_tests {
     }
 
     #[test]
-    fn rust_module_semantics_remain_limited_in_first_slice() {
+    fn rust_module_declaration_has_bounded_local_candidates() {
+        let candidates = definitive_local_candidates(
+            "mod::missing",
+            Path::new("/repo/src/lib.rs"),
+            Path::new("/repo"),
+        )
+        .expect("a plain Rust module declaration has two file forms");
+
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("/repo/src/missing.rs"),
+                PathBuf::from("/repo/src/missing/mod.rs"),
+            ]
+        );
+    }
+
+    #[test]
+    fn rust_relative_file_attribute_has_one_bounded_candidate() {
+        let candidates = definitive_local_candidates(
+            "relfile::sections/header.rs",
+            Path::new("/repo/src/lib.rs"),
+            Path::new("/repo"),
+        )
+        .expect("a literal Rust relative file path is definitive");
+
+        assert_eq!(
+            candidates,
+            vec![PathBuf::from("/repo/src/sections/header.rs")]
+        );
+    }
+
+    #[test]
+    fn rust_relative_file_that_escapes_repository_is_not_definitive() {
         assert_eq!(
             definitive_local_candidates(
-                "mod::missing",
+                "relfile::../../outside.rs",
+                Path::new("/repo/src/lib.rs"),
+                Path::new("/repo"),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn malformed_rust_module_name_is_not_definitive() {
+        assert_eq!(
+            definitive_local_candidates(
+                "mod::not#a_module",
                 Path::new("/repo/src/lib.rs"),
                 Path::new("/repo"),
             ),

--- a/src/graph/resolver/rust.rs
+++ b/src/graph/resolver/rust.rs
@@ -75,15 +75,14 @@ pub(super) fn definitive_local_candidates(
             dir.join(format!("{name}.rs")),
             dir.join(name).join("mod.rs"),
         ]
-    } else if let Some(rel) = raw.strip_prefix("relfile::") {
+    } else {
+        let rel = raw.strip_prefix("relfile::")?;
         let path = Path::new(rel);
         if rel.is_empty() || path.is_absolute() || rel.contains('\0') {
             return None;
         }
         let base = from_file.parent().unwrap_or(root);
         vec![base.join(path)]
-    } else {
-        return None;
     };
 
     let root = super::normalize_path(root);

--- a/src/graph/resolver/rust.rs
+++ b/src/graph/resolver/rust.rs
@@ -54,6 +54,66 @@ pub(super) fn resolve_rust(
     None
 }
 
+/// Enumerates Rust imports whose file target is fixed by the syntax itself.
+///
+/// A `mod name;` declaration can only be backed by `name.rs` or
+/// `name/mod.rs` beside the declaring module. `#[path = "..."]` and
+/// `include!("...")` are represented as `relfile::...` and name exactly one
+/// path. `use crate::...` stays out of this set because it may refer to an
+/// inline module or a re-export rather than a file.
+pub(super) fn definitive_local_candidates(
+    raw: &str,
+    from_file: &Path,
+    root: &Path,
+) -> Option<Vec<PathBuf>> {
+    let candidates = if let Some(name) = raw.strip_prefix("mod::") {
+        if !is_module_name(name) {
+            return None;
+        }
+        let dir = rust_current_module_dir(from_file, root);
+        vec![
+            dir.join(format!("{name}.rs")),
+            dir.join(name).join("mod.rs"),
+        ]
+    } else if let Some(rel) = raw.strip_prefix("relfile::") {
+        let path = Path::new(rel);
+        if rel.is_empty() || path.is_absolute() || rel.contains('\0') {
+            return None;
+        }
+        let base = from_file.parent().unwrap_or(root);
+        vec![base.join(path)]
+    } else {
+        return None;
+    };
+
+    let root = super::normalize_path(root);
+    let candidates = candidates
+        .into_iter()
+        .map(|candidate| super::normalize_path(&candidate))
+        .collect::<Vec<_>>();
+    (candidates
+        .iter()
+        .all(|candidate| candidate.starts_with(&root)))
+    .then_some(candidates)
+}
+
+fn is_module_name(name: &str) -> bool {
+    let identifier = name.strip_prefix("r#").unwrap_or(name);
+    !identifier.is_empty()
+        && name != "self"
+        && name != "super"
+        && name != "crate"
+        && is_rust_identifier(identifier)
+}
+
+fn is_rust_identifier(identifier: &str) -> bool {
+    let mut chars = identifier.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_alphabetic()) && chars.all(|ch| ch == '_' || ch.is_alphanumeric())
+}
+
 fn resolve_rust_module_path(
     base_dir: &Path,
     module_path: &str,

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -794,7 +794,7 @@ risk = { id = "knowledge.circular-dependency", label = "cycle risk", weight = 6,
 [[rules]]
 rule_id = "architecture.unresolved-local-import"
 minimum_support = "rule-aware"
-languages = ["python", "typescript", "typescript-react", "javascript", "javascript-react"]
+languages = ["rust", "python", "typescript", "typescript-react", "javascript", "javascript-react"]
 suppress_low_signal = true
 suppress_generated = true
 risk = { id = "knowledge.unresolved-local-import", label = "broken local import", weight = 8, reason = "a proven missing local module prevents the importing source from loading or compiling" }

--- a/src/languages/rust/imports.rs
+++ b/src/languages/rust/imports.rs
@@ -125,13 +125,18 @@ fn rust_mod_path_attr(stmt: &str) -> Option<String> {
 fn rust_include_path(stmt: &str) -> Option<String> {
     let rest = stmt.trim_start().strip_prefix("include")?;
     let rest = rest.trim_start().strip_prefix('!')?;
+    let rest = rest.trim_start().strip_prefix('(')?;
     first_string_literal(rest)
 }
 
-/// Returns the contents of the first double-quoted string literal in `input`.
+/// Returns a direct double-quoted string literal at the start of `input`.
+///
+/// Rust permits expressions such as `concat!(...)` in both `include!` and
+/// `#[path]`; taking the first nested literal would invent a file edge for a
+/// path that is not statically known.
 fn first_string_literal(input: &str) -> Option<String> {
-    let open = input.find('"')?;
-    let rest = &input[open + 1..];
+    let input = input.trim_start();
+    let rest = input.strip_prefix('"')?;
     let close = rest.find('"')?;
     Some(rest[..close].to_string())
 }
@@ -330,6 +335,18 @@ mod tests {
     #[test]
     fn include_str_is_not_a_module_edge() {
         let got = imports("const D: &str = include_str!(\"data.txt\");\n");
+        assert!(got.iter().all(|i| !i.starts_with("relfile::")), "{got:?}");
+    }
+
+    #[test]
+    fn computed_include_path_is_not_a_module_edge() {
+        let got = imports("include!(concat!(env!(\"MODULE_DIR\"), \"/header.rs\"));\n");
+        assert!(got.iter().all(|i| !i.starts_with("relfile::")), "{got:?}");
+    }
+
+    #[test]
+    fn computed_path_attribute_is_not_a_module_edge() {
+        let got = imports("#[path = concat!(\"parts\", \"/header.rs\")]\nmod header;\n");
         assert!(got.iter().all(|i| !i.starts_with("relfile::")), "{got:?}");
     }
 

--- a/src/rules/registry/architecture.rs
+++ b/src/rules/registry/architecture.rs
@@ -130,7 +130,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
             "Restore the imported module, update the import path, or run the project compiler to confirm the intended generated target.",
         ),
         false_positive_notes: Some(
-            "Only explicit supported TypeScript/JavaScript file extensions and explicit Python relative modules are reported. Python imports guarded by an absorbing ImportError or ModuleNotFoundError handler are excluded; broad or unrelated handlers and bare re-raises do not qualify. Extensionless imports, aliases, workspace packages, Rust module forms, generated targets, and unsupported semantics remain limitations rather than findings.",
+            "Only explicit supported TypeScript/JavaScript file extensions, explicit Python relative modules, and file-backed Rust mod/path/include forms are reported. Python imports guarded by an absorbing ImportError or ModuleNotFoundError handler are excluded; broad or unrelated handlers and bare re-raises do not qualify. Extensionless imports, aliases, workspace packages, computed Rust paths, generated targets, and unsupported semantics remain limitations rather than findings.",
         ),
         ..RuleMetadata::DEFAULT
     },

--- a/tests/fixtures/rules/architecture.unresolved-local-import/expected.json
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/expected.json
@@ -13,6 +13,12 @@
       ]
     },
     {
+      "path": "true_positive_rust",
+      "expected_rule_ids": [
+        "architecture.unresolved-local-import"
+      ]
+    },
+    {
       "path": "false_positive_existing",
       "expected_rule_ids": []
     },
@@ -22,6 +28,10 @@
     },
     {
       "path": "false_positive_package_member",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "false_positive_rust_existing",
       "expected_rule_ids": []
     }
   ]

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_rust_existing/src/lib.rs
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_rust_existing/src/lib.rs
@@ -1,0 +1,3 @@
+mod present;
+
+pub fn run() {}

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_rust_existing/src/present.rs
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_rust_existing/src/present.rs
@@ -1,0 +1,3 @@
+pub fn value() -> u8 {
+    1
+}

--- a/tests/fixtures/rules/architecture.unresolved-local-import/true_positive_rust/src/lib.rs
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/true_positive_rust/src/lib.rs
@@ -1,0 +1,3 @@
+mod missing;
+
+pub fn run() {}

--- a/tests/unresolved_local_import.rs
+++ b/tests/unresolved_local_import.rs
@@ -40,6 +40,39 @@ fn full_and_warm_changed_scans_preserve_broken_import_evidence() {
 }
 
 #[test]
+fn full_and_warm_changed_scans_preserve_missing_rust_module_evidence() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(
+        &temp.path().join("src/lib.rs"),
+        "mod present;\n\npub fn run() {}\n",
+    );
+    write(
+        &temp.path().join("src/present.rs"),
+        "pub fn value() -> u8 { 1 }\n",
+    );
+    commit_all(temp.path(), "initial");
+    write(
+        &temp.path().join("src/lib.rs"),
+        "mod missing;\n\npub fn run() {}\n",
+    );
+
+    let full = scan_json(temp.path(), &[]);
+    let _cold_changed = scan_json(temp.path(), &["--changed"]);
+    let warm_changed = scan_json(temp.path(), &["--changed"]);
+    let full_finding = rule_finding(&full);
+    let changed_finding = rule_finding(&warm_changed);
+
+    assert_eq!(full_finding["rule_id"], RULE_ID);
+    assert_eq!(full_finding["severity"], "HIGH");
+    assert_eq!(full_finding["confidence"], "HIGH");
+    assert_eq!(full_finding["evidence"][0]["path"], "src/lib.rs");
+    assert_eq!(full_finding["evidence"][0]["line_start"], 1);
+    assert_eq!(full_finding["evidence"][0], changed_finding["evidence"][0]);
+    assert_eq!(full_finding["id"], changed_finding["id"]);
+}
+
+#[test]
 fn full_and_warm_changed_scans_ignore_guarded_optional_python_import() {
     let temp = tempdir().expect("temp dir");
     init_repo(temp.path());


### PR DESCRIPTION
## What changed

This PR extends the v0.23 evidence work into the review engine: `architecture.unresolved-local-import` now reports missing Rust files when the source syntax fixes the target, while remaining conservative for ambiguous Rust semantics.

- resolve bounded candidates for `mod name;` (`name.rs` and `name/mod.rs`);
- resolve literal relative targets from `#[path = "..."]` and `include!("...")`;
- classify these edges as `RustFileBacked` evidence and include Rust in the rule's knowledge applicability;
- fail closed for computed Rust paths such as `concat!(...)`, malformed module names, absolute paths, and paths escaping the repository;
- add unit, fixture, and full/warm changed-scan parity coverage;
- retain the real-history evidence packet and keep raw JSON/worksheets under `/tmp`.

## Why

Before this change, a missing Rust module could be visible to the parser but could not produce a high-confidence broken-import finding. The extractor could also mistake a nested string inside a computed path for a concrete file edge. The new contract adds useful Rust coverage without pretending to implement compiler-level name resolution.

## Evidence

- `mod missing;` and missing literal `include!`/`#[path]` targets produce high-confidence findings with stable evidence.
- Existing Rust files remain false-positive guarded by rule fixtures.
- Full, cold changed, and warm changed scans preserve the same Rust evidence and baseline id.
- Computed paths do not create synthetic file edges.
- Real-history holdout remains honest: 6 cases, all pending independent labels; no precision/recall claim is made from it.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` — 935 library tests, 85 binary tests, all integration suites passed; 1 compatibility test ignored by design
- `cargo run -- scan . --fail-on-priority p1` — PASS, 0 visible findings, P0/P1 0, health 100/100, maintainability 91/100
- strict self-scan — 463 findings (3 HIGH, 390 MEDIUM, 70 LOW), health 91/100; 46 unresolved-import cases remain informational limitations
- `python3 -m unittest discover -s scripts/tests` — 249 passed
- `python3 scripts/release-contract.py check` — passed for 0.22.0
- `npm run test:release-contract` — 249 passed
- `python3 scripts/zoo.py scorecard` — committed scorecard matches expectations
- `python3 scripts/real_history.py check && python3 scripts/differential.py check` — valid 6-case protocol, 3 repetitions
- `npm run review:performance` — changed/full ratio 0.441 (limit 0.6), finalization 3,867µs
- `npm run scan:performance` — all warm/cold budgets passed

## Limits and next step

Rust `use` paths, re-exports, inline modules, generated targets, and computed expressions remain outside definitive evidence. The next evidence step is independent labeling plus adjudication of the six real-history cases; after that, use the measured gaps to choose the next resolver or rule slice.
