### PR TITLE
feat: add bounded Go module import evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,6 +380,12 @@ instead of a separate Python implementation.
   the explicit `from <package>.<module> import name` form, which never records
   the parent package, is claimed as a missing module. The rule now carries
   labeled zoo evidence.
+- Extend `architecture.unresolved-local-import` with bounded Go module-path
+  evidence. Imports under the repository's `go.mod` module are mapped to the
+  package directory's non-test `.go` files and emit the same High/High finding
+  only when that complete local set is absent. Go `replace` directives,
+  external modules, build-tag semantics, and other unresolved package forms
+  remain limited evidence rather than fabricated breakage.
 - Measure rules that only fire in the strict profile. `scripts/zoo.py sample
   --rule <id>` draws a deterministic, evenly spread subset of one rule's zoo
   findings to label, and the rule scorecard reports that sampled evidence in its

--- a/docs/agent-guardrail.md
+++ b/docs/agent-guardrail.md
@@ -132,9 +132,9 @@ Two review-first checks look for provably broken code rather than risky
 patterns, so an agent's own edits get caught before a human does:
 
 - **`architecture.unresolved-local-import`** — an explicit local file-backed
-  Rust, TypeScript/JavaScript or Python relative import whose complete candidate
-  set is absent.
-  Ambiguous forms (aliases, extensionless imports, workspace packages) stay
+  Rust, TypeScript/JavaScript or Python relative import, or a Go module-path
+  import owned by `go.mod`, whose complete candidate set is absent.
+  Ambiguous forms (Go `replace`/external modules, aliases, extensionless imports, workspace packages) stay
   bounded diagnostics, never a false broken-code claim.
 - **`behavioral.removed-export-still-imported`** — a named export an agent
   deleted or renamed while a local caller still imports the old name. Fires

--- a/docs/architecture-antipatterns.md
+++ b/docs/architecture-antipatterns.md
@@ -41,7 +41,7 @@ from broad architecture structure heuristics.
 | `architecture.test-leak` | Does production code import a test or fixture file? | On by default; evidence cites the import line. |
 | `architecture.layer-violation` | Does a module import against the declared layer order? | Strictly opt-in via `[[architecture.layers]]`. |
 | `architecture.package-boundary-violation` | Does one package reach into another's internals instead of its public API? | Auto-enabled on a detected workspace (manifest boundaries → High confidence); also configurable via `[architecture] package_roots` (→ Medium). |
-| `architecture.unresolved-local-import` | Does a supported explicit local import point to a module that is absent? | High/High only for bounded TS/JS file candidates, Python relative modules, and file-backed Rust `mod`/`#[path]`/`include!` forms; ambiguous semantics produce an informational limitation, not a finding. |
+| `architecture.unresolved-local-import` | Does a supported explicit local import point to a module that is absent? | High/High only for bounded TS/JS file candidates, Python relative modules, file-backed Rust `mod`/`#[path]`/`include!` forms, and Go module paths owned by `go.mod`; Go `replace`, external modules, and other ambiguous semantics produce an informational limitation, not a finding. |
 
 ## Broken local import boundary
 
@@ -55,6 +55,8 @@ only:
   package initializer exists.
 - file-backed Rust `mod name;` declarations and literal `#[path = "..."]` /
   `include!("...")` references when the target path is absent.
+- Go module-path imports under the repository's `go.mod` module when the
+  package directory has no regular non-test `.go` source files.
 
 Python imports inside a `try` body are not reported when an explicit
 `ImportError` or `ModuleNotFoundError` handler absorbs the failure. A handler
@@ -65,8 +67,9 @@ reparse source text.
 
 RepoPilot checks every bounded candidate on disk before reporting, so a valid
 target omitted by ignore or scan-size policy remains quiet. Extensionless
-imports, path aliases, workspace packages, generated targets, Rust `use` paths,
-root escapes, and unsupported language semantics remain uncertainty. They are
+imports, path aliases, workspace packages, generated targets, Go `replace` or
+external modules, Rust `use` paths, root escapes, and unsupported language
+semantics remain uncertainty. They are
 counted in an aggregated informational diagnostic and are never described as a
 proven build failure.
 

--- a/docs/engineering/v0.23-evidence-ledger.md
+++ b/docs/engineering/v0.23-evidence-ledger.md
@@ -784,3 +784,25 @@ bump is needed to start.
   resolution or repository-wide recall. Computed `include!`/`#[path]`
   expressions are intentionally declined, so a nested string cannot become a
   fabricated file edge.
+
+## 0ZC — Go Module-Path Import Evidence (2026-09-10)
+
+- `architecture.unresolved-local-import` now recognizes an import as
+  file-backed when it is under the module path declared by the repository's
+  local `go.mod`. The candidate set is the package directory's regular,
+  non-test `.go` files, sorted deterministically; an absent directory or an
+  empty package is therefore a definitive missing-target result.
+- The evidence carries a distinct `GoFileBacked` kind so downstream metrics can
+  separate Go package proofs from generic workspace-package limitations. The
+  same rule and evidence survive full, cold changed, and warm changed scans.
+- `replace` directives are a deliberate fail-closed boundary in this slice:
+  local-looking module paths remain limited because the replacement may point
+  outside the repository. External modules, malformed/escaping paths, and
+  imports that do not share the declared module prefix are also left limited.
+- Fixtures pin one missing package and one existing package. Unit tests pin
+  module-prefix ownership, empty candidate sets, replacement and external
+  guards; the end-to-end parity test checks source line, finding identity, and
+  evidence across full and cached changed scans.
+- This proves the bounded `go.mod` contract only. RepoPilot does not invoke the
+  Go compiler, evaluate build tags, model generated files, or claim repository-
+  wide Go import recall. Those are separate evidence slices.

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -218,7 +218,7 @@ A supported explicit local import does not resolve to any bounded source-file ca
 
 **Recommendation:** Restore the imported module, update the import path, or run the project compiler to confirm the intended generated target.
 
-**Known false positives:** Only explicit supported TypeScript/JavaScript file extensions, explicit Python relative modules, and file-backed Rust mod/path/include forms are reported. Python imports guarded by an absorbing ImportError or ModuleNotFoundError handler are excluded; broad or unrelated handlers and bare re-raises do not qualify. Extensionless imports, aliases, workspace packages, computed Rust paths, generated targets, and unsupported semantics remain limitations rather than findings.
+**Known false positives:** Only explicit supported TypeScript/JavaScript file extensions, explicit Python relative modules, file-backed Rust mod/path/include forms, and Go module paths owned by the repository's go.mod are reported. Python imports guarded by an absorbing ImportError or ModuleNotFoundError handler are excluded; broad or unrelated handlers and bare re-raises do not qualify. Go replace directives, external modules, extensionless imports, aliases, workspace packages, computed Rust paths, generated targets, and unsupported semantics remain limitations rather than findings.
 
 **Reference:** <https://github.com/MykytaStel/repopilot/blob/main/docs/rulesets.md#architecture>
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -180,7 +180,7 @@ fn process_import(
             source,
             repo_jvm_packages,
             repo_dirs,
-        ) =>
+        ) || resolution_stats::is_unresolved_go_module_import(raw.trim(), source, root) =>
         {
             resolution.record_classified(source, raw.trim(), root)
         }

--- a/src/graph/resolution_stats.rs
+++ b/src/graph/resolution_stats.rs
@@ -8,9 +8,10 @@
 //! Genuine third-party packages (`react`, `numpy`) are real external
 //! dependencies and are not recorded; only imports that *should* have resolved
 //! to a scanned file are — relative imports, recognized local path aliases,
-//! Rust file-backed module references, and bare imports whose leading segment
-//! names a directory that exists in the repository (a monorepo/workspace
-//! package the resolver did not wire up).
+//! Rust file-backed module references, Go module paths declared by the
+//! repository's `go.mod`, and bare imports whose leading segment names a
+//! directory that exists in the repository (a monorepo/workspace package the
+//! resolver did not wire up).
 
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -23,6 +24,8 @@ pub enum UnresolvedImportKind {
     LocalAlias,
     /// A Rust `mod`/`#[path]`/`include!` reference represented by the parser.
     RustFileBacked,
+    /// A Go module-path import mapped to a package directory inside `go.mod`.
+    GoFileBacked,
     /// A bare import that resembles a workspace package.
     WorkspacePackage,
 }
@@ -75,7 +78,7 @@ impl ImportResolutionStats {
         self.insert(UnresolvedImportEvidence {
             source: source.to_path_buf(),
             raw_import: raw_import.to_string(),
-            kind: unresolved_import_kind(raw_import),
+            kind: unresolved_import_kind_for_source(source, raw_import, root),
             proof,
         });
     }
@@ -155,6 +158,18 @@ fn unresolved_import_kind(raw_import: &str) -> UnresolvedImportKind {
     }
 }
 
+fn unresolved_import_kind_for_source(
+    source: &Path,
+    raw_import: &str,
+    root: &Path,
+) -> UnresolvedImportKind {
+    if is_unresolved_go_module_import(raw_import, source, root) {
+        UnresolvedImportKind::GoFileBacked
+    } else {
+        unresolved_import_kind(raw_import)
+    }
+}
+
 #[cfg(test)]
 mod tests;
 
@@ -189,10 +204,18 @@ pub(crate) fn is_relative_import(import: &str) -> bool {
     import.starts_with('.')
 }
 
+pub(crate) fn is_unresolved_go_module_import(import: &str, source: &Path, root: &Path) -> bool {
+    source
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension == "go")
+        && crate::graph::resolver::is_local_go_module_import(import, root)
+}
+
 /// Whether an unresolved import should weaken absence claims (dead module,
-/// instability). Relative imports, recognizable local path aliases, and
-/// file-backed Rust module references always count. JVM imports require a
-/// matching local package; other bare imports count when their leading segment
+/// instability). Relative imports, recognizable local path aliases, file-backed
+/// Rust references, and local Go module paths always count. JVM imports require
+/// a matching local package; other bare imports count when their leading segment
 /// names a repository directory.
 pub(crate) fn is_unresolved_internal_import(
     import: &str,

--- a/src/graph/resolution_stats/tests.rs
+++ b/src/graph/resolution_stats/tests.rs
@@ -118,6 +118,35 @@ fn rust_file_backed_evidence_has_its_own_kind() {
 }
 
 #[test]
+fn go_module_file_backed_evidence_has_its_own_kind() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("go.mod"), "module example.com/app\n").unwrap();
+    let source = root.join("cmd/app/main.go");
+    let mut stats = ImportResolutionStats::default();
+    stats.record_classified(&source, "example.com/app/internal/missing", root);
+
+    assert_eq!(
+        stats.evidence().next().map(|evidence| evidence.kind),
+        Some(UnresolvedImportKind::GoFileBacked)
+    );
+}
+
+#[test]
+fn go_module_import_classifier_does_not_claim_external_modules() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("go.mod"), "module example.com/app\n").unwrap();
+    let source = root.join("cmd/app/main.go");
+
+    assert!(!is_unresolved_go_module_import(
+        "example.com/other/missing",
+        &source,
+        root,
+    ));
+}
+
+#[test]
 fn repo_directory_names_collects_parent_segments_only() {
     let paths = [
         Path::new("apps/ml/app/train.py"),

--- a/src/graph/resolver/go.rs
+++ b/src/graph/resolver/go.rs
@@ -50,6 +50,61 @@ pub(super) fn resolve_go(
     None
 }
 
+/// Enumerates source files for an import inside the module declared by the
+/// repository's `go.mod`.
+///
+/// Go packages are directories rather than one conventionally named file, so
+/// the candidate set is the package's non-test `.go` files. A `replace`
+/// directive can redirect even an otherwise local-looking module path outside
+/// this repository; those imports remain limited instead of becoming a false
+/// missing-package finding.
+pub(super) fn definitive_local_candidates(raw: &str, root: &Path) -> Option<Vec<PathBuf>> {
+    let module_name = read_go_module_name(root)?;
+    let rest = strip_go_module_prefix(raw, &module_name)?;
+    if go_mod_has_replace(root) || rest == "/" || rest.contains('\\') || rest.contains('\0') {
+        return None;
+    }
+
+    let relative = rest.trim_start_matches('/');
+    let relative_path = Path::new(relative);
+    if relative_path
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return None;
+    }
+    let package_dir = normalize_path(&root.join(relative_path));
+    let root = normalize_path(root);
+    if !package_dir.starts_with(&root) {
+        return None;
+    }
+
+    let mut candidates = std::fs::read_dir(&package_dir)
+        .ok()
+        .into_iter()
+        .flat_map(|entries| entries.filter_map(Result::ok))
+        .filter_map(|entry| {
+            let file_type = entry.file_type().ok()?;
+            if !file_type.is_file() {
+                return None;
+            }
+            let path = entry.path();
+            let name = path.file_name()?.to_str()?;
+            (path.extension().and_then(|extension| extension.to_str()) == Some("go")
+                && !name.ends_with("_test.go"))
+            .then_some(path)
+        })
+        .collect::<Vec<_>>();
+    candidates.sort();
+    Some(candidates)
+}
+
+pub(super) fn is_local_module_import(raw: &str, root: &Path) -> bool {
+    read_go_module_name(root)
+        .and_then(|module| strip_go_module_prefix(raw, &module))
+        .is_some()
+}
+
 fn strip_go_module_prefix<'a>(raw: &'a str, module_name: &str) -> Option<&'a str> {
     raw.strip_prefix(module_name)
         .filter(|rest| rest.is_empty() || rest.starts_with('/'))
@@ -94,4 +149,13 @@ fn read_go_module_name(root: &Path) -> Option<String> {
         .unwrap()
         .insert(root.to_path_buf(), module.clone());
     module
+}
+
+fn go_mod_has_replace(root: &Path) -> bool {
+    std::fs::read_to_string(root.join("go.mod")).is_ok_and(|content| {
+        content.lines().any(|line| {
+            let trimmed = line.trim();
+            trimmed.split_whitespace().next() == Some("replace")
+        })
+    })
 }

--- a/src/graph/resolver/mod.rs
+++ b/src/graph/resolver/mod.rs
@@ -94,6 +94,7 @@ pub(crate) fn definitive_local_candidates(
         }
         "py" => python::definitive_relative_candidates(raw_import, &source)?,
         "rs" => rust::definitive_local_candidates(raw_import, &source, &root)?,
+        "go" => go::definitive_local_candidates(raw_import, &root)?,
         _ => return None,
     };
     let candidates = candidates
@@ -101,8 +102,12 @@ pub(crate) fn definitive_local_candidates(
         .map(|candidate| normalize_path(&candidate))
         .collect::<Vec<_>>();
 
-    (!candidates.is_empty() && candidates.iter().all(|path| path.starts_with(&root)))
-        .then_some(candidates)
+    let stays_under_root = candidates.iter().all(|path| path.starts_with(&root));
+    (stays_under_root && (ext == "go" || !candidates.is_empty())).then_some(candidates)
+}
+
+pub(crate) fn is_local_go_module_import(raw_import: &str, root: &Path) -> bool {
+    go::is_local_module_import(raw_import, root)
 }
 
 /// Returns the first candidate that exists in `known_files`, after normalizing
@@ -263,6 +268,66 @@ mod definitive_candidates_tests {
                 Path::new("/repo/src/lib.rs"),
                 Path::new("/repo"),
             ),
+            None
+        );
+    }
+
+    #[test]
+    fn go_module_import_maps_to_source_files_in_local_package() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("go.mod"), "module example.com/app\n\ngo 1.22\n").unwrap();
+        let package = root.join("internal/present");
+        std::fs::create_dir_all(&package).unwrap();
+        std::fs::write(package.join("present.go"), "package present\n").unwrap();
+
+        let candidates = definitive_local_candidates(
+            "example.com/app/internal/present",
+            &root.join("cmd/app/main.go"),
+            root,
+        )
+        .expect("a local Go module import should have bounded file candidates");
+
+        assert_eq!(candidates, vec![package.join("present.go")]);
+    }
+
+    #[test]
+    fn missing_go_module_package_is_definitive_with_no_candidates() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("go.mod"), "module example.com/app\n").unwrap();
+
+        let candidates =
+            definitive_local_candidates("example.com/app/missing", &root.join("main.go"), root)
+                .expect("a local Go module import remains definitive when its package is absent");
+
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn go_module_replace_keeps_resolution_limited() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(
+            root.join("go.mod"),
+            "module example.com/app\n\nreplace\texample.com/app => ../local\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            definitive_local_candidates("example.com/app/missing", &root.join("main.go"), root,),
+            None
+        );
+    }
+
+    #[test]
+    fn external_go_module_is_not_definitive() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("go.mod"), "module example.com/app\n").unwrap();
+
+        assert_eq!(
+            definitive_local_candidates("example.com/other/missing", &root.join("main.go"), root,),
             None
         );
     }

--- a/src/knowledge/packs/core.toml
+++ b/src/knowledge/packs/core.toml
@@ -794,7 +794,7 @@ risk = { id = "knowledge.circular-dependency", label = "cycle risk", weight = 6,
 [[rules]]
 rule_id = "architecture.unresolved-local-import"
 minimum_support = "rule-aware"
-languages = ["rust", "python", "typescript", "typescript-react", "javascript", "javascript-react"]
+languages = ["rust", "python", "typescript", "typescript-react", "javascript", "javascript-react", "go"]
 suppress_low_signal = true
 suppress_generated = true
 risk = { id = "knowledge.unresolved-local-import", label = "broken local import", weight = 8, reason = "a proven missing local module prevents the importing source from loading or compiling" }

--- a/src/rules/registry/architecture.rs
+++ b/src/rules/registry/architecture.rs
@@ -130,7 +130,7 @@ pub(super) static RULES: &[RuleMetadata] = &[
             "Restore the imported module, update the import path, or run the project compiler to confirm the intended generated target.",
         ),
         false_positive_notes: Some(
-            "Only explicit supported TypeScript/JavaScript file extensions, explicit Python relative modules, and file-backed Rust mod/path/include forms are reported. Python imports guarded by an absorbing ImportError or ModuleNotFoundError handler are excluded; broad or unrelated handlers and bare re-raises do not qualify. Extensionless imports, aliases, workspace packages, computed Rust paths, generated targets, and unsupported semantics remain limitations rather than findings.",
+            "Only explicit supported TypeScript/JavaScript file extensions, explicit Python relative modules, file-backed Rust mod/path/include forms, and Go module paths owned by the repository's go.mod are reported. Python imports guarded by an absorbing ImportError or ModuleNotFoundError handler are excluded; broad or unrelated handlers and bare re-raises do not qualify. Go replace directives, external modules, extensionless imports, aliases, workspace packages, computed Rust paths, generated targets, and unsupported semantics remain limitations rather than findings.",
         ),
         ..RuleMetadata::DEFAULT
     },

--- a/tests/fixtures/rules/architecture.unresolved-local-import/expected.json
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/expected.json
@@ -19,6 +19,12 @@
       ]
     },
     {
+      "path": "true_positive_go",
+      "expected_rule_ids": [
+        "architecture.unresolved-local-import"
+      ]
+    },
+    {
       "path": "false_positive_existing",
       "expected_rule_ids": []
     },
@@ -32,6 +38,18 @@
     },
     {
       "path": "false_positive_rust_existing",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "false_positive_go_existing",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "false_positive_go_external",
+      "expected_rule_ids": []
+    },
+    {
+      "path": "false_positive_go_replace",
       "expected_rule_ids": []
     }
   ]

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_existing/cmd/app/main.go
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_existing/cmd/app/main.go
@@ -1,0 +1,5 @@
+package main
+
+import "example.com/app/internal/present"
+
+func main() { present.Run() }

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_existing/go.mod
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_existing/go.mod
@@ -1,0 +1,3 @@
+module example.com/app
+
+go 1.22

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_existing/internal/present/present.go
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_existing/internal/present/present.go
@@ -1,0 +1,3 @@
+package present
+
+func Run() {}

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_external/cmd/app/main.go
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_external/cmd/app/main.go
@@ -1,0 +1,5 @@
+package main
+
+import "example.com/other/missing"
+
+func main() { missing.Run() }

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_external/go.mod
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_external/go.mod
@@ -1,0 +1,3 @@
+module example.com/app
+
+go 1.22

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_replace/cmd/app/main.go
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_replace/cmd/app/main.go
@@ -1,0 +1,5 @@
+package main
+
+import "example.com/app/internal/missing"
+
+func main() { missing.Run() }

--- a/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_replace/go.mod
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/false_positive_go_replace/go.mod
@@ -1,0 +1,5 @@
+module example.com/app
+
+go 1.22
+
+replace example.com/app => ../local-copy

--- a/tests/fixtures/rules/architecture.unresolved-local-import/true_positive_go/cmd/app/main.go
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/true_positive_go/cmd/app/main.go
@@ -1,0 +1,5 @@
+package main
+
+import "example.com/app/internal/missing"
+
+func main() { missing.Run() }

--- a/tests/fixtures/rules/architecture.unresolved-local-import/true_positive_go/go.mod
+++ b/tests/fixtures/rules/architecture.unresolved-local-import/true_positive_go/go.mod
@@ -1,0 +1,3 @@
+module example.com/app
+
+go 1.22

--- a/tests/unresolved_local_import.rs
+++ b/tests/unresolved_local_import.rs
@@ -73,6 +73,43 @@ fn full_and_warm_changed_scans_preserve_missing_rust_module_evidence() {
 }
 
 #[test]
+fn full_and_warm_changed_scans_preserve_missing_go_module_evidence() {
+    let temp = tempdir().expect("temp dir");
+    init_repo(temp.path());
+    write(
+        &temp.path().join("go.mod"),
+        "module example.com/app\n\ngo 1.22\n",
+    );
+    write(
+        &temp.path().join("cmd/app/main.go"),
+        "package main\n\nimport \"example.com/app/internal/present\"\n\nfunc main() { present.Run() }\n",
+    );
+    write(
+        &temp.path().join("internal/present/present.go"),
+        "package present\n\nfunc Run() {}\n",
+    );
+    commit_all(temp.path(), "initial");
+    write(
+        &temp.path().join("cmd/app/main.go"),
+        "package main\n\nimport \"example.com/app/internal/missing\"\n\nfunc main() { missing.Run() }\n",
+    );
+
+    let full = scan_json(temp.path(), &[]);
+    let _cold_changed = scan_json(temp.path(), &["--changed"]);
+    let warm_changed = scan_json(temp.path(), &["--changed"]);
+    let full_finding = rule_finding(&full);
+    let changed_finding = rule_finding(&warm_changed);
+
+    assert_eq!(full_finding["rule_id"], RULE_ID);
+    assert_eq!(full_finding["severity"], "HIGH");
+    assert_eq!(full_finding["confidence"], "HIGH");
+    assert_eq!(full_finding["evidence"][0]["path"], "cmd/app/main.go");
+    assert_eq!(full_finding["evidence"][0]["line_start"], 3);
+    assert_eq!(full_finding["evidence"][0], changed_finding["evidence"][0]);
+    assert_eq!(full_finding["id"], changed_finding["id"]);
+}
+
+#[test]
 fn full_and_warm_changed_scans_ignore_guarded_optional_python_import() {
     let temp = tempdir().expect("temp dir");
     init_repo(temp.path());


### PR DESCRIPTION
## Problem

RepoPilot already resolves Go module imports for graph edges, but a missing local Go package was not eligible for `architecture.unresolved-local-import`. That left a real broken import as an unresolved graph limitation and weakened the correctness signal.

## What changed

- Map imports under the repository module declared by local `go.mod` to the package directory.
- Enumerate deterministic regular non-test `.go` candidates and emit the existing High/High missing-target finding when the set is empty.
- Record a distinct `GoFileBacked` evidence kind and keep the knowledge applicability gate aligned with Go.
- Preserve fail-closed behavior for external module paths, `replace` directives, malformed/escaping paths, generated/build-tag uncertainty, and other unsupported semantics.
- Add true-positive, existing-package, external-module, and `replace` fixtures.
- Add unit coverage plus full/cold/warm changed-scan parity for source line, evidence, and stable finding identity.
- Update registry, generated rule reference, changelog, guardrail, antipattern, and v0.23 evidence-ledger documentation.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (941 lib, 85 bin, all integration tests passed; one pre-existing compatibility test remains explicitly ignored)
- `python3 scripts/release-contract.py check`
- `python3 -m unittest discover -s scripts/tests` (249 passed)
- `npm run test:release-contract` (249 passed)
- `npm run review:performance` (changed/full ratio 0.454 <= 0.6; finalization 3,939 us)
- `npm run scan:performance` (all budgets passed)
- `python3 scripts/zoo.py scorecard`
- `python3 scripts/real_history.py check && python3 scripts/differential.py check` (6 cases, 3 repetitions, all labels still pending)
- `cargo run --quiet -- scan . --fail-on-priority p1` (PASS; default profile has 0 visible findings)

## Limits

This is bounded `go.mod` evidence, not Go compiler parity. RepoPilot does not invoke `go test`/`go list`, evaluate build tags, discover generated files, or claim repository-wide Go import recall. A module path redirected by `replace` stays a limitation even when the replacement happens to be local.
